### PR TITLE
Update deprecated SKStoreReviewController requestReview

### DIFF
--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -7,7 +7,8 @@ import StoreKit
 protocol SKStoreReviewControllerProtocol {
     /// Displays the in app app store review alert.
     ///
-    static func requestReview()
+    @available(iOS 10.3, *) static func requestReview()
+    @available(iOS 14.0, *) static func requestReview(in windowScene: UIWindowScene)
 }
 
 extension SKStoreReviewController: SKStoreReviewControllerProtocol { }
@@ -91,8 +92,13 @@ private extension InAppFeedbackCardViewController {
             guard let self = self else {
                 return
             }
-
-            self.storeReviewControllerType.requestReview()
+            if #available(iOS 14.0, *) {
+                if let windowScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive}) as? UIWindowScene {
+                    self.storeReviewControllerType.requestReview(in: windowScene)
+                }
+            } else {
+                self.storeReviewControllerType.requestReview()
+            }
             self.onFeedbackGiven?()
             self.analytics.track(event: .appFeedbackPrompt(action: .liked))
         }

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -7,8 +7,7 @@ import StoreKit
 protocol SKStoreReviewControllerProtocol {
     /// Displays the in app app store review alert.
     ///
-    @available(iOS 10.3, *) static func requestReview()
-    @available(iOS 14.0, *) static func requestReview(in windowScene: UIWindowScene)
+    static func requestReview(in windowScene: UIWindowScene)
 }
 
 extension SKStoreReviewController: SKStoreReviewControllerProtocol { }
@@ -92,12 +91,8 @@ private extension InAppFeedbackCardViewController {
             guard let self = self else {
                 return
             }
-            if #available(iOS 14.0, *) {
-                if let windowScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive}) as? UIWindowScene {
-                    self.storeReviewControllerType.requestReview(in: windowScene)
-                }
-            } else {
-                self.storeReviewControllerType.requestReview()
+            if let windowScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive}) as? UIWindowScene {
+                self.storeReviewControllerType.requestReview(in: windowScene)
             }
             self.onFeedbackGiven?()
             self.analytics.track(event: .appFeedbackPrompt(action: .liked))

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -92,21 +92,21 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         XCTAssertEqual(eventProperties["plugin_slug"] as? String, Mocks.paymentGatewayAccount)
     }
 
-//    func test_collectPayment_processing_completion_does_not_track_collectInteracPaymentSuccess_event_when_payment_method_is_not_interac() throws {
-//        // Given
-//        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: .cardPresent(details: .fake()))])
-//        mockSuccessfulCardPresentPaymentActions(intent: intent)
-//
-//        // When
-//        waitFor { promise in
-//            self.useCase.collectPayment(onCollect: { _ in
-//                promise(())
-//            }, onCancel: {}, onCompleted: {})
-//        }
-//
-//        // Then
-//        XCTAssertFalse(analyticsProvider.receivedEvents.contains("card_interac_collect_payment_success"))
-//    }
+    func test_collectPayment_processing_completion_does_not_track_collectInteracPaymentSuccess_event_when_payment_method_is_not_interac() throws {
+        // Given
+        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: .cardPresent(details: .fake()))])
+        mockSuccessfulCardPresentPaymentActions(intent: intent)
+
+        // When
+        waitFor { promise in
+            self.useCase.collectPayment(onCollect: { _ in
+                promise(())
+            }, onCancel: {}, onCompleted: {})
+        }
+
+        // Then
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("card_interac_collect_payment_success"))
+    }
 
     // MARK: Success alert actions
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -92,21 +92,21 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         XCTAssertEqual(eventProperties["plugin_slug"] as? String, Mocks.paymentGatewayAccount)
     }
 
-    func test_collectPayment_processing_completion_does_not_track_collectInteracPaymentSuccess_event_when_payment_method_is_not_interac() throws {
-        // Given
-        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: .cardPresent(details: .fake()))])
-        mockSuccessfulCardPresentPaymentActions(intent: intent)
-
-        // When
-        waitFor { promise in
-            self.useCase.collectPayment(onCollect: { _ in
-                promise(())
-            }, onCancel: {}, onCompleted: {})
-        }
-
-        // Then
-        XCTAssertFalse(analyticsProvider.receivedEvents.contains("card_interac_collect_payment_success"))
-    }
+//    func test_collectPayment_processing_completion_does_not_track_collectInteracPaymentSuccess_event_when_payment_method_is_not_interac() throws {
+//        // Given
+//        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: .cardPresent(details: .fake()))])
+//        mockSuccessfulCardPresentPaymentActions(intent: intent)
+//
+//        // When
+//        waitFor { promise in
+//            self.useCase.collectPayment(onCollect: { _ in
+//                promise(())
+//            }, onCancel: {}, onCompleted: {})
+//        }
+//
+//        // Then
+//        XCTAssertFalse(analyticsProvider.receivedEvents.contains("card_interac_collect_payment_success"))
+//    }
 
     // MARK: Success alert actions
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/inAppFeedback/InAppFeedbackCardViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/inAppFeedback/InAppFeedbackCardViewControllerTests.swift
@@ -151,11 +151,7 @@ private extension InAppFeedbackCardViewControllerTests {
 private class MockStoreReviewController: SKStoreReviewControllerProtocol {
     private(set) static var requestReviewInvoked = false
 
-    @available(iOS 10.3, *) static func requestReview() {
-        requestReviewInvoked = true
-    }
-
-    @available(iOS 14.0, *) static func requestReview(in windowScene: UIWindowScene) {
+    static func requestReview(in windowScene: UIWindowScene) {
         requestReviewInvoked = true
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/inAppFeedback/InAppFeedbackCardViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/inAppFeedback/InAppFeedbackCardViewControllerTests.swift
@@ -149,10 +149,13 @@ private extension InAppFeedbackCardViewControllerTests {
 }
 
 private class MockStoreReviewController: SKStoreReviewControllerProtocol {
-
     private(set) static var requestReviewInvoked = false
 
-    static func requestReview() {
+    @available(iOS 10.3, *) static func requestReview() {
+        requestReviewInvoked = true
+    }
+
+    @available(iOS 14.0, *) static func requestReview(in windowScene: UIWindowScene) {
         requestReviewInvoked = true
     }
 


### PR DESCRIPTION
### Description

Closes: #3076 

Since iOS 14.0, `SKStoreReviewController`'s `requestReview()` method as been deprecated in favor of `requestReview(in: UIWindowScene)`. This PR addresses this deprecation by adding `#available()` logic to either use one method or the other based on the iOS version we're running.

### Testing instructions

1. Force the feedback card to appear by going to `InAppFeedbackCardVisibilityUseCase.shouldBeVisible()` method, and switching the `feedbackType.general` case to `true`:

```
    func shouldBeVisible(currentDate: Date = Date()) throws -> Bool {
        switch feedbackType {
        case .general:
            return true
        case .shippingLabelsRelease3, .couponManagement, .ordersCreation:
            return settings.feedbackStatus(of: feedbackType) == .pending
        }
    }
```

2. Run the app
3. See the feedback card works normally

### Screenshots

| <img width=300 src="https://user-images.githubusercontent.com/3812076/182916995-56b18cb6-3c4b-4722-91e2-310e171646d5.png"> | | <img width=300 src="https://user-images.githubusercontent.com/3812076/182917008-89a3fa46-f19c-4109-a2cf-78abbef92ea8.png">



