### PR TITLE
Site picker: Add explanation for non-Atomic sites

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -686,10 +686,16 @@ extension StorePickerViewController: UITableViewDelegate {
         }
 
         guard site.isWooCommerceActive else {
-            ServiceLocator.analytics.track(.sitePickerNonWooSiteTapped, withProperties: ["is_non_atomic": !site.isJetpackConnected])
-            tableView.deselectRow(at: indexPath, animated: true)
-            showNoWooError(for: site)
-            return
+            let isNonAtomicSite = !site.isJetpackConnected
+            ServiceLocator.analytics.track(.sitePickerNonWooSiteTapped, withProperties: ["is_non_atomic": isNonAtomicSite])
+
+            if isNonAtomicSite {
+                showNonAtomicSiteError(for: site)
+            } else {
+                showNoWooError(for: site)
+            }
+            
+            return tableView.deselectRow(at: indexPath, animated: true)
         }
 
         reloadSelectedStoreRows() {
@@ -720,6 +726,13 @@ private extension StorePickerViewController {
             }
             self.stores.dispatch(action)
         }
+    }
+
+    func showNonAtomicSiteError(for site: Site) {
+        let viewModel = NonAtomicSiteViewModel(site: site, stores: stores)
+        let errorController = ULErrorViewController(viewModel: viewModel)
+        navigationController?.show(errorController, sender: nil)
+        navigationController?.setNavigationBarHidden(false, animated: true)
     }
 
     func showNoWooError(for site: Site) {

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -694,7 +694,7 @@ extension StorePickerViewController: UITableViewDelegate {
             } else {
                 showNoWooError(for: site)
             }
-            
+
             return tableView.deselectRow(at: indexPath, animated: true)
         }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NonAtomicSiteViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NonAtomicSiteViewModel.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Yosemite
+
+/// Configuration and actions for an ULErrorViewController, modelling
+/// an error when the user tries to log in to the app with a simple WP.com site.
+struct NonAtomicSiteViewModel: ULErrorViewModel {
+    private let site: Site
+    private let stores: StoresManager
+
+    var title: String? { site.name }
+
+    let image: UIImage = .loginNoWordPressError
+    
+    var text: NSAttributedString {
+        let font: UIFont = .body
+        let boldFont: UIFont = font.bold
+
+        let boldSiteAddress = NSAttributedString(string: site.url.trimHTTPScheme(),
+                                                 attributes: [.font: boldFont])
+        let message = NSMutableAttributedString(string: Localization.errorMessage)
+
+        message.replaceFirstOccurrence(of: "%@", with: boldSiteAddress)
+
+        return message
+    }
+    
+    let isAuxiliaryButtonHidden = true
+    let auxiliaryButtonTitle = ""
+
+    let isPrimaryButtonHidden = true
+    let primaryButtonTitle = ""
+    
+    let secondaryButtonTitle = Localization.secondaryButtonTitle
+
+    init(site: Site, stores: StoresManager = ServiceLocator.stores) {
+        self.site = site
+        self.stores = stores
+    }
+    
+    func viewDidLoad(_ viewController: UIViewController?) {
+        // no-op
+    }
+    
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        // no-op
+    }
+    
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        stores.deauthenticate()
+        viewController?.navigationController?.popToRootViewController(animated: true)
+    }
+    
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {
+        // no-op
+    }
+}
+
+private extension NonAtomicSiteViewModel {
+    enum Localization {
+        static let errorMessage = NSLocalizedString(
+            "It seems that your site %@ is a simple WordPress.com site that cannot install plugins. Please upgrade your plan to use WooCommerce.",
+            comment: "An error message displayed when the user tries to log in to the app with a simple WP.com site. " +
+            "Reads like: It seems that your site google.com is a simple WordPress.com site that cannot install plugins. Please upgrade your plan to use WooCommerce."
+        )
+
+        static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",
+                                                            comment: "Action button that will restart the login flow."
+                                                            + "Presented when the user tries to log in to the app with a simple WP.com site.")
+    }
+}

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NonAtomicSiteViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NonAtomicSiteViewModel.swift
@@ -10,7 +10,7 @@ struct NonAtomicSiteViewModel: ULErrorViewModel {
     var title: String? { site.name }
 
     let image: UIImage = .loginNoWordPressError
-    
+
     var text: NSAttributedString {
         let font: UIFont = .body
         let boldFont: UIFont = font.bold
@@ -23,33 +23,33 @@ struct NonAtomicSiteViewModel: ULErrorViewModel {
 
         return message
     }
-    
+
     let isAuxiliaryButtonHidden = true
     let auxiliaryButtonTitle = ""
 
     let isPrimaryButtonHidden = true
     let primaryButtonTitle = ""
-    
+
     let secondaryButtonTitle = Localization.secondaryButtonTitle
 
     init(site: Site, stores: StoresManager = ServiceLocator.stores) {
         self.site = site
         self.stores = stores
     }
-    
+
     func viewDidLoad(_ viewController: UIViewController?) {
         // no-op
     }
-    
+
     func didTapPrimaryButton(in viewController: UIViewController?) {
         // no-op
     }
-    
+
     func didTapSecondaryButton(in viewController: UIViewController?) {
         stores.deauthenticate()
         viewController?.navigationController?.popToRootViewController(animated: true)
     }
-    
+
     func didTapAuxiliaryButton(in viewController: UIViewController?) {
         // no-op
     }
@@ -60,7 +60,8 @@ private extension NonAtomicSiteViewModel {
         static let errorMessage = NSLocalizedString(
             "It seems that your site %@ is a simple WordPress.com site that cannot install plugins. Please upgrade your plan to use WooCommerce.",
             comment: "An error message displayed when the user tries to log in to the app with a simple WP.com site. " +
-            "Reads like: It seems that your site google.com is a simple WordPress.com site that cannot install plugins. Please upgrade your plan to use WooCommerce."
+            "Reads like: It seems that your site google.com is a simple WordPress.com site that cannot install plugins. " +
+            "Please upgrade your plan to use WooCommerce."
         )
 
         static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1635,6 +1635,7 @@
 		DE279BAF26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BAE26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift */; };
 		DE279BB126EA184A002BA963 /* ShippingLabelPackageListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BB026EA184A002BA963 /* ShippingLabelPackageListViewModel.swift */; };
 		DE2BF4FD2846192B00FBE68A /* CouponAllowedEmailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2BF4FC2846192B00FBE68A /* CouponAllowedEmailsViewModelTests.swift */; };
