### PR TITLE
[Mobile Payments] Skip button on pending requirements onboarding step

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Login: on the WP.com password screen, the magic link login option is moved from below "Reset your password" to below the primary Continue button for higher visibility. [https://github.com/woocommerce/woocommerce-ios/pull/7469]
 - [*] Login: some minor enhancements are made to the error screen after entering an invalid WP.com email - a new "What is WordPress.com?" link, hiding the "Log in with store address" button when it's from the store address login flow, and some copy changes. [https://github.com/woocommerce/woocommerce-ios/pull/7485]
+- [**] In-Person Payments: Accounts with pending requirements are no longer blocked from taking payments - we have added a skip button to the relevant screen. [https://github.com/woocommerce/woocommerce-ios/pull/7504]
 
 9.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -71,7 +71,7 @@ struct InPersonPaymentsView: View {
             case .stripeAccountOverdueRequirement:
                 InPersonPaymentsStripeAccountOverdue()
             case .stripeAccountPendingRequirement(_, let deadline):
-                InPersonPaymentsStripeAccountPending(deadline: deadline)
+                InPersonPaymentsStripeAccountPending(deadline: deadline, onSkip: viewModel.skipPendingRequirements)
             case .stripeAccountUnderReview:
                 InPersonPaymentsStripeAccountReview()
             case .stripeAccountRejected:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -66,6 +66,12 @@ final class InPersonPaymentsViewModel: ObservableObject {
         useCase.refresh()
     }
 
+    /// Skips the Pending Requirements step when the user taps `Skip`
+    ///
+    func skipPendingRequirements() {
+        useCase.skipPendingRequirements()
+    }
+
     /// Selects the plugin to use as a payment gateway when there are multiple available
     ///
     func selectPlugin(_ plugin: CardPresentPaymentsPlugin) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsStripeAccountPending: View {
     let deadline: Date?
+    let onSkip: () -> ()
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -9,12 +10,16 @@ struct InPersonPaymentsStripeAccountPending: View {
             message: message,
             image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo(
                 image: .paymentErrorImage,
-                height: 180.0
+                height: Constants.imageHeight
             ),
             supportLink: true,
-            learnMore: true
+            learnMore: true,
+            button: InPersonPaymentsOnboardingError.ButtonInfo(
+                text: Localization.skipButton,
+                action: onSkip
+            )
         )
-      }
+    }
 
     private var message: String {
         guard let deadline = deadline else {
@@ -28,31 +33,32 @@ struct InPersonPaymentsStripeAccountPending: View {
 private enum Localization {
     static let title = NSLocalizedString(
         "Your payments account has pending requirements",
-        comment: "Title for the error screen when the merchant's In-Person Payments account is restricted because there are pending requirements"
+        comment: "Title for the error screen when the merchant's In-Person Payments account has pending " +
+        "requirements which will result in their account being restricted if not resolved by a deadline"
     )
 
     static let messageDeadline = NSLocalizedString(
         "There are pending requirements for your account. Please complete those requirements by %1$@ to keep accepting In-Person Payments.",
-        comment: "Error message when In-Person Payments is not supported because there are pending requirements in the merchant's payment account."
-            +
-            "%1$d will contain the localized deadline (e.g. August 11, 2021)"
+        comment: "Error message when because there are pending requirements in the merchant's " +
+        "In-Person Payments account. %1$d will contain the localized deadline (e.g. August 11, 2021)"
     )
 
     static let messageUnknownDeadline = NSLocalizedString(
         "There are pending requirements for your account. Please complete those requirements to keep accepting In-Person Payments.",
-        comment: "Error message when In-Person Payments is not supported"
-            +
-            "There are pending requirements in the merchant's payment account (without a known deadline)"
+        comment: "Error message when there are pending requirements in the merchant's payment account (without a known deadline)"
     )
 
-     static let message = NSLocalizedString(
-         "There are pending requirements for your account. Please complete those requirements by",
-         comment: "Error message when the Stripe account is restricted because there are pending requirements"
-     )
- }
+    static let skipButton = NSLocalizedString(
+        "Skip",
+        comment: "Title for the button to skip the onboarding step informing the merchant of pending account requirements")
+}
 
 struct InPersonPaymentsStripeAccountPending_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAccountPending(deadline: Date())
+        InPersonPaymentsStripeAccountPending(deadline: Date(), onSkip: {})
     }
+}
+
+private enum Constants {
+    static let imageHeight: CGFloat = 180.0
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7502
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The onboarding state for `Stripe account has pending requirements` informs the merchant that there's additional information needed on their account, but that they have some time to complete that information before it becomes a requirement. The deadline is also shown.

Previously, it did not have a button, so it prevented merchants taking payments even though the deadline had not passed.

This change adds a skip button so that the merchant can still take payments. Once the deadline is past, the overdue requirements screen is shown instead, which does not have a skip button.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Hardcode [the `isStripeAccountPendingRequirements` helper function](https://github.com/woocommerce/woocommerce-ios/blob/c5b13e5fa1a9b1b11db3ff556e9a5172dfa4bce0/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person%20Payments/CardPresentPaymentsOnboardingUseCase.swift#L393) to always `return true`

Payments menu:
1. Open the Payments menu
2. You should see the `Continue setup` button after the spinner completes: tap this
3. The `Pending Requirements` onboarding screen should show
4. Tap the `Skip` button, the onboarding flow should complete and return you to the menu.
5. Observe that the `Continue setup` button is still there, and the above flow can be repeated.

Order payment:
1. Add a new order, or open an order which is `Pending payment`
2. Tap `Collect Payment` and select the `Card` payment method
3. Observe that the `Pending Requirements` onboarding screen is shown, and can be skipped
4. Confirm that you can take the payment after skipping.

N.B. The onboarding checks appear to be being run every time the merchant takes a payment, which is not correct: they should only be run when a reader is connected, or the Payments menu is opened. That is a pre-existing issue.
- #7505 

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/185157673-6c6038d6-ba7f-46da-ab59-6afa6c251d9d.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
