### PR TITLE
Login: Improve Woo setup flow

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -195,9 +195,8 @@ class AuthenticationManager: Authentication {
         if let matchedSite = matcher.matchedSite(originalURL: siteURL),
            matchedSite.isWooCommerceActive == false {
             let viewModel = NoWooErrorViewModel(
-                siteURL: siteURL,
+                site: matchedSite,
                 showsConnectedStores: matcher.hasConnectedStores,
-                showsInstallButton: matchedSite.isJetpackConnected && matchedSite.isJetpackThePluginInstalled,
                 onSetupCompletion: { [weak self] siteID in
                     guard let self = self else { return }
                     self.startStorePicker(with: siteID, in: navigationController, onDismiss: onStorePickerDismiss)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -683,9 +683,8 @@ private extension StorePickerViewController {
 
     func showNoWooError(for site: Site) {
         let viewModel = NoWooErrorViewModel(
-            siteURL: site.url,
+            site: site,
             showsConnectedStores: false, // avoid looping from store picker > no woo > store picker
-            showsInstallButton: site.isJetpackConnected && site.isJetpackThePluginInstalled,
             onSetupCompletion: { [weak self] siteID in
                 guard let self = self else { return }
                 self.navigationController?.popViewController(animated: true)

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -156,10 +156,6 @@ private extension NoWooErrorViewModel {
                                                             comment: "Action button that will restart the login flow."
                                                             + "Presented when logging in with a site address that does not have WooCommerce")
 
-        static let yourSite = NSLocalizedString("your site",
-                                                comment: "Placeholder for site url, if the url is unknown."
-                                                    + "Presented when logging in with a site address that does not have WooCommerce."
-                                                + "The error would read: to use this app for your site you'll need...")
         static let verifyingInstallation = NSLocalizedString("Verifying installation...",
                                                              comment: "Message displayed when checking whether a site has successfully installed WooCommerce")
         static let setupErrorMessage = NSLocalizedString("Cannot verify your site's WooCommerce installation.",

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -64,6 +64,8 @@ final class NoWooErrorViewModel: ULErrorViewModel {
             viewController.navigationController?.popViewController(animated: true)
             self.showInProgressView(in: viewController)
             self.handleSetupCompletion(in: viewController)
+        }, onDismiss: {
+            viewController.navigationController?.popViewController(animated: true)
         })
         let setupViewController = PluginSetupWebViewController(viewModel: viewModel)
         viewController.navigationController?.show(setupViewController, sender: nil)

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -18,6 +18,7 @@ final class NoWooErrorViewModel: ULErrorViewModel {
          stores: StoresManager = ServiceLocator.stores,
          onSetupCompletion: @escaping (Int64) -> Void) {
         self.site = site
+        self.title = site.name
         self.showsConnectedStores = showsConnectedStores
         self.analytics = analytics
         self.stores = stores
@@ -25,7 +26,7 @@ final class NoWooErrorViewModel: ULErrorViewModel {
     }
 
     // MARK: - Data and configuration
-    var title: String? { site.name }
+    let title: String?
 
     let image: UIImage = .noStoreImage
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -105,9 +105,10 @@ private extension NoWooErrorViewModel {
                   site.isWooCommerceActive else {
                 if retryCount < 2 {
                     // delays for 2 seconds to buy some time for the data to be synced
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                        return self.handleSetupCompletion(in: viewController, retryCount: retryCount + 1)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+                        self?.handleSetupCompletion(in: viewController, retryCount: retryCount + 1)
                     }
+                    return
                 }
                 // dismisses the in-progress view
                 viewController.navigationController?.dismiss(animated: true)

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -25,6 +25,8 @@ final class NoWooErrorViewModel: ULErrorViewModel {
     }
 
     // MARK: - Data and configuration
+    var title: String? { site.name }
+
     let image: UIImage = .noStoreImage
 
     var text: NSAttributedString {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -41,6 +41,7 @@ final class ULErrorViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        configureTitle()
         configureImageView()
         configureErrorMessage()
         configureExtraInfoButton()
@@ -69,6 +70,10 @@ final class ULErrorViewController: UIViewController {
 
 // MARK: - View configuration
 private extension ULErrorViewController {
+    func configureTitle() {
+        title = viewModel.title
+    }
+
     func configureImageView() {
         imageView.image = viewModel.image
     }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewModel.swift
@@ -3,7 +3,7 @@ import UIKit
 /// Abstracts different configurations and logic related to user interaction
 /// for error view controllers presented as part of the Unified Login flow
 protocol ULErrorViewModel {
-    /// A title for  the error screen
+    /// A title for the error screen
     var title: String? { get }
 
     /// An illustration accompanying the error

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewModel.swift
@@ -3,6 +3,9 @@ import UIKit
 /// Abstracts different configurations and logic related to user interaction
 /// for error view controllers presented as part of the Unified Login flow
 protocol ULErrorViewModel {
+    /// A title for  the error screen
+    var title: String? { get }
+
     /// An illustration accompanying the error
     var image: UIImage { get }
 
@@ -42,5 +45,7 @@ protocol ULErrorViewModel {
 
 // MARK: - Default implementation for optional variables
 extension ULErrorViewModel {
+    var title: String? { nil }
+
     var isPrimaryButtonHidden: Bool { false }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/NoWooErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NoWooErrorViewModelTests.swift
@@ -1,11 +1,13 @@
 import XCTest
+import Yosemite
 @testable import WooCommerce
 
 final class NoWooErrorViewModelTests: XCTestCase {
 
     func test_image_is_correct() {
         // Given
-        let viewModel = NoWooErrorViewModel(siteURL: nil, showsConnectedStores: false, showsInstallButton: false, onSetupCompletion: { _ in })
+        let site = Site.fake()
+        let viewModel = NoWooErrorViewModel(site: site, showsConnectedStores: false, onSetupCompletion: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.image, UIImage.noStoreImage)
@@ -13,8 +15,8 @@ final class NoWooErrorViewModelTests: XCTestCase {
 
     func test_error_message_is_correct() {
         // Given
-        let siteAddress = "https://test.com"
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, showsInstallButton: false, onSetupCompletion: { _ in })
+        let site = Site.fake().copy(url: "https://test.com")
+        let viewModel = NoWooErrorViewModel(site: site, showsConnectedStores: false, onSetupCompletion: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.text.string, String(format: Localization.errorMessage, "test.com"))
@@ -22,8 +24,8 @@ final class NoWooErrorViewModelTests: XCTestCase {
 
     func test_auxiliary_button_is_hidden_when_connected_stores_are_not_shown() {
         // Given
-        let siteAddress = "https://test.com"
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, showsInstallButton: false, onSetupCompletion: { _ in })
+        let site = Site.fake().copy(url: "https://test.com")
+        let viewModel = NoWooErrorViewModel(site: site, showsConnectedStores: false, onSetupCompletion: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.isAuxiliaryButtonHidden)
@@ -31,8 +33,8 @@ final class NoWooErrorViewModelTests: XCTestCase {
 
     func test_auxiliary_button_is_not_hidden_when_connected_stores_are_shown() {
         // Given
-        let siteAddress = "https://test.com"
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: true, showsInstallButton: false, onSetupCompletion: { _ in })
+        let site = Site.fake().copy(url: "https://test.com")
+        let viewModel = NoWooErrorViewModel(site: site, showsConnectedStores: true, onSetupCompletion: { _ in })
 
         // Then
         XCTAssertFalse(viewModel.isAuxiliaryButtonHidden)
@@ -40,8 +42,8 @@ final class NoWooErrorViewModelTests: XCTestCase {
 
     func test_auxiliary_button_title_is_correct() {
         // Given
-        let siteAddress = "https://test.com"
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, showsInstallButton: false, onSetupCompletion: { _ in })
+        let site = Site.fake().copy(url: "https://test.com")
+        let viewModel = NoWooErrorViewModel(site: site, showsConnectedStores: false, onSetupCompletion: { _ in })
 
         //  Then
         XCTAssertEqual(viewModel.auxiliaryButtonTitle, Localization.seeConnectedStores)
@@ -49,26 +51,35 @@ final class NoWooErrorViewModelTests: XCTestCase {
 
     func test_primary_button_title_is_correct() {
         // Given
-        let siteAddress = "https://test.com"
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, showsInstallButton: false, onSetupCompletion: { _ in })
+        let site = Site.fake().copy(url: "https://test.com")
+        let viewModel = NoWooErrorViewModel(site: site, showsConnectedStores: false, onSetupCompletion: { _ in })
 
         //  Then
         XCTAssertEqual(viewModel.primaryButtonTitle, Localization.primaryButtonTitle)
     }
 
-    func test_primary_button_is_hidden_when_install_button_is_not_shown() {
+    func test_primary_button_is_hidden_when_the_site_does_not_have_jetpack_connection() {
         // Given
-        let siteAddress = "https://test.com"
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, showsInstallButton: false, onSetupCompletion: { _ in })
+        let site = Site.fake().copy(url: "https://test.com", isJetpackThePluginInstalled: true, isJetpackConnected: false)
+        let viewModel = NoWooErrorViewModel(site: site, showsConnectedStores: false, onSetupCompletion: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.isPrimaryButtonHidden)
     }
 
-    func test_primary_button_is_not_hidden_when_install_button_is_shown() {
+    func test_primary_button_is_hidden_when_the_site_does_not_have_jetpack_the_plugin() {
         // Given
-        let siteAddress = "https://test.com"
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, showsInstallButton: true, onSetupCompletion: { _ in })
+        let site = Site.fake().copy(url: "https://test.com", isJetpackThePluginInstalled: false, isJetpackConnected: true)
+        let viewModel = NoWooErrorViewModel(site: site, showsConnectedStores: false, onSetupCompletion: { _ in })
+
+        // Then
+        XCTAssertTrue(viewModel.isPrimaryButtonHidden)
+    }
+
+    func test_primary_button_is_not_hidden_when_the_site_has_both_jetpack_connection_and_the_plugin() {
+        // Given
+        let site = Site.fake().copy(url: "https://test.com", isJetpackThePluginInstalled: true, isJetpackConnected: true)
+        let viewModel = NoWooErrorViewModel(site: site, showsConnectedStores: false, onSetupCompletion: { _ in })
 
         // Then
         XCTAssertFalse(viewModel.isPrimaryButtonHidden)
@@ -76,8 +87,8 @@ final class NoWooErrorViewModelTests: XCTestCase {
 
     func test_secondary_button_title_is_correct() {
         // Given
-        let siteAddress = "https://test.com"
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress, showsConnectedStores: false, showsInstallButton: false, onSetupCompletion: { _ in })
+        let site = Site.fake().copy(url: "https://test.com")
+        let viewModel = NoWooErrorViewModel(site: site, showsConnectedStores: false, onSetupCompletion: { _ in })
 
         //  Then
         XCTAssertEqual(viewModel.secondaryButtonTitle, Localization.secondaryButtonTitle)
@@ -85,11 +96,10 @@ final class NoWooErrorViewModelTests: XCTestCase {
 
     func test_user_is_logged_out_when_tapping_secondary_button() {
         // Given
-        let siteAddress = "https://test.com"
+        let site = Site.fake().copy(url: "https://test.com")
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress,
+        let viewModel = NoWooErrorViewModel(site: site,
                                             showsConnectedStores: false,
-                                            showsInstallButton: false,
                                             stores: stores,
                                             onSetupCompletion: { _ in })
         let rootViewController = UIViewController()
@@ -108,12 +118,11 @@ final class NoWooErrorViewModelTests: XCTestCase {
 
     func test_woocommerce_setup_button_tapped_is_tracked_when_tapping_primary_button() {
         // Given
-        let siteAddress = "https://test.com"
+        let site = Site.fake().copy(url: "https://test.com")
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress,
+        let viewModel = NoWooErrorViewModel(site: site,
                                             showsConnectedStores: false,
-                                            showsInstallButton: false,
                                             analytics: analytics,
                                             onSetupCompletion: { _ in })
 
@@ -126,12 +135,11 @@ final class NoWooErrorViewModelTests: XCTestCase {
 
     func test_woocommerce_error_screen_is_tracked_when_the_view_is_loaded() {
         // Given
-        let siteAddress = "https://test.com"
+        let site = Site.fake().copy(url: "https://test.com")
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewModel = NoWooErrorViewModel(siteURL: siteAddress,
+        let viewModel = NoWooErrorViewModel(site: site,
                                             showsConnectedStores: false,
-                                            showsInstallButton: false,
                                             analytics: analytics,
                                             onSetupCompletion: { _ in })
 

--- a/WooCommerce/WooCommerceTests/Authentication/NoWooErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NoWooErrorViewModelTests.swift
@@ -4,6 +4,15 @@ import Yosemite
 
 final class NoWooErrorViewModelTests: XCTestCase {
 
+    func test_title_is_correct() {
+        // Given
+        let site = Site.fake().copy(name: "Test")
+        let viewModel = NoWooErrorViewModel(site: site, showsConnectedStores: false, onSetupCompletion: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.title, "Test")
+    }
+
     func test_image_is_correct() {
         // Given
         let site = Site.fake()

--- a/WooCommerce/WooCommerceTests/Authentication/ULErrorViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/ULErrorViewControllerTests.swift
@@ -16,6 +16,19 @@ final class ULErrorViewControllerTests: XCTestCase {
         super.tearDown()
     }
 
+    func test_viewcontroller_presents_title_provided_by_viewmodel() throws {
+        // Given
+        let viewModel = ErrorViewModel()
+        let viewController = ULErrorViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let title = viewController.title
+
+        // Then
+        XCTAssertEqual(title, viewModel.title)
+    }
+
     func test_viewcontroller_presents_image_provided_by_viewmodel() throws {
         // Given
         let viewModel = ErrorViewModel()
@@ -155,6 +168,8 @@ final class ULErrorViewControllerTests: XCTestCase {
 
 
 private final class ErrorViewModel: ULErrorViewModel {
+    let title: String? = "Test"
+
     let image: UIImage = .loginNoJetpackError
 
     let text: NSAttributedString = NSAttributedString(string: "woocommerce")

--- a/WooCommerce/WooCommerceTests/Authentication/WooSetupWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WooSetupWebViewModelTests.swift
@@ -6,7 +6,7 @@ final class WooSetupWebViewModelTests: XCTestCase {
     func test_initial_url_is_correct() {
         // Given
         let siteURL = "https://test.com"
-        let viewModel = WooSetupWebViewModel(siteURL: siteURL, onCompletion: {})
+        let viewModel = WooSetupWebViewModel(siteURL: siteURL, onCompletion: {}, onDismiss: {})
 
         // Then
         let expectedURL = "https://wordpress.com/plugins/woocommerce/test.com"
@@ -20,7 +20,7 @@ final class WooSetupWebViewModelTests: XCTestCase {
         let completionHandler: () -> Void = {
             triggeredCompletion = true
         }
-        let viewModel = WooSetupWebViewModel(siteURL: siteURL, onCompletion: completionHandler)
+        let viewModel = WooSetupWebViewModel(siteURL: siteURL, onCompletion: completionHandler, onDismiss: {})
 
         // When
         let url = URL(string: "https://wordpress.com/marketplace/thank-you/woocommerce/")
@@ -35,7 +35,7 @@ final class WooSetupWebViewModelTests: XCTestCase {
         let siteURL = "https://test.com"
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewModel = WooSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: {})
+        let viewModel = WooSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: {}, onDismiss: {})
 
         // When
         viewModel.handleDismissal()
@@ -51,7 +51,7 @@ final class WooSetupWebViewModelTests: XCTestCase {
         let siteURL = "https://test.com"
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewModel = WooSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: {})
+        let viewModel = WooSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: {}, onDismiss: {})
 
         // When
         let url = URL(string: "https://wordpress.com/marketplace/thank-you/woocommerce/")
@@ -68,7 +68,7 @@ final class WooSetupWebViewModelTests: XCTestCase {
         let siteURL = "https://test.com"
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewModel = WooSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: {})
+        let viewModel = WooSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: {}, onDismiss: {})
 
         // When
         let url = URL(string: "https://wordpress.com/marketplace/thank-you/woocommerce/")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7453
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a few enhancements to the current Woo setup flow:
- Add a 2-second delay before every retry when verifying Woo installation. This is needed since it was reported (p5T066-3tg-p2#comment-13236) that the verification failed - this happens sporadically so for now we can only add the delay as a workaround.
- Keep the progress bar for verifying Woo installation and only dismiss it when the verification completes.
- Detect when the Back button on the web view is tapped - the web view should be dismissed then.
- Add title for the No Woo error screen to avoid the empty navigation bar reported [here](https://github.com/woocommerce/woocommerce-ios/pull/7439#pullrequestreview-1069094265).
- Improve the check for the installation button to avoid duplicated code.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: make sure your WP.com account have access to at least one Woo Store and at least one non-Woo site and JCP site.

1. Log out of the app if necessary and select Continue with WP.com.
2. Log in with your WP.com account. On the store picker, select the JN site with no Woo.
3. Notice that the No Woo error view is displayed. Select Install WooCommerce.
4. On the web view, tab the Back button on the web view (not on the navigation bar). Notice that the web view is dismissed, and Xcode console should log `🔵 Tracked login_woocommerce_setup_dismissed, properties: [AnyHashable("source"): "web"]`.
5. Select Install WooCommerce and tap the Install and Activate button. When the installation completes, make sure that the verification succeeds more consistently.
6. Select non-Woo site or a JCP site from the list. Notice that the Install WooCommerce button is disabled for these sites.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Back from the web view:

https://user-images.githubusercontent.com/5533851/184104813-22bf7130-5dfa-4a3e-8469-bf652cd5de96.mp4





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->