### PR TITLE
Login Reminder: schedule a local notification 24 hours after an invalid WP.com password

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -42,8 +42,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  # pod 'WordPressAuthenticator', '~> 2.1.0-beta.5'
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'f3e746f386a94d79dd25adff1cb5d90f354ccad3'
+  pod 'WordPressAuthenticator', '~> 2.1.0-beta.6'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -42,8 +42,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 2.1.0-beta.5'
-#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+  # pod 'WordPressAuthenticator', '~> 2.1.0-beta.5'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'f3e746f386a94d79dd25adff1cb5d90f354ccad3'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -42,7 +42,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (2.1.0-beta.5):
+  - WordPressAuthenticator (2.1.0-beta.6):
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 6.0.1)
@@ -92,7 +92,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 2.1.0-beta.5)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `f3e746f386a94d79dd25adff1cb5d90f354ccad3`)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -102,8 +102,6 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -141,6 +139,16 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :commit: f3e746f386a94d79dd25adff1cb5d90f354ccad3
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: f3e746f386a94d79dd25adff1cb5d90f354ccad3
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
@@ -163,7 +171,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 9e1c5823cfb3211c85f5fe2904889fbe245952f1
+  WordPressAuthenticator: 80287223ba547b06dda99554c83ac4941f7788cb
   WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -179,6 +187,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 208edb9e9dba7ac6e218df285821229b0bd4c505
+PODFILE CHECKSUM: a080abefedf653562b44fc7bfb5b0c5e1b174540
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -92,7 +92,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `f3e746f386a94d79dd25adff1cb5d90f354ccad3`)
+  - WordPressAuthenticator (~> 2.1.0-beta.6)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -102,6 +102,8 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
+  https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -139,16 +141,6 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :commit: f3e746f386a94d79dd25adff1cb5d90f354ccad3
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: f3e746f386a94d79dd25adff1cb5d90f354ccad3
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
@@ -171,7 +163,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 80287223ba547b06dda99554c83ac4941f7788cb
+  WordPressAuthenticator: c37f46275abe8dabcf7c9e4067a8a74a4d2319f8
   WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -187,6 +179,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: a080abefedf653562b44fc7bfb5b0c5e1b174540
