### PR TITLE
Custom help content for "Enter WordPress.com email" screen

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -42,8 +42,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  # pod 'WordPressAuthenticator', '~> 2.4.0-beta.1'
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'c882069165c489251a4689cce5db53a746f4d456'
+  pod 'WordPressAuthenticator', '~> 2.4.0-beta.2'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -42,8 +42,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 2.4.0-beta.1'
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+  # pod 'WordPressAuthenticator', '~> 2.4.0-beta.1'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'c882069165c489251a4689cce5db53a746f4d456'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -42,7 +42,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (2.4.0-beta.1):
+  - WordPressAuthenticator (2.4.0-beta.2):
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 6.0.1)
@@ -92,7 +92,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 2.4.0-beta.1)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `c882069165c489251a4689cce5db53a746f4d456`)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -102,8 +102,6 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -141,6 +139,16 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :commit: c882069165c489251a4689cce5db53a746f4d456
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: c882069165c489251a4689cce5db53a746f4d456
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
@@ -163,7 +171,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 2f32568a4af71b5b464f65706ac64040e2e7775b
+  WordPressAuthenticator: 3bbf11ce1b45ae5a69a38a1301ab2cc0dcb36a52
   WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -179,6 +187,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 87786ee269bb59fb815d859df9cbe54bb00dac3d
+PODFILE CHECKSUM: e7d56626ef8feed6a13eadf3b7e72d24f025423c
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -92,7 +92,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `c882069165c489251a4689cce5db53a746f4d456`)
+  - WordPressAuthenticator (~> 2.4.0-beta.2)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -102,6 +102,8 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
+  https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -139,16 +141,6 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :commit: c882069165c489251a4689cce5db53a746f4d456
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: c882069165c489251a4689cce5db53a746f4d456
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
@@ -171,7 +163,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 3bbf11ce1b45ae5a69a38a1301ab2cc0dcb36a52
+  WordPressAuthenticator: 7ce9bd63949c9684a07ff547f80fd40bbdd9d8b4
   WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -187,6 +179,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: e7d56626ef8feed6a13eadf3b7e72d24f025423c
