### PR TITLE
[Mobile Payments] Cash on Delivery onboarding UI

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -55,6 +55,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .loginMagicLinkEmphasis:
             return true
+        case .promptToEnableCodInIppOnboarding:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -113,4 +113,8 @@ public enum FeatureFlag: Int {
     /// Whether to prefer magic link to password in the login flow
     ///
     case loginMagicLinkEmphasis
+
+    /// Whether to include the Cash on Delivery enable step in In-Person Payment onboarding
+    ///
+    case promptToEnableCodInIppOnboarding
 }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -117,7 +117,7 @@ public enum FeatureFlag: Int {
     /// Whether to show the magic link as a secondary button instead of a table view cell on the password screen
     ///
     case loginMagicLinkEmphasisM2
-    
+
     /// Whether to include the Cash on Delivery enable step in In-Person Payment onboarding
     ///
     case promptToEnableCodInIppOnboarding

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -658,6 +658,33 @@ extension OrderTaxLine {
     }
 }
 
+extension PaymentGateway {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        gatewayID: CopiableProp<String> = .copy,
+        title: CopiableProp<String> = .copy,
+        description: CopiableProp<String> = .copy,
+        enabled: CopiableProp<Bool> = .copy,
+        features: CopiableProp<[PaymentGateway.Feature]> = .copy
+    ) -> PaymentGateway {
+        let siteID = siteID ?? self.siteID
+        let gatewayID = gatewayID ?? self.gatewayID
+        let title = title ?? self.title
+        let description = description ?? self.description
+        let enabled = enabled ?? self.enabled
+        let features = features ?? self.features
+
+        return PaymentGateway(
+            siteID: siteID,
+            gatewayID: gatewayID,
+            title: title,
+            description: description,
+            enabled: enabled,
+            features: features
+        )
+    }
+}
+
 extension PaymentGatewayAccount {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/PaymentGateway.swift
+++ b/Networking/Networking/Model/PaymentGateway.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a Payment Gateway.
 ///
-public struct PaymentGateway: Equatable, GeneratedFakeable {
+public struct PaymentGateway: Equatable, GeneratedFakeable, GeneratedCopiable {
 
     /// Features for payment gateway.
     ///

--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -60,18 +60,21 @@ extension GeneralStoreSettings {
         isTelemetryAvailable: CopiableProp<Bool> = .copy,
         telemetryLastReportedTime: NullableCopiableProp<Date> = .copy,
         areSimplePaymentTaxesEnabled: CopiableProp<Bool> = .copy,
-        preferredInPersonPaymentGateway: NullableCopiableProp<String> = .copy
+        preferredInPersonPaymentGateway: NullableCopiableProp<String> = .copy,
+        skippedCodOnboardingStep: CopiableProp<Bool> = .copy
     ) -> GeneralStoreSettings {
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
         let telemetryLastReportedTime = telemetryLastReportedTime ?? self.telemetryLastReportedTime
         let areSimplePaymentTaxesEnabled = areSimplePaymentTaxesEnabled ?? self.areSimplePaymentTaxesEnabled
         let preferredInPersonPaymentGateway = preferredInPersonPaymentGateway ?? self.preferredInPersonPaymentGateway
+        let skippedCodOnboardingStep = skippedCodOnboardingStep ?? self.skippedCodOnboardingStep
 
         return GeneralStoreSettings(
             isTelemetryAvailable: isTelemetryAvailable,
             telemetryLastReportedTime: telemetryLastReportedTime,
             areSimplePaymentTaxesEnabled: areSimplePaymentTaxesEnabled,
-            preferredInPersonPaymentGateway: preferredInPersonPaymentGateway
+            preferredInPersonPaymentGateway: preferredInPersonPaymentGateway,
+            skippedCodOnboardingStep: skippedCodOnboardingStep
         )
     }
 }

--- a/Storage/Storage/Model/GeneralStoreSettings.swift
+++ b/Storage/Storage/Model/GeneralStoreSettings.swift
@@ -33,14 +33,20 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public let preferredInPersonPaymentGateway: String?
 
+    /// Stores whether the Enable Cash on Delivery In-Person Payments Onboarding step has been skipped for this store
+    ///
+    public let skippedCodOnboardingStep: Bool
+
     public init(isTelemetryAvailable: Bool = false,
                 telemetryLastReportedTime: Date? = nil,
                 areSimplePaymentTaxesEnabled: Bool = false,
-                preferredInPersonPaymentGateway: String? = nil) {
+                preferredInPersonPaymentGateway: String? = nil,
+                skippedCodOnboardingStep: Bool = false) {
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
         self.areSimplePaymentTaxesEnabled = areSimplePaymentTaxesEnabled
         self.preferredInPersonPaymentGateway = preferredInPersonPaymentGateway
+        self.skippedCodOnboardingStep = skippedCodOnboardingStep
     }
 }
 
@@ -55,6 +61,7 @@ extension GeneralStoreSettings {
         self.telemetryLastReportedTime = try container.decodeIfPresent(Date.self, forKey: .telemetryLastReportedTime)
         self.areSimplePaymentTaxesEnabled = try container.decodeIfPresent(Bool.self, forKey: .areSimplePaymentTaxesEnabled) ?? false
         self.preferredInPersonPaymentGateway = try container.decodeIfPresent(String.self, forKey: .preferredInPersonPaymentGateway)
+        self.skippedCodOnboardingStep = try container.decodeIfPresent(Bool.self, forKey: .skippedCodOnboardingStep) ?? false
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -302,8 +302,10 @@ private extension CardPresentPaymentsOnboardingUseCase {
         guard !isStripeAccountRejected(account: account) else {
             return .stripeAccountRejected(plugin: plugin)
         }
-        guard isCodSetUp() else {
-            return .codPaymentGatewayNotSetUp
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.promptToEnableCodInIppOnboarding) {
+            guard isCodSetUp() else {
+                return .codPaymentGatewayNotSetUp
+            }
         }
         guard !isInUndefinedState(account: account) else {
             return .genericError

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -302,6 +302,9 @@ private extension CardPresentPaymentsOnboardingUseCase {
         guard !isStripeAccountRejected(account: account) else {
             return .stripeAccountRejected(plugin: plugin)
         }
+        guard isCodSetUp() else {
+            return .codPaymentGatewayNotSetUp
+        }
         guard !isInUndefinedState(account: account) else {
             return .genericError
         }
@@ -405,6 +408,16 @@ private extension CardPresentPaymentsOnboardingUseCase {
             || account.wcpayStatus == .rejectedListed
             || account.wcpayStatus == .rejectedTermsOfService
             || account.wcpayStatus == .rejectedOther
+    }
+
+    func isCodSetUp() -> Bool {
+        guard let siteID = siteID,
+              let codGateway = storageManager.viewStorage.loadPaymentGateway(siteID: siteID, gatewayID: "cod")?.toReadOnly()
+        else {
+            return false
+        }
+
+        return codGateway.enabled
     }
 
     func isInUndefinedState(account: PaymentGatewayAccount) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -77,7 +77,7 @@ struct InPersonPaymentsView: View {
             case .stripeAccountRejected:
                 InPersonPaymentsStripeRejected()
             case .codPaymentGatewayNotSetUp:
-                InPersonPaymentsCodPaymentGatewayNotSetUp()
+                InPersonPaymentsCodPaymentGatewayNotSetUp(viewModel: viewModel.codStepViewModel)
             case .completed(let pluginState):
                 if viewModel.showMenuOnCompletion {
                     InPersonPaymentsMenu(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -76,6 +76,8 @@ struct InPersonPaymentsView: View {
                 InPersonPaymentsStripeAccountReview()
             case .stripeAccountRejected:
                 InPersonPaymentsStripeRejected()
+            case .codPaymentGatewayNotSetUp:
+                InPersonPaymentsCodPaymentGatewayNotSetUp()
             case .completed(let pluginState):
                 if viewModel.showMenuOnCompletion {
                     InPersonPaymentsMenu(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -12,6 +12,10 @@ final class InPersonPaymentsViewModel: ObservableObject {
     private let useCase: CardPresentPaymentsOnboardingUseCase
     let stores: StoresManager
 
+    lazy var codStepViewModel: InPersonPaymentsCodPaymentGatewayNotSetUpViewModel = {
+        InPersonPaymentsCodPaymentGatewayNotSetUpViewModel(completion: refresh)
+    }()
+
     /// Initializes the view model for a specific site
     ///
     init(stores: StoresManager = ServiceLocator.stores,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUp.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUp.swift
@@ -2,16 +2,31 @@ import SwiftUI
 
 struct InPersonPaymentsCodPaymentGatewayNotSetUp: View {
     var body: some View {
-        InPersonPaymentsOnboardingError(
-            title: Localization.title,
-            message: Localization.message,
-            image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
-                image: .paymentErrorImage,
-                height: 180.0
-            ),
-            supportLink: true,
-            learnMore: true
-        )
+        VStack {
+            Spacer()
+
+            InPersonPaymentsOnboardingErrorMainContentView(
+                title: Localization.title,
+                message: Localization.message,
+                image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
+                    image: .paymentErrorImage,
+                    height: 180.0
+                ),
+                supportLink: true
+            )
+
+            Spacer()
+
+            Button(Localization.skipButton, action: {})
+                .buttonStyle(SecondaryButtonStyle())
+
+            Button(Localization.enableButton, action: {})
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: false))
+
+            Spacer()
+
+            InPersonPaymentsLearnMore()
+        }.padding()
     }
 }
 
@@ -31,4 +46,14 @@ private enum Localization {
         "A \"Pay in Person\" option on your checkout lets you accept card or cash payments on collection or delivery",
         comment: "The message explaining what will happen when the merchant enables the Pay in Person payment " +
         "gateway during card present payments onboarding.")
+
+    static let skipButton = NSLocalizedString(
+        "Skip for now",
+        comment: "Title for the button to skip the onboarding step encoraging the merchant to enable the" +
+        "Pay in Person payment gateway")
+
+    static let enableButton = NSLocalizedString(
+        "Enable Pay in Person",
+        comment: "Title for the button to enable the Pay in Person payment gateway during card present " +
+        "payments onboarding.")
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUp.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUp.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsCodPaymentGatewayNotSetUp: View {
     var body: some View {
-        VStack {
+        ScrollableVStack {
             Spacer()
 
             InPersonPaymentsOnboardingErrorMainContentView(
@@ -10,7 +10,7 @@ struct InPersonPaymentsCodPaymentGatewayNotSetUp: View {
                 message: Localization.message,
                 image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                     image: .paymentErrorImage,
-                    height: 180.0
+                    height: Constants.imageHeight
                 ),
                 supportLink: true
             )
@@ -26,7 +26,7 @@ struct InPersonPaymentsCodPaymentGatewayNotSetUp: View {
             Spacer()
 
             InPersonPaymentsLearnMore()
-        }.padding()
+        }
     }
 }
 
@@ -56,4 +56,8 @@ private enum Localization {
         "Enable Pay in Person",
         comment: "Title for the button to enable the Pay in Person payment gateway during card present " +
         "payments onboarding.")
+}
+
+private enum Constants {
+    static let imageHeight: CGFloat = 180.0
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUp.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUp.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct InPersonPaymentsCodPaymentGatewayNotSetUp: View {
+    let viewModel: InPersonPaymentsCodPaymentGatewayNotSetUpViewModel
+
     var body: some View {
         ScrollableVStack {
             Spacer()
@@ -17,7 +19,7 @@ struct InPersonPaymentsCodPaymentGatewayNotSetUp: View {
 
             Spacer()
 
-            Button(Localization.skipButton, action: {})
+            Button(Localization.skipButton, action: viewModel.skipTapped)
                 .buttonStyle(SecondaryButtonStyle())
 
             Button(Localization.enableButton, action: {})
@@ -32,7 +34,8 @@ struct InPersonPaymentsCodPaymentGatewayNotSetUp: View {
 
 struct InPersonPaymentsCodPaymentGatewayNotSetUp_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsCodPaymentGatewayNotSetUp()
+        let viewModel = InPersonPaymentsCodPaymentGatewayNotSetUpViewModel(completion: {})
+        return InPersonPaymentsCodPaymentGatewayNotSetUp(viewModel: viewModel)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUp.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUp.swift
@@ -5,7 +5,7 @@ struct InPersonPaymentsCodPaymentGatewayNotSetUp: View {
         InPersonPaymentsOnboardingError(
             title: Localization.title,
             message: Localization.message,
-            image: InPersonPaymentsOnboardingError.ImageInfo(
+            image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                 image: .paymentErrorImage,
                 height: 180.0
             ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUp.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUp.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct InPersonPaymentsCodPaymentGatewayNotSetUp: View {
+    var body: some View {
+        InPersonPaymentsOnboardingError(
+            title: Localization.title,
+            message: Localization.message,
+            image: InPersonPaymentsOnboardingError.ImageInfo(
+                image: .paymentErrorImage,
+                height: 180.0
+            ),
+            supportLink: true,
+            learnMore: true
+        )
+    }
+}
+
+struct InPersonPaymentsCodPaymentGatewayNotSetUp_Previews: PreviewProvider {
+    static var previews: some View {
+        InPersonPaymentsCodPaymentGatewayNotSetUp()
+    }
+}
+
+private enum Localization {
+    static let title = NSLocalizedString(
+        "Add Pay in Person to your checkout",
+        comment: "Title for the card present payments onboarding step encouraging the merchant to enable the " +
+        "Pay in Person payment gateway.")
+
+    static let message = NSLocalizedString(
+        "A \"Pay in Person\" option on your checkout lets you accept card or cash payments on collection or delivery",
+        comment: "The message explaining what will happen when the merchant enables the Pay in Person payment " +
+        "gateway during card present payments onboarding.")
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Yosemite
+
+struct InPersonPaymentsCodPaymentGatewayNotSetUpViewModel {
+    let completion: () -> ()
+    let stores: StoresManager = ServiceLocator.stores
+
+    private var siteID: Int64? {
+        stores.sessionManager.defaultStoreID
+    }
+
+    func skipTapped() {
+        guard let siteID = siteID else {
+            return completion()
+        }
+
+        let action = AppSettingsAction.setSkippedCodOnboardingStep(siteID: siteID)
+        stores.dispatch(action)
+        completion()
+    }
+
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
@@ -7,7 +7,7 @@ struct InPersonPaymentsCountryNotSupported: View {
         InPersonPaymentsOnboardingError(
             title: title,
             message: Localization.message,
-            image: InPersonPaymentsOnboardingError.ImageInfo(
+            image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                 image: .paymentErrorImage,
                 height: 180.0
             ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
@@ -7,7 +7,7 @@ struct InPersonPaymentsCountryNotSupportedStripe: View {
         InPersonPaymentsOnboardingError(
             title: title,
             message: Localization.message,
-            image: InPersonPaymentsOnboardingError.ImageInfo(
+            image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                 image: .paymentErrorImage,
                 height: 180.0
             ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsDeactivateStripeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsDeactivateStripeView.swift
@@ -10,10 +10,10 @@ struct InPersonPaymentsDeactivateStripeView: View {
         ScrollableVStack {
             Spacer()
 
-            InPersonPaymentsOnboardingError.MainContent(
+            InPersonPaymentsOnboardingErrorMainContentView(
                 title: Localization.title,
                 message: showSetupPluginsButton ? Localization.buttonMessage : Localization.message,
-                image: InPersonPaymentsOnboardingError.ImageInfo(
+                image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                     image: .paymentErrorImage,
                     height: Constants.height
                 ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
@@ -9,7 +9,7 @@ struct InPersonPaymentsLiveSiteInTestMode: View {
         InPersonPaymentsOnboardingError(
             title: String(format: Localization.title, plugin.pluginName),
             message: String(format: Localization.message, plugin.pluginName),
-            image: InPersonPaymentsOnboardingError.ImageInfo(
+            image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                 image: plugin.image,
                 height: 108.0
             ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
@@ -7,7 +7,7 @@ struct InPersonPaymentsNoConnection: View {
         InPersonPaymentsOnboardingError(
             title: Localization.title,
             message: Localization.message,
-            image: InPersonPaymentsOnboardingError.ImageInfo(
+            image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                 image: .errorStateImage,
                 height: 108.0
             ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
@@ -4,7 +4,7 @@ import Yosemite
 struct InPersonPaymentsOnboardingError: View {
     let title: String
     let message: String
-    let image: ImageInfo
+    let image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo
     let supportLink: Bool
     let learnMore: Bool
     var button: ButtonInfo? = nil
@@ -14,16 +14,11 @@ struct InPersonPaymentsOnboardingError: View {
         let action: () -> Void
     }
 
-    struct ImageInfo {
-        let image: UIImage
-        let height: CGFloat
-    }
-
     var body: some View {
         VStack {
             Spacer()
 
-            MainContent(
+            InPersonPaymentsOnboardingErrorMainContentView(
                 title: title,
                 message: message,
                 image: image,
@@ -41,41 +36,6 @@ struct InPersonPaymentsOnboardingError: View {
                 InPersonPaymentsLearnMore()
             }
         }.padding()
-    }
-
-    struct MainContent: View {
-        let title: String
-        let message: String
-        let image: ImageInfo
-        let supportLink: Bool
-
-        @Environment(\.verticalSizeClass) var verticalSizeClass
-
-        var isCompact: Bool {
-            get {
-                verticalSizeClass == .compact
-            }
-        }
-
-        var body: some View {
-            VStack(alignment: .center) {
-                Text(title)
-                    .font(.headline)
-                    .padding(.bottom, isCompact ? 16 : 32)
-                Image(uiImage: image.image)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(height: isCompact ? image.height / 3 : image.height)
-                    .padding(.bottom, isCompact ? 16 : 32)
-                Text(message)
-                    .font(.callout)
-                    .padding(.bottom, isCompact ? 12 : 24)
-                if supportLink {
-                    InPersonPaymentsSupportLink()
-                }
-            }.multilineTextAlignment(.center)
-            .frame(maxWidth: 500)
-        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingErrorMainContentView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingErrorMainContentView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import Yosemite
+
+struct InPersonPaymentsOnboardingErrorMainContentView: View {
+    let title: String
+    let message: String
+    let image: ImageInfo
+    let supportLink: Bool
+
+    struct ImageInfo {
+        let image: UIImage
+        let height: CGFloat
+    }
+
+    @Environment(\.verticalSizeClass) var verticalSizeClass
+
+    var isCompact: Bool {
+        get {
+            verticalSizeClass == .compact
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .center) {
+            Text(title)
+                .font(.headline)
+                .padding(.bottom, isCompact ? 16 : 32)
+            Image(uiImage: image.image)
+                .resizable()
+                .scaledToFit()
+                .frame(height: isCompact ? image.height / 3 : image.height)
+                .padding(.bottom, isCompact ? 16 : 32)
+            Text(message)
+                .font(.callout)
+                .padding(.bottom, isCompact ? 12 : 24)
+            if supportLink {
+                InPersonPaymentsSupportLink()
+            }
+        }.multilineTextAlignment(.center)
+        .frame(maxWidth: 500)
+    }
+}
+
+struct InPersonPaymentsOnboardingErrorMainContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        InPersonPaymentsOnboardingErrorMainContentView(title: "Title",
+                                                       message: "Lorem ipsum dolor sit amet",
+                                                       image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
+                                                        image: .paymentErrorImage,
+                                                        height: 180),
+                                                       supportLink: true)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingErrorMainContentView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingErrorMainContentView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Yosemite
 
 struct InPersonPaymentsOnboardingErrorMainContentView: View {
     let title: String

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictAdminView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictAdminView.swift
@@ -15,10 +15,10 @@ struct InPersonPaymentsPluginConflictAdmin: View {
         ScrollableVStack {
             Spacer()
 
-            InPersonPaymentsOnboardingError.MainContent(
+            InPersonPaymentsOnboardingErrorMainContentView(
                 title: Localization.title,
                 message: Localization.message,
-                image: InPersonPaymentsOnboardingError.ImageInfo(
+                image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                     image: .paymentErrorImage,
                     height: 108.0
                 ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictShopManagerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictShopManagerView.swift
@@ -16,10 +16,10 @@ struct InPersonPaymentsPluginConflictShopManager: View {
         ScrollableVStack {
             Spacer()
 
-            InPersonPaymentsOnboardingError.MainContent(
+            InPersonPaymentsOnboardingErrorMainContentView(
                 title: Localization.title,
                 message: Localization.message,
-                image: InPersonPaymentsOnboardingError.ImageInfo(
+                image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                     image: .paymentErrorImage,
                     height: 108.0
                 ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
@@ -9,7 +9,7 @@ struct InPersonPaymentsPluginNotActivated: View {
         InPersonPaymentsOnboardingError(
             title: String(format: Localization.title, plugin.pluginName),
             message: String(format: Localization.message, plugin.pluginName),
-            image: InPersonPaymentsOnboardingError.ImageInfo(
+            image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                 image: plugin.image,
                 height: 108.0
             ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
@@ -7,7 +7,7 @@ struct InPersonPaymentsPluginNotInstalled: View {
         InPersonPaymentsOnboardingError(
             title: Localization.title,
             message: Localization.message,
-            image: InPersonPaymentsOnboardingError.ImageInfo(
+            image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                 image: .wcPayPlugin,
                 height: 126.0
             ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -10,10 +10,10 @@ struct InPersonPaymentsPluginNotSetup: View {
         ScrollableVStack {
             Spacer()
 
-            InPersonPaymentsOnboardingError.MainContent(
+            InPersonPaymentsOnboardingErrorMainContentView(
                 title: String(format: Localization.title, plugin.pluginName),
                 message: String(format: Localization.message, plugin.pluginName),
-                image: InPersonPaymentsOnboardingError.ImageInfo(
+                image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                     image: plugin.image,
                     height: 108.0
                 ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
@@ -9,7 +9,7 @@ struct InPersonPaymentsPluginNotSupportedVersion: View {
         InPersonPaymentsOnboardingError(
             title: String(format: Localization.title, plugin.pluginName),
             message: String(format: Localization.message, plugin.pluginName),
-            image: InPersonPaymentsOnboardingError.ImageInfo(
+            image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                 image: plugin.image,
                 height: 108.0
             ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -5,7 +5,7 @@ struct InPersonPaymentsStripeAccountOverdue: View {
         InPersonPaymentsOnboardingError(
             title: Localization.title,
             message: Localization.message,
-            image: InPersonPaymentsOnboardingError.ImageInfo(
+            image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                 image: .paymentErrorImage,
                 height: 180.0
             ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
@@ -7,7 +7,7 @@ struct InPersonPaymentsStripeAccountPending: View {
         InPersonPaymentsOnboardingError(
             title: Localization.title,
             message: message,
-            image: InPersonPaymentsOnboardingError.ImageInfo(
+            image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                 image: .paymentErrorImage,
                 height: 180.0
             ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
@@ -5,7 +5,7 @@ struct InPersonPaymentsStripeAccountReview: View {
         InPersonPaymentsOnboardingError(
             title: Localization.title,
             message: Localization.message,
-            image: InPersonPaymentsOnboardingError.ImageInfo(
+            image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                 image: .paymentErrorImage,
                 height: 180.0
             ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
@@ -5,7 +5,7 @@ struct InPersonPaymentsStripeRejected: View {
         InPersonPaymentsOnboardingError(
             title: Localization.title,
             message: Localization.message,
-            image: InPersonPaymentsOnboardingError.ImageInfo(
+            image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                 image: .paymentErrorImage,
                 height: 180.0
             ),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsUnavailableView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsUnavailableView.swift
@@ -5,7 +5,7 @@ struct InPersonPaymentsUnavailable: View {
         InPersonPaymentsOnboardingError(
             title: Localization.unavailable,
             message: Localization.message,
-            image: InPersonPaymentsOnboardingError.ImageInfo(
+            image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                 image: .paymentErrorImage,
                 height: 180.0
             ),

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -430,6 +430,7 @@
 		02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */; };
 		02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
+		0313651128AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651028AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift */; };
 		031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */; };
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
 		035F2308275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */; };
@@ -2262,6 +2263,7 @@
 		02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsBanner.swift; sourceTree = "<group>"; };
 		02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingViewController.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
+		0313651028AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCodPaymentGatewayNotSetUp.swift; sourceTree = "<group>"; };
 		03180BE52763AA8F00B938A8 /* Woo-Release-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Release-macOS.entitlements"; sourceTree = "<group>"; };
 		03180BE62763AA8F00B938A8 /* Woo-Alpha-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha-macOS.entitlements"; sourceTree = "<group>"; };
 		03180BE72763AA9000B938A8 /* Woo-Debug-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Debug-macOS.entitlements"; sourceTree = "<group>"; };
@@ -8210,6 +8212,7 @@
 				319A625E27ACAD4800BC96C3 /* InPersonPaymentsPluginConflictShopManagerView.swift */,
 				ABC35A4B736A0B2D8348DD08 /* InPersonPaymentsOnboardingError.swift */,
 				B979A9B9282D62A500EBB383 /* InPersonPaymentsDeactivateStripeView.swift */,
+				0313651028AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift */,
 			);
 			path = "Onboarding Errors";
 			sourceTree = "<group>";
@@ -9499,6 +9502,7 @@
 				DE61978B28991F0E005E4362 /* WKWebView+Authenticated.swift in Sources */,
 				D8810086257DCCF0008DE6F2 /* WordPressComSiteInfo+Woo.swift in Sources */,
 				311237EE2714DA240033C44E /* CardPresentModalDisplayMessage.swift in Sources */,
+				0313651128AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift in Sources */,
 				45E3C8F325E7D30300102E84 /* ShippingLabelAddress+Woo.swift in Sources */,
 				57A25C7C25ACFAEC00A54A62 /* OrderFulfillmentNoticePresenter.swift in Sources */,
 				B9E4364C287587D300883CFA /* FeatureAnnouncementCardView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -431,6 +431,7 @@
 		02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		0313651128AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651028AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift */; };
+		0313651328ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651228ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift */; };
 		031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */; };
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
 		035F2308275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */; };
@@ -2264,6 +2265,7 @@
 		02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingViewController.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		0313651028AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCodPaymentGatewayNotSetUp.swift; sourceTree = "<group>"; };
+		0313651228ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsOnboardingErrorMainContentView.swift; sourceTree = "<group>"; };
 		03180BE52763AA8F00B938A8 /* Woo-Release-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Release-macOS.entitlements"; sourceTree = "<group>"; };
 		03180BE62763AA8F00B938A8 /* Woo-Alpha-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha-macOS.entitlements"; sourceTree = "<group>"; };
 		03180BE72763AA9000B938A8 /* Woo-Debug-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Debug-macOS.entitlements"; sourceTree = "<group>"; };
@@ -8211,6 +8213,7 @@
 				D89FAF4D2795BDFF00D8DA66 /* InPersonPaymentsPluginConflictAdminView.swift */,
 				319A625E27ACAD4800BC96C3 /* InPersonPaymentsPluginConflictShopManagerView.swift */,
 				ABC35A4B736A0B2D8348DD08 /* InPersonPaymentsOnboardingError.swift */,
+				0313651228ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift */,
 				B979A9B9282D62A500EBB383 /* InPersonPaymentsDeactivateStripeView.swift */,
 				0313651028AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift */,
 			);
@@ -9277,6 +9280,7 @@
 				0211259F2578DE310075AD2A /* ShippingLabelPrintingStepView.swift in Sources */,
 				B58B4AB22108F01700076FDD /* NoticeView.swift in Sources */,
 				74B5713621CD7604008F9B8E /* SharingHelper.swift in Sources */,
+				0313651328ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift in Sources */,
 				260C315E2523CC4000157BC2 /* RefundProductsTotalViewModel.swift in Sources */,
 				0286B27D23C7051F003D784B /* ProductImagesViewController.swift in Sources */,
 				4569317F2653E82B009ED69D /* ShippingLabelCarriers.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		0313651128AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651028AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift */; };
 		0313651328ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651228ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift */; };
+		0313651728ACE9F400EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651628ACE9F400EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift */; };
 		031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */; };
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
 		035F2308275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */; };
@@ -2266,6 +2267,7 @@
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		0313651028AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCodPaymentGatewayNotSetUp.swift; sourceTree = "<group>"; };
 		0313651228ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsOnboardingErrorMainContentView.swift; sourceTree = "<group>"; };
+		0313651628ACE9F400EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift; sourceTree = "<group>"; };
 		03180BE52763AA8F00B938A8 /* Woo-Release-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Release-macOS.entitlements"; sourceTree = "<group>"; };
 		03180BE62763AA8F00B938A8 /* Woo-Alpha-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha-macOS.entitlements"; sourceTree = "<group>"; };
 		03180BE72763AA9000B938A8 /* Woo-Debug-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Debug-macOS.entitlements"; sourceTree = "<group>"; };
@@ -8216,6 +8218,7 @@
 				0313651228ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift */,
 				B979A9B9282D62A500EBB383 /* InPersonPaymentsDeactivateStripeView.swift */,
 				0313651028AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift */,
+				0313651628ACE9F400EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift */,
 			);
 			path = "Onboarding Errors";
 			sourceTree = "<group>";
@@ -9947,6 +9950,7 @@
 				4515C88D25D6BE540099C8E3 /* ShippingLabelAddressFormViewController.swift in Sources */,
 				CE5F462A23AACA0A006B1A5C /* RefundDetailsDataSource.swift in Sources */,
 				02162726237963AF000208D2 /* ProductFormViewController.swift in Sources */,
+				0313651728ACE9F400EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift in Sources */,
 				571CDD5A250ACC470076B8CC /* UITableViewDiffableDataSource+Helpers.swift in Sources */,
 				4580BA7423F192D400B5F764 /* ProductSettingsViewController.swift in Sources */,
 				45977EBA2603F632006CDFB8 /* MapsHelper.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -129,7 +129,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-simulate-stripe-card-reader"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-force-crash-logging 1"

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -129,7 +129,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-simulate-stripe-card-reader"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-force-crash-logging 1"

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -20,6 +20,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     ///
     private var preferredInPersonPaymentGatewayBySite = [Int64: String]()
 
+    private var skippedCodOnboardingStep = true
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -38,7 +39,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
             case .setSkippedCodOnboardingStep(_):
                 break
             case .getSkippedCodOnboardingStep(_, let completion):
-                completion(true)
+                completion(self.skippedCodOnboardingStep)
                 break
             default:
                 fatalError("Not available")
@@ -797,6 +798,54 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .stripeAccountRejected(plugin: .wcPay))
     }
 
+    func test_onboarding_returns_enable_COD_prompt_when_cod_disabled_and_not_skipped() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
+        setupCodPaymentGateway(enabled: false)
+        skippedCodOnboardingStep = false
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        assertEqual(.codPaymentGatewayNotSetUp, state)
+    }
+
+    func test_onboarding_returns_complete_when_cod_disabled_and_cod_step_was_skipped() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
+        setupCodPaymentGateway(enabled: false)
+        skippedCodOnboardingStep = true
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        assertEqual(.completed(plugin: .wcPayOnly), state)
+    }
+
+    func test_onboarding_returns_complete_when_cod_enabled() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
+        setupCodPaymentGateway(enabled: true)
+        skippedCodOnboardingStep = false
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        assertEqual(.completed(plugin: .wcPayOnly), state)
+    }
+
     func test_onboarding_returns_generic_error_when_account_status_unknown_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
@@ -941,3 +990,25 @@ private protocol GatewayAccountProtocol {
 
 extension WCPayAccount: GatewayAccountProtocol {}
 extension StripeAccount: GatewayAccountProtocol {}
+
+// MARK: - Gateway helpers
+private extension CardPresentPaymentsOnboardingUseCaseTests {
+    @discardableResult
+    func setupCodPaymentGateway(
+        enabled: Bool = true,
+        title: String = "",
+        description: String = ""
+    ) -> PaymentGateway {
+        let paymentGateway = PaymentGateway
+            .fake()
+            .copy(
+                siteID: sampleSiteID,
+                gatewayID: "cod",
+                title: title,
+                description: description,
+                enabled: enabled
+            )
+        storageManager.insertSamplePaymentGateway(readOnlyGateway: paymentGateway)
+        return paymentGateway
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -35,6 +35,11 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
                 onCompletion(self.preferredInPersonPaymentGatewayBySite[siteID])
             case .forgetPreferredInPersonPaymentGateway(_):
                 break
+            case .setSkippedCodOnboardingStep(_):
+                break
+            case .getSkippedCodOnboardingStep(_, let completion):
+                completion(true)
+                break
             default:
                 fatalError("Not available")
             }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -187,6 +187,14 @@ public enum AppSettingsAction: Action {
     ///
     case resetGeneralStoreSettings
 
+    /// Marks the Enable Cash on Delivery In-Person Payments Onboarding step as skipped
+    ///
+    case setSkippedCodOnboardingStep(siteID: Int64)
+
+    /// Gets whether the Enable Cash on Delivery In-Person Payments Onboarding step has been skipped
+    ///
+    case getSkippedCodOnboardingStep(siteID: Int64, onCompletion: (Bool) -> Void)
+
     // MARK: - Feature Announcement Card Visibility
 
     case setFeatureAnnouncementDismissed(campaign: FeatureAnnouncementCampaign, remindLater: Bool, onCompletion: ((Result<Bool, Error>) -> ())?)

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -67,6 +67,11 @@ public enum CardPresentPaymentOnboardingState: Equatable {
     ///
     case stripeAccountRejected(plugin: CardPresentPaymentsPlugin)
 
+    /// The Cash on Delivery payment gateway is missing or disabled
+    /// Enabling Cash on Delivery is not essential for Card Present Payments, but allows web store customers to place orders and pay by card in person.
+    ///
+    case codPaymentGatewayNotSetUp
+
     /// Generic error - for example, one of the requests failed.
     ///
     case genericError
@@ -109,6 +114,8 @@ extension CardPresentPaymentOnboardingState {
             return "account_overdue_requirements"
         case .stripeAccountRejected:
             return "account_rejected"
+        case .codPaymentGatewayNotSetUp:
+            return "cod_not_set_up"
         case .genericError:
             return "generic_error"
         case .noConnectionError:

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -182,6 +182,10 @@ public class AppSettingsStore: Store {
             setFeatureAnnouncementDismissed(campaign: campaign, remindLater: remindLater, onCompletion: completion)
         case .getFeatureAnnouncementVisibility(campaign: let campaign, onCompletion: let completion):
             getFeatureAnnouncementVisibility(campaign: campaign, onCompletion: completion)
+        case .setSkippedCodOnboardingStep(siteID: let siteID):
+            setSkippedCodOnboardingStep(siteID: siteID)
+        case .getSkippedCodOnboardingStep(siteID: let siteID, onCompletion: let completion):
+            getSkippedCodOnboardingStep(siteID: siteID, onCompletion: completion)
         }
     }
 }
@@ -718,7 +722,6 @@ private extension AppSettingsStore {
     func getPreferredInPersonPaymentGateway(siteID: Int64, onCompletion: (String?) -> Void) {
         let storeSettings = getStoreSettings(for: siteID)
         onCompletion(storeSettings.preferredInPersonPaymentGateway)
-
     }
 
     /// Forgets the preferred payment gateway for In-Person Payments
@@ -727,6 +730,21 @@ private extension AppSettingsStore {
         let storeSettings = getStoreSettings(for: siteID)
         let newSettings = storeSettings.copy(preferredInPersonPaymentGateway: .some(nil))
         setStoreSettings(settings: newSettings, for: siteID, onCompletion: nil)
+    }
+
+    /// Marks the Enable Cash on Delivery In-Person Payments Onboarding step as skipped
+    ///
+    func setSkippedCodOnboardingStep(siteID: Int64) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let newSettings = storeSettings.copy(skippedCodOnboardingStep: true)
+        setStoreSettings(settings: newSettings, for: siteID)
+    }
+
+    /// Gets whether the Enable Cash on Delivery In-Person Payments Onboarding step has been skipped
+    ///
+    func getSkippedCodOnboardingStep(siteID: Int64, onCompletion: (Bool) -> Void) {
+        let storeSettings = getStoreSettings(for: siteID)
+        onCompletion(storeSettings.skippedCodOnboardingStep)
     }
 
 }

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
@@ -40,6 +40,16 @@ extension MockStorageManager {
         return newAccount
     }
 
+    /// Inserts a new (Sample) Payment Gateway into the specified context.
+    ///
+    @discardableResult
+    func insertSamplePaymentGateway(readOnlyGateway: PaymentGateway) -> StoragePaymentGateway {
+        let newGateway = viewStorage.insertNewObject(ofType: StoragePaymentGateway.self)
+        newGateway.update(with: readOnlyGateway)
+
+        return newGateway
+    }
+
     /// Inserts a new (Sample) Product into the specified context.
     ///
     @discardableResult


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7475 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the UI for a new onboarding step, which prompts the merchant to enable the Cash on Delivery payment gateway, if it's missing or disabled.

We want to encourage merchants to enable the `cod` gateway, because doing so allows them to take In-Person Payments for web orders.

This is the last onboarding step shown.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a store with COD disabled (check that it's disabled in `WP Admin > WooCommerce > Settings > Payments`)

1. Go to the hub menu
2. Tap Payments and wait for the spinner to complete
3. The onboarding incomplete footer message should appear: tap `Continue Setup`
4. The `Add Pay in Person to your checkout` onboarding screen should show

Using a store with COD enabled, repeat the above steps: the onboarding screen should not show.

### Notes
#### Buttons
The buttons on this screen do not do anything. The functionality will be added in future PRs.

#### Syncing
We do not currently do an extra refresh for Payment Gateways for this feature. This means the app will use the Payment Gateways synced at the last launch, as they are only refreshed [when the user launches the app or changes site](https://github.com/woocommerce/woocommerce-ios/blob/9bf2a29f09c4f1e0d4e28e9cf185d84cbb61be52/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift#L471).

We could add a `synchronizePaymentGateways` action in `CardPresentPaymentsOnboardingUseCase.synchronizeStoreCountryAndPlugins`, but that would mean quite a lot of extra GET requests with little justification. I think we should (at most) do an extra sync of Payment Gateways after the user enables the COD gateway.

Happy to discuss this!

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![onboarding cod ui](https://user-images.githubusercontent.com/2472348/184910248-15088759-0fda-4427-b693-26009d795a50.jpg)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
