### PR TITLE
Support `/wc-analytics/leaderboards/products` endpoint

### DIFF
--- a/Networking/Networking/Network/MockNetwork.swift
+++ b/Networking/Networking/Network/MockNetwork.swift
@@ -165,7 +165,10 @@ private extension MockNetwork {
                 return responseQueue[keyAndQueue.key]?.dequeue()
             }
         } else {
-            if let filename = responseMap.filter({ searchPath.hasSuffix($0.key) }).first?.value {
+            if let filename = responseMap.filter({ searchPath.hasSuffix($0.key) })
+                // In cases where a suffix is a substring of another suffix, the longer suffix is preferred in matched results.
+                .sorted(by: { $0.key.count > $1.key.count })
+                .first?.value {
                 return filename
             }
         }

--- a/Networking/Networking/Remote/LeaderboardsRemote.swift
+++ b/Networking/Networking/Remote/LeaderboardsRemote.swift
@@ -29,6 +29,33 @@ public class LeaderboardsRemote: Remote {
         let mapper = LeaderboardListMapper()
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Fetch the leaderboards with the deprecated API for a given site under WooCommerce version 6.7,
+    /// depending on the given granularity of the `unit` parameter.
+    ///
+    /// - Parameters:
+    ///   - siteID: The site ID
+    ///   - unit: Defines the granularity of the stats we are fetching (one of 'hour', 'day', 'week', 'month', or 'year')
+    ///   - earliestDateToInclude: The earliest date to include in the results. This string is ISO8601 compliant
+    ///   - latestDateToInclude: The latest date to include in the results. This string is ISO8601 compliant
+    ///   - quantity: Number of results to fetch
+    ///   - completion: Closure to be executed upon completion
+    ///
+    public func loadLeaderboardsDeprecated(for siteID: Int64,
+                                           unit: StatsGranularityV4,
+                                           earliestDateToInclude: String,
+                                           latestDateToInclude: String,
+                                           quantity: Int,
+                                           completion: @escaping (Result<[Leaderboard], Error>) -> Void) {
+        let parameters = [ParameterKeys.interval: unit.rawValue,
+                          ParameterKeys.after: earliestDateToInclude,
+                          ParameterKeys.before: latestDateToInclude,
+                          ParameterKeys.quantity: String(quantity)]
+
+        let request = JetpackRequest(wooApiVersion: .wcAnalytics, method: .get, siteID: siteID, path: Constants.pathDeprecated, parameters: parameters)
+        let mapper = LeaderboardListMapper()
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 
@@ -36,7 +63,8 @@ public class LeaderboardsRemote: Remote {
 //
 private extension LeaderboardsRemote {
     enum Constants {
-        static let path = "leaderboards"
+        static let pathDeprecated = "leaderboards"
+        static let path = "leaderboards/products"
     }
 
     enum ParameterKeys {

--- a/Networking/NetworkingTests/Remote/LeaderboardsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/LeaderboardsRemoteTests.swift
@@ -39,7 +39,7 @@ final class LeaderboardsRemoteV4Tests: XCTestCase {
         let topProducts = leaderboards[3]
         XCTAssertFalse(topProducts.rows.isEmpty)
 
-        // Each prodcut should have non-empty values
+        // Each product should have non-empty values
         let expectedValues = [(quantity: 4, total: 20000.0), (quantity: 1, total: 15.99)]
         zip(topProducts.rows, expectedValues).forEach { product, expectedValue in
             XCTAssertFalse(product.subject.display.isEmpty)
@@ -77,7 +77,7 @@ final class LeaderboardsRemoteV4Tests: XCTestCase {
         let topProducts = leaderboards[3]
         XCTAssertFalse(topProducts.rows.isEmpty)
 
-        // Each prodcut should have non-empty values
+        // Each product should have non-empty values
         let expectedValues = [(quantity: 4, total: 20000.0), (quantity: 1, total: 15.99)]
         zip(topProducts.rows, expectedValues).forEach { product, expectedValue in
             XCTAssertFalse(product.subject.display.isEmpty)
@@ -89,7 +89,7 @@ final class LeaderboardsRemoteV4Tests: XCTestCase {
         }
     }
 
-    func testLeaderboardsProperlyRelaysNetwokingErrors() {
+    func testLeaderboardsProperlyRelaysNetworkingErrors() {
         // Given
         let remote = LeaderboardsRemote(network: network)
 

--- a/Networking/NetworkingTests/Remote/LeaderboardsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/LeaderboardsRemoteTests.swift
@@ -5,34 +5,70 @@ import XCTest
 ///
 final class LeaderboardsRemoteV4Tests: XCTestCase {
 
-    let network = MockNetwork()
-    let sampleSiteID: Int64 = 1234
+    private let network = MockNetwork()
+    private let sampleSiteID: Int64 = 1234
 
     override func setUp() {
         super.setUp()
         network.removeAllSimulatedResponses()
     }
 
-    func testLeaderboardReturnsCorrectParsedValues() throws {
+    func test_leaderboard_returns_correctly_parsed_values() throws {
+        // Given
+        let remote = LeaderboardsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "leaderboards/products", filename: "leaderboards-year")
+
+        // When
+        let result = waitFor { promise in
+            remote.loadLeaderboards(for: self.sampleSiteID,
+                                    unit: .yearly,
+                                    earliestDateToInclude: "2020-01-01T00:00:00",
+                                    latestDateToInclude: "2020-12-31T23:59:59",
+                                    quantity: 3) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let leaderboards = try XCTUnwrap(result.get())
+
+        // API Returns 4 leaderboards
+        XCTAssertEqual(leaderboards.count, 4)
+
+        // The 4th leaderboard contains the top products and should not be empty
+        let topProducts = leaderboards[3]
+        XCTAssertFalse(topProducts.rows.isEmpty)
+
+        // Each prodcut should have non-empty values
+        let expectedValues = [(quantity: 4, total: 20000.0), (quantity: 1, total: 15.99)]
+        zip(topProducts.rows, expectedValues).forEach { product, expectedValue in
+            XCTAssertFalse(product.subject.display.isEmpty)
+            XCTAssertFalse(product.subject.value.isEmpty)
+            XCTAssertFalse(product.quantity.display.isEmpty)
+            XCTAssertEqual(product.quantity.value, expectedValue.quantity)
+            XCTAssertFalse(product.total.display.isEmpty)
+            XCTAssertEqual(product.total.value, expectedValue.total)
+        }
+    }
+
+    func test_leaderboardDeprecated_returns_correctly_parsed_values() throws {
         // Given
         let remote = LeaderboardsRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "leaderboards", filename: "leaderboards-year")
 
         // When
-        var remoteResult: Result<[Leaderboard], Error>?
-        waitForExpectation { exp in
-            remote.loadLeaderboards(for: sampleSiteID,
-                                    unit: .yearly,
-                                    earliestDateToInclude: "2020-01-01T00:00:00",
-                                    latestDateToInclude: "2020-12-31T23:59:59",
-                                    quantity: 3) { result in
-                                        remoteResult = result
-                                        exp.fulfill()
+        let result = waitFor { promise in
+            remote.loadLeaderboardsDeprecated(for: self.sampleSiteID,
+                                              unit: .yearly,
+                                              earliestDateToInclude: "2020-01-01T00:00:00",
+                                              latestDateToInclude: "2020-12-31T23:59:59",
+                                              quantity: 3) { result in
+                promise(result)
             }
         }
 
         // Then
-        let leaderboards = try XCTUnwrap(remoteResult?.get())
+        let leaderboards = try XCTUnwrap(result.get())
 
         // API Returns 4 leaderboards
         XCTAssertEqual(leaderboards.count, 4)

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -5,7 +5,6 @@ import XCTest
 
 /// StatsStoreV4Tests Unit Tests
 ///
-@MainActor
 final class StatsStoreV4Tests: XCTestCase {
 
     /// Mock Dispatcher!
@@ -290,7 +289,7 @@ final class StatsStoreV4Tests: XCTestCase {
 
         // When
         let quantity = 6
-        waitFor { promise in
+        let _: Void = waitFor { promise in
             let action = StatsActionV4.retrieveTopEarnerStats(siteID: self.sampleSiteID,
                                                               timeRange: .thisYear,
                                                               earliestDateToInclude: DateFormatter.dateFromString(with: "2020-01-01T00:00:00"),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7034 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Starting WooCommerce version 6.7.0, we have a new endpoint for the top performing products on the dashboard `wc-analytics/leaderboards/products`, which is more performant than the one we currently use `wc-analytics/leaderboards` that contains information beyond the products not used in the app. This PR updated the Yosemite `StatsStoreV4` store to try the new endpoint first, and if a "no rest route" error is returned it falls back to the previous endpoint.

In `MockNetwork`, sorting on the request suffix length is necessary to support network mocks for both `leaderboards/products` (the new endpoint) and another endpoint `products` used for fetching missing products that share the same suffix.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisites:
Have two sites, one with WC version >= 6.7.0, and another below 6.7.0. If you don't have a site with WC version < 6.7.0, you can create a JN site with `Include WooCommerce Beta Tester` option enabled and then switch the WC version to a lower version in the `WooCommerce Beta Tester` plugin settings.


#### Site with WC version >= 6.7.0

- Launch the app
- Log in and select a site with WC version >= 6.7.0, if needed --> the top performing products should be loaded correctly in all 4 time range tabs (same as in production)

#### Site with WC version < 6.7.0

- Switch to a site with WC version < 6.7.0 --> the top performing products should be loaded correctly in all 4 time range tabs

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
