### PR TITLE
Login: improve the invalid WP.com email error screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 10.0
 -----
-
+- [*] Login: some minor enhancements are made to the error screen after entering an invalid WP.com email - a new "What is WordPress.com?" link, hiding the "Log in with store address" button when it's from the store address login flow, and some copy changes. [https://github.com/woocommerce/woocommerce-ios/pull/7485]
 
 9.9
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -81,6 +81,7 @@ public enum WooAnalyticsStat: String {
     case onePasswordSignup = "one_password_signup"
     case twoFactorCodeRequested = "two_factor_code_requested"
     case twoFactorSentSMS = "two_factor_sent_sms"
+    case whatIsWPComOnInvalidEmailScreenTapped = "what_is_wordpress_com_on_invalid_email_screen"
 
     // MARK: Dashboard View Events
     //

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -549,7 +549,7 @@ extension AuthenticationManager {
 
         switch wooAuthError {
         case .emailDoesNotMatchWPAccount, .invalidEmailFromWPComLogin, .invalidEmailFromSiteAddressLogin:
-            return NotWPAccountViewModel()
+            return NotWPAccountViewModel(error: error)
         case .notWPSite,
              .notValidAddress:
             return NotWPErrorViewModel()

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
@@ -71,7 +71,7 @@ struct JetpackErrorViewModel: ULErrorViewModel {
         analytics.track(.loginWhatIsJetpackHelpScreenViewed)
     }
 
-    func viewDidLoad() {
+    func viewDidLoad(_ viewController: UIViewController?) {
         analytics.track(.loginJetpackRequiredScreenViewed)
     }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoSecureConnectionErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoSecureConnectionErrorViewModel.swift
@@ -32,7 +32,7 @@ struct NoSecureConnectionErrorViewModel: ULErrorViewModel {
         // NO-OP
     }
 
-    func viewDidLoad() {
+    func viewDidLoad(_ viewController: UIViewController?) {
         // NO-OP
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -89,7 +89,7 @@ final class NoWooErrorViewModel: ULErrorViewModel {
         storePickerCoordinator?.start()
     }
 
-    func viewDidLoad() {
+    func viewDidLoad(_ viewController: UIViewController?) {
         analytics.track(.loginWooCommerceErrorShown)
     }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -85,19 +85,19 @@ private extension NotWPAccountViewModel {
 // MARK: - Private data structures
 private extension NotWPAccountViewModel {
     enum Localization {
-        static let errorMessage = NSLocalizedString("It looks like this email isn't associated with a WordPress.com account.",
+        static let errorMessage = NSLocalizedString("This email isn't used with a WordPress.com account.",
                                                     comment: "Message explaining that an email is not associated with a WordPress.com account. "
                                                         + "Presented when logging in with an email address that is not a WordPress.com account")
 
-        static let needHelpFindingEmail = NSLocalizedString("Need help finding the connected email?",
+        static let needHelpFindingEmail = NSLocalizedString("Need help finding the required email?",
                                                      comment: "Button linking to webview that explains what Jetpack is"
                                                         + "Presented when logging in with a site address that does not have a valid Jetpack installation")
 
-        static let primaryButtonTitle = NSLocalizedString("Enter Your Store Address",
+        static let primaryButtonTitle = NSLocalizedString("Log in with your store address",
                                                           comment: "Action button linking to instructions for enter another store."
                                                           + "Presented when logging in with an email address that is not a WordPress.com account")
 
-        static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",
+        static let secondaryButtonTitle = NSLocalizedString("Log in with another account",
                                                             comment: "Action button that will restart the login flow."
                                                             + "Presented when logging in with an email address that does not match a WordPress.com account")
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -17,10 +17,10 @@ final class NotWPAccountViewModel: ULErrorViewModel {
 
     let auxiliaryButtonTitle = AuthenticationConstants.whatIsWPComLinkTitle
 
-    let primaryButtonTitle = Localization.primaryButtonTitle
-    let isPrimaryButtonHidden: Bool
+    let primaryButtonTitle: String
 
-    let secondaryButtonTitle = Localization.secondaryButtonTitle
+    let secondaryButtonTitle = Localization.restartLogin
+    let isSecondaryButtonHidden: Bool
 
     private weak var viewController: UIViewController?
 
@@ -39,9 +39,11 @@ final class NotWPAccountViewModel: ULErrorViewModel {
         if let error = error as? SignInError,
            case let .invalidWPComEmail(source) = error,
            source == .wpComSiteAddress {
-            isPrimaryButtonHidden = true
+            isSecondaryButtonHidden = true
+            primaryButtonTitle = Localization.restartLogin
         } else {
-            isPrimaryButtonHidden = false
+            isSecondaryButtonHidden = false
+            primaryButtonTitle = Localization.loginWithSiteAddress
         }
     }
 
@@ -93,13 +95,13 @@ private extension NotWPAccountViewModel {
                                                      comment: "Button linking to webview that explains what Jetpack is"
                                                         + "Presented when logging in with a site address that does not have a valid Jetpack installation")
 
-        static let primaryButtonTitle = NSLocalizedString("Log in with your store address",
-                                                          comment: "Action button linking to instructions for enter another store."
-                                                          + "Presented when logging in with an email address that is not a WordPress.com account")
+        static let loginWithSiteAddress = NSLocalizedString("Log in with your store address",
+                                                            comment: "Action button linking to instructions for enter another store."
+                                                            + "Presented when logging in with an email address that is not a WordPress.com account")
 
-        static let secondaryButtonTitle = NSLocalizedString("Log in with another account",
-                                                            comment: "Action button that will restart the login flow."
-                                                            + "Presented when logging in with an email address that does not match a WordPress.com account")
+        static let restartLogin = NSLocalizedString("Log in with another account",
+                                                    comment: "Action button that will restart the login flow."
+                                                    + "Presented when logging in with an email address that does not match a WordPress.com account")
 
     }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPErrorViewModel.swift
@@ -35,7 +35,7 @@ struct NotWPErrorViewModel: ULErrorViewModel {
         // NO-OP
     }
 
-    func viewDidLoad() {
+    func viewDidLoad(_ viewController: UIViewController?) {
         // NO-OP
     }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -13,8 +13,8 @@ final class ULErrorViewController: UIViewController {
 
     /// Contains a vertical stack of the image, error message, and extra info button by default.
     @IBOutlet private weak var contentStackView: UIStackView!
-    @IBOutlet private weak var primaryButton: NUXButton!
-    @IBOutlet private weak var secondaryButton: NUXButton!
+    @IBOutlet private weak var primaryButton: UIButton!
+    @IBOutlet private weak var secondaryButton: UIButton!
     @IBOutlet private weak var imageView: UIImageView!
     @IBOutlet private weak var errorMessage: UILabel!
     @IBOutlet private weak var extraInfoButton: UIButton!
@@ -110,7 +110,7 @@ private extension ULErrorViewController {
     }
 
     func configurePrimaryButton() {
-        primaryButton.isPrimary = true
+        primaryButton.applyPrimaryButtonStyle()
         primaryButton.isHidden = viewModel.isPrimaryButtonHidden
         primaryButton.setTitle(viewModel.primaryButtonTitle, for: .normal)
         primaryButton.on(.touchUpInside) { [weak self] _ in
@@ -119,6 +119,8 @@ private extension ULErrorViewController {
     }
 
     func configureSecondaryButton() {
+        secondaryButton.applySecondaryButtonStyle()
+        secondaryButton.isHidden = viewModel.isSecondaryButtonHidden
         secondaryButton.setTitle(viewModel.secondaryButtonTitle, for: .normal)
         secondaryButton.on(.touchUpInside) { [weak self] _ in
             self?.didTapSecondaryButton()

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -11,6 +11,8 @@ final class ULErrorViewController: UIViewController {
     /// and support for user actions
     private let viewModel: ULErrorViewModel
 
+    /// Contains a vertical stack of the image, error message, and extra info button by default.
+    @IBOutlet private weak var contentStackView: UIStackView!
     @IBOutlet private weak var primaryButton: NUXButton!
     @IBOutlet private weak var secondaryButton: NUXButton!
     @IBOutlet private weak var imageView: UIImageView!
@@ -45,6 +47,7 @@ final class ULErrorViewController: UIViewController {
         configureImageView()
         configureErrorMessage()
         configureExtraInfoButton()
+        configureAuxiliaryView()
 
         configurePrimaryButton()
         configureSecondaryButton()
@@ -53,7 +56,7 @@ final class ULErrorViewController: UIViewController {
 
         setUnifiedMargins(forWidth: view.frame.width)
 
-        viewModel.viewDidLoad()
+        viewModel.viewDidLoad(self)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -97,6 +100,13 @@ private extension ULErrorViewController {
         extraInfoButton.on(.touchUpInside) { [weak self] _ in
             self?.didTapAuxiliaryButton()
         }
+    }
+
+    func configureAuxiliaryView() {
+        guard let auxiliaryView = viewModel.auxiliaryView else {
+            return
+        }
+        contentStackView.addArrangedSubview(auxiliaryView)
     }
 
     func configurePrimaryButton() {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
@@ -28,7 +28,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P2D-aP-RUP">
-                    <rect key="frame" x="0.0" y="44" width="414" height="658"/>
+                    <rect key="frame" x="0.0" y="44" width="414" height="692"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
                             <rect key="frame" x="34" y="0.0" width="346" height="508"/>
@@ -69,36 +69,24 @@
                     <viewLayoutGuide key="frameLayoutGuide" id="aGD-4D-8tI"/>
                 </scrollView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
-                    <rect key="frame" x="0.0" y="702" width="414" height="160"/>
+                    <rect key="frame" x="0.0" y="736" width="414" height="126"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="mhI-fa-Yzw">
-                            <rect key="frame" x="20" y="20" width="374" height="120"/>
+                            <rect key="frame" x="20" y="20" width="374" height="86"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button" customClass="NUXButton" customModule="WordPressAuthenticator">
-                                    <rect key="frame" x="0.0" y="0.0" width="374" height="50"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="50" id="Gcd-Af-CS9"/>
-                                    </constraints>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHa-is-GJK" userLabel="secondary action button">
+                                    <rect key="frame" x="0.0" y="0.0" width="374" height="33"/>
                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                     <state key="normal" title="Primary Action Button">
                                         <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </state>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                    </userDefinedRuntimeAttributes>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button" customClass="NUXButton" customModule="WordPressAuthenticator">
-                                    <rect key="frame" x="0.0" y="70" width="374" height="50"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="50" id="ju1-aE-m26"/>
-                                    </constraints>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ap-Te-Fsi" userLabel="Action Button">
+                                    <rect key="frame" x="0.0" y="53" width="374" height="33"/>
                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                     <state key="normal" title="Secondary Action Button">
                                         <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </state>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
-                                    </userDefinedRuntimeAttributes>
                                 </button>
                             </subviews>
                         </stackView>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21179.7" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21169.4"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -13,6 +13,7 @@
             <connections>
                 <outlet property="buttonViewLeadingConstraint" destination="r9Z-y5-j3W" id="bWb-vV-0U2"/>
                 <outlet property="buttonViewTrailingConstraint" destination="3Fe-tr-bmb" id="DjF-95-KFx"/>
+                <outlet property="contentStackView" destination="jIt-xb-rrN" id="peH-Jx-pst"/>
                 <outlet property="errorMessage" destination="a2d-le-aKc" id="YgT-Ex-Gwh"/>
                 <outlet property="extraInfoButton" destination="GOR-hg-dbC" id="I7z-hN-FAo"/>
                 <outlet property="imageView" destination="Osv-Wo-lxW" id="yIN-vL-DOA"/>
@@ -71,20 +72,20 @@
                     </constraints>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                    <rect key="frame" x="34" y="268" width="346" height="330.5"/>
+                    <rect key="frame" x="34" y="240" width="346" height="386.5"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="woo-no-jetpack-error" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
-                            <rect key="frame" x="32.5" y="0.0" width="281" height="150"/>
+                            <rect key="frame" x="55" y="0.0" width="236" height="206"/>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2d-le-aKc">
-                            <rect key="frame" x="0.0" y="182" width="346" height="86.5"/>
+                            <rect key="frame" x="0.0" y="238" width="346" height="86.5"/>
                             <string key="text">Qui eum est quo et recusandae ut. Hic cupiditate nobis et pariatur quidem dolorum. Doloribus est tempora ipsam eius. Quos ab et aspernatur velit corporis aut rem.</string>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <color key="textColor" systemColor="secondaryLabelColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GOR-hg-dbC" userLabel="Action Button">
-                            <rect key="frame" x="59" y="300.5" width="228" height="30"/>
+                            <rect key="frame" x="59" y="356.5" width="228" height="30"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="228" id="Dh0-gH-21U"/>
                             </constraints>
@@ -108,7 +109,7 @@
         </view>
     </objects>
     <resources>
-        <image name="woo-no-jetpack-error" width="281" height="150"/>
+        <image name="woo-no-jetpack-error" width="236" height="206"/>
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.xib
@@ -19,8 +19,6 @@
                 <outlet property="imageView" destination="Osv-Wo-lxW" id="yIN-vL-DOA"/>
                 <outlet property="primaryButton" destination="ZHa-is-GJK" id="wzn-TJ-1Sm"/>
                 <outlet property="secondaryButton" destination="9Ap-Te-Fsi" id="07U-PT-JrQ"/>
-                <outlet property="stackViewLeadingConstraint" destination="jMe-jj-6Bt" id="JnU-my-QgI"/>
-                <outlet property="stackViewTrailingConstraint" destination="Z7E-hC-lbB" id="RHp-Ac-R58"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -29,6 +27,47 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P2D-aP-RUP">
+                    <rect key="frame" x="0.0" y="44" width="414" height="658"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
+                            <rect key="frame" x="34" y="0.0" width="346" height="508"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="B4M-dS-aoc">
+                                    <rect key="frame" x="53" y="0.0" width="240" height="89.5"/>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </view>
+                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" image="woo-no-jetpack-error" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
+                                    <rect key="frame" x="55" y="121.5" width="236" height="206"/>
+                                </imageView>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2d-le-aKc">
+                                    <rect key="frame" x="0.0" y="359.5" width="346" height="86.5"/>
+                                    <string key="text">Qui eum est quo et recusandae ut. Hic cupiditate nobis et pariatur quidem dolorum. Doloribus est tempora ipsam eius. Quos ab et aspernatur velit corporis aut rem.</string>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                    <color key="textColor" systemColor="secondaryLabelColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GOR-hg-dbC" userLabel="Action Button">
+                                    <rect key="frame" x="59" y="478" width="228" height="30"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="228" id="Dh0-gH-21U"/>
+                                    </constraints>
+                                    <state key="normal" title="Action Button"/>
+                                </button>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="8" placeholder="YES" id="5Uu-E7-hKF"/>
+                        <constraint firstAttribute="trailing" secondItem="jIt-xb-rrN" secondAttribute="trailing" constant="34" id="Pk3-Sh-ehv"/>
+                        <constraint firstItem="jIt-xb-rrN" firstAttribute="top" secondItem="P2D-aP-RUP" secondAttribute="top" id="YJQ-Cw-Xod"/>
+                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="jIt-xb-rrN" secondAttribute="bottom" constant="8" id="fpv-AM-a0m"/>
+                        <constraint firstItem="jIt-xb-rrN" firstAttribute="width" secondItem="P2D-aP-RUP" secondAttribute="width" constant="-68" id="hZF-94-MxE"/>
+                        <constraint firstItem="jIt-xb-rrN" firstAttribute="leading" secondItem="P2D-aP-RUP" secondAttribute="leading" constant="34" id="szV-S7-ERd"/>
+                    </constraints>
+                    <viewLayoutGuide key="contentLayoutGuide" id="iXe-gP-Rb6"/>
+                    <viewLayoutGuide key="frameLayoutGuide" id="aGD-4D-8tI"/>
+                </scrollView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="10Z-y1-ZQ6" userLabel="Action Background View">
                     <rect key="frame" x="0.0" y="702" width="414" height="160"/>
                     <subviews>
@@ -71,37 +110,16 @@
                         <constraint firstItem="mhI-fa-Yzw" firstAttribute="leading" secondItem="10Z-y1-ZQ6" secondAttribute="leading" constant="20" id="vz3-FU-z4g"/>
                     </constraints>
                 </view>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="jIt-xb-rrN">
-                    <rect key="frame" x="34" y="240" width="346" height="386.5"/>
-                    <subviews>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="woo-no-jetpack-error" translatesAutoresizingMaskIntoConstraints="NO" id="Osv-Wo-lxW">
-                            <rect key="frame" x="55" y="0.0" width="236" height="206"/>
-                        </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2d-le-aKc">
-                            <rect key="frame" x="0.0" y="238" width="346" height="86.5"/>
-                            <string key="text">Qui eum est quo et recusandae ut. Hic cupiditate nobis et pariatur quidem dolorum. Doloribus est tempora ipsam eius. Quos ab et aspernatur velit corporis aut rem.</string>
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                            <color key="textColor" systemColor="secondaryLabelColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GOR-hg-dbC" userLabel="Action Button">
-                            <rect key="frame" x="59" y="356.5" width="228" height="30"/>
-                            <constraints>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="228" id="Dh0-gH-21U"/>
-                            </constraints>
-                            <state key="normal" title="Action Button"/>
-                        </button>
-                    </subviews>
-                </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="10Z-y1-ZQ6" secondAttribute="trailing" id="3Fe-tr-bmb"/>
-                <constraint firstItem="jIt-xb-rrN" firstAttribute="top" relation="greaterThanOrEqual" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="8" id="4vu-ll-3S2"/>
-                <constraint firstAttribute="trailing" secondItem="jIt-xb-rrN" secondAttribute="trailing" constant="34" id="Z7E-hC-lbB"/>
-                <constraint firstItem="jIt-xb-rrN" firstAttribute="centerY" secondItem="fnl-2z-Ty3" secondAttribute="centerY" constant="-20" id="ZZg-jd-e4d"/>
-                <constraint firstItem="jIt-xb-rrN" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="34" id="jMe-jj-6Bt"/>
+                <constraint firstItem="P2D-aP-RUP" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="9WK-tc-r1t"/>
+                <constraint firstItem="10Z-y1-ZQ6" firstAttribute="top" secondItem="P2D-aP-RUP" secondAttribute="bottom" id="J2T-Ss-cY5"/>
+                <constraint firstItem="P2D-aP-RUP" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="PWn-7R-2S4"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="P2D-aP-RUP" secondAttribute="trailing" id="RpQ-MV-UNb"/>
+                <constraint firstItem="B4M-dS-aoc" firstAttribute="height" secondItem="i5M-Pr-FkT" secondAttribute="height" multiplier="0.1" id="dH0-d3-ijp"/>
                 <constraint firstItem="10Z-y1-ZQ6" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="r9Z-y5-j3W"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="10Z-y1-ZQ6" secondAttribute="bottom" id="rPP-rT-zVR"/>
             </constraints>

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewModel.swift
@@ -27,6 +27,9 @@ protocol ULErrorViewModel {
     /// Provides a title for a secondary action button
     var secondaryButtonTitle: String { get }
 
+    /// Indicates whether the secondary button is visible
+    var isSecondaryButtonHidden: Bool { get }
+
     /// Additional view to the bottom of the vertical stack view that contains the image, text, and auxiliary button.
     var auxiliaryView: UIView? { get }
 
@@ -52,6 +55,8 @@ extension ULErrorViewModel {
     var title: String? { nil }
 
     var isPrimaryButtonHidden: Bool { false }
+
+    var isSecondaryButtonHidden: Bool { false }
 
     var auxiliaryView: UIView? { nil }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewModel.swift
@@ -27,8 +27,12 @@ protocol ULErrorViewModel {
     /// Provides a title for a secondary action button
     var secondaryButtonTitle: String { get }
 
+    /// Additional view to the bottom of the vertical stack view that contains the image, text, and auxiliary button.
+    var auxiliaryView: UIView? { get }
+
     /// Executed by the view controller when its view was loaded.
-    func viewDidLoad()
+    /// - Parameter viewController: the view controller that loads the view.
+    func viewDidLoad(_ viewController: UIViewController?)
 
     /// Executes action associated to a tap in the view controller primary button
     /// - Parameter viewController: usually the view controller sending the tap
@@ -48,4 +52,6 @@ extension ULErrorViewModel {
     var title: String? { nil }
 
     var isPrimaryButtonHidden: Bool { false }
+
+    var auxiliaryView: UIView? { nil }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/JetpackErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/JetpackErrorViewModelTests.swift
@@ -82,7 +82,7 @@ final class JetpackErrorViewModelTests: XCTestCase {
         assertEmpty(analyticsProvider.receivedEvents)
 
         // When
-        viewModel.viewDidLoad()
+        viewModel.viewDidLoad(nil)
 
         // Then
         let firstEvent = try XCTUnwrap(analyticsProvider.receivedEvents.first)

--- a/WooCommerce/WooCommerceTests/Authentication/NoWooErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NoWooErrorViewModelTests.swift
@@ -153,7 +153,7 @@ final class NoWooErrorViewModelTests: XCTestCase {
                                             onSetupCompletion: { _ in })
 
         // When
-        viewModel.viewDidLoad()
+        viewModel.viewDidLoad(nil)
 
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_woocommerce_error_shown" }))

--- a/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
@@ -57,28 +57,52 @@ final class NotWPAccountViewModelTests: XCTestCase {
         let primaryButtonTitle = viewModel.primaryButtonTitle
 
         // Then
-        XCTAssertEqual(primaryButtonTitle, Expectations.primaryButtonTitle)
+        XCTAssertEqual(primaryButtonTitle, Expectations.loginWithSiteAddressTitle)
     }
 
-    // MARK: - `isPrimaryButtonHidden`
+    // MARK: - `primaryButtonTitle`
 
-    func test_viewmodel_primary_button_is_hidden_for_invalidWPComEmail_from_site_address_error() {
+    func test_primary_button_title_is_restart_login_for_invalidWPComEmail_from_site_address_error() {
         // Given
         let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpComSiteAddress))
 
         // When
-        let isPrimaryButtonHidden = viewModel.isPrimaryButtonHidden
+        let primaryButtonTitle = viewModel.primaryButtonTitle
+
+        // Then
+        XCTAssertEqual(primaryButtonTitle, Expectations.restartLoginTitle)
+    }
+
+    func test_primary_button_title_is_login_with_site_address_for_invalidWPComEmail_from_wpCom_error() {
+        // Given
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom))
+
+        // When
+        let primaryButtonTitle = viewModel.primaryButtonTitle
+
+        // Then
+        XCTAssertEqual(primaryButtonTitle, Expectations.loginWithSiteAddressTitle)
+    }
+
+    // MARK: - `isSecondaryButtonHidden`
+
+    func test_secondary_button_is_hidden_for_invalidWPComEmail_from_site_address_error() {
+        // Given
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpComSiteAddress))
+
+        // When
+        let isPrimaryButtonHidden = viewModel.isSecondaryButtonHidden
 
         // Then
         XCTAssertTrue(isPrimaryButtonHidden)
     }
 
-    func test_viewmodel_primary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error() {
+    func test_secondary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error() {
         // Given
         let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom))
 
         // When
-        let isPrimaryButtonHidden = viewModel.isPrimaryButtonHidden
+        let isPrimaryButtonHidden = viewModel.isSecondaryButtonHidden
 
         // Then
         XCTAssertFalse(isPrimaryButtonHidden)
@@ -94,7 +118,7 @@ final class NotWPAccountViewModelTests: XCTestCase {
         let secondaryButtonTitle = viewModel.secondaryButtonTitle
 
         // Then
-        XCTAssertEqual(secondaryButtonTitle, Expectations.secondaryButtonTitle)
+        XCTAssertEqual(secondaryButtonTitle, Expectations.restartLoginTitle)
     }
 }
 
@@ -106,13 +130,13 @@ private extension NotWPAccountViewModelTests {
                                                     comment: "Message explaining that an email is not associated with a WordPress.com account. "
                                                         + "Presented when logging in with an email address that is not a WordPress.com account")
 
-        static let primaryButtonTitle = NSLocalizedString("Log in with your store address",
-                                                          comment: "Action button linking to instructions for enter another store."
-                                                          + "Presented when logging in with an email address that is not a WordPress.com account")
+        static let loginWithSiteAddressTitle = NSLocalizedString("Log in with your store address",
+                                                                 comment: "Action button linking to instructions for enter another store."
+                                                                 + "Presented when logging in with an email address that is not a WordPress.com account")
 
-        static let secondaryButtonTitle = NSLocalizedString("Log in with another account",
-                                                            comment: "Action button that will restart the login flow."
-                                                            + "Presented when logging in with an email address that does not match a WordPress.com account")
+        static let restartLoginTitle = NSLocalizedString("Log in with another account",
+                                                         comment: "Action button that will restart the login flow."
+                                                         + "Presented when logging in with an email address that does not match a WordPress.com account")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import enum WordPressAuthenticator.SignInError
 @testable import WooCommerce
 
 final class NotWPAccountViewModelTests: XCTestCase {
@@ -45,7 +46,7 @@ final class NotWPAccountViewModelTests: XCTestCase {
         let auxiliaryButtonTitle = viewModel.auxiliaryButtonTitle
 
         // Then
-        XCTAssertEqual(auxiliaryButtonTitle, Expectations.needHelpFindingEmail)
+        XCTAssertEqual(auxiliaryButtonTitle, AuthenticationConstants.whatIsWPComLinkTitle)
     }
 
     func test_viewmodel_provides_expected_title_for_primary_button() {
@@ -58,6 +59,32 @@ final class NotWPAccountViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(primaryButtonTitle, Expectations.primaryButtonTitle)
     }
+
+    // MARK: - `isPrimaryButtonHidden`
+
+    func test_viewmodel_primary_button_is_hidden_for_invalidWPComEmail_from_site_address_error() {
+        // Given
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpComSiteAddress))
+
+        // When
+        let isPrimaryButtonHidden = viewModel.isPrimaryButtonHidden
+
+        // Then
+        XCTAssertTrue(isPrimaryButtonHidden)
+    }
+
+    func test_viewmodel_primary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error() {
+        // Given
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom))
+
+        // When
+        let isPrimaryButtonHidden = viewModel.isPrimaryButtonHidden
+
+        // Then
+        XCTAssertFalse(isPrimaryButtonHidden)
+    }
+
+    // MARK: - `secondaryButtonTitle`
 
     func test_viewmodel_provides_expected_title_for_secondary_button() {
         // Given
@@ -79,10 +106,6 @@ private extension NotWPAccountViewModelTests {
                                                     comment: "Message explaining that an email is not associated with a WordPress.com account. "
                                                         + "Presented when logging in with an email address that is not a WordPress.com account")
 
-        static let needHelpFindingEmail = NSLocalizedString("Need help finding the connected email?",
-                                                     comment: "Button linking to webview that explains what Jetpack is"
-                                                        + "Presented when logging in with a site address that does not have a valid Jetpack installation")
-
         static let primaryButtonTitle = NSLocalizedString("Enter Your Store Address",
                                                           comment: "Action button linking to instructions for enter another store."
                                                           + "Presented when logging in with an email address that is not a WordPress.com account")
@@ -90,5 +113,11 @@ private extension NotWPAccountViewModelTests {
         static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",
                                                             comment: "Action button that will restart the login flow."
                                                             + "Presented when logging in with an email address that does not match a WordPress.com account")
+    }
+}
+
+private extension NotWPAccountViewModel {
+    convenience init() {
+        self.init(error: SignInError.invalidWPComEmail(source: .wpCom))
     }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
@@ -102,15 +102,15 @@ final class NotWPAccountViewModelTests: XCTestCase {
 private extension NotWPAccountViewModelTests {
     private enum Expectations {
         static let image = UIImage.loginNoWordPressError
-        static let errorMessage = NSLocalizedString("It looks like this email isn't associated with a WordPress.com account.",
+        static let errorMessage = NSLocalizedString("This email isn't used with a WordPress.com account.",
                                                     comment: "Message explaining that an email is not associated with a WordPress.com account. "
                                                         + "Presented when logging in with an email address that is not a WordPress.com account")
 
-        static let primaryButtonTitle = NSLocalizedString("Enter Your Store Address",
+        static let primaryButtonTitle = NSLocalizedString("Log in with your store address",
                                                           comment: "Action button linking to instructions for enter another store."
                                                           + "Presented when logging in with an email address that is not a WordPress.com account")
 
-        static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",
+        static let secondaryButtonTitle = NSLocalizedString("Log in with another account",
                                                             comment: "Action button that will restart the login flow."
                                                             + "Presented when logging in with an email address that does not match a WordPress.com account")
     }

--- a/WooCommerce/WooCommerceTests/Authentication/ULErrorViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/ULErrorViewControllerTests.swift
@@ -199,7 +199,7 @@ private final class ErrorViewModel: ULErrorViewModel {
         auxiliaryButtonTapped = true
     }
 
-    func viewDidLoad() {
+    func viewDidLoad(_ viewController: UIViewController?) {
         viewDidLoadTriggered = true
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7483 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR follows the Android changes to improve the existing invalid WP.com email error screen. The main changes are:

- The "Enter Your Store Address" button is hidden when the merchant starts from the login with store address flow
- Added a "What is WordPress.com" button similar to other places on the login flow
  - The existing `ULErrorViewController` does not support additional views below the current UI. In order to make it more flexible for any other customizations, I added an outlet for the content stack view and an optional `auxiliaryView: View?` in the ULError view model. `NotWPAccountViewModel` then configures a `UIButton` for the pre-existing CTA to find the email
  - A new optional view controller parameter is passed to `ULErrorViewModel.viewDidLoad` call because the button handlers often need the view controller to present other UI. This isn't a very ideal, please feel free to suggest other ways that work with the current ULError screen technical design
  - A click event is tracked `what_is_wordpress_com_on_invalid_email_screen`, it's slightly different from Android because this screen is inside the WPAuthenticator and click events are embedded in `unified_login_interaction`
- [Copy changes ](https://github.com/woocommerce/woocommerce-android/pull/7163)

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Login with WP.com

- Launch the app
- Log out if needed, and skip onboarding if needed
- Tap "Continue With WordPress.com"
- Enter an invalid WP.com email and tap "Continue" --> an error screen should be shown with a "What is WordPress.com?" link above the "Need help finding the required email?" link. There should be a "Log in with store address" at the bottom above the "Log in with another account" CTA
- Tap on "What is WordPress.com?" CTA --> a webview about WP.com should be shown
- Navigate back and tap on "Need help finding the required email?" CTA --> an alert should be shown as before

#### Login with site address

- Launch the app
- Log out if needed, and skip onboarding if needed
- Tap "Enter Your Store Address"
- Enter an invalid WP.com email and tap "Continue" --> an error screen should be shown with a "What is WordPress.com?" link above the "Need help finding the required email?" link. There should **not** be a "Log in with store address" at the bottom above the "Log in with another account" CTA

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

\ | light | dark
-- | -- | --
login with WP.com | ![Simulator Screen Shot - iPhone 13 - 2022-08-16 at 11 23 07](https://user-images.githubusercontent.com/1945542/184791624-044d71dc-0daf-4d76-bab8-edc9a8f64f68.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-16 at 11 23 46](https://user-images.githubusercontent.com/1945542/184791628-919d96fb-4920-4c0e-aa6c-a978764c1ceb.png)
login with store address | ![Simulator Screen Shot - iPhone 13 - 2022-08-16 at 11 24 37](https://user-images.githubusercontent.com/1945542/184791630-6b473e84-0a64-45c2-a640-5872dd89241b.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-16 at 11 24 45](https://user-images.githubusercontent.com/1945542/184791631-a660fc13-0bac-4bda-9952-d5ae90c3ef73.png)


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
