### PR TITLE
Custom help content for "Enter WordPress.com email" screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 10.2
 -----
-- [*] Help center: Added help center web page with FAQs for "Enter Store Credentials" screen. [https://github.com/woocommerce/woocommerce-ios/pull/7588]
+- [*] Help center: Added help center web page with FAQs for "Enter Store Credentials" and "Enter WordPress.com email "screens. [https://github.com/woocommerce/woocommerce-ios/pull/7588, https://github.com/woocommerce/woocommerce-ios/pull/7590]
 
 
 10.1

--- a/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
+++ b/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
@@ -31,6 +31,8 @@ extension CustomHelpCenterContent {
             url = WooConstants.URLs.helpCenterForEnterStoreAddress.asURL()
         case .enterEmailAddress where flow == .loginWithSiteAddress: // Enter WordPress.com email screen from store address flow
             url = WooConstants.URLs.helpCenterForWPCOMEmailFromSiteAddressFlow.asURL()
+        case .enterEmailAddress where flow == .wpCom: // Enter WordPress.com email screen from store WPCOM email flow
+            url = WooConstants.URLs.helpCenterForWPCOMEmailScreen.asURL()
         case .usernamePassword: // Enter Store credentials screen (wp-admin creds)
             url = WooConstants.URLs.helpCenterForEnterStoreCredentials.asURL()
         default:

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -83,6 +83,15 @@ extension WooConstants {
 
         /// Help Center for "Enter WordPress.com email" screen
         ///
+        /// - Used for providing help in the "Enter WordPress.com email screen" when user tries to login using WordPress.com email address
+        ///
+        // swiftlint:disable:next line_length
+        case helpCenterForWPCOMEmailScreen = "https://woocommerce.com/document/android-ios-apps-login-help-faq/#login-with-wordpress-com"
+
+        /// Help Center for "Enter WordPress.com email" screen
+        ///
+        /// - Used for providing help in the "Ente WordPress.comr email screen" when user tries to login using the store address
+        ///
         // swiftlint:disable:next line_length
         case helpCenterForWPCOMEmailFromSiteAddressFlow = "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-wordpress-com-email-address-login-using-store-address-flow"
 

--- a/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
@@ -70,6 +70,26 @@ final class CustomHelpCenterContentTests: XCTestCase {
         XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.url.rawValue], helpContentURL.absoluteString)
     }
 
+    // MARK: Enter WordPress.com email screen from WPCOM email flow
+    //
+    func test_init_using_step_and_flow_returns_valid_instance_for_enter_WPCOM_email_address_screen_from_WPCOM_flow() throws {
+        // Given
+        let step: AuthenticatorAnalyticsTracker.Step = .enterEmailAddress
+        let flow: AuthenticatorAnalyticsTracker.Flow = .wpCom
+        let helpContentURL = WooConstants.URLs.helpCenterForWPCOMEmailScreen.asURL()
+
+        // When
+        let sut = try XCTUnwrap(CustomHelpCenterContent(step: step, flow: flow))
+
+        // Then
+        XCTAssertEqual(sut.url, helpContentURL)
+
+        // Test the `trackingProperties` dictionary values
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.step.rawValue], step.rawValue)
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.flow.rawValue], flow.rawValue)
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.url.rawValue], helpContentURL.absoluteString)
+    }
+
     // MARK: Enter Store credentials screen (wp-admin creds)
     //
     func test_init_using_step_and_flow_returns_valid_instance_for_enter_store_creds_screen() throws {


### PR DESCRIPTION
Part of: #7547 

- [ ] ⚠️ Please make sure the parent PR https://github.com/woocommerce/woocommerce-ios/pull/7588 is reviewed before reviewing this. ⚠️

### Description
As a part of improving the help center content, this PR adds custom content with FAQs and Answers for the "Enter WordPress.com email" screen at the following URL.

https://woocommerce.com/document/android-ios-apps-login-help-faq/#login-with-wordpress-com

Internal ref - pe5sF9-sZ-p2

### Testing instructions

1. Install and launch the app.
1. Tap `Skip` to reach the login prologue screen.
1. Tap the `Continue with WordPress.com` button.
1. Tap `Help` -> `Help Center`
1. Observe that you are directed to https://woocommerce.com/document/android-ios-apps-login-help-faq/#login-with-wordpress-com in a web view
1. In Xcode debug console observe that the following event is tracked 
```
Tracked support_help_center_viewed, properties: [AnyHashable("source_step"): "enter_email_address", AnyHashable("help_content_url"): "https://woocommerce.com/document/android-ios-apps-login-help-faq/#login-with-wordpress-com", AnyHashable("source_flow"): "wordpress_com"]
```

### Screenshots

https://user-images.githubusercontent.com/524475/187158694-86568c1d-b79d-4704-9c6b-252e2a68cf0d.mov



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.