+PODFILE CHECKSUM: 9f2faf915539665343e6d18bbab3710def723697
 
 COCOAPODS: 1.11.2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,10 +3,9 @@
 10.1
 -----
 - [*] In-Person Payments: The onboarding notice on the In-Person Payments menu is correctly dismissed after multiple prompts are shown. [https://github.com/woocommerce/woocommerce-ios/pull/7543]
-- [*] Help center: Added custom help center web page with FAQs for "Enter Store Address" screen. [https://github.com/woocommerce/woocommerce-ios/pull/7553]
+- [*] Help center: Added custom help center web page with FAQs for "Enter Store Address" and "Enter WordPress.com email" screens. [https://github.com/woocommerce/woocommerce-ios/pull/7553, https://github.com/woocommerce/woocommerce-ios/pull/7573]
 - [*] In-Person Payments: The plugin selection is saved correctly after multiple onboarding prompts. [https://github.com/woocommerce/woocommerce-ios/pull/7544]
 - [*] In-Person Payments: A new prompt to enable `Pay in Person` for your store's checkout, to accept In-Person Payments for website orders [https://github.com/woocommerce/woocommerce-ios/issues/7474]
-- [*] Help center: Added custom help center web page with FAQs for "Enter WordPress.com email" screen. [https://github.com/woocommerce/woocommerce-ios/pull/7573]
 
 10.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Help center: Added custom help center web page with FAQs for "Enter Store Address" screen. [https://github.com/woocommerce/woocommerce-ios/pull/7553]
 - [*] In-Person Payments: The plugin selection is saved correctly after multiple onboarding prompts. [https://github.com/woocommerce/woocommerce-ios/pull/7544]
 - [*] In-Person Payments: A new prompt to enable `Pay in Person` for your store's checkout, to accept In-Person Payments for website orders [https://github.com/woocommerce/woocommerce-ios/issues/7474]
+- [*] Help center: Added custom help center web page with FAQs for "Enter WordPress.com email" screen. [https://github.com/woocommerce/woocommerce-ios/pull/7573]
 
 10.0
 -----

--- a/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
+++ b/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
@@ -29,6 +29,8 @@ extension CustomHelpCenterContent {
         switch step {
         case .start where flow == .loginWithSiteAddress:
             url = WooConstants.URLs.helpCenterForEnterStoreAddress.asURL()
+        case .enterEmailAddress where flow == .loginWithSiteAddress:
+            url = WooConstants.URLs.helpCenterForEnterWPCOMEmail.asURL()
         default:
             return nil
         }

--- a/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
+++ b/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
@@ -29,7 +29,7 @@ extension CustomHelpCenterContent {
         switch step {
         case .start where flow == .loginWithSiteAddress: // Enter Store Address screen
             url = WooConstants.URLs.helpCenterForEnterStoreAddress.asURL()
-        case .enterEmailAddress where flow == .loginWithSiteAddress: // Enter WordPress.com email screen
+        case .enterEmailAddress where flow == .loginWithSiteAddress: // Enter WordPress.com email screen from store address flow
             url = WooConstants.URLs.helpCenterForWPCOMEmailFromSiteAddressFlow.asURL()
         default:
             return nil

--- a/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
+++ b/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
@@ -30,7 +30,7 @@ extension CustomHelpCenterContent {
         case .start where flow == .loginWithSiteAddress: // Enter Store Address screen
             url = WooConstants.URLs.helpCenterForEnterStoreAddress.asURL()
         case .enterEmailAddress where flow == .loginWithSiteAddress: // Enter WordPress.com email screen
-            url = WooConstants.URLs.helpCenterForEnterWPCOMEmail.asURL()
+            url = WooConstants.URLs.helpCenterForWPCOMEmailFromSiteAddressFlow.asURL()
         default:
             return nil
         }

--- a/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
+++ b/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
@@ -27,9 +27,9 @@ extension CustomHelpCenterContent {
     ///
     init?(step: AuthenticatorAnalyticsTracker.Step, flow: AuthenticatorAnalyticsTracker.Flow) {
         switch step {
-        case .start where flow == .loginWithSiteAddress:
+        case .start where flow == .loginWithSiteAddress: // Enter Store Address screen
             url = WooConstants.URLs.helpCenterForEnterStoreAddress.asURL()
-        case .enterEmailAddress where flow == .loginWithSiteAddress:
+        case .enterEmailAddress where flow == .loginWithSiteAddress: // Enter WordPress.com email screen
             url = WooConstants.URLs.helpCenterForEnterWPCOMEmail.asURL()
         default:
             return nil

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -81,6 +81,11 @@ extension WooConstants {
         ///
         case helpCenterForEnterStoreAddress = "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-store-address"
 
+        /// Help Center for "Enter WordPress.com email" screen
+        ///
+        // swiftlint:disable:next line_length
+        case helpCenterForEnterWPCOMEmail = "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-wordpress-com-email-address-login-using-store-address-flow"
+
         /// URL used for Learn More button in Orders empty state.
         ///
         case blog = "https://woocommerce.com/blog/"

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -84,7 +84,7 @@ extension WooConstants {
         /// Help Center for "Enter WordPress.com email" screen
         ///
         // swiftlint:disable:next line_length
-        case helpCenterForEnterWPCOMEmail = "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-wordpress-com-email-address-login-using-store-address-flow"
+        case helpCenterForWPCOMEmailFromSiteAddressFlow = "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-wordpress-com-email-address-login-using-store-address-flow"
 
         /// URL used for Learn More button in Orders empty state.
         ///

--- a/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
@@ -56,7 +56,7 @@ final class CustomHelpCenterContentTests: XCTestCase {
         // Given
         let step: AuthenticatorAnalyticsTracker.Step = .enterEmailAddress
         let flow: AuthenticatorAnalyticsTracker.Flow = .loginWithSiteAddress
-        let helpContentURL = WooConstants.URLs.helpCenterForEnterWPCOMEmail.asURL()
+        let helpContentURL = WooConstants.URLs.helpCenterForWPCOMEmailFromSiteAddressFlow.asURL()
 
         // When
         let sut = try XCTUnwrap(CustomHelpCenterContent(step: step, flow: flow))

--- a/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
@@ -50,7 +50,7 @@ final class CustomHelpCenterContentTests: XCTestCase {
         XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.url.rawValue], helpContentURL.absoluteString)
     }
 
-    // MARK: Enter WordPress.com email screen
+    // MARK: Enter WordPress.com email screen from store address flow
     //
     func test_init_using_step_and_flow_returns_valid_instance_for_enter_WPCOM_email_address_screen() throws {
         // Given

--- a/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
@@ -43,4 +43,22 @@ final class CustomHelpCenterContentTests: XCTestCase {
 
         XCTAssertNil(CustomHelpCenterContent(step: step, flow: flow))
     }
+
+    func test_init_using_step_and_flow_returns_valid_instance_for_enter_WPCOM_email_address_screen() throws {
+        // Given
+        let step: AuthenticatorAnalyticsTracker.Step = .enterEmailAddress
+        let flow: AuthenticatorAnalyticsTracker.Flow = .loginWithSiteAddress
+        let helpContentURL = WooConstants.URLs.helpCenterForEnterWPCOMEmail.asURL()
+
+        // When
+        let sut = try XCTUnwrap(CustomHelpCenterContent(step: step, flow: flow))
+
+        // Then
+        XCTAssertEqual(sut.url, helpContentURL)
+
+        // Test the `trackingProperties` dictionary values
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.step.rawValue], step.rawValue)
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.flow.rawValue], flow.rawValue)
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.url.rawValue], helpContentURL.absoluteString)
+    }
 }

--- a/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
@@ -4,6 +4,8 @@ import XCTest
 
 final class CustomHelpCenterContentTests: XCTestCase {
 
+    // MARK: CustomHelpCenterContent.Key
+    //
     func test_step_key_has_correct_rawValue() {
         let sut = CustomHelpCenterContent.Key.step
         XCTAssertEqual(sut.rawValue, "source_step")
@@ -19,6 +21,17 @@ final class CustomHelpCenterContentTests: XCTestCase {
         XCTAssertEqual(sut.rawValue, "help_content_url")
     }
 
+    // MARK: Invalid `Step` and `Flow`
+    //
+    func test_init_using_invalid_step_and_flow_returns_nil() {
+        let step: AuthenticatorAnalyticsTracker.Step = .magicLinkRequested
+        let flow: AuthenticatorAnalyticsTracker.Flow = .prologue
+
+        XCTAssertNil(CustomHelpCenterContent(step: step, flow: flow))
+    }
+
+    // MARK: Enter Store Address screen
+    //
     func test_init_using_step_and_flow_returns_valid_instance_for_enter_store_address_screen() throws {
         // Given
         let step: AuthenticatorAnalyticsTracker.Step = .start
@@ -37,13 +50,8 @@ final class CustomHelpCenterContentTests: XCTestCase {
         XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.url.rawValue], helpContentURL.absoluteString)
     }
 
-    func test_init_using_invalid_step_and_flow_returns_nil() {
-        let step: AuthenticatorAnalyticsTracker.Step = .magicLinkRequested
-        let flow: AuthenticatorAnalyticsTracker.Flow = .prologue
-
-        XCTAssertNil(CustomHelpCenterContent(step: step, flow: flow))
-    }
-
+    // MARK: Enter WordPress.com email screen
+    //
     func test_init_using_step_and_flow_returns_valid_instance_for_enter_WPCOM_email_address_screen() throws {
         // Given
         let step: AuthenticatorAnalyticsTracker.Step = .enterEmailAddress


### PR DESCRIPTION
Closes: #7572
Part of: #7547 

- [ ] ⚠️ Please review https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/674 ⚠️
- [ ] ⚠️ @selanthiraiyan update Podfile after https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/674 is merged and released ⚠️

### Description
As a part of improving the help center content, this PR adds custom content with FAQs and Answers for the "Enter WordPress.com email" screen at the following URL.

https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-wordpress-com-email-address-login-using-store-address-flow

Internal ref - pe5sF9-sZ-p2

### Testing instructions

#### For #7572 
1. Install and launch the app.
1. Tap `Skip` to reach the login prologue screen.
1. Tap the `Enter Your Store Address` button.
1. In Xcode debug console, observe that the following event is tracked 
```
Tracked unified_login_step, properties: [AnyHashable("flow"): "login_site_address", AnyHashable("step"): "start", AnyHashable("source"): "default"]
```
1. Enter a valid store address and tap the `Continue` button
1. In Xcode debug console, observe that the following event is tracked upon landing in enter WPCOM email screen
```
Tracked unified_login_step, properties: [AnyHashable("step"): "enter_email_address", AnyHashable("flow"): "login_site_address", AnyHashable("source"): "default"]
```

#### For #7547 
1. Install and launch the app.
1. Tap `Skip` to reach the login prologue screen.
1. Tap the `Enter Your Store Address` button.
1. Enter a valid store address and tap the `Continue` button
1. Tap `Help` -> `Help Center`
1. Observe that you are directed to https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-wordpress-com-email-address-login-using-store-address-flow in a web view
1. In Xcode debug console observe that the following event is tracked 
```
Tracked support_help_center_viewed, properties: [AnyHashable("help_content_url"): "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-wordpress-com-email-address-login-using-store-address-flow", AnyHashable("source_flow"): "login_site_address", AnyHashable("source_step"): "enter_email_address"]
```

### Screenshots


https://user-images.githubusercontent.com/524475/186804166-13010858-4d1c-4854-b959-f4b6837743c2.mov


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.