### PR TITLE
Login: Hide connected stores button on account mismatched screen if necessary

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -283,7 +283,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
         guard matcher.match(originalURL: siteURL) else {
             DDLogWarn("⚠️ Present account mismatch error for site: \(String(describing: siteURL))")
-            let viewModel = WrongAccountErrorViewModel(siteURL: siteURL)
+            let viewModel = WrongAccountErrorViewModel(siteURL: siteURL, showsConnectedStores: matcher.hasConnectedStores)
             let mismatchAccountUI = ULAccountMismatchViewController(viewModel: viewModel)
 
             return navigationController.show(mismatchAccountUI, sender: nil)

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -131,6 +131,7 @@ private extension ULAccountMismatchViewController {
 
     func configurePrimaryButton() {
         primaryButton.isPrimary = true
+        primaryButton.isHidden = viewModel.isPrimaryButtonHidden
         primaryButton.setTitle(viewModel.primaryButtonTitle, for: .normal)
         primaryButton.on(.touchUpInside) { [weak self] _ in
             self?.didTapPrimaryButton()

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewModel.swift
@@ -27,6 +27,9 @@ protocol ULAccountMismatchViewModel {
     /// Provides a title for a primary action button
     var primaryButtonTitle: String { get }
 
+    /// Provides the visibility of the primary button
+    var isPrimaryButtonHidden: Bool { get }
+
     /// Provides the title for the logout button
     var logOutButtonTitle: String { get }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -8,13 +8,16 @@ import Yosemite
 /// an error when Jetpack is not installed or is not connected
 struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
     private let siteURL: String
+    private let showsConnectedStores: Bool
     private let defaultAccount: Account?
     private let storesManager: StoresManager
 
     init(siteURL: String?,
+         showsConnectedStores: Bool,
          sessionManager: SessionManagerProtocol =  ServiceLocator.stores.sessionManager,
          storesManager: StoresManager = ServiceLocator.stores) {
         self.siteURL = siteURL ?? Localization.yourSite
+        self.showsConnectedStores = showsConnectedStores
         self.defaultAccount = sessionManager.defaultAccount
         self.storesManager = storesManager
     }
@@ -74,6 +77,8 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
     let auxiliaryButtonTitle = Localization.findYourConnectedEmail
 
     let primaryButtonTitle = Localization.primaryButtonTitle
+
+    var isPrimaryButtonHidden: Bool { !showsConnectedStores }
 
     // MARK: - Actions
     func didTapPrimaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/WooCommerceTests/Authentication/ULAccountMismatchViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/ULAccountMismatchViewControllerTests.swift
@@ -151,7 +151,7 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
         XCTAssertTrue(viewModel.logOutButtonTapped)
     }
 
-    func test_primary_button_is_hidden_if_set_by_view_model() throws {
+    func test_viewcontroller_assigns_title_provided_by_viewmodel_to_primary_button() throws {
         // Given
         let viewModel = MismatchViewModel()
         let viewController = ULAccountMismatchViewController(viewModel: viewModel)
@@ -161,7 +161,7 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
         let primaryButton = viewController.getPrimaryActionButton()
 
         // Then
-        XCTAssertTrue(primaryButton.isHidden)
+        XCTAssertEqual(primaryButton.isHidden, viewModel.isPrimaryButtonHidden)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Authentication/ULAccountMismatchViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/ULAccountMismatchViewControllerTests.swift
@@ -151,7 +151,7 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
         XCTAssertTrue(viewModel.logOutButtonTapped)
     }
 
-    func test_viewcontroller_assigns_title_provided_by_viewmodel_to_primary_button() throws {
+    func test_viewcontroller_assigns_visibility_provided_by_viewmodel_to_primary_button() throws {
         // Given
         let viewModel = MismatchViewModel()
         let viewController = ULAccountMismatchViewController(viewModel: viewModel)

--- a/WooCommerce/WooCommerceTests/Authentication/ULAccountMismatchViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/ULAccountMismatchViewControllerTests.swift
@@ -68,19 +68,6 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
         XCTAssertEqual(auxiliaryButtonTitle, viewModel.auxiliaryButtonTitle)
     }
 
-    func test_viewcontroller_assigns_visibility_provided_by_viewmodel_to_auxbutton() throws {
-        // Given
-        let viewModel = MismatchViewModel()
-        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
-
-        // When
-        _ = try XCTUnwrap(viewController.view)
-        let auxiliaryButtonHidden = viewController.getAuxiliaryButton().isHidden
-
-        // Then
-        XCTAssertEqual(auxiliaryButtonHidden, viewModel.isAuxiliaryButtonHidden)
-    }
-
     func test_viewcontroller_hits_viewmodel_when_auxbutton_is_tapped() throws {
         // Given
         let viewModel = MismatchViewModel()
@@ -180,8 +167,6 @@ private final class MismatchViewModel: ULAccountMismatchViewModel {
     let image: UIImage = .loginNoJetpackError
 
     let text: NSAttributedString = NSAttributedString(string: "woocommerce")
-
-    let isAuxiliaryButtonHidden: Bool = true
 
     let auxiliaryButtonTitle: String = "Aux"
 

--- a/WooCommerce/WooCommerceTests/Authentication/ULAccountMismatchViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/ULAccountMismatchViewControllerTests.swift
@@ -5,7 +5,7 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
 
     func test_viewcontroller_presents_username_provided_by_viewmodel() throws {
         // Given
-        let viewModel = MistmatchViewModel()
+        let viewModel = MismatchViewModel()
         let viewController = ULAccountMismatchViewController(viewModel: viewModel)
 
         // When
@@ -18,7 +18,7 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
 
     func test_viewcontroller_presents_signedIn_provided_by_viewmodel() throws {
         // Given
-        let viewModel = MistmatchViewModel()
+        let viewModel = MismatchViewModel()
         let viewController = ULAccountMismatchViewController(viewModel: viewModel)
 
         // When
@@ -31,7 +31,7 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
 
     func test_viewcontroller_presents_image_provided_by_viewmodel() throws {
         // Given
-        let viewModel = MistmatchViewModel()
+        let viewModel = MismatchViewModel()
         let viewController = ULAccountMismatchViewController(viewModel: viewModel)
 
         // When
@@ -44,7 +44,7 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
 
     func test_viewcontroller_presents_text_provided_by_viewmodel() throws {
         // Given
-        let viewModel = MistmatchViewModel()
+        let viewModel = MismatchViewModel()
         let viewController = ULAccountMismatchViewController(viewModel: viewModel)
 
         // When
@@ -57,7 +57,7 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
 
     func test_viewcontroller_assigns_title_provided_by_viewmodel_to_auxbutton() throws {
         // Given
-        let viewModel = MistmatchViewModel()
+        let viewModel = MismatchViewModel()
         let viewController = ULAccountMismatchViewController(viewModel: viewModel)
 
         // When
@@ -70,7 +70,7 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
 
     func test_viewcontroller_assigns_visibility_provided_by_viewmodel_to_auxbutton() throws {
         // Given
-        let viewModel = MistmatchViewModel()
+        let viewModel = MismatchViewModel()
         let viewController = ULAccountMismatchViewController(viewModel: viewModel)
 
         // When
@@ -83,7 +83,7 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
 
     func test_viewcontroller_hits_viewmodel_when_auxbutton_is_tapped() throws {
         // Given
-        let viewModel = MistmatchViewModel()
+        let viewModel = MismatchViewModel()
         let viewController = ULAccountMismatchViewController(viewModel: viewModel)
 
         // When
@@ -99,7 +99,7 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
 
     func test_viewcontroller_assigns_title_provided_by_viewmodel_to_primary_button() throws {
         // Given
-        let viewModel = MistmatchViewModel()
+        let viewModel = MismatchViewModel()
         let viewController = ULAccountMismatchViewController(viewModel: viewModel)
 
         // When
@@ -112,7 +112,7 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
 
     func test_viewcontroller_hits_viewmodel_when_primary_button_is_tapped() throws {
         // Given
-        let viewModel = MistmatchViewModel()
+        let viewModel = MismatchViewModel()
         let viewController = ULAccountMismatchViewController(viewModel: viewModel)
 
         // When
@@ -126,7 +126,7 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
 
     func test_viewcontroller_assigns_title_provided_by_viewmodel_to_logout_button() throws {
         // Given
-        let viewModel = MistmatchViewModel()
+        let viewModel = MismatchViewModel()
         let viewController = ULAccountMismatchViewController(viewModel: viewModel)
 
         // When
@@ -139,7 +139,7 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
 
     func test_viewcontroller_hits_viewmodel_when_logout_button_is_tapped() throws {
         // Given
-        let viewModel = MistmatchViewModel()
+        let viewModel = MismatchViewModel()
         let viewController = ULAccountMismatchViewController(viewModel: viewModel)
 
         // When
@@ -150,10 +150,23 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.logOutButtonTapped)
     }
+
+    func test_primary_button_is_hidden_if_set_by_view_model() throws {
+        // Given
+        let viewModel = MismatchViewModel()
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let primaryButton = viewController.getPrimaryActionButton()
+
+        // Then
+        XCTAssertTrue(primaryButton.isHidden)
+    }
 }
 
 
-private final class MistmatchViewModel: ULAccountMismatchViewModel {
+private final class MismatchViewModel: ULAccountMismatchViewModel {
     let userEmail: String = "email@awebsite.com"
 
     var userName: String = "username"
@@ -168,13 +181,13 @@ private final class MistmatchViewModel: ULAccountMismatchViewModel {
 
     let text: NSAttributedString = NSAttributedString(string: "woocommerce")
 
-    let isAuxiliaryButtonHidden: Bool = false
+    let isAuxiliaryButtonHidden: Bool = true
 
     let auxiliaryButtonTitle: String = "Aux"
 
     let primaryButtonTitle: String = "Primary"
 
-
+    let isPrimaryButtonHidden: Bool = false
     var primaryButtonTapped: Bool = false
     var logOutButtonTapped: Bool = false
     var auxiliaryButtonTapped: Bool = false

--- a/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
@@ -5,7 +5,7 @@ final class WrongAccountErrorViewModelTests: XCTestCase {
 
     func test_viewmodel_provides_expected_image() {
         // Given
-        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url)
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url, showsConnectedStores: false)
 
         // When
         let image = viewModel.image
@@ -16,7 +16,7 @@ final class WrongAccountErrorViewModelTests: XCTestCase {
 
     func test_viewmodel_provides_expected_title_for_auxiliary_button() {
         // Given
-        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url)
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url, showsConnectedStores: false)
 
         // When
         let auxiliaryButtonTitle = viewModel.auxiliaryButtonTitle
@@ -27,7 +27,7 @@ final class WrongAccountErrorViewModelTests: XCTestCase {
 
     func test_viewmodel_provides_expected_title_for_primary_button() {
         // Given
-        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url)
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url, showsConnectedStores: false)
 
         // When
         let primaryButtonTitle = viewModel.primaryButtonTitle
@@ -38,13 +38,24 @@ final class WrongAccountErrorViewModelTests: XCTestCase {
 
     func test_viewmodel_provides_expected_title_for_log_out_button() {
         // Given
-        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url)
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url, showsConnectedStores: false)
 
         // When
         let logoutButtonTitle = viewModel.logOutButtonTitle
 
         // Then
         XCTAssertEqual(logoutButtonTitle, Expectations.logOutButtonTitle)
+    }
+
+    func test_viewmodel_provides_expected_visibility_state_for_primary_button() {
+        // Given
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url, showsConnectedStores: false)
+
+        // When
+        let visibility = viewModel.isPrimaryButtonHidden
+
+        // Then
+        XCTAssertTrue(visibility)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
⚠️ Please make sure that #7401 is reviewed and merged first ⚠️

Closes: #7406 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR hides the "See connected stores" button on the Account Mismatched screen if the user has no WooCommerce store. Changes:
- Add `primaryButtonHidden` to `ULAccountMismatchViewModel`.
- Use `ULAccountMatcher` to check if user has any store
- Update `WrongAccountErrorViewModel` to accept a new param in the initializer for hiding the "See connected stores" button and update `primaryButtonHidden` accordingly.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: you need a WP.com account that doesn't have access to any Woo site.
- Log out and select "Enter site address"
- Enter the address of a Woo store that you don't have access to.
- Enter your WP.com credentials
- After the login succeeds, notice that the app navigates to the Account Mismatched screen without the "See Connected Stores" button.

Please feel free to test again with another account with access to more than one Woo site.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/182753097-c21d12b2-b276-4696-b2ce-139808ca4dfb.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
