### PR TITLE
Update instructions in .org site credentials entry screen.

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -65,6 +65,13 @@ struct AuthenticationConstants {
         comment: "Button title. Takes the user to the site credentials entry screen."
     )
 
+    /// Instruction in Enter Site Credentials screen.
+    //
+    static let siteCredentialInstructions = NSLocalizedString(
+        "Enter your store credentials for %@.",
+        comment: "Enter your store credentials for {site url}. Asks the user to enter .org site credentials for their store."
+    )
+
     /// Title of views in Unified Login
     //
     static let loginTitle = NSLocalizedString(

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -97,6 +97,7 @@ class AuthenticationManager: Authentication {
                                                                   getStartedInstructions: AuthenticationConstants.getStartedInstructions,
                                                                   jetpackLoginInstructions: AuthenticationConstants.jetpackInstructions,
                                                                   siteLoginInstructions: AuthenticationConstants.siteInstructions,
+                                                                  siteCredentialInstructions: AuthenticationConstants.siteCredentialInstructions,
                                                                   usernamePasswordInstructions: AuthenticationConstants.usernamePasswordInstructions,
                                                                   continueWithWPButtonTitle: AuthenticationConstants.continueWithWPButtonTitle,
                                                                   enterYourSiteAddressButtonTitle: AuthenticationConstants.enterYourSiteAddressButtonTitle,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7438

### Description
Inputs from design team - Internal reference - p1659935908568309/1659511159.269209-slack-C0354HSNUJH

Based on inputs from the design team, this PR changes the instructions text in  "Enter store credentials screen". 

- Change instruction text from “account information” into “store credentials”

### What is changed?

https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/trunk/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift#L163

The above default string from `WordPressAuthenticator-iOS` is used for the instructions. 

In this PR, we are introducing `siteCredentialInstructions` String and passing it in `WordPressAuthenticatorDisplayStrings` constructor to override the default value. 

<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Screenshots
|Before|After|
|--|--|
| ![Before](https://user-images.githubusercontent.com/524475/183830436-e10baa53-5f7e-4df4-af15-446c1eab6b27.jpeg) | ![After](https://user-images.githubusercontent.com/524475/183830418-fe084f78-69f3-4efd-88d6-f5da0fe2500a.jpeg) |



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
