### PR TITLE
Login Reminder: feature release

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -48,7 +48,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .loginPrologueOnboarding:
             return true
         case .loginErrorNotifications:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .paymentsHubMenuSection:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .linkedProductsPromo:

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -40,6 +40,7 @@ public enum WooAnalyticsStat: String {
     case loginJetpackRequiredViewInstructionsButtonTapped = "login_jetpack_required_view_instructions_button_tapped"
     case loginLocalNotificationTapped = "login_local_notification_tapped"
     case loginLocalNotificationDismissed = "login_local_notification_dismissed"
+    case loginLocalNotificationScheduled = "login_local_notification_scheduled"
     case loginWhatIsJetpackHelpScreenViewed = "login_what_is_jetpack_help_screen_viewed"
     case loginWhatIsJetpackHelpScreenOkButtonTapped = "login_what_is_jetpack_help_screen_ok_button_tapped"
     case loginWhatIsJetpackHelpScreenLearnMoreButtonTapped = "login_what_is_jetpack_help_screen_learn_more_button_tapped"

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -437,7 +437,7 @@ private extension AuthenticationManager {
             ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: [notification.scenario])
             ServiceLocator.pushNotesManager.requestLocalNotification(notification,
                                                                      // 24 hours from now.
-                                                                     trigger: UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false))
+                                                                     trigger: UNTimeIntervalNotificationTrigger(timeInterval: 86400, repeats: false))
         }
     }
 }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -335,6 +335,9 @@ extension PushNotificationsManager {
                                                 trigger: trigger)
             do {
                 try await center.add(request)
+                ServiceLocator.analytics.track(.loginLocalNotificationScheduled, withProperties: [
+                    "type": notification.scenario.rawValue
+                ])
             } catch {
                 DDLogError("⛔️ Unable to request a local notification: \(error)")
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7318 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For release 9.8, we're releasing local notifications for Iterations 1 & 2 pe5sF9-h9-p2. This PR added another tracking event when a local notification is scheduled (ref pe5sF9-h9-p2#comment-510), turned on the feature flag, and fixed a mistake from a previous commit 😓 


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please update the 24 hours schedule to a few seconds or a minute in `AuthenticationManager` (search for "86400") to test this PR (I used 5 seconds).

You can test this PR in a simulator.

- Log out if needed
- Skip the onboarding if needed
- Tap "Continue With WordPress.com"
- Enter an invalid email that doesn't belong to a WP.com account --> an error screen should be shown, and an event should be logged in the console: `🔵 Tracked login_local_notification_scheduled, properties: [AnyHashable("type"): "wpcom_email_error"]`



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->