### PR TITLE
Remove `.orderListFilters` feature flag references

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -7,8 +7,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         switch featureFlag {
         case .barcodeScanner:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .orderListFilters:
-            return true
         case .jetpackConnectionPackageSupport:
             return true
         case .hubMenu:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -14,10 +14,6 @@ public enum FeatureFlag: Int {
     ///
     case reviews
 
-    /// Display the bar for displaying the filters in the Order List
-    ///
-    case orderListFilters
-
     /// Allows sites with plugins that include Jetpack Connection Package and without Jetpack-the-plugin to connect to the app
     ///
     case jetpackConnectionPackageSupport

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -212,11 +212,7 @@ private extension OrdersRootViewController {
 
     func configureFiltersBar() {
         // Display the filtered orders bar
-        // if the feature flag is enabled
-        let isOrderListFiltersEnabled = featureFlagService.isFeatureFlagEnabled(.orderListFilters)
-        if isOrderListFiltersEnabled {
-            stackView.addArrangedSubview(filtersBar)
-        }
+        stackView.addArrangedSubview(filtersBar)
         filtersBar.onAction = { [weak self] in
             self?.filterButtonTapped()
         }


### PR DESCRIPTION

### Description
As part of #7605, this PR removes the `.orderListFilter` feature flag, as well as logic that relies on this feature flag to display (or not) the Order Filter within the `OrdersRootViewController`.

### Testing instructions
1. Go to your App > Orders
2. See `All Orders` (left) and `Filter` (right) at the top of the screen
3. Confirm that the `Filter` button still appears and works as expected, for example selecting a "Order Status: Completed" will show these Orders, as well as change the text from "All Orders" to "Filtered Orders"

### Screenshots

<img width=400 src="https://user-images.githubusercontent.com/3812076/187447356-d0d57683-4f10-41b3-a8e4-468f26ff8a76.png">



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
