### PR TITLE
Load orders products in list request

### DIFF
--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -75,7 +75,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                 paymentMethodTitle: String,
                 paymentURL: URL?,
                 chargeID: String?,
-                items: [OrderItem]?,
+                items: [OrderItem],
                 billingAddress: Address?,
                 shippingAddress: Address?,
                 shippingLines: [ShippingLine],
@@ -114,7 +114,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         self.paymentURL = paymentURL
         self.chargeID = chargeID
 
-        self.items = items ?? []
+        self.items = items
         self.billingAddress = billingAddress
         self.shippingAddress = shippingAddress
         self.shippingLines = shippingLines
@@ -166,7 +166,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         var chargeID: String? = nil
         chargeID = allOrderMetaData?.first(where: { $0.key == "_charge_id" })?.value
 
-        let items = try? container.decodeIfPresent([OrderItem].self, forKey: .items) ?? []
+        let items = try container.decode([OrderItem].self, forKey: .items)
 
         var shippingAddress = try? container.decode(Address.self, forKey: .shippingAddress)
         // In WooCommerce <5.6.0, the shipping phone number can be stored in the order metadata

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -288,20 +288,20 @@ public extension OrdersRemote {
     }
 
     enum ParameterValues {
-        // Same as singleOrderFieldValues except we exclude the line_items and shipping fields
+        // Same as singleOrderFieldValues except we exclude the shipping field
         static let listFieldValues: String = commonOrderFieldValues.joined(separator: ",")
         static let singleOrderFieldValues: String = (commonOrderFieldValues + singleOrderExtraFieldValues).joined(separator: ",")
         private static let commonOrderFieldValues = [
             "id", "parent_id", "number", "status", "currency", "customer_id", "customer_note", "date_created_gmt", "date_modified_gmt", "date_paid_gmt",
             "discount_total", "discount_tax", "shipping_total", "shipping_tax", "total", "total_tax", "payment_method", "payment_method_title",
-            "payment_url", "billing", "coupon_lines", "shipping_lines", "refunds", "fee_lines", "order_key", "tax_lines", "meta_data", "is_editable",
+            "payment_url", "line_items", "billing", "coupon_lines", "shipping_lines", "refunds", "fee_lines", "order_key", "tax_lines", "meta_data", "is_editable",
             "needs_payment", "needs_processing"
         ]
         // Use with caution. Any fields in here will be overwritten with empty values by
         // `Order+ReadOnlyConvertible.swift: Order.update(with:)` when the list of orders is fetched.
         // See p91TBi-7yL-p2 for discussion.
         private static let singleOrderExtraFieldValues = [
-            "line_items", "shipping"
+            "shipping"
         ]
     }
 

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -294,8 +294,8 @@ public extension OrdersRemote {
         private static let commonOrderFieldValues = [
             "id", "parent_id", "number", "status", "currency", "customer_id", "customer_note", "date_created_gmt", "date_modified_gmt", "date_paid_gmt",
             "discount_total", "discount_tax", "shipping_total", "shipping_tax", "total", "total_tax", "payment_method", "payment_method_title",
-            "payment_url", "line_items", "billing", "coupon_lines", "shipping_lines", "refunds", "fee_lines", "order_key", "tax_lines", "meta_data", "is_editable",
-            "needs_payment", "needs_processing"
+            "payment_url", "line_items", "billing", "coupon_lines", "shipping_lines", "refunds", "fee_lines", "order_key", "tax_lines", "meta_data",
+            "is_editable", "needs_payment", "needs_processing"
         ]
         // Use with caution. Any fields in here will be overwritten with empty values by
         // `Order+ReadOnlyConvertible.swift: Order.update(with:)` when the list of orders is fetched.


### PR DESCRIPTION
Partial rollback of #4997.

## Description

This PR moves `line_items` field to orders list request, instead of querying it only for individual order details.
This will prevent flicker/jumping of data sections in order details.

## Test

1. Go to the Order tab, open order.
2. Open different orders and verify products load correctly.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.