### PR TITLE
[Mobile Payments] Moooore IPP: Disable reader manuals cell if they country is not supported for IPP

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -13,6 +13,15 @@ final class InPersonPaymentsMenuViewController: UIViewController {
     private let cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCase
     private var cancellables: Set<AnyCancellable> = []
 
+    private var enableCardReaderManualsCell: Bool {
+        !(cardPresentPaymentsOnboardingUseCase.state == .loading ||
+        cardPresentPaymentsOnboardingUseCase.state.isCountryNotSupported)
+    }
+
+    private var enableManageCardReaderCell: Bool {
+        cardPresentPaymentsOnboardingUseCase.state.isCompleted
+    }
+
     /// Main TableView
     ///
     private lazy var tableView: UITableView = {
@@ -213,13 +222,12 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func configureManageCardReader(cell: LeftImageTableViewCell) {
-        let cellShouldBeEnabled = cardPresentPaymentsOnboardingUseCase.state.isCompleted
         cell.imageView?.tintColor = .text
-        cell.accessoryType = cellShouldBeEnabled ? .disclosureIndicator : .none
-        cell.selectionStyle = cellShouldBeEnabled ? .default : .none
+        cell.accessoryType = enableManageCardReaderCell ? .disclosureIndicator : .none
+        cell.selectionStyle = enableManageCardReaderCell ? .default : .none
         cell.configure(image: .creditCardIcon, text: Localization.manageCardReader)
 
-        updateEnabledState(in: cell, shouldBeEnabled: cellShouldBeEnabled)
+        updateEnabledState(in: cell, shouldBeEnabled: enableManageCardReaderCell)
     }
 
     func configureManagePaymentGateways(cell: LeftImageTitleSubtitleTableViewCell) {
@@ -233,11 +241,11 @@ private extension InPersonPaymentsMenuViewController {
 
     func configureCardReaderManuals(cell: LeftImageTableViewCell) {
         cell.imageView?.tintColor = .text
-        cell.accessoryType = .disclosureIndicator
-        cell.selectionStyle = .default
+        cell.accessoryType = enableCardReaderManualsCell ? .disclosureIndicator : .none
+        cell.selectionStyle = enableCardReaderManualsCell ? .default : .none
         cell.configure(image: .cardReaderManualIcon, text: Localization.cardReaderManuals)
 
-        updateEnabledState(in: cell)
+        updateEnabledState(in: cell, shouldBeEnabled: enableCardReaderManualsCell)
     }
 
     func configureCollectPayment(cell: LeftImageTableViewCell) {
@@ -273,7 +281,7 @@ extension InPersonPaymentsMenuViewController {
     }
 
     func manageCardReaderWasPressed() {
-        guard cardPresentPaymentsOnboardingUseCase.state.isCompleted else {
+        guard enableManageCardReaderCell else {
             return
         }
 
@@ -288,6 +296,10 @@ extension InPersonPaymentsMenuViewController {
     }
 
     func cardReaderManualsWasPressed() {
+        guard enableCardReaderManualsCell else {
+            return
+        }
+
         ServiceLocator.analytics.track(.paymentsMenuCardReadersManualsTapped)
         let view = UIHostingController(rootView: CardReaderManualsView())
         navigationController?.pushViewController(view, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -13,6 +13,8 @@ final class InPersonPaymentsMenuViewController: UIViewController {
     private let cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCase
     private var cancellables: Set<AnyCancellable> = []
 
+    /// No Manuals to be shown in a country where IPP is not supported
+    /// 
     private var enableCardReaderManualsCell: Bool {
         !(cardPresentPaymentsOnboardingUseCase.state == .loading ||
         cardPresentPaymentsOnboardingUseCase.state.isCountryNotSupported)

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -131,4 +131,13 @@ extension CardPresentPaymentOnboardingState {
             return false
         }
     }
+
+    public var isCountryNotSupported: Bool {
+        if case .countryNotSupported(_) = self {
+            return true
+        } else {
+            return false
+        }
+
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7488 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR disables the "Card Reader Manuals" cell in the Payments Hub Menu if the store country is not supported for In-Person Payments. Before we allowed the user in that state navigation into the reader manuals screen, only to find an empty list with no message whatsoever.
If the country is supported (US or Canada) but the onboarding is not finished for any other reason, the user should be able to tap on "Card Reader Manuals" and browse the reader manuals available in their country.

⚠️  **Note**: This PR mergeability depends on the decision taken in this p2: pdfdoF-1aF-p2:

- If we decide to filter manuals depending on the country, I think the logic implemented through this PR makes more sense
- If we decide to show all readers for all users, we can go with https://github.com/woocommerce/woocommerce-ios/pull/7497
In either case, one of the two should be merged to avoid #7488 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Case 1
Prerequisites: The country of the store selected should not be supported by In-Person Payments (Any country except US and Canada)

1. Go to Menu
2. Tap on Payments
3. "Card Reader Manuals" cell should be disabled

https://user-images.githubusercontent.com/1864060/185131104-c3325b2f-3389-4f95-95b7-01467f43a1be.mp4

#### Case 2
Prerequisites: The country of the store selected is supported by In-Person Payments  (US and Canada). The behavior is independent of whether they finished the onboarding or not.

1. Go to Menu
2. Tap on Payments
3. "Card Reader Manuals" cell should be enabled

https://user-images.githubusercontent.com/1864060/185130429-fdab5fd0-b483-4b50-8601-68f0da7516ec.mp4

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

See above

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->