### PR TITLE
Login Reminder: add an action to reset password for invalid password local notifications

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -42,8 +42,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  # pod 'WordPressAuthenticator', '~> 2.2.1-beta.1'
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'b6965adde51fb7ce26eefb4dd6aa616677d6f282'
+  pod 'WordPressAuthenticator', '~> 2.2.1-beta.2'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -42,8 +42,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 2.2.1-beta.1'
-  # pod 'WordPressAuthenticator', :git => ''
+  # pod 'WordPressAuthenticator', '~> 2.2.1-beta.1'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'b6965adde51fb7ce26eefb4dd6aa616677d6f282'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -42,7 +42,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (2.2.1-beta.1):
+  - WordPressAuthenticator (2.2.1-beta.2):
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 6.0.1)
@@ -92,7 +92,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 2.2.1-beta.1)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `b6965adde51fb7ce26eefb4dd6aa616677d6f282`)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -102,8 +102,6 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -141,6 +139,16 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :commit: b6965adde51fb7ce26eefb4dd6aa616677d6f282
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: b6965adde51fb7ce26eefb4dd6aa616677d6f282
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
@@ -163,7 +171,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: a1cfe16300440d628dc26b3215d1c6372c4ecd5e
+  WordPressAuthenticator: 309e3c060d1a777a1d691d393f0e17b8d3484791
   WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -179,6 +187,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 203984094d25f40842032fe99d4d8f575ca164ea
+PODFILE CHECKSUM: d3fc81d9f65d8716282ec33f18d1d359058d869c
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -92,7 +92,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `b6965adde51fb7ce26eefb4dd6aa616677d6f282`)
+  - WordPressAuthenticator (~> 2.2.1-beta.2)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -102,6 +102,8 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
+  https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -139,16 +141,6 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :commit: b6965adde51fb7ce26eefb4dd6aa616677d6f282
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: b6965adde51fb7ce26eefb4dd6aa616677d6f282
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
@@ -171,7 +163,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 309e3c060d1a777a1d691d393f0e17b8d3484791
+  WordPressAuthenticator: 5695f2f517df46414456195914eccfe2a6be4b1b
   WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -187,6 +179,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: d3fc81d9f65d8716282ec33f18d1d359058d869c
+PODFILE CHECKSUM: a9489557183401ff27ecf7a8b78378f0e3363892
 
 COCOAPODS: 1.11.2

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -480,8 +480,8 @@ private extension AuthenticationManager {
             notification = LocalNotification(scenario: .invalidEmailFromSiteAddressLogin)
         case .invalidEmailFromWPComLogin:
             notification = LocalNotification(scenario: .invalidEmailFromWPComLogin)
-        case .invalidPasswordFromSiteAddressLogin:
-            notification = LocalNotification(scenario: .invalidPasswordFromSiteAddressLogin)
+        case .invalidPasswordFromSiteAddressWPComLogin:
+            notification = LocalNotification(scenario: .invalidPasswordFromSiteAddressWPComLogin)
         case .invalidPasswordFromWPComLogin:
             notification = LocalNotification(scenario: .invalidPasswordFromWPComLogin)
         default:
@@ -558,7 +558,7 @@ extension AuthenticationManager {
             return NotWPErrorViewModel()
         case .noSecureConnection:
             return NoSecureConnectionErrorViewModel()
-        case .unknown, .invalidPasswordFromWPComLogin, .invalidPasswordFromSiteAddressLogin:
+        case .unknown, .invalidPasswordFromWPComLogin, .invalidPasswordFromSiteAddressWPComLogin:
             return nil
         }
     }
