### PR TITLE
[Mobile Payments] PUT PaymentGateway network request and Action

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -77,6 +77,9 @@
 		02E7FFCB256218F600C53030 /* ShippingLabelRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */; };
 		02E7FFCF25621C7900C53030 /* shipping-label-print.json in Resources */ = {isa = PBXBuildFile; fileRef = 02E7FFCE25621C7900C53030 /* shipping-label-print.json */; };
 		02F096C22406691100C0C1D5 /* media-library.json in Resources */ = {isa = PBXBuildFile; fileRef = 02F096C12406691100C0C1D5 /* media-library.json */; };
+		0313651928AE559D00EEE571 /* PaymentGatewayMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651828AE559D00EEE571 /* PaymentGatewayMapper.swift */; };
+		0313651B28AE60E000EEE571 /* payment-gateway-cod.json in Resources */ = {isa = PBXBuildFile; fileRef = 0313651A28AE60E000EEE571 /* payment-gateway-cod.json */; };
+		0313651D28AE625300EEE571 /* PaymentGatewayMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651C28AE625300EEE571 /* PaymentGatewayMapperTests.swift */; };
 		0329CF9B27A82E19008AFF91 /* WCPayCharge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0329CF9A27A82E19008AFF91 /* WCPayCharge.swift */; };
 		034480C327A42F9100DFACD2 /* order-with-charge.json in Resources */ = {isa = PBXBuildFile; fileRef = 034480C227A42F9100DFACD2 /* order-with-charge.json */; };
 		0359EA0D27AAC5F80048DE2D /* WCPayChargeStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359EA0C27AAC5F80048DE2D /* WCPayChargeStatus.swift */; };
@@ -751,6 +754,9 @@
 		02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRemoteTests.swift; sourceTree = "<group>"; };
 		02E7FFCE25621C7900C53030 /* shipping-label-print.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-print.json"; sourceTree = "<group>"; };
 		02F096C12406691100C0C1D5 /* media-library.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-library.json"; sourceTree = "<group>"; };
+		0313651828AE559D00EEE571 /* PaymentGatewayMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayMapper.swift; sourceTree = "<group>"; };
+		0313651A28AE60E000EEE571 /* payment-gateway-cod.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "payment-gateway-cod.json"; sourceTree = "<group>"; };
+		0313651C28AE625300EEE571 /* PaymentGatewayMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayMapperTests.swift; sourceTree = "<group>"; };
 		0329CF9A27A82E19008AFF91 /* WCPayCharge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayCharge.swift; sourceTree = "<group>"; };
 		034480C227A42F9100DFACD2 /* order-with-charge.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-charge.json"; sourceTree = "<group>"; };
 		0359EA0C27AAC5F80048DE2D /* WCPayChargeStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCPayChargeStatus.swift; sourceTree = "<group>"; };
@@ -1913,6 +1919,7 @@
 				0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */,
 				A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */,
 				261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */,
+				0313651A28AE60E000EEE571 /* payment-gateway-cod.json */,
 				261CF2CA255C50010090D8D3 /* payment-gateway-list-half.json */,
 				DEC51A96274DD962009F3DF4 /* plugin.json */,
 				DEC51A9A274E3206009F3DF4 /* plugin-inactive.json */,
@@ -2077,6 +2084,7 @@
 				02C254B825637BA000A04423 /* OrderShippingLabelListMapper.swift */,
 				D8FBFF1022D3B3FC006E3336 /* OrderStatsV4Mapper.swift */,
 				26731336255ACA850026F7EF /* PaymentGatewayListMapper.swift */,
+				0313651828AE559D00EEE571 /* PaymentGatewayMapper.swift */,
 				74749B96224134FF005C4CF2 /* ProductMapper.swift */,
 				45152810257A81730076B03C /* ProductAttributeMapper.swift */,
 				4515280C257A7EEC0076B03C /* ProductAttributeListMapper.swift */,
@@ -2217,6 +2225,7 @@
 				74C8F06D20EEC1E700B6EDC9 /* OrderNotesMapperTests.swift */,
 				D8FBFF1D22D51F39006E3336 /* OrderStatsMapperV4Tests.swift */,
 				262E5AD4255ACD6F000B2416 /* PaymentGatewayListMapperTests.swift */,
+				0313651C28AE625300EEE571 /* PaymentGatewayMapperTests.swift */,
 				D8A2849925FBB2E70019A84B /* ProductAttributeTermListMapperTests.swift */,
 				CE0A0F1C22398D520075ED8D /* ProductListMapperTests.swift */,
 				74CF0A8B22414D7800DB993F /* ProductMapperTests.swift */,
