### PR TITLE
[Engage] Universal Links: Handle Order Details universal links

### DIFF
--- a/WooCommerce/Classes/Universal Links/RouteMatcher.swift
+++ b/WooCommerce/Classes/Universal Links/RouteMatcher.swift
@@ -7,7 +7,7 @@ struct MatchedRoute {
     let route: Route
     let parameters: [String: String]
 
-    func performAction() {
+    func performAction() -> Bool {
         route.perform(with: parameters)
     }
 }

--- a/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
@@ -17,7 +17,7 @@ struct OrderDetailsRoute: Route {
         }
 
         MainTabBarController.navigateToOrderDetails(with: orderId, siteID: storeId)
-        
+
         return true
     }
 }

--- a/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
@@ -11,7 +11,7 @@ struct OrderDetailsRoute: Route {
               let storeId = Int64(storeIdString),
               let orderIdString = parameters[ParametersKeys.orderId],
               let orderId = Int64(orderIdString) else {
-            return
+            return DDLogError("Error: we receive an universal link for order details but parameters couldn't be parsed.")
         }
 
         MainTabBarController.navigateToOrderDetails(with: orderId, siteID: storeId)

--- a/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
@@ -6,26 +6,15 @@ import Yosemite
 struct OrderDetailsRoute: Route {
     let path = "/orders/details"
 
-    private let switchStoreUseCase: SwitchStoreUseCaseProtocol
-
-    init(switchStoreUseCase: SwitchStoreUseCaseProtocol = SwitchStoreUseCase(stores: ServiceLocator.stores)) {
-        self.switchStoreUseCase = switchStoreUseCase
-    }
-
     func perform(with parameters: [String: String]) {
         guard let storeIdString = parameters[ParametersKeys.blogId],
               let storeId = Int64(storeIdString),
-              let orderId = parameters[ParametersKeys.orderId] else {
+              let orderIdString = parameters[ParametersKeys.orderId],
+              let orderId = Int64(orderIdString) else {
             return
         }
 
-        switchStoreUseCase.switchStore(with: storeId, onCompletion: { siteChanged in
-            if siteChanged {
-                let presenter = SwitchStoreNoticePresenter(siteID: storeId)
-                presenter.presentStoreSwitchedNoticeWhenSiteIsAvailable(configuration: .switchingStores)
-                MainTabBarController.switchToOrdersTab()
-            }
-        })
+        MainTabBarController.presentOrderDetails(with: orderId, siteID: storeId)
     }
 }
 

--- a/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
@@ -6,15 +6,19 @@ import Yosemite
 struct OrderDetailsRoute: Route {
     let path = "/orders/details"
 
-    func perform(with parameters: [String: String]) {
+    func perform(with parameters: [String: String]) -> Bool {
         guard let storeIdString = parameters[ParametersKeys.blogId],
               let storeId = Int64(storeIdString),
               let orderIdString = parameters[ParametersKeys.orderId],
               let orderId = Int64(orderIdString) else {
-            return DDLogError("Error: we receive an universal link for order details but parameters couldn't be parsed.")
+            DDLogError("Error: we receive an universal link for order details but parameters couldn't be parsed.")
+
+            return false
         }
 
         MainTabBarController.navigateToOrderDetails(with: orderId, siteID: storeId)
+        
+        return true
     }
 }
 

--- a/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
@@ -1,11 +1,31 @@
 import Foundation
+import Yosemite
 
 /// Shows order details from a given universal link that matches the right path
 ///
 struct OrderDetailsRoute: Route {
     let path = "/orders/details"
 
+    private let switchStoreUseCase: SwitchStoreUseCaseProtocol
+
+    init(switchStoreUseCase: SwitchStoreUseCaseProtocol = SwitchStoreUseCase(stores: ServiceLocator.stores)) {
+        self.switchStoreUseCase = switchStoreUseCase
+    }
+
     func perform(with parameters: [String: String]) {
-        DDLogInfo("We received an order details universal link with parameters: \(parameters)")
+        guard let storeIdString = parameters[ParametersKeys.blogId],
+              let storeId = Int64(storeIdString),
+              let orderId = parameters[ParametersKeys.orderId] else {
+            return
+        }
+
+        switchStoreUseCase.switchStore(with: storeId, onCompletion: {_ in})
+    }
+}
+
+private extension OrderDetailsRoute {
+    enum ParametersKeys {
+        static let blogId = "blog_id"
+        static let orderId = "order_id"
     }
 }

--- a/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
@@ -19,7 +19,13 @@ struct OrderDetailsRoute: Route {
             return
         }
 
-        switchStoreUseCase.switchStore(with: storeId, onCompletion: {_ in})
+        switchStoreUseCase.switchStore(with: storeId, onCompletion: { siteChanged in
+            if siteChanged {
+                let presenter = SwitchStoreNoticePresenter(siteID: storeId)
+                presenter.presentStoreSwitchedNoticeWhenSiteIsAvailable(configuration: .switchingStores)
+                MainTabBarController.switchToOrdersTab()
+            }
+        })
     }
 }
 

--- a/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
@@ -14,7 +14,7 @@ struct OrderDetailsRoute: Route {
             return
         }
 
-        MainTabBarController.presentOrderDetails(with: orderId, siteID: storeId)
+        MainTabBarController.navigateToOrderDetails(with: orderId, siteID: storeId)
     }
 }
 

