### PR TITLE
Remove `.systemStatusReport` feature flag references

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -11,8 +11,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .hubMenu:
             return true
-        case .systemStatusReport:
-            return true
         case .couponView:
             return true
         case .productSKUInputScanner:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -22,10 +22,6 @@ public enum FeatureFlag: Int {
     ///
     case hubMenu
 
-    /// Displays the System Status Report on Settings/Help screen
-    ///
-    case systemStatusReport
-
     /// Displays the option to view coupons
     ///
     case couponView

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -165,10 +165,8 @@ private extension HelpAndSupportViewController {
 
         rows.append(contentsOf: [.myTickets,
                                  .contactEmail,
-                                 .applicationLog])
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.systemStatusReport) {
-            rows.append(.systemStatusReport)
-        }
+                                 .applicationLog,
+                                 .systemStatusReport])
         return rows
     }
 


### PR DESCRIPTION
### Description
As part of https://github.com/woocommerce/woocommerce-ios/issues/7605 (removing feature-flag-related code that has been in production for a while) this PR removes the `.systemStatusReport` feature flag, as well as logic that relies on it.

In this case, the only change happens in `HelpAndSupportViewController`, where the flag performs a check to append the "System Status Report" row to the rest of available options.

### Testing instructions
1. Navigate to Menu > Help & Support > System Status Report
2. Confirm that the "System Status Report" row still appears, is tappable, and works normally.

### Screenshots
<img width=400 src="https://user-images.githubusercontent.com/3812076/187625884-cffc3043-97f8-4673-830a-3039fee9ffbb.png">


<!-- Include before and after images or gifs when appropriate. -->


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