@@ -2534,6 +2543,7 @@
 				D865CE6B278CA266002C8520 /* stripe-payment-intent-error.json in Resources */,
 				CCB2CAA82620ABCC00285CA0 /* shipping-label-create-package-error.json in Resources */,
 				B57B1E6C21C94C9F0046E764 /* timeout_error.json in Resources */,
+				0313651B28AE60E000EEE571 /* payment-gateway-cod.json in Resources */,
 				B5C6FCD620A3768900A4F8E4 /* order.json in Resources */,
 				3158FE7426129D9F00E566B9 /* wcpay-account-rejected-other.json in Resources */,
 				CC0786C7267BB10700BA9AC1 /* shipping-label-status-success.json in Resources */,
@@ -2877,6 +2887,7 @@
 				CC6A1FF5270E042200F6AF4A /* OrderMetaData.swift in Sources */,
 				DEC51B02276AFB35009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift in Sources */,
 				02C254A4256371B200A04423 /* ShippingLabelSettings.swift in Sources */,
+				0313651928AE559D00EEE571 /* PaymentGatewayMapper.swift in Sources */,
 				B554FA912180BCFC00C54DFF /* NoteHash.swift in Sources */,
 				CE0A0F19223987DF0075ED8D /* ProductListMapper.swift in Sources */,
 				021C7BF723863D1800A3BCBD /* Encodable+Serialization.swift in Sources */,
@@ -3067,6 +3078,7 @@
 				B505F6D320BEE3A500BB1B69 /* AccountMapperTests.swift in Sources */,
 				CC9A254A26442D26005DE56E /* ShippingLabelCreationEligibilityMapperTests.swift in Sources */,
 				5726F7342460A8F00031CAAC /* CopiableTests.swift in Sources */,
+				0313651D28AE625300EEE571 /* PaymentGatewayMapperTests.swift in Sources */,
 				26615479242DA54D00A31661 /* ProductCategoyListMapperTests.swift in Sources */,
 				B5C6FCC820A32E4800A4F8E4 /* DateFormatterWooTests.swift in Sources */,
 				74C8F06A20EEBC8C00B6EDC9 /* OrderMapperTests.swift in Sources */,

--- a/Networking/Networking/Mapper/PaymentGatewayListMapper.swift
+++ b/Networking/Networking/Mapper/PaymentGatewayListMapper.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 struct PaymentGatewayListMapper: Mapper {
 
-    /// Site Identifier associated to the shipment trackings that will be parsed.
+    /// Site Identifier associated to the payment gateways that will be parsed.
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't
     /// return the siteID for the payment gateway endpoint
     ///

--- a/Networking/Networking/Mapper/PaymentGatewayMapper.swift
+++ b/Networking/Networking/Mapper/PaymentGatewayMapper.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Mapper for a `PaymentGateway` JSON object
+///
+struct PaymentGatewayMapper: Mapper {
+
+    /// Site Identifier associated to the payment gateway that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't
+    /// return the siteID for the payment gateway endpoint
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert a dictionary into `PaymentGateway`
+    ///
+    func map(response: Data) throws -> PaymentGateway {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID,
+        ]
+        return try decoder.decode(PaymentGatewayEnvelope.self, from: response).paymentGateway
+    }
+}
+
+/// PaymentGateway list disposable entity:
+/// `Load Payment Gateway` endpoint returns all of the gateway information within a `body` obejcts in the `data` key. This entity
+/// allows us to parse all the things with JSONDecoder.
+///
+private struct PaymentGatewayEnvelope: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case paymentGateway = "data"
+    }
+
+    let paymentGateway: PaymentGateway
+}

--- a/Networking/Networking/Model/PaymentGateway.swift
+++ b/Networking/Networking/Model/PaymentGateway.swift
@@ -48,7 +48,7 @@ public struct PaymentGateway: Equatable, GeneratedFakeable, GeneratedCopiable {
 }
 
 // MARK: Gateway Decodable
