### PR TITLE
[Mobile Payments] Cash on Delivery Learn More link correction for WCPay

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 10.2
 -----
 - [*] Help center: Added help center web page with FAQs for "Enter Store Credentials" and "Enter WordPress.com email "screens. [https://github.com/woocommerce/woocommerce-ios/pull/7588, https://github.com/woocommerce/woocommerce-ios/pull/7590]
-
+- [*] In-Person Payments: Fixed the Learn More link from the `Enable Pay in Person` onboarding screen for WCPay [https://github.com/woocommerce/woocommerce-ios/pull/7598]
 
 10.1
 -----

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -180,9 +180,14 @@ extension WooConstants {
 #else
         case couponManagementFeedback = "https://automattic.survey.fm/woo-app-coupon-management-production"
 #endif
-        /// URL for the Enable Cash on Delivery (or Pay in Person) onboarding step's learn more link.
+        /// URL for the Enable Cash on Delivery (or Pay in Person) onboarding step's learn more link using the Stripe plugin
         /// 
-        case cashOnDeliveryLearnMoreUrl = "https://woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/#section-8"
+        case stripeCashOnDeliveryLearnMoreUrl = "https://woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/#section-8"
+
+        /// URL for the Enable Cash on Delivery (or Pay in Person) onboarding step's learn more link using the WCPay plugin
+        ///
+        case wcPayCashOnDeliveryLearnMoreUrl =
+                "https://woocommerce.com/document/payments/getting-started-with-in-person-payments-with-woocommerce-payments/#add-cod-payment-method"
 
         /// Returns the URL version of the receiver
         ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -309,7 +309,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         }
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.promptToEnableCodInIppOnboarding) {
             if shouldShowCashOnDeliveryStep {
-                return .codPaymentGatewayNotSetUp
+                return .codPaymentGatewayNotSetUp(plugin: plugin)
             }
         }
         guard !isInUndefinedState(account: account) else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Yosemite
 
 final class InPersonPaymentsViewController: UIHostingController<InPersonPaymentsView> {
     private let onWillDisappear: (() -> ())?
@@ -71,8 +72,12 @@ struct InPersonPaymentsView: View {
                 InPersonPaymentsStripeAccountReview(analyticReason: viewModel.state.reasonForAnalytics)
             case .stripeAccountRejected:
                 InPersonPaymentsStripeRejected(analyticReason: viewModel.state.reasonForAnalytics)
-            case .codPaymentGatewayNotSetUp:
-                InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView(viewModel: viewModel.codStepViewModel)
+            case .codPaymentGatewayNotSetUp(let plugin):
+                InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView(
+                    viewModel: InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(
+                        plugin: plugin,
+                        analyticReason: viewModel.state.reasonForAnalytics,
+                        completion: viewModel.refresh))
             case .completed:
                 InPersonPaymentsCompleted()
             case .noConnectionError:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -9,11 +9,6 @@ final class InPersonPaymentsViewModel: ObservableObject {
     private let useCase: CardPresentPaymentsOnboardingUseCase
     let stores: StoresManager
 
-    lazy var codStepViewModel: InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel = {
-        InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(configuration: useCase.configurationLoader.configuration,
-                                                                      completion: refresh)
-    }()
-
     /// Initializes the view model for a specific site
     ///
     init(stores: StoresManager = ServiceLocator.stores,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -106,23 +106,23 @@ private extension InPersonPaymentsViewModel {
     }
 
     func trackState(_ state: CardPresentPaymentOnboardingState) {
-        guard let reason = state.reasonForAnalytics else {
+        guard state.shouldTrackOnboardingStepEvents else {
             return
         }
         ServiceLocator.analytics
             .track(event: .InPersonPayments
-                    .cardPresentOnboardingNotCompleted(reason: reason,
-                                                       countryCode: countryCode))
+                .cardPresentOnboardingNotCompleted(reason: state.reasonForAnalytics,
+                                                   countryCode: countryCode))
     }
 
     func trackSkipped(state: CardPresentPaymentOnboardingState, remindLater: Bool) {
-        guard let reason = state.reasonForAnalytics else {
+        guard state.shouldTrackOnboardingStepEvents else {
             return
         }
 
         ServiceLocator.analytics.track(
             event: .InPersonPayments.cardPresentOnboardingStepSkipped(
-                reason: reason,
+                reason: state.reasonForAnalytics,
                 remindLater: remindLater,
                 countryCode: countryCode))
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift
@@ -28,7 +28,7 @@ struct InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView: View {
 
             Spacer()
 
-            InPersonPaymentsLearnMore(url: WooConstants.URLs.cashOnDeliveryLearnMoreUrl.asURL(),
+            InPersonPaymentsLearnMore(url: viewModel.learnMoreURL,
                                       formatText: Localization.cashOnDeliveryLearnMore,
                                       analyticReason: viewModel.analyticReason)
         }
@@ -37,8 +37,11 @@ struct InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView: View {
 
 struct InPersonPaymentsCodPaymentGatewayNotSetUp_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(configuration: CardPresentPaymentsConfiguration(country: "US"),
-                                                                                      completion: {})
+        let viewModel = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(
+            configuration: CardPresentPaymentsConfiguration(country: "US"),
+            plugin: .wcPay,
+            analyticReason: "",
+            completion: {})
         return InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -36,7 +36,7 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
 
     @Published var awaitingResponse = false
 
-    let analyticReason: String = CardPresentPaymentOnboardingState.codPaymentGatewayNotSetUp.reasonForAnalytics
+    let analyticReason: String
 
     // MARK: - Configuration properties
     private let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
@@ -45,11 +45,17 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
         stores.sessionManager.defaultStoreID
     }
 
+    let learnMoreURL: URL
+
     init(dependencies: Dependencies = Dependencies(),
-         configuration: CardPresentPaymentsConfiguration,
+         configuration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
+         plugin: CardPresentPaymentsPlugin,
+         analyticReason: String,
          completion: @escaping () -> Void) {
         self.dependencies = dependencies
         self.cardPresentPaymentsConfiguration = configuration
+        self.learnMoreURL = plugin.cashOnDeliveryLearnMoreURL
+        self.analyticReason = analyticReason
         self.completion = completion
     }
 
@@ -168,4 +174,15 @@ private enum Localization {
 
 private enum Constants {
     static let cashOnDeliveryGatewayID = "cod"
+}
+
+private extension CardPresentPaymentsPlugin {
+    var cashOnDeliveryLearnMoreURL: URL {
+        switch self {
+        case .wcPay:
+            return WooConstants.URLs.wcPayCashOnDeliveryLearnMoreUrl.asURL()
+        case .stripe:
+            return WooConstants.URLs.stripeCashOnDeliveryLearnMoreUrl.asURL()
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -36,7 +36,7 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
 
     @Published var awaitingResponse = false
 
-    let analyticReason: String = CardPresentPaymentOnboardingState.codPaymentGatewayNotSetUp.reasonForAnalytics ?? ""
+    let analyticReason: String = CardPresentPaymentOnboardingState.codPaymentGatewayNotSetUp.reasonForAnalytics
 
     // MARK: - Configuration properties
     private let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsCountryNotSupported: View {
     let countryCode: String
-    let analyticReason: String?
+    let analyticReason: String
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -47,8 +47,8 @@ private enum Localization {
 struct InPersonPaymentsCountryNotSupported_Previews: PreviewProvider {
     static var previews: some View {
         // Valid country code
-        InPersonPaymentsCountryNotSupported(countryCode: "ES", analyticReason: nil)
+        InPersonPaymentsCountryNotSupported(countryCode: "ES", analyticReason: "")
         // Invalid country code
-        InPersonPaymentsCountryNotSupported(countryCode: "OO", analyticReason: nil)
+        InPersonPaymentsCountryNotSupported(countryCode: "OO", analyticReason: "")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsCountryNotSupportedStripe: View {
     let countryCode: String
-    let analyticReason: String?
+    let analyticReason: String
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -47,8 +47,8 @@ private enum Localization {
 struct InPersonPaymentsCountryNotSupportedStripe_Previews: PreviewProvider {
     static var previews: some View {
         // Valid country code
-        InPersonPaymentsCountryNotSupportedStripe(countryCode: "ES", analyticReason: nil)
+        InPersonPaymentsCountryNotSupportedStripe(countryCode: "ES", analyticReason: "")
         // Invalid country code
-        InPersonPaymentsCountryNotSupportedStripe(countryCode: "OO", analyticReason: nil)
+        InPersonPaymentsCountryNotSupportedStripe(countryCode: "OO", analyticReason: "")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 struct InPersonPaymentsLiveSiteInTestMode: View {
     let plugin: CardPresentPaymentsPlugin
-    let analyticReason: String?
+    let analyticReason: String
     let onRefresh: () -> Void
 
     var body: some View {
@@ -46,6 +46,6 @@ private enum Localization {
 
 struct InPersonPaymentsLiveSiteInTestMode_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsLiveSiteInTestMode(plugin: .wcPay, analyticReason: nil, onRefresh: {})
+        InPersonPaymentsLiveSiteInTestMode(plugin: .wcPay, analyticReason: "", onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsNoConnection: View {
-    let analyticReason: String?
+    let analyticReason: String
     let onRefresh: () -> Void
 
     var body: some View {
@@ -43,6 +43,6 @@ private enum Localization {
 
 struct InPersonPaymentsNoConnection_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsNoConnection(analyticReason: nil, onRefresh: {})
+        InPersonPaymentsNoConnection(analyticReason: "", onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
@@ -7,7 +7,7 @@ struct InPersonPaymentsOnboardingError: View {
     let image: InPersonPaymentsOnboardingErrorMainContentView.ImageInfo
     let supportLink: Bool
     let learnMore: Bool
-    let analyticReason: String?
+    let analyticReason: String
     var buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel? = nil
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingErrorButtonViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingErrorButtonViewModel.swift
@@ -4,14 +4,14 @@ import Yosemite
 struct InPersonPaymentsOnboardingErrorButtonViewModel {
     let text: String
 
-    private let analyticReason: String?
+    private let analyticReason: String
 
     private let cardPresentConfiguration: CardPresentPaymentsConfiguration
 
     let action: () -> Void
 
     init(text: String,
-         analyticReason: String?,
+         analyticReason: String,
          cardPresentConfiguration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
          action: @escaping () -> Void) {
         self.text = text
@@ -20,7 +20,7 @@ struct InPersonPaymentsOnboardingErrorButtonViewModel {
         self.action = {
             ServiceLocator.analytics.track(
                 event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaTapped(
-                    reason: analyticReason ?? "",
+                    reason: analyticReason,
                     countryCode: cardPresentConfiguration.countryCode))
             action()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 struct InPersonPaymentsPluginNotActivated: View {
     let plugin: CardPresentPaymentsPlugin
-    let analyticReason: String?
+    let analyticReason: String
     let onRefresh: () -> Void
 
     var body: some View {
@@ -45,6 +45,6 @@ private enum Localization {
 
 struct InPersonPaymentsPluginNotActivated_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotActivated(plugin: .wcPay, analyticReason: nil, onRefresh: {})
+        InPersonPaymentsPluginNotActivated(plugin: .wcPay, analyticReason: "", onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsPluginNotInstalled: View {
-    let analyticReason: String?
+    let analyticReason: String
     let onRefresh: () -> Void
 
     var body: some View {
@@ -43,6 +43,6 @@ private enum Localization {
 
 struct InPersonPaymentsPluginNotInstalled_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotInstalled(analyticReason: nil, onRefresh: {})
+        InPersonPaymentsPluginNotInstalled(analyticReason: "", onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 struct InPersonPaymentsPluginNotSetup: View {
     let plugin: CardPresentPaymentsPlugin
-    let analyticReason: String?
+    let analyticReason: String
     private let cardPresentConfiguration = CardPresentConfigurationLoader().configuration
     let onRefresh: () -> Void
     @State private var presentedSetupURL: URL? = nil
@@ -28,7 +28,7 @@ struct InPersonPaymentsPluginNotSetup: View {
                 presentedSetupURL = setupURL
                 ServiceLocator.analytics.track(
                     event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaTapped(
-                        reason: analyticReason ?? "",
+                        reason: analyticReason,
                         countryCode: cardPresentConfiguration.countryCode))
             } label: {
                 HStack {
@@ -71,6 +71,6 @@ private enum Localization {
 }
 struct InPersonPaymentsPluginNotSetup_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotSetup(plugin: .wcPay, analyticReason: nil, onRefresh: {})
+        InPersonPaymentsPluginNotSetup(plugin: .wcPay, analyticReason: "", onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 struct InPersonPaymentsPluginNotSupportedVersion: View {
     let plugin: CardPresentPaymentsPlugin
-    let analyticReason: String?
+    let analyticReason: String
     let onRefresh: () -> Void
 
     var body: some View {
@@ -46,6 +46,6 @@ private enum Localization {
 
 struct InPersonPaymentsPluginNotSupportedVersion_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsPluginNotSupportedVersion(plugin: .wcPay, analyticReason: nil, onRefresh: {})
+        InPersonPaymentsPluginNotSupportedVersion(plugin: .wcPay, analyticReason: "", onRefresh: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsStripeAccountOverdue: View {
-    let analyticReason: String?
+    let analyticReason: String
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -33,6 +33,6 @@ private enum Localization {
 
 struct InPersonPaymentsStripeAccountOverdue_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAccountOverdue(analyticReason: nil)
+        InPersonPaymentsStripeAccountOverdue(analyticReason: "")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InPersonPaymentsStripeAccountPending: View {
     let deadline: Date?
-    let analyticReason: String?
+    let analyticReason: String
     let onSkip: () -> ()
 
     var body: some View {
@@ -58,7 +58,7 @@ private enum Localization {
 
 struct InPersonPaymentsStripeAccountPending_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAccountPending(deadline: Date(), analyticReason: nil, onSkip: {})
+        InPersonPaymentsStripeAccountPending(deadline: Date(), analyticReason: "", onSkip: {})
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsStripeAccountReview: View {
-    let analyticReason: String?
+    let analyticReason: String
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -32,6 +32,6 @@ private enum Localization {
 
 struct InPersonPaymentsStripeAccountReview_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAccountReview(analyticReason: nil)
+        InPersonPaymentsStripeAccountReview(analyticReason: "")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsStripeRejected: View {
-    let analyticReason: String?
+    let analyticReason: String
     var body: some View {
         InPersonPaymentsOnboardingError(
             title: Localization.title,
@@ -31,6 +31,6 @@ private enum Localization {
 
 struct InPersonPaymentsStripeRejected_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeRejected(analyticReason: nil)
+        InPersonPaymentsStripeRejected(analyticReason: "")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsUnavailableView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsUnavailableView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct InPersonPaymentsUnavailable: View {
-    let analyticReason: String?
+    let analyticReason: String
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -32,6 +32,6 @@ private enum Localization {
 
 struct InPersonPaymentsUnavailable_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsUnavailable(analyticReason: nil)
+        InPersonPaymentsUnavailable(analyticReason: "")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -780,7 +780,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        assertEqual(.codPaymentGatewayNotSetUp, state)
+        assertEqual(.codPaymentGatewayNotSetUp(plugin: .wcPay), state)
     }
 
     func test_onboarding_returns_complete_when_cod_disabled_and_cod_step_was_skipped() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift
@@ -31,19 +31,25 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests: 
             noticePresenter: noticePresenter,
             analytics: analytics
         )
-        sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(dependencies: dependencies,
-                                                                            configuration: configuration,
-                                                                            completion: {})
+        sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(
+            dependencies: dependencies,
+            configuration: configuration,
+            plugin: .wcPay,
+            analyticReason: AnalyticProperties.cashOnDeliveryDisabledReason,
+            completion: {})
     }
 
     func test_skip_always_calls_completion() {
         // Given
         let completionCalled: Bool = waitFor { promise in
-            let sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(dependencies: self.dependencies,
-                                                                                    configuration: self.configuration,
-                                                                                    completion: {
-                promise(true)
-            })
+            let sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(
+                dependencies: self.dependencies,
+                configuration: self.configuration,
+                plugin: .wcPay,
+                analyticReason: AnalyticProperties.cashOnDeliveryDisabledReason,
+                completion: {
+                    promise(true)
+                })
 
             // When
             sut.skipTapped()
@@ -85,11 +91,14 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests: 
         }
 
         let completionCalled: Bool = waitFor { promise in
-            let sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(dependencies: self.dependencies,
-                                                                                    configuration: self.configuration,
-                                                                                    completion: {
-                promise(true)
-            })
+            let sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(
+                dependencies: self.dependencies,
+                configuration: self.configuration,
+                plugin: .wcPay,
+                analyticReason: AnalyticProperties.cashOnDeliveryDisabledReason,
+                completion: {
+                    promise(true)
+                })
             // When
             sut.enableTapped()
         }
@@ -163,9 +172,12 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests: 
         }
 
         let _: Void = waitFor { promise in
-            let sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(dependencies: self.dependencies,
-                                                                                    configuration: self.configuration,
-                                                                                    completion: {
+            let sut = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel(
+                dependencies: self.dependencies,
+                configuration: self.configuration,
+                plugin: .wcPay,
+                analyticReason: AnalyticProperties.cashOnDeliveryDisabledReason,
+                completion: {
                 promise(())
             })
             // When

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -64,7 +64,7 @@ public enum CardPresentPaymentOnboardingState: Equatable {
     /// The Cash on Delivery payment gateway is missing or disabled
     /// Enabling Cash on Delivery is not essential for Card Present Payments, but allows web store customers to place orders and pay by card in person.
     ///
-    case codPaymentGatewayNotSetUp
+    case codPaymentGatewayNotSetUp(plugin: CardPresentPaymentsPlugin)
 
     /// Generic error - for example, one of the requests failed.
     ///

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -76,12 +76,12 @@ public enum CardPresentPaymentOnboardingState: Equatable {
 }
 
 extension CardPresentPaymentOnboardingState {
-    public var reasonForAnalytics: String? {
+    public var reasonForAnalytics: String {
         switch self {
         case .loading:
-            return nil
+            return "loading"
         case .completed:
-            return nil
+            return "completed"
         case .selectPlugin:
             return "multiple_payment_providers_conflict"
         case .countryNotSupported(countryCode: _):
@@ -112,6 +112,15 @@ extension CardPresentPaymentOnboardingState {
             return "generic_error"
         case .noConnectionError:
             return "no_connection_error"
+        }
+    }
+
+    public var shouldTrackOnboardingStepEvents: Bool {
+        switch self {
+        case .completed(_), .loading:
+            return false
+        default:
+            return true
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7596 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

On the Enable Pay in Person screen added as part of the Cash on Delivery project, we previously used the same Learn More link for both WCPay and Stripe.

The link went to the Stripe documentation, so could have caused confusion for WCPay users.

This PR provides a specific link for WCPay.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using two stores, both with Cash on Delivery disabled, one set up for WCPay and the other for Stripe, test the following:

1. Go to the Menu tab
2. Go to Payments
3. Tap "Continue Setup" (if it's not there, check the CoD setting is disabled and/or reinstall the app, you may have previously skipped it.)
4. The Enable Pay in Person IPP Onboarding step should show
5. Tap Learn More
6. Observe that a webview opens
7. Check that it opens to the correct (WCPay or Stripe) documentation for the plugin you're using.


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/187342650-2653f148-b686-4023-b162-683d82dc355b.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
