### PR TITLE
[Mobile Payments] Pass onboarding error, to avoid another onboarding check

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -126,6 +126,8 @@ private extension InPersonPaymentsMenuViewController {
             return
         }
 
+        // Instead of using `CardPresentPaymentsOnboardingPresenter` we create the view directly because we already have the onboarding state in the use case.
+        // That way we avoid triggering the onboarding check again that comes with the presenter.
         let onboardingViewModel = InPersonPaymentsViewModel(useCase: cardPresentPaymentsOnboardingUseCase, showMenuOnCompletion: false)
         onboardingViewModel.onOnboardingCompletion = { [weak self] plugin in
             self?.refreshAfterNewOnboardingState(.completed(plugin: plugin))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -15,8 +15,6 @@ final class InPersonPaymentsMenuViewController: UIViewController {
     private let cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCase
     private var cancellables: Set<AnyCancellable> = []
 
-    private var cardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardingPresenting?
-
     /// Main TableView
     ///
     private lazy var tableView: UITableView = {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -8,6 +8,7 @@ final class InPersonPaymentsViewModel: ObservableObject {
     var learnMoreURL: URL? = nil
     let showMenuOnCompletion: Bool
     let gatewaySelectionAvailable: Bool
+    var onOnboardingCompletion: ((CardPresentPaymentsPluginState) -> ())?
     private let useCase: CardPresentPaymentsOnboardingUseCase
     let stores: StoresManager
 
@@ -29,6 +30,9 @@ final class InPersonPaymentsViewModel: ObservableObject {
             .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
             .removeDuplicates()
             .handleEvents(receiveOutput: { [weak self] result in
+                if case let .completed(plugin) = result {
+                    self?.onOnboardingCompletion?(plugin)
+                }
                 self?.updateLearnMoreURL(state: result)
             })
             .handleEvents(receiveOutput: trackState(_:))

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentsOnboardingPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentsOnboardingPresenter.swift
@@ -9,6 +9,9 @@ protocol CardPresentPaymentsOnboardingPresenting {
     func refresh()
 }
 
+/// Checks for the current user status regarding Card Present Payments,
+/// and shows the onboarding if the user didn't finish the onboarding to use CPP
+/// 
 final class CardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardingPresenting {
 
     private let stores: StoresManager


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7470 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we change the implementation so, instead of running the onboarding checks again that are performed within `CardPresentPaymentsOnboardingPresenter`, we create the onboarding view directly passing the use case that contains the current state. That way we do not show the loading screen nor do we trigger onboarding checks again.
In the same way, as we get the onboarding completed status once the onboarding is finished, we avoid calling the onboarding use case to refresh and directly display the content depending on the plugin state.
Furthermore, I added some comments that might add more light on when to use `CardPresentPaymentsOnboardingPresenter`, and why we do not do it in our case.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisites: use a store with not finished payments onboarding (e.g WooCommerce Payments deactivated)

1. Go to Menu Hub
2. Go to Payments
3. Wait until the not finished onboarding notice appears. Tap on Continue Setup
4. Notice that there is no loading screen, and no new onboarding checks are triggered.
5. Finish onboarding (e.g activate WooCommerce Payments in wp-admin)
6. It should go back to the In-Person Payments Menu Screen, and without any loading, it should show the new UI matching the onboarding state

https://user-images.githubusercontent.com/1864060/184619048-78d18781-95f3-45b0-9dcd-4fe1eb6dd60d.mp4




### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
See above


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
