### PR TITLE
[Mobile Payments] Tracks events for Cash on Delivery Onboarding prompt

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -745,6 +745,8 @@ extension WooAnalyticsEvent {
             static let batteryLevel = "battery_level"
             static let cardReaderModel = "card_reader_model"
             static let countryCode = "country"
+            static let reason = "reason"
+            static let remindLater = "remind_later"
             static let gatewayID = "plugin_slug"
             static let errorDescription = "error_description"
             static let paymentMethodType = "payment_method_type"
@@ -1150,7 +1152,23 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingNotCompleted,
                               properties: [
                                 Keys.countryCode: countryCode,
-                                "reason": reason
+                                Keys.reason: reason
+                              ])
+        }
+
+        /// Tracked when a In-Person Payments onboarding step is skipped by the user.
+        ///
+        /// - Parameters:
+        ///   - reason: the reason why the onboarding step was shown (effectively the name of the step.)
+        ///   - remindLater: whether the user will see this onboarding step again
+        ///   - countryCode: the country code of the store.
+        ///
+        static func cardPresentOnboardingStepSkipped(reason: String, remindLater: Bool, countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .cardPresentOnboardingStepSkipped,
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.reason: reason,
+                                Keys.remindLater: remindLater
                               ])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1186,6 +1186,32 @@ extension WooAnalyticsEvent {
                               ])
         }
 
+        /// Tracked when the Cash on Delivery Payment Gateway is successfully enabled, e.g. from the IPP onboarding flow.
+        ///
+        /// - Parameters:
+        ///   - countryCode: the country code of the store.
+        ///
+        static func enableCashOnDeliverySuccess(countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .enableCashOnDeliverySuccess,
+                              properties: [
+                                Keys.countryCode: countryCode
+                              ])
+        }
+
+        /// Tracked when the Cash on Delivery Payment Gateway enabling fails, e.g. from the IPP onboarding flow.
+        ///
+        /// - Parameters:
+        ///   - countryCode: the country code of the store.
+        ///
+        static func enableCashOnDeliveryFailed(countryCode: String,
+                                               error: Error?) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .enableCashOnDeliveryFailed,
+                              properties: [
+                                Keys.countryCode: countryCode
+                              ],
+                              error: error)
+        }
+
         /// Tracked when the user taps on the "See Receipt" button to view a receipt.
         /// - Parameter countryCode: the country code of the store.
         ///

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1137,9 +1137,12 @@ extension WooAnalyticsEvent {
         ///
         /// - Parameter countryCode: the country code of the store.
         ///
-        static func cardPresentOnboardingLearnMoreTapped(countryCode: String) -> WooAnalyticsEvent {
+        static func cardPresentOnboardingLearnMoreTapped(reason: String, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingLearnMoreTapped,
-                              properties: [Keys.countryCode: countryCode])
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.reason: reason
+                              ])
         }
 
         /// Tracked when the In-Person Payments onboarding cannot be completed for some reason.

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1172,6 +1172,20 @@ extension WooAnalyticsEvent {
                               ])
         }
 
