### PR TITLE
[Mobile Payments] Save plugin selection on onboarding completion

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 10.1
 -----
 - [*] In-Person Payments: The onboarding notice on the In-Person Payments menu is correctly dismissed after multiple prompts are shown. [https://github.com/woocommerce/woocommerce-ios/pull/7543]
+- [*] In-Person Payments: The plugin selection is saved correctly after multiple onboarding prompts. [https://github.com/woocommerce/woocommerce-ios/pull/7544]
 
 10.0
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7541
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, the plugin selection a user made was only stored if the next onboarding state was `.complete`.

Our original intention was to only save their selection when they reached `.complete`, so that if they returned to an unfinished onboarding flow they would start from the beginning, including the plugin selection.

This change fixes the bug that we wouldn’t save if they saw another onboarding step before `.complete`, by deferring the save until `.complete` rather than only checking the very next state.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

On a store with both Stripe and WooCommerce Payments installed and activated, and Cash on Delivery disabled:

1. Delete the app and do a fresh install.
2. Navigate to `Menu > In-Person Payments`
3. Tap `Continue Setup`
4. Observe that you are asked which plugin you would like to use: choose a plugin.
5. Tap back on the `Enable Pay in Person` screen
6. Observe that your plugin selection has not been saved
7. Repeat step 4
5. Tap `Skip for now` on the `Enable Pay in Person` screen
6. You'll return to the menu: observe that the `Continue setup` button and notice is not displayed, and your plugin has been saved
8. Leave the IPP menu and return to it.
9. Observe that the `Continue setup` button and notice is still not displayed.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/185962762-89fc9636-cf16-4ad4-a19e-79a342e8c918.mp4



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
