### PR TITLE
[Elevate] Add A/B experiment for linked products promo

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -16,6 +16,10 @@ public enum ABTest: String, CaseIterable {
     /// Experiment ref: pbxNRc-1S0-p2
     case aaTestLoggedOut202208 = "woocommerceios_explat_aa_test_logged_out_202208"
 
+    /// A/B test for promoting linked products in Product Details.
+    /// Experiment ref: pbxNRc-1Pp-p2
+    case linkedProductsPromo = "woocommerceios_product_details_linked_products_banner"
+
     /// Returns a variation for the given experiment
     public var variation: Variation {
         ExPlat.shared?.experiment(rawValue) ?? .control

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -51,8 +51,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .paymentsHubMenuSection:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .linkedProductsPromo:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .loginPrologueOnboardingSurvey:
             return true
         case .loginMagicLinkEmphasis:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -106,10 +106,6 @@ public enum FeatureFlag: Int {
     ///
     case paymentsHubMenuSection
 
-    /// Banner promoting cross-sells and upsells in product details
-    ///
-    case linkedProductsPromo
-
     /// Whether to show a survey at the end of the login onboarding screen after feature carousel
     ///
     case loginPrologueOnboardingSurvey

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -1,4 +1,5 @@
 import Yosemite
+import Experiments
 
 /// Edit actions in the product form. Each action allows the user to edit a subset of product properties.
 enum ProductFormEditAction: Equatable {
@@ -77,6 +78,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
 
         let newLinkedProductsPromoViewModel = linkedProductsPromoViewModel
         let shouldShowLinkedProductsPromo = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.linkedProductsPromo)
+        && ABTest.linkedProductsPromo.variation == .treatment(nil)
         && isLinkedProductsPromoEnabled
         && newLinkedProductsPromoViewModel.shouldBeVisible
         && product.upsellIDs.isEmpty

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -77,8 +77,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         let shouldShowDescriptionRow = editable || product.description?.isNotEmpty == true
 
         let newLinkedProductsPromoViewModel = linkedProductsPromoViewModel
-        let shouldShowLinkedProductsPromo = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.linkedProductsPromo)
-        && ABTest.linkedProductsPromo.variation == .treatment(nil)
+        let shouldShowLinkedProductsPromo = ABTest.linkedProductsPromo.variation == .treatment(nil)
         && isLinkedProductsPromoEnabled
         && newLinkedProductsPromoViewModel.shouldBeVisible
         && product.upsellIDs.isEmpty


### PR DESCRIPTION
Closes: #7375

## Description

This PR adds the A/B test for the linked product promo banner, and removes the feature flag. The banner will only be visible to users in the A/B test treatment group, and only after the A/B test is started on the backend.

## Changes

* Adds the experiment `woocommerceios_product_details_linked_products_banner` to `ABTest`.
* Removes the feature flag `linkedProductsPromo` from `FeatureFlag` and `DefaultFeatureFlagService`.
* Updates `ProductFormActionsFactory` to check that the experiment variation is `treatment` and to remove the feature flag check.

## Testing

**Prerequisite (before launching the app)**

1. Open the experiment details in Abacus (linked at the top of pbxNRc-1Pp-p2 or ping me for the direct link).
2. In the Audience section of the experiment setup, go to Variations > Manual Assignment and use the bookmarklet to assign yourself to the **control** group.

**Test the control behavior**

1. Build and run the app. **Note:** You must be logged in to the app with an a8c account to test the experiment assignment/behavior while the experiment is in staging. If you are logged in to a different account, log out and log in again with your a8c account.
2. Open a product without any linked products.
3. Update some property and tap "Save".
4. Confirm no banner appears.

**Test the treatment behavior**

1. Close the app.
2. Repeat the prerequisite steps, this time using the bookmarklet to assign yourself to the **treatment** group.
3. Run the app.
4. Open a product without any linked products.
5. Update some property and tap "Save".
6. Confirm promo banner appears.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.