@@ -572,7 +572,7 @@ private extension AuthenticationManager {
         case emailDoesNotMatchWPAccount
         case invalidEmailFromSiteAddressLogin
         case invalidEmailFromWPComLogin
-        case invalidPasswordFromSiteAddressLogin
+        case invalidPasswordFromSiteAddressWPComLogin
         case invalidPasswordFromWPComLogin
         case notWPSite
         case notValidAddress
@@ -594,7 +594,7 @@ private extension AuthenticationManager {
                     case .wpCom:
                         return .invalidPasswordFromWPComLogin
                     case .wpComSiteAddress:
-                        return .invalidPasswordFromSiteAddressLogin
+                        return .invalidPasswordFromSiteAddressWPComLogin
                     }
                 }
             }

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -75,7 +75,7 @@ private extension LocalNotification {
         static let errorLoggingInTitle = NSLocalizedString("Problems with logging in?",
                                                            comment: "Local notification title when the user encounters an error logging in " +
                                                            "with site address.")
-        static let passwordErrorTitle = NSLocalizedString("Can't remember your WordPress.com password?",
+        static let passwordErrorTitle = NSLocalizedString("Can't remember your password?",
                                                            comment: "Local notification title when the user encounters an error with WP.com password.")
         static let errorLoggingInBody = NSLocalizedString("Get some help!",
                                                           comment: "Local notification body when the user encounters an error logging in " +

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -75,7 +75,7 @@ private extension LocalNotification {
         static let errorLoggingInTitle = NSLocalizedString("Problems with logging in?",
                                                            comment: "Local notification title when the user encounters an error logging in " +
                                                            "with site address.")
-        static let passwordErrorTitle = NSLocalizedString("Can't remember your password?",
+        static let passwordErrorTitle = NSLocalizedString("Can't remember your WordPress.com password?",
                                                            comment: "Local notification title when the user encounters an error with WP.com password.")
         static let errorLoggingInBody = NSLocalizedString("Get some help!",
                                                           comment: "Local notification body when the user encounters an error logging in " +

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -19,7 +19,7 @@ struct LocalNotification {
         case loginSiteAddressError = "site_address_error"
         case invalidEmailFromSiteAddressLogin = "site_address_email_error"
         case invalidEmailFromWPComLogin = "wpcom_email_error"
-        case invalidPasswordFromSiteAddressLogin = "site_address_wpcom_password_error"
+        case invalidPasswordFromSiteAddressWPComLogin = "site_address_wpcom_password_error"
         case invalidPasswordFromWPComLogin = "wpcom_password_error"
     }
 
@@ -61,7 +61,7 @@ extension LocalNotification {
                       body: Localization.errorLoggingInBody,
                       scenario: scenario,
                       actions: .init(category: .loginError, actions: [.contactSupport]))
-        case .invalidPasswordFromWPComLogin, .invalidPasswordFromSiteAddressLogin:
+        case .invalidPasswordFromWPComLogin, .invalidPasswordFromSiteAddressWPComLogin:
             self.init(title: Localization.passwordErrorTitle,
                       body: Localization.errorLoggingInBody,
                       scenario: scenario,

--- a/WooCommerce/Classes/Notifications/LocalNotification.swift
+++ b/WooCommerce/Classes/Notifications/LocalNotification.swift
@@ -32,6 +32,7 @@ struct LocalNotification {
     enum Action: String {
         case contactSupport
         case loginWithWPCom
+        case resetPassword
 
         /// The title of the action in a local notification.
         var title: String {
@@ -40,6 +41,8 @@ struct LocalNotification {
                 return NSLocalizedString("Contact support", comment: "Local notification action to contact support.")
             case .loginWithWPCom:
                 return NSLocalizedString("Login with WordPress.com", comment: "Local notification action to log in with WordPress.com.")
+            case .resetPassword:
+                return NSLocalizedString("Reset password", comment: "Local notification action to reset password.")
             }
         }
     }
@@ -59,10 +62,10 @@ extension LocalNotification {
                       scenario: scenario,
                       actions: .init(category: .loginError, actions: [.contactSupport]))
         case .invalidPasswordFromWPComLogin, .invalidPasswordFromSiteAddressLogin:
-            self.init(title: Localization.errorLoggingInTitle,
+            self.init(title: Localization.passwordErrorTitle,
                       body: Localization.errorLoggingInBody,
                       scenario: scenario,
-                      actions: .init(category: .loginError, actions: [.contactSupport]))
+                      actions: .init(category: .loginError, actions: [.resetPassword, .contactSupport]))
         }
     }
 }
@@ -72,6 +75,8 @@ private extension LocalNotification {
         static let errorLoggingInTitle = NSLocalizedString("Problems with logging in?",
                                                            comment: "Local notification title when the user encounters an error logging in " +
                                                            "with site address.")
+        static let passwordErrorTitle = NSLocalizedString("Can't remember your password?",
+                                                           comment: "Local notification title when the user encounters an error with WP.com password.")
         static let errorLoggingInBody = NSLocalizedString("Get some help!",
                                                           comment: "Local notification body when the user encounters an error logging in " +
                                                           "with site address.")

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -291,6 +291,17 @@ private extension AppCoordinator {
                 "action": "login_with_wpcom",
                 "type": response.notification.request.identifier
             ])
+        case LocalNotification.Action.resetPassword.rawValue:
+            let loginFields: LoginFields = {
+                let fields = LoginFields()
+                fields.meta.userIsDotCom = true
+                return fields
+            }()
+            WordPressAuthenticator.openForgotPasswordURL(loginFields)
+            analytics.track(.loginLocalNotificationTapped, withProperties: [
+                "action": "reset_password",
+                "type": response.notification.request.identifier
+            ])
         case UNNotificationDefaultActionIdentifier:
             // Triggered when the user taps on the notification itself instead of one of the actions.
             let requestIdentifier = response.notification.request.identifier


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7318 
Project thread: pe5sF9-h9-p2
<!-- Id number of the GitHub issue this PR addresses. -->

- [ ] ⚠️ Please also review the WPAuthenticator PR https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/667, which contains most of the changes ⚠️ 
- [ ] ⚠️ Make sure the WPAutheticator pod is using the production version in the Podfile ⚠️ 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We'd like to add an action to reset password for users who encounter an error logging in with their WP.com password, other than the current single action to contact support. It reuses the "forgot password" flow in the WPAuthenticator library.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please update the 24 hours schedule to a few seconds or a minute in `AuthenticationManager` (search for "86400") to test this PR (I used 5 seconds).

You can test this PR in a simulator.

#### WP.com flow - contact support action

- Reinstall the app to clear any previous notifications permission state if needed
- Skip the onboarding if needed
- Tap "Continue With WordPress.com"
- Enter a valid email that is linked to a WP.com account
- If magic links are enabled (e.g. non-a8c email), tap "Use password to sign in" to log in with password
- Enter an invalid password
- Quickly put the app to the background since we don't support local notifications in the foreground --> a local notification should be shown after the duration you set in `AuthenticationManager`
- Long press on the notification to see actions --> there should be two actions: "Reset password" and "Contact support"
- Tap "Reset password" --> it should open a web view to reset the WP.com password, and an event is logged in the console: `🔵 Tracked login_local_notification_tapped, properties: [AnyHashable("type"): "wpcom_password_error", AnyHashable("action"): "reset_password"]`

#### Site address flow - default action

- Continue from the previous test case
- Navigate back to the prologue screen
- Tap "Enter Your Store Address"
- Enter a valid WP.com store address
- Enter a valid email that is linked to a WP.com account
- If magic links are enabled (e.g. non-a8c email), tap "Use password to sign in" to log in with password
- Enter an invalid password
- Quickly put the app to the background since we don't support local notifications in the foreground --> a local notification should be shown after the duration you set in `AuthenticationManager`
- Long press on the notification to see actions --> there should be two actions: "Reset password" and "Contact support"
- Tap "Reset password" --> it should open a web view to reset the WP.com password, with an event in the console: `🔵 Tracked login_local_notification_tapped, properties: [AnyHashable("type"): "site_address_wpcom_password_error", AnyHashable("action"): "reset_password"]`

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Please note that the screenshots are on an iOS 16 simulator due to copy/paste issues in Xcode 13.4.1.

notification | notification actions | reset password web view
-- | -- | --
![Simulator Screen Shot - iPhone 13 - 2022-08-17 at 21 16 07](https://user-images.githubusercontent.com/1945542/185143908-b99e2111-4968-4e55-a4d8-dccdafa4c7fb.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-17 at 21 16 13](https://user-images.githubusercontent.com/1945542/185143956-38f26cd5-0d90-43cf-bc6a-2b08f1af68ac.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-17 at 21 10 45](https://user-images.githubusercontent.com/1945542/185143900-2b7cfe2d-6685-44bc-8137-12f60a327145.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->