### PR TITLE
Save anonymous ID to Keychain for identifying a logged-out user potentially across installs

### DIFF
--- a/WooCommerce/Classes/Authentication/Keychain+Entries.swift
+++ b/WooCommerce/Classes/Authentication/Keychain+Entries.swift
@@ -6,4 +6,10 @@ extension Keychain {
         get { self[WooConstants.keychainAppleIDKey] }
         set { self[WooConstants.keychainAppleIDKey] = newValue }
     }
+
+    /// The anonymous ID used to identify a logged-out user potentially across installs in analytics and A/B experiments.
+    var anonymousID: String? {
+        get { self[WooConstants.anonymousIDKey] }
+        set { self[WooConstants.anonymousIDKey] = newValue }
+    }
 }

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -119,14 +119,16 @@ final class SessionManager: SessionManagerProtocol {
     /// Anonymous UserID.
     ///
     var anonymousUserID: String? {
-        get {
-            if let anonID = defaults[.defaultAnonymousID] as? String, !anonID.isEmpty {
-                return anonID
-            } else {
-                let newValue = UUID().uuidString
-                defaults[.defaultAnonymousID] = newValue
-                return newValue
-            }
+        if let anonID = defaults[.defaultAnonymousID] as? String, !anonID.isEmpty {
+            return anonID
+        } else if let keychainAnonID = keychain.anonymousID, !keychainAnonID.isEmpty {
+            defaults[.defaultAnonymousID] = keychainAnonID
+            return keychainAnonID
+        } else {
+            let newValue = UUID().uuidString
+            defaults[.defaultAnonymousID] = newValue
+            keychain.anonymousID = newValue
+            return newValue
         }
     }
 

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -21,6 +21,10 @@ enum WooConstants {
     ///
     static let keychainAppleIDKey = "AppleID"
 
+    /// Keychain Access's Key for anonymous ID
+    ///
+    static let anonymousIDKey = "anonymousID"
+
     /// Push Notifications ApplicationID
     ///
 #if DEBUG


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes #7435
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Now that we're getting results for the logged-out A/A experiment (link at the top of pbxNRc-1S0-p2), there is a significantly higher crossover rate where the same logged-in user could have experienced both variations. Currently, the app generates a UUID if an anonymous ID isn't set in the UserDefauls which is cleared after app deletion. As Aaron@ExPlat suggested in pbxNRc-1S0-p2#comment-3684, we want to try sending the same anonymous ID potentially across installs and devices for users who are on multiple devices or have reinstalled the app.

It isn't straightforward to find a good solution, because Apple has prevented developers to identify an iOS device/user for privacy reasons. Even for the Ads identifier (which we can't use because we don't serve ads), the user can still reset the identifier in the device settings easily. I also tried the iOS 11+ [DeviceCheck API](https://developer.apple.com/documentation/devicecheck/dcdevice?changes=latest_minor), but after testing the token is not unique every time. I'm guessing some time-dependent information is encoded so that it can only be decoded by the Apple server.

Eventually, I came back to the Keychain solution which [seems to be the only way](https://stackoverflow.com/questions/42672750/ios-unique-identifier-across-installs). Even though Apple is supposed to delete data in the Keychain after the app is uninstalled, our app has enabled "Keychain Sharing" which makes it **more likely** to keep the Keychain data across installs if the user has other Automattic apps. From my testing in the simulator and a physical device without other Automattic apps, I actually noticed the Keychain data persisted. Please feel free to share your findings, this PR is meant to increase the chance of keeping the same anonymous ID for new app users for our [next A/B experiment](https://github.com/woocommerce/woocommerce-ios/issues/7550), even though it might not work for 100% of the users.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisites:
In Xcode, set a breakpoint at `ExPlatService` L47 where `anon_id` is set in the URL request

- Delete the app
- Install the app from the PR branch --> make a note of the anon ID in the Xcode console
- Delete the app, and make sure all other [Automattic apps](https://apps.apple.com/au/developer/automattic/id335703883) are deleted (if possible 😅) 
- Install the app from the PR branch --> hopefully, the anon ID in the Xcode console is the same as before

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->