### PR TITLE
[UI Tests] Added CODEOWNERS for WCiOS.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Adding `mobile-ui-testing-squad` as codeowners for UI tests related folders
+
+/WooCommerce/UITestsFoundation/ @woocommerce/mobile-ui-testing-squad
+/WooCommerce/WooCommerceUITests/ @woocommerce/mobile-ui-testing-squad

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 /WooCommerce/UITestsFoundation/ @woocommerce/mobile-ui-testing-squad
 /WooCommerce/WooCommerceUITests/ @woocommerce/mobile-ui-testing-squad
+/WooCommerce/WooCommerceScreenshots/ @woocommerce/mobile-ui-testing-squad

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,2 @@
-# Adding `mobile-ui-testing-squad` as codeowners for UI tests related folders
-
 /WooCommerce/UITestsFoundation/ @woocommerce/mobile-ui-testing-squad
 /WooCommerce/WooCommerceUITests/ @woocommerce/mobile-ui-testing-squad


### PR DESCRIPTION
### Description
As mentioned in p1659432783574949-slack-CC7L49W13, there might be a communicational benefit of adding folks from `mobile-ui-testing-squad` as code owners for UI-tests-related folders.

### Testing instructions
- #7409 which is based on the current branch, and adds a file to one of the folders listed in `CODEOWNERS`:
    - [x] Contains `mobile-ui-testing-squad` as reviewers.
- #7410 which is based on the current branch, and adds a file to NOT one of the folders listed in `CODEOWNERS`:
    - [x] DOES NOT contain `mobile-ui-testing-squad` as reviewers.