### PR TITLE
Experiment – Dedicated Test Analytics suites via CI-step-time env injection, using `$(key)`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1118,7 +1118,7 @@ def inject_buildkite_analytics_environment(xctestrun_path:)
         value = ENV.fetch(key)
         next if value.nil?
 
-        target['EnvironmentVariables'][key] = value
+        target['EnvironmentVariables'][key] = "$(#{key})"
       end
     end
   end


### PR DESCRIPTION
See discussion at https://github.com/woocommerce/woocommerce-ios/pull/7467#discussion_r945566308

---

The experiment showed that the `$(key)` syntax doesn't work:

<img width="1177" alt="image" src="https://user-images.githubusercontent.com/1218433/184763386-21505f06-8244-4524-98f0-96480397b3ec.png">
