### PR TITLE
[UI tests] - Update test to return to orders list after create order

### DIFF
--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -39,6 +39,7 @@ final class OrdersTests: XCTestCase {
             .addCustomerNote(order.customer_note)
             .createOrder()
             .verifySingleOrderScreenLoaded()
+            .goBackToOrdersScreen()
     }
 
     func test_edit_existing_order() throws {


### PR DESCRIPTION
### Description
To match the implementation on Android, we're updating the create order test to end on the orders list screen instead of the order details screen.

Internal discussion: p1661499467676939-slack-C03H94A621E

### Testing instructions
Test should pass locally and in CI

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->