### PR TITLE
Rename WooFoundation SemanticColors to avoid UIColor conflicts

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -208,7 +208,7 @@ extension HubMenuViewModel {
 
         let title: String = Localization.woocommerceAdmin
         let icon: UIImage = .wordPressLogoImage
-        let iconColor: UIColor = .blue
+        let iconColor: UIColor = .wooBlue
         let badge: HubMenuBadgeType = .number(number: 0)
         let accessibilityIdentifier: String = "menu-woocommerce-admin"
         let trackingOption: String = "admin_menu"

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewViewModel.swift
@@ -43,7 +43,7 @@ final class ReviewViewModel {
             return NSAttributedString(string: review.review.strippedHTML).trimNewlines()
         }
 
-        let accentColor = UIColor.orange
+        let accentColor = UIColor.wooOrange
         let textColor = UIColor.textSubtle
 
         let pendingReviewLiteral = NSAttributedString(string: Strings.pendingReviews,

--- a/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
+++ b/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
@@ -64,14 +64,14 @@ public extension UIColor {
 
     /// Blue. Blue-50 (< iOS 13 and Light Mode) and Blue-30 (Dark Mode)
     ///
-    static var blue: UIColor {
+    static var wooBlue: UIColor {
         return UIColor(light: .withColorStudio(.blue, shade: .shade50),
                        dark: .withColorStudio(.blue, shade: .shade30))
     }
 
     /// Orange. Orange-50 (< iOS 13 and Light Mode) and Orange-30 (Dark Mode)
     ///
-    static var orange: UIColor {
+    static var wooOrange: UIColor {
         return UIColor(light: .withColorStudio(.orange, shade: .shade50),
                        dark: .withColorStudio(.orange, shade: .shade30))
     }


### PR DESCRIPTION
Closes: #7599
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR renames our `UIColor+SemanticColors` definition of `.blue` and `.orange` to `.wooBlue` and `.wooOrange` instead, in order to avoid conflicts with their same `UIColor` definitions. This is done to avoid unexpected behaviour or conflicts like the one reported on #7599

It seems we only use these in one place each: The WooCommerce Admin logo, and the "pending review" text. Happy to change the names as needed!

### Testing instructions
1. To check `wooBlue`: Go to the Menu tab, check that both light and dark mode display the correct colour for WooCommerce Admin logo.
2. To check `.wooOrange`: Go to one of your products in your site, leave a review. In the app, go to Menu > Reviews > Tap on the review > Mark "Approve" > check that both light and dark mode display the correct colour for review snippet text. This is easier to test by adding a breakpoint here: 

https://github.com/woocommerce/woocommerce-ios/blob/81ed7b18078c58d3337f53a91d0f09c802bf3c3f/WooCommerce/Classes/ViewRelated/Reviews/ReviewViewModel.swift#L46

### Screenshots
| Admin light| Admin dark| Reviews light| Reviews dark|
|--|--|--|--|
| ![Simulator Screen Shot - iPhone 11 - 2022-08-30 at 12 38 49](https://user-images.githubusercontent.com/3812076/187417099-4f5f8cfd-5858-404a-97ce-3dac01ccfd50.png)|![Simulator Screen Shot - iPhone 11 - 2022-08-30 at 12 39 00](https://user-images.githubusercontent.com/3812076/187417104-37a21e96-b51d-42d9-8ab3-a55413087d9f.png)|![Simulator Screen Shot - iPhone 11 - 2022-08-30 at 12 38 08](https://user-images.githubusercontent.com/3812076/187417278-c014f562-23b4-42a8-98d8-b841919ade16.png)|![Simulator Screen Shot - iPhone 11 - 2022-08-30 at 12 37 55](https://user-images.githubusercontent.com/3812076/187417270-c4276bf6-1ae4-4f63-bedf-1b51704e9222.png)|



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
