### PR TITLE
[UI Tests] - Re-enable skipped login test cases

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -160,15 +160,18 @@ struct HubMenu: View {
                     Text(storeTitle)
                         .headlineStyle()
                         .lineLimit(1)
+                        .accessibilityIdentifier("store-title")
                     if let storeURL = storeURL {
                         Text(storeURL)
                             .subheadlineStyle()
                             .lineLimit(1)
+                            .accessibilityIdentifier("store-url")
                     }
                     Button(Localization.switchStore) {
                         switchStoreHandler?()
                     }
                     .linkStyle()
+                    .accessibilityIdentifier("switch-store-button")
                 }
                 Spacer()
                 VStack {

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -11,7 +11,7 @@ public final class LoginEpilogueScreen: BaseScreen {
     private let displayNameField: XCUIElement
     private let siteUrlField: XCUIElement
 
-    init() {
+    public init() {
         let app = XCUIApplication()
         displayNameField = app.staticTexts[ElementStringIDs.displayNameField]
         siteUrlField = app.staticTexts[ElementStringIDs.siteUrlField]
@@ -20,6 +20,7 @@ public final class LoginEpilogueScreen: BaseScreen {
         super.init(element: continueButton)
     }
 
+    @discardableResult
     public func continueWithSelectedSite() throws -> MyStoreScreen {
         continueButton.tap()
         return try MyStoreScreen()

--- a/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
@@ -21,10 +21,8 @@ public final class PasswordScreen: BaseScreen {
         super.init(element: passwordTextField)
     }
 
-    public func proceedWith(password: String) -> LoginEpilogueScreen {
+    public func proceedWith(password: String) {
         _ = tryProceed(password: password)
-
-        return LoginEpilogueScreen()
     }
 
     public func tryProceed(password: String) -> PasswordScreen {

--- a/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
@@ -21,4 +21,10 @@ public final class PrologueScreen: ScreenObject {
 
         return LoginSiteAddressScreen()
     }
+
+    @discardableResult
+    public func verifyPrologueScreenLoaded() throws -> Self {
+        XCTAssertTrue(isLoaded)
+        return self
+    }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Menu/MenuScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Menu/MenuScreen.swift
@@ -14,6 +14,14 @@ public final class MenuScreen: ScreenObject {
         $0.buttons["menu-view-store"]
     }
 
+    private let selectedStoreTitleGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["store-title"]
+    }
+
+    private let selectedStoreUrlGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["store-url"]
+    }
+
     /// Button to open the Reviews section
     ///
     private var reviewsButton: XCUIElement { reviewsButtonGetter(app) }
@@ -38,5 +46,17 @@ public final class MenuScreen: ScreenObject {
     public func openSettingsPane() throws -> SettingsScreen {
         app.buttons["dashboard-settings-button"].tap()
         return try SettingsScreen()
+    }
+
+    @discardableResult
+    public func verifySelectedStoreDisplays(storeTitle expectedStoreTitle: String, storeURL expectedStoreUrl: String) -> MenuScreen {
+        let actualStoreTitle = selectedStoreTitleGetter(app).label
+        let actualStoreUrl = selectedStoreUrlGetter(app).label
+
+        XCTAssertEqual(expectedStoreTitle, actualStoreTitle,
+                       "Expected display name '\(expectedStoreTitle)' but '\(actualStoreTitle)' was displayed instead.")
+        XCTAssertEqual(expectedStoreUrl, actualStoreUrl,
+                       "Expected site URL \(expectedStoreUrl) but \(actualStoreUrl) was displayed instead.")
+        return self
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Menu/MenuScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Menu/MenuScreen.swift
@@ -49,14 +49,12 @@ public final class MenuScreen: ScreenObject {
     }
 
     @discardableResult
-    public func verifySelectedStoreDisplays(storeTitle expectedStoreTitle: String, storeURL expectedStoreUrl: String) -> MenuScreen {
+    public func verifySelectedStoreDisplays(storeTitle expectedStoreTitle: String, storeURL expectedStoreUrl: String) -> Self {
         let actualStoreTitle = selectedStoreTitleGetter(app).label
         let actualStoreUrl = selectedStoreUrlGetter(app).label
 
-        XCTAssertEqual(expectedStoreTitle, actualStoreTitle,
-                       "Expected display name '\(expectedStoreTitle)' but '\(actualStoreTitle)' was displayed instead.")
-        XCTAssertEqual(expectedStoreUrl, actualStoreUrl,
-                       "Expected site URL \(expectedStoreUrl) but \(actualStoreUrl) was displayed instead.")
+        XCTAssertEqual(expectedStoreTitle, actualStoreTitle)
+        XCTAssertEqual(expectedStoreUrl, actualStoreUrl)
         return self
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Settings/SettingsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Settings/SettingsScreen.swift
@@ -2,15 +2,6 @@ import ScreenObject
 import XCTest
 
 public final class SettingsScreen: ScreenObject {
-
-    private let selectedStoreNameGetter: (XCUIApplication) -> XCUIElement = {
-        $0.cells.staticTexts["headline-label"]
-    }
-
-    private let selectedSiteUrlGetter: (XCUIApplication) -> XCUIElement = {
-        $0.cells.staticTexts["body-label"]
-    }
-
     private let betaFeaturesGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["settings-beta-features-button"]
     }
@@ -58,21 +49,5 @@ public final class SettingsScreen: ScreenObject {
     public func goToExperimentalFeatures() throws -> BetaFeaturesScreen {
         betaFeaturesGetter(app).tap()
         return try BetaFeaturesScreen()
-    }
-}
-
-/// Assertions
-extension SettingsScreen {
-
-    public func verifySelectedStoreDisplays(storeName expectedStoreName: String, siteUrl expectedSiteUrl: String) -> SettingsScreen {
-        let actualStoreName = selectedStoreNameGetter(app).label
-        let expectedSiteUrl = expectedSiteUrl.replacingOccurrences(of: "http://", with: "")
-        let actualSiteUrl = selectedSiteUrlGetter(app).label
-
-        XCTAssertEqual(expectedStoreName, actualStoreName,
-                       "Expected display name '\(expectedStoreName)' but '\(actualStoreName)' was displayed instead.")
-        XCTAssertEqual(expectedSiteUrl, actualSiteUrl,
-                       "Expected site URL \(expectedSiteUrl) but \(actualSiteUrl) was displayed instead.")
-        return self
     }
 }

--- a/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
@@ -5,9 +5,11 @@ class LoginFlow {
 
     @discardableResult
     static func logInWithWPcom() throws -> MyStoreScreen {
-       return try PrologueScreen().selectContinueWithWordPress()
+        try PrologueScreen().selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
+
+        return try LoginEpilogueScreen()
             .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
             .continueWithSelectedSite()
     }

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -12,45 +12,39 @@ final class LoginTests: XCTestCase {
         app.launch()
     }
 
-    // Login with Store Address and log out.
-    func skipped_test_site_address_login_logout() throws {
-        try skipTillSettingsFixed()
-
-        let prologue = try PrologueScreen().selectSiteAddress()
+    func test_site_address_login_logout() throws {
+        try PrologueScreen()
+            .selectSiteAddress()
             .proceedWith(siteUrl: TestCredentials.siteUrl)
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
-            .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
-            .continueWithSelectedSite()
 
-        // Log out
+        // Log out and verify
         try TabNavComponent()
             .goToMenuScreen()
+            .verifySelectedStoreDisplays(storeTitle: TestCredentials.storeName, storeURL: TestCredentials.siteUrl)
             .openSettingsPane()
-            .verifySelectedStoreDisplays(storeName: TestCredentials.storeName, siteUrl: TestCredentials.siteUrl)
             .logOut()
-
-        XCTAssert(prologue.isLoaded)
+            .verifyPrologueScreenLoaded()
     }
 
-    // Login with WordPress.com account and log out
-    func skipped_test_WordPress_login_logout() throws {
-        try skipTillSettingsFixed()
+    func test_WordPress_login_logout() throws {
 
-        let prologue = try PrologueScreen().selectContinueWithWordPress()
+        try PrologueScreen().selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
+
+        try LoginEpilogueScreen()
             .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
             .continueWithSelectedSite()
 
-        // Log out
+        // Log out and verify
         try TabNavComponent()
             .goToMenuScreen()
+            .verifySelectedStoreDisplays(storeTitle: TestCredentials.storeName, storeURL: TestCredentials.siteUrl)
             .openSettingsPane()
-            .verifySelectedStoreDisplays(storeName: TestCredentials.storeName, siteUrl: TestCredentials.siteUrl)
             .logOut()
-
-        XCTAssert(prologue.isLoaded)
+            .verifyPrologueScreenLoaded()
     }
 
     func test_WordPress_unsuccessfull_login() throws {
@@ -58,14 +52,5 @@ final class LoginTests: XCTestCase {
             .proceedWith(email: TestCredentials.emailAddress)
             .tryProceed(password: "invalidPswd")
             .verifyLoginError()
-    }
-
-    func skipTillSettingsFixed(file: StaticString = #file, line: UInt = #line) throws {
-        try XCTSkipIf(true,
-            """
-            Skipping test because settings icon was moved from My Store to Hub Menu,
-            the icon no longer have an accessibilityIdentifier,
-            so test will fail during logout.
-            """, file: file, line: line)
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -6,7 +6,6 @@ final class LoginTests: XCTestCase {
     override func setUp() {
         continueAfterFailure = false
 
-        // UI tests must launch the application that they test.
         let app = XCUIApplication()
         app.launchArguments = ["logout-at-launch", "disable-animations", "mocked-wpcom-api", "-ui_testing"]
         app.launch()
@@ -19,7 +18,6 @@ final class LoginTests: XCTestCase {
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
 
-        // Log out and verify
         try TabNavComponent()
             .goToMenuScreen()
             .verifySelectedStoreDisplays(storeTitle: TestCredentials.storeName, storeURL: TestCredentials.siteUrl)
@@ -38,7 +36,6 @@ final class LoginTests: XCTestCase {
             .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
             .continueWithSelectedSite()
 
-        // Log out and verify
         try TabNavComponent()
             .goToMenuScreen()
             .verifySelectedStoreDisplays(storeTitle: TestCredentials.storeName, storeURL: TestCredentials.siteUrl)


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/7515

### Description
With the introduction of Hub Menu a while ago, the Settings icon was moved from My Store screen to the Hub Menu. Login-related UI test cases were not updated then to match the design and flow change, and were skipped instead. 

This is to re-enable the two skipped test cases `test_site_address_login_logout()` and `test_WordPress_login_logout()` so they can run again.

### Testing instructions
UI tests should pass locally and in CI

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
