### PR TITLE
[Order Details] Reorder Print Shipping Label section to be shown below Refunded Products

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1241,10 +1241,10 @@ extension OrderDetailsDataSource {
                      shippingNotice,
                      products,
                      customFields,
-                     installWCShipSection] +
+                     installWCShipSection,
+                     refundedProducts] +
                     shippingLabelSections +
-                    [refundedProducts,
-                     payment,
+                    [payment,
                      customerInformation,
                      tracking,
                      addTracking,


### PR DESCRIPTION
Closes: #7073 

### Description
As part of the Ducks in a Row project, we're moving the `Print Shipping Label` section to be shown below the `Refunded Products` section, for parity with Android. This keeps all product information together and removes ambiguity around what has been refunded and what hasn’t.

Currently, when an Order has both Refunded products and Shipping Labels, these appear in the following order:
- Android: `Product` | `Refunded Products` | `Shipping Label`
- iOS: `Product` | `Shipping Label` | `Refunded Products` 

<img width="600" alt="_7073 comparison" src="https://user-images.githubusercontent.com/3812076/183633829-c8b6471c-5d51-4283-8c3b-472bbda0e321.png">

### Changes

What we render and the order in which sections are rendered is decided in `OrderDetailsDataSource.reloadSections()`, by changing the order of the elements in this `[Section]` collection is enough to display the section in a different order. We're moving the `refundedProducts` section to appear before the `shippingLabelSections` collection of sections.

We use a `compactMap` here because some elements are Optional (pe: Shipping Labels won't appear if the plugin is not installed) while others aren't, so this way we can just return a new array with the non-nil sections.

### Testing instructions
1 - Install and enable WCShipping
2 - Create an Order with two or more Shippable products. Mark the Order as `completed`. 
3 - Refund one of the products from your Order, leaving one or more shippable products not refunded.
4 - Back to the Order details screen you should see the `Print Shipping Label` button.
5 - If you haven't setup a fake test card in your WPCOM account, follow the process added with https://github.com/woocommerce/woocommerce-ios/pull/5023
6 - Go through the `Print Shipping Label` flow, pay for the label using a fake test card.
7 - Check the Order Details screen again, and see that the order of sections is: `Product` | `Refunded Products` | `Shipping Label`

<img width="450" src="https://user-images.githubusercontent.com/3812076/183634687-ac332d72-14a4-414f-ac7b-438435cbaf27.png">

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