-extension PaymentGateway: Decodable {
+extension PaymentGateway: Codable {
 
     public enum DecodingError: Error {
         case missingSiteID
@@ -85,7 +85,7 @@ extension PaymentGateway: Decodable {
 }
 
 // MARK: Features Decodable
-extension PaymentGateway.Feature: RawRepresentable, Decodable {
+extension PaymentGateway.Feature: RawRepresentable, Codable {
 
     /// Enum containing the 'Known' Feature Keys
     ///

--- a/Networking/Networking/Remote/PaymentGatewayRemote.swift
+++ b/Networking/Networking/Remote/PaymentGatewayRemote.swift
@@ -15,6 +15,35 @@ public class PaymentGatewayRemote: Remote {
         let mapper = PaymentGatewayListMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    // MARK: - Update Payment Gateway
+
+    /// Updates a `PaymentGateway`.
+    ///
+    /// - Parameters:
+    ///     - paymentGateway: The Payment Gateway to be updated remotely.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func updatePaymentGateway(_ paymentGateway: PaymentGateway,
+                             completion: @escaping (Result<PaymentGateway, Error>) -> Void) {
+        do {
+            let parameters = try paymentGateway.toDictionary(keyEncodingStrategy: .convertToSnakeCase)
+            let siteID = paymentGateway.siteID
+            let path = Constants.path + "/\(paymentGateway.gatewayID)"
+
+            let request = JetpackRequest(wooApiVersion: .mark3,
+                                         method: .put,
+                                         siteID: siteID,
+                                         path: path,
+                                         parameters: parameters)
+
+            let mapper = PaymentGatewayMapper(siteID: siteID)
+
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
+    }
 }
 
 // MARK: Constant

--- a/Networking/NetworkingTests/Mapper/PaymentGatewayMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/PaymentGatewayMapperTests.swift
@@ -52,7 +52,7 @@ private extension PaymentGatewayMapperTests {
         return try PaymentGatewayMapper(siteID: dummySiteID).map(response: response)
     }
 
-    /// Returns the PaymentGatewayMapper output from `paymentGateway.json`
+    /// Returns the PaymentGatewayMapper output from `payment-gateway-cod.json`
     ///
     func mapRetrievePaymentGatewayResponse() throws -> PaymentGateway {
         return try mapPaymentGateway(from: "payment-gateway-cod")

--- a/Networking/NetworkingTests/Mapper/PaymentGatewayMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/PaymentGatewayMapperTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Networking
+
+final class PaymentGatewayMapperTests: XCTestCase {
+
+    /// Dummy Site ID.
+    ///
+    fileprivate let dummySiteID: Int64 = 12983476
+
+    /// Verifies that the PaymentGateway is parsed.
+    ///
+    func test_PaymentGateway_map_parses_all_paymentGateways_in_response() throws {
+        let paymentGateway = try mapRetrievePaymentGatewayResponse()
+        XCTAssertNotNil(paymentGateway)
+    }
+
+    /// Verifies that the `siteID` is added in the mapper, because it's not provided by the API endpoint
+    ///
+    func test_PaymentGatewaysList_map_includes_siteID_in_parsed_results() throws {
+        let paymentGateway = try mapRetrievePaymentGatewayResponse()
+        XCTAssertEqual(paymentGateway.siteID, dummySiteID)
+    }
+
+    /// Verifies that the fields are all parsed correctly
+    ///
+    func test_PaymentGatewaysList_map_parses_all_fields_in_result() throws {
+        let paymentGateway = try mapRetrievePaymentGatewayResponse()
+
+        let expectedPaymentGateway = PaymentGateway(siteID: dummySiteID,
+                                                    gatewayID: "cod",
+                                                    title: "Cash on delivery",
+                                                    description: "Pay with cash upon delivery.",
+                                                    enabled: true,
+                                                    features: [.products])
+
+        XCTAssertEqual(paymentGateway, expectedPaymentGateway)
+    }
+}
+
+
+// MARK: - Test Helpers
+///
+private extension PaymentGatewayMapperTests {
+
+    /// Returns the PaymentGatewayMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapPaymentGateway(from filename: String) throws -> PaymentGateway {
+        guard let response = Loader.contentsOf(filename) else {
+            throw FileNotFoundError()
+        }
+
+        return try PaymentGatewayMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    /// Returns the PaymentGatewayMapper output from `paymentGateway.json`
+    ///
+    func mapRetrievePaymentGatewayResponse() throws -> PaymentGateway {
+        return try mapPaymentGateway(from: "payment-gateway-cod")
+    }
+
+    struct FileNotFoundError: Error {}
+}

--- a/Networking/NetworkingTests/Remote/PaymentsGatewayRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/PaymentsGatewayRemoteTests.swift
@@ -38,4 +38,63 @@ final class PaymentsGatewayRemoteTests: XCTestCase {
         let gateways = try result.get()
         XCTAssertFalse(gateways.isEmpty)
     }
+
+    // MARK: - Update Payment Gateway tests
+
+    /// Verifies that updatepaymentGateway properly parses the `paymentGateway` sample response.
+    ///
+    func test_updatePaymentGateway_properly_returns_parsed_paymentGateway() throws {
+        // Given
+        let remote = PaymentGatewayRemote(network: network)
+        let paymentGateway = samplePaymentGateway()
+        network.simulateResponse(requestUrlSuffix: "payment_gateways/\(paymentGateway.gatewayID)", filename: "payment-gateway-cod")
+
+        // When
+        let result = waitFor { promise in
+            remote.updatePaymentGateway(paymentGateway) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssert(result.isSuccess)
+        let returnedPaymentGateway = try XCTUnwrap(result.get())
+        XCTAssertEqual(returnedPaymentGateway, paymentGateway)
+    }
+
+    /// Verifies that updatepaymentGateway properly relays Networking Layer errors.
+    ///
+    func test_updatePaymentGateway_properly_relays_networking_errors() throws {
+        // Given
+        let remote = PaymentGatewayRemote(network: network)
+        let paymentGateway = samplePaymentGateway()
+
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "payment_gateways/\(paymentGateway.gatewayID)", error: error)
+
+        // When
+        let result = waitFor { promise in
+            remote.updatePaymentGateway(paymentGateway) { (result) in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let resultError = try XCTUnwrap(result.failure as? NetworkError)
+        XCTAssertEqual(resultError, .unacceptableStatusCode(statusCode: 500))
+    }
+}
+
+// MARK: - Helper methods
+
+extension PaymentsGatewayRemoteTests {
+    func samplePaymentGateway() -> PaymentGateway {
+        PaymentGateway.fake().copy(siteID: sampleSiteID,
+                                   gatewayID: "cod",
+                                   title: "Cash on delivery",
+                                   description: "Pay with cash upon delivery.",
+                                   enabled: true,
+                                   features: [.products])
+    }
 }

--- a/Networking/NetworkingTests/Responses/payment-gateway-cod.json
+++ b/Networking/NetworkingTests/Responses/payment-gateway-cod.json
@@ -1,0 +1,14 @@
+{
+    "data": {
+        "id": "cod",
+        "title": "Cash on delivery",
+        "description": "Pay with cash upon delivery.",
+        "order": "",
+        "enabled": true,
+        "method_title": "Cash on delivery",
+        "method_description": "Have your customers pay with cash (or by other means) upon delivery.",
+        "method_supports": [
+            "products"
+        ]
+    }
+}

--- a/Yosemite/Yosemite/Actions/PaymentGatewayAction.swift
+++ b/Yosemite/Yosemite/Actions/PaymentGatewayAction.swift
@@ -6,4 +6,12 @@ public enum PaymentGatewayAction: Action {
     /// Retrieves and stores all payment gateways for the provided `siteID`
     ///
     case synchronizePaymentGateways(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Updates a Payment Gateway for a site given its ID and returns the updated Payment Gateway if the request succeeds.
+    ///
+    /// - `paymentGateway`: the Payment Gateway to be updated.
+    /// - `onCompletion`: invoked when the update finishes.
+    ///
+    case updatePaymentGateway(_ paymentGateway: PaymentGateway,
+                              onCompletion: (Result<PaymentGateway, Error>) -> Void)
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7477 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We are adding the option for merchants to enable the `Cash on Delivery` payment method by tapping a button on a new screen in In-Person Payments onboarding.

To implement the button's action, we will need to make a PUT request to update the Payment Gateway.

This PR adds the PUT endpoint to the existing Remote, and an associated `update` `PaymentGatewayAction` and implementation in `PaymentGatewayStore`.

The new request is not used anywhere yet, so cannot be directly tested, however unit tests are provided.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run unit tests.

Further testing isn't really required as it will be covered when the button is implemented, but if you want to see the request working, add the following to `InPersonPaymentsCodPaymentGatewayNotSetUpViewModel`:

```
func enableCod() {
            guard let siteID = siteID else {
                return completion()
            }
        let action = PaymentGatewayAction.updatePaymentGateway(PaymentGateway(siteID: siteID, gatewayID: "cod", title: "Pay in Person", description: "Pay in person by card or cash", enabled: true, features: [.products])) { result in
            guard let response = try? result.get() else {
                DDLogError("💰 Could not update Payment Gateway : \(String(describing: result.failure))")
                return
            }
            DDLogInfo("💰 Updated Payment Gateway : \(response)")
        }
        stores.dispatch(action)
    }
```
and then update the `InPersonPaymentsCodPaymentGatewayNotSetUp` by setting the button's action to
```
Button(Localization.enableButton, action: viewModel.enableCod)
                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: false))
```

Then you can tap the Enable button on the new screen, and it will send the network request for you to inspect in the console, and/or a network proxy tool such as Proxyman.

### Testing output
<!-- Include before and after images or gifs when appropriate. -->
Here is the request and response from my testing

#### Request
```
POST /rest/v1.1/jetpack-blogs/200370280/rest-api/ HTTP/1.1
Host: public-api.wordpress.com
Content-Type: application/x-www-form-urlencoded; charset=utf-8
Content-Length: 232
Connection: keep-alive
Accept: application/json
User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 15_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 wc-ios/9.9
Accept-Encoding: gzip;q=1.0, compress;q=0.5
Accept-Language: en;q=1.0

body=%7B%22id%22%3A%22cod%22%2C%22enabled%22%3Atrue%2C%22description%22%3A%22Pay%20in%20person%22%2C%22title%22%3A%22Pay%20in%20person%22%2C%22method_supports%22%3A%5B%5D%7D&json=true&path=/wc/v3/payment_gateways/cod%26_method%3Dput
```

#### Response
```
HTTP/1.1 200 OK
Server: nginx
Date: Thu, 18 Aug 2022 13:24:34 GMT
Content-Type: application/json
Transfer-Encoding: chunked
Connection: keep-alive
Vary: Accept-Encoding
Host-Header: WordPress.com
X-hacker: Oh, Awesome: Opossum
Expires: Wed, 11 Jan 1984 05:00:00 GMT
Cache-Control: no-cache, must-revalidate, max-age=0
X-Jetpack-Proxy-Timing: 387.26401329041
Content-Encoding: gzip
X-ac: 2.lhr _dca 
Strict-Transport-Security: max-age=15552000

{
  "data": {
    "id": "cod",
    "title": "Pay in person",
    "description": "Pay in person",
    "order": 3,
    "enabled": true,
    "method_title": "Cash on delivery",
    "method_description": "Have your customers pay with cash (or by other means) upon delivery.",
    "method_supports": [
      "products"
    ],
    "settings": {
      "title": {
        "id": "title",
        "label": "Title",
        "description": "Payment method description that the customer will see on your checkout.",
        "type": "safe_text",
        "value": "Pay in person",
        "default": "Cash on delivery",
        "tip": "Payment method description that the customer will see on your checkout.",
        "placeholder": ""
      },
      "instructions": {
        "id": "instructions",
        "label": "Instructions",
        "description": "Instructions that will be added to the thank you page.",
        "type": "textarea",
        "value": "Inst Pay with card when collecting from store",
        "default": "Pay with cash upon delivery.",
        "tip": "Instructions that will be added to the thank you page.",
        "placeholder": ""
      },
      "enable_for_methods": {
        "id": "enable_for_methods",
        "label": "Enable for shipping methods",
        "description": "If COD is only available for certain methods, set it up here. Leave blank to enable for all methods.",
        "type": "multiselect",
        "value": "",
        "default": "",
        "tip": "If COD is only available for certain methods, set it up here. Leave blank to enable for all methods.",
        "placeholder": "",
        "options": {
          "Flat rate": {
            "flat_rate": "Any &quot;Flat rate&quot; method",
            "flat_rate:4": "Iowa &ndash; Flat rate (#4)",
            "flat_rate:1": "United States (US) &ndash; Flat rate (#1)",
            "flat_rate:2": "Other locations &ndash; Flat rate (#2)"
          },
          "Free shipping": {
            "free_shipping": "Any &quot;Free shipping&quot; method"
          },
          "Local pickup": {
            "local_pickup": "Any &quot;Local pickup&quot; method",
            "local_pickup:5": "Iowa &ndash; Local pickup (#5)"
          }
        }
      },
      "enable_for_virtual": {
        "id": "enable_for_virtual",
        "label": "Accept COD if the order is virtual",
        "description": "",
        "type": "checkbox",
        "value": "yes",
        "default": "yes",
        "tip": "",
        "placeholder": ""
      }
    },
    "needs_setup": false,
    "post_install_scripts": [],
    "settings_url": "https://pointlessdivision.wpcomstaging.com/wp-admin/admin.php?page=wc-settings&tab=checkout&section=cod",
    "connection_url": null,
    "setup_help_text": null,
    "required_settings_keys": [],
    "_links": {
      "self": [
        {
          "href": "https://pointlessdivision.wpcomstaging.com/wp-json/wc/v3/payment_gateways/cod"
        }
      ],
      "collection": [
        {
          "href": "https://pointlessdivision.wpcomstaging.com/wp-json/wc/v3/payment_gateways"
        }
      ]
    }
  }
}
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
