### PR TITLE
[Mobile Payments] Hide IPP Settings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -223,12 +223,24 @@ private extension SettingsViewModel {
         }()
 
         // Store settings
-        let storeSettingsSection: Section = {
-            var rows: [Row] = upsellCardReadersAnnouncementViewModel.shouldBeVisible ? [.upsellCardReadersFeatureAnnouncement] : []
-            rows.append(.inPersonPayments)
+        let storeSettingsSection: Section? = {
+            var rows: [Row] = []
+
+            if !featureFlagService.isFeatureFlagEnabled(.paymentsHubMenuSection) {
+                if upsellCardReadersAnnouncementViewModel.shouldBeVisible {
+                    rows.append(.upsellCardReadersFeatureAnnouncement)
+                }
+
+                rows.append(.inPersonPayments)
+            }
+
             if stores.sessionManager.defaultSite?.isJetpackCPConnected == true,
                 featureFlagService.isFeatureFlagEnabled(.jetpackConnectionPackageSupport) {
                 rows.append(.installJetpack)
+            }
+
+            guard rows.isNotEmpty else {
+                return nil
             }
 
             return Section(title: Localization.storeSettingsTitle,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -241,7 +241,6 @@ final class SettingsViewModelTests: XCTestCase {
     func test_sections_when_paymentsHubMenuSection_is_enabled_then_it_hides_inPersonPayments_row() {
         // Given
         let featureFlagService = MockFeatureFlagService(isPaymentsHubMenuSectionEnabled: true)
-        let appleIDCredentialChecker = MockAppleIDCredentialChecker(hasAppleUserID: true)
         let viewModel = SettingsViewModel(stores: stores,
                                           storageManager: storageManager,
                                           featureFlagService: featureFlagService,
@@ -257,7 +256,6 @@ final class SettingsViewModelTests: XCTestCase {
     func test_sections_when_paymentsHubMenuSection_is_not_enabled_then_it_shows_inPersonPayments_row() {
         // Given
         let featureFlagService = MockFeatureFlagService(isPaymentsHubMenuSectionEnabled: false)
-        let appleIDCredentialChecker = MockAppleIDCredentialChecker(hasAppleUserID: true)
         let viewModel = SettingsViewModel(stores: stores,
                                           storageManager: storageManager,
                                           featureFlagService: featureFlagService,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -237,6 +237,38 @@ final class SettingsViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.removeAppleIDAccess) })
     }
+
+    func test_sections_when_paymentsHubMenuSection_is_enabled_then_it_hides_inPersonPayments_row() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPaymentsHubMenuSectionEnabled: true)
+        let appleIDCredentialChecker = MockAppleIDCredentialChecker(hasAppleUserID: true)
+        let viewModel = SettingsViewModel(stores: stores,
+                                          storageManager: storageManager,
+                                          featureFlagService: featureFlagService,
+                                          appleIDCredentialChecker: appleIDCredentialChecker)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.inPersonPayments) })
+    }
+
+    func test_sections_when_paymentsHubMenuSection_is_not_enabled_then_it_shows_inPersonPayments_row() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isPaymentsHubMenuSectionEnabled: false)
+        let appleIDCredentialChecker = MockAppleIDCredentialChecker(hasAppleUserID: true)
+        let viewModel = SettingsViewModel(stores: stores,
+                                          storageManager: storageManager,
+                                          featureFlagService: featureFlagService,
+                                          appleIDCredentialChecker: appleIDCredentialChecker)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.inPersonPayments) })
+    }
 }
 
 private final class MockSettingsPresenter: SettingsViewPresenter {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7363 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we hide the IPP Settings if the "payments in hub menu" feature flag is enabled. The reason behind is that we already have the settings in the newly added Menu section "Payments", so we do not need it to be duplicated.
We also have a future task to remove the feature flag and the code behind that: https://github.com/woocommerce/woocommerce-ios/issues/7367. Within the scope of this one we will remove the non-necessary code.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You can enable/disable the paymentsHubMenuSection feature flag in this [line](https://github.com/woocommerce/woocommerce-ios/blob/b206b7d2529d2ddca6f3729d89010ab10f0aa8c0/Experiments/Experiments/DefaultFeatureFlagService.swift#L52)

#### Feature Flag enabled

1. Go to Menu
2. Tap on Settings Action
3. In-Person Payments row should not be visible

<img src="https://user-images.githubusercontent.com/1864060/183931593-7cd2418e-34f6-487c-aaec-77b448c30dba.png" width="375">

#### Feature Flag disabled

1. Go to Menu
2. Tap on Settings Action
3. In-Person Payments row should be visible

<img src="https://user-images.githubusercontent.com/1864060/183932049-d728e115-a18d-4d4c-8648-560ffa123d39.png" width="375">

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
See above


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
