### PR TITLE
Fix refunds crash

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -67,12 +67,6 @@ final class OrderDetailsDataSource: NSObject {
             !isEligibleForPayment
     }
 
-    /// Whether the row for amount paid should be visible.
-    ///
-    private var shouldShowCustomerPaidRow: Bool {
-        order.datePaid != nil
-    }
-
     /// Whether the option to re-create shipping labels should be visible.
     ///
     var shouldAllowRecreatingShippingLabels: Bool {
@@ -603,7 +597,7 @@ private extension OrderDetailsDataSource {
     }
 
     private func configureRefund(cell: TwoColumnHeadlineFootnoteTableViewCell, at indexPath: IndexPath) {
-        let index = indexPath.row - Constants.paymentCell - Constants.paidByCustomerCell(isDisplayed: shouldShowCustomerPaidRow)
+        let index = indexPath.row - Constants.paymentCell - Constants.paidByCustomerCell
         let condensedRefund = condensedRefunds[index]
         let refund = lookUpRefund(by: condensedRefund.refundID)
         let paymentViewModel = OrderPaymentDetailsViewModel(order: order, refund: refund)
@@ -1254,7 +1248,7 @@ extension OrderDetailsDataSource {
     }
 
     func refund(at indexPath: IndexPath) -> Refund? {
-        let index = indexPath.row - Constants.paymentCell - Constants.paidByCustomerCell(isDisplayed: shouldShowCustomerPaidRow)
+        let index = indexPath.row - Constants.paymentCell - Constants.paidByCustomerCell
         let condensedRefund = condensedRefunds[index]
         let refund = refunds.first { $0.refundID == condensedRefund.refundID }
 
@@ -1658,12 +1652,7 @@ extension OrderDetailsDataSource {
     enum Constants {
         static let addOrderCell = 1
         static let paymentCell = 1
-
-        /// Input value required because cell is displayed conditionally
-        ///
-        static func paidByCustomerCell(isDisplayed: Bool) -> Int {
-            isDisplayed ? 1 : 0
-        }
+        static let paidByCustomerCell = 1
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -35,7 +35,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Given
         let order = makeOrder()
 
-        insert(refund: makeRefund(orderID: order.orderID, siteID: order.siteID))
+        insert(refund: makeRefund(refundID: 1, orderID: order.orderID, siteID: order.siteID))
 
         let dataSource = OrderDetailsDataSource(
             order: order,
@@ -66,10 +66,12 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Given
         let refundItems = [
             OrderRefundCondensed(refundID: 1, reason: nil, total: "1"),
+            OrderRefundCondensed(refundID: 2, reason: nil, total: "1"),
         ]
         let order = makeOrder().copy(datePaid: .some(nil), refunds: refundItems)
 
-        insert(refund: makeRefund(orderID: order.orderID, siteID: order.siteID))
+        insert(refund: makeRefund(refundID: 1, orderID: order.orderID, siteID: order.siteID))
+        insert(refund: makeRefund(refundID: 2, orderID: order.orderID, siteID: order.siteID))
 
         let dataSource = OrderDetailsDataSource(
             order: order,
@@ -572,7 +574,7 @@ private extension OrderDetailsDataSourceTests {
                   attributes: [])
     }
 
-    func makeRefund(orderID: Int64, siteID: Int64) -> Refund {
+    func makeRefund(refundID: Int64, orderID: Int64, siteID: Int64) -> Refund {
         let orderItemRefund = OrderItemRefund(itemID: 1,
                                               name: "OrderItemRefund",
                                               productID: 1,
@@ -587,7 +589,7 @@ private extension OrderDetailsDataSourceTests {
                                               taxes: [],
                                               total: "1",
                                               totalTax: "1")
-        return Refund(refundID: 1,
+        return Refund(refundID: refundID,
                       orderID: orderID,
                       siteID: siteID,
                       dateCreated: Date(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -81,6 +81,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         dataSource.configureResultsControllers { }
 
+        // Temp tableview to test refunds rows configuration
+        let tableView = UITableView()
+        tableView.registerNib(for: TwoColumnHeadlineFootnoteTableViewCell.self)
+
         // When
         dataSource.reloadSections()
 
@@ -93,6 +97,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         }
 
         // Then
+        // Each `refund` row should be initialized without any issues
+        for refundIndexPath in refundsRowsIndexes {
+            let _ = dataSource.tableView(tableView, cellForRowAt: refundIndexPath)
+        }
         // Each `refund` row should have `Refund` object accessible for its IndexPath
         let expectedRefunds: [Refund] = try refundsRowsIndexes.map { try XCTUnwrap(dataSource.refund(at: $0)) }
         XCTAssertEqual(expectedRefunds.count, refundsRowsIndexes.count)


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/7112
Related (previous fix): https://github.com/woocommerce/woocommerce-ios/pull/7113

## Description

In `OrderDetailsDataSource` refunds logic is relying on directly accessing array by index. Since refunds list is sharing section with other cells (see `let payment: Section`), index is calculated by subtracting 1 for "Payment" and "Paid by Customer" cells.

The crash appeared because we removed previous condition to hide "Paid by Customer" when there are no payments yet.
But it was removed only for section logic, but not for refunds index calculation.

So it's essentially a rollback of the previous fix (#7113) that is not required anymore.

⚠️ base branch is `release/9.9`, so it's a beta fix now. Please rebase/cherry-pick if hotfix needed.

## Fix

This PR just removes `shouldShowCustomerPaidRow` condition, since it is unused now.

## Testing

1. Prepare order without payments, but with refunds. Easy to do on the web, not sure about mobile.
2. Go to the Order tab, open order.
3. Confirm it doesn't crash.
4. Open "Refunded Products" list, confirm correct data.

## Screenshots

<img width=350 src=https://user-images.githubusercontent.com/3132438/184944724-f51cd1ee-d47e-4d70-9016-f3760519c102.png>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.