### PR TITLE
[Mobile Payments] Extended IPP onboarding tracks events

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 - [*] In-Person Payments: The onboarding notice on the In-Person Payments menu is correctly dismissed after multiple prompts are shown. [https://github.com/woocommerce/woocommerce-ios/pull/7543]
 - [*] Help center: Added custom help center web page with FAQs for "Enter Store Address" and "Enter WordPress.com email" screens. [https://github.com/woocommerce/woocommerce-ios/pull/7553, https://github.com/woocommerce/woocommerce-ios/pull/7573]
 - [*] In-Person Payments: The plugin selection is saved correctly after multiple onboarding prompts. [https://github.com/woocommerce/woocommerce-ios/pull/7544]
-- [*] In-Person Payments: A new prompt to enable `Pay in Person` for your store's checkout, to accept In-Person Payments for website orders [https://github.com/woocommerce/woocommerce-ios/issues/7474]
+- [**] In-Person Payments: A new prompt to enable `Pay in Person` for your store's checkout, to accept In-Person Payments for website orders [https://github.com/woocommerce/woocommerce-ios/issues/7474]
 
 10.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -47,43 +47,49 @@ struct InPersonPaymentsView: View {
                         ServiceLocator.analytics.track(.cardPresentPaymentGatewaySelected, withProperties: ["payment_gateway": plugin.pluginName])
                     }
                 } else if viewModel.userIsAdministrator {
-                    InPersonPaymentsPluginConflictAdmin(onRefresh: viewModel.refresh)
+                    InPersonPaymentsPluginConflictAdmin(analyticReason: viewModel.state.reasonForAnalytics, onRefresh: viewModel.refresh)
                 } else {
-                    InPersonPaymentsPluginConflictShopManager(onRefresh: viewModel.refresh)
+                    InPersonPaymentsPluginConflictShopManager(analyticReason: viewModel.state.reasonForAnalytics, onRefresh: viewModel.refresh)
                 }
             case let .pluginShouldBeDeactivated(plugin) where plugin == .stripe:
-                InPersonPaymentsDeactivateStripeView(onRefresh: viewModel.refresh, showSetupPluginsButton: viewModel.userIsAdministrator)
+                InPersonPaymentsDeactivateStripeView(
+                    analyticReason: viewModel.state.reasonForAnalytics,
+                    onRefresh: viewModel.refresh,
+                    showSetupPluginsButton: viewModel.userIsAdministrator)
             case .countryNotSupported(let countryCode):
-                InPersonPaymentsCountryNotSupported(countryCode: countryCode)
+                InPersonPaymentsCountryNotSupported(countryCode: countryCode, analyticReason: viewModel.state.reasonForAnalytics)
             case .countryNotSupportedStripe(_, let countryCode):
-                InPersonPaymentsCountryNotSupportedStripe(countryCode: countryCode)
+                InPersonPaymentsCountryNotSupportedStripe(countryCode: countryCode, analyticReason: viewModel.state.reasonForAnalytics)
             case .pluginNotInstalled:
-                InPersonPaymentsPluginNotInstalled(onRefresh: viewModel.refresh)
+                InPersonPaymentsPluginNotInstalled(analyticReason: viewModel.state.reasonForAnalytics, onRefresh: viewModel.refresh)
             case .pluginUnsupportedVersion(let plugin):
-                InPersonPaymentsPluginNotSupportedVersion(plugin: plugin, onRefresh: viewModel.refresh)
+                InPersonPaymentsPluginNotSupportedVersion(plugin: plugin, analyticReason: viewModel.state.reasonForAnalytics, onRefresh: viewModel.refresh)
             case .pluginNotActivated(let plugin):
-                InPersonPaymentsPluginNotActivated(plugin: plugin, onRefresh: viewModel.refresh)
+                InPersonPaymentsPluginNotActivated(plugin: plugin, analyticReason: viewModel.state.reasonForAnalytics, onRefresh: viewModel.refresh)
             case .pluginInTestModeWithLiveStripeAccount(let plugin):
-                InPersonPaymentsLiveSiteInTestMode(plugin: plugin, onRefresh:
+                InPersonPaymentsLiveSiteInTestMode(plugin: plugin, analyticReason: viewModel.state.reasonForAnalytics, onRefresh:
                     viewModel.refresh)
             case .pluginSetupNotCompleted(let plugin):
-                InPersonPaymentsPluginNotSetup(plugin: plugin, onRefresh: viewModel.refresh)
+                InPersonPaymentsPluginNotSetup(plugin: plugin, analyticReason: viewModel.state.reasonForAnalytics, onRefresh: viewModel.refresh)
             case .stripeAccountOverdueRequirement:
-                InPersonPaymentsStripeAccountOverdue()
+                InPersonPaymentsStripeAccountOverdue(analyticReason: viewModel.state.reasonForAnalytics)
             case .stripeAccountPendingRequirement(_, let deadline):
-                InPersonPaymentsStripeAccountPending(deadline: deadline, onSkip: viewModel.skipPendingRequirements)
+                InPersonPaymentsStripeAccountPending(
+                    deadline: deadline,
+                    analyticReason: viewModel.state.reasonForAnalytics,
+                    onSkip: viewModel.skipPendingRequirements)
             case .stripeAccountUnderReview:
-                InPersonPaymentsStripeAccountReview()
+                InPersonPaymentsStripeAccountReview(analyticReason: viewModel.state.reasonForAnalytics)
             case .stripeAccountRejected:
-                InPersonPaymentsStripeRejected()
+                InPersonPaymentsStripeRejected(analyticReason: viewModel.state.reasonForAnalytics)
             case .codPaymentGatewayNotSetUp:
                 InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView(viewModel: viewModel.codStepViewModel)
             case .completed:
                 InPersonPaymentsCompleted()
             case .noConnectionError:
-                InPersonPaymentsNoConnection(onRefresh: viewModel.refresh)
+                InPersonPaymentsNoConnection(analyticReason: viewModel.state.reasonForAnalytics, onRefresh: viewModel.refresh)
             default:
-                InPersonPaymentsUnavailable()
+                InPersonPaymentsUnavailable(analyticReason: viewModel.state.reasonForAnalytics)
             }
         }
         .customOpenURL(action: { url in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -62,6 +62,7 @@ final class InPersonPaymentsViewModel: ObservableObject {
     /// Skips the Pending Requirements step when the user taps `Skip`
     ///
     func skipPendingRequirements() {
+        trackSkipped(state: useCase.state, remindLater: true)
         useCase.skipPendingRequirements()
     }
 
@@ -104,6 +105,10 @@ final class InPersonPaymentsViewModel: ObservableObject {
 }
 
 private extension InPersonPaymentsViewModel {
+    var countryCode: String {
+        useCase.configurationLoader.configuration.countryCode
+    }
+
     func trackState(_ state: CardPresentPaymentOnboardingState) {
         // When we remove this feature flag, we can switch reason to let and remove the state.isSelectPlugin block
         guard var reason = state.reasonForAnalytics else {
@@ -115,6 +120,18 @@ private extension InPersonPaymentsViewModel {
         ServiceLocator.analytics
             .track(event: .InPersonPayments
                     .cardPresentOnboardingNotCompleted(reason: reason,
-                                                       countryCode: useCase.configurationLoader.configuration.countryCode))
+                                                       countryCode: countryCode))
+    }
+
+    func trackSkipped(state: CardPresentPaymentOnboardingState, remindLater: Bool) {
+        guard let reason = state.reasonForAnalytics else {
+            return
+        }
+
+        ServiceLocator.analytics.track(
+            event: .InPersonPayments.cardPresentOnboardingStepSkipped(
+                reason: reason,
+                remindLater: remindLater,
+                countryCode: countryCode))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsCountryNotSupported: View {
     let countryCode: String
+    let analyticReason: String?
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -12,7 +13,8 @@ struct InPersonPaymentsCountryNotSupported: View {
                 height: 180.0
             ),
             supportLink: true,
-            learnMore: true
+            learnMore: true,
+            analyticReason: analyticReason
         )
     }
 
@@ -45,8 +47,8 @@ private enum Localization {
 struct InPersonPaymentsCountryNotSupported_Previews: PreviewProvider {
     static var previews: some View {
         // Valid country code
-        InPersonPaymentsCountryNotSupported(countryCode: "ES")
+        InPersonPaymentsCountryNotSupported(countryCode: "ES", analyticReason: nil)
         // Invalid country code
-        InPersonPaymentsCountryNotSupported(countryCode: "OO")
+        InPersonPaymentsCountryNotSupported(countryCode: "OO", analyticReason: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsCountryNotSupportedStripe: View {
     let countryCode: String
+    let analyticReason: String?
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -12,7 +13,8 @@ struct InPersonPaymentsCountryNotSupportedStripe: View {
                 height: 180.0
             ),
             supportLink: true,
-            learnMore: true
+            learnMore: true,
+            analyticReason: analyticReason
         )
     }
 
@@ -45,8 +47,8 @@ private enum Localization {
 struct InPersonPaymentsCountryNotSupportedStripe_Previews: PreviewProvider {
     static var previews: some View {
         // Valid country code
-        InPersonPaymentsCountryNotSupportedStripe(countryCode: "ES")
+        InPersonPaymentsCountryNotSupportedStripe(countryCode: "ES", analyticReason: nil)
         // Invalid country code
-        InPersonPaymentsCountryNotSupportedStripe(countryCode: "OO")
+        InPersonPaymentsCountryNotSupportedStripe(countryCode: "OO", analyticReason: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsDeactivateStripeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsDeactivateStripeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Yosemite
 
 struct InPersonPaymentsDeactivateStripeView: View {
+    let analyticReason: String?
     let onRefresh: () -> Void
     let showSetupPluginsButton: Bool
     @State private var presentedSetupURL: URL? = nil
@@ -37,7 +38,7 @@ struct InPersonPaymentsDeactivateStripeView: View {
                 .padding(.bottom, Constants.padding)
             }
 
-            InPersonPaymentsLearnMore()
+            InPersonPaymentsLearnMore(analyticReason: analyticReason)
         }
         .safariSheet(url: $presentedSetupURL, onDismiss: onRefresh)
     }
@@ -81,6 +82,6 @@ private enum Constants {
 
 struct InPersonPaymentsDeactivateStripeAdmin_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginConflictAdmin(onRefresh: {})
+        InPersonPaymentsPluginConflictAdmin(analyticReason: nil, onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsDeactivateStripeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsDeactivateStripeView.swift
@@ -5,6 +5,7 @@ struct InPersonPaymentsDeactivateStripeView: View {
     let analyticReason: String?
     let onRefresh: () -> Void
     let showSetupPluginsButton: Bool
+    private let cardPresentConfiguration = CardPresentConfigurationLoader().configuration
     @State private var presentedSetupURL: URL? = nil
 
     var body: some View {
@@ -28,6 +29,10 @@ struct InPersonPaymentsDeactivateStripeView: View {
             if showSetupPluginsButton {
                 Button {
                     presentedSetupURL = setupURL
+                    ServiceLocator.analytics.track(
+                        event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaTapped(
+                            reason: analyticReason ?? "",
+                            countryCode: cardPresentConfiguration.countryCode))
                 } label: {
                     HStack {
                         Text(Localization.primaryButton)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
@@ -3,6 +3,7 @@ import Yosemite
 
 struct InPersonPaymentsLiveSiteInTestMode: View {
     let plugin: CardPresentPaymentsPlugin
+    let analyticReason: String?
     let onRefresh: () -> Void
 
     var body: some View {
@@ -15,6 +16,7 @@ struct InPersonPaymentsLiveSiteInTestMode: View {
             ),
             supportLink: false,
             learnMore: true,
+            analyticReason: analyticReason,
             button: InPersonPaymentsOnboardingError.ButtonInfo(
                 text: Localization.primaryButton,
                 action: onRefresh
@@ -43,6 +45,6 @@ private enum Localization {
 
 struct InPersonPaymentsLiveSiteInTestMode_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsLiveSiteInTestMode(plugin: .wcPay, onRefresh: {})
+        InPersonPaymentsLiveSiteInTestMode(plugin: .wcPay, analyticReason: nil, onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
@@ -17,8 +17,9 @@ struct InPersonPaymentsLiveSiteInTestMode: View {
             supportLink: false,
             learnMore: true,
             analyticReason: analyticReason,
-            button: InPersonPaymentsOnboardingError.ButtonInfo(
+            buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.primaryButton,
+                analyticReason: analyticReason,
                 action: onRefresh
             )
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
@@ -15,8 +15,9 @@ struct InPersonPaymentsNoConnection: View {
             supportLink: false,
             learnMore: false,
             analyticReason: analyticReason,
-            button: InPersonPaymentsOnboardingError.ButtonInfo(
+            buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.primaryButton,
+                analyticReason: analyticReason,
                 action: onRefresh
             )
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsNoConnection: View {
+    let analyticReason: String?
     let onRefresh: () -> Void
 
     var body: some View {
@@ -13,6 +14,7 @@ struct InPersonPaymentsNoConnection: View {
             ),
             supportLink: false,
             learnMore: false,
+            analyticReason: analyticReason,
             button: InPersonPaymentsOnboardingError.ButtonInfo(
                 text: Localization.primaryButton,
                 action: onRefresh
@@ -40,6 +42,6 @@ private enum Localization {
 
 struct InPersonPaymentsNoConnection_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsNoConnection(onRefresh: {})
+        InPersonPaymentsNoConnection(analyticReason: nil, onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
@@ -7,6 +7,7 @@ struct InPersonPaymentsOnboardingError: View {
     let image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo
     let supportLink: Bool
     let learnMore: Bool
+    let analyticReason: String?
     var button: ButtonInfo? = nil
 
     struct ButtonInfo {
@@ -33,7 +34,7 @@ struct InPersonPaymentsOnboardingError: View {
                     .padding(.bottom, 24.0)
             }
             if learnMore {
-                InPersonPaymentsLearnMore()
+                InPersonPaymentsLearnMore(analyticReason: analyticReason)
             }
         }.padding()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
@@ -8,12 +8,7 @@ struct InPersonPaymentsOnboardingError: View {
     let supportLink: Bool
     let learnMore: Bool
     let analyticReason: String?
-    var button: ButtonInfo? = nil
-
-    struct ButtonInfo {
-        let text: String
-        let action: () -> Void
-    }
+    var buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel? = nil
 
     var body: some View {
         VStack {
@@ -28,8 +23,8 @@ struct InPersonPaymentsOnboardingError: View {
 
             Spacer()
 
-            if button != nil {
-                Button(button!.text, action: button!.action)
+            if let buttonViewModel = buttonViewModel {
+                Button(buttonViewModel.text, action: buttonViewModel.action)
                     .buttonStyle(PrimaryButtonStyle())
                     .padding(.bottom, 24.0)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingErrorButtonViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingErrorButtonViewModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Yosemite
+
+struct InPersonPaymentsOnboardingErrorButtonViewModel {
+    let text: String
+
+    private let analyticReason: String?
+
+    private let cardPresentConfiguration: CardPresentPaymentsConfiguration
+
+    let action: () -> Void
+
+    init(text: String,
+         analyticReason: String?,
+         cardPresentConfiguration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
+         action: @escaping () -> Void) {
+        self.text = text
+        self.analyticReason = analyticReason
+        self.cardPresentConfiguration = cardPresentConfiguration
+        self.action = {
+            ServiceLocator.analytics.track(
+                event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaTapped(
+                    reason: analyticReason ?? "",
+                    countryCode: cardPresentConfiguration.countryCode))
+            action()
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictAdminView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictAdminView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsPluginConflictAdmin: View {
     let analyticReason: String?
+    private let cardPresentConfiguration = CardPresentConfigurationLoader().configuration
     let onRefresh: () -> Void
     @State private var presentedSetupURL: URL? = nil
     @Environment(\.verticalSizeClass) var verticalSizeClass
@@ -34,6 +35,10 @@ struct InPersonPaymentsPluginConflictAdmin: View {
 
             Button {
                 presentedSetupURL = setupURL
+                ServiceLocator.analytics.track(
+                    event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaTapped(
+                        reason: analyticReason ?? "",
+                        countryCode: cardPresentConfiguration.countryCode))
             } label: {
                 HStack {
                     Text(Localization.primaryButton)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictAdminView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictAdminView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsPluginConflictAdmin: View {
+    let analyticReason: String?
     let onRefresh: () -> Void
     @State private var presentedSetupURL: URL? = nil
     @Environment(\.verticalSizeClass) var verticalSizeClass
@@ -42,7 +43,7 @@ struct InPersonPaymentsPluginConflictAdmin: View {
             .buttonStyle(PrimaryButtonStyle())
             .padding(.bottom, Constants.padding)
 
-            InPersonPaymentsLearnMore()
+            InPersonPaymentsLearnMore(analyticReason: analyticReason)
         }
         .safariSheet(url: $presentedSetupURL, onDismiss: onRefresh)
     }
@@ -80,6 +81,6 @@ private enum Constants {
 
 struct InPersonPaymentsPluginConfictAdmin_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginConflictAdmin(onRefresh: {})
+        InPersonPaymentsPluginConflictAdmin(analyticReason: nil, onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictShopManagerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginConflictShopManagerView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Yosemite
 
 struct InPersonPaymentsPluginConflictShopManager: View {
+    let analyticReason: String?
     let onRefresh: () -> Void
     @State private var presentedSetupURL: URL? = nil
     @Environment(\.verticalSizeClass) var verticalSizeClass
@@ -32,7 +33,7 @@ struct InPersonPaymentsPluginConflictShopManager: View {
 
             Spacer()
 
-            InPersonPaymentsLearnMore()
+            InPersonPaymentsLearnMore(analyticReason: analyticReason)
         }
         .safariSheet(url: $presentedSetupURL, onDismiss: onRefresh)
     }
@@ -66,6 +67,6 @@ private enum Constants {
 
 struct InPersonPaymentsPluginConfictShopManager_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginConflictShopManager(onRefresh: {})
+        InPersonPaymentsPluginConflictShopManager(analyticReason: nil, onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
@@ -17,8 +17,9 @@ struct InPersonPaymentsPluginNotActivated: View {
             supportLink: false,
             learnMore: true,
             analyticReason: analyticReason,
-            button: InPersonPaymentsOnboardingError.ButtonInfo(
+            buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.primaryButton,
+                analyticReason: analyticReason,
                 action: onRefresh
             )
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
@@ -3,6 +3,7 @@ import Yosemite
 
 struct InPersonPaymentsPluginNotActivated: View {
     let plugin: CardPresentPaymentsPlugin
+    let analyticReason: String?
     let onRefresh: () -> Void
 
     var body: some View {
@@ -15,6 +16,7 @@ struct InPersonPaymentsPluginNotActivated: View {
             ),
             supportLink: false,
             learnMore: true,
+            analyticReason: analyticReason,
             button: InPersonPaymentsOnboardingError.ButtonInfo(
                 text: Localization.primaryButton,
                 action: onRefresh
@@ -42,6 +44,6 @@ private enum Localization {
 
 struct InPersonPaymentsPluginNotActivated_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotActivated(plugin: .wcPay, onRefresh: {})
+        InPersonPaymentsPluginNotActivated(plugin: .wcPay, analyticReason: nil, onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsPluginNotInstalled: View {
+    let analyticReason: String?
     let onRefresh: () -> Void
 
     var body: some View {
@@ -13,6 +14,7 @@ struct InPersonPaymentsPluginNotInstalled: View {
             ),
             supportLink: false,
             learnMore: true,
+            analyticReason: analyticReason,
             button: InPersonPaymentsOnboardingError.ButtonInfo(
                 text: Localization.primaryButton,
                 action: onRefresh
@@ -40,6 +42,6 @@ private enum Localization {
 
 struct InPersonPaymentsPluginNotInstalled_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotInstalled(onRefresh: {})
+        InPersonPaymentsPluginNotInstalled(analyticReason: nil, onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
@@ -15,8 +15,9 @@ struct InPersonPaymentsPluginNotInstalled: View {
             supportLink: false,
             learnMore: true,
             analyticReason: analyticReason,
-            button: InPersonPaymentsOnboardingError.ButtonInfo(
+            buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.primaryButton,
+                analyticReason: analyticReason,
                 action: onRefresh
             )
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -4,6 +4,7 @@ import Yosemite
 struct InPersonPaymentsPluginNotSetup: View {
     let plugin: CardPresentPaymentsPlugin
     let analyticReason: String?
+    private let cardPresentConfiguration = CardPresentConfigurationLoader().configuration
     let onRefresh: () -> Void
     @State private var presentedSetupURL: URL? = nil
 
@@ -25,6 +26,10 @@ struct InPersonPaymentsPluginNotSetup: View {
 
             Button {
                 presentedSetupURL = setupURL
+                ServiceLocator.analytics.track(
+                    event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaTapped(
+                        reason: analyticReason ?? "",
+                        countryCode: cardPresentConfiguration.countryCode))
             } label: {
                 HStack {
                     Text(Localization.primaryButton)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -3,6 +3,7 @@ import Yosemite
 
 struct InPersonPaymentsPluginNotSetup: View {
     let plugin: CardPresentPaymentsPlugin
+    let analyticReason: String?
     let onRefresh: () -> Void
     @State private var presentedSetupURL: URL? = nil
 
@@ -33,7 +34,7 @@ struct InPersonPaymentsPluginNotSetup: View {
             .buttonStyle(PrimaryButtonStyle())
             .padding(.bottom, 24.0)
 
-            InPersonPaymentsLearnMore()
+            InPersonPaymentsLearnMore(analyticReason: analyticReason)
         }
         .safariSheet(url: $presentedSetupURL, onDismiss: onRefresh)
     }
@@ -65,6 +66,6 @@ private enum Localization {
 }
 struct InPersonPaymentsPluginNotSetup_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotSetup(plugin: .wcPay, onRefresh: {})
+        InPersonPaymentsPluginNotSetup(plugin: .wcPay, analyticReason: nil, onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
@@ -17,8 +17,9 @@ struct InPersonPaymentsPluginNotSupportedVersion: View {
             supportLink: false,
             learnMore: true,
             analyticReason: analyticReason,
-            button: InPersonPaymentsOnboardingError.ButtonInfo(
+            buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.primaryButton,
+                analyticReason: analyticReason,
                 action: onRefresh
             )
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
@@ -3,6 +3,7 @@ import Yosemite
 
 struct InPersonPaymentsPluginNotSupportedVersion: View {
     let plugin: CardPresentPaymentsPlugin
+    let analyticReason: String?
     let onRefresh: () -> Void
 
     var body: some View {
@@ -15,6 +16,7 @@ struct InPersonPaymentsPluginNotSupportedVersion: View {
             ),
             supportLink: false,
             learnMore: true,
+            analyticReason: analyticReason,
             button: InPersonPaymentsOnboardingError.ButtonInfo(
                 text: Localization.primaryButton,
                 action: onRefresh
@@ -43,6 +45,6 @@ private enum Localization {
 
 struct InPersonPaymentsPluginNotSupportedVersion_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotSupportedVersion(plugin: .wcPay, onRefresh: {})
+        InPersonPaymentsPluginNotSupportedVersion(plugin: .wcPay, analyticReason: nil, onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct InPersonPaymentsStripeAccountOverdue: View {
+    let analyticReason: String?
+
     var body: some View {
         InPersonPaymentsOnboardingError(
             title: Localization.title,
@@ -10,7 +12,8 @@ struct InPersonPaymentsStripeAccountOverdue: View {
                 height: 180.0
             ),
             supportLink: true,
-            learnMore: true
+            learnMore: true,
+            analyticReason: analyticReason
         )
      }
 }
@@ -30,6 +33,6 @@ private enum Localization {
 
 struct InPersonPaymentsStripeAccountOverdue_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAccountOverdue()
+        InPersonPaymentsStripeAccountOverdue(analyticReason: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsStripeAccountPending: View {
     let deadline: Date?
+    let analyticReason: String?
     let onSkip: () -> ()
 
     var body: some View {
@@ -14,6 +15,7 @@ struct InPersonPaymentsStripeAccountPending: View {
             ),
             supportLink: true,
             learnMore: true,
+            analyticReason: analyticReason,
             button: InPersonPaymentsOnboardingError.ButtonInfo(
                 text: Localization.skipButton,
                 action: onSkip
@@ -55,7 +57,7 @@ private enum Localization {
 
 struct InPersonPaymentsStripeAccountPending_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAccountPending(deadline: Date(), onSkip: {})
+        InPersonPaymentsStripeAccountPending(deadline: Date(), analyticReason: nil, onSkip: {})
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
@@ -16,8 +16,9 @@ struct InPersonPaymentsStripeAccountPending: View {
             supportLink: true,
             learnMore: true,
             analyticReason: analyticReason,
-            button: InPersonPaymentsOnboardingError.ButtonInfo(
+            buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.skipButton,
+                analyticReason: analyticReason,
                 action: onSkip
             )
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct InPersonPaymentsStripeAccountReview: View {
+    let analyticReason: String?
+
     var body: some View {
         InPersonPaymentsOnboardingError(
             title: Localization.title,
@@ -10,7 +12,8 @@ struct InPersonPaymentsStripeAccountReview: View {
                 height: 180.0
             ),
             supportLink: true,
-            learnMore: true
+            learnMore: true,
+            analyticReason: analyticReason
         )
     }
 }
@@ -29,6 +32,6 @@ private enum Localization {
 
 struct InPersonPaymentsStripeAccountReview_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAccountReview()
+        InPersonPaymentsStripeAccountReview(analyticReason: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsStripeRejected: View {
+    let analyticReason: String?
     var body: some View {
         InPersonPaymentsOnboardingError(
             title: Localization.title,
@@ -10,7 +11,8 @@ struct InPersonPaymentsStripeRejected: View {
                 height: 180.0
             ),
             supportLink: true,
-            learnMore: true
+            learnMore: true,
+            analyticReason: analyticReason
         )
     }
 }
@@ -29,6 +31,6 @@ private enum Localization {
 
 struct InPersonPaymentsStripeRejected_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeRejected()
+        InPersonPaymentsStripeRejected(analyticReason: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsUnavailableView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsUnavailableView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct InPersonPaymentsUnavailable: View {
+    let analyticReason: String?
+
     var body: some View {
         InPersonPaymentsOnboardingError(
             title: Localization.unavailable,
@@ -10,7 +12,8 @@ struct InPersonPaymentsUnavailable: View {
                 height: 180.0
             ),
             supportLink: false,
-            learnMore: true
+            learnMore: true,
+            analyticReason: analyticReason
         )
     }
 }
@@ -29,6 +32,6 @@ private enum Localization {
 
 struct InPersonPaymentsUnavailable_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsUnavailable()
+        InPersonPaymentsUnavailable(analyticReason: nil)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -450,6 +450,7 @@
 		039D948D27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */; };
 		039D948F276113490044EF38 /* UIView+SuperviewConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */; };
 		03A6C18428B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A6C18328B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift */; };
+		03A6C18628B8CC7F00AADF23 /* InPersonPaymentsOnboardingErrorButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A6C18528B8CC7F00AADF23 /* InPersonPaymentsOnboardingErrorButtonViewModel.swift */; };
 		03AA165E2719B7EF005CCB7B /* ReceiptActionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */; };
 		03AA16602719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */; };
 		03AFDE02282C0B82003B67CD /* InPersonPaymentsCompletedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */; };
@@ -2301,6 +2302,7 @@
 		039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SafeAreaConstraints.swift"; sourceTree = "<group>"; };
 		039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SuperviewConstraints.swift"; sourceTree = "<group>"; };
 		03A6C18328B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift; sourceTree = "<group>"; };
+		03A6C18528B8CC7F00AADF23 /* InPersonPaymentsOnboardingErrorButtonViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsOnboardingErrorButtonViewModel.swift; sourceTree = "<group>"; };
 		03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinator.swift; sourceTree = "<group>"; };
 		03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinatorTests.swift; sourceTree = "<group>"; };
 		03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCompletedView.swift; sourceTree = "<group>"; };
@@ -8293,6 +8295,7 @@
 				D89FAF4D2795BDFF00D8DA66 /* InPersonPaymentsPluginConflictAdminView.swift */,
 				319A625E27ACAD4800BC96C3 /* InPersonPaymentsPluginConflictShopManagerView.swift */,
 				ABC35A4B736A0B2D8348DD08 /* InPersonPaymentsOnboardingError.swift */,
+				03A6C18528B8CC7F00AADF23 /* InPersonPaymentsOnboardingErrorButtonViewModel.swift */,
 				0313651228ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift */,
 				B979A9B9282D62A500EBB383 /* InPersonPaymentsDeactivateStripeView.swift */,
 				0313651028AB81B100EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift */,
@@ -9447,6 +9450,7 @@
 				02B8650F24A9E2D800265779 /* Product+SwiftUIPreviewHelpers.swift in Sources */,
 				454B28BE23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift in Sources */,
 				AE6DBE3B2732CAAD00957E7A /* AdaptiveStack.swift in Sources */,
+				03A6C18628B8CC7F00AADF23 /* InPersonPaymentsOnboardingErrorButtonViewModel.swift in Sources */,
 				024DF3052372ADCD006658FE /* KeyboardScrollable.swift in Sources */,
 				BAE4F8432734325C00871344 /* SettingsViewModel.swift in Sources */,
 				0212276324498CDC0042161F /* ProductFormBottomSheetAction.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7525 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We added a new IPP onboarding step to enable Cash on Delivery in a merchants store, to allow them to take payments for web orders using their card reader.

During that work, we added some new generic onboarding tracks events: this PR extends those so that they are logged by all the previously existing onboarding steps, where appropriate.

Specifically, these events are added/updated:
`card_present_onboarding_learn_more_tapped`: `reason` added.
`card_present_onboarding_step_skipped`: tracked when the merchant skips the `Pending Requirements` screen.
`card_present_onboarding_cta_tapped`: new event, tracked whenever a primary button is tapped on an onboarding screen, including the `reason`.

N.B. for Pending requirements, the Skip button is also the CTA. In this case, we track both events.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Hardcode the onboarding step desired in `CardPresentPaymentsOnboardingUseCase.accountChecks(plugin:)`, e.g.

```
    func accountChecks(plugin: CardPresentPaymentsPlugin) -> CardPresentPaymentOnboardingState {
        return .stripeAccountPendingRequirement(plugin: plugin, deadline: Date())
        [...]
```

Launch the app, and go to `Menu > Payments > Continue Setup`
Tap on the button you're looking to test: `Learn More`, `Skip`, or the CTA.
Check the logs for the record of the analytics that were sent, e.g.

```
🔵 Tracked card_present_onboarding_cta_tapped, properties: [AnyHashable("country"): "US", AnyHashable("is_wpcom_store"): false, AnyHashable("reason"): "account_pending_requirements", AnyHashable("blog_id"): 197448330]
```

Also check in the Tracks Live View for the analytics you were expecting to be tracked:

<img width="635" alt="CleanShot 2022-08-26 at 11 43 27@2x" src="https://user-images.githubusercontent.com/2472348/186887179-0b8f357c-9f69-49e3-99b7-7ab89980520e.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