+		DE3404E828B4B96800CF0D97 /* NonAtomicSiteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */; };
 		DE34771327F174C8009CA300 /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34771227F174C8009CA300 /* StatusView.swift */; };
 		DE3877E0283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */; };
 		DE3877E2283CCBC20075D87E /* BottomSheetListSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */; };
@@ -3486,6 +3487,7 @@
 		DE279BAE26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSinglePackageViewModelTests.swift; sourceTree = "<group>"; };
 		DE279BB026EA184A002BA963 /* ShippingLabelPackageListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageListViewModel.swift; sourceTree = "<group>"; };
 		DE2BF4FC2846192B00FBE68A /* CouponAllowedEmailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmailsViewModelTests.swift; sourceTree = "<group>"; };
+		DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModel.swift; sourceTree = "<group>"; };
 		DE34771227F174C8009CA300 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
 		DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountTypeBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
 		DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelector.swift; sourceTree = "<group>"; };
@@ -7964,6 +7966,7 @@
 				DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */,
 				DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */,
 				DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */,
+				DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */,
 			);
 			path = "Navigation Exceptions";
 			sourceTree = "<group>";
@@ -10061,6 +10064,7 @@
 				021FB44C24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift in Sources */,
 				456C7EEB25EE71F10016CBC6 /* ShippingLabelSuggestedAddressViewController.swift in Sources */,
 				D89CFE9025B256E9000E4683 /* ULAccountMatcher.swift in Sources */,
+				DE3404E828B4B96800CF0D97 /* NonAtomicSiteViewModel.swift in Sources */,
 				D8815B0126385E3F00EDAD62 /* CardPresentModalTapCard.swift in Sources */,
 				773077EE251E943700178696 /* ProductDownloadFileViewController.swift in Sources */,
 				45D1CF4523BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1636,6 +1636,7 @@
 		DE279BB126EA184A002BA963 /* ShippingLabelPackageListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BB026EA184A002BA963 /* ShippingLabelPackageListViewModel.swift */; };
 		DE2BF4FD2846192B00FBE68A /* CouponAllowedEmailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2BF4FC2846192B00FBE68A /* CouponAllowedEmailsViewModelTests.swift */; };
 		DE3404E828B4B96800CF0D97 /* NonAtomicSiteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */; };
+		DE3404EA28B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */; };
 		DE34771327F174C8009CA300 /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34771227F174C8009CA300 /* StatusView.swift */; };
 		DE3877E0283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */; };
 		DE3877E2283CCBC20075D87E /* BottomSheetListSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */; };
@@ -3488,6 +3489,7 @@
 		DE279BB026EA184A002BA963 /* ShippingLabelPackageListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackageListViewModel.swift; sourceTree = "<group>"; };
 		DE2BF4FC2846192B00FBE68A /* CouponAllowedEmailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModel.swift; sourceTree = "<group>"; };
+		DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModelTests.swift; sourceTree = "<group>"; };
 		DE34771227F174C8009CA300 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
 		DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountTypeBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
 		DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelector.swift; sourceTree = "<group>"; };
@@ -5844,6 +5846,7 @@
 				DE61978C289A5326005E4362 /* WooSetupWebViewModelTests.swift */,
 				DE61978E289A5674005E4362 /* NoWooErrorViewModelTests.swift */,
 				DE61979428A25842005E4362 /* StorePickerViewModelTests.swift */,
