### PR TITLE
Login: Fix issue log in to a site with HTTP only 

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,7 +43,7 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
 #  pod 'WordPressAuthenticator', '~> 2.2.1-beta.3'
-     pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'cc19bccef10ac9512a310843ecb6bb7f90ba739f'
+     pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '1687e5573d611f98859aefa0439b3f48979dcbd0'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -42,8 +42,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 2.2.1-beta.3'
-  #   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '7cdd0c6e44fb1f5356a974cdd6a05c3d2d5210f6'
+#  pod 'WordPressAuthenticator', '~> 2.2.1-beta.3'
+     pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'cc19bccef10ac9512a310843ecb6bb7f90ba739f'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -42,8 +42,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-#  pod 'WordPressAuthenticator', '~> 2.2.1-beta.3'
-     pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '1687e5573d611f98859aefa0439b3f48979dcbd0'
+  pod 'WordPressAuthenticator', '~> 2.2.1-beta.5'
+#     pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '1687e5573d611f98859aefa0439b3f48979dcbd0'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -92,7 +92,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `cc19bccef10ac9512a310843ecb6bb7f90ba739f`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `1687e5573d611f98859aefa0439b3f48979dcbd0`)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -141,12 +141,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: cc19bccef10ac9512a310843ecb6bb7f90ba739f
+    :commit: 1687e5573d611f98859aefa0439b3f48979dcbd0
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: cc19bccef10ac9512a310843ecb6bb7f90ba739f
+    :commit: 1687e5573d611f98859aefa0439b3f48979dcbd0
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -187,6 +187,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 9f27a6804ee44aea19d04cecd81ade48ae32aa3b
+PODFILE CHECKSUM: 7bee85410dd7d0a2f8f3b6a4f37638fd0d232a35
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -92,7 +92,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `1687e5573d611f98859aefa0439b3f48979dcbd0`)
+  - WordPressAuthenticator (~> 2.2.1-beta.5)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -102,6 +102,8 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
+  https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -139,16 +141,6 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :commit: 1687e5573d611f98859aefa0439b3f48979dcbd0
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: 1687e5573d611f98859aefa0439b3f48979dcbd0
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
@@ -171,7 +163,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 889484ce5e0bc5417c1ea4435592049fd8900aa8
+  WordPressAuthenticator: e898a1e3a297607534b18520921e3fc9e7ccf7b4
   WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -187,6 +179,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 7bee85410dd7d0a2f8f3b6a4f37638fd0d232a35
+PODFILE CHECKSUM: a0cb10fb7598f064a8b7e16a115bfd1923918cf8
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -42,7 +42,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (2.2.1-beta.3):
+  - WordPressAuthenticator (2.2.1-beta.5):
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 6.0.1)
@@ -92,7 +92,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 2.2.1-beta.3)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `cc19bccef10ac9512a310843ecb6bb7f90ba739f`)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -102,8 +102,6 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -141,6 +139,16 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :commit: cc19bccef10ac9512a310843ecb6bb7f90ba739f
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: cc19bccef10ac9512a310843ecb6bb7f90ba739f
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
@@ -163,7 +171,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 40d028b26ceeb093620d3748198f142f4e416e65
+  WordPressAuthenticator: 889484ce5e0bc5417c1ea4435592049fd8900aa8
   WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -179,6 +187,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 2f80965199751d9b642db8d680aa08c11547a548
+PODFILE CHECKSUM: 9f27a6804ee44aea19d04cecd81ade48ae32aa3b
 
 COCOAPODS: 1.11.2

--- a/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
+++ b/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
@@ -43,8 +43,8 @@ final class ULAccountMatcher {
         }
 
         return sites
-            .map { $0.url }
-            .contains(originalURL)
+            .map { $0.url.trimHTTPScheme() }
+            .contains(originalURL.trimHTTPScheme())
     }
 
     /// Returns a locally stored site that matches the given site URL.
@@ -59,7 +59,7 @@ final class ULAccountMatcher {
             return nil
         }
 
-        return sites.first { $0.url == originalURL }
+        return sites.first { $0.url.contains(originalURL.trimHTTPScheme()) }
     }
 
     /// Refreshes locally stored sites that were synced previously.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7523 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Currently, when a user enters a site address without the HTTP scheme, the `WordPressAuthenticator` library assumes that the site has HTTPS.

However, after logging in, the app fetches the site list and find that the site has HTTP. This causes `ULAccountMatcher`to to be unable to find the matching site, since the HTTP schemes mismatch.

This PR adds a fix to `ULAccountMatcher` to compare site addresses without the HTTP scheme. 

Also: this includes a fix in https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/669 to fix the issue when the user enters an address with the HTTP-only scheme.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: ensure you have access to a valid HTTP-only woo store.
1. Log out of the app if necessary and select Enter Your Store Address.
2. Enter the address of the site in the prerequisite.
3. Log in to your WP.com account.
4. After the login succeeds, notice that you are navigated directly to the home screen.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
No screenshot due to sensitive information (email address etc)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
