### PR TITLE
Add WooCommerce installation with web view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 9.8
 -----
 - [***] Login: Introduce a way to sign in using store credentials.  [https://github.com/woocommerce/woocommerce-ios/pull/7320]
+- [**] Login: You can now install WooCommerce to your self-hosted sites from the login flow. [https://github.com/woocommerce/woocommerce-ios/pull/7401]
 - [**] Orders: Now you can quickly mark an order as completed by swiping it to the left! [https://github.com/woocommerce/woocommerce-ios/pull/7385]
 - [*] In-Person Payments: The purchase card reader information card appears also in the Orders list screen. [https://github.com/woocommerce/woocommerce-ios/pull/7326]
 

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,102 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "AutomatticAbout",
-        "repositoryURL": "https://github.com/automattic/AutomatticAbout-swift",
-        "state": {
-          "branch": null,
-          "revision": "d3e8b4d8133984d9ae20936a55e747d27661e2a1",
-          "version": "1.1.1"
-        }
-      },
-      {
-        "package": "Charts",
-        "repositoryURL": "https://github.com/danielgindi/Charts",
-        "state": {
-          "branch": null,
-          "revision": "b38b8d45a8cbda9f0f2a3566778ed114f06056b7",
-          "version": "4.0.3"
-        }
-      },
-      {
         "package": "Difference",
         "repositoryURL": "https://github.com/krzysztofzablocki/Difference.git",
         "state": {
           "branch": "master",
           "revision": "6b121174e4a4bfed28ef8bb725156fac6e7c12bc",
           "version": null
-        }
-      },
-      {
-        "package": "Embassy",
-        "repositoryURL": "https://github.com/envoy/Embassy",
-        "state": {
-          "branch": null,
-          "revision": "065b6ce52596bd06b867cfe17fea2c56dcb53b30",
-          "version": "4.1.3"
-        }
-      },
-      {
-        "package": "Inject",
-        "repositoryURL": "https://github.com/krzysztofzablocki/Inject.git",
-        "state": {
-          "branch": null,
-          "revision": "c0ed5f5de62475e286a3b7c676cec99fa34533ce",
-          "version": "1.1.1"
-        }
-      },
-      {
-        "package": "ScreenObject",
-        "repositoryURL": "https://github.com/Automattic/ScreenObject",
-        "state": {
-          "branch": null,
-          "revision": "e27405a65672c62e5a055697eafdeaf073ea63ff",
-          "version": "0.2.1"
-        }
-      },
-      {
-        "package": "swift-algorithms",
-        "repositoryURL": "https://github.com/apple/swift-algorithms",
-        "state": {
-          "branch": null,
-          "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
-          "version": "1.0.0"
-        }
-      },
-      {
-        "package": "swift-numerics",
-        "repositoryURL": "https://github.com/apple/swift-numerics",
-        "state": {
-          "branch": null,
-          "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",
-          "version": "1.0.2"
-        }
-      },
-      {
-        "package": "SwiftUI-Shimmer",
-        "repositoryURL": "https://github.com/markiv/SwiftUI-Shimmer",
-        "state": {
-          "branch": null,
-          "revision": "61411771350a5a4e96666a8a202ae4b2be327a2b",
-          "version": "1.0.1"
-        }
-      },
-      {
-        "package": "BuildkiteTestCollector",
-        "repositoryURL": "https://github.com/buildkite/test-collector-swift",
-        "state": {
-          "branch": null,
-          "revision": "87afcecfb58dd017d6e835ec8e88e9eaa18095ba",
-          "version": "0.1.1"
-        }
-      },
-      {
-        "package": "XCUITestHelpers",
-        "repositoryURL": "https://github.com/Automattic/XCUITestHelpers",
-        "state": {
-          "branch": null,
-          "revision": "5179cb69d58b90761cc713bdee7740c4889d3295",
-          "version": "0.4.0"
         }
       }
     ]

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,102 @@
   "object": {
     "pins": [
       {
+        "package": "AutomatticAbout",
+        "repositoryURL": "https://github.com/automattic/AutomatticAbout-swift",
+        "state": {
+          "branch": null,
+          "revision": "d3e8b4d8133984d9ae20936a55e747d27661e2a1",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "package": "Charts",
+        "repositoryURL": "https://github.com/danielgindi/Charts",
+        "state": {
+          "branch": null,
+          "revision": "b38b8d45a8cbda9f0f2a3566778ed114f06056b7",
+          "version": "4.0.3"
+        }
+      },
+      {
         "package": "Difference",
         "repositoryURL": "https://github.com/krzysztofzablocki/Difference.git",
         "state": {
           "branch": "master",
           "revision": "6b121174e4a4bfed28ef8bb725156fac6e7c12bc",
           "version": null
+        }
+      },
+      {
+        "package": "Embassy",
+        "repositoryURL": "https://github.com/envoy/Embassy",
+        "state": {
+          "branch": null,
+          "revision": "065b6ce52596bd06b867cfe17fea2c56dcb53b30",
+          "version": "4.1.3"
+        }
+      },
+      {
+        "package": "Inject",
+        "repositoryURL": "https://github.com/krzysztofzablocki/Inject.git",
+        "state": {
+          "branch": null,
+          "revision": "c0ed5f5de62475e286a3b7c676cec99fa34533ce",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "package": "ScreenObject",
+        "repositoryURL": "https://github.com/Automattic/ScreenObject",
+        "state": {
+          "branch": null,
+          "revision": "e27405a65672c62e5a055697eafdeaf073ea63ff",
+          "version": "0.2.1"
+        }
+      },
+      {
+        "package": "swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms",
+        "state": {
+          "branch": null,
+          "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
+        "state": {
+          "branch": null,
+          "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "package": "SwiftUI-Shimmer",
+        "repositoryURL": "https://github.com/markiv/SwiftUI-Shimmer",
+        "state": {
+          "branch": null,
+          "revision": "61411771350a5a4e96666a8a202ae4b2be327a2b",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "package": "BuildkiteTestCollector",
+        "repositoryURL": "https://github.com/buildkite/test-collector-swift",
+        "state": {
+          "branch": null,
+          "revision": "87afcecfb58dd017d6e835ec8e88e9eaa18095ba",
+          "version": "0.1.1"
+        }
+      },
+      {
+        "package": "XCUITestHelpers",
+        "repositoryURL": "https://github.com/Automattic/XCUITestHelpers",
+        "state": {
+          "branch": null,
+          "revision": "5179cb69d58b90761cc713bdee7740c4889d3295",
+          "version": "0.4.0"
         }
       }
     ]

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1335,7 +1335,7 @@ extension WooAnalyticsEvent {
 //
 extension WooAnalyticsEvent {
     enum LoginWooCommerceSetup {
-        /// The source that user sets up Jetpack: on the web or natively on the app.
+        /// The source that user sets up WooCommerce: on the web or natively on the app.
         enum Source: String {
             case web
             case native

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1330,3 +1330,29 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - Login WooCommerce Setup
+//
+extension WooAnalyticsEvent {
+    enum LoginWooCommerceSetup {
+        /// The source that user sets up Jetpack: on the web or natively on the app.
+        enum Source: String {
+            case web
+            case native
+        }
+
+        enum Key: String {
+            case source
+        }
+
+        /// Tracks when the user dismisses the WooCommerce Setup flow.
+        static func setupDismissed(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginWooCommerceSetupDismissed, properties: [Key.source.rawValue: source.rawValue])
+        }
+
+        /// Tracks when the user completes the WooCommerce Setup flow.
+        static func setupCompleted(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginWooCommerceSetupCompleted, properties: [Key.source.rawValue: source.rawValue])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -637,6 +637,12 @@ public enum WooAnalyticsStat: String {
     case loginJetpackSetupDismissed = "login_jetpack_setup_dismissed"
     case loginJetpackSetupCompleted = "login_jetpack_setup_completed"
     case loginJetpackSetupFlow = "login_jetpack_setup_flow"
+
+    // MARK: Login WooCommerce setup
+    case loginWooCommerceErrorShown = "login_woocommerce_error_shown"
+    case loginWooCommerceSetupButtonTapped = "login_woocommerce_setup_button_tapped"
+    case loginWooCommerceSetupDismissed = "login_woocommerce_setup_dismissed"
+    case loginWooCommerceSetupCompleted = "login_woocommerce_setup_completed"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -281,12 +281,17 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         let matcher = ULAccountMatcher()
         matcher.refreshStoredSites()
 
-        guard matcher.match(originalURL: siteURL) else {
+        guard let matchedSite = matcher.matchedSite(originalURL: siteURL) else {
             DDLogWarn("⚠️ Present account mismatch error for site: \(String(describing: siteURL))")
             let viewModel = WrongAccountErrorViewModel(siteURL: siteURL)
             let mismatchAccountUI = ULAccountMismatchViewController(viewModel: viewModel)
 
             return navigationController.show(mismatchAccountUI, sender: nil)
+        }
+
+        guard matchedSite.isWooCommerceActive else {
+            // TODO: show the no Woo error
+            return
         }
 
         storePickerCoordinator = StorePickerCoordinator(navigationController, config: .login)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -290,8 +290,9 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         }
 
         guard matchedSite.isWooCommerceActive else {
-            // TODO: show the no Woo error
-            return
+            let viewModel = NoWooErrorViewModel(siteURL: siteURL, showsConnectedStores: matcher.hasConnectedStores)
+            let noWooUI = ULErrorViewController(viewModel: viewModel)
+            return navigationController.show(noWooUI, sender: nil)
         }
 
         storePickerCoordinator = StorePickerCoordinator(navigationController, config: .login)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -281,7 +281,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         let matcher = ULAccountMatcher()
         matcher.refreshStoredSites()
 
-        guard let matchedSite = matcher.matchedSite(originalURL: siteURL) else {
+        guard matcher.match(originalURL: siteURL) else {
             DDLogWarn("⚠️ Present account mismatch error for site: \(String(describing: siteURL))")
             let viewModel = WrongAccountErrorViewModel(siteURL: siteURL)
             let mismatchAccountUI = ULAccountMismatchViewController(viewModel: viewModel)
@@ -289,7 +289,8 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             return navigationController.show(mismatchAccountUI, sender: nil)
         }
 
-        guard matchedSite.isWooCommerceActive else {
+        if let matchedSite = matcher.matchedSite(originalURL: siteURL),
+           matchedSite.isWooCommerceActive == false {
             let viewModel = NoWooErrorViewModel(siteURL: siteURL, showsConnectedStores: matcher.hasConnectedStores)
             let noWooUI = ULErrorViewController(viewModel: viewModel)
             return navigationController.show(noWooUI, sender: nil)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -291,7 +291,11 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
         if let matchedSite = matcher.matchedSite(originalURL: siteURL),
            matchedSite.isWooCommerceActive == false {
-            let viewModel = NoWooErrorViewModel(siteURL: siteURL, showsConnectedStores: matcher.hasConnectedStores, onSetupCompletion: { [weak self] siteID in
+            let viewModel = NoWooErrorViewModel(
+                siteURL: siteURL,
+                showsConnectedStores: matcher.hasConnectedStores,
+                showsInstallButton: matchedSite.isJetpackConnected,
+                onSetupCompletion: { [weak self] siteID in
                 guard let self = self else { return }
                 self.storePickerCoordinator = StorePickerCoordinator(navigationController, config: .login)
                 self.storePickerCoordinator?.onDismiss = onDismiss

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -289,29 +289,21 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             return navigationController.show(mismatchAccountUI, sender: nil)
         }
 
-        if let matchedSite = matcher.matchedSite(originalURL: siteURL),
-           matchedSite.isWooCommerceActive == false {
+        let matchedSite = matcher.matchedSite(originalURL: siteURL)
+        if let matchedSite = matchedSite, matchedSite.isWooCommerceActive == false {
             let viewModel = NoWooErrorViewModel(
                 siteURL: siteURL,
                 showsConnectedStores: matcher.hasConnectedStores,
                 showsInstallButton: matchedSite.isJetpackConnected,
                 onSetupCompletion: { [weak self] siteID in
-                guard let self = self else { return }
-                self.storePickerCoordinator = StorePickerCoordinator(navigationController, config: .login)
-                self.storePickerCoordinator?.onDismiss = onDismiss
-                self.storePickerCoordinator?.didSelectStore(with: siteID, onCompletion: onDismiss)
+                    guard let self = self else { return }
+                    self.startStorePicker(with: siteID, in: navigationController, onDismiss: onDismiss)
             })
             let noWooUI = ULErrorViewController(viewModel: viewModel)
             return navigationController.show(noWooUI, sender: nil)
         }
 
-        storePickerCoordinator = StorePickerCoordinator(navigationController, config: .login)
-        storePickerCoordinator?.onDismiss = onDismiss
-        if let site = matcher.matchedSite(originalURL: siteURL) {
-            storePickerCoordinator?.didSelectStore(with: site.siteID, onCompletion: onDismiss)
-        } else {
-            storePickerCoordinator?.start()
-        }
+        self.startStorePicker(with: matchedSite?.siteID, in: navigationController, onDismiss: onDismiss)
     }
 
     /// Presents the Signup Epilogue, in the specified NavigationController.
@@ -329,8 +321,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         //
         // This is effectively a useless screen for them other than telling them to install Jetpack.
         sync(credentials: credentials) { [weak self] in
-            self?.storePickerCoordinator = StorePickerCoordinator(navigationController, config: .login)
-            self?.storePickerCoordinator?.start()
+            self?.startStorePicker(in: navigationController)
         }
     }
 
@@ -492,6 +483,16 @@ private extension AuthenticationManager {
         })
         let installJetpackUI = ULErrorViewController(viewModel: viewModel)
         navigationController.show(installJetpackUI, sender: nil)
+    }
+
+    func startStorePicker(with siteID: Int64? = nil, in navigationController: UINavigationController, onDismiss: @escaping () -> Void = {}) {
+        storePickerCoordinator = StorePickerCoordinator(navigationController, config: .login)
+        storePickerCoordinator?.onDismiss = onDismiss
+        if let siteID = siteID {
+            storePickerCoordinator?.didSelectStore(with: siteID, onCompletion: onDismiss)
+        } else {
+            storePickerCoordinator?.start()
+        }
     }
 }
 

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -291,7 +291,12 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
         if let matchedSite = matcher.matchedSite(originalURL: siteURL),
            matchedSite.isWooCommerceActive == false {
-            let viewModel = NoWooErrorViewModel(siteURL: siteURL, showsConnectedStores: matcher.hasConnectedStores)
+            let viewModel = NoWooErrorViewModel(siteURL: siteURL, showsConnectedStores: matcher.hasConnectedStores, onSetupCompletion: { [weak self] in
+                self?.checkWooCommerceSetupAndShowStoreIfPossible(for: siteURL,
+                                                                  with: matcher,
+                                                                  in: navigationController,
+                                                                  onDismiss: onDismiss)
+            })
             let noWooUI = ULErrorViewController(viewModel: viewModel)
             return navigationController.show(noWooUI, sender: nil)
         }
@@ -483,6 +488,23 @@ private extension AuthenticationManager {
         })
         let installJetpackUI = ULErrorViewController(viewModel: viewModel)
         navigationController.show(installJetpackUI, sender: nil)
+    }
+
+    func checkWooCommerceSetupAndShowStoreIfPossible(for siteURL: String,
+                                                     with matcher: ULAccountMatcher,
+                                                     in navigationController: UINavigationController,
+                                                     onDismiss: @escaping () -> Void) {
+        ServiceLocator.stores.synchronizeEntities { [weak self] in
+            guard let self = self else { return }
+            matcher.refreshStoredSites()
+            guard let site = matcher.matchedSite(originalURL: siteURL),
+                  site.isWooCommerceActive else {
+                return
+            }
+            self.storePickerCoordinator = StorePickerCoordinator(navigationController, config: .login)
+            self.storePickerCoordinator?.onDismiss = onDismiss
+            self.storePickerCoordinator?.didSelectStore(with: site.siteID, onCompletion: onDismiss)
+        }
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewModel.swift
@@ -36,6 +36,10 @@ final class JetpackSetupWebViewModel: PluginSetupWebViewModel {
         analytics.track(event: .LoginJetpackSetup.setupDismissed(source: .web))
     }
 
+    func handleRedirect(for url: URL?) {
+        // No-op
+    }
+
     func decidePolicy(for navigationURL: URL, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         let url = navigationURL.absoluteString
         switch url {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -8,11 +8,13 @@ struct NoWooErrorViewModel: ULErrorViewModel {
     private let siteURL: String
     private let showsConnectedStores: Bool
     private let analytics: Analytics
+    private let setupCompletionHandler: () -> Void
 
-    init(siteURL: String?, showsConnectedStores: Bool, analytics: Analytics = ServiceLocator.analytics) {
+    init(siteURL: String?, showsConnectedStores: Bool, analytics: Analytics = ServiceLocator.analytics, onSetupCompletion: @escaping () -> Void) {
         self.siteURL = siteURL ?? Localization.yourSite
         self.showsConnectedStores = showsConnectedStores
         self.analytics = analytics
+        self.setupCompletionHandler = onSetupCompletion
     }
 
     // MARK: - Data and configuration
@@ -45,9 +47,9 @@ struct NoWooErrorViewModel: ULErrorViewModel {
         guard let viewController = viewController else {
             return
         }
-        let viewModel = WooSetupWebViewModel(siteURL: siteURL)
+        let viewModel = WooSetupWebViewModel(siteURL: siteURL, onCompletion: setupCompletionHandler)
         let setupViewController = PluginSetupWebViewController(viewModel: viewModel)
-        viewController.present(setupViewController, animated: true, completion: nil)
+        viewController.navigationController?.show(setupViewController, sender: nil)
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -93,6 +93,7 @@ private extension NoWooErrorViewModel {
         showInProgressView(in: viewController)
 
         ServiceLocator.stores.synchronizeEntities {
+            // dismisses the in-progress view
             viewController.navigationController?.dismiss(animated: true)
 
             let matcher = ULAccountMatcher()

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -1,5 +1,4 @@
 import UIKit
-import WordPressAuthenticator
 import Yosemite
 
 /// Configuration and actions for an ULErrorViewController,
@@ -139,15 +138,15 @@ private extension NoWooErrorViewModel {
 
         static let primaryButtonTitle = NSLocalizedString("Install WooCommerce",
                                                           comment: "Action button for installing WooCommerce."
-                                                          + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+                                                          + "Presented when logging in with a site address that does not have WooCommerce")
 
         static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",
                                                             comment: "Action button that will restart the login flow."
-                                                            + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+                                                            + "Presented when logging in with a site address that does not have WooCommerce")
 
         static let yourSite = NSLocalizedString("your site",
                                                 comment: "Placeholder for site url, if the url is unknown."
-                                                    + "Presented when logging in with a site address that does not have a valid Jetpack installation."
+                                                    + "Presented when logging in with a site address that does not have WooCommerce."
                                                 + "The error would read: to use this app for your site you'll need...")
         static let verifyingInstallation = NSLocalizedString("Verifying installation...",
                                                              comment: "Message displayed when checking whether a site has successfully installed WooCommerce")

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -43,6 +43,12 @@ struct NoWooErrorViewModel: ULErrorViewModel {
     // MARK: - Actions
     func didTapPrimaryButton(in viewController: UIViewController?) {
         // TODO: Analytics
+        guard let viewController = viewController,
+              let url = URL(string: Strings.installWooCommerceURLString + siteURL.trimHTTPScheme()) else {
+            return
+        }
+        let safariViewController = SFSafariViewController(url: url)
+        viewController.present(safariViewController, animated: true, completion: nil)
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -1,5 +1,4 @@
 import UIKit
-import SafariServices
 import WordPressAuthenticator
 import WordPressUI
 
@@ -43,12 +42,12 @@ struct NoWooErrorViewModel: ULErrorViewModel {
     // MARK: - Actions
     func didTapPrimaryButton(in viewController: UIViewController?) {
         // TODO: Analytics
-        guard let viewController = viewController,
-              let url = URL(string: Strings.installWooCommerceURLString + siteURL.trimHTTPScheme()) else {
+        guard let viewController = viewController else {
             return
         }
-        let safariViewController = SFSafariViewController(url: url)
-        viewController.present(safariViewController, animated: true, completion: nil)
+        let viewModel = WooSetupWebViewModel(siteURL: siteURL)
+        let setupViewController = PluginSetupWebViewController(viewModel: viewModel)
+        viewController.present(setupViewController, animated: true, completion: nil)
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
@@ -99,9 +98,5 @@ private extension NoWooErrorViewModel {
                                                     + "Presented when logging in with a site address that does not have a valid Jetpack installation."
                                                 + "The error would read: to use this app for your site you'll need...")
 
-    }
-
-    enum Strings {
-        static let installWooCommerceURLString = "https://wordpress.com/plugins/woocommerce/"
     }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -43,7 +43,7 @@ struct NoWooErrorViewModel: ULErrorViewModel {
 
     // MARK: - Actions
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        // TODO: Analytics
+        analytics.track(.loginWooCommerceSetupButtonTapped)
         guard let viewController = viewController else {
             return
         }
@@ -69,12 +69,10 @@ struct NoWooErrorViewModel: ULErrorViewModel {
         storePicker.configuration = .listStores
 
         navigationController.pushViewController(storePicker, animated: true)
-
-        // TODO: Analytics
     }
 
     func viewDidLoad() {
-        // TODO: Analytics
+        analytics.track(.loginWooCommerceErrorShown)
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -1,0 +1,101 @@
+import UIKit
+import SafariServices
+import WordPressAuthenticator
+import WordPressUI
+
+/// Configuration and actions for an ULErrorViewController,
+/// modelling an error when WooCommerce is not installed or activated.
+struct NoWooErrorViewModel: ULErrorViewModel {
+    private let siteURL: String
+    private let showsConnectedStores: Bool
+    private let analytics: Analytics
+
+    init(siteURL: String?, showsConnectedStores: Bool, analytics: Analytics = ServiceLocator.analytics) {
+        self.siteURL = siteURL ?? Localization.yourSite
+        self.showsConnectedStores = showsConnectedStores
+        self.analytics = analytics
+    }
+
+    // MARK: - Data and configuration
+    let image: UIImage = .noStoreImage
+
+    var text: NSAttributedString {
+        let font: UIFont = .body
+        let boldFont: UIFont = font.bold
+
+        let boldSiteAddress = NSAttributedString(string: siteURL.trimHTTPScheme(),
+                                                           attributes: [.font: boldFont])
+        let message = NSMutableAttributedString(string: Localization.errorMessage)
+
+        message.replaceFirstOccurrence(of: "%@", with: boldSiteAddress)
+
+        return message
+    }
+
+    var isAuxiliaryButtonHidden: Bool { !showsConnectedStores }
+
+    let auxiliaryButtonTitle = Localization.seeConnectedStores
+
+    let primaryButtonTitle = Localization.primaryButtonTitle
+
+    let secondaryButtonTitle = Localization.secondaryButtonTitle
+
+    // MARK: - Actions
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        // TODO: Analytics
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        let refreshCommand = NavigateToRoot()
+        refreshCommand.execute(from: viewController)
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {
+        guard let navigationController = viewController?.navigationController else {
+            return
+        }
+
+        let storePicker = StorePickerViewController()
+        storePicker.configuration = .listStores
+
+        navigationController.pushViewController(storePicker, animated: true)
+
+        // TODO: Analytics
+    }
+
+    func viewDidLoad() {
+        // TODO: Analytics
+    }
+
+}
+
+// MARK: - Private data structures
+private extension NoWooErrorViewModel {
+    enum Localization {
+        static let errorMessage = NSLocalizedString("It looks like %@ is not a WooCommerce site.",
+                                                    comment: "Message explaining that the site entered doesn't have WooCommerce installed or activated. "
+                                                        + "Reads like 'It looks like awebsite.com is not a WooCommerce site.")
+
+        static let seeConnectedStores = NSLocalizedString("See Connected Stores",
+                                                          comment: "Action button linking to a list of connected stores. "
+                                                          + "Presented when logging in with a store address that does not have WooCommerce.")
+
+        static let primaryButtonTitle = NSLocalizedString("Install WooCommerce",
+                                                          comment: "Action button for installing WooCommerce."
+                                                          + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+
+        static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",
+                                                            comment: "Action button that will restart the login flow."
+                                                            + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+
+        static let yourSite = NSLocalizedString("your site",
+                                                comment: "Placeholder for site url, if the url is unknown."
+                                                    + "Presented when logging in with a site address that does not have a valid Jetpack installation."
+                                                + "The error would read: to use this app for your site you'll need...")
+
+    }
+
+    enum Strings {
+        static let installWooCommerceURLString = "https://wordpress.com/plugins/woocommerce/"
+    }
+}

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -1,6 +1,6 @@
 import UIKit
 import WordPressAuthenticator
-import WordPressUI
+import Yosemite
 
 /// Configuration and actions for an ULErrorViewController,
 /// modelling an error when WooCommerce is not installed or activated.
@@ -9,17 +9,20 @@ struct NoWooErrorViewModel: ULErrorViewModel {
     private let showsConnectedStores: Bool
     private let showsInstallButton: Bool
     private let analytics: Analytics
+    private let stores: StoresManager
     private let setupCompletionHandler: (Int64) -> Void
 
     init(siteURL: String?,
          showsConnectedStores: Bool,
          showsInstallButton: Bool,
          analytics: Analytics = ServiceLocator.analytics,
+         stores: StoresManager = ServiceLocator.stores,
          onSetupCompletion: @escaping (Int64) -> Void) {
         self.siteURL = siteURL ?? Localization.yourSite
         self.showsConnectedStores = showsConnectedStores
         self.showsInstallButton = showsInstallButton
         self.analytics = analytics
+        self.stores = stores
         self.setupCompletionHandler = onSetupCompletion
     }
 
@@ -64,8 +67,9 @@ struct NoWooErrorViewModel: ULErrorViewModel {
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
-        let refreshCommand = NavigateToRoot()
-        refreshCommand.execute(from: viewController)
+        // Log out and pop
+        stores.deauthenticate()
+        viewController?.navigationController?.popToRootViewController(animated: true)
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -7,12 +7,18 @@ import WordPressUI
 struct NoWooErrorViewModel: ULErrorViewModel {
     private let siteURL: String
     private let showsConnectedStores: Bool
+    private let showsInstallButton: Bool
     private let analytics: Analytics
     private let setupCompletionHandler: (Int64) -> Void
 
-    init(siteURL: String?, showsConnectedStores: Bool, analytics: Analytics = ServiceLocator.analytics, onSetupCompletion: @escaping (Int64) -> Void) {
+    init(siteURL: String?,
+         showsConnectedStores: Bool,
+         showsInstallButton: Bool,
+         analytics: Analytics = ServiceLocator.analytics,
+         onSetupCompletion: @escaping (Int64) -> Void) {
         self.siteURL = siteURL ?? Localization.yourSite
         self.showsConnectedStores = showsConnectedStores
+        self.showsInstallButton = showsInstallButton
         self.analytics = analytics
         self.setupCompletionHandler = onSetupCompletion
     }
@@ -38,6 +44,8 @@ struct NoWooErrorViewModel: ULErrorViewModel {
     let auxiliaryButtonTitle = Localization.seeConnectedStores
 
     let primaryButtonTitle = Localization.primaryButtonTitle
+
+    var isPrimaryButtonHidden: Bool { !showsInstallButton }
 
     let secondaryButtonTitle = Localization.secondaryButtonTitle
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/PluginSetupWebViewModel.swift
@@ -13,6 +13,9 @@ protocol PluginSetupWebViewModel {
     /// Triggered when the web view is dismissed
     func handleDismissal()
 
+    /// Triggered when the web view redirects to a new URL
+    func handleRedirect(for url: URL?)
+
     /// Handler for a navigation URL
     func decidePolicy(for navigationURL: URL, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void)
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -96,6 +96,7 @@ private extension ULErrorViewController {
 
     func configurePrimaryButton() {
         primaryButton.isPrimary = true
+        primaryButton.isHidden = viewModel.isPrimaryButtonHidden
         primaryButton.setTitle(viewModel.primaryButtonTitle, for: .normal)
         primaryButton.on(.touchUpInside) { [weak self] _ in
             self?.didTapPrimaryButton()

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewModel.swift
@@ -9,7 +9,7 @@ protocol ULErrorViewModel {
     /// Extended description of the error.
     var text: NSAttributedString { get }
 
-    /// Indicates wheter an auxiliary button is visible
+    /// Indicates whether the auxiliary button is visible
     var isAuxiliaryButtonHidden: Bool { get }
 
     /// Provides the title for an auxiliary button
@@ -17,6 +17,9 @@ protocol ULErrorViewModel {
 
     /// Provides a title for a primary action button
     var primaryButtonTitle: String { get }
+
+    /// Indicates whether the primary button is visible
+    var isPrimaryButtonHidden: Bool { get }
 
     /// Provides a title for a secondary action button
     var secondaryButtonTitle: String { get }
@@ -35,4 +38,9 @@ protocol ULErrorViewModel {
     /// Executes action associated to a tap in the view controller auxiliary button
     /// - Parameter viewController: usually the view controller sending the tap
     func didTapAuxiliaryButton(in viewController: UIViewController?)
+}
+
+// MARK: - Default implementation for optional variables
+extension ULErrorViewModel {
+    var isPrimaryButtonHidden: Bool { false }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
@@ -20,12 +20,12 @@ struct WooSetupWebViewModel: PluginSetupWebViewModel {
     }
 
     func handleDismissal() {
-        // TODO
+        analytics.track(event: .LoginWooCommerceSetup.setupDismissed(source: .web))
     }
 
     func handleRedirect(for url: URL?) {
         if let url = url, url.absoluteString.hasPrefix(Constants.completionURL) {
-            // TODO: analytics
+            analytics.track(event: .LoginWooCommerceSetup.setupCompleted(source: .web))
             completionHandler()
         }
     }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
@@ -1,0 +1,38 @@
+import Foundation
+import WebKit
+
+struct WooSetupWebViewModel: PluginSetupWebViewModel {
+    private let siteURL: String
+    private let analytics: Analytics
+
+    init(siteURL: String, analytics: Analytics = ServiceLocator.analytics) {
+        self.siteURL = siteURL
+        self.analytics = analytics
+    }
+
+    // MARK: - `PluginSetupWebViewModel` conformance
+    var title: String { Localization.title }
+
+    var initialURL: URL? {
+        URL(string: Constants.installWooCommerceURLString + siteURL.trimHTTPScheme())
+    }
+
+    func trackDismissal() {
+        // TODO
+    }
+
+    func decidePolicy(for navigationURL: URL, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        print("🧭 \(navigationURL.absoluteString)")
+        decisionHandler(.allow)
+    }
+}
+
+private extension WooSetupWebViewModel {
+    enum Localization {
+        static let title = NSLocalizedString("WooCommerce Setup", comment: "Title for the WooCommerce Setup screen in the login flow")
+    }
+
+    enum Constants {
+        static let installWooCommerceURLString = "https://wordpress.com/plugins/woocommerce/"
+    }
+}

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
@@ -23,16 +23,15 @@ struct WooSetupWebViewModel: PluginSetupWebViewModel {
         // TODO
     }
 
-    func decidePolicy(for navigationURL: URL, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        print("🧭 \(navigationURL.absoluteString)")
-        switch navigationURL.absoluteString {
-        case let url where url.hasPrefix(Constants.completionURL):
-            decisionHandler(.cancel)
+    func handleRedirect(for url: URL?) {
+        if let url = url, url.absoluteString.hasPrefix(Constants.completionURL) {
             // TODO: analytics
             completionHandler()
-        default:
-            decisionHandler(.allow)
         }
+    }
+
+    func decidePolicy(for navigationURL: URL, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        decisionHandler(.allow)
     }
 }
 
@@ -43,6 +42,6 @@ private extension WooSetupWebViewModel {
 
     enum Constants {
         static let installWooCommerceURL = "https://wordpress.com/plugins/woocommerce/"
-        static let completionURL = "https://public-api.wordpress.com/wpcom/v2/marketplace/products/woocommerce"
+        static let completionURL = "https://wordpress.com/marketplace/thank-you/woocommerce/"
     }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
@@ -1,10 +1,11 @@
 import Foundation
 import WebKit
 
-struct WooSetupWebViewModel: PluginSetupWebViewModel {
+final class WooSetupWebViewModel: PluginSetupWebViewModel {
     private let siteURL: String
     private let analytics: Analytics
     private let completionHandler: () -> Void
+    private var hasCompleted = false
 
     init(siteURL: String, analytics: Analytics = ServiceLocator.analytics, onCompletion: @escaping () -> Void) {
         self.siteURL = siteURL
@@ -20,12 +21,15 @@ struct WooSetupWebViewModel: PluginSetupWebViewModel {
     }
 
     func handleDismissal() {
-        analytics.track(event: .LoginWooCommerceSetup.setupDismissed(source: .web))
+        if !hasCompleted {
+            analytics.track(event: .LoginWooCommerceSetup.setupDismissed(source: .web))
+        }
     }
 
     func handleRedirect(for url: URL?) {
         if let url = url, url.absoluteString.hasPrefix(Constants.completionURL) {
             analytics.track(event: .LoginWooCommerceSetup.setupCompleted(source: .web))
+            hasCompleted = true
             completionHandler()
         }
     }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
@@ -27,11 +27,12 @@ final class WooSetupWebViewModel: PluginSetupWebViewModel {
     }
 
     func handleRedirect(for url: URL?) {
-        if let url = url, url.absoluteString.hasPrefix(Constants.completionURL) {
-            analytics.track(event: .LoginWooCommerceSetup.setupCompleted(source: .web))
-            hasCompleted = true
-            completionHandler()
+        guard let url = url, url.absoluteString.hasPrefix(Constants.completionURL) else {
+            return
         }
+        analytics.track(event: .LoginWooCommerceSetup.setupCompleted(source: .web))
+        hasCompleted = true
+        completionHandler()
     }
 
     func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
@@ -30,8 +30,8 @@ struct WooSetupWebViewModel: PluginSetupWebViewModel {
         }
     }
 
-    func decidePolicy(for navigationURL: URL, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        decisionHandler(.allow)
+    func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy {
+        return .allow
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
@@ -19,14 +19,14 @@ struct WooSetupWebViewModel: PluginSetupWebViewModel {
         URL(string: Constants.installWooCommerceURL + siteURL.trimHTTPScheme())
     }
 
-    func trackDismissal() {
+    func handleDismissal() {
         // TODO
     }
 
     func decidePolicy(for navigationURL: URL, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         print("🧭 \(navigationURL.absoluteString)")
         switch navigationURL.absoluteString {
-        case Constants.completionURL:
+        case let url where url.hasPrefix(Constants.completionURL):
             decisionHandler(.cancel)
             // TODO: analytics
             completionHandler()

--- a/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
+++ b/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
@@ -18,6 +18,11 @@ final class ULAccountMatcher {
         resultsController.fetchedObjects
     }
 
+    /// Checks if the user has any site that has WooCommerce.
+    ///
+    var hasConnectedStores: Bool {
+        return sites.first(where: { $0.isWooCommerceActive }) != nil
+    }
 
     /// Checks if the URL passed as parameter is one of the sites
     /// saved in Storage

--- a/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
+++ b/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
@@ -1,18 +1,17 @@
 import Foundation
 import Yosemite
 
-/// Used to match a store address with a wordpress.com account, as part
+/// Used to match a site address with a wordpress.com account, as part
 /// of the Unified Login process
 final class ULAccountMatcher {
     private let wpComURL = "https://wordpress.com"
-    /// ResultsController: Loads Sites from the Storage Layer.
+    /// ResultsController: Loads all Sites from the Storage Layer.
     ///
     private let resultsController: ResultsController<StorageSite> = {
         let storageManager = ServiceLocator.storageManager
-        let predicate = NSPredicate(format: "isWooCommerceActive == YES")
         let descriptor = NSSortDescriptor(key: "name", ascending: true)
 
-        return ResultsController(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+        return ResultsController(storageManager: storageManager, sortedBy: [descriptor])
     }()
 
     private var sites: [Site] {

--- a/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
+++ b/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
@@ -21,7 +21,7 @@ final class ULAccountMatcher {
     /// Checks if the user has any site that has WooCommerce.
     ///
     var hasConnectedStores: Bool {
-        return sites.first(where: { $0.isWooCommerceActive }) != nil
+        sites.first(where: { $0.isWooCommerceActive }) != nil
     }
 
     /// Checks if the URL passed as parameter is one of the sites

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1634,6 +1634,7 @@
 		DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */; };
 		DE61978B28991F0E005E4362 /* WKWebView+Authenticated.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */; };
 		DE61978D289A5326005E4362 /* WooSetupWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61978C289A5326005E4362 /* WooSetupWebViewModelTests.swift */; };
+		DE61978F289A5674005E4362 /* NoWooErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61978E289A5674005E4362 /* NoWooErrorViewModelTests.swift */; };
 		DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */; };
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
 		DE68B81F26F86B1700C86CFB /* OfflineBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */; };
@@ -3466,6 +3467,7 @@
 		DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Woo.swift"; sourceTree = "<group>"; };
 		DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+Authenticated.swift"; sourceTree = "<group>"; };
 		DE61978C289A5326005E4362 /* WooSetupWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModelTests.swift; sourceTree = "<group>"; };
+		DE61978E289A5674005E4362 /* NoWooErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModelTests.swift; sourceTree = "<group>"; };
 		DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFrom.swift"; sourceTree = "<group>"; };
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
 		DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBannerView.swift; sourceTree = "<group>"; };
@@ -5799,6 +5801,7 @@
 				FEEB2F6D268A2F7B0075A6E0 /* RoleEligibilityUseCaseTests.swift */,
 				DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */,
 				DE61978C289A5326005E4362 /* WooSetupWebViewModelTests.swift */,
+				DE61978E289A5674005E4362 /* NoWooErrorViewModelTests.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -10254,6 +10257,7 @@
 				02645D8C27BA342D0065DC68 /* InboxNoteRowViewModelTests.swift in Sources */,
 				D85136D5231E40B500DD0539 /* ProductReviewTableViewCellTests.swift in Sources */,
 				45FBDF2B238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift in Sources */,
+				DE61978F289A5674005E4362 /* NoWooErrorViewModelTests.swift in Sources */,
 				D89C009A25B4EEA4000E4683 /* WrongAccountErrorViewModelTests.swift in Sources */,
 				02C3FDEA251091CE009569EE /* ProductFactoryTests.swift in Sources */,
 				021125B82578ECF10075AD2A /* BoldableTextParserTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1633,6 +1633,7 @@
 		DE4FB7732812AE96003D20D6 /* FilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4FB7722812AE96003D20D6 /* FilterListView.swift */; };
 		DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */; };
 		DE61978B28991F0E005E4362 /* WKWebView+Authenticated.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */; };
+		DE61978D289A5326005E4362 /* WooSetupWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61978C289A5326005E4362 /* WooSetupWebViewModelTests.swift */; };
 		DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */; };
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
 		DE68B81F26F86B1700C86CFB /* OfflineBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */; };
@@ -3464,6 +3465,7 @@
 		DE4FB7722812AE96003D20D6 /* FilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListView.swift; sourceTree = "<group>"; };
 		DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Woo.swift"; sourceTree = "<group>"; };
 		DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+Authenticated.swift"; sourceTree = "<group>"; };
+		DE61978C289A5326005E4362 /* WooSetupWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModelTests.swift; sourceTree = "<group>"; };
 		DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFrom.swift"; sourceTree = "<group>"; };
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
 		DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBannerView.swift; sourceTree = "<group>"; };
@@ -5796,6 +5798,7 @@
 				FEED57F92686544D00E47FD9 /* RoleErrorViewModelTests.swift */,
 				FEEB2F6D268A2F7B0075A6E0 /* RoleEligibilityUseCaseTests.swift */,
 				DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */,
+				DE61978C289A5326005E4362 /* WooSetupWebViewModelTests.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -10126,6 +10129,7 @@
 				0271E1642509C66200633F7A /* DefaultProductFormTableViewModelTests.swift in Sources */,
 				2602A64827BDBF8000B347F1 /* ProductInputTransformerTests.swift in Sources */,
 				02C27BD0282CDF9E0065471A /* CardPresentPaymentReceiptEmailCoordinatorTests.swift in Sources */,
+				DE61978D289A5326005E4362 /* WooSetupWebViewModelTests.swift in Sources */,
 				D802548726552E07001B2CC1 /* CardPresentModalNonRetryableErrorTests.swift in Sources */,
 				02BAB02924D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift in Sources */,
 				B53A569B21123E8E000776C9 /* MockTableView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1691,6 +1691,7 @@
 		DEF36DEA2898D3CF00178AC2 /* PluginSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */; };
 		DEF36DEC2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */; };
 		DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */; };
+		DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
 		E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */; };
@@ -3520,6 +3521,7 @@
 		DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupWebViewModelTests.swift; sourceTree = "<group>"; };
 		DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModel.swift; sourceTree = "<group>"; };
+		DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
 		E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationLoader.swift; sourceTree = "<group>"; };
@@ -7893,6 +7895,7 @@
 				DEF36DE62898D3CF00178AC2 /* PluginSetupWebViewController.swift */,
 				DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */,
 				DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */,
+				DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */,
 			);
 			path = "Navigation Exceptions";
 			sourceTree = "<group>";
@@ -9050,6 +9053,7 @@
 				FEDD70AF26A7223500194C3A /* StorageEligibilityErrorInfo+Woo.swift in Sources */,
 				AE9E04752776213E003FA09E /* OrderCustomerSection.swift in Sources */,
 				CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */,
+				DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */,
 				02E8B17A23E2C4BD00A43403 /* CircleSpinnerView.swift in Sources */,
 				CCE4CD282669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift in Sources */,
 				02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1690,6 +1690,7 @@
 		DEF36DE92898D3CF00178AC2 /* PluginSetupWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE62898D3CF00178AC2 /* PluginSetupWebViewController.swift */; };
 		DEF36DEA2898D3CF00178AC2 /* PluginSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */; };
 		DEF36DEC2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */; };
+		DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
 		DEFD6E86264ABFB700E51E0D /* PluginListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */; };
 		E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */; };
@@ -3518,6 +3519,7 @@
 		DEF36DE62898D3CF00178AC2 /* PluginSetupWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginSetupWebViewController.swift; sourceTree = "<group>"; };
 		DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupWebViewModelTests.swift; sourceTree = "<group>"; };
+		DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
 		DEFD6E85264ABFB700E51E0D /* PluginListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListViewController.xib; sourceTree = "<group>"; };
 		E10459C527BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentConfigurationLoader.swift; sourceTree = "<group>"; };
@@ -7890,6 +7892,7 @@
 				DEF36DE52898D3CF00178AC2 /* JetpackSetupWebViewModel.swift */,
 				DEF36DE62898D3CF00178AC2 /* PluginSetupWebViewController.swift */,
 				DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */,
+				DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */,
 			);
 			path = "Navigation Exceptions";
 			sourceTree = "<group>";
@@ -9943,6 +9946,7 @@
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
 				311F827426CD897900DF5BAD /* CardReaderSettingsAlertsProvider.swift in Sources */,
 				CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */,
+				DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */,
 				020A55F127F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift in Sources */,
 				DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */,
 				CC69236226010946002FB669 /* LoginProloguePages.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/NoWooErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NoWooErrorViewModelTests.swift
@@ -83,6 +83,29 @@ final class NoWooErrorViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.secondaryButtonTitle, Localization.secondaryButtonTitle)
     }
 
+    func test_user_is_logged_out_when_tapping_secondary_button() {
+        // Given
+        let siteAddress = "https://test.com"
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress,
+                                            showsConnectedStores: false,
+                                            showsInstallButton: false,
+                                            stores: stores,
+                                            onSetupCompletion: { _ in })
+        let rootViewController = UIViewController()
+        let noWooController = ULErrorViewController(viewModel: viewModel)
+        let navigationController = UINavigationController()
+        navigationController.viewControllers = [rootViewController, noWooController]
+
+        // When
+        viewModel.didTapSecondaryButton(in: noWooController)
+
+        // Then
+        XCTAssertFalse(stores.isAuthenticated)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        XCTAssertFalse(navigationController.topViewController is ULErrorViewController)
+    }
+
     func test_woocommerce_setup_button_tapped_is_tracked_when_tapping_primary_button() {
         // Given
         let siteAddress = "https://test.com"

--- a/WooCommerce/WooCommerceTests/Authentication/NoWooErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NoWooErrorViewModelTests.swift
@@ -5,7 +5,7 @@ final class NoWooErrorViewModelTests: XCTestCase {
 
     func test_image_is_correct() {
         // Given
-        let viewModel = NoWooErrorViewModel(siteURL: nil, showsConnectedStores: false, onSetupCompletion: { _ in })
+        let viewModel = NoWooErrorViewModel(siteURL: nil, showsConnectedStores: false, showsInstallButton: false, onSetupCompletion: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.image, UIImage.noStoreImage)
@@ -14,7 +14,7 @@ final class NoWooErrorViewModelTests: XCTestCase {
     func test_error_message_is_correct() {
         // Given
         let siteAddress = "https://test.com"
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, onSetupCompletion: { _ in })
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, showsInstallButton: false, onSetupCompletion: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.text.string, String(format: Localization.errorMessage, "test.com"))
@@ -23,7 +23,7 @@ final class NoWooErrorViewModelTests: XCTestCase {
     func test_auxiliary_button_is_hidden_when_connected_stores_are_not_shown() {
         // Given
         let siteAddress = "https://test.com"
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, onSetupCompletion: { _ in })
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, showsInstallButton: false, onSetupCompletion: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.isAuxiliaryButtonHidden)
@@ -32,7 +32,7 @@ final class NoWooErrorViewModelTests: XCTestCase {
     func test_auxiliary_button_is_not_hidden_when_connected_stores_are_shown() {
         // Given
         let siteAddress = "https://test.com"
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: true, onSetupCompletion: { _ in })
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: true, showsInstallButton: false, onSetupCompletion: { _ in })
 
         // Then
         XCTAssertFalse(viewModel.isAuxiliaryButtonHidden)
@@ -41,7 +41,7 @@ final class NoWooErrorViewModelTests: XCTestCase {
     func test_auxiliary_button_title_is_correct() {
         // Given
         let siteAddress = "https://test.com"
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, onSetupCompletion: { _ in })
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, showsInstallButton: false, onSetupCompletion: { _ in })
 
         //  Then
         XCTAssertEqual(viewModel.auxiliaryButtonTitle, Localization.seeConnectedStores)
@@ -50,16 +50,34 @@ final class NoWooErrorViewModelTests: XCTestCase {
     func test_primary_button_title_is_correct() {
         // Given
         let siteAddress = "https://test.com"
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, onSetupCompletion: { _ in })
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, showsInstallButton: false, onSetupCompletion: { _ in })
 
         //  Then
         XCTAssertEqual(viewModel.primaryButtonTitle, Localization.primaryButtonTitle)
     }
 
+    func test_primary_button_is_hidden_when_install_button_is_not_shown() {
+        // Given
+        let siteAddress = "https://test.com"
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, showsInstallButton: false, onSetupCompletion: { _ in })
+
+        // Then
+        XCTAssertTrue(viewModel.isPrimaryButtonHidden)
+    }
+
+    func test_primary_button_is_not_hidden_when_install_button_is_shown() {
+        // Given
+        let siteAddress = "https://test.com"
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, showsInstallButton: true, onSetupCompletion: { _ in })
+
+        // Then
+        XCTAssertFalse(viewModel.isPrimaryButtonHidden)
+    }
+
     func test_secondary_button_title_is_correct() {
         // Given
         let siteAddress = "https://test.com"
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, onSetupCompletion: { _ in })
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, showsInstallButton: false, onSetupCompletion: { _ in })
 
         //  Then
         XCTAssertEqual(viewModel.secondaryButtonTitle, Localization.secondaryButtonTitle)
@@ -70,7 +88,11 @@ final class NoWooErrorViewModelTests: XCTestCase {
         let siteAddress = "https://test.com"
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, analytics: analytics, onSetupCompletion: { _ in })
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress,
+                                            showsConnectedStores: false,
+                                            showsInstallButton: false,
+                                            analytics: analytics,
+                                            onSetupCompletion: { _ in })
 
         // When
         viewModel.didTapPrimaryButton(in: nil)
@@ -84,7 +106,11 @@ final class NoWooErrorViewModelTests: XCTestCase {
         let siteAddress = "https://test.com"
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, analytics: analytics, onSetupCompletion: { _ in })
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress,
+                                            showsConnectedStores: false,
+                                            showsInstallButton: false,
+                                            analytics: analytics,
+                                            onSetupCompletion: { _ in })
 
         // When
         viewModel.viewDidLoad()

--- a/WooCommerce/WooCommerceTests/Authentication/NoWooErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NoWooErrorViewModelTests.swift
@@ -154,10 +154,10 @@ private extension NoWooErrorViewModelTests {
 
         static let primaryButtonTitle = NSLocalizedString("Install WooCommerce",
                                                           comment: "Action button for installing WooCommerce."
-                                                          + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+                                                          + "Presented when logging in with a site address that does not have WooCommerce")
 
         static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",
                                                             comment: "Action button that will restart the login flow."
-                                                            + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+                                                            + "Presented when logging in with a site address that does not have WooCommerce")
     }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/NoWooErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NoWooErrorViewModelTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import WooCommerce
+
+final class NoWooErrorViewModelTests: XCTestCase {
+
+    func test_image_is_correct() {
+        // Given
+        let viewModel = NoWooErrorViewModel(siteURL: nil, showsConnectedStores: false, onSetupCompletion: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.image, UIImage.noStoreImage)
+    }
+
+    func test_error_message_is_correct() {
+        // Given
+        let siteAddress = "https://test.com"
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, onSetupCompletion: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.text.string, String(format: Localization.errorMessage, "test.com"))
+    }
+
+    func test_auxiliary_button_is_hidden_when_connected_stores_are_not_shown() {
+        // Given
+        let siteAddress = "https://test.com"
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, onSetupCompletion: { _ in })
+
+        // Then
+        XCTAssertTrue(viewModel.isAuxiliaryButtonHidden)
+    }
+
+    func test_auxiliary_button_is_not_hidden_when_connected_stores_are_shown() {
+        // Given
+        let siteAddress = "https://test.com"
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: true, onSetupCompletion: { _ in })
+
+        // Then
+        XCTAssertFalse(viewModel.isAuxiliaryButtonHidden)
+    }
+
+    func test_auxiliary_button_title_is_correct() {
+        // Given
+        let siteAddress = "https://test.com"
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, onSetupCompletion: { _ in })
+
+        //  Then
+        XCTAssertEqual(viewModel.auxiliaryButtonTitle, Localization.seeConnectedStores)
+    }
+
+    func test_primary_button_title_is_correct() {
+        // Given
+        let siteAddress = "https://test.com"
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, onSetupCompletion: { _ in })
+
+        //  Then
+        XCTAssertEqual(viewModel.primaryButtonTitle, Localization.primaryButtonTitle)
+    }
+
+    func test_secondary_button_title_is_correct() {
+        // Given
+        let siteAddress = "https://test.com"
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, onSetupCompletion: { _ in })
+
+        //  Then
+        XCTAssertEqual(viewModel.secondaryButtonTitle, Localization.secondaryButtonTitle)
+    }
+
+    func test_woocommerce_setup_button_tapped_is_tracked_when_tapping_primary_button() {
+        // Given
+        let siteAddress = "https://test.com"
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, analytics: analytics, onSetupCompletion: { _ in })
+
+        // When
+        viewModel.didTapPrimaryButton(in: nil)
+
+        // Then
+        XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_woocommerce_setup_button_tapped" }))
+    }
+
+    func test_woocommerce_error_screen_is_tracked_when_the_view_is_loaded() {
+        // Given
+        let siteAddress = "https://test.com"
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, analytics: analytics, onSetupCompletion: { _ in })
+
+        // When
+        viewModel.viewDidLoad()
+
+        // Then
+        XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_woocommerce_error_shown" }))
+    }
+}
+
+private extension NoWooErrorViewModelTests {
+    enum Localization {
+        static let errorMessage = NSLocalizedString("It looks like %@ is not a WooCommerce site.",
+                                                    comment: "Message explaining that the site entered doesn't have WooCommerce installed or activated. "
+                                                        + "Reads like 'It looks like awebsite.com is not a WooCommerce site.")
+        static let seeConnectedStores = NSLocalizedString("See Connected Stores",
+                                                          comment: "Action button linking to a list of connected stores. "
+                                                          + "Presented when logging in with a store address that does not have WooCommerce.")
+
+        static let primaryButtonTitle = NSLocalizedString("Install WooCommerce",
+                                                          comment: "Action button for installing WooCommerce."
+                                                          + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+
+        static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",
+                                                            comment: "Action button that will restart the login flow."
+                                                            + "Presented when logging in with a site address that does not have a valid Jetpack installation")
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/WooSetupWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WooSetupWebViewModelTests.swift
@@ -63,4 +63,19 @@ final class WooSetupWebViewModelTests: XCTestCase {
         XCTAssertEqual(properties["source"] as? String, "web")
     }
 
+    func test_dismissal_is_not_tracked_after_completion() throws {
+        // Given
+        let siteURL = "https://test.com"
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let viewModel = WooSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: {})
+
+        // When
+        let url = URL(string: "https://wordpress.com/marketplace/thank-you/woocommerce/")
+        viewModel.handleRedirect(for: url)
+        viewModel.handleDismissal()
+
+        // Then
+        XCTAssertNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_woocommerce_setup_dismissed" }))
+    }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/WooSetupWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WooSetupWebViewModelTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import WooCommerce
+
+final class WooSetupWebViewModelTests: XCTestCase {
+
+    func test_initial_url_is_correct() {
+        // Given
+        let siteURL = "https://test.com"
+        let viewModel = WooSetupWebViewModel(siteURL: siteURL, onCompletion: {})
+
+        // Then
+        let expectedURL = "https://wordpress.com/plugins/woocommerce/test.com"
+        XCTAssertEqual(viewModel.initialURL?.absoluteString, expectedURL)
+    }
+
+    func test_completion_handler_is_called_when_navigating_to_mobile_redirect() {
+        // Given
+        let siteURL = "https://test.com"
+        var triggeredCompletion = false
+        let completionHandler: () -> Void = {
+            triggeredCompletion = true
+        }
+        let viewModel = WooSetupWebViewModel(siteURL: siteURL, onCompletion: completionHandler)
+
+        // When
+        let url = URL(string: "https://wordpress.com/marketplace/thank-you/woocommerce/")
+        viewModel.handleRedirect(for: url)
+
+        // Then
+        XCTAssertTrue(triggeredCompletion)
+    }
+
+    func test_dismissal_is_tracked() throws {
+        // Given
+        let siteURL = "https://test.com"
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let viewModel = WooSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: {})
+
+        // When
+        viewModel.handleDismissal()
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "login_woocommerce_setup_dismissed" }))
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(properties["source"] as? String, "web")
+    }
+
+    func test_completion_is_tracked() throws {
+        // Given
+        let siteURL = "https://test.com"
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let viewModel = WooSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: {})
+
+        // When
+        let url = URL(string: "https://wordpress.com/marketplace/thank-you/woocommerce/")
+        viewModel.handleRedirect(for: url)
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "login_woocommerce_setup_completed" }))
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(properties["source"] as? String, "web")
+    }
+
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7236 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the incorrect view displayed when a user tries to log in to a site without WooCommerce. Here, we're displaying a new screen for the error with a button to install Woo from the app.

The Woo Setup screen is using the same `PluginSetupWebViewController` from #7395. Here for the Woo Setup flow, we don't have a real redirect URL for the completion, so I have to listen to the changes in the web view URL  to detect the end of the flow.

Edge case: if a site is non-atomic, it bypasses the check for Jetpack and the app will show the No Woo error screen. In this case, if the user taps the Install WooCommerce button, they will be presented with a button to upgrade their account, which we don't want. So for now, I'm hiding the install button for this case.

The design and copies for this screen is not final yet since we haven't got them reviewed, but we can update them in another PR.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
**Case 1**: Self-hosted store with Jetpack and without WooCommerce.
1. Select Enter site address and enter your address.
2. Proceed to log in with either WP credentials or site credentials.
3. After login succeeds, notice that the app navigates to the No Woo error screen. In Xcode console, notice "🔵 Tracked login_woocommerce_error_shown".
4. If your account has other connected stores, notice that the link button for "See connected stores" is visible. Tapping it should navigate to the site picker with the sites that have WooCommerce.  If your account doesn't have other connected stores, notice that the link button is not visible.
5. Select Install WooCommerce. Notice that the app navigates to a web view for installing Woo. You shouldn't have to re-enter WP.com credentials here.  In Xcode console, notice "🔵 Tracked login_woocommerce_setup_button_tapped".
6. Dismiss the view, notice "🔵 Tracked login_woocommerce_setup_dismissed, properties: [AnyHashable("source"): "web"]" in Xcode console.
7. Select the Install WooCommerce button again. 
9. Select "Install & Activate WooCommerce" button on the web page. When the setup completes, notice that a loading screen is displayed and then the app navigates to the home screen. In Xcode console, notice "🔵 Tracked login_woocommerce_setup_completed".

**Case 2**: Non-atomic site
1. Select Enter site address and enter your site address.
2. Proceed to log in with either WP credentials.
3. After login succeeds, notice that the app navigates to the No Woo error screen.
4. If your account has other connected stores, notice that the link button for "See connected stores" is visible. Tapping it should navigate to the site picker with the sites that have WooCommerce. Otherwise, the button should be hidden.
5. Notice that the Install WooCommerce button should be hidden in this case.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Install flow for a self-hosted site:

https://user-images.githubusercontent.com/5533851/182523399-d2a89e7a-c902-438f-b3e5-21e190d4f610.mp4

No Woo error screen for a non-atomic site without connected stores:

<img src="https://user-images.githubusercontent.com/5533851/182648422-0b2243d4-2431-4ca6-a37e-9dc2baceef13.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
