### PR TITLE
Urgent: Fix adding products on orders

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -171,9 +171,9 @@ final class EditableOrderViewModel: ObservableObject {
         ProductSelectorViewModel(siteID: siteID, purchasableItemsOnly: true, storageManager: storageManager, stores: stores) { [weak self] product in
             guard let self = self else { return }
             self.addProductToOrder(product)
-        } onVariationSelected: { [weak self] variation in
+        } onVariationSelected: { [weak self] variation, parentProduct in
             guard let self = self else { return }
-            self.addProductVariationToOrder(variation)
+            self.addProductVariationToOrder(variation, parent: parentProduct)
         }
     }()
 
@@ -654,6 +654,7 @@ private extension EditableOrderViewModel {
     /// Adds a selected product (from the product list) to the order.
     ///
     func addProductToOrder(_ product: Product) {
+        // Needed because `allProducts` is only updated at start, so product from new pages are not synced.
         if !allProducts.contains(product) {
             allProducts.append(product)
         }
@@ -666,7 +667,12 @@ private extension EditableOrderViewModel {
 
     /// Adds a selected product variation (from the product list) to the order.
     ///
-    func addProductVariationToOrder(_ variation: ProductVariation) {
+    func addProductVariationToOrder(_ variation: ProductVariation, parent product: Product) {
+        // Needed because `allProducts` is only updated at start, so product from new pages are not synced.
+        if !allProducts.contains(product) {
+            allProducts.append(product)
+        }
+
         if !allProductVariations.contains(variation) {
             allProductVariations.append(variation)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -71,7 +71,7 @@ final class ProductSelectorViewModel: ObservableObject {
 
     /// Closure to be invoked when a product variation is selected
     ///
-    private let onVariationSelected: ((ProductVariation) -> Void)?
+    private let onVariationSelected: ((ProductVariation, Product) -> Void)?
 
     /// Closure to be invoked when multiple selection is completed
     ///
@@ -146,7 +146,7 @@ final class ProductSelectorViewModel: ObservableObject {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          onProductSelected: ((Product) -> Void)? = nil,
-         onVariationSelected: ((ProductVariation) -> Void)? = nil) {
+         onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
@@ -208,26 +208,35 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
     func test_selectVariation_invokes_onVariationSelected_closure_for_existing_variation() {
         // Given
         var selectedVariationID: Int64?
-        let product = Product.fake().copy(productID: sampleProductID)
+        var selectedProductID: Int64?
+
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID)
         let productVariation = sampleProductVariation.copy(productVariationID: 1)
         insert(productVariation)
+        insert(product)
+
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID,
                                                             product: product,
                                                             storageManager: storageManager,
-                                                            onVariationSelected: { selectedVariationID = $0.productVariationID })
+                                                            onVariationSelected: { variation, product in
+            selectedVariationID = variation.productVariationID
+            selectedProductID = product.productID
+        })
 
         // When
         viewModel.selectVariation(productVariation.productVariationID)
 
         // Then
         XCTAssertEqual(selectedVariationID, productVariation.productVariationID)
+        XCTAssertEqual(selectedProductID, product.productID)
     }
 
     func test_selecting_a_variation_set_its_row_to_selected() {
         // Given
-        let product = Product.fake().copy(productID: sampleProductID)
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID)
         let productVariation = sampleProductVariation.copy(productVariationID: 1)
         insert(productVariation)
+        insert(product)
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID,
                                                           product: product,
                                                           storageManager: storageManager)
@@ -243,9 +252,10 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
 
     func test_clearSelection_unselects_previously_selected_rows() {
         // Given
-        let product = Product.fake().copy(productID: sampleProductID)
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID)
         let productVariation = sampleProductVariation.copy(productVariationID: 1)
         insert(productVariation)
+        insert(product)
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID,
                                                           product: product,
                                                           storageManager: storageManager)
@@ -278,6 +288,12 @@ private extension ProductVariationSelectorViewModelTests {
             storageAttributes.append(newStorageAttribute)
         }
         productVariation.attributes = NSOrderedSet(array: storageAttributes)
+    }
+
+    /// Insert a `Product` into storage.
+    func insert(_ readOnlyProduct: Yosemite.Product) {
+        let product = storage.insertNewObject(ofType: StorageProduct.self)
+        product.update(with: readOnlyProduct)
     }
 
     /// Insert an array of `ProductVariation`s into storage

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -141,8 +141,7 @@ private extension ProductStore {
                                  excludedProductIDs: excludedProductIDs) { [weak self] result in
             switch result {
             case .success(let products):
-                //let shouldDeleteExistingProducts = pageNumber == Default.firstPageNumber
-                let shouldDeleteExistingProducts = false
+                let shouldDeleteExistingProducts = pageNumber == Default.firstPageNumber
                 self?.upsertSearchResultsInBackground(siteID: siteID,
                                                       keyword: keyword,
                                                       readOnlyProducts: products,

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -141,7 +141,8 @@ private extension ProductStore {
                                  excludedProductIDs: excludedProductIDs) { [weak self] result in
             switch result {
             case .success(let products):
-                let shouldDeleteExistingProducts = pageNumber == Default.firstPageNumber
+                //let shouldDeleteExistingProducts = pageNumber == Default.firstPageNumber
+                let shouldDeleteExistingProducts = false
                 self?.upsertSearchResultsInBackground(siteID: siteID,
                                                       keyword: keyword,
                                                       readOnlyProducts: products,


### PR DESCRIPTION
Closes: #7448

# Why 

It was [reported](https://github.com/woocommerce/woocommerce-ios/issues/7448) that a merchant had some issues when adding products to an order. 

Then, @jostnes replicated a similar issue when selecting variations after a sign-in.

After investigating, I noticed a couple of problems:

### First Problem

On order creation, products are only synced to `EditableOrderViewModel` when the view is presented, as the merchants scroll through multiple pages when selecting a product, those products are not synced internally in the `EditableOrderViewModel`. If then the merchants selected a variation, the `EditableOrderViewModel` ignores that selection because it could not find its parent product.

https://github.com/woocommerce/woocommerce-ios/blob/7c3d2d7a8e686e00a7d67a1c013db0820802123c/WooCommerce/Classes/ViewRelated/Orders/Order%20Creation/EditableOrderViewModel.swift#L309-L313

My first attempt to fix that problem was to make sure the products on `EditableOrderViewModel` were always in sync but that uncovered the second problem.


### Second Problem

It appears that recently, we introduced [some changes](https://github.com/woocommerce/woocommerce-ios/pull/6740) to add filters to our general product selector. In those changes, there is a line that clears the underlying product store when the merchant performs a search query. 

https://github.com/woocommerce/woocommerce-ios/blob/7c3d2d7a8e686e00a7d67a1c013db0820802123c/Yosemite/Yosemite/Stores/ProductStore.swift#L143-L150

This reset of products, prevents `EditableOrderViewModel` to keep all products in sync as well as creates other issues in [other parts of the app](https://github.com/woocommerce/woocommerce-ios/issues/7464).

# How

As this bug is quite critic, and I'm not able to evaluate easily what it means to revert the search/filter changes, I've opted to update the `ProductVariationSelectorViewModel` to always return the parent product together with the variation selection so the consumer(`EditableOrderViewModel`) has all the necessary dependencies that it needs.


# Testing Steps

- Do a fresh Sign in to the app
- Without going to the products tab, start the create order flow
- Search for a product variation
- Make sure the variation appears correctly on the order form.

# Demo

https://user-images.githubusercontent.com/562080/184452428-3a15357b-f853-4d1c-9c8d-fff2fd8e4d0a.mov


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