+PODFILE CHECKSUM: bdb50696f693707df5492c7db72c483dc9ce402c
 
 COCOAPODS: 1.11.2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 - [***] Login: Introduce a way to sign in using store credentials.  [https://github.com/woocommerce/woocommerce-ios/pull/7320]
 - [**] Orders: Now you can quickly mark an order as completed by swiping it to the left! [https://github.com/woocommerce/woocommerce-ios/pull/7385]
 - [*] In-Person Payments: The purchase card reader information card appears also in the Orders list screen. [https://github.com/woocommerce/woocommerce-ios/pull/7326]
-- [*] Login: a local notification is scheduled after the user encounters an error from logging in with an invalid site address or WP.com email. Please see testing scenarios in the PR, with regression testing on order/review remote notifications. [https://github.com/woocommerce/woocommerce-ios/pull/7323, https://github.com/woocommerce/woocommerce-ios/pull/7372]
+- [*] Login: a local notification is scheduled after the user encounters an error from logging in with an invalid site address or WP.com email/password. Please see testing scenarios in the PR, with regression testing on order/review remote notifications. [https://github.com/woocommerce/woocommerce-ios/pull/7323, https://github.com/woocommerce/woocommerce-ios/pull/7372, https://github.com/woocommerce/woocommerce-ios/pull/7422]
 
 9.7
 -----

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -429,6 +429,10 @@ private extension AuthenticationManager {
             notification = LocalNotification(scenario: .invalidEmailFromSiteAddressLogin)
         case .invalidEmailFromWPComLogin:
             notification = LocalNotification(scenario: .invalidEmailFromWPComLogin)
+        case .invalidPasswordFromSiteAddressLogin:
+            notification = LocalNotification(scenario: .invalidPasswordFromSiteAddressLogin)
+        case .invalidPasswordFromWPComLogin:
+            notification = LocalNotification(scenario: .invalidPasswordFromWPComLogin)
         default:
             notification = nil
         }
@@ -493,7 +497,7 @@ extension AuthenticationManager {
             return NotWPErrorViewModel()
         case .noSecureConnection:
             return NoSecureConnectionErrorViewModel()
-        case .unknown:
+        case .unknown, .invalidPasswordFromWPComLogin, .invalidPasswordFromSiteAddressLogin:
             return nil
         }
     }
@@ -507,6 +511,8 @@ private extension AuthenticationManager {
         case emailDoesNotMatchWPAccount
         case invalidEmailFromSiteAddressLogin
         case invalidEmailFromWPComLogin
+        case invalidPasswordFromSiteAddressLogin
+        case invalidPasswordFromWPComLogin
         case notWPSite
         case notValidAddress
         case noSecureConnection
@@ -521,6 +527,13 @@ private extension AuthenticationManager {
                         return .invalidEmailFromWPComLogin
                     case .wpComSiteAddress:
                         return .invalidEmailFromSiteAddressLogin
+                    }
+                case .invalidWPComPassword(let source):
+                    switch source {
+                    case .wpCom:
+                        return .invalidPasswordFromWPComLogin
+                    case .wpComSiteAddress:
+                        return .invalidPasswordFromSiteAddressLogin
                     }
                 }
             }

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -19,6 +19,8 @@ struct LocalNotification {
         case loginSiteAddressError = "site_address_error"
         case invalidEmailFromSiteAddressLogin = "site_address_email_error"
         case invalidEmailFromWPComLogin = "wpcom_email_error"
+        case invalidPasswordFromSiteAddressLogin = "site_address_password_error"
+        case invalidPasswordFromWPComLogin = "wpcom_password_error"
     }
 
     /// The category of actions for a local notification.
@@ -52,6 +54,11 @@ extension LocalNotification {
                       scenario: scenario,
                       actions: .init(category: .loginError, actions: [.contactSupport, .loginWithWPCom]))
         case .invalidEmailFromWPComLogin, .invalidEmailFromSiteAddressLogin:
+            self.init(title: Localization.errorLoggingInTitle,
+                      body: Localization.errorLoggingInBody,
+                      scenario: scenario,
+                      actions: .init(category: .loginError, actions: [.contactSupport]))
+        case .invalidPasswordFromWPComLogin, .invalidPasswordFromSiteAddressLogin:
             self.init(title: Localization.errorLoggingInTitle,
                       body: Localization.errorLoggingInBody,
                       scenario: scenario,

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -19,7 +19,7 @@ struct LocalNotification {
         case loginSiteAddressError = "site_address_error"
         case invalidEmailFromSiteAddressLogin = "site_address_email_error"
         case invalidEmailFromWPComLogin = "wpcom_email_error"
-        case invalidPasswordFromSiteAddressLogin = "site_address_password_error"
+        case invalidPasswordFromSiteAddressLogin = "site_address_wpcom_password_error"
         case invalidPasswordFromWPComLogin = "wpcom_password_error"
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7318 
<!-- Id number of the GitHub issue this PR addresses. -->

- [x] ⚠️ Please also review https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/656 ⚠️ 
- [x] ⚠️ @jaclync update Podfile after https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/656 is merged and released ⚠️ 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For Iteration 3, we want to schedule a local notification 24 hours after the user enters an invalid WP.com password during the login process. In order to handle the invalid password error, a custom error `SignInError.invalidWPComPassword(source:)` was added in the WPAuthenticator PR https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/656 and handled in this PR to schedule a local notification similar to previous iterations.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please update the 24 hours schedule to a few seconds or a minute in `AuthenticationManager` (search for "86400") to test this PR (I used 5 seconds).

You can test this PR in a simulator.

#### WP.com flow - contact support action

- Reinstall the app to clear any previous notifications permission state if needed
- Skip the onboarding if needed
- Tap "Continue With WordPress.com"
- Enter a valid email that is linked to a WP.com account
- Enter an invalid password --> an inline error screen should be shown, and an event is logged `🔵 Tracked login_local_notification_scheduled, properties: [AnyHashable("type"): "wpcom_password_error"]`
- Quickly put the app to the background since we don't support local notifications in the foreground --> a local notification should be shown after the duration you set in `AuthenticationManager`
- Long press on the notification to see actions --> there should be a "Contact Support" action
- Tap "Contact Support" --> it should open the app then show Zendesk support, with an event in the console: `🔵 Tracked login_local_notification_tapped, properties: [AnyHashable("action"): "contact_support", AnyHashable("type"): "wpcom_password_error"]`

#### Site address flow - default action

- Continue from the previous test case
- Navigate back to the prologue screen
- Tap "Enter Your Store Address"
- Enter a valid WP.com store address
- Enter a valid email that is linked to a WP.com account
- Enter an invalid password --> an inline error screen should be shown, and an event is logged: `🔵 Tracked login_local_notification_scheduled, properties: [AnyHashable("type"): "site_address_password_error"]`
- Quickly put the app to the background since we don't support local notifications in the foreground --> a local notification should be shown after the duration you set in `AuthenticationManager`
- Long press on the notification to see actions --> there should be a "Contact Support" action
- Tap "Contact Support" --> it should open the app then show Zendesk support, with an event in the console: `🔵 Tracked login_local_notification_tapped, properties: [AnyHashable("action"): "default", AnyHashable("type"): "site_address_password_error"]`

### Example screenshots
<!-- Include before and after images or gifs when appropriate. -->

Note: the screenshots are from an iOS 16 simulator because copy/paste doesn't work in Xcode 13.4.1 potentially from Xcode 14 beta 😬 

password error | local notification | local notification action
-- | -- | --
![Simulator Screen Shot - iPhone 13 - 2022-08-05 at 09 09 06](https://user-images.githubusercontent.com/1945542/182980491-50ae1dd1-9df3-4f59-8aa4-470c0f4b9953.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-05 at 08 55 15](https://user-images.githubusercontent.com/1945542/182980384-3271aebb-fff7-4a2b-8489-56db97999cb0.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-05 at 08 55 24](https://user-images.githubusercontent.com/1945542/182980401-924fd2a7-fbf9-47ae-902d-860ba68c15ad.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
