### PR TITLE
[Orders Performance] Fire sync requests conditionally

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -482,6 +482,12 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentTapped,
                               properties: [:])
         }
+
+        /// Tracked when accessing the system plugin list without it being in sync.
+        ///
+        static func pluginsNotSyncedYet() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .pluginsNotSyncedYet, properties: [:])
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -658,6 +658,9 @@ public enum WooAnalyticsStat: String {
     case paymentsMenuCardReadersManualsTapped = "payments_hub_card_readers_manuals_tapped"
     case paymentsMenuManageCardReadersTapped = "payments_hub_manage_card_readers_tapped"
     case paymentsMenuPaymentProviderTapped = "settings_card_present_select_payment_gateway_tapped"
+
+    // MARK: Payments Menu
+    case pluginsNotSyncedYet = "plugins_not_synced_yet"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
+++ b/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
@@ -5,5 +5,6 @@ import Yosemite
 extension SitePlugin {
     enum SupportedPlugin {
         public static let WCShip = "WooCommerce Shipping &amp; Tax"
+        public static let WCTracking = "WooCommerce Shipment Tracking"
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -265,12 +265,18 @@ extension OrderDetailsViewModel {
     }
 
     func syncTrackingsEnablingAddButtonIfReachable(onReloadSections: (() -> ())? = nil, onCompletion: (() -> Void)? = nil) {
-        syncTracking { [weak self] error in
-            if error == nil {
-                self?.trackingIsReachable = true
+        // If the plugin is not active, there is no point on continuing with a request that will fail.
+        isPluginActive(SitePlugin.SupportedPlugin.WCTracking) { [weak self] isActive in
+            guard let self = self, isActive else {
+                onCompletion?()
+                return
             }
-            onReloadSections?()
-            onCompletion?()
+
+            self.trackingIsReachable = true
+            self.syncTracking { error in
+                onReloadSections?()
+                onCompletion?()
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -8,10 +8,12 @@ import Experiments
 import WooFoundation
 import SwiftUI
 import enum Networking.DotcomError
+import protocol Storage.StorageManagerType
 
 final class OrderDetailsViewModel {
 
     private let stores: StoresManager
+    private let storageManager: StorageManagerType
     private let currencyFormatter: CurrencyFormatter
 
     private(set) var order: Order
@@ -26,9 +28,11 @@ final class OrderDetailsViewModel {
 
     init(order: Order,
          stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
         self.order = order
         self.stores = stores
+        self.storageManager = storageManager
         self.currencyFormatter = currencyFormatter
     }
 
@@ -663,7 +667,7 @@ extension OrderDetailsViewModel {
     ///
     private func arePluginsSynced() -> Bool {
         let predicate = NSPredicate(format: "siteID == %lld", order.siteID)
-        let resultsController = ResultsController<StorageSystemPlugin>(storageManager: ServiceLocator.storageManager, matching: predicate, sortedBy: [])
+        let resultsController = ResultsController<StorageSystemPlugin>(storageManager: storageManager, matching: predicate, sortedBy: [])
         try? resultsController.performFetch()
         return !resultsController.isEmpty
     }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -643,11 +643,12 @@ extension OrderDetailsViewModel {
     }
 
     /// Helper function that returns `true` in its callback if the provided plugin name is active on the order's store.
-    /// Additionally it logs to tracks if the plugin store is accessed without it being in sync.
+    /// Additionally it logs to tracks if the plugin store is accessed without it being in sync so we can handle that edge-case if it happens recurrently.
     ///
     private func isPluginActive(_ plugin: String, completion: @escaping (Bool) -> (Void)) {
         guard arePluginsSynced() else {
             DDLogError("⚠️ SystemPlugins acceded without being in sync.")
+            ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.pluginsNotSyncedYet())
             return completion(false)
         }
 


### PR DESCRIPTION
# Why

The order details screen launches 3 requests whose result depends on plugins being installed.

- Sync Shiping Labels
- Sync Shipment Tracking
- Sync Shipping Label Eligibility

The idea with this PR is to only fire those requests when we know for sure that such plugins exist on the merchant site. With the aim of reducing requests from stores that are not using that functionality.

# How

Since we sync `SystemPlugins` when we start the app or when we change the store, we can quickly check if those plugins are installed & active on the store before firing the request.

There is an edge case where the merchant can enter the order detail screen without plugins being synced. This PR adds a tracking event so we can measure how often is this happening before spending the time on handling that case.

# Testing Steps

- Log in a store that have the `WooCommerce Shipping & Tax` and the `WooCommerce Shipment Tracking` plugins active.
- See that both shipping labels + tracking buttons are available as always.



- Log in a store that does not have the `WooCommerce Shipping & Tax` and the `WooCommerce Shipment Tracking` plugins active.
- See that both shipping labels + tracking buttons are not visible.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
