### PR TITLE
[Mobile Payments] Display maximum one notice at a time

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 10.1
 -----
-
+- [*] In-Person Payments: The onboarding notice on the In-Person Payments menu is correctly dismissed after multiple prompts are shown. [https://github.com/woocommerce/woocommerce-ios/pull/7543]
 
 10.0
 -----

--- a/WooCommerce/Classes/Tools/Notices/PermanentNotice/PermanentNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/PermanentNotice/PermanentNoticePresenter.swift
@@ -17,8 +17,13 @@ final class PermanentNoticePresenter {
     private var hostingController: UIHostingController<PermanentNoticeView>?
 
     /// Presents the given notice into the passed view controller with an animation
+    /// This will ignore any calls to present if a notice is already displayed
     ///
     func presentNotice(notice: PermanentNotice, from viewController: UIViewController) {
+        guard hostingController == nil else {
+            return
+        }
+
         let permanentNoticeView = PermanentNoticeView(notice: notice)
         let newHostingController = ConstraintsUpdatingHostingController(rootView: permanentNoticeView)
 
@@ -76,12 +81,14 @@ private extension PermanentNoticePresenter {
 
         UIView.animate(withDuration: Animations.appearanceDuration,
                        delay: 0,
-                       options: .transitionFlipFromLeft, animations: {
+                       options: .transitionFlipFromLeft,
+                       animations: {
             hostingController.view.alpha = 0
-            }) { _ in
-                hostingController.willMove(toParent: nil)
-                hostingController.view.removeFromSuperview()
-            }
+        }) { [weak self] _ in
+            hostingController.willMove(toParent: nil)
+            hostingController.view.removeFromSuperview()
+            self?.hostingController = nil
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7540 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, the PermanentNoticePresenter would display a new notice every time `presentNotice` was called, losing it’s reference to any existing notice, but leaving it in the view hierarchy.

This meant that in the In-Person Payments onboarding flow, the “Continue Setup” notice would be displayed once for every failure that was shown, and only the top one removed by `dismiss` when the `.completed` step was reached.

This change makes `presentNotice` do nothing if a notice is already presented, so in the In-Person Payments scenario, there will only ever be one presented and dismissed.

The PermanentNoticePresenter is not currently used elsewhere.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Delete the app and do a fresh install.
2. Navigate to `Menu > In-Person Payments`
3. Tap `Continue Setup`
4. Observe that you are asked which plugin you would like to use: choose a plugin.
5. Observe that you are asked to enable Pay in Person on checkout: skip this step.
6. Observe that you are returned to the IPP menu, and the notice does not show


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/2472348/185961277-044ffefe-1ff4-4f34-b28f-9b519079b855.mp4

N.B. The issue #7541 is shown at the end of the above video. This is fixed in a later PR.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
