### PR TITLE
Add test for refunds data in order details

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -35,7 +35,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Given
         let order = makeOrder()
 
-        insert(refund: makeRefund(orderID: order.orderID, siteID: order.siteID))
+        insert(refund: makeRefund(refundID: 1, orderID: order.orderID, siteID: order.siteID))
 
         let dataSource = OrderDetailsDataSource(
             order: order,
@@ -66,10 +66,12 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Given
         let refundItems = [
             OrderRefundCondensed(refundID: 1, reason: nil, total: "1"),
+            OrderRefundCondensed(refundID: 2, reason: nil, total: "1"),
         ]
         let order = makeOrder().copy(datePaid: .some(nil), refunds: refundItems)
 
-        insert(refund: makeRefund(orderID: order.orderID, siteID: order.siteID))
+        insert(refund: makeRefund(refundID: 1, orderID: order.orderID, siteID: order.siteID))
+        insert(refund: makeRefund(refundID: 2, orderID: order.orderID, siteID: order.siteID))
 
         let dataSource = OrderDetailsDataSource(
             order: order,
@@ -572,7 +574,7 @@ private extension OrderDetailsDataSourceTests {
                   attributes: [])
     }
 
-    func makeRefund(orderID: Int64, siteID: Int64) -> Refund {
+    func makeRefund(refundID: Int64, orderID: Int64, siteID: Int64) -> Refund {
         let orderItemRefund = OrderItemRefund(itemID: 1,
                                               name: "OrderItemRefund",
                                               productID: 1,
@@ -587,7 +589,7 @@ private extension OrderDetailsDataSourceTests {
                                               taxes: [],
                                               total: "1",
                                               totalTax: "1")
-        return Refund(refundID: 1,
+        return Refund(refundID: refundID,
                       orderID: orderID,
                       siteID: siteID,
                       dateCreated: Date(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -81,6 +81,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
         dataSource.configureResultsControllers { }
 
+        // Temp tableview to test refunds rows configuration
+        let tableView = UITableView()
+        tableView.registerNib(for: TwoColumnHeadlineFootnoteTableViewCell.self)
+
         // When
         dataSource.reloadSections()
 
@@ -93,6 +97,10 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         }
 
         // Then
+        // Each `refund` row should be initialized without any issues
+        for refundIndexPath in refundsRowsIndexes {
+            let _ = dataSource.tableView(tableView, cellForRowAt: refundIndexPath)
+        }
         // Each `refund` row should have `Refund` object accessible for its IndexPath
         let expectedRefunds: [Refund] = try refundsRowsIndexes.map { try XCTUnwrap(dataSource.refund(at: $0)) }
         XCTAssertEqual(expectedRefunds.count, refundsRowsIndexes.count)


### PR DESCRIPTION
Original issue: https://github.com/woocommerce/woocommerce-ios/issues/7112

## Description

In `OrderDetailsDataSource` refunds logic is relying on directly accessing array by index. Since refunds list is sharing section with other cells (see `let payment: Section`), index is calculated by subtracting 1 for "Payment" and "Paid by Customer" cells.

When order of cells in section changes, there is a high probability that refunds array access will crash.

This PR adds test for both functions (refund cell config and details navigation).

### Known limitations

When indexes logic breaks, Xcode test runner will crash instead of reporting correct failure reason. For example - check #7498 CI output. It's better than handling production issue, but is not ideal for readability.

## Testing

Check CI status.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.