### PR TITLE
Use dedicated Test Analytics suites for unit, UI iOS, and UI iPadOS tests.

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -6,6 +6,14 @@ IOS_VERSION=$3
 
 echo "Running $TEST_NAME on $DEVICE for iOS $IOS_VERSION"
 
+# Run this at the start to fail early if value not available
+echo '--- :test-analytics: Configuring Test Analytics'
+if [[ $DEVICE =~ ^iPhone ]]; then
+  export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPHONE
+else
+  export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPAD
+fi
+
 # Workaround for https://github.com/Automattic/buildkite-ci/issues/79
 echo "--- :rubygems: Fixing Ruby Setup"
 gem install bundler

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+# Run this at the start to fail early if value not available
+echo '--- :test-analytics: Configuring Test Analytics'
+export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS
+
 echo "--- 📦 Downloading Build Artifacts"
 buildkite-agent artifact download build-products.tar .
 tar -xf build-products.tar

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,9 @@ Metrics/BlockLength:
   Exclude:
     - fastlane/Fastfile
 
+Metrics/MethodLength:
+  Max: 20
+
 Style/AsciiComments:
   Exclude:
     - fastlane/Fastfile

--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/buildkite/test-collector-swift",
         "state": {
           "branch": null,
-          "revision": "87afcecfb58dd017d6e835ec8e88e9eaa18095ba",
-          "version": "0.1.1"
+          "revision": "77c7f492f5c1c9ca159f73d18f56bbd1186390b0",
+          "version": "0.3.0"
         }
       },
       {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2488,6 +2488,7 @@
 		31FE28C125E6D338003519F2 /* LearnMoreTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreTableViewCell.swift; sourceTree = "<group>"; };
 		31FE28C725E6D384003519F2 /* LearnMoreTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LearnMoreTableViewCell.xib; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
+		3F271A9728A2684400E656AE /* UITests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = "<group>"; };
 		3F58701E281B947E004F7556 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		3F587020281B9494004F7556 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		3F587027281B9C19004F7556 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -3192,7 +3193,6 @@
 		CCDC49CE23FFFFF4003166BA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CCDC49EC24000533003166BA /* TestCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCredentials.swift; sourceTree = "<group>"; };
 		CCDC49F1240060F3003166BA /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UnitTests.xctestplan; path = WooCommerceTests/UnitTests.xctestplan; sourceTree = SOURCE_ROOT; };
-		CCDC49F224006130003166BA /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UITests.xctestplan; path = WooCommerceUITests/UITests.xctestplan; sourceTree = SOURCE_ROOT; };
 		CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
 		CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsTopBanner.swift; sourceTree = "<group>"; };
 		CCEC256927B581E800EF9FA3 /* ProductVariationFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormatter.swift; sourceTree = "<group>"; };
@@ -6987,8 +6987,8 @@
 		CCDC49CB23FFFFF4003166BA /* WooCommerceUITests */ = {
 			isa = PBXGroup;
 			children = (
+				3F271A9728A2684400E656AE /* UITests.xctestplan */,
 				800A5B9C275623E9009DE2CD /* Flows */,
-				CCDC49F224006130003166BA /* UITests.xctestplan */,
 				CCDC49D9240000B7003166BA /* Tests */,
 				CCFC00B623E9BD5500157A78 /* Mocks */,
 				CCDC49D8240000A5003166BA /* Utils */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -11321,7 +11321,7 @@
 			repositoryURL = "https://github.com/buildkite/test-collector-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.1;
+				minimumVersion = 0.3.0;
 			};
 		};
 		3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */ = {

--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -17,38 +17,7 @@
       }
     ],
     "environmentVariableEntries" : [
-      {
-        "key" : "BUILDKITE_ANALYTICS_TOKEN",
-        "value" : "$(BUILDKITE_ANALYTICS_TOKEN)"
-      },
-      {
-        "key" : "BUILDKITE_BRANCH",
-        "value" : "$(BUILDKITE_BRANCH)"
-      },
-      {
-        "key" : "BUILDKITE_BUILD_ID",
-        "value" : "$(BUILDKITE_BUILD_ID)"
-      },
-      {
-        "key" : "BUILDKITE_BUILD_NUMBER",
-        "value" : "$(BUILDKITE_BUILD_NUMBER)"
-      },
-      {
-        "key" : "BUILDKITE_BUILD_URL",
-        "value" : "$(BUILDKITE_BUILD_URL)"
-      },
-      {
-        "key" : "BUILDKITE_COMMIT",
-        "value" : "$(BUILDKITE_COMMIT)"
-      },
-      {
-        "key" : "BUILDKITE_JOB_ID",
-        "value" : "$(BUILDKITE_JOB_ID)"
-      },
-      {
-        "key" : "BUILDKITE_MESSAGE",
-        "value" : "$(BUILDKITE_MESSAGE)"
-      }
+
     ],
     "language" : "en",
     "region" : "US",

