### PR TITLE
Product selector: Stop clearing product store and fix issue combining search term with filter

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -435,7 +435,7 @@ private extension ProductSelectorViewModel {
             .dropFirst() // Drop initial value
             .removeDuplicates()
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
-        
+
         searchTermPublisher.combineLatest($filters.removeDuplicates())
             .sink { [weak self] searchTerm, filters in
                 guard let self = self else { return }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -141,11 +141,9 @@ private extension ProductStore {
                                  excludedProductIDs: excludedProductIDs) { [weak self] result in
             switch result {
             case .success(let products):
-                let shouldDeleteExistingProducts = pageNumber == Default.firstPageNumber
                 self?.upsertSearchResultsInBackground(siteID: siteID,
                                                       keyword: keyword,
-                                                      readOnlyProducts: products,
-                                                      shouldDeleteExistingProducts: shouldDeleteExistingProducts) {
+                                                      readOnlyProducts: products) {
                     onCompletion(.success(()))
                 }
             case .failure(let error):
@@ -673,13 +671,9 @@ private extension ProductStore {
     private func upsertSearchResultsInBackground(siteID: Int64,
                                                  keyword: String,
                                                  readOnlyProducts: [Networking.Product],
-                                                 shouldDeleteExistingProducts: Bool = false,
                                                  onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform { [weak self] in
-            if shouldDeleteExistingProducts {
-                derivedStorage.deleteProducts(siteID: siteID)
-            }
             self?.upsertStoredProducts(readOnlyProducts: readOnlyProducts, in: derivedStorage)
             self?.upsertStoredResults(siteID: siteID, keyword: keyword, readOnlyProducts: readOnlyProducts, in: derivedStorage)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7464 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously we were clearing all products saved in the local storage for every search. This messes with the product list in the Products tab and make the list unreliable.

This PR fixes this by removing the storage clearing, and instead update the product selector to correctly combine the filters and search term to display the correct matching products. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Testing product search in Coupons:
- Navigate to Menu > Coupons > Select "+" button to create a new coupon
- In the coupon creation form, select the "All Products" button.
- Enter some keyword to the search bar to filter some products in the list.
- Update the filter to match only some or none of the filtered products.
- Clear the search keyword, notice that the list is updated correctly with the current filter.
- Close the coupon creation form and navigate back to the Products tab. Notice that the tab still displays the correct products.

Testing Products tab search:
- Navigate to Products tab.
- Tap the search button and enter some keyword.
- Close the search view without clearing the keyword.
- Notice that the product list on the Products tab is still correct.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/186072676-8e62ce39-acb2-495d-8a9c-0f28cfa978b4.MOV



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
