### PR TITLE
Login: Disable Continue button on the store picker if no site has Woo

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -369,9 +369,12 @@ private extension StorePickerViewController {
             updateActionButtonAndTableState(animating: false, enabled: false)
             enterSiteAddressButton.isHidden = false
             newToWooButton.isHidden = false
-        default:
+        case .available(let sites):
             enterSiteAddressButton.isHidden = true
             newToWooButton.isHidden = true
+            if sites.allSatisfy({ $0.isWooCommerceActive == false }) {
+                updateActionButtonAndTableState(animating: false, enabled: false)
+            }
         }
 
         tableView.separatorStyle = viewModel.separatorStyle


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7511 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a simple fix to disable the Continue button if all sites in the store picker don't have WooCommerce.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Make sure that you have a WP.com account with access to only sites without WooCommerce.
1. Log out of the app if necessary and select Continue with WordPress.com.
2. Log in to your WP.com account.
3. After the login succeeds, notice that you are navigated to the store picker with only sites in the Other sites section, and the Continue  button is disabled.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/185423929-9bd3f379-d22a-4af1-8734-0a28e57e4148.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
