### PR TITLE
[Mobile Payments] Add a “Learn more” action to the connecting dialog

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -7,7 +7,7 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
     private let cancelAction: () -> Void
 
     let textMode: PaymentsModalTextMode = .reducedBottomInfo
-    let actionsMode: PaymentsModalActionsMode = .secondaryOnlyAction
+    let actionsMode: PaymentsModalActionsMode = .newCase
 
     let topTitle: String = Localization.title
 
@@ -19,7 +19,7 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
 
     let secondaryButtonTitle: String? = Localization.cancel
 
-    let auxiliaryButtonTitle: String? = nil
+    let auxiliaryButtonTitle: String? = "Learn more about In-Person Payments"
 
     let bottomTitle: String? = Localization.instruction
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -19,7 +19,7 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
 
     let secondaryButtonTitle: String? = Localization.cancel
 
-    let auxiliaryButtonTitle: String? = "Learn more about In-Person Payments"
+    let auxiliaryButtonTitle: String? = Localization.learnMoreText
 
     let bottomTitle: String? = Localization.instruction
 
@@ -43,10 +43,19 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
         viewController?.dismiss(animated: true, completion: nil)
     }
 
-    func didTapAuxiliaryButton(in viewController: UIViewController?) {}
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {
+        guard let viewController = viewController else {
+            return
+        }
+        WebviewHelper.launch(Constants.learnMoreURL.asURL(), with: viewController)
+    }
 }
 
 private extension CardPresentModalScanningForReader {
+    enum Constants {
+        static let learnMoreURL = WooConstants.URLs.inPersonPaymentsLearnMoreWCPay
+    }
+
     enum Localization {
         static let title = NSLocalizedString(
             "Scanning for reader",
@@ -61,6 +70,11 @@ private extension CardPresentModalScanningForReader {
         static let cancel = NSLocalizedString(
             "Cancel",
             comment: "Label for a cancel button"
+        )
+
+        static let learnMoreText = NSLocalizedString(
+            "Learn more about In-Person Payments",
+            comment: "..."
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -22,19 +22,15 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
     let auxiliaryButtonTitle: String? = nil
 
     var auxiliaryAttributedButtonTitle: NSAttributedString? {
-        // AttributtedString components
-        let learnMoreLinkString = Localization.learnMoreLink
-        let learnMoreTextString = NSAttributedString(string: Localization.learnMoreText)
-        let url = WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL()
-        // AttributtedString attributes
-        let attributes: [NSAttributedString.Key: Any] = [
-            NSAttributedString.Key.link: url,
-            NSAttributedString.Key.attachment: UIColor.accent
+        let moreLinkAttributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: UIColor.accent,
+            .underlineStyle: NSUnderlineStyle.single.rawValue
         ]
-        let attributedString = NSMutableAttributedString(string: learnMoreLinkString, attributes: attributes)
-        // AttributtedString output
-        attributedString.append(learnMoreTextString)
-        return attributedString
+        let moreTextAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.text]
+        let linkAttributedString = NSMutableAttributedString(string: Localization.learnMoreLink, attributes: moreLinkAttributes)
+        let moreAttributedString = NSMutableAttributedString(string: Localization.learnMoreText, attributes: moreTextAttributes)
+        linkAttributedString.append(moreAttributedString)
+        return linkAttributedString
     }
 
     let bottomTitle: String? = Localization.instruction

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -7,7 +7,7 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
     private let cancelAction: () -> Void
 
     let textMode: PaymentsModalTextMode = .reducedBottomInfo
-    let actionsMode: PaymentsModalActionsMode = .secondaryActionAndAuxiliary
+    let actionsMode: PaymentsModalActionsMode = .secondaryActionAndAttributedAuxiliaryButton
 
     let topTitle: String = Localization.title
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -7,7 +7,7 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
     private let cancelAction: () -> Void
 
     let textMode: PaymentsModalTextMode = .reducedBottomInfo
-    let actionsMode: PaymentsModalActionsMode = .secondaryActionAndAttributedAuxiliaryButton
+    let actionsMode: PaymentsModalActionsMode = .secondaryActionAndAuxiliaryButton
 
     let topTitle: String = Localization.title
 
@@ -20,6 +20,8 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
     let secondaryButtonTitle: String? = Localization.cancel
 
     let auxiliaryButtonTitle: String? = nil
+
+    let auxiliaryButtonimage: UIImage? = .infoOutlineImage
 
     var auxiliaryAttributedButtonTitle: NSAttributedString? {
         let result = NSMutableAttributedString(

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -56,6 +56,7 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {
+        ServiceLocator.analytics.track(.cardPresentOnboardingLearnMoreTapped)
         guard let viewController = viewController else {
             return
         }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -22,15 +22,24 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
     let auxiliaryButtonTitle: String? = nil
 
     var auxiliaryAttributedButtonTitle: NSAttributedString? {
-        let moreLinkAttributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: UIColor.accent,
-            .underlineStyle: NSUnderlineStyle.single.rawValue
-        ]
-        let moreTextAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.text]
-        let linkAttributedString = NSMutableAttributedString(string: Localization.learnMoreLink, attributes: moreLinkAttributes)
-        let moreAttributedString = NSMutableAttributedString(string: Localization.learnMoreText, attributes: moreTextAttributes)
-        linkAttributedString.append(moreAttributedString)
-        return linkAttributedString
+        let result = NSMutableAttributedString(
+            string: .localizedStringWithFormat(
+                Localization.learnMoreText,
+                Localization.learnMoreLink
+            ),
+            attributes: [.foregroundColor: UIColor.text]
+        )
+        result.replaceFirstOccurrence(
+            of: Localization.learnMoreLink,
+            with: NSAttributedString(
+                string: Localization.learnMoreLink,
+                attributes: [
+                    .foregroundColor: UIColor.accent,
+                    .underlineStyle: NSUnderlineStyle.single.rawValue
+                ]
+            ))
+        result.addAttribute(.font, value: UIFont.footnote, range: NSRange(location: 0, length: result.length))
+        return result
     }
 
     let bottomTitle: String? = Localization.instruction
@@ -94,10 +103,12 @@ private extension CardPresentModalScanningForReader {
         )
 
         static let learnMoreText = NSLocalizedString(
-            " about In\u{2011}Person Payments",
+            "%1$@ about In\u{2011}Person Payments",
             comment: """
-                     A label prompting users to learn more about In-Person Payments"
+                     A label prompting users to learn more about In-Person Payments.
                      \u{2011} is a special character that acts as nonbreaking hyphen for "-" in the "In-Person" string.
+                     %1$@ is a placeholder that always replaced with \"Learn more\" string,
+                     which should be translated separately and considered part of this sentence.
                      """
         )
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -7,7 +7,7 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
     private let cancelAction: () -> Void
 
     let textMode: PaymentsModalTextMode = .reducedBottomInfo
-    let actionsMode: PaymentsModalActionsMode = .newCase
+    let actionsMode: PaymentsModalActionsMode = .secondaryActionAndAuxiliary
 
     let topTitle: String = Localization.title
 
@@ -27,8 +27,11 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
         let learnMoreTextString = NSAttributedString(string: Localization.learnMoreText)
         let url = WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL()
         // AttributtedString attributes
-        let learnMoreLinkAttribute = [NSAttributedString.Key.link: url]
-        let attributedString = NSMutableAttributedString(string: learnMoreLinkString, attributes: learnMoreLinkAttribute)
+        let attributes: [NSAttributedString.Key: Any] = [
+            NSAttributedString.Key.link: url,
+            NSAttributedString.Key.attachment: UIColor.accent
+        ]
+        let attributedString = NSMutableAttributedString(string: learnMoreLinkString, attributes: attributes)
         // AttributtedString output
         attributedString.append(learnMoreTextString)
         return attributedString

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -19,7 +19,20 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
 
     let secondaryButtonTitle: String? = Localization.cancel
 
-    let auxiliaryButtonTitle: String? = Localization.learnMoreText
+    let auxiliaryButtonTitle: String? = nil
+
+    var auxiliaryAttributedButtonTitle: NSAttributedString? {
+        // AttributtedString components
+        let learnMoreLinkString = Localization.learnMoreLink
+        let learnMoreTextString = NSAttributedString(string: Localization.learnMoreText)
+        let url = WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL()
+        // AttributtedString attributes
+        let learnMoreLinkAttribute = [NSAttributedString.Key.link: url]
+        let attributedString = NSMutableAttributedString(string: learnMoreLinkString, attributes: learnMoreLinkAttribute)
+        // AttributtedString output
+        attributedString.append(learnMoreTextString)
+        return attributedString
+    }
 
     let bottomTitle: String? = Localization.instruction
 
@@ -72,9 +85,20 @@ private extension CardPresentModalScanningForReader {
             comment: "Label for a cancel button"
         )
 
+        static let learnMoreLink = NSLocalizedString(
+            "Learn more",
+            comment: """
+                     A label prompting users to learn more about In-Person Payments.
+                     This is the link to the website, and forms part of a longer sentence which it should be considered a part of.
+                     """
+        )
+
         static let learnMoreText = NSLocalizedString(
-            "Learn more about In-Person Payments",
-            comment: "..."
+            " about In\u{2011}Person Payments",
+            comment: """
+                     A label prompting users to learn more about In-Person Payments"
+                     \u{2011} is a special character that acts as nonbreaking hyphen for "-" in the "In-Person" string.
+                     """
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -88,4 +88,7 @@ enum PaymentsModalActionsMode {
 
     /// Two action buttons and an auxiliary button
     case twoActionAndAuxiliary
+
+    /// New case
+    case newCase
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -27,6 +27,9 @@ protocol CardPresentPaymentsModalViewModel {
     /// Provides a title for an auxiliary button
     var auxiliaryButtonTitle: String? { get }
 
+    /// Provides a title as a NSAttributedString for an auxiliary button
+    var auxiliaryAttributedButtonTitle: NSAttributedString? { get }
+
     /// The title in the bottom section of the modal. Right below the image
     var bottomTitle: String? { get }
 
@@ -91,4 +94,12 @@ enum PaymentsModalActionsMode {
 
     /// New case
     case newCase
+}
+
+extension CardPresentPaymentsModalViewModel {
+    /// Default implementation for NSAttributedString auxiliary button title.
+    /// If is not set directly by each Modal's ViewModel, it will default to nil
+    var auxiliaryAttributedButtonTitle: NSAttributedString? {
+        get { return nil }
+    }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -86,14 +86,15 @@ enum PaymentsModalActionsMode {
     /// One secondary action button
     case secondaryOnlyAction
 
+    /// One secondary action button and an auxiliary button
+    case secondaryActionAndAuxiliary
+
     /// Two action buttons
     case twoAction
 
     /// Two action buttons and an auxiliary button
     case twoActionAndAuxiliary
 
-    /// New case
-    case newCase
 }
 
 extension CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -30,6 +30,9 @@ protocol CardPresentPaymentsModalViewModel {
     /// Provides a title as a NSAttributedString for an auxiliary button
     var auxiliaryAttributedButtonTitle: NSAttributedString? { get }
 
+    /// Provides an image for the auxiliary button
+    var auxiliaryButtonimage: UIImage? { get }
+
     /// The title in the bottom section of the modal. Right below the image
     var bottomTitle: String? { get }
 
@@ -86,8 +89,8 @@ enum PaymentsModalActionsMode {
     /// One secondary action button
     case secondaryOnlyAction
 
-    /// One secondary action button and an auxiliary button that uses NSAttributedString
-    case secondaryActionAndAttributedAuxiliaryButton
+    /// One secondary action button and an auxiliary button
+    case secondaryActionAndAuxiliaryButton
 
     /// Two action buttons
     case twoAction
@@ -101,6 +104,10 @@ extension CardPresentPaymentsModalViewModel {
     /// Default implementation for NSAttributedString auxiliary button title.
     /// If is not set directly by each Modal's ViewModel, it will default to nil
     var auxiliaryAttributedButtonTitle: NSAttributedString? {
+        get { return nil }
+    }
+
+    var auxiliaryButtonimage: UIImage? {
         get { return nil }
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -86,8 +86,8 @@ enum PaymentsModalActionsMode {
     /// One secondary action button
     case secondaryOnlyAction
 
-    /// One secondary action button and an auxiliary button
-    case secondaryActionAndAuxiliary
+    /// One secondary action button and an auxiliary button that uses NSAttributedString
+    case secondaryActionAndAttributedAuxiliaryButton
 
     /// Two action buttons
     case twoAction

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -52,6 +52,10 @@ final class CardPresentPaymentsModalViewController: UIViewController {
         styleContent()
         populateContent()
     }
+    /// Debugging. Remove before submitting PR for review
+    override func viewDidAppear(_ animated: Bool) {
+        print("Debugging breakpoint")
+    }
 
     func setViewModel(_ newViewModel: CardPresentPaymentsModalViewModel) {
         self.viewModel = newViewModel
@@ -158,9 +162,13 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func styleAuxiliaryButton() {
-        auxiliaryButton.applyLinkButtonStyle()
-        auxiliaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        if viewModel.actionsMode == .newCase {
+            auxiliaryButton.titleLabel?.lineBreakMode = .byWordWrapping
+        } else {
+            auxiliaryButton.applyLinkButtonStyle()
+        }
         auxiliaryButton.titleLabel?.minimumScaleFactor = 0.5
+        auxiliaryButton.titleLabel?.adjustsFontSizeToFitWidth = true
     }
 
     func initializeContent() {
@@ -338,12 +346,12 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func shouldShowBottomActionButton() -> Bool {
-        [.secondaryOnlyAction, .twoAction, .twoActionAndAuxiliary]
+        [.secondaryOnlyAction, .twoAction, .twoActionAndAuxiliary, .newCase]
             .contains(viewModel.actionsMode)
     }
 
     func shouldShowAuxiliaryButton() -> Bool {
-        viewModel.actionsMode == .twoActionAndAuxiliary
+        [.twoActionAndAuxiliary, .newCase].contains(viewModel.actionsMode)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -164,6 +164,8 @@ private extension CardPresentPaymentsModalViewController {
     func styleAuxiliaryButton() {
         if viewModel.actionsMode == .newCase {
             auxiliaryButton.titleLabel?.lineBreakMode = .byWordWrapping
+            auxiliaryButton.titleLabel?.font = UIFont.footnote
+            auxiliaryButton.setImage(.infoOutlineImage, for: .normal)
         } else {
             auxiliaryButton.applyLinkButtonStyle()
         }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -158,7 +158,7 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func styleAuxiliaryButton() {
-        if viewModel.actionsMode != .secondaryActionAndAuxiliary {
+        if viewModel.actionsMode != .secondaryActionAndAttributedAuxiliaryButton {
             auxiliaryButton.applyLinkButtonStyle()
         }
         auxiliaryButton.titleLabel?.minimumScaleFactor = 0.5
@@ -279,18 +279,29 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func configureAuxiliaryButton() {
+        clearAuxiliaryButton()
+
         guard shouldShowAuxiliaryButton() else {
             auxiliaryButton.isHidden = true
             return
         }
 
         auxiliaryButton.isHidden = false
+        auxiliaryButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
         auxiliaryButton.accessibilityIdentifier = Accessibility.auxiliaryButton
 
-        if viewModel.actionsMode == .secondaryActionAndAuxiliary {
+        if viewModel.actionsMode == .secondaryActionAndAttributedAuxiliaryButton {
             auxiliaryButton.setImage(.infoOutlineImage, for: .normal)
             auxiliaryButton.setAttributedTitle(viewModel.auxiliaryAttributedButtonTitle, for: .normal)
+            auxiliaryButton.distributeTitleAndImage(spacing: 12.0)
         }
+    }
+
+    func clearAuxiliaryButton() {
+        auxiliaryButton.setImage(nil, for: .normal)
+        auxiliaryButton.setAttributedTitle(nil, for: .normal)
+        auxiliaryButton.setTitle(nil, for: .normal)
+        auxiliaryButton.accessibilityIdentifier = nil
     }
 
     func configureSpacer() {
@@ -344,12 +355,12 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func shouldShowBottomActionButton() -> Bool {
-        [.secondaryOnlyAction, .twoAction, .twoActionAndAuxiliary, .secondaryActionAndAuxiliary]
+        [.secondaryOnlyAction, .twoAction, .twoActionAndAuxiliary, .secondaryActionAndAttributedAuxiliaryButton]
             .contains(viewModel.actionsMode)
     }
 
     func shouldShowAuxiliaryButton() -> Bool {
-        [.twoActionAndAuxiliary, .secondaryActionAndAuxiliary].contains(viewModel.actionsMode)
+        [.twoActionAndAuxiliary, .secondaryActionAndAttributedAuxiliaryButton].contains(viewModel.actionsMode)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -287,7 +287,7 @@ private extension CardPresentPaymentsModalViewController {
         }
 
         auxiliaryButton.isHidden = false
-        auxiliaryButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
+        auxiliaryButton.setTitleWithoutAnimation(viewModel.auxiliaryButtonTitle, for: .normal)
         auxiliaryButton.accessibilityIdentifier = Accessibility.auxiliaryButton
 
         if viewModel.actionsMode == .secondaryActionAndAttributedAuxiliaryButton {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -158,7 +158,7 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func styleAuxiliaryButton() {
-        if viewModel.actionsMode != .secondaryActionAndAttributedAuxiliaryButton {
+        if viewModel.actionsMode != .secondaryActionAndAuxiliaryButton {
             auxiliaryButton.applyLinkButtonStyle()
         }
         auxiliaryButton.titleLabel?.minimumScaleFactor = 0.5
@@ -279,7 +279,6 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func configureAuxiliaryButton() {
-        clearAuxiliaryButton()
 
         guard shouldShowAuxiliaryButton() else {
             auxiliaryButton.isHidden = true
@@ -287,21 +286,17 @@ private extension CardPresentPaymentsModalViewController {
         }
 
         auxiliaryButton.isHidden = false
-        auxiliaryButton.setTitleWithoutAnimation(viewModel.auxiliaryButtonTitle, for: .normal)
         auxiliaryButton.accessibilityIdentifier = Accessibility.auxiliaryButton
-
-        if viewModel.actionsMode == .secondaryActionAndAttributedAuxiliaryButton {
-            auxiliaryButton.setImage(.infoOutlineImage, for: .normal)
+        // Prevents UI flicker when loading different content
+        UIView.performWithoutAnimation {
+            auxiliaryButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
             auxiliaryButton.setAttributedTitle(viewModel.auxiliaryAttributedButtonTitle, for: .normal)
-            auxiliaryButton.distributeTitleAndImage(spacing: 12.0)
+            auxiliaryButton.setImage(viewModel.auxiliaryButtonimage, for: .normal)
+            if viewModel.auxiliaryButtonimage != nil {
+                auxiliaryButton.distributeTitleAndImage(spacing: 8.0)
+            }
+            view.layoutIfNeeded()
         }
-    }
-
-    func clearAuxiliaryButton() {
-        auxiliaryButton.setImage(nil, for: .normal)
-        auxiliaryButton.setAttributedTitle(nil, for: .normal)
-        auxiliaryButton.setTitle(nil, for: .normal)
-        auxiliaryButton.accessibilityIdentifier = nil
     }
 
     func configureSpacer() {
@@ -355,12 +350,12 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func shouldShowBottomActionButton() -> Bool {
-        [.secondaryOnlyAction, .twoAction, .twoActionAndAuxiliary, .secondaryActionAndAttributedAuxiliaryButton]
+        [.secondaryOnlyAction, .twoAction, .twoActionAndAuxiliary, .secondaryActionAndAuxiliaryButton]
             .contains(viewModel.actionsMode)
     }
 
     func shouldShowAuxiliaryButton() -> Bool {
-        [.twoActionAndAuxiliary, .secondaryActionAndAttributedAuxiliaryButton].contains(viewModel.actionsMode)
+        [.twoActionAndAuxiliary, .secondaryActionAndAuxiliaryButton].contains(viewModel.actionsMode)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -162,10 +162,7 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func styleAuxiliaryButton() {
-        if viewModel.actionsMode == .newCase {
-            auxiliaryButton.titleLabel?.lineBreakMode = .byWordWrapping
-            auxiliaryButton.titleLabel?.font = UIFont.footnote
-        } else {
+        if viewModel.actionsMode != .secondaryActionAndAuxiliary {
             auxiliaryButton.applyLinkButtonStyle()
         }
         auxiliaryButton.titleLabel?.minimumScaleFactor = 0.5
@@ -290,10 +287,14 @@ private extension CardPresentPaymentsModalViewController {
             auxiliaryButton.isHidden = true
             return
         }
-        auxiliaryButton.setImage(.infoOutlineImage, for: .normal)
-        auxiliaryButton.setAttributedTitle(viewModel.auxiliaryAttributedButtonTitle, for: .normal)
+
         auxiliaryButton.isHidden = false
         auxiliaryButton.accessibilityIdentifier = Accessibility.auxiliaryButton
+
+        if viewModel.actionsMode == .secondaryActionAndAuxiliary {
+            auxiliaryButton.setImage(.infoOutlineImage, for: .normal)
+            auxiliaryButton.setAttributedTitle(viewModel.auxiliaryAttributedButtonTitle, for: .normal)
+        }
     }
 
     func configureSpacer() {
@@ -347,12 +348,12 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func shouldShowBottomActionButton() -> Bool {
-        [.secondaryOnlyAction, .twoAction, .twoActionAndAuxiliary, .newCase]
+        [.secondaryOnlyAction, .twoAction, .twoActionAndAuxiliary, .secondaryActionAndAuxiliary]
             .contains(viewModel.actionsMode)
     }
 
     func shouldShowAuxiliaryButton() -> Bool {
-        [.twoActionAndAuxiliary, .newCase].contains(viewModel.actionsMode)
+        [.twoActionAndAuxiliary, .secondaryActionAndAuxiliary].contains(viewModel.actionsMode)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -165,7 +165,6 @@ private extension CardPresentPaymentsModalViewController {
         if viewModel.actionsMode == .newCase {
             auxiliaryButton.titleLabel?.lineBreakMode = .byWordWrapping
             auxiliaryButton.titleLabel?.font = UIFont.footnote
-            auxiliaryButton.setImage(.infoOutlineImage, for: .normal)
         } else {
             auxiliaryButton.applyLinkButtonStyle()
         }
@@ -291,8 +290,8 @@ private extension CardPresentPaymentsModalViewController {
             auxiliaryButton.isHidden = true
             return
         }
-
-        auxiliaryButton.setTitleWithoutAnimation(viewModel.auxiliaryButtonTitle, for: .normal)
+        auxiliaryButton.setImage(.infoOutlineImage, for: .normal)
+        auxiliaryButton.setAttributedTitle(viewModel.auxiliaryAttributedButtonTitle, for: .normal)
         auxiliaryButton.isHidden = false
         auxiliaryButton.accessibilityIdentifier = Accessibility.auxiliaryButton
     }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -52,10 +52,6 @@ final class CardPresentPaymentsModalViewController: UIViewController {
         styleContent()
         populateContent()
     }
-    /// Debugging. Remove before submitting PR for review
-    override func viewDidAppear(_ animated: Bool) {
-        print("Debugging breakpoint")
-    }
 
     func setViewModel(_ newViewModel: CardPresentPaymentsModalViewModel) {
         self.viewModel = newViewModel


### PR DESCRIPTION
Closes: #7518
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
As part of pdfdoF-1cz-p2, this PR adds a “Learn more” action to the Card Reader connecting dialog. This appears as a tappable "Learn More about In-Person Payments" text section just below the `Cancel` button when the app is scanning for readers. 

This is also tracked to Woo Events under `card_present_connection_learn_more_tapped`

### Changes
- Adds a new case to `PaymentsModalActionsMode`, which describes a new Modal that has a secondary button, and attributed text as its title.
- Adds a protocol extension to `CardPresentPaymentsModalViewModel` so we can provide with a nil default value to all other modals that conform to this protocol but do not use the new `auxiliaryAttributedButtonTitle`
- Adds logic to `configureAuxiliaryButton()` based on the view model that will be used to fill the Modal. We start by clearing any previous data via `clearAuxiliaryButton()`, then populate the contents of the Modal.
- Tapping the button launches a WebView to the "Getting started with IPP" website, as well as track the tap via the existing `.cardPresentOnboardingLearnMoreTapped`

### Testing instructions
1. If testing only with the simulator, enable -simulate-stripe-card-reader at Product > Scheme > Edit Scheme
2. Disable your Card Reader at HubMenu > Payments > Manager Card Readers > Disconnect
3. Open an Order that is pending payment > Tap Collect Payment
4. See the app Scanning for reader
5. Tapping on the text will redirect you to https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/

As the flow doesn't require user interaction to change modals, for easier checking/testing you can override `viewDidAppear()` in `CardPresentPaymentsModalViewController` and add a breakpoint there ( https://github.com/woocommerce/woocommerce-ios/pull/7545/commits/c8dde2625d2108725195f1cb18cec2a2ebc305d9)
```
override func viewDidAppear(_ animated: Bool) {}
```
### Screenshots
<img width= 400 src="https://user-images.githubusercontent.com/3812076/186670917-d6591345-ccbc-4edb-b3dd-64ea814e79e6.png">

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
