### PR TITLE
[Mobile Payments] Make reasonForAnalytics non-optional

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -106,23 +106,23 @@ private extension InPersonPaymentsViewModel {
     }
 
     func trackState(_ state: CardPresentPaymentOnboardingState) {
-        guard let reason = state.reasonForAnalytics else {
+        guard state.shouldTrackOnboardingStepEvents else {
             return
         }
         ServiceLocator.analytics
             .track(event: .InPersonPayments
-                    .cardPresentOnboardingNotCompleted(reason: reason,
-                                                       countryCode: countryCode))
+                .cardPresentOnboardingNotCompleted(reason: state.reasonForAnalytics,
+                                                   countryCode: countryCode))
     }
 
     func trackSkipped(state: CardPresentPaymentOnboardingState, remindLater: Bool) {
-        guard let reason = state.reasonForAnalytics else {
+        guard state.shouldTrackOnboardingStepEvents else {
             return
         }
 
         ServiceLocator.analytics.track(
             event: .InPersonPayments.cardPresentOnboardingStepSkipped(
-                reason: reason,
+                reason: state.reasonForAnalytics,
                 remindLater: remindLater,
                 countryCode: countryCode))
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -36,7 +36,7 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
 
     @Published var awaitingResponse = false
 
-    let analyticReason: String = CardPresentPaymentOnboardingState.codPaymentGatewayNotSetUp.reasonForAnalytics ?? ""
+    let analyticReason: String = CardPresentPaymentOnboardingState.codPaymentGatewayNotSetUp.reasonForAnalytics
 
     // MARK: - Configuration properties
     private let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsCountryNotSupported: View {
     let countryCode: String
-    let analyticReason: String?
+    let analyticReason: String
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -47,8 +47,8 @@ private enum Localization {
 struct InPersonPaymentsCountryNotSupported_Previews: PreviewProvider {
     static var previews: some View {
         // Valid country code
-        InPersonPaymentsCountryNotSupported(countryCode: "ES", analyticReason: nil)
+        InPersonPaymentsCountryNotSupported(countryCode: "ES", analyticReason: "")
         // Invalid country code
-        InPersonPaymentsCountryNotSupported(countryCode: "OO", analyticReason: nil)
+        InPersonPaymentsCountryNotSupported(countryCode: "OO", analyticReason: "")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsCountryNotSupportedStripe: View {
     let countryCode: String
-    let analyticReason: String?
+    let analyticReason: String
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -47,8 +47,8 @@ private enum Localization {
 struct InPersonPaymentsCountryNotSupportedStripe_Previews: PreviewProvider {
     static var previews: some View {
         // Valid country code
-        InPersonPaymentsCountryNotSupportedStripe(countryCode: "ES", analyticReason: nil)
+        InPersonPaymentsCountryNotSupportedStripe(countryCode: "ES", analyticReason: "")
         // Invalid country code
-        InPersonPaymentsCountryNotSupportedStripe(countryCode: "OO", analyticReason: nil)
+        InPersonPaymentsCountryNotSupportedStripe(countryCode: "OO", analyticReason: "")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 struct InPersonPaymentsLiveSiteInTestMode: View {
     let plugin: CardPresentPaymentsPlugin
-    let analyticReason: String?
+    let analyticReason: String
     let onRefresh: () -> Void
 
     var body: some View {
@@ -46,6 +46,6 @@ private enum Localization {
 
 struct InPersonPaymentsLiveSiteInTestMode_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsLiveSiteInTestMode(plugin: .wcPay, analyticReason: nil, onRefresh: {})
+        InPersonPaymentsLiveSiteInTestMode(plugin: .wcPay, analyticReason: "", onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsNoConnection: View {
-    let analyticReason: String?
+    let analyticReason: String
     let onRefresh: () -> Void
 
     var body: some View {
@@ -43,6 +43,6 @@ private enum Localization {
 
 struct InPersonPaymentsNoConnection_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsNoConnection(analyticReason: nil, onRefresh: {})
+        InPersonPaymentsNoConnection(analyticReason: "", onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
@@ -7,7 +7,7 @@ struct InPersonPaymentsOnboardingError: View {
     let image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo
     let supportLink: Bool
     let learnMore: Bool
-    let analyticReason: String?
+    let analyticReason: String
     var buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel? = nil
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingErrorButtonViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingErrorButtonViewModel.swift
@@ -4,14 +4,14 @@ import Yosemite
 struct InPersonPaymentsOnboardingErrorButtonViewModel {
     let text: String
 
-    private let analyticReason: String?
+    private let analyticReason: String
 
     private let cardPresentConfiguration: CardPresentPaymentsConfiguration
 
     let action: () -> Void
 
     init(text: String,
-         analyticReason: String?,
+         analyticReason: String,
          cardPresentConfiguration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
          action: @escaping () -> Void) {
         self.text = text
@@ -20,7 +20,7 @@ struct InPersonPaymentsOnboardingErrorButtonViewModel {
         self.action = {
             ServiceLocator.analytics.track(
                 event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaTapped(
-                    reason: analyticReason ?? "",
+                    reason: analyticReason,
                     countryCode: cardPresentConfiguration.countryCode))
             action()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 struct InPersonPaymentsPluginNotActivated: View {
     let plugin: CardPresentPaymentsPlugin
-    let analyticReason: String?
+    let analyticReason: String
     let onRefresh: () -> Void
 
     var body: some View {
@@ -45,6 +45,6 @@ private enum Localization {
 
 struct InPersonPaymentsPluginNotActivated_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotActivated(plugin: .wcPay, analyticReason: nil, onRefresh: {})
+        InPersonPaymentsPluginNotActivated(plugin: .wcPay, analyticReason: "", onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsPluginNotInstalled: View {
-    let analyticReason: String?
+    let analyticReason: String
     let onRefresh: () -> Void
 
     var body: some View {
@@ -43,6 +43,6 @@ private enum Localization {
 
 struct InPersonPaymentsPluginNotInstalled_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotInstalled(analyticReason: nil, onRefresh: {})
+        InPersonPaymentsPluginNotInstalled(analyticReason: "", onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 struct InPersonPaymentsPluginNotSetup: View {
     let plugin: CardPresentPaymentsPlugin
-    let analyticReason: String?
+    let analyticReason: String
     private let cardPresentConfiguration = CardPresentConfigurationLoader().configuration
     let onRefresh: () -> Void
     @State private var presentedSetupURL: URL? = nil
@@ -28,7 +28,7 @@ struct InPersonPaymentsPluginNotSetup: View {
                 presentedSetupURL = setupURL
                 ServiceLocator.analytics.track(
                     event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaTapped(
-                        reason: analyticReason ?? "",
+                        reason: analyticReason,
                         countryCode: cardPresentConfiguration.countryCode))
             } label: {
                 HStack {
@@ -71,6 +71,6 @@ private enum Localization {
 }
 struct InPersonPaymentsPluginNotSetup_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotSetup(plugin: .wcPay, analyticReason: nil, onRefresh: {})
+        InPersonPaymentsPluginNotSetup(plugin: .wcPay, analyticReason: "", onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 struct InPersonPaymentsPluginNotSupportedVersion: View {
     let plugin: CardPresentPaymentsPlugin
-    let analyticReason: String?
+    let analyticReason: String
     let onRefresh: () -> Void
 
     var body: some View {
@@ -46,6 +46,6 @@ private enum Localization {
 
 struct InPersonPaymentsPluginNotSupportedVersion_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotSupportedVersion(plugin: .wcPay, analyticReason: nil, onRefresh: {})
+        InPersonPaymentsPluginNotSupportedVersion(plugin: .wcPay, analyticReason: "", onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsStripeAccountOverdue: View {
-    let analyticReason: String?
+    let analyticReason: String
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -33,6 +33,6 @@ private enum Localization {
 
 struct InPersonPaymentsStripeAccountOverdue_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAccountOverdue(analyticReason: nil)
+        InPersonPaymentsStripeAccountOverdue(analyticReason: "")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsStripeAccountPending: View {
     let deadline: Date?
-    let analyticReason: String?
+    let analyticReason: String
     let onSkip: () -> ()
 
     var body: some View {
@@ -58,7 +58,7 @@ private enum Localization {
 
 struct InPersonPaymentsStripeAccountPending_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAccountPending(deadline: Date(), analyticReason: nil, onSkip: {})
+        InPersonPaymentsStripeAccountPending(deadline: Date(), analyticReason: "", onSkip: {})
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsStripeAccountReview: View {
-    let analyticReason: String?
+    let analyticReason: String
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -32,6 +32,6 @@ private enum Localization {
 
 struct InPersonPaymentsStripeAccountReview_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAccountReview(analyticReason: nil)
+        InPersonPaymentsStripeAccountReview(analyticReason: "")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsStripeRejected: View {
-    let analyticReason: String?
+    let analyticReason: String
     var body: some View {
         InPersonPaymentsOnboardingError(
             title: Localization.title,
@@ -31,6 +31,6 @@ private enum Localization {
 
 struct InPersonPaymentsStripeRejected_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeRejected(analyticReason: nil)
+        InPersonPaymentsStripeRejected(analyticReason: "")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsUnavailableView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsUnavailableView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsUnavailable: View {
-    let analyticReason: String?
+    let analyticReason: String
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -32,6 +32,6 @@ private enum Localization {
 
 struct InPersonPaymentsUnavailable_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsUnavailable(analyticReason: nil)
+        InPersonPaymentsUnavailable(analyticReason: "")
     }
 }

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -76,12 +76,12 @@ public enum CardPresentPaymentOnboardingState: Equatable {
 }
 
 extension CardPresentPaymentOnboardingState {
-    public var reasonForAnalytics: String? {
+    public var reasonForAnalytics: String {
         switch self {
         case .loading:
-            return nil
+            return "loading"
         case .completed:
-            return nil
+            return "completed"
         case .selectPlugin:
             return "multiple_payment_providers_conflict"
         case .countryNotSupported(countryCode: _):
@@ -112,6 +112,15 @@ extension CardPresentPaymentOnboardingState {
             return "generic_error"
         case .noConnectionError:
             return "no_connection_error"
+        }
+    }
+
+    public var shouldTrackOnboardingStepEvents: Bool {
+        switch self {
+        case .completed(_), .loading:
+            return false
+        default:
+            return true
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7592
<!-- Id number of the GitHub issue this PR addresses. -->

Merge after #7594

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

PR feedback identified that it would be better if `reasonForAnalytics` were not optional. This removes the optionality, and adds a method to check whether the `shown` and `skipped` events should be logged for a particular step. Previously, we used the absence of a `reasonForAnalytics` to avoid logging these events for `completed` and `loading` steps.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Synthesise onboarding failures by hardcoding a step at the top of `accountChecks`, e.g. 
```
return .stripeAccountOverdueRequirement(plugin: .wcPay)
```

1. In the Payments tab, tap Continue Setup
2. Verify that the expected `card_present_onboarding_not_completed` event is tracked, with a reason name.
3. Verify that none of the `reason`s are `loading` or `completed`

```
🔵 Tracked card_present_onboarding_not_completed, properties: [AnyHashable("reason"): "account_overdue_requirements", AnyHashable("country"): "CA", AnyHashable("blog_id"): 203184915, AnyHashable("is_wpcom_store"): false]
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
