### PR TITLE
[Elevate] Add linked products banner present/dismiss logic

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -19,7 +19,7 @@ struct DefaultProductFormTableViewModel: ProductFormTableViewModel {
 
     // Timezone of the website
     //
-    var siteTimezone: TimeZone = TimeZone.siteTimezone
+    private let siteTimezone: TimeZone = TimeZone.siteTimezone
 
     init(product: ProductFormDataModel,
          actionsFactory: ProductFormActionsFactoryProtocol,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -49,6 +49,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
     private let addOnsFeatureEnabled: Bool
     private let variationsPrice: VariationsPrice
 
+    private let isLinkedProductsPromoEnabled: Bool
     private let linkedProductsPromoCampaign = LinkedProductsPromoCampaign()
     private var linkedProductsPromoViewModel: FeatureAnnouncementCardViewModel {
         .init(analytics: ServiceLocator.analytics,
@@ -56,26 +57,34 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
     }
 
     // TODO: Remove default parameter
-    init(product: EditableProductModel, formType: ProductFormType, addOnsFeatureEnabled: Bool = true, variationsPrice: VariationsPrice = .unknown) {
+    init(product: EditableProductModel,
+         formType: ProductFormType,
+         addOnsFeatureEnabled: Bool = true,
+         isLinkedProductsPromoEnabled: Bool = false,
+         variationsPrice: VariationsPrice = .unknown) {
         self.product = product
         self.formType = formType
         self.editable = formType != .readonly
         self.addOnsFeatureEnabled = addOnsFeatureEnabled
         self.variationsPrice = variationsPrice
+        self.isLinkedProductsPromoEnabled = isLinkedProductsPromoEnabled
     }
 
     /// Returns an array of actions that are visible in the product form primary section.
     func primarySectionActions() -> [ProductFormEditAction] {
         let shouldShowImagesRow = editable || product.images.isNotEmpty
         let shouldShowDescriptionRow = editable || product.description?.isNotEmpty == true
+
+        let newLinkedProductsPromoViewModel = linkedProductsPromoViewModel
         let shouldShowLinkedProductsPromo = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.linkedProductsPromo)
-        && linkedProductsPromoViewModel.shouldBeVisible
+        && isLinkedProductsPromoEnabled
+        && newLinkedProductsPromoViewModel.shouldBeVisible
         && product.upsellIDs.isEmpty
         && product.crossSellIDs.isEmpty
 
         let actions: [ProductFormEditAction?] = [
             shouldShowImagesRow ? .images(editable: editable): nil,
-            shouldShowLinkedProductsPromo ? .linkedProductsPromo(viewModel: linkedProductsPromoViewModel) : nil,
+            shouldShowLinkedProductsPromo ? .linkedProductsPromo(viewModel: newLinkedProductsPromoViewModel) : nil,
             .name(editable: editable),
             shouldShowDescriptionRow ? .description(editable: editable): nil
         ]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -26,6 +26,7 @@ final class ProductFormTableViewDataSource: NSObject {
     private let productUIImageLoader: ProductUIImageLoader
 
     var openLinkedProductsAction: (() -> Void)?
+    var reloadLinkedPromoAction: (() -> Void)?
 
     init(viewModel: ProductFormTableViewModel,
          productImageStatuses: [ProductImageStatus],
@@ -204,6 +205,10 @@ private extension ProductFormTableViewDataSource {
         }
 
         cell.configure(with: viewModel)
+
+        cell.dismiss = { [weak self] in
+            self?.reloadLinkedPromoAction?()
+        }
         cell.callToAction = { [weak self] in
             self?.openLinkedProductsAction?()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -589,14 +589,21 @@ private extension ProductFormViewController {
     }
 
     /// Recreates `tableViewDataSource` and reloads the `tableView` data.
+    /// - Parameters:
+    ///   - reloadClosure: custom tableView reload action, by default `reloadData()` will be triggered
     ///
-    func reconfigureDataSource(tableViewModel: ProductFormTableViewModel, statuses: [ProductImageStatus]) {
+    func reconfigureDataSource(tableViewModel: ProductFormTableViewModel, statuses: [ProductImageStatus], reloadClosure: (() -> Void)? = nil) {
         tableViewDataSource = ProductFormTableViewDataSource(viewModel: tableViewModel,
                                                              productImageStatuses: statuses,
                                                              productUIImageLoader: productUIImageLoader)
         updateDataSourceActions()
         tableView.dataSource = tableViewDataSource
-        tableView.reloadData()
+
+        if let reloadClosure = reloadClosure {
+            reloadClosure()
+        } else {
+            tableView.reloadData()
+        }
     }
 
     func updateDataSourceActions() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -646,6 +646,10 @@ private extension ProductFormViewController {
         tableViewDataSource.openLinkedProductsAction = { [weak self] in
             self?.editLinkedProducts()
         }
+        tableViewDataSource.reloadLinkedPromoAction = { [weak self] in
+            guard let self = self else { return }
+            self.reloadLinkedPromoCellAnimated()
+        }
         tableViewDataSource.configureActions(onNameChange: { [weak self] name in
             self?.onEditProductNameCompletion(newName: name ?? "")
         }, onStatusChange: { [weak self] isEnabled in

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -773,6 +773,10 @@ private extension ProductFormViewController {
                 // Dismisses the in-progress UI, then presents the confirmation alert.
                 self?.navigationController?.dismiss(animated: true, completion: nil)
                 self?.presentProductConfirmationSaveAlert()
+
+                // Show linked products promo banner after product save
+                (self?.viewModel as? ProductFormViewModel)?.isLinkedProductsPromoEnabled = true
+                self?.reloadLinkedPromoCellAnimated()
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -543,6 +543,42 @@ private extension ProductFormViewController {
         }
     }
 
+    /// Updates table viewmodel and datasource and attempts to animate cell deletion/insertion.
+    ///
+    func reloadLinkedPromoCellAnimated() {
+        let indexPathBeforeReload = findLinkedPromoCellIndexPath()
+        tableViewModel = DefaultProductFormTableViewModel(product: viewModel.productModel,
+                                                          actionsFactory: viewModel.actionsFactory,
+                                                          currency: currency)
+        let indexPathAfterReload = findLinkedPromoCellIndexPath()
+
+        reconfigureDataSource(tableViewModel: tableViewModel, statuses: productImageActionHandler.productImageStatuses) { [weak self] in
+            guard let self = self else { return }
+
+            switch (indexPathBeforeReload, indexPathAfterReload) {
+            case (let indexPathBeforeReload?, nil):
+                self.tableView.deleteRows(at: [indexPathBeforeReload], with: .left)
+            case (nil, let indexPathAfterReload?):
+                self.tableView.insertRows(at: [indexPathAfterReload], with: .automatic)
+            default:
+                self.tableView.reloadData()
+            }
+        }
+    }
+
+    func findLinkedPromoCellIndexPath() -> IndexPath? {
+        for (sectionIndex, section) in tableViewModel.sections.enumerated() {
+            if case .primaryFields(rows: let sectionRows) = section {
+                for (rowIndex, row) in sectionRows.enumerated() {
+                    if case .linkedProductsPromo = row {
+                        return IndexPath(row: rowIndex, section: sectionIndex)
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
     func onProductUpdated(product: ProductModel) {
         updateMoreDetailsButtonVisibility()
         tableViewModel = DefaultProductFormTableViewModel(product: product,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -62,6 +62,15 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         }
     }
 
+    /// Returns `true` if the `linkedProductsPromo` banner should be displayed. `False` otherwise.
+    /// Assigning this value will recreate the `actionsFactory` property.
+    ///
+    var isLinkedProductsPromoEnabled: Bool = false {
+        didSet {
+            updateActionsFactory()
+        }
+    }
+
     /// The product model before any potential edits; reset after a remote update.
     private var originalProduct: EditableProductModel {
         didSet {
@@ -617,6 +626,7 @@ private extension ProductFormViewModel {
         actionsFactory = ProductFormActionsFactory(product: product,
                                                    formType: formType,
                                                    addOnsFeatureEnabled: isAddOnsFeatureEnabled,
+                                                   isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
                                                    variationsPrice: calculateVariationPriceState())
     }
 }


### PR DESCRIPTION
Closes #7374.

## Description

This PR adds promo banner state management and correct appear/disappear flows.

**Known limitation:** somehow banner animates only on dismiss, but never on appear. Since it appears in a middle of "product save progress" fullscreen transition, it's hard to notice.

## Testing

0. Checkout branch `issue/7374-linked-products-banner-state-with-helper`, it has useful helper in 82eb5cc.
1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Open product *without* any linked products.
3. Update some property and tap "Save".
4. Confirm promo banner appears.
5. Tap "Try it now" and confirm it navigates to linked products screen.
6. Navigate back, tap "X" button - confirm banner disappears.

## Video

https://user-images.githubusercontent.com/3132438/184219016-3c3a0bce-573c-48a0-ba02-be1ce86185f8.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.