### PR TITLE
Adjust orders report request frequency

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -43,8 +43,6 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
         logOutOfCurrentStore {
             self.finalizeStoreSelection(storeID)
 
-            // Reload orders badge
-            NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
             onCompletion(true)
         }
     }

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -76,12 +76,11 @@ final class MainTabViewModel {
         saveInstallationDateIfNecessary()
     }
 
-    /// Bootstrap the data pipeline for the orders badge
-    /// Fetches the initial badge count and observes notifications requesting a refresh
-    /// The notification observed will be `ordersBadgeReloadRequired`
+    /// Get last known data from cache (if exists) and draw it on a badge
     ///
-    func startObservingOrdersCount() {
-        updateBadgeFromCache()
+    func updateBadgeFromCache() {
+        let initialCachedOrderStatus = statusResultsController?.fetchedObjects.first
+        processBadgeCount(initialCachedOrderStatus)
     }
 
     /// Loads the the hub Menu tab badge and listens to any change to update it

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -81,9 +81,7 @@ final class MainTabViewModel {
     /// The notification observed will be `ordersBadgeReloadRequired`
     ///
     func startObservingOrdersCount() {
-        observeBadgeRefreshNotifications()
         updateBadgeFromCache()
-        requestBadgeCount()
     }
 
     /// Loads the the hub Menu tab badge and listens to any change to update it
@@ -120,13 +118,6 @@ private extension MainTabViewModel {
 
         try? statusResultsController?.performFetch()
         updateBadgeFromCache()
-    }
-
-    /// Get last known data from cache (if exists) and draw it on a badge
-    ///
-    func updateBadgeFromCache() {
-        let initialCachedOrderStatus = statusResultsController?.fetchedObjects.first
-        processBadgeCount(initialCachedOrderStatus)
     }
 
     /// Trigger network action to update underlying cache. Badge redraw will be triggered by `statusResultsController`

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -76,11 +76,13 @@ final class MainTabViewModel {
         saveInstallationDateIfNecessary()
     }
 
-    /// Get last known data from cache (if exists) and draw it on a badge
+    /// Bootstrap the data pipeline for the orders badge
+    /// Fetches the initial badge count and observes notifications requesting a refresh
+    /// The notification observed will be `ordersBadgeReloadRequired`
     ///
-    func updateBadgeFromCache() {
-        let initialCachedOrderStatus = statusResultsController?.fetchedObjects.first
-        processBadgeCount(initialCachedOrderStatus)
+    func startObservingOrdersCount() {
+        observeBadgeRefreshNotifications()
+        updateBadgeFromCache()
     }
 
     /// Loads the the hub Menu tab badge and listens to any change to update it
@@ -117,6 +119,13 @@ private extension MainTabViewModel {
 
         try? statusResultsController?.performFetch()
         updateBadgeFromCache()
+    }
+
+    /// Get last known data from cache (if exists) and draw it on a badge
+    ///
+    func updateBadgeFromCache() {
+        let initialCachedOrderStatus = statusResultsController?.fetchedObjects.first
+        processBadgeCount(initialCachedOrderStatus)
     }
 
     /// Trigger network action to update underlying cache. Badge redraw will be triggered by `statusResultsController`

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -552,7 +552,7 @@ private extension MainTabBarController {
             orderTab.badgeColor = .primary
         }
 
-        viewModel.startObservingOrdersCount()
+        viewModel.updateBadgeFromCache()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -552,7 +552,7 @@ private extension MainTabBarController {
             orderTab.badgeColor = .primary
         }
 
-        viewModel.updateBadgeFromCache()
+        viewModel.startObservingOrdersCount()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -161,8 +161,6 @@ final class OrderListViewController: UIViewController, GhostableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        viewModel.syncOrderStatuses()
-
         syncingCoordinator.resynchronize(reason: SyncReason.viewWillAppear.rawValue)
 
         // Fix any incomplete animation of the refresh control
@@ -304,7 +302,6 @@ extension OrderListViewController {
     @objc func pullToRefresh(sender: UIRefreshControl) {
         ServiceLocator.analytics.track(.ordersListPulledToRefresh)
         delegate?.orderListViewControllerWillSynchronizeOrders(self)
-        viewModel.syncOrderStatuses()
         syncingCoordinator.resynchronize(reason: SyncReason.pullToRefresh.rawValue) {
             sender.endRefreshing()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -302,6 +302,7 @@ extension OrderListViewController {
     @objc func pullToRefresh(sender: UIRefreshControl) {
         ServiceLocator.analytics.track(.ordersListPulledToRefresh)
         delegate?.orderListViewControllerWillSynchronizeOrders(self)
+        NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
         syncingCoordinator.resynchronize(reason: SyncReason.pullToRefresh.rawValue) {
             sender.endRefreshing()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -240,18 +240,6 @@ final class OrderListViewModel {
         )
     }
 
-    /// Fetch all `OrderStatus` from the API
-    ///
-    func syncOrderStatuses() {
-        let action = OrderStatusAction.retrieveOrderStatuses(siteID: siteID) { result in
-            if case let .failure(error) = result {
-                DDLogError("⛔️ Order List — Error synchronizing order statuses: \(error)")
-            }
-        }
-
-        stores.dispatch(action)
-    }
-
     func updateFilters(filters: FilterOrderListViewModel.Filters?) {
         self.filters = filters
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -102,12 +102,6 @@ final class OrdersRootViewController: UIViewController {
         }
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-
-        ServiceLocator.pushNotesManager.resetBadgeCount(type: .storeOrder)
-    }
-
     override var shouldShowOfflineBanner: Bool {
         if featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
             return false


### PR DESCRIPTION
Summary
==========
Fix issue #7383 by removing redundant Orders totals report request calls throughout the code base.

The strategy adopted here is to rely on the session restoration as the entry point for the orders badge data and leave everything else to be updated only when an event that might change the badge happens.

P2: pe5pgL-sn

How to Test
==========

## Scenario 1: Opening the app

### Before:

- Session restoration started -> Request 1: DefaultStoresManager triggers a request coming from the session restoration
- Tab view started -> Request 2: MainTabViewModel triggers a request coming from the viewWillAppear lifecycle event

Only request 1 will introduce new data to the app. Request 2 is redundant.

### Now:

- Session restoration started -> Request 1: DefaultStoresManager triggers a request coming from the session restoration

## Scenario 2: Changing stores

### Before:

- Session restoration started -> Request 1: DefaultStoresManager triggers a request coming from the session restoration
- Tab view started -> Request 2: MainTabViewModel triggers a request coming from the viewWillAppear lifecycle event
- Store switch triggers another session restoration -> Request 3: SwitchStoreUseCase triggers a badge request coming from the switchStore function call

Only request 1 will introduce new data to the app. Requests 2 and 3 are redundant.

### Now:

- Session restoration started -> Request 1: DefaultStoresManager triggers a request coming from the session restoration

## Scenario 3: Starting from My Store view to Order Details and changing an order status

### Before:

- Orders section tab clicked -> Request 1: OrdersRootViewController triggers a badge request coming from the viewWillAppear lifecycle event
- Order list view started -> Request 2: OrderListViewController triggers a badge request coming from the viewWillAppear lifecycle event
- Order status changed inside the app by the user -> Request 3: OrderDetailsViewController triggers a bade request coming from the updateOrderStatusAction

Only request 3 will introduce new data to the app. Requests 1 and 2 are redundant unless something changed from when the app started to open the list. Still, request 3 will bring the data missing here.

### Now:

- Order status changed inside the app by the user -> Request 3: OrderDetailsViewController triggers a bade request coming from the updateOrderStatusAction

## Complete use case scenario: Opening the app to change an Order Status

### Before:

- Session restoration started -> Request 1: DefaultStoresManager triggers a request coming from the session restoration
- Tab view started -> Request 2: MainTabViewModel triggers a request coming from the viewWillAppear lifecycle event
- Orders section tab clicked -> Request 3: OrdersRootViewController triggers a badge request coming from the - viewWillAppear lifecycle event
- Order list view started -> Request 4: OrderListViewController triggers a badge request coming from the viewWillAppear lifecycle event
- Order status changed inside the app by the user -> Request 5: OrderDetailsViewController triggers a bade request coming from the updateOrderStatusAction

Only requests 1 and 5 will introduce new data to the app. Requests 2, 3, and 4 are redundant.

### Now:

- Session restoration started -> Request 1: DefaultStoresManager triggers a request coming from the session restoration
- Order status changed inside the app by the user -> Request 2: OrderDetailsViewController triggers a bade request coming from the updateOrderStatusAction

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.