+				DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -10451,6 +10454,7 @@
 				093B265927DF15100026F92D /* BulkUpdatePriceViewControllerTests.swift in Sources */,
 				2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */,
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,
+				DE3404EA28B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift in Sources */,
 				02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */,
 				D88D5A3B230B5D63007B6E01 /* MockAnalyticsProvider.swift in Sources */,
 				B9C4AB29280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/NonAtomicSiteViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NonAtomicSiteViewModelTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class NonAtomicSiteViewModelTests: XCTestCase {
+
+    func test_viewmodel_provides_expected_title() {
+        // Given
+        let site = Site.fake().copy(name: "Test")
+        let viewModel = NonAtomicSiteViewModel(site: site)
+
+        // When
+        let title = viewModel.title
+
+        // Then
+        XCTAssertEqual(title, site.name)
+    }
+
+    func test_viewmodel_provides_expected_image() {
+        // Given
+        let viewModel = NonAtomicSiteViewModel(site: Site.fake())
+
+        // When
+        let image = viewModel.image
+
+        // Then
+        XCTAssertEqual(image, Expectations.image)
+    }
+
+    func test_viewmodel_provides_expected_error_message() {
+        // Given
+        let site = Site.fake().copy(url: "https://test.com")
+        let viewModel = NonAtomicSiteViewModel(site: site)
+        let expectation = Expectations.errorMessage.replacingOccurrences(of: "%@", with: "test.com")
+
+        // When
+        let errorMessage = viewModel.text.string
+
+        // Then
+        XCTAssertEqual(errorMessage, expectation)
+    }
+
+    func test_viewmodel_provides_expected_visibility_for_auxiliary_button() {
+        // Given
+        let viewModel = NonAtomicSiteViewModel(site: Site.fake())
+
+        // When
+        let isHidden = viewModel.isAuxiliaryButtonHidden
+
+        // Then
+        XCTAssertTrue(isHidden)
+    }
+
+    func test_viewmodel_provides_expected_title_for_auxiliary_button() {
+        // Given
+        let viewModel = NonAtomicSiteViewModel(site: Site.fake())
+
+        // When
+        let auxiliaryButtonTitle = viewModel.auxiliaryButtonTitle
+
+        // Then
+        XCTAssertEqual(auxiliaryButtonTitle, "")
+    }
+
+    func test_viewmodel_provides_expected_visibility_for_primary_button() {
+        // Given
+        let viewModel = NonAtomicSiteViewModel(site: Site.fake())
+
+        // When
+        let isHidden = viewModel.isPrimaryButtonHidden
+
+        // Then
+        XCTAssertTrue(isHidden)
+    }
+
+    func test_viewmodel_provides_expected_title_for_primary_button() {
+        // Given
+        let viewModel = NonAtomicSiteViewModel(site: Site.fake())
+
+        // When
+        let primaryButtonTitle = viewModel.primaryButtonTitle
+
+        // Then
+        XCTAssertEqual(primaryButtonTitle, "")
+    }
+
+    func test_viewmodel_provides_expected_title_for_secondary_button() {
+        // Given
+        let viewModel = NonAtomicSiteViewModel(site: Site.fake())
+
+        // When
+        let secondaryButtonTitle = viewModel.secondaryButtonTitle
+
+        // Then
+        XCTAssertEqual(secondaryButtonTitle, Expectations.secondaryButtonTitle)
+    }
+
+}
+
+private extension NonAtomicSiteViewModelTests {
+    enum Expectations {
+        static let image = UIImage.loginNoWordPressError
+
+        static let errorMessage = NSLocalizedString(
+            "It seems that your site %@ is a simple WordPress.com site that cannot install plugins. Please upgrade your plan to use WooCommerce.",
+            comment: "An error message displayed when the user tries to log in to the app with a simple WP.com site. " +
+            "Reads like: It seems that your site google.com is a simple WordPress.com site that cannot install plugins. " +
+            "Please upgrade your plan to use WooCommerce."
+        )
+
+        static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",
+                                                            comment: "Action button that will restart the login flow."
+                                                            + "Presented when the user tries to log in to the app with a simple WP.com site.")
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7549 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new screen to explain the need for a plan upgrade when a user selects a simple WP.com site from the site picker. This screen is now displayed instead of the No Woo error screen as before.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Make sure that you have access to a simple WP.com site.
- Log out of the app if needed and select Continue with WordPress.com.
- Enter your credentials to log in.
- After the login succeeds, select the simple WP.com site from the site picker.
- Notice that the app now displays a new error screen explaining the need for a plan upgrade.
- Feel free to select another site from the site picker: an Atomic site or a site with Jetpack connection package. These should work as before.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/186122841-365011db-2122-4ebf-a729-f97cd79461a9.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