--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -4,44 +4,20 @@
       "id" : "DA512AA1-66D1-4829-BC02-EEFD0E226DE7",
       "name" : "Configuration 1",
       "options" : {
+        "environmentVariableEntries" : [
 
+        ],
+        "targetForVariableExpansion" : {
+          "containerPath" : "container:WooCommerce.xcodeproj",
+          "identifier" : "B56DB3C52049BFAA00D4AA8E",
+          "name" : "WooCommerce"
+        }
       }
     }
   ],
   "defaultOptions" : {
     "environmentVariableEntries" : [
-      {
-        "key" : "BUILDKITE_ANALYTICS_TOKEN",
-        "value" : "$BUILDKITE_ANALYTICS_TOKEN"
-      },
-      {
-        "key" : "BUILDKITE_BRANCH",
-        "value" : "$(BUILDKITE_BRANCH)"
-      },
-      {
-        "key" : "BUILDKITE_BUILD_ID",
-        "value" : "$(BUILDKITE_BUILD_ID)"
-      },
-      {
-        "key" : "BUILDKITE_BUILD_NUMBER",
-        "value" : "$(BUILDKITE_BUILD_NUMBER)"
-      },
-      {
-        "key" : "BUILDKITE_BUILD_URL",
-        "value" : "$(BUILDKITE_BUILD_URL)"
-      },
-      {
-        "key" : "BUILDKITE_COMMIT",
-        "value" : "$(BUILDKITE_COMMIT)"
-      },
-      {
-        "key" : "BUILDKITE_JOB_ID",
-        "value" : "$(BUILDKITE_JOB_ID)"
-      },
-      {
-        "key" : "BUILDKITE_MESSAGE",
-        "value" : "$(BUILDKITE_MESSAGE)"
-      }
+
     ],
     "testRepetitionMode" : "retryOnFailure"
   },

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,6 +28,8 @@ SCREENSHOT_DEVICES = [
 MAIN_BUNDLE_IDENTIFIERS = %w[com.automattic.woocommerce].freeze        # Registered in our main account, for development and AppStore
 ALPHA_BUNDLE_IDENTIFIERS = %w[com.automattic.alpha.woocommerce].freeze # Registered in our Enterprise account, for App Center / Installable Builds
 
+TEST_SCHEME = 'WooCommerce'
+
 # List of `.strings` files manually maintained by developers (as opposed to being automatically extracted from the code)
 # which we will merge into the main `Localizable.strings` file imported by GlotPress, then extract back once we download the translations.
 #
@@ -556,7 +558,7 @@ platform :ios do
   lane :build_for_testing do |options|
     run_tests(
       workspace: 'WooCommerce.xcworkspace',
-      scheme: 'WooCommerce',
+      scheme: TEST_SCHEME,
       derived_data_path: 'DerivedData',
       build_for_testing: true,
       device: options[:device],
@@ -1046,7 +1048,7 @@ lane :test_without_building do |options|
 
   run_tests(
     workspace: 'WooCommerce.xcworkspace',
-    scheme: 'WooCommerce',
+    scheme: TEST_SCHEME,
     device: options[:device],
     deployment_target_version: options[:ios_version],
     test_without_building: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1105,3 +1105,37 @@ def trigger_buildkite_release_build(branch:, beta:)
     pipeline_file: 'release-builds.yml'
   )
 end
+
+def inject_buildkite_analytics_environment(xctestrun_path:)
+  require 'plist'
+
+  xctestrun = Plist.parse_xml(xctestrun_path)
+  xctestrun['TestConfigurations'].each do |configuration|
+    configuration['TestTargets'].each do |target|
+      TEST_ANALYTICS_ENVIRONMENT.each do |key|
+        value = ENV.fetch(key)
+        next if value.nil?
+
+        target['EnvironmentVariables'][key] = value
+      end
+    end
+  end
+
+  File.write(xctestrun_path, Plist::Emit.dump(xctestrun))
+end
+
+def buildkite_ci?
+  ENV.fetch('BUILDKITE', false)
+end
+
+# https://buildkite.com/docs/test-analytics/ci-environments
+TEST_ANALYTICS_ENVIRONMENT = %w[
+  BUILDKITE_ANALYTICS_TOKEN
+  BUILDKITE_BUILD_ID
+  BUILDKITE_BUILD_NUMBER
+  BUILDKITE_JOB_ID
+  BUILDKITE_BRANCH
+  BUILDKITE_COMMIT
+  BUILDKITE_MESSAGE
+  BUILDKITE_BUILD_URL
+].freeze

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1044,7 +1044,9 @@ lane :test_without_building do |options|
     e.include?(options[:name])
   end.first
 
-  UI.user_error!('Unable to find .xctestrun file') unless !xctestrun_path.nil? && File.exist?((xctestrun_path))
+  unless !xctestrun_path.nil? && File.exist?((xctestrun_path))
+    UI.user_error!("Unable to find .xctestrun file at #{xctestrun_path}")
+  end
 
   run_tests(
     workspace: 'WooCommerce.xcworkspace',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1048,6 +1048,8 @@ lane :test_without_building do |options|
     UI.user_error!("Unable to find .xctestrun file at #{xctestrun_path}")
   end
 
+  inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
+
   run_tests(
     workspace: 'WooCommerce.xcworkspace',
     scheme: TEST_SCHEME,


### PR DESCRIPTION
### Description
Supersedes https://github.com/woocommerce/woocommerce-ios/pull/7163, https://github.com/woocommerce/woocommerce-ios/pull/7282, and #7415. Based on the discussion in [here](https://github.com/woocommerce/woocommerce-ios/pull/7415#issuecomment-1212653113) and the [here](https://github.com/woocommerce/woocommerce-ios/pull/7467)

- Inject Test Analytics environment variables via Fastlane in CI, so we don't need to jump through configuration hoops via Xcode and we have a single source of truth for the values.
- From Buildkite, make user the token for the current suite is exported as `BUILDKITE_ANALYTICS_TOKEN`, so Fastlane can inject it. _I suppose this could have been done via Fastlane, too, but it felt more appropriate to manage those tokens in CI, because that's where they are available via `mobile-secrets/CI/...`_.
- Remove now redundant env var declarations in the `xctestplan` files, so we don't need to maintain duplicated versions of them.

### Testing instructions

If CI reports in all three suites, we're good.

<img width="1180" alt="image" src="https://user-images.githubusercontent.com/1218433/184803877-368522af-9c3d-4ae8-9860-6cde7179e43b.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – N.A.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
