### PR TITLE
[Mobile payments] Improve CardReaderType cases when has no Manual associated

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderType.swift
+++ b/Hardware/Hardware/CardReader/CardReaderType.swift
@@ -1,6 +1,6 @@
 /// Card reader type. Indicates if a reader is meant to be used
 /// handheld or as a countertop device
-public enum CardReaderType {
+public enum CardReaderType: CaseIterable {
     /// Chipper
     case chipper
     /// Stripe M2

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsViewModel.swift
@@ -13,6 +13,6 @@ final class CardReaderManualsViewModel {
 
     init() {
         // Display all card readers at all times. Ref: pdfdoF-1aF-p2
-        self.manuals = CardReaderType.allSupportedReaders.map { $0.manual }
+        self.manuals = CardReaderType.allCases.compactMap { $0.manual }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsViewModel.swift
@@ -9,10 +9,13 @@ struct Manual: Identifiable, Equatable {
 }
 
 final class CardReaderManualsViewModel {
+    var configurationLoader: CardPresentConfigurationLoader
     let manuals: [Manual]
 
     init() {
-        // Display all card readers at all times. Ref: pdfdoF-1aF-p2
-        self.manuals = CardReaderType.allCases.compactMap { $0.manual }
+        // Initialize the ViewModel only with the supported readers for the specific store's country
+        self.configurationLoader = CardPresentConfigurationLoader()
+        let supportedReaders = configurationLoader.configuration.supportedReaders
+        self.manuals = supportedReaders.compactMap { $0.manual }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderManualsViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 import Yosemite
 
 struct Manual: Identifiable, Equatable {
@@ -10,13 +9,10 @@ struct Manual: Identifiable, Equatable {
 }
 
 final class CardReaderManualsViewModel {
-    var configurationLoader: CardPresentConfigurationLoader
     let manuals: [Manual]
 
     init() {
-        // Initialize the View Model only with the supported readers for a specific Store
-        self.configurationLoader = CardPresentConfigurationLoader()
-        let supportedReaders = configurationLoader.configuration.supportedReaders
-        self.manuals = supportedReaders.map { $0.manual }
+        // Display all card readers at all times. Ref: pdfdoF-1aF-p2
+        self.manuals = CardReaderType.allSupportedReaders.map { $0.manual }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderType+Manual.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderType+Manual.swift
@@ -2,9 +2,7 @@ import Foundation
 import Yosemite
 
 extension CardReaderType {
-    static let allSupportedReaders: [CardReaderType] = [CardReaderType.chipper, CardReaderType.stripeM2, CardReaderType.wisepad3]
-
-    var manual: Manual {
+    var manual: Manual? {
         switch self {
         case .chipper:
             return Manual(
@@ -28,7 +26,7 @@ extension CardReaderType {
                 urlString: "https://stripe.com/files/docs/terminal/wp3_product_sheet.pdf"
             )
         case .other:
-            return Manual(id: 5, image: .cardReaderManualIcon, name: "", urlString: "")
+            return nil
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderType+Manual.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderType+Manual.swift
@@ -2,6 +2,7 @@ import Foundation
 import Yosemite
 
 extension CardReaderType {
+    static let allSupportedReaders: [CardReaderType] = [CardReaderType.chipper, CardReaderType.stripeM2, CardReaderType.wisepad3]
 
     var manual: Manual {
         switch self {

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderManualsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderManualsViewModelTests.swift
@@ -7,6 +7,7 @@ class CardReaderManualsViewModelTests: XCTestCase {
     private var storageManager: MockStorageManager!
     private var stores: MockStoresManager!
     private let sampleSiteID: Int64 = 1234
+    private let availableReaderTypes = [CardReaderType.chipper, CardReaderType.stripeM2, CardReaderType.wisepad3]
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -32,7 +33,7 @@ class CardReaderManualsViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel)
     }
 
-    func test_viewModel_when_US_store_then_available_card_reader_manuals() {
+    func test_viewModel_when_US_store_then_all_card_reader_manuals_are_available() {
         // Given
         let setting = SiteSetting.fake()
             .copy(
@@ -46,14 +47,13 @@ class CardReaderManualsViewModelTests: XCTestCase {
         let viewModel = CardReaderManualsViewModel()
 
         // When
-        let availableReaderTypes = [CardReaderType.chipper, CardReaderType.stripeM2]
         let expectedManuals = availableReaderTypes.map { $0.manual }
 
         // Then
         XCTAssertEqual(viewModel.manuals, expectedManuals)
     }
 
-    func test_viewModel_when_CA_store_then_available_card_reader_manuals() {
+    func test_viewModel_when_CA_store_then_all_card_reader_manuals_are_available() {
         // Given
         let setting = SiteSetting.fake()
             .copy(
@@ -67,14 +67,13 @@ class CardReaderManualsViewModelTests: XCTestCase {
         let viewModel = CardReaderManualsViewModel()
 
         // When:
-        let availableReaderTypes = [CardReaderType.wisepad3]
         let expectedManuals = availableReaderTypes.map { $0.manual }
 
         // Then
         XCTAssertEqual(viewModel.manuals, expectedManuals)
     }
 
-    func test_viewModel_when_IPP_not_available_country_then_available_card_reader_manuals_is_empty() {
+    func test_viewModel_when_IPP_not_available_country_then_all_card_reader_manuals_are_available() {
         // Given
         let setting = SiteSetting.fake()
                     .copy(
@@ -87,7 +86,6 @@ class CardReaderManualsViewModelTests: XCTestCase {
         let viewModel = CardReaderManualsViewModel.init()
 
         // When
-        let availableReaderTypes: [CardReaderType] = []
         let expectedManuals = availableReaderTypes.map { $0.manual }
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderManualsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderManualsViewModelTests.swift
@@ -7,7 +7,6 @@ class CardReaderManualsViewModelTests: XCTestCase {
     private var storageManager: MockStorageManager!
     private var stores: MockStoresManager!
     private let sampleSiteID: Int64 = 1234
-    private let availableReaderTypes = [CardReaderType.chipper, CardReaderType.stripeM2, CardReaderType.wisepad3]
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -33,7 +32,7 @@ class CardReaderManualsViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel)
     }
 
-    func test_viewModel_when_US_store_then_all_card_reader_manuals_are_available() {
+    func test_viewModel_when_US_store_then_available_card_reader_manuals() {
         // Given
         let setting = SiteSetting.fake()
             .copy(
@@ -47,13 +46,14 @@ class CardReaderManualsViewModelTests: XCTestCase {
         let viewModel = CardReaderManualsViewModel()
 
         // When
+        let availableReaderTypes = [CardReaderType.chipper, CardReaderType.stripeM2]
         let expectedManuals = availableReaderTypes.map { $0.manual }
 
         // Then
         XCTAssertEqual(viewModel.manuals, expectedManuals)
     }
 
-    func test_viewModel_when_CA_store_then_all_card_reader_manuals_are_available() {
+    func test_viewModel_when_CA_store_then_available_card_reader_manuals() {
         // Given
         let setting = SiteSetting.fake()
             .copy(
@@ -67,13 +67,14 @@ class CardReaderManualsViewModelTests: XCTestCase {
         let viewModel = CardReaderManualsViewModel()
 
         // When:
+        let availableReaderTypes = [CardReaderType.wisepad3]
         let expectedManuals = availableReaderTypes.map { $0.manual }
 
         // Then
         XCTAssertEqual(viewModel.manuals, expectedManuals)
     }
 
-    func test_viewModel_when_IPP_not_available_country_then_all_card_reader_manuals_are_available() {
+    func test_viewModel_when_IPP_not_available_country_then_available_card_reader_manuals_is_empty() {
         // Given
         let setting = SiteSetting.fake()
                     .copy(
@@ -86,6 +87,7 @@ class CardReaderManualsViewModelTests: XCTestCase {
         let viewModel = CardReaderManualsViewModel.init()
 
         // When
+        let availableReaderTypes: [CardReaderType] = []
         let expectedManuals = availableReaderTypes.map { $0.manual }
 
         // Then


### PR DESCRIPTION
Closes: #7488 

## Description

Update: We decided to go with the initial implementation, which was already in trunk, but improve the way we deal with manuals when we have a potential card reader type without manual.

## Changes

In order to accept a `nil` case for the manuals, we make `Manual` optional and initialize it by using a `compactMap`, which will returns an array containing the non-nil results, hence the manuals that are supported specifically for each store.

## Testing instructions:
Confirm that works as before: In your US or CA store, go to HubMenu > Payments > Card Reader manuals:
-- See manuals for Chipper and M2 in the US store.
-- See the manual for Wisepad 3 in the CA store.

~~### Description~~

~~Up until now, the `CardReaderManualsViewModel` pulled the data to be shown (card reader manuals) based on the store's `CardPresentConfiguration` country eligibility: We were showing only the manuals for card readers that a merchant could effectively use.~~

~~This PR changes changes this, so now the view model will provide all available card readers at all times, despite the store location or its eligibility.~~

~~Discussion at: pdfdoF-1aF-p2~~

~~### Testing instructions~~
~~1. In your store (US, CA, or other) go to the Hub Menu > Payments > Card Reader manuals:~~
~~2. See manuals for Chipper, M2, and Wisepad3.~~

