### PR TITLE
[Mobile Payments] Skip button on CoD IPP onboarding step

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -658,6 +658,33 @@ extension OrderTaxLine {
     }
 }
 
+extension PaymentGateway {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        gatewayID: CopiableProp<String> = .copy,
+        title: CopiableProp<String> = .copy,
+        description: CopiableProp<String> = .copy,
+        enabled: CopiableProp<Bool> = .copy,
+        features: CopiableProp<[PaymentGateway.Feature]> = .copy
+    ) -> PaymentGateway {
+        let siteID = siteID ?? self.siteID
+        let gatewayID = gatewayID ?? self.gatewayID
+        let title = title ?? self.title
+        let description = description ?? self.description
+        let enabled = enabled ?? self.enabled
+        let features = features ?? self.features
+
+        return PaymentGateway(
+            siteID: siteID,
+            gatewayID: gatewayID,
+            title: title,
+            description: description,
+            enabled: enabled,
+            features: features
+        )
+    }
+}
+
 extension PaymentGatewayAccount {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/PaymentGateway.swift
+++ b/Networking/Networking/Model/PaymentGateway.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a Payment Gateway.
 ///
-public struct PaymentGateway: Equatable, GeneratedFakeable {
+public struct PaymentGateway: Equatable, GeneratedFakeable, GeneratedCopiable {
 
     /// Features for payment gateway.
     ///

--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -60,18 +60,21 @@ extension GeneralStoreSettings {
         isTelemetryAvailable: CopiableProp<Bool> = .copy,
         telemetryLastReportedTime: NullableCopiableProp<Date> = .copy,
         areSimplePaymentTaxesEnabled: CopiableProp<Bool> = .copy,
-        preferredInPersonPaymentGateway: NullableCopiableProp<String> = .copy
+        preferredInPersonPaymentGateway: NullableCopiableProp<String> = .copy,
+        skippedCodOnboardingStep: CopiableProp<Bool> = .copy
     ) -> GeneralStoreSettings {
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
         let telemetryLastReportedTime = telemetryLastReportedTime ?? self.telemetryLastReportedTime
         let areSimplePaymentTaxesEnabled = areSimplePaymentTaxesEnabled ?? self.areSimplePaymentTaxesEnabled
         let preferredInPersonPaymentGateway = preferredInPersonPaymentGateway ?? self.preferredInPersonPaymentGateway
+        let skippedCodOnboardingStep = skippedCodOnboardingStep ?? self.skippedCodOnboardingStep
 
         return GeneralStoreSettings(
             isTelemetryAvailable: isTelemetryAvailable,
             telemetryLastReportedTime: telemetryLastReportedTime,
             areSimplePaymentTaxesEnabled: areSimplePaymentTaxesEnabled,
-            preferredInPersonPaymentGateway: preferredInPersonPaymentGateway
+            preferredInPersonPaymentGateway: preferredInPersonPaymentGateway,
+            skippedCodOnboardingStep: skippedCodOnboardingStep
         )
     }
 }

--- a/Storage/Storage/Model/GeneralStoreSettings.swift
+++ b/Storage/Storage/Model/GeneralStoreSettings.swift
@@ -33,14 +33,20 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public let preferredInPersonPaymentGateway: String?
 
+    /// Stores whether the Enable Cash on Delivery In-Person Payments Onboarding step has been skipped for this store
+    ///
+    public let skippedCodOnboardingStep: Bool
+
     public init(isTelemetryAvailable: Bool = false,
                 telemetryLastReportedTime: Date? = nil,
                 areSimplePaymentTaxesEnabled: Bool = false,
-                preferredInPersonPaymentGateway: String? = nil) {
+                preferredInPersonPaymentGateway: String? = nil,
+                skippedCodOnboardingStep: Bool = false) {
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
         self.areSimplePaymentTaxesEnabled = areSimplePaymentTaxesEnabled
         self.preferredInPersonPaymentGateway = preferredInPersonPaymentGateway
+        self.skippedCodOnboardingStep = skippedCodOnboardingStep
     }
 }
 
@@ -55,6 +61,7 @@ extension GeneralStoreSettings {
         self.telemetryLastReportedTime = try container.decodeIfPresent(Date.self, forKey: .telemetryLastReportedTime)
         self.areSimplePaymentTaxesEnabled = try container.decodeIfPresent(Bool.self, forKey: .areSimplePaymentTaxesEnabled) ?? false
         self.preferredInPersonPaymentGateway = try container.decodeIfPresent(String.self, forKey: .preferredInPersonPaymentGateway)
+        self.skippedCodOnboardingStep = try container.decodeIfPresent(Bool.self, forKey: .skippedCodOnboardingStep) ?? false
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -77,7 +77,7 @@ struct InPersonPaymentsView: View {
             case .stripeAccountRejected:
                 InPersonPaymentsStripeRejected()
             case .codPaymentGatewayNotSetUp:
-                InPersonPaymentsCodPaymentGatewayNotSetUp()
+                InPersonPaymentsCodPaymentGatewayNotSetUp(viewModel: viewModel.codStepViewModel)
             case .completed(let pluginState):
                 if viewModel.showMenuOnCompletion {
                     InPersonPaymentsMenu(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -12,6 +12,10 @@ final class InPersonPaymentsViewModel: ObservableObject {
     private let useCase: CardPresentPaymentsOnboardingUseCase
     let stores: StoresManager
 
+    lazy var codStepViewModel: InPersonPaymentsCodPaymentGatewayNotSetUpViewModel = {
+        InPersonPaymentsCodPaymentGatewayNotSetUpViewModel(completion: refresh)
+    }()
+
     /// Initializes the view model for a specific site
     ///
     init(stores: StoresManager = ServiceLocator.stores,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUp.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUp.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct InPersonPaymentsCodPaymentGatewayNotSetUp: View {
+    let viewModel: InPersonPaymentsCodPaymentGatewayNotSetUpViewModel
+
     var body: some View {
         ScrollableVStack {
             Spacer()
@@ -17,7 +19,7 @@ struct InPersonPaymentsCodPaymentGatewayNotSetUp: View {
 
             Spacer()
 
-            Button(Localization.skipButton, action: {})
+            Button(Localization.skipButton, action: viewModel.skipTapped)
                 .buttonStyle(SecondaryButtonStyle())
 
             Button(Localization.enableButton, action: {})
@@ -32,7 +34,8 @@ struct InPersonPaymentsCodPaymentGatewayNotSetUp: View {
 
 struct InPersonPaymentsCodPaymentGatewayNotSetUp_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsCodPaymentGatewayNotSetUp()
+        let viewModel = InPersonPaymentsCodPaymentGatewayNotSetUpViewModel(completion: {})
+        return InPersonPaymentsCodPaymentGatewayNotSetUp(viewModel: viewModel)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Yosemite
+
+struct InPersonPaymentsCodPaymentGatewayNotSetUpViewModel {
+    let completion: () -> ()
+    let stores: StoresManager = ServiceLocator.stores
+
+    private var siteID: Int64? {
+        stores.sessionManager.defaultStoreID
+    }
+
+    func skipTapped() {
+        guard let siteID = siteID else {
+            return completion()
+        }
+
+        let action = AppSettingsAction.setSkippedCodOnboardingStep(siteID: siteID)
+        stores.dispatch(action)
+        completion()
+    }
+
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		0313651128AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651028AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift */; };
 		0313651328ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651228ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift */; };
+		0313651728ACE9F400EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651628ACE9F400EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift */; };
 		031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */; };
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
 		035F2308275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */; };
@@ -2266,6 +2267,7 @@
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		0313651028AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCodPaymentGatewayNotSetUp.swift; sourceTree = "<group>"; };
 		0313651228ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsOnboardingErrorMainContentView.swift; sourceTree = "<group>"; };
+		0313651628ACE9F400EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift; sourceTree = "<group>"; };
 		03180BE52763AA8F00B938A8 /* Woo-Release-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Release-macOS.entitlements"; sourceTree = "<group>"; };
 		03180BE62763AA8F00B938A8 /* Woo-Alpha-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha-macOS.entitlements"; sourceTree = "<group>"; };
 		03180BE72763AA9000B938A8 /* Woo-Debug-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Debug-macOS.entitlements"; sourceTree = "<group>"; };
@@ -8216,6 +8218,7 @@
 				0313651228ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift */,
 				B979A9B9282D62A500EBB383 /* InPersonPaymentsDeactivateStripeView.swift */,
 				0313651028AB81B100EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUp.swift */,
+				0313651628ACE9F400EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift */,
 			);
 			path = "Onboarding Errors";
 			sourceTree = "<group>";
@@ -9947,6 +9950,7 @@
 				4515C88D25D6BE540099C8E3 /* ShippingLabelAddressFormViewController.swift in Sources */,
 				CE5F462A23AACA0A006B1A5C /* RefundDetailsDataSource.swift in Sources */,
 				02162726237963AF000208D2 /* ProductFormViewController.swift in Sources */,
+				0313651728ACE9F400EEE571 /* InPersonPaymentsCodPaymentGatewayNotSetUpViewModel.swift in Sources */,
 				571CDD5A250ACC470076B8CC /* UITableViewDiffableDataSource+Helpers.swift in Sources */,
 				4580BA7423F192D400B5F764 /* ProductSettingsViewController.swift in Sources */,
 				45977EBA2603F632006CDFB8 /* MapsHelper.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -20,6 +20,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     ///
     private var preferredInPersonPaymentGatewayBySite = [Int64: String]()
 
+    private var skippedCodOnboardingStep = true
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -38,7 +39,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
             case .setSkippedCodOnboardingStep(_):
                 break
             case .getSkippedCodOnboardingStep(_, let completion):
-                completion(true)
+                completion(self.skippedCodOnboardingStep)
                 break
             default:
                 fatalError("Not available")
@@ -797,6 +798,54 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .stripeAccountRejected(plugin: .wcPay))
     }
 
+    func test_onboarding_returns_enable_COD_prompt_when_cod_disabled_and_not_skipped() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
+        setupCodPaymentGateway(enabled: false)
+        skippedCodOnboardingStep = false
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        assertEqual(.codPaymentGatewayNotSetUp, state)
+    }
+
+    func test_onboarding_returns_complete_when_cod_disabled_and_cod_step_was_skipped() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
+        setupCodPaymentGateway(enabled: false)
+        skippedCodOnboardingStep = true
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        assertEqual(.completed(plugin: .wcPayOnly), state)
+    }
+
+    func test_onboarding_returns_complete_when_cod_enabled() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .complete)
+        setupCodPaymentGateway(enabled: true)
+        skippedCodOnboardingStep = false
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager, stores: stores)
+        let state = useCase.state
+
+        // Then
+        assertEqual(.completed(plugin: .wcPayOnly), state)
+    }
+
     func test_onboarding_returns_generic_error_when_account_status_unknown_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)
@@ -941,3 +990,25 @@ private protocol GatewayAccountProtocol {
 
 extension WCPayAccount: GatewayAccountProtocol {}
 extension StripeAccount: GatewayAccountProtocol {}
+
+// MARK: - Gateway helpers
+private extension CardPresentPaymentsOnboardingUseCaseTests {
+    @discardableResult
+    func setupCodPaymentGateway(
+        enabled: Bool = true,
+        title: String = "",
+        description: String = ""
+    ) -> PaymentGateway {
+        let paymentGateway = PaymentGateway
+            .fake()
+            .copy(
+                siteID: sampleSiteID,
+                gatewayID: "cod",
+                title: title,
+                description: description,
+                enabled: enabled
+            )
+        storageManager.insertSamplePaymentGateway(readOnlyGateway: paymentGateway)
+        return paymentGateway
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -35,6 +35,11 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
                 onCompletion(self.preferredInPersonPaymentGatewayBySite[siteID])
             case .forgetPreferredInPersonPaymentGateway(_):
                 break
+            case .setSkippedCodOnboardingStep(_):
+                break
+            case .getSkippedCodOnboardingStep(_, let completion):
+                completion(true)
+                break
             default:
                 fatalError("Not available")
             }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -187,6 +187,14 @@ public enum AppSettingsAction: Action {
     ///
     case resetGeneralStoreSettings
 
+    /// Marks the Enable Cash on Delivery In-Person Payments Onboarding step as skipped
+    ///
+    case setSkippedCodOnboardingStep(siteID: Int64)
+
+    /// Gets whether the Enable Cash on Delivery In-Person Payments Onboarding step has been skipped
+    ///
+    case getSkippedCodOnboardingStep(siteID: Int64, onCompletion: (Bool) -> Void)
+
     // MARK: - Feature Announcement Card Visibility
 
     case setFeatureAnnouncementDismissed(campaign: FeatureAnnouncementCampaign, remindLater: Bool, onCompletion: ((Result<Bool, Error>) -> ())?)

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -182,6 +182,10 @@ public class AppSettingsStore: Store {
             setFeatureAnnouncementDismissed(campaign: campaign, remindLater: remindLater, onCompletion: completion)
         case .getFeatureAnnouncementVisibility(campaign: let campaign, onCompletion: let completion):
             getFeatureAnnouncementVisibility(campaign: campaign, onCompletion: completion)
+        case .setSkippedCodOnboardingStep(siteID: let siteID):
+            setSkippedCodOnboardingStep(siteID: siteID)
+        case .getSkippedCodOnboardingStep(siteID: let siteID, onCompletion: let completion):
+            getSkippedCodOnboardingStep(siteID: siteID, onCompletion: completion)
         }
     }
 }
@@ -718,7 +722,6 @@ private extension AppSettingsStore {
     func getPreferredInPersonPaymentGateway(siteID: Int64, onCompletion: (String?) -> Void) {
         let storeSettings = getStoreSettings(for: siteID)
         onCompletion(storeSettings.preferredInPersonPaymentGateway)
-
     }
 
     /// Forgets the preferred payment gateway for In-Person Payments
@@ -727,6 +730,21 @@ private extension AppSettingsStore {
         let storeSettings = getStoreSettings(for: siteID)
         let newSettings = storeSettings.copy(preferredInPersonPaymentGateway: .some(nil))
         setStoreSettings(settings: newSettings, for: siteID, onCompletion: nil)
+    }
+
+    /// Marks the Enable Cash on Delivery In-Person Payments Onboarding step as skipped
+    ///
+    func setSkippedCodOnboardingStep(siteID: Int64) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let newSettings = storeSettings.copy(skippedCodOnboardingStep: true)
+        setStoreSettings(settings: newSettings, for: siteID)
+    }
+
+    /// Gets whether the Enable Cash on Delivery In-Person Payments Onboarding step has been skipped
+    ///
+    func getSkippedCodOnboardingStep(siteID: Int64, onCompletion: (Bool) -> Void) {
+        let storeSettings = getStoreSettings(for: siteID)
+        onCompletion(storeSettings.skippedCodOnboardingStep)
     }
 
 }

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
@@ -40,6 +40,16 @@ extension MockStorageManager {
         return newAccount
     }
 
+    /// Inserts a new (Sample) Payment Gateway into the specified context.
+    ///
+    @discardableResult
+    func insertSamplePaymentGateway(readOnlyGateway: PaymentGateway) -> StoragePaymentGateway {
+        let newGateway = viewStorage.insertNewObject(ofType: StoragePaymentGateway.self)
+        newGateway.update(with: readOnlyGateway)
+
+        return newGateway
+    }
+
     /// Inserts a new (Sample) Product into the specified context.
     ///
     @discardableResult


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7476
- #7476 
<!-- Id number of the GitHub issue this PR addresses. -->
Merge after: #7475
- #7475 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We are adding a prompt during In-Person Payments onboarding, encouraging the merchant to enable Cash on Delivery.

Completing this new step is optional, because it’s only required if they want to accept IPP for web orders.

This PR implements the skip button, which will prevent the step from being shown again in future if the merchant decides they don’t want to enable CoD.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a store with CoD disabled (check that it's disabled in `WP Admin > WooCommerce > Settings > Payments`)

1. Go to the hub menu
2. Tap Payments and wait for the spinner to complete
3. The onboarding incomplete footer message should appear: tap `Continue Setup`
4. The `Add Pay in Person to your checkout` onboarding screen should show
5. Tap Skip – Onboarding should complete
6. Re-launch the app and complete the above steps again: the new onboarding screen should not show.

N.B. Once you have tapped skip, you will have to delete the app from the simulator/device, and reinstall it to get it to show again.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/185105858-51413324-421d-4a35-a1d9-ac0ab8f4d888.mp4

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
