### PR TITLE
[Mobile Payments] Moooore IPP: Prevent cell selection when it is disabled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -216,7 +216,7 @@ private extension InPersonPaymentsMenuViewController {
         let cellShouldBeEnabled = cardPresentPaymentsOnboardingUseCase.state.isCompleted
         cell.imageView?.tintColor = .text
         cell.accessoryType = cellShouldBeEnabled ? .disclosureIndicator : .none
-        cell.selectionStyle = .default
+        cell.selectionStyle = cellShouldBeEnabled ? .default : .none
         cell.configure(image: .creditCardIcon, text: Localization.manageCardReader)
 
         updateEnabledState(in: cell, shouldBeEnabled: cellShouldBeEnabled)
@@ -273,6 +273,10 @@ extension InPersonPaymentsMenuViewController {
     }
 
     func manageCardReaderWasPressed() {
+        guard cardPresentPaymentsOnboardingUseCase.state.isCompleted else {
+            return
+        }
+        
         ServiceLocator.analytics.track(.paymentsMenuManageCardReadersTapped)
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsPresentingViewController.self) else {
             fatalError("Cannot instantiate `CardReaderSettingsPresentingViewController` from Dashboard storyboard")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -276,7 +276,7 @@ extension InPersonPaymentsMenuViewController {
         guard cardPresentPaymentsOnboardingUseCase.state.isCompleted else {
             return
         }
-        
+
         ServiceLocator.analytics.track(.paymentsMenuManageCardReadersTapped)
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: CardReaderSettingsPresentingViewController.self) else {
             fatalError("Cannot instantiate `CardReaderSettingsPresentingViewController` from Dashboard storyboard")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7486
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When the user has not yet completed the card present payment onboarding we want to disable the Manage Card Reader cell  by greying it out and preventing its selection. With this PR we prevent the selection by:

- Setting the selection style to none so there is no UI effect when tapped.
- Checking if the user completed the onboarding before opening the manager card reader screen.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisites: A store without the onboarding finished

1. Go to Menu
2. Tap on Payments
3. Wait until the onboarding background check finishes
4. Manage Card Reader should be greyed out
5. Tapping on it has no effect

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/1864060/184835686-9780517c-c639-43f7-bc67-1d5ecfc67a11.png" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
