### PR TITLE
Add clarity to Apple ID login instructions

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,11 +3,6 @@
 10.1
 -----
 
-- [*] In-Person Payments: The onboarding notice on the In-Person Payments menu is correctly dismissed after multiple prompts are shown. [https://github.com/woocommerce/woocommerce-ios/pull/7543]
-- [*] Help center: Added custom help center web page with FAQs for "Enter Store Address" and "Enter WordPress.com email" screens. [https://github.com/woocommerce/woocommerce-ios/pull/7553, https://github.com/woocommerce/woocommerce-ios/pull/7573]
-- [*] In-Person Payments: The plugin selection is saved correctly after multiple onboarding prompts. [https://github.com/woocommerce/woocommerce-ios/pull/7544]
-- [*] In-Person Payments: A new prompt to enable `Pay in Person` for your store's checkout, to accept In-Person Payments for website orders [https://github.com/woocommerce/woocommerce-ios/issues/7474]
-- [internal] Add clarity to Apple ID login instructions. [https://github.com/woocommerce/woocommerce-ios/pull/7602]
 
 10.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,11 @@
 10.1
 -----
 
+- [*] In-Person Payments: The onboarding notice on the In-Person Payments menu is correctly dismissed after multiple prompts are shown. [https://github.com/woocommerce/woocommerce-ios/pull/7543]
+- [*] Help center: Added custom help center web page with FAQs for "Enter Store Address" and "Enter WordPress.com email" screens. [https://github.com/woocommerce/woocommerce-ios/pull/7553, https://github.com/woocommerce/woocommerce-ios/pull/7573]
+- [*] In-Person Payments: The plugin selection is saved correctly after multiple onboarding prompts. [https://github.com/woocommerce/woocommerce-ios/pull/7544]
+- [*] In-Person Payments: A new prompt to enable `Pay in Person` for your store's checkout, to accept In-Person Payments for website orders [https://github.com/woocommerce/woocommerce-ios/issues/7474]
+- [internal] Add clarity to Apple ID login instructions. [https://github.com/woocommerce/woocommerce-ios/pull/7602]
 
 10.0
 -----

--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -44,6 +44,13 @@ struct AuthenticationConstants {
         comment: "Sign in instructions for logging in with a username and password."
     )
 
+    /// Sign in using Apple screen's instructions.
+    ///
+    static let applePasswordInstructions = NSLocalizedString(
+        "To proceed with this account, please first log in with your WordPress.com password. This will only be asked once.",
+        comment: "Sign in instructions asking user to enter WordPress.com password to proceed with sign in using Apple process"
+    )
+
     /// Title of "Continue With WordPress.com" button in Login Prologue
     //
     static let continueWithWPButtonTitle = NSLocalizedString(

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -104,6 +104,7 @@ class AuthenticationManager: Authentication {
                                                                   siteLoginInstructions: AuthenticationConstants.siteInstructions,
                                                                   siteCredentialInstructions: AuthenticationConstants.siteCredentialInstructions,
                                                                   usernamePasswordInstructions: AuthenticationConstants.usernamePasswordInstructions,
+                                                                  applePasswordInstructions: AuthenticationConstants.applePasswordInstructions,
                                                                   continueWithWPButtonTitle: AuthenticationConstants.continueWithWPButtonTitle,
                                                                   enterYourSiteAddressButtonTitle: AuthenticationConstants.enterYourSiteAddressButtonTitle,
                                                                   signInWithSiteCredentialsButtonTitle: AuthenticationConstants.signInWithSiteCredsButtonTitle,


### PR DESCRIPTION
Closes: #7601

### Description
While logging in using Apple, we ask the user to enter WordPress.com email before proceeding with the sign-in the process. (Refer attached screenshot)

The instructions are "To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once.".

1. The phrase "Apple ID" from the instructions isn't clear enough, and users might end up entering their Apple ID password instead of the WordPress.com password.
1. This also violates Apple's guidelines as it looks like we are asking the user to enter their Apple ID password in our app.

### Changes
This PR injects a String for `applePasswordInstructions` in  `WordPressAuthenticatorDisplayStrings` initializer to replace Apple ID login instructions. 

### Testing instructions

⚠️ I cannot test this in the simulator. My iOS device is running iOS 15.6, and I cannot run the app from Xcode 13.4.1.  Kindly help me test this on a real device. ⚠️

1. Install and launch the app.
2. Tap on Continue with WordPress.com button
3. Tap on Continue with Apple button
4. After selecting the Apple ID, you will land in the `PasswordViewController` from the WordPressAuthenticator library.
5. Observe that the instructions string is "To proceed with this account, please first log in with your WordPress.com password. This will only be asked once."

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.