--- a/WooCommerce/Classes/Universal Links/Routes/Route.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/Route.swift
@@ -4,7 +4,13 @@ import Foundation
 /// A universal link route, used to encapsulate a URL path and action
 /// 
 protocol Route {
+    /// The url path to match so this route can perform its navigation
+    ///
     var path: String { get }
 
-    func perform(with parameters: [String: String])
+    /// Performs the action related to this route, usually a navigation.
+    /// - Parameter parameters: The parameters dictionary that was contained in the URL
+    /// - Returns: Whether the `Route` could perform the action or not.
+    ///
+    func perform(with parameters: [String: String]) -> Bool
 }

--- a/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
+++ b/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
@@ -29,10 +29,9 @@ struct UniversalLinkRouter {
     ]
 
     func handle(url: URL) {
-        guard let matchedRoute = matcher.firstRouteMatching(url) else {
+        guard let matchedRoute = matcher.firstRouteMatching(url),
+              matchedRoute.performAction() else {
             return bouncingURLOpener.open(url)
         }
-
-        matchedRoute.performAction()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -347,14 +347,11 @@ extension MainTabBarController {
                 return
             }
             let siteID = Int64(note.meta.identifier(forKey: .site) ?? Int.min)
-            SwitchStoreUseCase(stores: ServiceLocator.stores).switchStore(with: siteID) { siteChanged in
+
+            switchToStore(with: siteID, onCompletion: {
                 presentNotificationDetails(for: note)
 
-                if siteChanged {
-                    let presenter = SwitchStoreNoticePresenter(siteID: siteID)
-                    presenter.presentStoreSwitchedNoticeWhenSiteIsAvailable(configuration: .switchingStores)
-                }
-            }
+            })
         }
         ServiceLocator.stores.dispatch(action)
     }
@@ -382,6 +379,17 @@ extension MainTabBarController {
                                                                               "already_read": note.read ])
     }
 
