### PR TITLE
[Mobile Payments] Turn on Pay in Person onboarding prompt

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -54,7 +54,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .loginMagicLinkEmphasisM2:
             return true
         case .promptToEnableCodInIppOnboarding:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] In-Person Payments: The onboarding notice on the In-Person Payments menu is correctly dismissed after multiple prompts are shown. [https://github.com/woocommerce/woocommerce-ios/pull/7543]
 - [*] In-Person Payments: The plugin selection is saved correctly after multiple onboarding prompts. [https://github.com/woocommerce/woocommerce-ios/pull/7544]
+- [*] In-Person Payments: A new prompt to enable `Pay in Person` for your store's checkout, to accept In-Person Payments for website orders [https://github.com/woocommerce/woocommerce-ios/issues/7474]
 
 10.0
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #7474
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We have added a new In-Person Payments onboarding step which prompts the merchant to enable `Cash on Delivery` on their checkout, and relabels it `Pay in Person`.

This PR makes this new onboarding step available in all builds of the app, as it is now ready for release.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Make a release build of the app, by changing the build configuration for the scheme to `Release`

![CleanShot 2022-08-25 at 12 10 12@2x](https://user-images.githubusercontent.com/2472348/186649538-75372346-904a-441c-a902-1a0186ed859a.png)

Using a store with WCPay installed and Cash on Delivery disabled (disable it in wp-admin > Settings > Payments):

1. Delete the app before running.
2. Run the app and log in to your account, selecting the store.
3. Go to `Menu > Payments`
4. You should see the `Continue setup` notice at the bottom of the screen: tap the link.
5. Select a payment gateway (if asked)
6. Observe that you're shown the `Add Pay in Person` onboarding step


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/186651313-acf7fe6b-25aa-40d7-b976-519bb1cae724.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
