### PR TITLE
Login: Show error screens upon app start if there was error during site login address flow previously

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -5,6 +5,7 @@ import WordPressKit
 import Yosemite
 import class Networking.UserAgent
 import struct Networking.Settings
+import protocol Storage.StorageManagerType
 
 
 /// Encapsulates all of the interactions with the WordPress Authenticator
@@ -31,6 +32,14 @@ class AuthenticationManager: Authentication {
     ///
     private var loggedOutAppSettings: LoggedOutAppSettingsProtocol?
 
+    /// Storage manager to inject to account matcher
+    ///
+    private let storageManager: StorageManagerType
+
+    init(storageManager: StorageManagerType = ServiceLocator.storageManager) {
+        self.storageManager = storageManager
+    }
+    
     /// Initializes the WordPress Authenticator.
     ///
     func initialize() {
@@ -319,7 +328,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: [.loginSiteAddressError])
         }
 
-        let matcher = ULAccountMatcher()
+        let matcher = ULAccountMatcher(storageManager: storageManager)
         matcher.refreshStoredSites()
         if let vc = errorViewController(for: siteURL, with: matcher, navigationController: navigationController) {
             loggedOutAppSettings?.setErrorLoginSiteAddress(siteURL)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -39,7 +39,7 @@ class AuthenticationManager: Authentication {
     init(storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.storageManager = storageManager
     }
-    
+
     /// Initializes the WordPress Authenticator.
     ///
     func initialize() {
@@ -182,8 +182,8 @@ class AuthenticationManager: Authentication {
         /// Account mismatched case
         guard matcher.match(originalURL: siteURL) else {
             DDLogWarn("⚠️ Present account mismatch error for site: \(String(describing: siteURL))")
-            let viewModel = WrongAccountErrorViewModel(siteURL: siteURL)
-            let mismatchAccountUI = ULAccountMismatchViewController(viewModel: viewModel, showsConnectedStores: matcher.hasConnectedStores)
+            let viewModel = WrongAccountErrorViewModel(siteURL: siteURL, showsConnectedStores: matcher.hasConnectedStores)
+            let mismatchAccountUI = ULAccountMismatchViewController(viewModel: viewModel)
             return mismatchAccountUI
         }
 

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -177,7 +177,10 @@ class AuthenticationManager: Authentication {
 
     /// Checks the given site address and see if it's valid
     /// and returns an error view controller if not.
-    func errorViewController(for siteURL: String, with matcher: ULAccountMatcher, navigationController: UINavigationController) -> UIViewController? {
+    func errorViewController(for siteURL: String,
+                             with matcher: ULAccountMatcher,
+                             navigationController: UINavigationController,
+                             onStorePickerDismiss: @escaping () -> Void) -> UIViewController? {
 
         /// Account mismatched case
         guard matcher.match(originalURL: siteURL) else {
@@ -196,7 +199,7 @@ class AuthenticationManager: Authentication {
                 showsInstallButton: matchedSite.isJetpackConnected,
                 onSetupCompletion: { [weak self] siteID in
                     guard let self = self else { return }
-                    self.startStorePicker(with: siteID, in: navigationController)
+                    self.startStorePicker(with: siteID, in: navigationController, onDismiss: onStorePickerDismiss)
             })
             let noWooUI = ULErrorViewController(viewModel: viewModel)
             return noWooUI
@@ -331,7 +334,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         let matcher = ULAccountMatcher(storageManager: storageManager)
         matcher.refreshStoredSites()
 
-        if let vc = errorViewController(for: siteURL, with: matcher, navigationController: navigationController) {
+        if let vc = errorViewController(for: siteURL, with: matcher, navigationController: navigationController, onStorePickerDismiss: onDismiss) {
             loggedOutAppSettings?.setErrorLoginSiteAddress(siteURL)
             navigationController.show(vc, sender: nil)
         } else {

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -330,7 +330,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
         let matcher = ULAccountMatcher(storageManager: storageManager)
         matcher.refreshStoredSites()
-  
+
         if let vc = errorViewController(for: siteURL, with: matcher, navigationController: navigationController) {
             loggedOutAppSettings?.setErrorLoginSiteAddress(siteURL)
             navigationController.show(vc, sender: nil)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -354,9 +354,6 @@ private extension StorePickerViewController {
     /// Sets the first available Store as the default one. If possible!
     ///
     func preselectStoreIfPossible() {
-        guard configuration != .listStores else {
-            return
-        }
 
         guard case let .available(sites) = state, let firstSite = sites.first else {
             return

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -670,7 +670,7 @@ extension StorePickerViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
-        guard state.multipleStoresAvailable && configuration != .listStores else {
+        guard state.multipleStoresAvailable else {
             // If we only have a single store available, don't allow the row to be selected
             return false
         }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -179,8 +179,6 @@ final class StorePickerViewController: UIViewController {
             startABTesting()
         case .switchingStores:
             secondaryActionButton.isHidden = true
-        case .listStores:
-            hideActionButtons()
         default:
             break
         }
@@ -248,11 +246,6 @@ private extension StorePickerViewController {
         title = NSLocalizedString("Connected Stores", comment: "Page title for the list of connected stores")
     }
 
-    func hideActionButtons() {
-        actionButton.isHidden = true
-        secondaryActionButton.isHidden = true
-    }
-
     func setupViewForCurrentConfiguration() {
         guard isViewLoaded else {
             return
@@ -262,7 +255,6 @@ private extension StorePickerViewController {
         case .switchingStores:
             setupNavigation()
         case .listStores:
-            hideActionButtons()
             setupNavigationForListOfConnectedStores()
         default:
             navigationController?.setNavigationBarHidden(true, animated: true)

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -3,13 +3,15 @@ import Yosemite
 
 /// Configuration and actions for an ULErrorViewController,
 /// modelling an error when WooCommerce is not installed or activated.
-struct NoWooErrorViewModel: ULErrorViewModel {
+final class NoWooErrorViewModel: ULErrorViewModel {
     private let siteURL: String
     private let showsConnectedStores: Bool
     private let showsInstallButton: Bool
     private let analytics: Analytics
     private let stores: StoresManager
     private let setupCompletionHandler: (Int64) -> Void
+
+    private var storePickerCoordinator: StorePickerCoordinator?
 
     init(siteURL: String?,
          showsConnectedStores: Bool,
@@ -57,9 +59,10 @@ struct NoWooErrorViewModel: ULErrorViewModel {
         guard let viewController = viewController else {
             return
         }
-        let viewModel = WooSetupWebViewModel(siteURL: siteURL, onCompletion: {
+        let viewModel = WooSetupWebViewModel(siteURL: siteURL, onCompletion: { [weak self] in
+            guard let self = self else { return }
             viewController.navigationController?.popViewController(animated: true)
-            handleSetupCompletion(in: viewController)
+            self.handleSetupCompletion(in: viewController)
         })
         let setupViewController = PluginSetupWebViewController(viewModel: viewModel)
         viewController.navigationController?.show(setupViewController, sender: nil)
@@ -76,10 +79,8 @@ struct NoWooErrorViewModel: ULErrorViewModel {
             return
         }
 
-        let storePicker = StorePickerViewController()
-        storePicker.configuration = .listStores
-
-        navigationController.pushViewController(storePicker, animated: true)
+        storePickerCoordinator = StorePickerCoordinator(navigationController, config: .listStores)
+        storePickerCoordinator?.start()
     }
 
     func viewDidLoad() {
@@ -92,20 +93,21 @@ private extension NoWooErrorViewModel {
     func handleSetupCompletion(in viewController: UIViewController, retryCount: Int = 0) {
         showInProgressView(in: viewController)
 
-        ServiceLocator.stores.synchronizeEntities {
+        ServiceLocator.stores.synchronizeEntities { [weak self] in
+            guard let self = self else { return }
             // dismisses the in-progress view
             viewController.navigationController?.dismiss(animated: true)
 
             let matcher = ULAccountMatcher()
             matcher.refreshStoredSites()
-            guard let site = matcher.matchedSite(originalURL: siteURL),
+            guard let site = matcher.matchedSite(originalURL: self.siteURL),
                   site.isWooCommerceActive else {
                 if retryCount < 1 {
-                    return handleSetupCompletion(in: viewController, retryCount: retryCount + 1)
+                    return self.handleSetupCompletion(in: viewController, retryCount: retryCount + 1)
                 }
-                return showSetupErrorNotice(in: viewController)
+                return self.showSetupErrorNotice(in: viewController)
             }
-            setupCompletionHandler(site.siteID)
+            self.setupCompletionHandler(site.siteID)
         }
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -102,7 +102,7 @@ private extension NoWooErrorViewModel {
             matcher.refreshStoredSites()
             guard let site = matcher.matchedSite(originalURL: self.siteURL),
                   site.isWooCommerceActive else {
-                if retryCount < 1 {
+                if retryCount < 2 {
                     return self.handleSetupCompletion(in: viewController, retryCount: retryCount + 1)
                 }
                 return self.showSetupErrorNotice(in: viewController)

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -6,11 +6,13 @@ import Yosemite
 
 /// Configuration and actions for an ULErrorViewController, modelling
 /// an error when Jetpack is not installed or is not connected
-struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
+final class WrongAccountErrorViewModel: ULAccountMismatchViewModel {
     private let siteURL: String
     private let showsConnectedStores: Bool
     private let defaultAccount: Account?
     private let storesManager: StoresManager
+
+    private var storePickerCoordinator: StorePickerCoordinator?
 
     init(siteURL: String?,
          showsConnectedStores: Bool,
@@ -86,10 +88,8 @@ struct WrongAccountErrorViewModel: ULAccountMismatchViewModel {
             return
         }
 
-        let storePicker = StorePickerViewController()
-        storePicker.configuration = .listStores
-
-        navigationController.pushViewController(storePicker, animated: true)
+        storePickerCoordinator = StorePickerCoordinator(navigationController, config: .listStores)
+        storePickerCoordinator?.start()
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/Authentication/Prologue/LoggedOutAppSettingsProtocol.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoggedOutAppSettingsProtocol.swift
@@ -4,6 +4,9 @@ import Foundation
 protocol LoggedOutAppSettingsProtocol {
     var hasFinishedOnboarding: Bool { get }
     func setHasFinishedOnboarding(_ hasFinishedOnboarding: Bool)
+
+    var errorLoginSiteAddress: String? { get }
+    func setErrorLoginSiteAddress(_ address: String)
 }
 
 /// UserDefaults based settings when the app is in logged out state.
@@ -23,5 +26,13 @@ extension LoggedOutAppSettings: LoggedOutAppSettingsProtocol {
 
     func setHasFinishedOnboarding(_ hasFinishedOnboarding: Bool) {
         userDefaults.set(hasFinishedOnboarding, forKey: .hasFinishedOnboarding)
+    }
+
+    var errorLoginSiteAddress: String? {
+        userDefaults.object(forKey: .errorLoginSiteAddress)
+    }
+
+    func setErrorLoginSiteAddress(_ address: String) {
+        userDefaults.set(address, forKey: .errorLoginSiteAddress)
     }
 }

--- a/WooCommerce/Classes/Authentication/Prologue/LoggedOutAppSettingsProtocol.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoggedOutAppSettingsProtocol.swift
@@ -38,6 +38,5 @@ extension LoggedOutAppSettings: LoggedOutAppSettingsProtocol {
         } else {
             userDefaults.removeObject(forKey: .errorLoginSiteAddress)
         }
-        
     }
 }

--- a/WooCommerce/Classes/Authentication/Prologue/LoggedOutAppSettingsProtocol.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoggedOutAppSettingsProtocol.swift
@@ -6,7 +6,7 @@ protocol LoggedOutAppSettingsProtocol {
     func setHasFinishedOnboarding(_ hasFinishedOnboarding: Bool)
 
     var errorLoginSiteAddress: String? { get }
-    func setErrorLoginSiteAddress(_ address: String)
+    func setErrorLoginSiteAddress(_ address: String?)
 }
 
 /// UserDefaults based settings when the app is in logged out state.
@@ -32,7 +32,12 @@ extension LoggedOutAppSettings: LoggedOutAppSettingsProtocol {
         userDefaults.object(forKey: .errorLoginSiteAddress)
     }
 
-    func setErrorLoginSiteAddress(_ address: String) {
-        userDefaults.set(address, forKey: .errorLoginSiteAddress)
+    func setErrorLoginSiteAddress(_ address: String?) {
+        if let address = address {
+            userDefaults.set(address, forKey: .errorLoginSiteAddress)
+        } else {
+            userDefaults.removeObject(forKey: .errorLoginSiteAddress)
+        }
+        
     }
 }

--- a/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
+++ b/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import protocol Storage.StorageManagerType
 
 /// Used to match a site address with a wordpress.com account, as part
 /// of the Unified Login process
@@ -7,15 +8,19 @@ final class ULAccountMatcher {
     private let wpComURL = "https://wordpress.com"
     /// ResultsController: Loads all Sites from the Storage Layer.
     ///
-    private let resultsController: ResultsController<StorageSite> = {
-        let storageManager = ServiceLocator.storageManager
+    private lazy var resultsController: ResultsController<StorageSite> = {
         let descriptor = NSSortDescriptor(key: "name", ascending: true)
-
         return ResultsController(storageManager: storageManager, sortedBy: [descriptor])
     }()
 
     private var sites: [Site] {
         resultsController.fetchedObjects
+    }
+
+    private let storageManager: StorageManagerType
+
+    init(storageManager: StorageManagerType = ServiceLocator.storageManager) {
+        self.storageManager = storageManager
     }
 
     /// Checks if the user has any site that has WooCommerce.

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -14,6 +14,7 @@ extension UserDefaults {
         case defaultRoles
         case deviceID
         case deviceToken
+        case errorLoginSiteAddress
         case hasFinishedOnboarding
         case userOptedInAnalytics
         case userOptedInCrashLogging = "userOptedInCrashlytics"
@@ -21,7 +22,6 @@ extension UserDefaults {
         case analyticsUsername
         case notificationsLastSeenTime
         case notificationsMarkAsReadCount
-        case errorLoginSiteAddress
     }
 }
 

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -21,6 +21,7 @@ extension UserDefaults {
         case analyticsUsername
         case notificationsLastSeenTime
         case notificationsMarkAsReadCount
+        case errorLoginSiteAddress
     }
 }
 

--- a/WooCommerce/Classes/ServiceLocator/Authentication.swift
+++ b/WooCommerce/Classes/ServiceLocator/Authentication.swift
@@ -21,4 +21,13 @@ protocol Authentication {
     /// Initializes the WordPress Authenticator.
     ///
     func initialize()
+
+    /// Injects `loggedOutAppSettings`
+    ///
+    func setLoggedOutAppSettings(_ settings: LoggedOutAppSettingsProtocol)
+
+    /// Checks the given site address and see if it's valid
+    /// and returns an error view controller if not.
+    ///
+    func errorViewController(for siteURL: String, with matcher: ULAccountMatcher, navigationController: UINavigationController) -> UIViewController?
 }

--- a/WooCommerce/Classes/ServiceLocator/Authentication.swift
+++ b/WooCommerce/Classes/ServiceLocator/Authentication.swift
@@ -29,5 +29,8 @@ protocol Authentication {
     /// Checks the given site address and see if it's valid
     /// and returns an error view controller if not.
     ///
-    func errorViewController(for siteURL: String, with matcher: ULAccountMatcher, navigationController: UINavigationController) -> UIViewController?
+    func errorViewController(for siteURL: String,
+                             with matcher: ULAccountMatcher,
+                             navigationController: UINavigationController,
+                             onStorePickerDismiss: @escaping () -> Void) -> UIViewController?
 }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -192,7 +192,7 @@ private extension AppCoordinator {
                let errorController = authenticationManager.errorViewController(for: siteURL, with: matcher, navigationController: authenticationUI) {
                 window.rootViewController = authenticationUI
                 // don't let user navigate back to the login screen unless they tap log out.
-                authenticationUI.navigationItem.hidesBackButton = true
+                errorController.navigationItem.hidesBackButton = true
                 authenticationUI.show(errorController, sender: nil)
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -187,8 +187,7 @@ private extension AppCoordinator {
 
         // Show error for the current site URL if exists.
         if let siteURL = loggedOutAppSettings.errorLoginSiteAddress {
-            let authenticationUI = authenticationManager.authenticationUI()
-            if let authenticationUI = authenticationUI as? UINavigationController,
+            if let authenticationUI = authenticationManager.authenticationUI() as? UINavigationController,
                let errorController = authenticationManager.errorViewController(for: siteURL, with: matcher, navigationController: authenticationUI) {
                 window.rootViewController = authenticationUI
                 // don't let user navigate back to the login screen unless they tap log out.

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -66,7 +66,7 @@ final class AppCoordinator {
                 case (false, true), (false, false):
                     self.displayAuthenticator()
                 case (true, true):
-                    self.handleLoggedInStateWithoutDefaultStore()
+                    self.displayLoggedInStateWithoutDefaultStore()
                 case (true, false):
                     self.validateRoleEligibility {
                         self.displayLoggedInUI()
@@ -175,7 +175,7 @@ private extension AppCoordinator {
     /// If the app is authenticated but there is no default store ID on launch,
     /// check for errors and display store picker if none exists.
     ///
-    func handleLoggedInStateWithoutDefaultStore() {
+    func displayLoggedInStateWithoutDefaultStore() {
         // Store picker is only displayed by `AppCoordinator` on launch, when the window's root is uninitialized.
         // In other cases when the app is authenticated but there is no default store ID, the store picker is shown by authentication UI.
         guard window.rootViewController == nil else {

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -188,7 +188,10 @@ private extension AppCoordinator {
         // Show error for the current site URL if exists.
         if let siteURL = loggedOutAppSettings.errorLoginSiteAddress {
             if let authenticationUI = authenticationManager.authenticationUI() as? UINavigationController,
-               let errorController = authenticationManager.errorViewController(for: siteURL, with: matcher, navigationController: authenticationUI) {
+               let errorController = authenticationManager.errorViewController(for: siteURL,
+                                                                               with: matcher,
+                                                                               navigationController: authenticationUI,
+                                                                               onStorePickerDismiss: {}) {
                 window.rootViewController = authenticationUI
                 // don't let user navigate back to the login screen unless they tap log out.
                 errorController.navigationItem.hidesBackButton = true

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -197,13 +197,6 @@ private extension AppCoordinator {
             }
         }
 
-        // If no store is found and no error is detected, log the user out.
-        if matcher.hasConnectedStores == false {
-            stores.deauthenticate()
-            displayAuthenticator()
-            return
-        }
-
         // All good, show store picker
         let navigationController = WooNavigationController()
         setWindowRootViewControllerAndAnimateIfNeeded(navigationController)

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -59,7 +59,7 @@ final class AppCoordinatorTests: XCTestCase {
 
         let site = Site.fake().copy(siteID: 123, isWooCommerceActive: true)
         storageManager.insertSampleSite(readOnlySite: site)
-        let appCoordinator = makeCoordinator(window: window, stores: stores, storageManager: storageManager, authenticationManager: authenticationManager)
+        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager)
 
         // When
         appCoordinator.start()
@@ -77,7 +77,7 @@ final class AppCoordinatorTests: XCTestCase {
 
         let site = Site.fake().copy(siteID: 123, isWooCommerceActive: false)
         storageManager.insertSampleSite(readOnlySite: site)
-        let appCoordinator = makeCoordinator(window: window, stores: stores, storageManager: storageManager, authenticationManager: authenticationManager)
+        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager)
 
         // When
         appCoordinator.start()
@@ -99,7 +99,6 @@ final class AppCoordinatorTests: XCTestCase {
         let settings = MockLoggedOutAppSettings(errorLoginSiteAddress: "https://test.com")
         let appCoordinator = makeCoordinator(window: window,
                                              stores: stores,
-                                             storageManager: storageManager,
                                              authenticationManager: authenticationManager,
                                              loggedOutAppSettings: settings)
 
@@ -129,7 +128,6 @@ final class AppCoordinatorTests: XCTestCase {
         let settings = MockLoggedOutAppSettings(errorLoginSiteAddress: siteURL)
         let appCoordinator = makeCoordinator(window: window,
                                              stores: stores,
-                                             storageManager: storageManager,
                                              authenticationManager: authenticationManager,
                                              loggedOutAppSettings: settings)
 
@@ -389,7 +387,6 @@ private extension AppCoordinatorTests {
     /// Convenience method to make AppCoordinator instances.
     func makeCoordinator(window: UIWindow? = nil,
                          stores: StoresManager? = nil,
-                         storageManager: StorageManagerType? = nil,
                          authenticationManager: Authentication? = nil,
                          roleEligibilityUseCase: RoleEligibilityUseCaseProtocol? = nil,
                          analytics: Analytics = ServiceLocator.analytics,

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -69,7 +69,7 @@ final class AppCoordinatorTests: XCTestCase {
         assertThat(storePickerNavigationController.topViewController, isAnInstanceOf: StorePickerViewController.self)
     }
 
-    func test_starting_app_logged_in_without_selected_site_presents_authentication_if_there_are_no_connected_stores() throws {
+    func test_starting_app_logged_in_without_selected_site_presents_store_picker_if_there_are_no_connected_stores() throws {
         // Given
         // Authenticates the app without selecting a site, so that the store picker is shown.
         stores.authenticate(credentials: SessionSettings.credentials)
@@ -83,7 +83,8 @@ final class AppCoordinatorTests: XCTestCase {
         appCoordinator.start()
 
         // Then
-        assertThat(window.rootViewController, isAnInstanceOf: LoginNavigationController.self)
+        let storePickerNavigationController = try XCTUnwrap(window.rootViewController?.presentedViewController as? UINavigationController)
+        assertThat(storePickerNavigationController.topViewController, isAnInstanceOf: StorePickerViewController.self)
     }
 
     func test_starting_app_logged_in_without_selected_site_presents_account_mismatched_if_there_is_no_store_matching_the_error_site_address() throws {

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -4,10 +4,12 @@ import WordPressAuthenticator
 import XCTest
 @testable import WooCommerce
 import Yosemite
+import protocol Storage.StorageManagerType
 
 final class AppCoordinatorTests: XCTestCase {
     private var sessionManager: SessionManager!
     private var stores: MockStoresManager!
+    private var storageManager: MockStorageManager!
     private var authenticationManager: AuthenticationManager!
 
     private let window = UIWindow(frame: UIScreen.main.bounds)
@@ -19,6 +21,7 @@ final class AppCoordinatorTests: XCTestCase {
 
         sessionManager = .makeForTesting(authenticated: false)
         stores = MockStoresManager(sessionManager: sessionManager)
+        storageManager = MockStorageManager()
         authenticationManager = AuthenticationManager()
         authenticationManager.initialize()
     }
@@ -27,6 +30,7 @@ final class AppCoordinatorTests: XCTestCase {
         authenticationManager = nil
         sessionManager.defaultStoreID = nil
         stores = nil
+        storageManager = nil
         sessionManager = nil
 
         // If not resetting the window, `AsyncDictionaryTests.testAsyncUpdatesWhereTheFirstOperationFinishesLast` fails.
@@ -47,12 +51,15 @@ final class AppCoordinatorTests: XCTestCase {
         assertThat(window.rootViewController, isAnInstanceOf: LoginNavigationController.self)
     }
 
-    func test_starting_app_logged_in_without_selected_site_presents_store_picker() throws {
+    func test_starting_app_logged_in_without_selected_site_presents_store_picker_if_there_are_connected_stores() throws {
         // Given
         // Authenticates the app without selecting a site, so that the store picker is shown.
         stores.authenticate(credentials: SessionSettings.credentials)
         sessionManager.defaultStoreID = nil
-        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager)
+
+        let site = Site.fake().copy(siteID: 123, isWooCommerceActive: true)
+        storageManager.insertSampleSite(readOnlySite: site)
+        let appCoordinator = makeCoordinator(window: window, stores: stores, storageManager: storageManager, authenticationManager: authenticationManager)
 
         // When
         appCoordinator.start()
@@ -60,6 +67,82 @@ final class AppCoordinatorTests: XCTestCase {
         // Then
         let storePickerNavigationController = try XCTUnwrap(window.rootViewController?.presentedViewController as? UINavigationController)
         assertThat(storePickerNavigationController.topViewController, isAnInstanceOf: StorePickerViewController.self)
+    }
+
+    func test_starting_app_logged_in_without_selected_site_presents_authentication_if_there_are_no_connected_stores() throws {
+        // Given
+        // Authenticates the app without selecting a site, so that the store picker is shown.
+        stores.authenticate(credentials: SessionSettings.credentials)
+        sessionManager.defaultStoreID = nil
+
+        let site = Site.fake().copy(siteID: 123, isWooCommerceActive: false)
+        storageManager.insertSampleSite(readOnlySite: site)
+        let appCoordinator = makeCoordinator(window: window, stores: stores, storageManager: storageManager, authenticationManager: authenticationManager)
+
+        // When
+        appCoordinator.start()
+
+        // Then
+        assertThat(window.rootViewController, isAnInstanceOf: LoginNavigationController.self)
+    }
+
+    func test_starting_app_logged_in_without_selected_site_presents_account_mismatched_if_there_is_no_store_matching_the_error_site_address() throws {
+        // Given
+        // Authenticates the app without selecting a site, so that the store picker is shown.
+        stores.authenticate(credentials: SessionSettings.credentials)
+        sessionManager.defaultStoreID = nil
+
+        let site = Site.fake().copy(siteID: 123, url: "https://abc.com", isWooCommerceActive: true)
+        storageManager.insertSampleSite(readOnlySite: site)
+
+        let settings = MockLoggedOutAppSettings(errorLoginSiteAddress: "https://test.com")
+        let appCoordinator = makeCoordinator(window: window,
+                                             stores: stores,
+                                             storageManager: storageManager,
+                                             authenticationManager: authenticationManager,
+                                             loggedOutAppSettings: settings)
+
+        // When
+        appCoordinator.start()
+
+        // Then
+        let loginNavigationController = try XCTUnwrap(window.rootViewController as? LoginNavigationController)
+        waitUntil {
+            // it takes some time for `show()` to insert the controller to the stack
+            // so we have to wait a bit
+            loginNavigationController.viewControllers.count > 1
+        }
+        XCTAssertTrue(loginNavigationController.topViewController is ULAccountMismatchViewController)
+    }
+
+    func test_starting_app_logged_in_without_selected_site_presents_error_if_the_error_site_address_does_not_have_woo() throws {
+        // Given
+        // Authenticates the app without selecting a site, so that the store picker is shown.
+        stores.authenticate(credentials: SessionSettings.credentials)
+        sessionManager.defaultStoreID = nil
+
+        let siteURL = "https://test.com"
+        let site = Site.fake().copy(siteID: 123, url: siteURL, isWooCommerceActive: false)
+        storageManager.insertSampleSite(readOnlySite: site)
+
+        let settings = MockLoggedOutAppSettings(errorLoginSiteAddress: siteURL)
+        let appCoordinator = makeCoordinator(window: window,
+                                             stores: stores,
+                                             storageManager: storageManager,
+                                             authenticationManager: authenticationManager,
+                                             loggedOutAppSettings: settings)
+
+        // When
+        appCoordinator.start()
+
+        // Then
+        let loginNavigationController = try XCTUnwrap(window.rootViewController as? LoginNavigationController)
+        waitUntil {
+            // it takes some time for `show()` to insert the controller to the stack
+            // so we have to wait a bit
+            loginNavigationController.viewControllers.count > 1
+        }
+        XCTAssertTrue(loginNavigationController.topViewController is ULErrorViewController)
     }
 
     func test_starting_app_logged_in_with_selected_site_stays_on_tabbar() throws {
@@ -305,6 +388,7 @@ private extension AppCoordinatorTests {
     /// Convenience method to make AppCoordinator instances.
     func makeCoordinator(window: UIWindow? = nil,
                          stores: StoresManager? = nil,
+                         storageManager: StorageManagerType? = nil,
                          authenticationManager: Authentication? = nil,
                          roleEligibilityUseCase: RoleEligibilityUseCaseProtocol? = nil,
                          analytics: Analytics = ServiceLocator.analytics,
@@ -313,6 +397,7 @@ private extension AppCoordinatorTests {
                          featureFlagService: FeatureFlagService = MockFeatureFlagService()) -> AppCoordinator {
         return AppCoordinator(window: window ?? self.window,
                               stores: stores ?? self.stores,
+                              storageManager: storageManager ?? self.storageManager,
                               authenticationManager: authenticationManager ?? self.authenticationManager,
                               roleEligibilityUseCase: roleEligibilityUseCase ?? MockRoleEligibilityUseCase(),
                               analytics: analytics,

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import WordPressKit
 import WordPressAuthenticator
-
+import Yosemite
 @testable import WooCommerce
 
 /// Test cases for `AuthenticationManager`.
@@ -189,5 +189,108 @@ final class AuthenticationManagerTests: XCTestCase {
         // Then
         let rootController = navigationController.viewControllers.first
         XCTAssertTrue(rootController is ULErrorViewController)
+    }
+
+    func test_errorViewController_returns_account_mismatch_if_no_site_matches_the_given_url() {
+        // Given
+        let manager = AuthenticationManager()
+        let testSite = "http://test.com"
+        let navigationController = UINavigationController()
+        let storage = MockStorageManager()
+        let matcher = ULAccountMatcher(storageManager: storage)
+
+        // When
+        let controller = manager.errorViewController(for: testSite, with: matcher, navigationController: navigationController)
+
+        // Then
+        XCTAssertNotNil(controller)
+        XCTAssertTrue(controller is ULAccountMismatchViewController)
+    }
+
+    func test_errorViewController_returns_error_if_the_given_site_does_not_have_woo() {
+        // Given
+        let manager = AuthenticationManager()
+        let navigationController = UINavigationController()
+
+        let testSiteURL = "http://test.com"
+        let testSite = Site.fake().copy(siteID: 1234, name: "Test", url: testSiteURL, isWooCommerceActive: false)
+
+        let storage = MockStorageManager()
+        storage.insertSampleSite(readOnlySite: testSite)
+        let matcher = ULAccountMatcher(storageManager: storage)
+        matcher.refreshStoredSites()
+
+        // When
+        let controller = manager.errorViewController(for: testSiteURL, with: matcher, navigationController: navigationController)
+
+        // Then
+        XCTAssertNotNil(controller)
+        XCTAssertTrue(controller is ULErrorViewController)
+    }
+
+    func test_errorViewController_returns_nil_if_the_given_site_has_woo() {
+        // Given
+        let manager = AuthenticationManager()
+        let navigationController = UINavigationController()
+
+        let testSiteURL = "http://test.com"
+        let testSite = Site.fake().copy(siteID: 1234, name: "Test", url: testSiteURL, isWooCommerceActive: true)
+
+        let storage = MockStorageManager()
+        storage.insertSampleSite(readOnlySite: testSite)
+        let matcher = ULAccountMatcher(storageManager: storage)
+        matcher.refreshStoredSites()
+
+        // When
+        let controller = manager.errorViewController(for: testSiteURL, with: matcher, navigationController: navigationController)
+
+        // Then
+        XCTAssertNil(controller)
+    }
+
+    func test_site_address_is_saved_to_local_storage_if_there_is_error_with_the_site() {
+        // Given
+        let navigationController = UINavigationController()
+
+        let testSiteURL = "http://test.com"
+        let testSite = Site.fake().copy(siteID: 1234, name: "Test", url: testSiteURL, isWooCommerceActive: false) // No Woo
+
+        let storage = MockStorageManager()
+        storage.insertSampleSite(readOnlySite: testSite)
+        let manager = AuthenticationManager(storageManager: storage)
+        let settings = MockLoggedOutAppSettings()
+        manager.setLoggedOutAppSettings(settings)
+
+        let wpcomCredentials = WordPressComCredentials(authToken: "abc", isJetpackLogin: false, multifactor: false, siteURL: testSiteURL)
+        let credentials = AuthenticatorCredentials(wpcom: wpcomCredentials, wporg: nil)
+
+        // When
+        manager.presentLoginEpilogue(in: navigationController, for: credentials, onDismiss: {})
+
+        // Then
+        XCTAssertEqual(settings.errorLoginSiteAddress, testSiteURL)
+    }
+
+    func test_site_address_is_cleared_if_there_is_no_error_with_the_site() {
+        // Given
+        let navigationController = UINavigationController()
+
+        let testSiteURL = "http://test.com"
+        let testSite = Site.fake().copy(siteID: 1234, name: "Test", url: testSiteURL, isWooCommerceActive: true)
+
+        let storage = MockStorageManager()
+        storage.insertSampleSite(readOnlySite: testSite)
+        let manager = AuthenticationManager(storageManager: storage)
+        let settings = MockLoggedOutAppSettings(errorLoginSiteAddress: "http//:test.com")
+        manager.setLoggedOutAppSettings(settings)
+
+        let wpcomCredentials = WordPressComCredentials(authToken: "abc", isJetpackLogin: false, multifactor: false, siteURL: testSiteURL)
+        let credentials = AuthenticatorCredentials(wpcom: wpcomCredentials, wporg: nil)
+
+        // When
+        manager.presentLoginEpilogue(in: navigationController, for: credentials, onDismiss: {})
+
+        // Then
+        XCTAssertNil(settings.errorLoginSiteAddress)
     }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -200,7 +200,7 @@ final class AuthenticationManagerTests: XCTestCase {
         let matcher = ULAccountMatcher(storageManager: storage)
 
         // When
-        let controller = manager.errorViewController(for: testSite, with: matcher, navigationController: navigationController)
+        let controller = manager.errorViewController(for: testSite, with: matcher, navigationController: navigationController) {}
 
         // Then
         XCTAssertNotNil(controller)
@@ -221,7 +221,7 @@ final class AuthenticationManagerTests: XCTestCase {
         matcher.refreshStoredSites()
 
         // When
-        let controller = manager.errorViewController(for: testSiteURL, with: matcher, navigationController: navigationController)
+        let controller = manager.errorViewController(for: testSiteURL, with: matcher, navigationController: navigationController) {}
 
         // Then
         XCTAssertNotNil(controller)
@@ -242,7 +242,7 @@ final class AuthenticationManagerTests: XCTestCase {
         matcher.refreshStoredSites()
 
         // When
-        let controller = manager.errorViewController(for: testSiteURL, with: matcher, navigationController: navigationController)
+        let controller = manager.errorViewController(for: testSiteURL, with: matcher, navigationController: navigationController) {}
 
         // Then
         XCTAssertNil(controller)

--- a/WooCommerce/WooCommerceTests/Mocks/MockLoggedOutAppSettings.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockLoggedOutAppSettings.swift
@@ -2,12 +2,19 @@
 
 final class MockLoggedOutAppSettings: LoggedOutAppSettingsProtocol {
     var hasFinishedOnboarding: Bool
+    var errorLoginSiteAddress: String?
 
-    init(hasFinishedOnboarding: Bool = false) {
+    init(hasFinishedOnboarding: Bool = false,
+         errorLoginSiteAddress: String? = nil) {
         self.hasFinishedOnboarding = hasFinishedOnboarding
+        self.errorLoginSiteAddress = errorLoginSiteAddress
     }
 
     func setHasFinishedOnboarding(_ hasFinishedOnboarding: Bool) {
         self.hasFinishedOnboarding = hasFinishedOnboarding
+    }
+
+    func setErrorLoginSiteAddress(_ address: String?) {
+        self.errorLoginSiteAddress = address
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7419
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, when a user is logged in without a selected site, we're showing the store picker. In many cases, they end up with an empty store picker with an action button to install Jetpack. This screen can be misleading and is not helpful.

This PR improves this experience by adding a few checks:
- If the user encountered an issue with the site address login flow earlier, we keep the site URL in the local storage. So the next time they start the app, we check for the problem of the app and display an error screen to help them pick up where they left off (e.g account mismatched or missing Woo).
- If the user doesn't have any connected store, we log them out since the empty store picker isn't helpful. We can consider showing some other content for store creation here for further enhancement later.

Technical changes:
- Update `LoggedOutAppSettings` with a new variable for `errorLoginSiteAddress`.
- Inject `LoggedOutAppSettings` to `AuthenticationManager` from `AppCoordinator`. Since `AuthenticationManager` is a singleton, and I don't want to move `LoggedOutAppSettings` to `ServiceLocator` as well, so I use method injection here instead of initializer injection.
- Extract a method for getting the error view controller for a given site URL in `AuthenticationManager`. This method is internal so that it can be accessed by `AppCoordinator`.
- Update `AppCoordinator` to present error view controller or log out if needed when handling the logged-in state without default store.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Testing Account Mismatch error:
1. Log out of the app if needed, and select Enter site address.
2. Enter the address for a Woo store to which you don't have ac
cess.
3. Proceed to log in with your WP.com account.
4. After the login succeeds, the Account Mismatch screen is presented. Kill the app.
5. Open the app again, notice that you get the Account Mismatch screen again. Tap Log out, you should get back to the login screen.

Testing No Woo error:
1. Log out of the app if needed, and select Enter site address.
2. Enter the address of a self-hosted site with Jetpack and no Woo.
3. Proceed to log in with your WP.com account.
4. After the login succeeds, the No Woo screen is presented. Kill the app.
5. Open the app again, notice that you get the No Woo screen again. The Install WooCommerce and Log out buttons should still work as expected.

The last case where user is logged in without neither of the above errors and has no connected store is probably an edge case. Please feel free to test it by the following steps:
- Invite a test user to your store.
- Follow the site address login flow to log in with that user.
- On the store picker screen, kill the app.
- Remove the test user from your store.
- Open the app again, the user should stay in the prologue screen now.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Account Mismatch error:
<img src="https://user-images.githubusercontent.com/5533851/183052618-25c6ddab-4e66-4779-94bc-d89f7ee71ae6.png" width=320 />

No Woo error:
<img src="https://user-images.githubusercontent.com/5533851/183052700-f2063d99-7164-4428-90e1-cb0c509a1965.png" width=320 />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