+    private static func switchToStore(with siteID: Int64, onCompletion: @escaping () -> Void) {
+        SwitchStoreUseCase(stores: ServiceLocator.stores).switchStore(with: siteID) { siteChanged in
+            if siteChanged {
+                let presenter = SwitchStoreNoticePresenter(siteID: siteID)
+                presenter.presentStoreSwitchedNoticeWhenSiteIsAvailable(configuration: .switchingStores)
+            }
+
+            onCompletion()
+        }
+    }
+
     /// Switches to the My Store Tab, and presents the Settings .
     ///
     static func presentSettings() {
@@ -392,6 +400,18 @@ extension MainTabBarController {
         }
 
         dashBoard.presentSettings()
+    }
+
+    static func presentOrderDetails(with orderID: Int64, siteID: Int64) {
+        switchToStore(with: siteID, onCompletion: {
+            switchToOrdersTab {
+                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+                    (childViewController() as? OrdersSplitViewWrapperController)?.presentDetails(for: orderID, siteID: siteID)
+                } else {
+                    (childViewController() as? OrdersRootViewController)?.presentDetails(for: orderID, siteID: siteID)
+                }
+            }
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -402,16 +402,23 @@ extension MainTabBarController {
         dashBoard.presentSettings()
     }
 
-    static func presentOrderDetails(with orderID: Int64, siteID: Int64) {
+    static func navigateToOrderDetails(with orderID: Int64, siteID: Int64) {
         switchToStore(with: siteID, onCompletion: {
             switchToOrdersTab {
-                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-                    (childViewController() as? OrdersSplitViewWrapperController)?.presentDetails(for: orderID, siteID: siteID)
-                } else {
-                    (childViewController() as? OrdersRootViewController)?.presentDetails(for: orderID, siteID: siteID)
+                // We give some time to the orders tab transition to finish, otherwise it might prevent the second navigation from happening
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    presentDetails(for: orderID, siteID: siteID)
                 }
             }
         })
+    }
+
+    private static func presentDetails(for orderID: Int64, siteID: Int64) {
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+            (childViewController() as? OrdersSplitViewWrapperController)?.presentDetails(for: orderID, siteID: siteID)
+        } else {
+            (childViewController() as? OrdersRootViewController)?.presentDetails(for: orderID, siteID: siteID)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
@@ -14,7 +14,7 @@ class OrderLoaderViewController: UIViewController {
 
     /// Source push notification `Note`
     ///
-    private let note: Note
+    private let note: Note?
 
     /// Target OrderID
     ///
@@ -50,7 +50,7 @@ class OrderLoaderViewController: UIViewController {
 
     // MARK: - Initializers
 
-    init(note: Note, orderID: Int64, siteID: Int64) {
+    init(note: Note?, orderID: Int64, siteID: Int64) {
         self.note = note
         self.orderID = orderID
         self.siteID = siteID
@@ -264,7 +264,9 @@ private extension OrderLoaderViewController {
             startSpinner()
         case .success(let order):
             presentOrderDetails(for: order)
-            markNotificationAsReadIfNeeded(note: note)
+            if let note = note {
+                markNotificationAsReadIfNeeded(note: note)
+            }
         case .failure:
             displayFailureOverlay()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
@@ -3,8 +3,9 @@ import UIKit
 import Yosemite
 
 
-// MARK: - OrderLoaderViewController: Loads asynchronously an Order from a push notification (given it's OrderID + SiteID).
-//         On Success the OrderDetailsViewController will be rendered "in place".
+// Loads and render an Order details asynchronously.
+// This is useful for showing the details of an order coming from a push notification or universal link.
+// On Success the OrderDetailsViewController will be rendered "in place".
 //
 class OrderLoaderViewController: UIViewController {
 
@@ -50,10 +51,10 @@ class OrderLoaderViewController: UIViewController {
 
     // MARK: - Initializers
 
-    init(note: Note?, orderID: Int64, siteID: Int64) {
-        self.note = note
+    init(orderID: Int64, siteID: Int64, note: Note? = nil) {
         self.orderID = orderID
         self.siteID = siteID
+        self.note = note
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -136,7 +136,7 @@ final class OrdersRootViewController: UIViewController {
     }
 
     func presentDetails(for orderID: Int64, siteID: Int64, note: Note? = nil) {
-        let loaderViewController = OrderLoaderViewController(note: note, orderID: Int64(orderID), siteID: Int64(siteID))
+        let loaderViewController = OrderLoaderViewController(orderID: Int64(orderID), siteID: Int64(siteID), note: note)
         navigationController?.pushViewController(loaderViewController, animated: true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -126,10 +126,16 @@ final class OrdersRootViewController: UIViewController {
     /// Presents the Details for the Notification with the specified Identifier.
     ///
     func presentDetails(for note: Note) {
-        guard let orderID = note.meta.identifier(forKey: .order), let siteID = note.meta.identifier(forKey: .site) else {
+        guard let orderID = note.meta.identifier(forKey: .order),
+              let siteID = note.meta.identifier(forKey: .site) else {
             DDLogError("## Notification with [\(note.noteID)] lacks its OrderID!")
             return
         }
+
+        presentDetails(for: Int64(orderID), siteID: Int64(siteID), note: note)
+    }
+
+    func presentDetails(for orderID: Int64, siteID: Int64, note: Note? = nil) {
         let loaderViewController = OrderLoaderViewController(note: note, orderID: Int64(orderID), siteID: Int64(siteID))
         navigationController?.pushViewController(loaderViewController, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -32,12 +32,17 @@ final class OrdersSplitViewWrapperController: UIViewController {
     /// Presents the Details for the Notification with the specified Identifier.
     ///
     func presentDetails(for note: Note) {
-        guard let orderID = note.meta.identifier(forKey: .order), let siteID = note.meta.identifier(forKey: .site) else {
+        guard let orderID = note.meta.identifier(forKey: .order),
+              let siteID = note.meta.identifier(forKey: .site) else {
             DDLogError("## Notification with [\(note.noteID)] lacks its OrderID!")
             return
         }
 
-        let loaderViewController = OrderLoaderViewController(note: note, orderID: Int64(orderID), siteID: Int64(siteID))
+        presentDetails(for: Int64(orderID), siteID: Int64(siteID), note: note)
+    }
+
+    func presentDetails(for orderID: Int64, siteID: Int64, note: Note? = nil) {
+        let loaderViewController = OrderLoaderViewController(note: note, orderID: orderID, siteID: Int64(siteID))
         let loaderNavigationController = WooNavigationController(rootViewController: loaderViewController)
 
         ordersSplitViewController.showDetailViewController(loaderNavigationController, sender: nil)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -42,7 +42,7 @@ final class OrdersSplitViewWrapperController: UIViewController {
     }
 
     func presentDetails(for orderID: Int64, siteID: Int64, note: Note? = nil) {
-        let loaderViewController = OrderLoaderViewController(note: note, orderID: orderID, siteID: Int64(siteID))
+        let loaderViewController = OrderLoaderViewController(orderID: orderID, siteID: Int64(siteID), note: note)
         let loaderNavigationController = WooNavigationController(rootViewController: loaderViewController)
 
         ordersSplitViewController.showDetailViewController(loaderNavigationController, sender: nil)

--- a/WooCommerce/WooCommerceTests/Mocks/MockRoute.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockRoute.swift
@@ -2,14 +2,14 @@
 
 final class MockRoute: Route {
     let path: String
-    let performAction: ([String: String]) -> ()
+    let performAction: ([String: String]) -> Bool
 
-    init(path: String, performAction: @escaping ([String: String]) -> ()) {
+    init(path: String, performAction: @escaping ([String: String]) -> Bool) {
         self.path = path
         self.performAction = performAction
     }
 
-    func perform(with parameters: [String: String]) {
+    func perform(with parameters: [String: String]) -> Bool {
         performAction(parameters)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7537 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the app navigation to the order details screen when the app is opened through a universal link. For that, we reuse parts of the order notification code base, that already had a view controller to load and render the order details asynchronously. Likewise, we reuse some code of the `MainTabBarController` (such as switching the store) and extend it with the required functionality of this task (opening details with `siteID` and `orderID`).
As we are performing two transitions to show the order details (go to orders tab, show order details view) we can have unbalanced begin/end appearance transitions, preventing the second transition from happening. That happens even if we perform the second transition when the completion block of the first is called:  Xcode console warning: 

`Unbalanced calls to begin/end appearance transitions for <WooCommerce.OrdersSplitViewWrapperController: 0x124d2be80>.`

Because of that, I added a delay of 0.3 before performing the second transition. The purpose of this is twofold; firstly we want to avoid the problem above, secondly, we want to show the orders list in the orders tab before showing the details we let the user know where in the app are we. While adding a delay is not the most optimal solution, I think it represents a good compromise to solve these challenges.

### Changes
- Call the navigation action from `OrderDetailsRoute`
- Implement navigation in `MainTabBarController` reusing the code we had for showing Order details from notification
- Extend the implementation of `OrdersSplitViewWrapperController` and `OrdersRootViewController` to open the details given `siteID` and `orderID`
- Adapt `OrderLoaderViewController` to open order details from a source other than a pushed notification

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
At the moment there is no easy way to test it as the domain verification is not yet implemented in woocommerce.com, so either you can wait for the domain verification to be added, or the next steps to test it now:

1. Add applinks:thelinkswootester.mystagingwebsite.com to the Associated Domains in the WooCommerce target screen. 
<img width="915" alt="Screenshot 2022-08-23 at 18 28 17" src="https://user-images.githubusercontent.com/1864060/186211830-d2a37a93-0e41-4082-8a76-92a6121ce8af.png">
This is my dummy pressable test site. (We do not have domain verification ready in woocommerce.com) I uploaded the [`apple-app-site-association`](https://thelinkswootester.mystagingwebsite.com/apple-app-site-association) with paths:

```
"paths":[
               "/payments",
	             "/orders/details"
            ]
```

2. Send yourself an email containing a link with the format 
https://thelinkswootester.mystagingwebsite.com/orders/details?blog_id=your storeID&order_id=an existing orderID

3. Tap on it. You can also test the switch to a different store by adding a store id to the link other than the currently selected in Woo app.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
#### Open link with an order belonging to a store already selected in the app

https://user-images.githubusercontent.com/1864060/187661029-73b218a0-f28f-44cb-9da8-5fae53eb31cf.mov

#### Open link with an order belonging to a store not selected in the app. Switch store

https://user-images.githubusercontent.com/1864060/187661149-cf24c898-a9d1-4201-bde4-f3ae3f7384a7.mov

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
