### PR TITLE
[Mobile Payments] Moooore IPP Tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -656,7 +656,7 @@ public enum WooAnalyticsStat: String {
     case paymentsMenuOrderCardReaderTapped = "payments_hub_order_card_reader_tapped"
     case paymentsMenuCardReadersManualsTapped = "payments_hub_card_readers_manuals_tapped"
     case paymentsMenuManageCardReadersTapped = "payments_hub_manage_card_readers_tapped"
-    case paymentsMenuPaymentProviderTapped = "payments_hub_payment_provider_tapped"
+    case paymentsMenuPaymentProviderTapped = "settings_card_present_select_payment_gateway_tapped"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -140,8 +140,6 @@ public enum WooAnalyticsStat: String {
     case settingsTapped = "main_menu_settings_tapped"
     case settingsSelectedStoreTapped = "settings_selected_site_tapped"
     case settingsContactSupportTapped = "main_menu_contact_support_tapped"
-    case settingsCardReadersTapped = "settings_card_readers_tapped"
-    case settingsCardPresentSelectedPaymentGatewayTapped = "settings_card_present_select_payment_gateway_tapped"
 
     case settingsBetaFeaturesButtonTapped = "settings_beta_features_button_tapped"
     case settingsBetaFeaturesProductsToggled = "settings_beta_features_products_toggled"
@@ -651,6 +649,14 @@ public enum WooAnalyticsStat: String {
     case loginWooCommerceSetupButtonTapped = "login_woocommerce_setup_button_tapped"
     case loginWooCommerceSetupDismissed = "login_woocommerce_setup_dismissed"
     case loginWooCommerceSetupCompleted = "login_woocommerce_setup_completed"
+
+    // MARK: Payments Menu
+    case paymentsMenuCollectPaymentTapped = "payments_hub_collect_payment_tapped"
+    case paymentsMenuOnboardingErrorTapped = "payments_hub_onboarding_error_tapped"
+    case paymentsMenuOrderCardReaderTapped = "payments_hub_order_card_reader_tapped"
+    case paymentsMenuCardReadersManualsTapped = "payments_hub_card_readers_manuals_tapped"
+    case paymentsMenuManageCardReadersTapped = "payments_hub_manage_card_readers_tapped"
+    case paymentsMenuManagePaymentGatewaysTapped = "payments_hub_manage_payment_gateways_tapped"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -656,7 +656,7 @@ public enum WooAnalyticsStat: String {
     case paymentsMenuOrderCardReaderTapped = "payments_hub_order_card_reader_tapped"
     case paymentsMenuCardReadersManualsTapped = "payments_hub_card_readers_manuals_tapped"
     case paymentsMenuManageCardReadersTapped = "payments_hub_manage_card_readers_tapped"
-    case paymentsMenuManagePaymentGatewaysTapped = "payments_hub_manage_payment_gateways_tapped"
+    case paymentsMenuPaymentProviderTapped = "payments_hub_payment_provider_tapped"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -295,7 +295,7 @@ extension InPersonPaymentsMenuViewController {
     }
 
     func managePaymentGatewaysWasPressed() {
-        ServiceLocator.analytics.track(.paymentsMenuManagePaymentGatewaysTapped)
+        ServiceLocator.analytics.track(.paymentsMenuPaymentProviderTapped)
         onPluginSelectionCleared?()
 
         if featureFlagService.isFeatureFlagEnabled(.paymentsHubMenuSection) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -105,6 +105,7 @@ private extension InPersonPaymentsMenuViewController {
                             feedbackType: .error,
                             actionTitle: Localization.inPersonPaymentsSetupNotFinishedNoticeButtonTitle,
                             actionHandler: { [weak self] in
+            ServiceLocator.analytics.track(.paymentsMenuOnboardingErrorTapped)
             self?.showOnboardingIfRequired()
         })
 
@@ -272,11 +273,12 @@ private extension InPersonPaymentsMenuViewController {
 //
 extension InPersonPaymentsMenuViewController {
     func orderCardReaderWasPressed() {
+        ServiceLocator.analytics.track(.paymentsMenuOrderCardReaderTapped)
         WebviewHelper.launch(configurationLoader.configuration.purchaseCardReaderUrl(), with: self)
     }
 
     func manageCardReaderWasPressed() {
-        ServiceLocator.analytics.track(.settingsCardReadersTapped)
+        ServiceLocator.analytics.track(.paymentsMenuManageCardReadersTapped)
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsPresentingViewController.self) else {
             fatalError("Cannot instantiate `CardReaderSettingsPresentingViewController` from Dashboard storyboard")
         }
@@ -287,12 +289,13 @@ extension InPersonPaymentsMenuViewController {
     }
 
     func cardReaderManualsWasPressed() {
+        ServiceLocator.analytics.track(.paymentsMenuCardReadersManualsTapped)
         let view = UIHostingController(rootView: CardReaderManualsView())
         navigationController?.pushViewController(view, animated: true)
     }
 
     func managePaymentGatewaysWasPressed() {
-        ServiceLocator.analytics.track(.settingsCardPresentSelectedPaymentGatewayTapped)
+        ServiceLocator.analytics.track(.paymentsMenuManagePaymentGatewaysTapped)
         onPluginSelectionCleared?()
 
         if featureFlagService.isFeatureFlagEnabled(.paymentsHubMenuSection) {
@@ -311,6 +314,8 @@ extension InPersonPaymentsMenuViewController {
     }
 
     func collectPaymentWasPressed() {
+        ServiceLocator.analytics.track(.paymentsMenuCollectPaymentTapped)
+
         guard let siteID = stores.sessionManager.defaultStoreID,
               let navigationController = navigationController else {
             return

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -54,7 +54,11 @@ struct HubMenu: View {
                                        badge: menu.badge,
                                        isDisabled: $shouldDisableItemTaps,
                                        onTapGesture: {
-                            ServiceLocator.analytics.track(.hubMenuOptionTapped, withProperties: [Constants.option: menu.trackingOption])
+                            ServiceLocator.analytics.track(.hubMenuOptionTapped,
+                                                           withProperties: [
+                                                            Constants.trackingOptionKey: menu.trackingOption,
+                                                            Constants.trackingBadgeVisibleKey: menu.badge.shouldBeRendered
+                                                           ])
                             switch type(of: menu).id {
                             case HubMenuViewModel.Payments.id:
                                 viewModel.paymentsScreenWasOpened()
@@ -209,7 +213,8 @@ struct HubMenu: View {
         static let padding: CGFloat = 16
         static let topBarSpacing: CGFloat = 2
         static let avatarSize: CGFloat = 40
-        static let option = "option"
+        static let trackingOptionKey = "option"
+        static let trackingBadgeVisibleKey = "badge_visible"
     }
 
     private enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -206,7 +206,7 @@ extension HubMenuViewModel {
         let iconColor: UIColor = .withColorStudio(.orange)
         var badge: HubMenuBadgeType = .number(number: 0)
         let accessibilityIdentifier: String = "menu-payments"
-        let trackingOption: String = "payments_menu"
+        let trackingOption: String = "payments"
     }
 
     struct WoocommerceAdmin: HubMenuItem {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7365 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the tracking for the Moooore IPP project, enhancing some events we already had with extra information (badge true or false in the Payments button when tapping at it), replacing some of them with the new strings (some of the events in the Payments menu) and adding new ones.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Make sure that these strings are printed on the Xcode console when debugging:

#### Tap on the Payments button on the Menu, badge visible
`🔵 Tracked hub_menu_option_tapped, properties: [AnyHashable("blog_id"): 205113380, AnyHashable("option"): "payments", AnyHashable("badge_visible"): true, AnyHashable("is_wpcom_store"): true]`
#### Tap on the Payments button on the Menu, badge not visible
`🔵 Tracked hub_menu_option_tapped, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("badge_visible"): false, AnyHashable("option"): "payments", AnyHashable("blog_id"): 205113380]`
#### Tap on the Collect Payment button, Payments Menu
`🔵 Tracked payments_hub_collect_payment_tapped, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 205113380]`
#### Tap on Order Card Reader, Payments Menu
`🔵 Tracked payments_hub_order_card_reader_tapped, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 205113380]`
#### Tap on Manage Card Reader, Payments Menu
`🔵 Tracked payments_hub_manage_card_readers_tapped, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 205113380]`
#### Tap on Card Readers Manual, Payments Menu
`🔵 Tracked payments_hub_card_readers_manuals_tapped, properties: [AnyHashable("blog_id"): 205113380, AnyHashable("is_wpcom_store"): true]`
#### Tap on Payment Provider, Payments Menu
`🔵 Tracked settings_card_present_select_payment_gateway_tapped, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 205113380]`
#### Tap on Onboarding Error Alert button

https://user-images.githubusercontent.com/1864060/184147896-f2e90c6c-3108-4492-adc3-13b54d537af8.mp4


`🔵 Tracked payments_hub_onboarding_error_tapped, properties: [AnyHashable("blog_id"): 205113380, AnyHashable("is_wpcom_store"): true]`

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
See above

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
