### PR TITLE
Introduce order details address validation analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -501,7 +501,7 @@ extension WooAnalyticsEvent {
                 ])
             case .remote(let error):
                 return WooAnalyticsEvent(statName: .orderAddressValidationError, properties: [
-                    Keys.errorMessage: "\(error)",
+                    Keys.errorMessage: "\(String(describing: error.addressError))",
                     Keys.validationScenario: "remote",
                     Keys.orderID: orderID
                 ])

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -491,6 +491,8 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .pluginsNotSyncedYet, properties: [:])
         }
 
+        /// Tracked when the Order details view detects a malformed shipping address data.
+        ///
         static func addressValidationFailed(error: AddressValidator.AddressValidationError, orderID: Int64) -> WooAnalyticsEvent {
             switch error {
             case .local(let errorMessage):

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -503,7 +503,7 @@ extension WooAnalyticsEvent {
                 ])
             case .remote(let error):
                 return WooAnalyticsEvent(statName: .orderAddressValidationError, properties: [
-                    Keys.errorMessage: "\(String(describing: error.addressError))",
+                    Keys.errorMessage: "\(String(describing: error?.addressError ?? "Unknown"))",
                     Keys.validationScenario: "remote",
                     Keys.orderID: orderID
                 ])

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -370,6 +370,8 @@ extension WooAnalyticsEvent {
             static let orderID = "id"
             static let hasMultipleShippingLines = "has_multiple_shipping_lines"
             static let hasMultipleFeeLines = "has_multiple_fee_lines"
+            static let errorMessage = "error_message"
+            static let validationScenario = "validation_scenario"
         }
 
         static func orderOpen(order: Order) -> WooAnalyticsEvent {
@@ -487,6 +489,23 @@ extension WooAnalyticsEvent {
         ///
         static func pluginsNotSyncedYet() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .pluginsNotSyncedYet, properties: [:])
+        }
+
+        static func addressValidationFailed(error: AddressValidator.AddressValidationError, orderID: Int64) -> WooAnalyticsEvent {
+            switch error {
+            case .local(let errorMessage):
+                return WooAnalyticsEvent(statName: .orderAddressValidationError, properties: [
+                    Keys.errorMessage: errorMessage,
+                    Keys.validationScenario: "local",
+                    Keys.orderID: orderID
+                ])
+            case .remote(let error):
+                return WooAnalyticsEvent(statName: .orderAddressValidationError, properties: [
+                    Keys.errorMessage: "\(error)",
+                    Keys.validationScenario: "remote",
+                    Keys.orderID: orderID
+                ])
+            }
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -263,6 +263,7 @@ public enum WooAnalyticsStat: String {
     case collectPaymentTapped = "payments_flow_order_collect_payment_tapped"
     case orderViewCustomFieldsTapped = "order_view_custom_fields_tapped"
     case orderDetailWaitingTimeLoaded = "order_detail_waiting_time_loaded"
+    case orderAddressValidationError = "order_address_validation_error"
 
     // MARK: Order List Sorting/Filtering
     //

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -584,11 +584,9 @@ extension OrderDetailsViewModel {
         let orderID = order.orderID
 
         addressValidator.validate(address: orderShippingAddress, onlyLocally: !shippingLabelPluginIsActive) { result in
-            guard let error = result.failure else {
-                return
+            if let error = result.failure {
+                ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.addressValidationFailed(error: error, orderID: orderID))
             }
-
-            ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.addressValidationFailed(error: error, orderID: orderID))
         }
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -544,6 +544,8 @@ extension OrderDetailsViewModel {
     func syncShippingLabels(onCompletion: ((Error?) -> ())? = nil) {
         // If the plugin is not active, there is no point on continuing with a request that will fail.
         isPluginActive(SitePlugin.SupportedPlugin.WCShip) { [weak self] isActive in
+            self?.startAddressValidation(shippingLabelPluginIsActive: isActive)
+
             guard let self = self, isActive else {
                 onCompletion?(nil)
                 return
@@ -567,6 +569,15 @@ extension OrderDetailsViewModel {
             self.stores.dispatch(action)
 
         }
+    }
+
+    func startAddressValidation(shippingLabelPluginIsActive: Bool) {
+        AddressValidator(siteID: order.siteID,
+                address: order.shippingAddress,
+                onlyLocally: !shippingLabelPluginIsActive,
+                stores: stores) { error in
+
+                }
     }
 
     func syncSavedReceipts(onCompletion: ((Error?) -> ())? = nil) {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -575,12 +575,17 @@ extension OrderDetailsViewModel {
     }
 
     func startAddressValidation(shippingLabelPluginIsActive: Bool) {
-        AddressValidator(siteID: order.siteID,
-                address: order.shippingAddress,
-                onlyLocally: !shippingLabelPluginIsActive,
-                stores: stores) { error in
+        guard let orderShippingAddress = order.shippingAddress else {
+            return
+        }
 
-                }
+        AddressValidator(siteID: order.siteID,
+                         address: orderShippingAddress,
+                         onlyLocally: !shippingLabelPluginIsActive,
+                         stores: stores) { error in
+            error.isFailure
+            //TODO: trigger metrics
+        }
     }
 
     func syncSavedReceipts(onCompletion: ((Error?) -> ())? = nil) {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -580,8 +580,15 @@ extension OrderDetailsViewModel {
         guard let orderShippingAddress = order.shippingAddress else {
             return
         }
-        addressValidator.validate(address: orderShippingAddress, onlyLocally: !shippingLabelPluginIsActive) { result in
 
+        let orderID = order.orderID
+
+        addressValidator.validate(address: orderShippingAddress, onlyLocally: !shippingLabelPluginIsActive) { result in
+            guard let error = result.failure else {
+                return
+            }
+
+            ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.addressValidationFailed(error: error, orderID: orderID))
         }
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -577,7 +577,7 @@ extension OrderDetailsViewModel {
     }
 
     func startAddressValidation(shippingLabelPluginIsActive: Bool) {
-        guard let orderShippingAddress = order.shippingAddress else {
+        guard let orderShippingAddress = order.shippingAddress, orderShippingAddress != Address.empty else {
             return
         }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -672,6 +672,13 @@ extension OrderDetailsViewModel {
     }
 }
 
+// MARK: Order Address validation
+private extension OrderDetailsViewModel {
+    func checkOrderAddressWithShippingLabelValidation() {
+
+    }
+}
+
 // MARK: Definitions
 private extension OrderDetailsViewModel {
     /// Defines the possible sync states of the view model data.

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -544,6 +544,9 @@ extension OrderDetailsViewModel {
     func syncShippingLabels(onCompletion: ((Error?) -> ())? = nil) {
         // If the plugin is not active, there is no point on continuing with a request that will fail.
         isPluginActive(SitePlugin.SupportedPlugin.WCShip) { [weak self] isActive in
+            // We're looking to measure how often an order contains an invalid address
+            // and validate it through the Shipping label plugin, so we need to trigger
+            // this call when it's possible to verify the plugin presence
             self?.startAddressValidation(shippingLabelPluginIsActive: isActive)
 
             guard let self = self, isActive else {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -15,6 +15,7 @@ final class OrderDetailsViewModel {
     private let stores: StoresManager
     private let storageManager: StorageManagerType
     private let currencyFormatter: CurrencyFormatter
+    private let addressValidator: AddressValidator
 
     private(set) var order: Order
 
@@ -34,6 +35,7 @@ final class OrderDetailsViewModel {
         self.stores = stores
         self.storageManager = storageManager
         self.currencyFormatter = currencyFormatter
+        addressValidator = AddressValidator(siteID: order.siteID, stores: stores)
     }
 
     func update(order newOrder: Order) {
@@ -578,13 +580,8 @@ extension OrderDetailsViewModel {
         guard let orderShippingAddress = order.shippingAddress else {
             return
         }
+        addressValidator.validate(address: orderShippingAddress, onlyLocally: !shippingLabelPluginIsActive) { result in
 
-        AddressValidator(siteID: order.siteID,
-                         address: orderShippingAddress,
-                         onlyLocally: !shippingLabelPluginIsActive,
-                         stores: stores) { error in
-            error.isFailure
-            //TODO: trigger metrics
         }
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -695,13 +695,6 @@ extension OrderDetailsViewModel {
     }
 }
 
-// MARK: Order Address validation
-private extension OrderDetailsViewModel {
-    func checkOrderAddressWithShippingLabelValidation() {
-
-    }
-}
-
 // MARK: Definitions
 private extension OrderDetailsViewModel {
     /// Defines the possible sync states of the view model data.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -50,7 +50,7 @@ class AddressValidator {
     private func validateAddressLocally(addressToBeValidated: ShippingLabelAddress) -> [LocalValidationError] {
         var errors: [LocalValidationError] = []
 
-        if addressToBeValidated.name.isEmpty {
+        if addressToBeValidated.name.isEmpty && addressToBeValidated.company.isEmpty {
             errors.append(.name)
         }
         if addressToBeValidated.address1.isEmpty {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -38,7 +38,10 @@ class AddressValidator {
             case .success:
                 onCompletion(.success(()))
             case .failure(let error):
-                onCompletion(.failure(.remote(error)))
+                guard let shippingLabelError = error as? ShippingLabelAddressValidationError else {
+                    return
+                }
+                onCompletion(.failure(.remote(shippingLabelError)))
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -1,10 +1,54 @@
 import Yosemite
 
 class AddressValidator {
-    func validate(address: ShippingLabelAddress,
+    let address: ShippingLabelAddress?
+    let onlyLocally: Bool
+    let nameRequired: Bool
+    let phoneNumberRequired: Bool
+    let stateOfCountryRequired: Bool
+    let onCompletion: (Result<Void, AddressValidationError>) -> Void
+
+    init(address: ShippingLabelAddress?,
+         onlyLocally: Bool,
+         nameRequired: Bool = false,
+         phoneNumberRequired: Bool = false,
+         stateOfCountryRequired: Bool = false,
+         onCompletion: @escaping (Result<Void, AddressValidationError>) -> Void) {
+        self.address = address
+        self.onlyLocally = onlyLocally
+        self.nameRequired = nameRequired
+        self.phoneNumberRequired = phoneNumberRequired
+        self.stateOfCountryRequired = stateOfCountryRequired
+        self.onCompletion = onCompletion
+    }
+
+    init(address: Address,
+         onlyLocally: Bool,
+         nameRequired: Bool = false,
+         phoneNumberRequired: Bool = false,
+         stateOfCountryRequired: Bool = false,
+         onCompletion: @escaping (Result<Void, AddressValidationError>) -> Void) {
+        self.onlyLocally = onlyLocally
+        self.nameRequired = nameRequired
+        self.phoneNumberRequired = phoneNumberRequired
+        self.stateOfCountryRequired = stateOfCountryRequired
+        self.onCompletion = onCompletion
+        self.address = ShippingLabelAddress(company: address.company ?? "",
+                                            name: address.firstName,
+                                            phone: address.phone ?? "",
+                                            country: address.country,
+                                            state: address.state,
+                                            address1: address.address1 ,
+                                            address2: address.address2 ?? "",
+                                            city: address.city,
+                                            postcode: address.postcode)
+    }
+
+    private func validate(address: ShippingLabelAddress,
                   onlyLocally: Bool,
+                  nameRequired: Bool = false,
                   completion: @escaping (Result<Void, AddressValidationError>) -> Void) {
-        if validateAddressLocally(address: address).isNotEmpty {
+        if validateAddressLocally().isNotEmpty {
             completion(.failure(.local))
             return
         }
@@ -15,13 +59,7 @@ class AddressValidator {
         }
     }
 
-    func validate(address: Address,
-                  onlyLocally: Bool,
-                  completion: @escaping (Result<Void, AddressValidationError>) -> Void) {
-        return validate(address: convertAddress(address: address), onlyLocally: onlyLocally, completion: completion)
-    }
-
-    private func validateAddressLocally(address: ShippingLabelAddress) -> [LocalValidationError] {
+    private func validateAddressLocally() -> [LocalValidationError] {
         var errors: [LocalValidationError] = []
 
         if let addressToBeValidated = address {
@@ -47,19 +85,6 @@ class AddressValidator {
         }
 
         return errors
-    }
-
-    private func convertAddress(address: Address) -> ShippingLabelAddress {
-        ShippingLabelAddress(name: address.firstName,
-                                    company: address.company,
-                                    address1: address.address1,
-                                    address2: address.address2,
-                                    city: address.city,
-                                    state: address.state,
-                                    postcode: address.postcode,
-                                    country: address.country,
-                                    phone: address.phone,
-                                    email: address.email)
     }
 
     enum ValidationType {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -79,7 +79,6 @@ class AddressValidator {
         case postcode = "Postcode is empty"
         case state = "State is empty"
         case country = "Country is empty"
-        case invalidPhoneNumber = "The phone number is invalid"
     }
 
     enum AddressValidationError: Error {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -69,12 +69,6 @@ class AddressValidator {
         return errors
     }
 
-    enum ValidationType {
-        case none
-        case local
-        case remote
-    }
-
     enum LocalValidationError: String {
         case name = "Customer name and company are empty"
         case address = "Address is empty"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -81,6 +81,6 @@ class AddressValidator {
 
     enum AddressValidationError: Error {
         case local(String)
-        case remote(Error)
+        case remote(ShippingLabelAddressValidationError)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -10,7 +10,20 @@ class AddressValidator {
     func validate(address: Address,
                   onlyLocally: Bool,
                   completion: @escaping (Result<Void, AddressValidationError>) -> Void) {
+        return validate(address: convertAddress(address: address), onlyLocally: onlyLocally, completion: completion)
+    }
 
+    private func convertAddress(address: Address) -> ShippingLabelAddress {
+        ShippingLabelAddress(name: address.firstName,
+                                    company: address.company,
+                                    address1: address.address1,
+                                    address2: address.address2,
+                                    city: address.city,
+                                    state: address.state,
+                                    postcode: address.postcode,
+                                    country: address.country,
+                                    phone: address.phone,
+                                    email: address.email)
     }
 
     enum ValidationType {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -7,6 +7,9 @@ class AddressValidator {
     let nameRequired: Bool
     let phoneNumberRequired: Bool
     let stateOfCountryRequired: Bool
+
+    private let stores: StoresManager
+
     let onCompletion: (Result<Void, AddressValidationError>) -> Void
 
     init(siteID: Int64,
@@ -15,12 +18,14 @@ class AddressValidator {
          nameRequired: Bool = false,
          phoneNumberRequired: Bool = false,
          stateOfCountryRequired: Bool = false,
+         stores: StoresManager,
          onCompletion: @escaping (Result<Void, AddressValidationError>) -> Void) {
         self.siteID = siteID
         self.onlyLocally = onlyLocally
         self.nameRequired = nameRequired
         self.phoneNumberRequired = phoneNumberRequired
         self.stateOfCountryRequired = stateOfCountryRequired
+        self.stores = stores
         self.onCompletion = onCompletion
         self.address = ShippingLabelAddress(company: address.company ?? "",
                                             name: address.firstName,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -1,5 +1,8 @@
 import Yosemite
 
+/// Reusable implementation of the Address validation introduced by the
+/// `ShippingLabelAddressFormViewModel`, but striped of the specifics to serve the form UI
+/// 
 class AddressValidator {
     let siteID: Int64
     private let stores: StoresManager

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -36,7 +36,7 @@ class AddressValidator {
         }
 
         let addressToBeVerified = ShippingLabelAddressVerification(address: convertedAddress, type: .destination)
-        let action = ShippingLabelAction.validateAddress(siteID: siteID, address: addressToBeVerified) { (result) in
+        let action = ShippingLabelAction.validateAddress(siteID: siteID, address: addressToBeVerified) { result in
             switch result {
             case .success:
                 onCompletion(.success(()))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -22,7 +22,7 @@ class AddressValidator {
 
         let localErrors = validateAddressLocally(addressToBeValidated: convertedAddress)
         if localErrors.isNotEmpty {
-            let localErrorMessage = localErrors.map { $0.rawValue }.joined(separator: ",")
+            let localErrorMessage = localErrors.map { $0.rawValue }.joined(separator: ", ")
             onCompletion(.failure(.local(localErrorMessage)))
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -4,13 +4,49 @@ class AddressValidator {
     func validate(address: ShippingLabelAddress,
                   onlyLocally: Bool,
                   completion: @escaping (Result<Void, AddressValidationError>) -> Void) {
+        if validateAddressLocally(address: address).isNotEmpty {
+            completion(.failure(.local))
+            return
+        }
 
+        if onlyLocally {
+            completion(.success(()))
+            return
+        }
     }
 
     func validate(address: Address,
                   onlyLocally: Bool,
                   completion: @escaping (Result<Void, AddressValidationError>) -> Void) {
         return validate(address: convertAddress(address: address), onlyLocally: onlyLocally, completion: completion)
+    }
+
+    private func validateAddressLocally(address: ShippingLabelAddress) -> [LocalValidationError] {
+        var errors: [LocalValidationError] = []
+
+        if let addressToBeValidated = address {
+            if addressToBeValidated.name.isEmpty && nameRequired {
+                errors.append(.name)
+            }
+            if addressToBeValidated.address1.isEmpty {
+                errors.append(.address)
+            }
+            if addressToBeValidated.city.isEmpty {
+                errors.append(.city)
+            }
+            if addressToBeValidated.postcode.isEmpty {
+                errors.append(.postcode)
+            }
+            if addressToBeValidated.state.isEmpty && stateOfCountryRequired {
+                errors.append(.state)
+            }
+            if addressToBeValidated.country.isEmpty {
+                errors.append(.country)
+            }
+            //TODO: validate phone number
+        }
+
+        return errors
     }
 
     private func convertAddress(address: Address) -> ShippingLabelAddress {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -49,6 +49,17 @@ class AddressValidator {
             onCompletion(.success(()))
             return
         }
+
+        let addressToBeVerified = ShippingLabelAddressVerification(address: address, type: .destination)
+        let action = ShippingLabelAction.validateAddress(siteID: siteID, address: addressToBeVerified) { [weak self] (result) in
+            switch result {
+            case .success:
+                self?.onCompletion(.success(()))
+            case .failure(let error):
+                self?.onCompletion(.failure(.remote(error)))
+            }
+        }
+        stores.dispatch(action)
     }
 
     private func validateAddressLocally() -> [LocalValidationError] {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+class AddressValidator {
+    enum AddressValidationError: Error {
+        case local
+        case remote(Error)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -41,10 +41,7 @@ class AddressValidator {
             case .success:
                 onCompletion(.success(()))
             case .failure(let error):
-                guard let shippingLabelError = error as? ShippingLabelAddressValidationError else {
-                    return
-                }
-                onCompletion(.failure(.remote(shippingLabelError)))
+                onCompletion(.failure(.remote(error as? ShippingLabelAddressValidationError)))
             }
         }
         stores.dispatch(action)
@@ -86,6 +83,6 @@ class AddressValidator {
 
     enum AddressValidationError: Error {
         case local(String)
-        case remote(ShippingLabelAddressValidationError)
+        case remote(ShippingLabelAddressValidationError?)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -11,7 +11,7 @@ class AddressValidator {
 
     func validate(address: Address, onlyLocally: Bool, onCompletion: @escaping (Result<Void, AddressValidationError>) -> Void) {
         let convertedAddress = ShippingLabelAddress(company: address.company ?? "",
-                                                    name: address.firstName,
+                                                    name: address.fullName,
                                                     phone: address.phone ?? "",
                                                     country: address.country,
                                                     state: address.state,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -63,7 +63,9 @@ class AddressValidator {
         if addressToBeValidated.country.isEmpty {
             errors.append(.country)
         }
-        //TODO: validate phone number
+        if addressToBeValidated.phone.isEmpty {
+            errors.append(.missingPhoneNumber)
+        }
 
         return errors
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -1,6 +1,7 @@
 import Yosemite
 
 class AddressValidator {
+    let siteID: Int64
     let address: ShippingLabelAddress?
     let onlyLocally: Bool
     let nameRequired: Bool
@@ -8,26 +9,14 @@ class AddressValidator {
     let stateOfCountryRequired: Bool
     let onCompletion: (Result<Void, AddressValidationError>) -> Void
 
-    init(address: ShippingLabelAddress?,
+    init(siteID: Int64,
+         address: Address,
          onlyLocally: Bool,
          nameRequired: Bool = false,
          phoneNumberRequired: Bool = false,
          stateOfCountryRequired: Bool = false,
          onCompletion: @escaping (Result<Void, AddressValidationError>) -> Void) {
-        self.address = address
-        self.onlyLocally = onlyLocally
-        self.nameRequired = nameRequired
-        self.phoneNumberRequired = phoneNumberRequired
-        self.stateOfCountryRequired = stateOfCountryRequired
-        self.onCompletion = onCompletion
-    }
-
-    init(address: Address,
-         onlyLocally: Bool,
-         nameRequired: Bool = false,
-         phoneNumberRequired: Bool = false,
-         stateOfCountryRequired: Bool = false,
-         onCompletion: @escaping (Result<Void, AddressValidationError>) -> Void) {
+        self.siteID = siteID
         self.onlyLocally = onlyLocally
         self.nameRequired = nameRequired
         self.phoneNumberRequired = phoneNumberRequired
@@ -42,19 +31,17 @@ class AddressValidator {
                                             address2: address.address2 ?? "",
                                             city: address.city,
                                             postcode: address.postcode)
+        validate()
     }
 
-    private func validate(address: ShippingLabelAddress,
-                  onlyLocally: Bool,
-                  nameRequired: Bool = false,
-                  completion: @escaping (Result<Void, AddressValidationError>) -> Void) {
+    private func validate() {
         if validateAddressLocally().isNotEmpty {
-            completion(.failure(.local))
+            onCompletion(.failure(.local))
             return
         }
 
         if onlyLocally {
-            completion(.success(()))
+            onCompletion(.success(()))
             return
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -20,8 +20,10 @@ class AddressValidator {
                                                     city: address.city,
                                                     postcode: address.postcode)
 
-        if validateAddressLocally(addressToBeValidated: convertedAddress).isNotEmpty {
-            onCompletion(.failure(.local))
+        let localErrors = validateAddressLocally(addressToBeValidated: convertedAddress)
+        if localErrors.isNotEmpty {
+            let localErrorMessage = localErrors.map { $0.rawValue }.joined(separator: ",")
+            onCompletion(.failure(.local(localErrorMessage)))
             return
         }
 
@@ -63,9 +65,6 @@ class AddressValidator {
         if addressToBeValidated.country.isEmpty {
             errors.append(.country)
         }
-        if addressToBeValidated.phone.isEmpty {
-            errors.append(.missingPhoneNumber)
-        }
 
         return errors
     }
@@ -76,19 +75,18 @@ class AddressValidator {
         case remote
     }
 
-    enum LocalValidationError {
-        case name
-        case address
-        case city
-        case postcode
-        case state
-        case country
-        case missingPhoneNumber
-        case invalidPhoneNumber
+    enum LocalValidationError: String {
+        case name = "Customer name and company are empty"
+        case address = "Address is empty"
+        case city = "City is empty"
+        case postcode = "Postcode is empty"
+        case state = "State is empty"
+        case country = "Country is empty"
+        case invalidPhoneNumber = "The phone number is invalid"
     }
 
     enum AddressValidationError: Error {
-        case local
+        case local(String)
         case remote(Error)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/AddressValidator.swift
@@ -1,6 +1,35 @@
-import Foundation
+import Yosemite
 
 class AddressValidator {
+    func validate(address: ShippingLabelAddress,
+                  onlyLocally: Bool,
+                  completion: @escaping (Result<Void, AddressValidationError>) -> Void) {
+
+    }
+
+    func validate(address: Address,
+                  onlyLocally: Bool,
+                  completion: @escaping (Result<Void, AddressValidationError>) -> Void) {
+
+    }
+
+    enum ValidationType {
+        case none
+        case local
+        case remote
+    }
+
+    enum LocalValidationError {
+        case name
+        case address
+        case city
+        case postcode
+        case state
+        case country
+        case missingPhoneNumber
+        case invalidPhoneNumber
+    }
+
     enum AddressValidationError: Error {
         case local
         case remote(Error)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1262,6 +1262,7 @@
 		B626C71B287659D60083820C /* OrderCustomFieldsDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = B626C71A287659D60083820C /* OrderCustomFieldsDetails.swift */; };
 		B63AAF4B254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63AAF4A254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift */; };
 		B651474527D644FF00C9C4E6 /* CustomerNoteSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B651474427D644FF00C9C4E6 /* CustomerNoteSection.swift */; };
+		B65EB44A28BD670000DF595D /* AddressValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65EB44928BD670000DF595D /* AddressValidatorTests.swift */; };
 		B687940C27699D420092BCA0 /* RefundFeesCalculationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B687940B27699D410092BCA0 /* RefundFeesCalculationUseCase.swift */; };
 		B6C838DE28793B3A003AB786 /* OrderCustomFieldsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C838DD28793B3A003AB786 /* OrderCustomFieldsViewModel.swift */; };
 		B6E851F3276320C70041D1BA /* RefundFeesDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E851F2276320C70041D1BA /* RefundFeesDetailsViewModel.swift */; };
@@ -3117,6 +3118,7 @@
 		B626C71A287659D60083820C /* OrderCustomFieldsDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomFieldsDetails.swift; sourceTree = "<group>"; };
 		B63AAF4A254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+SurveyViewControllerTests.swift"; sourceTree = "<group>"; };
 		B651474427D644FF00C9C4E6 /* CustomerNoteSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerNoteSection.swift; sourceTree = "<group>"; };
+		B65EB44928BD670000DF595D /* AddressValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressValidatorTests.swift; sourceTree = "<group>"; };
 		B687940B27699D410092BCA0 /* RefundFeesCalculationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundFeesCalculationUseCase.swift; sourceTree = "<group>"; };
 		B6C838DD28793B3A003AB786 /* OrderCustomFieldsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomFieldsViewModel.swift; sourceTree = "<group>"; };
 		B6E851F2276320C70041D1BA /* RefundFeesDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundFeesDetailsViewModel.swift; sourceTree = "<group>"; };
@@ -4298,6 +4300,7 @@
 				0277AE9A256CA8A200F45C4A /* AggregatedShippingLabelOrderItemsTests.swift */,
 				025678C625773399009D7E6C /* Collection+ShippingLabelTests.swift */,
 				0298431125936DFC00979CAE /* ShippingLabelsTopBannerFactoryTests.swift */,
+				B65EB44928BD670000DF595D /* AddressValidatorTests.swift */,
 			);
 			path = "Shipping Labels";
 			sourceTree = "<group>";
@@ -8686,7 +8689,7 @@
 				3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 				174CA86827D90A6200126524 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
 				3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */,
-				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject.git" */,
+				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */,
 				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
@@ -10315,6 +10318,7 @@
 				E17E3BFB266917E20009D977 /* CardPresentModalBluetoothRequiredTests.swift in Sources */,
 				CCD2E68925DD52C100BD975D /* ProductVariationsViewModelTests.swift in Sources */,
 				26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */,
+				B65EB44A28BD670000DF595D /* AddressValidatorTests.swift in Sources */,
 				0215320D2423309B003F2BBD /* UIStackView+SubviewsTests.swift in Sources */,
 				027B8BBD23FE0DE10040944E /* ProductImageActionHandlerTests.swift in Sources */,
 				CC53FB3E2758E2D500C4CA4F /* ProductRowViewModelTests.swift in Sources */,
@@ -11448,7 +11452,7 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject.git" */ = {
+		4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/krzysztofzablocki/Inject.git";
 			requirement = {
@@ -11534,7 +11538,7 @@
 		};
 		4598298028574688003A9AFE /* Inject */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject.git" */;
+			package = 4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */;
 			productName = Inject;
 		};
 		57150E0E24F462C200E81611 /* TestKit */ = {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -907,6 +907,7 @@
 		45FDDD66267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45FDDD64267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.xib */; };
 		532842FC64B572D4545BD98E /* OrderFormCustomerNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53284C9FD06F2BDABC554BEE /* OrderFormCustomerNoteViewModel.swift */; };
 		532846FAFFFCA93169B5E0BC /* WaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53284FB62FF7F94F18F0D3FF /* WaitingTimeTracker.swift */; };
+		53284C6D36BD5E88B99FECFA /* AddressValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53284768ECB0EABA5D3A10DA /* AddressValidator.swift */; };
 		570AAB052472FACB00516C0C /* OrderDetailsDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */; };
 		57150E0F24F462C200E81611 /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 57150E0E24F462C200E81611 /* TestKit */; };
 		5718852C2465D9EC00E2486F /* ReviewsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5718852B2465D9EC00E2486F /* ReviewsCoordinator.swift */; };
@@ -2731,6 +2732,7 @@
 		45FBDF3B238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedAddProductImageCollectionViewCellTests.swift; sourceTree = "<group>"; };
 		45FDDD63267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSummaryTableViewCell.swift; sourceTree = "<group>"; };
 		45FDDD64267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ShippingLabelSummaryTableViewCell.xib; sourceTree = "<group>"; };
+		53284768ECB0EABA5D3A10DA /* AddressValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressValidator.swift; sourceTree = "<group>"; };
 		53284C9FD06F2BDABC554BEE /* OrderFormCustomerNoteViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderFormCustomerNoteViewModel.swift; sourceTree = "<group>"; };
 		53284FB62FF7F94F18F0D3FF /* WaitingTimeTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaitingTimeTracker.swift; sourceTree = "<group>"; };
 		570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OrderDetailsDataSourceTests.swift; path = "Order Details/OrderDetailsDataSourceTests.swift"; sourceTree = "<group>"; };
@@ -5282,6 +5284,7 @@
 				45C91CFD25E55A1200FD8812 /* ShippingLabelAddressTopBannerFactory.swift */,
 				45BBE5C6268CBB090017D8F8 /* ShippingLabelStateOfACountryListSelectorCommand.swift */,
 				DE46133826B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift */,
+				53284768ECB0EABA5D3A10DA /* AddressValidator.swift */,
 			);
 			path = "Shipping Address Validation";
 			sourceTree = "<group>";
@@ -8683,7 +8686,7 @@
 				3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 				174CA86827D90A6200126524 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
 				3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */,
-				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */,
+				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject.git" */,
 				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
@@ -10153,6 +10156,7 @@
 				ABC3521A374A2355001E3CD6 /* CardReaderSettingsSearchingViewController.swift in Sources */,
 				532842FC64B572D4545BD98E /* OrderFormCustomerNoteViewModel.swift in Sources */,
 				532846FAFFFCA93169B5E0BC /* WaitingTimeTracker.swift in Sources */,
+				53284C6D36BD5E88B99FECFA /* AddressValidator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11444,7 +11448,7 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */ = {
+		4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/krzysztofzablocki/Inject.git";
 			requirement = {
@@ -11530,7 +11534,7 @@
 		};
 		4598298028574688003A9AFE /* Inject */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */;
+			package = 4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject.git" */;
 			productName = Inject;
 		};
 		57150E0E24F462C200E81611 /* TestKit */ = {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/AddressValidatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/AddressValidatorTests.swift
@@ -1,28 +1,39 @@
 import XCTest
+import Yosemite
+@testable import WooCommerce
 
+/// AddressValidator Unit Tests
+///
 class AddressValidatorTests: XCTestCase {
+    private var storesManager: MockStoresManager!
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    override func setUp() {
+        super.setUp()
+        storesManager = MockStoresManager(sessionManager: SessionManager.testingInstance)
+        ServiceLocator.setStores(storesManager)
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
+    func testExample() {
+        var onCompletionWasCalled = false
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
+        let addressValidator = AddressValidator(siteID: 123, stores: storesManager)
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
+        addressValidator.validate(address: Address.empty, onlyLocally: true, onCompletion: { result in
+            onCompletionWasCalled = true
+            guard let failure = result.failure else {
+                XCTFail("A failure result was expected for an empty address")
+                return
+            }
 
+            switch failure {
+            case .local(let errorMessage):
+                XCTAssertTrue(errorMessage.isNotEmpty)
+                break
+            default:
+                XCTFail("A local failure was expected")
+            }
+        })
+
+        XCTAssertTrue(onCompletionWasCalled)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/AddressValidatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/AddressValidatorTests.swift
@@ -26,6 +26,11 @@ class AddressValidatorTests: XCTestCase {
         ServiceLocator.setStores(storesManager)
     }
 
+    override func tearDown() {
+        storesManager = nil
+        super.tearDown()
+    }
+
     func testWhenAddressIsEmptyThenCompleteWithLocalFailure() {
         // Given
         var onCompletionWasCalled = false

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/AddressValidatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/AddressValidatorTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+
+class AddressValidatorTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/AddressValidatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/AddressValidatorTests.swift
@@ -133,7 +133,7 @@ class AddressValidatorTests: XCTestCase {
 
             switch failure {
             case .remote(let error):
-                XCTAssertTrue(error.addressError!.isNotEmpty)
+                XCTAssertTrue(error!.addressError!.isNotEmpty)
                 break
             default:
                 XCTFail("A remote failure was expected")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/AddressValidatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Shipping Labels/AddressValidatorTests.swift
@@ -76,4 +76,28 @@ class AddressValidatorTests: XCTestCase {
 
         XCTAssertTrue(onCompletionWasCalled)
     }
+
+    func testWhenAddressIsValidThenCompleteWithSuccessWithLocalAndRemoteValidation() {
+        // Given
+        var onCompletionWasCalled = false
+        var remoteValidationWasCalled = false
+        storesManager.whenReceivingAction(ofType: ShippingLabelAction.self, thenCall: { action in
+            if case let ShippingLabelAction.validateAddress(_, addressToBeValidated, onCompletion) = action {
+                remoteValidationWasCalled = true
+                onCompletion(.success(ShippingLabelAddressValidationSuccess(address: addressToBeValidated.address!, isTrivialNormalization: true)))
+            }
+        })
+        let addressValidator = AddressValidator(siteID: 123, stores: storesManager)
+
+        // When
+        addressValidator.validate(address: validAddress, onlyLocally: false, onCompletion: { result in
+            onCompletionWasCalled = true
+
+            // Then
+            XCTAssertTrue(result.isSuccess)
+        })
+
+        XCTAssertTrue(onCompletionWasCalled)
+        XCTAssertTrue(remoteValidationWasCalled)
+    }
 }


### PR DESCRIPTION
Closes: #7546

### Summary
This PR validates the shipping address in the order details screen and tracks the information when the address contains errors. Our goal is to enhance the user experience by adding an address validation mechanism similar to the one the shipping labels plugin uses, but first, we want to understand better the impact these changes could have.

The implementation strategy follows the code introduced by the `ShippingLabelAddressFormViewModel`, but in a reusable class format that's only focused on validating an address locally and remotely, without the specifics introduced in the shipping label feature. 

Please bear in mind that this is temporary code to achieve user measurements and understand some behaviors. It's possible to make some changes in the future so the `ShippingLabelAddressFormViewModel` could take advantage of the same code, avoid repetition, and improve code usage. Still, I think that should be tackled later in a separate PR since adjusting the current implementation of the `ShippingLabelAddressFormViewModel` to the code introduced here would be no simple task. 

### How to test

TC1
1. Open the order list
2. Select an order containing a shipping address with errors (invalid country/state names, empty Address 1 strings, etc)
3. Check that the errors are tracked in an event similar to this one:

```
🔵 Tracked: order_address_validation_error, Properties: {"error_message":"The phone number is invalid","validation_scenario":"local","order_id":683,"blog_id":202934350,"is_wpcom_store":true,"is_debug":true}
```

TC2
1. Open the order list
2. Select an order without a shipping address
3. Check that no errors are tracked

TC3
1. Deactivate the WooCommerce Shipping & Tax plugin in your store
2. Restart the Woo app on your device
3. Open the order list
4. Select an order
5. Check that the remote validation is not sent when the plugin is not activated (No request is sent to `/wc/v1/connect/normalize-address/&_method=post`) 

You can use Flipper to check TC3 and verify a request, as the one below never happens
<img width="1024" alt="Screen Shot 2022-08-28 at 14 07 45" src="https://user-images.githubusercontent.com/18119390/187086235-1fa731ff-a584-4d82-aaee-d7370994a15f.png">



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.