### PR TITLE
[Analytics] Trigger review_open event

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -367,6 +367,7 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Review Data/Action Events
     //
+    case reviewOpen = "review_open"
     case reviewLoaded = "review_loaded"
     case reviewLoadFailed = "review_load_failed"
     case reviewMarkRead = "review_mark_read"

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
@@ -95,6 +95,7 @@ final class HubMenuCoordinator: Coordinator {
                     }
 
                     Task { @MainActor in
+                        ServiceLocator.analytics.track(.reviewOpen)
                         await self.willPresentReviewDetailsFromPushNotification()
                         self.pushReviewDetailsViewController(using: parcel)
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
@@ -90,6 +90,7 @@ final class ReviewsCoordinator: Coordinator {
                         return
                     }
 
+                    ServiceLocator.analytics.track(.reviewOpen)
                     self.willPresentReviewDetailsFromPushNotification()
                     self.pushReviewDetailsViewController(using: parcel)
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSource.swift
@@ -229,6 +229,8 @@ extension ReviewsDataSource: ReviewsInteractionDelegate {
         let reviewedProduct = product(id: review.productID)
         let note = notification(id: review.reviewID)
 
+        ServiceLocator.analytics.track(.reviewOpen)
+
         let detailsViewController = ReviewDetailsViewController(productReview: review,
                                                                 product: reviewedProduct,
                                                                 notification: note)


### PR DESCRIPTION
Closes: #7533

## Description

Adds a new `review_open` event triggered when a review is opened from:

* The reviews list in Menu > Reviews
* The review list in a product detail > Reviews section
* A review push notification

Event registration: 1031-gh-Automattic/tracks-events-registration

## Changes

* Adds `review_open` to the list of review actions in `WooAnalyticsStat`.
* Tracks when a review is opened from a reviews list (`ReviewsDataSource`).
* Tracks when a review is opened from a push notification (`HubMenuCoordinator` and `ReviewsCoordinator` — the latter is only used if the `hubMenu` feature flag is disabled).

## Testing

1. Build and run the app on a real device (for ease of testing push notifications).
2. Go to Menu > Reviews and select a review from the list. Confirm the `review_open` event is tracked.
3. Go to Products > select a product with reviews > Reviews and select a review from the list. Confirm the `review_open` event is tracked.
4. Put the app in the background. Go to your store and add a new product review to trigger a push notification.
5. Tap on the push notification to open the review. Confirm the `review_open` event is tracked.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.