### PR TITLE
Cancel all local notification cases on login success

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -341,7 +341,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         }
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginErrorNotifications) {
-            ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: [.loginSiteAddressError])
+            ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: LocalNotification.Scenario.allCases)
         }
 
         let matcher = ULAccountMatcher(storageManager: storageManager)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -496,7 +496,7 @@ private extension AuthenticationManager {
         }
 
         if let notification = notification {
-            ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: [notification.scenario])
+            ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: LocalNotification.Scenario.allCases)
             ServiceLocator.pushNotesManager.requestLocalNotification(notification,
                                                                      // 24 hours from now.
                                                                      trigger: UNTimeIntervalNotificationTrigger(timeInterval: 86400, repeats: false))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7318 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While looking at the local notification code last week, I realized that only one local notification scenario is canceled when the user logs in successfully. Even though I wasn't able to reproduce the expected issue where a previously scheduled local notification still shows up after logging in, I thought it's still better to make a fix in any case.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please update the 24 hours schedule to about a minute in `AuthenticationManager` (search for "86400") to test this PR while allowing time to log in.

You can test this PR in a simulator.

The testing is mostly a confidence check to make sure a local notification isn't shown after logging in successfully:
- Reinstall the app to clear any previous notifications permission state if needed
- Skip the onboarding if needed
- Tap either CTA
- If choosing to log in with a site address, enter a valid WP site address
- Enter an invalid WP.com email to trigger a local notification scheduling with an event in the console `login_local_notification_scheduled`
- Enter a valid WP.com email after the error
- Enter an invalid password --> an inline error screen should be shown, with an event in the console `login_local_notification_scheduled`
- Quickly continue to enter the correct password and optional 2FA, then put the app to the background since we don't support local notifications in the foreground --> a local notification should **not** be shown after the duration you set in `AuthenticationManager`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