+        /// Tracked when a In-Person Payments onboarding step's CTA is tapped by the user.
+        ///
+        /// - Parameters:
+        ///   - reason: the reason why the onboarding step was shown (effectively the name of the step.)
+        ///   - countryCode: the country code of the store.
+        ///
+        static func cardPresentOnboardingCtaTapped(reason: String, countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .cardPresentOnboardingCtaTapped,
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.reason: reason
+                              ])
+        }
+
         /// Tracked when the user taps on the "See Receipt" button to view a receipt.
         /// - Parameter countryCode: the country code of the store.
         ///

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -185,6 +185,7 @@ public enum WooAnalyticsStat: String {
     case cardPresentOnboardingLearnMoreTapped = "card_present_onboarding_learn_more_tapped"
     case cardPresentOnboardingNotCompleted = "card_present_onboarding_not_completed"
     case cardPresentOnboardingStepSkipped = "card_present_onboarding_step_skipped"
+    case cardPresentOnboardingCtaTapped = "card_present_onboarding_cta_tapped"
 
     // MARK: Payment Gateways selection
     case cardPresentPaymentGatewaySelected = "card_present_payment_gateway_selected"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -184,6 +184,7 @@ public enum WooAnalyticsStat: String {
     // MARK: Card-Present Payments Onboarding
     case cardPresentOnboardingLearnMoreTapped = "card_present_onboarding_learn_more_tapped"
     case cardPresentOnboardingNotCompleted = "card_present_onboarding_not_completed"
+    case cardPresentOnboardingStepSkipped = "card_present_onboarding_step_skipped"
 
     // MARK: Payment Gateways selection
     case cardPresentPaymentGatewaySelected = "card_present_payment_gateway_selected"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -187,6 +187,10 @@ public enum WooAnalyticsStat: String {
     case cardPresentOnboardingStepSkipped = "card_present_onboarding_step_skipped"
     case cardPresentOnboardingCtaTapped = "card_present_onboarding_cta_tapped"
 
+    // MARK: Cash on Delivery Enable events
+    case enableCashOnDeliverySuccess = "enable_cash_on_delivery_success"
+    case enableCashOnDeliveryFailed = "enable_cash_on_delivery_failed"
+
     // MARK: Payment Gateways selection
     case cardPresentPaymentGatewaySelected = "card_present_payment_gateway_selected"
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -7,13 +7,16 @@ struct InPersonPaymentsLearnMore: View {
     let url: URL
     let linkText: String
     let formatText: String
+    let analyticReason: String?
 
     init(url: URL = learnMoreURL,
          linkText: String = Localization.learnMoreLink,
-         formatText: String = Localization.learnMoreText) {
+         formatText: String = Localization.learnMoreText,
+         analyticReason: String? = nil) {
         self.url = url
         self.linkText = linkText
         self.formatText = formatText
+        self.analyticReason = analyticReason
     }
 
     private let cardPresentConfiguration = CardPresentConfigurationLoader().configuration
@@ -28,8 +31,10 @@ struct InPersonPaymentsLearnMore: View {
         }
             .padding(.vertical, Constants.verticalPadding)
             .onTapGesture {
-                ServiceLocator.analytics.track(event: WooAnalyticsEvent.InPersonPayments
-                                                .cardPresentOnboardingLearnMoreTapped(countryCode: cardPresentConfiguration.countryCode))
+                ServiceLocator.analytics.track(
+                    event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingLearnMoreTapped(
+                        reason: analyticReason ?? "",
+                        countryCode: cardPresentConfiguration.countryCode))
                 customOpenURL?(url)
             }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -11,7 +11,8 @@ final class InPersonPaymentsViewModel: ObservableObject {
     let stores: StoresManager
 
     lazy var codStepViewModel: InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel = {
-        InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(completion: refresh)
+        InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(configuration: useCase.configurationLoader.configuration,
+                                                                      completion: refresh)
     }()
 
     /// Initializes the view model for a specific site

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Yosemite
 
 struct InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView: View {
     @ObservedObject var viewModel: InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel
@@ -35,7 +36,8 @@ struct InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView: View {
 
 struct InPersonPaymentsCodPaymentGatewayNotSetUp_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(completion: {})
+        let viewModel = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(configuration: CardPresentPaymentsConfiguration(country: "US"),
+                                                                                      completion: {})
         return InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift
@@ -29,7 +29,8 @@ struct InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView: View {
             Spacer()
 
             InPersonPaymentsLearnMore(url: WooConstants.URLs.cashOnDeliveryLearnMoreUrl.asURL(),
-                                      formatText: Localization.cashOnDeliveryLearnMore)
+                                      formatText: Localization.cashOnDeliveryLearnMore,
+                                      analyticReason: viewModel.analyticReason)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -2,30 +2,56 @@ import Foundation
 import Yosemite
 
 final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: ObservableObject {
+    // MARK: - Dependencies
+    struct Dependencies {
+        let stores: StoresManager
+        let noticePresenter: NoticePresenter
+        let analytics: Analytics
+
+        init(stores: StoresManager = ServiceLocator.stores,
+             noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
+             analytics: Analytics = ServiceLocator.analytics) {
+            self.stores = stores
+            self.noticePresenter = noticePresenter
+            self.analytics = analytics
+        }
+    }
+
+    private let dependencies: Dependencies
+
+    private var stores: StoresManager {
+        dependencies.stores
+    }
+
+    private var noticePresenter: NoticePresenter {
+        dependencies.noticePresenter
+    }
+
+    private var analytics: Analytics {
+        dependencies.analytics
+    }
+
+    // MARK: - Output properties
     let completion: () -> Void
-    private let stores: StoresManager
-    private let noticePresenter: NoticePresenter
-    private let analytics: Analytics
-    private let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
 
     @Published var awaitingResponse = false
+
+    // MARK: - Configuration properties
+    private let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
 
     private var siteID: Int64? {
         stores.sessionManager.defaultStoreID
     }
 
-    init(stores: StoresManager = ServiceLocator.stores,
-         noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
-         analytics: Analytics = ServiceLocator.analytics,
+    init(dependencies: Dependencies = Dependencies(),
          configuration: CardPresentPaymentsConfiguration,
          completion: @escaping () -> Void) {
-        self.stores = stores
-        self.noticePresenter = noticePresenter
-        self.analytics = analytics
+        self.dependencies = dependencies
         self.cardPresentPaymentsConfiguration = configuration
         self.completion = completion
     }
 
+    // MARK: - Actions
     func skipTapped() {
         trackSkipTapped()
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -79,9 +79,11 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
                 DDLogError("💰 Could not update Payment Gateway: \(String(describing: result.failure))")
                 self.awaitingResponse = false
                 self.displayEnableCashOnDeliveryFailureNotice()
+                self.trackEnableCashOnDeliveryFailed(error: result.failure)
                 return
             }
 
+            self.trackEnableCashOnDeliverySuccess()
             self.completion()
         }
         stores.dispatch(action)
@@ -126,6 +128,17 @@ private extension InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel 
     func trackEnableTapped() {
         let event = Event.cardPresentOnboardingCtaTapped(reason: reason,
                                                          countryCode: cardPresentPaymentsConfiguration.countryCode)
+        analytics.track(event: event)
+    }
+
+    func trackEnableCashOnDeliverySuccess() {
+        let event = Event.enableCashOnDeliverySuccess(countryCode: cardPresentPaymentsConfiguration.countryCode)
+        analytics.track(event: event)
+    }
+
+    func trackEnableCashOnDeliveryFailed(error: Error?) {
+        let event = Event.enableCashOnDeliveryFailed(countryCode: cardPresentPaymentsConfiguration.countryCode,
+                                                     error: error)
         analytics.track(event: event)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -65,6 +65,8 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
     }
 
     func enableTapped() {
+        trackEnableTapped()
+
         guard let siteID = siteID else {
             return completion()
         }
@@ -108,16 +110,22 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
 
 // MARK: - Analytics
 private extension InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel {
-    private typealias Event = WooAnalyticsEvent.InPersonPayments
+    typealias Event = WooAnalyticsEvent.InPersonPayments
 
-    private var reason: String {
+    var reason: String {
         CardPresentPaymentOnboardingState.codPaymentGatewayNotSetUp.reasonForAnalytics ?? ""
     }
 
-    private func trackSkipTapped() {
+    func trackSkipTapped() {
         let event = Event.cardPresentOnboardingStepSkipped(reason: reason,
                                                            remindLater: false,
                                                            countryCode: cardPresentPaymentsConfiguration.countryCode)
+        analytics.track(event: event)
+    }
+
+    func trackEnableTapped() {
+        let event = Event.cardPresentOnboardingCtaTapped(reason: reason,
+                                                         countryCode: cardPresentPaymentsConfiguration.countryCode)
         analytics.track(event: event)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -36,6 +36,8 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
 
     @Published var awaitingResponse = false
 
+    let analyticReason: String = CardPresentPaymentOnboardingState.codPaymentGatewayNotSetUp.reasonForAnalytics ?? ""
+
     // MARK: - Configuration properties
     private let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
 
@@ -114,19 +116,15 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
 private extension InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel {
     typealias Event = WooAnalyticsEvent.InPersonPayments
 
-    var reason: String {
-        CardPresentPaymentOnboardingState.codPaymentGatewayNotSetUp.reasonForAnalytics ?? ""
-    }
-
     func trackSkipTapped() {
-        let event = Event.cardPresentOnboardingStepSkipped(reason: reason,
+        let event = Event.cardPresentOnboardingStepSkipped(reason: analyticReason,
                                                            remindLater: false,
                                                            countryCode: cardPresentPaymentsConfiguration.countryCode)
         analytics.track(event: event)
     }
 
     func trackEnableTapped() {
-        let event = Event.cardPresentOnboardingCtaTapped(reason: reason,
+        let event = Event.cardPresentOnboardingCtaTapped(reason: analyticReason,
                                                          countryCode: cardPresentPaymentsConfiguration.countryCode)
         analytics.track(event: event)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift
@@ -15,6 +15,8 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests: 
 
     private var configuration: CardPresentPaymentsConfiguration!
 
+    private var dependencies: InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.Dependencies!
+
     private var sut: InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel!
 
     override func setUp() {
@@ -24,9 +26,12 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests: 
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         configuration = CardPresentPaymentsConfiguration.init(country: "US")
-        sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(stores: stores,
-                                                                            noticePresenter: noticePresenter,
-                                                                            analytics: analytics,
+        dependencies = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.Dependencies(
+            stores: stores,
+            noticePresenter: noticePresenter,
+            analytics: analytics
+        )
+        sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(dependencies: dependencies,
                                                                             configuration: configuration,
                                                                             completion: {})
     }
@@ -34,8 +39,7 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests: 
     func test_skip_always_calls_completion() {
         // Given
         let completionCalled: Bool = waitFor { promise in
-            let sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(stores: self.stores,
-                                                                                    noticePresenter: self.noticePresenter,
+            let sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(dependencies: self.dependencies,
                                                                                     configuration: self.configuration,
                                                                                     completion: {
                 promise(true)
@@ -81,8 +85,7 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests: 
         }
 
         let completionCalled: Bool = waitFor { promise in
-            let sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(stores: self.stores,
-                                                                                    noticePresenter: self.noticePresenter,
+            let sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(dependencies: self.dependencies,
                                                                                     configuration: self.configuration,
                                                                                     completion: {
                 promise(true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift
@@ -10,21 +10,34 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests: 
 
     private var noticePresenter: MockNoticePresenter!
 
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: Analytics!
+
+    private var configuration: CardPresentPaymentsConfiguration!
+
     private var sut: InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel!
 
     override func setUp() {
         stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.sessionManager.setStoreId(12345)
         noticePresenter = MockNoticePresenter()
-        sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(stores: stores, noticePresenter: noticePresenter, completion: {})
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        configuration = CardPresentPaymentsConfiguration.init(country: "US")
+        sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(stores: stores,
+                                                                            noticePresenter: noticePresenter,
+                                                                            analytics: analytics,
+                                                                            configuration: configuration,
+                                                                            completion: {})
     }
 
     func test_skip_always_calls_completion() {
         // Given
         let completionCalled: Bool = waitFor { promise in
             let sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(stores: self.stores,
-                                                                         noticePresenter: self.noticePresenter,
-                                                                         completion: {
+                                                                                    noticePresenter: self.noticePresenter,
+                                                                                    configuration: self.configuration,
+                                                                                    completion: {
                 promise(true)
             })
 
@@ -69,8 +82,9 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests: 
 
         let completionCalled: Bool = waitFor { promise in
             let sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(stores: self.stores,
-                                                                          noticePresenter: self.noticePresenter,
-                                                                          completion: {
+                                                                                    noticePresenter: self.noticePresenter,
+                                                                                    configuration: self.configuration,
+                                                                                    completion: {
                 promise(true)
             })
             // When
@@ -100,4 +114,32 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests: 
         let expectedTitle = "Failed to enable Pay in Person. Please try again later."
         assertEqual(expectedTitle, notice.title)
     }
+
+    // MARK: - Analytics tests
+    func test_skip_tapped_logs_onboarding_step_skipped_event() throws {
+        // Given
+        assertEmpty(analyticsProvider.receivedEvents)
+
+        // When
+        sut.skipTapped()
+
+        // Then
+        assertNotEmpty(analyticsProvider.receivedEvents)
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == AnalyticEvents.skippedEvent }))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        assertEqual(AnalyticProperties.cashOnDeliveryDisabledReason, eventProperties[AnalyticProperties.reasonKey] as? String)
+        assertEqual(false, eventProperties[AnalyticProperties.remindLaterKey] as? Bool)
+        assertEqual("US", eventProperties[AnalyticProperties.countryCodeKey] as? String)
+    }
+}
+
+private enum AnalyticEvents {
+    static let skippedEvent = "card_present_onboarding_step_skipped"
+}
+
+private enum AnalyticProperties {
+    static let reasonKey = "reason"
+    static let cashOnDeliveryDisabledReason = "cash_on_delivery_disabled"
+    static let remindLaterKey = "remind_later"
+    static let countryCodeKey = "country"
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift
@@ -134,10 +134,26 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests: 
         assertEqual(false, eventProperties[AnalyticProperties.remindLaterKey] as? Bool)
         assertEqual("US", eventProperties[AnalyticProperties.countryCodeKey] as? String)
     }
+
+    func test_enable_tapped_logs_cta_tapped_event() throws {
+        // Given
+        assertEmpty(analyticsProvider.receivedEvents)
+
+        // When
+        sut.enableTapped()
+
+        // Then
+        assertNotEmpty(analyticsProvider.receivedEvents)
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == AnalyticEvents.ctaTappedEvent }))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        assertEqual(AnalyticProperties.cashOnDeliveryDisabledReason, eventProperties[AnalyticProperties.reasonKey] as? String)
+        assertEqual("US", eventProperties[AnalyticProperties.countryCodeKey] as? String)
+    }
 }
 
 private enum AnalyticEvents {
     static let skippedEvent = "card_present_onboarding_step_skipped"
+    static let ctaTappedEvent = "card_present_onboarding_cta_tapped"
 }
 
 private enum AnalyticProperties {

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -115,7 +115,7 @@ extension CardPresentPaymentOnboardingState {
         case .stripeAccountRejected:
             return "account_rejected"
         case .codPaymentGatewayNotSetUp:
-            return "cod_not_set_up"
+            return "cash_on_delivery_disabled"
         case .genericError:
             return "generic_error"
         case .noConnectionError:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #7525
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We have added a prompt in In-Person Payments onboarding for merchants to enable `Cash on Delivery`, renamed to `Pay in Person`. This will allow them to accept payment in person for orders placed on the web, e.g. at collection or delivery.

This PR adds the analytics for the new onboarding step.

Extending the new `card_present_onboarding_step_skipped` and `card_present_onboarding_cta_tapped` events, and the new property on `card_present_onboarding_learn_more_tapped`, will be covered in another PR. They are not required for iteration 1 of CoD

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Set a breakpoint in Proxyman or Charles on `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/*/rest-api/`

Using a store with WCPay installed and Cash on Delivery disabled (disable it in wp-admin > Settings > Payments):

1. Delete the app before running.
2. Run the app and log in to your account, selecting the store.
3. Go to `Menu > Payments`
4. You should see the `Continue setup` notice at the bottom of the screen: tap the link.
5. Select a payment gateway (if asked)
6. Observe that when you're shown the `Add Pay in Person` onboarding step,  the `card_present_onboarding_not_completed` event is tracked with `reason: cash_on_delivery_disabled`
7. Tap Learn More – observe that the `card_present_onboarding_learn_more_tapped` event is tracked with `reason: cash_on_delivery_disabled`
8. Close the web view
9. Tap `Enable Pay in Person` – observe that the `card_present_onboarding_cta_tapped` event is tracked with `reason: cash_on_delivery_disabled`
10. Abort the response in Proxyman/Charles when it hits the breakpoint – observe that the `enable_cash_on_delivery_failed` event is tracked with the `error_description`
11. Retry, and allow the response this time – observe that the `enable_cash_on_delivery_success` event is tracked.

#### Skipped event
1. Delete the app before running.
2. Run the app and log in to your account, selecting the store.
3. Go to `Menu > Payments`
4. You should see the `Continue setup` notice at the bottom of the screen: tap the link.
5. Select a payment gateway (if asked)
6. On the `Enable Pay in Person` step, tap `Skip for now` – observe that the `card_present_onboarding_step_skipped ` event is tracked with `reason: cash_on_delivery_disabled` and `remind_later: false`


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

#### Shown
```
🔵 Tracked card_present_onboarding_not_completed, properties: [AnyHashable("country"): "US", AnyHashable("blog_id"): 197448330, AnyHashable("reason"): "cash_on_delivery_disabled", AnyHashable("is_wpcom_store"): false]
```

#### Enable tapped
```
🔵 Tracked card_present_onboarding_cta_tapped, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("country"): "US", AnyHashable("blog_id"): 197448330, AnyHashable("reason"): "cash_on_delivery_disabled"]
```

#### Enable failed
```
🔵 Tracked enable_cash_on_delivery_failed, properties: [AnyHashable("blog_id"): 197448330, AnyHashable("country"): "US", AnyHashable("error_domain"): "NSCocoaErrorDomain", AnyHashable("is_wpcom_store"): false, AnyHashable("error_code"): "4864", AnyHashable("error_description"): "Swift.DecodingError.dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: \"The given data was not valid JSON.\", underlyingError: Optional(Error Domain=NSCocoaErrorDomain Code=3840 \"Unable to parse empty data.\" UserInfo={NSDebugDescription=Unable to parse empty data.})))"]
```

#### Enable success
```
🔵 Tracked enable_cash_on_delivery_success, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("country"): "US", AnyHashable("blog_id"): 197448330]
```

#### Skipped
```
🔵 Tracked card_present_onboarding_step_skipped, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("remind_later"): false, AnyHashable("reason"): "cash_on_delivery_disabled", AnyHashable("country"): "US", AnyHashable("blog_id"): 197448330]
```

#### Learn More
```
🔵 Tracked card_present_onboarding_learn_more_tapped, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("country"): "US", AnyHashable("reason"): "cash_on_delivery_disabled", AnyHashable("blog_id"): 197448330]
```


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
