### PR TITLE
[Mobile Payments] UI for Enable Pay in Person toggle switch in IPP settings

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -52,7 +52,7 @@ class AuthenticationManager: Authentication {
                                                                 wpcomScheme: ApiCredentials.dotcomAuthScheme,
                                                                 wpcomTermsOfServiceURL: WooConstants.URLs.termsOfService.rawValue,
                                                                 wpcomAPIBaseURL: Settings.wordpressApiBaseURL,
-                                                                whatIsWPComURL: WooConstants.URLs.whatIsWPComURL.rawValue,
+                                                                whatIsWPComURL: WooConstants.URLs.whatIsWPCom.rawValue,
                                                                 googleLoginClientId: ApiCredentials.googleClientId,
                                                                 googleLoginServerClientId: ApiCredentials.googleServerId,
                                                                 googleLoginScheme: ApiCredentials.googleAuthScheme,

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -73,7 +73,7 @@ private extension NotWPAccountViewModel {
             return
         }
         ServiceLocator.analytics.track(.whatIsWPComOnInvalidEmailScreenTapped)
-        WebviewHelper.launch(WooConstants.URLs.whatIsWPComURL.asURL(), with: viewController)
+        WebviewHelper.launch(WooConstants.URLs.whatIsWPCom.asURL(), with: viewController)
     }
 
     func needHelpFindingEmailButtonTapped() {

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -55,7 +55,7 @@ extension WooConstants {
         ///
         /// Displayed by the Authenticator in the Continue with WordPress.com flow.
         ///
-        case whatIsWPComURL = "https://woocommerce.com/document/what-is-a-wordpress-com-account/"
+        case whatIsWPCom = "https://woocommerce.com/document/what-is-a-wordpress-com-account/"
 
         /// Terms of Service Website. Displayed by the Authenticator (when / if needed).
         ///
@@ -182,11 +182,11 @@ extension WooConstants {
 #endif
         /// URL for the Enable Cash on Delivery (or Pay in Person) onboarding step's learn more link using the Stripe plugin
         /// 
-        case stripeCashOnDeliveryLearnMoreUrl = "https://woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/#section-8"
+        case stripeCashOnDeliveryLearnMore = "https://woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/#section-8"
 
         /// URL for the Enable Cash on Delivery (or Pay in Person) onboarding step's learn more link using the WCPay plugin
         ///
-        case wcPayCashOnDeliveryLearnMoreUrl =
+        case wcPayCashOnDeliveryLearnMore =
                 "https://woocommerce.com/document/payments/getting-started-with-in-person-payments-with-woocommerce-payments/#add-cod-payment-method"
 
         /// Returns the URL version of the receiver

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -150,7 +150,7 @@ struct CardReaderSettingsSearchingView: View {
             InPersonPaymentsLearnMore()
                 .customOpenURL(action: { url in
                     switch url {
-                    case InPersonPaymentsLearnMore.learnMoreURL:
+                    case LearnMoreViewModel.learnMoreURL:
                         if let url = learnMoreUrl {
                             showURL?(url)
                         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsPlugin+CashOnDelivery.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsPlugin+CashOnDelivery.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Yosemite
+
+extension CardPresentPaymentsPlugin {
+    var cashOnDeliveryLearnMoreURL: URL {
+        switch self {
+        case .wcPay:
+            return WooConstants.URLs.wcPayCashOnDeliveryLearnMore.asURL()
+        case .stripe:
+            return WooConstants.URLs.stripeCashOnDeliveryLearnMore.asURL()
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Yosemite
+
+extension PaymentGateway {
+    /// Creates a PaymentGateway with default settings suitable for enabling Pay in Person on a store.
+    /// This provides customer-facing strings to update the store's gateway.
+    /// The gateway is enabled.
+    static func defaultPayInPersonGateway(siteID: Int64) -> PaymentGateway {
+        PaymentGateway(siteID: siteID,
+                       gatewayID: Constants.cashOnDeliveryGatewayID,
+                       title: Localization.cashOnDeliveryCheckoutTitle,
+                       description: Localization.cashOnDeliveryCheckoutDescription,
+                       enabled: true,
+                       features: [.products],
+                       instructions: Localization.cashOnDeliveryCheckoutInstructions)
+    }
+
+    enum Constants {
+        static let cashOnDeliveryGatewayID = "cod"
+    }
+
+    private enum Localization {
+        static let cashOnDeliveryCheckoutTitle = NSLocalizedString(
+            "Pay in Person",
+            comment: "Customer-facing title for the payment option added to the store checkout when the merchant enables " +
+            "Pay in Person")
+
+        static let cashOnDeliveryCheckoutDescription = NSLocalizedString(
+            "Pay by card or another accepted payment method",
+            comment: "Customer-facing description showing more details about the Pay in Person option which is added to " +
+            "the store checkout when the merchant enables Pay in Person")
+
+        static let cashOnDeliveryCheckoutInstructions = NSLocalizedString(
+            "Pay by card or another accepted payment method",
+            comment: "Customer-facing instructions shown on Order Thank-you pages and confirmation emails, showing more " +
+            "details about the Pay in Person option added to the store checkout when the merchant enables Pay in Person")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -1,22 +1,12 @@
 import SwiftUI
 
 struct InPersonPaymentsLearnMore: View {
-    static let learnMoreURL = URL(string: "woocommerce://in-person-payments/learn-more")!
     @Environment(\.customOpenURL) var customOpenURL
 
-    let url: URL
-    let linkText: String
-    let formatText: String
-    let analyticReason: String?
+    private let viewModel: LearnMoreViewModel
 
-    init(url: URL = learnMoreURL,
-         linkText: String = Localization.learnMoreLink,
-         formatText: String = Localization.learnMoreText,
-         analyticReason: String? = nil) {
-        self.url = url
-        self.linkText = linkText
-        self.formatText = formatText
-        self.analyticReason = analyticReason
+    init(viewModel: LearnMoreViewModel = LearnMoreViewModel()) {
+        self.viewModel = viewModel
     }
 
     private let cardPresentConfiguration = CardPresentConfigurationLoader().configuration
@@ -27,37 +17,17 @@ struct InPersonPaymentsLearnMore: View {
                 .resizable()
                 .foregroundColor(Color(.neutral(.shade60)))
                 .frame(width: iconSize, height: iconSize)
-            AttributedText(learnMoreAttributedString)
+            AttributedText(viewModel.learnMoreAttributedString)
         }
             .padding(.vertical, Constants.verticalPadding)
             .onTapGesture {
-                ServiceLocator.analytics.track(
-                    event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingLearnMoreTapped(
-                        reason: analyticReason ?? "",
-                        countryCode: cardPresentConfiguration.countryCode))
-                customOpenURL?(url)
+                viewModel.learnMoreTapped()
+                customOpenURL?(viewModel.url)
             }
     }
 
     var iconSize: CGFloat {
         UIFontMetrics(forTextStyle: .subheadline).scaledValue(for: 20)
-    }
-
-    private var learnMoreAttributedString: NSAttributedString {
-        let result = NSMutableAttributedString(
-            string: .localizedStringWithFormat(formatText, linkText),
-            attributes: [.foregroundColor: UIColor.textSubtle]
-        )
-        result.replaceFirstOccurrence(
-            of: linkText,
-            with: NSAttributedString(
-                string: linkText,
-                attributes: [.foregroundColor: UIColor.textLink]
-            ))
-
-        // https://github.com/gonzalezreal/AttributedText/issues/11
-        result.addAttribute(.font, value: UIFont.footnote, range: NSRange(location: 0, length: result.length))
-        return result
     }
 }
 
@@ -74,14 +44,6 @@ private enum Localization {
     static let acceptCash = NSLocalizedString(
         "You can still accept in-person cash payments by enabling the “Cash on Delivery” payment method on your store.",
         comment: "Generic error message when In-Person Payments is unavailable"
-    )
-
-    static let learnMoreLink = NSLocalizedString(
-        "Learn more",
-        comment: """
-                 A label prompting users to learn more about card readers.
-                 This part is the link to the website, and forms part of a longer sentence which it should be considered a part of.
-                 """
     )
 
     static let learnMoreText = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -110,6 +110,8 @@ private extension InPersonPaymentsMenuViewController {
             showCardPresentPaymentsOnboardingNotice()
         }
 
+        updateViewModelSelectedPlugin(state: state)
+
         activityIndicator?.stopAnimating()
         configureSections()
         tableView.reloadData()
@@ -128,6 +130,17 @@ private extension InPersonPaymentsMenuViewController {
 
     func dismissCardPresentPaymentsOnboardingNoticeIfPresent() {
         permanentNoticePresenter.dismiss()
+    }
+
+    func updateViewModelSelectedPlugin(state: CardPresentPaymentOnboardingState) {
+        switch state {
+        case let .completed(pluginState):
+            inPersonPaymentsMenuViewModel.selectedPlugin = pluginState.preferred
+        case let .codPaymentGatewayNotSetUp(plugin):
+            inPersonPaymentsMenuViewModel.selectedPlugin = plugin
+        default:
+            inPersonPaymentsMenuViewModel.selectedPlugin = nil
+        }
     }
 
     func showOnboarding() {
@@ -280,7 +293,11 @@ private extension InPersonPaymentsMenuViewController {
                        text: Localization.toggleEnableCashOnDelivery,
                        subtitle: learnMoreViewModel.learnMoreAttributedString,
                        switchState: inPersonPaymentsMenuViewModel.cashOnDeliveryEnabledState,
-                       switchAction: inPersonPaymentsMenuViewModel.updateCashOnDeliverySetting(enabled:))
+                       switchAction: inPersonPaymentsMenuViewModel.updateCashOnDeliverySetting(enabled:),
+                       subtitleTapAction: { [weak self] in
+            guard let self = self else { return }
+            self.inPersonPaymentsMenuViewModel.learnMoreTapped(from: self)
+        })
     }
 
     func updateEnabledState(in cell: UITableViewCell, shouldBeEnabled: Bool = true) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -13,7 +13,7 @@ final class InPersonPaymentsMenuViewController: UIViewController {
     private let cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCase
     private var cancellables: Set<AnyCancellable> = []
     private lazy var learnMoreViewModel: LearnMoreViewModel = {
-        LearnMoreViewModel(url: WooConstants.URLs.wcPayCashOnDeliveryLearnMoreUrl.asURL(),
+        LearnMoreViewModel(url: WooConstants.URLs.wcPayCashOnDeliveryLearnMore.asURL(),
                            linkText: Localization.toggleEnableCashOnDeliveryLearnMoreLink,
                            formatText: Localization.toggleEnableCashOnDeliveryLearnMoreFormat,
                            tappedAnalyticEvent: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingLearnMoreTapped(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -20,6 +20,7 @@ final class InPersonPaymentsMenuViewController: UIViewController {
                             reason: "reason",
                             countryCode: configurationLoader.configuration.countryCode))
     }()
+    private let inPersonPaymentsMenuViewModel: InPersonPaymentsMenuViewModel
 
     /// No Manuals to be shown in a country where IPP is not supported
     /// 
@@ -52,6 +53,7 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         self.featureFlagService = featureFlagService
         self.cardPresentPaymentsOnboardingUseCase = CardPresentPaymentsOnboardingUseCase()
         configurationLoader = CardPresentConfigurationLoader()
+        self.inPersonPaymentsMenuViewModel = InPersonPaymentsMenuViewModel()
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -66,6 +68,7 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         configureSections()
         configureTableView()
         registerTableViewCells()
+        configureTableReload()
         runCardPresentPaymentsOnboarding()
     }
 }
@@ -273,13 +276,22 @@ private extension InPersonPaymentsMenuViewController {
         cell.leftImageView?.tintColor = .text
         cell.accessoryType = .none
         cell.selectionStyle = .none
-        cell.configure(image: .creditCardIcon, text: Localization.toggleEnableCashOnDelivery, subtitle: learnMoreViewModel.learnMoreAttributedString)
+        cell.configure(image: .creditCardIcon,
+                       text: Localization.toggleEnableCashOnDelivery,
+                       subtitle: learnMoreViewModel.learnMoreAttributedString,
+                       switchState: inPersonPaymentsMenuViewModel.cashOnDeliveryEnabledState)
     }
 
     func updateEnabledState(in cell: UITableViewCell, shouldBeEnabled: Bool = true) {
         let alpha = shouldBeEnabled ? 1 : 0.3
         cell.imageView?.alpha = alpha
         cell.textLabel?.alpha = alpha
+    }
+
+    func configureTableReload() {
+        inPersonPaymentsMenuViewModel.$cashOnDeliveryEnabledState.sink { [weak self] _ in
+            self?.tableView.reloadData()
+        }.store(in: &cancellables)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -88,7 +88,7 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func refreshAfterNewOnboardingState(_ state: CardPresentPaymentOnboardingState) {
-        self.pluginState = nil
+        pluginState = nil
 
         guard state != .loading else {
             self.activityIndicator?.startAnimating()
@@ -97,22 +97,22 @@ private extension InPersonPaymentsMenuViewController {
 
         switch state {
         case let .completed(newPluginState):
-            self.pluginState = newPluginState
-            self.dismissCardPresentPaymentsOnboardingNoticeIfPresent()
-            self.dismissOnboardingIfPresented()
+            pluginState = newPluginState
+            dismissCardPresentPaymentsOnboardingNoticeIfPresent()
+            dismissOnboardingIfPresented()
         case let .selectPlugin(pluginSelectionWasCleared):
             // If it was cleared it means that we triggered it manually (e.g by tapping in this view on the plugin selection row)
             // No need to show the onboarding notice
             if !pluginSelectionWasCleared {
-                self.showCardPresentPaymentsOnboardingNotice()
+                showCardPresentPaymentsOnboardingNotice()
             }
         default:
-            self.showCardPresentPaymentsOnboardingNotice()
+            showCardPresentPaymentsOnboardingNotice()
         }
 
-        self.activityIndicator?.stopAnimating()
-        self.configureSections()
-        self.tableView.reloadData()
+        activityIndicator?.stopAnimating()
+        configureSections()
+        tableView.reloadData()
     }
 
     func showCardPresentPaymentsOnboardingNotice() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -279,7 +279,8 @@ private extension InPersonPaymentsMenuViewController {
         cell.configure(image: .creditCardIcon,
                        text: Localization.toggleEnableCashOnDelivery,
                        subtitle: learnMoreViewModel.learnMoreAttributedString,
-                       switchState: inPersonPaymentsMenuViewModel.cashOnDeliveryEnabledState)
+                       switchState: inPersonPaymentsMenuViewModel.cashOnDeliveryEnabledState,
+                       switchAction: inPersonPaymentsMenuViewModel.updateCashOnDeliverySetting(enabled:))
     }
 
     func updateEnabledState(in cell: UITableViewCell, shouldBeEnabled: Bool = true) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Yosemite
+
+class InPersonPaymentsMenuViewModel: ObservableObject {
+    let stores: StoresManager
+
+    @Published var cashOnDeliveryEnabledState: Bool = false
+
+    var siteID: Int64? {
+        stores.sessionManager.defaultStoreID
+    }
+
+    private lazy var paymentGatewaysFetchedResultsController: ResultsController<StoragePaymentGateway>? = {
+        guard let siteID = siteID else {
+            return nil
+        }
+
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+
+        return ResultsController<StoragePaymentGateway>(storageManager: ServiceLocator.storageManager,
+                                                        matching: predicate,
+                                                        sortedBy: [])
+    }()
+
+    init(stores: StoresManager = ServiceLocator.stores) {
+        self.stores = stores
+        observePaymentGateways()
+    }
+
+    private func observePaymentGateways() {
+        guard let paymentGatewaysFetchedResultsController = paymentGatewaysFetchedResultsController else {
+            return
+        }
+        paymentGatewaysFetchedResultsController.onDidChangeContent = updateCashOnDeliveryEnabledState
+        paymentGatewaysFetchedResultsController.onDidResetContent = updateCashOnDeliveryEnabledState
+        do {
+            try paymentGatewaysFetchedResultsController.performFetch()
+            updateCashOnDeliveryEnabledState()
+        } catch {
+            ServiceLocator.crashLogging.logError(error)
+        }
+    }
+
+    private func updateCashOnDeliveryEnabledState() {
+        let codGateway = paymentGatewaysFetchedResultsController?.fetchedObjects.first(where: { $0.gatewayID == "cod" })
+        cashOnDeliveryEnabledState = codGateway?.enabled ?? false
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
@@ -42,6 +42,8 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
 
     private let paymentGatewaysFetchedResultsController: ResultsController<StoragePaymentGateway>?
 
+    var selectedPlugin: CardPresentPaymentsPlugin?
+
     init(dependencies: Dependencies = Dependencies()) {
         self.dependencies = dependencies
         paymentGatewaysFetchedResultsController = Self.createPaymentGatewaysResultsController(
@@ -151,6 +153,16 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
                             actionHandler: disableCashOnDeliveryGateway)
 
         noticePresenter.enqueue(notice: notice)
+    }
+
+    // MARK: - Learn More
+
+    private var learnMoreURL: URL {
+        (selectedPlugin ?? .wcPay).cashOnDeliveryLearnMoreURL
+    }
+
+    func learnMoreTapped(from viewController: UIViewController) {
+        WebviewHelper.launch(learnMoreURL, with: viewController)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
@@ -4,8 +4,10 @@ import Yosemite
 class InPersonPaymentsMenuViewModel: ObservableObject {
     let stores: StoresManager
 
+    // MARK: - Output properties
     @Published var cashOnDeliveryEnabledState: Bool = false
 
+    // MARK: - Configuration properties
     private var siteID: Int64? {
         stores.sessionManager.defaultStoreID
     }
@@ -43,7 +45,17 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
     }
 
     private func updateCashOnDeliveryEnabledState() {
-        let codGateway = paymentGatewaysFetchedResultsController?.fetchedObjects.first(where: { $0.gatewayID == "cod" })
-        cashOnDeliveryEnabledState = codGateway?.enabled ?? false
+        cashOnDeliveryEnabledState = cashOnDeliveryGateway?.enabled ?? false
+    }
+
+    private var cashOnDeliveryGateway: PaymentGateway? {
+        paymentGatewaysFetchedResultsController?.fetchedObjects.first(where: {
+            $0.gatewayID == PaymentGateway.Constants.cashOnDeliveryGatewayID
+        })
+    }
+
+    // MARK: - Toggle Cash on Delivery Payment Gateway
+
+    func updateCashOnDeliverySetting(enabled: Bool) {
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
@@ -2,7 +2,35 @@ import Foundation
 import Yosemite
 
 class InPersonPaymentsMenuViewModel: ObservableObject {
-    let stores: StoresManager
+
+    // MARK: - Dependencies
+    struct Dependencies {
+        let stores: StoresManager
+        let noticePresenter: NoticePresenter
+        let analytics: Analytics
+
+        init(stores: StoresManager = ServiceLocator.stores,
+             noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
+             analytics: Analytics = ServiceLocator.analytics) {
+            self.stores = stores
+            self.noticePresenter = noticePresenter
+            self.analytics = analytics
+        }
+    }
+
+    private let dependencies: Dependencies
+
+    private var stores: StoresManager {
+        dependencies.stores
+    }
+
+    private var noticePresenter: NoticePresenter {
+        dependencies.noticePresenter
+    }
+
+    private var analytics: Analytics {
+        dependencies.analytics
+    }
 
     // MARK: - Output properties
     @Published var cashOnDeliveryEnabledState: Bool = false
@@ -14,9 +42,10 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
 
     private let paymentGatewaysFetchedResultsController: ResultsController<StoragePaymentGateway>?
 
-    init(stores: StoresManager = ServiceLocator.stores) {
-        self.stores = stores
-        paymentGatewaysFetchedResultsController = Self.createPaymentGatewaysResultsController(siteID: stores.sessionManager.defaultStoreID)
+    init(dependencies: Dependencies = Dependencies()) {
+        self.dependencies = dependencies
+        paymentGatewaysFetchedResultsController = Self.createPaymentGatewaysResultsController(
+            siteID: dependencies.stores.sessionManager.defaultStoreID)
         observePaymentGateways()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -90,7 +90,7 @@ struct InPersonPaymentsView: View {
             switch url {
             case InPersonPaymentsSupportLink.supportURL:
                 showSupport?()
-            case InPersonPaymentsLearnMore.learnMoreURL:
+            case LearnMoreViewModel.learnMoreURL:
                 if let url = viewModel.learnMoreURL {
                     showURL?(url)
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/LearnMoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/LearnMoreViewModel.swift
@@ -1,0 +1,66 @@
+import Foundation
+import UIKit
+
+struct LearnMoreViewModel {
+
+    static let learnMoreURL = URL(string: "woocommerce://in-person-payments/learn-more")!
+
+    let url: URL
+    let linkText: String
+    let formatText: String
+    let tappedAnalyticEvent: WooAnalyticsEvent?
+
+    init(url: URL = learnMoreURL,
+         linkText: String = Localization.learnMoreLink,
+         formatText: String = Localization.learnMoreText,
+         tappedAnalyticEvent: WooAnalyticsEvent? = nil) {
+        self.url = url
+        self.linkText = linkText
+        self.formatText = formatText
+        self.tappedAnalyticEvent = tappedAnalyticEvent
+    }
+
+    var learnMoreAttributedString: NSAttributedString {
+        let result = NSMutableAttributedString(
+            string: .localizedStringWithFormat(formatText, linkText),
+            attributes: [.foregroundColor: UIColor.textSubtle]
+        )
+        result.replaceFirstOccurrence(
+            of: linkText,
+            with: NSAttributedString(
+                string: linkText,
+                attributes: [.foregroundColor: UIColor.textLink]
+            ))
+
+        // https://github.com/gonzalezreal/AttributedText/issues/11
+        result.addAttribute(.font, value: UIFont.footnote, range: NSRange(location: 0, length: result.length))
+        return result
+    }
+
+    func learnMoreTapped() {
+        guard let tappedAnalyticEvent = tappedAnalyticEvent else {
+            return
+        }
+
+        ServiceLocator.analytics.track(event: tappedAnalyticEvent)
+    }
+}
+
+private enum Localization {
+    static let learnMoreLink = NSLocalizedString(
+        "Learn more",
+        comment: """
+                 A label prompting users to learn more about card readers.
+                 This part is the link to the website, and forms part of a longer sentence which it should be considered a part of.
+                 """
+    )
+
+    static let learnMoreText = NSLocalizedString(
+        "%1$@ about accepting payments with your mobile device and ordering card readers",
+        comment: """
+                 A label prompting users to learn more about card readers"
+                 %1$@ is a placeholder that always replaced with \"Learn more\" string,
+                 which should be translated separately and considered part of this sentence.
+                 """
+    )
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift
@@ -28,9 +28,11 @@ struct InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView: View {
 
             Spacer()
 
-            InPersonPaymentsLearnMore(url: viewModel.learnMoreURL,
-                                      formatText: Localization.cashOnDeliveryLearnMore,
-                                      analyticReason: viewModel.analyticReason)
+            InPersonPaymentsLearnMore(
+                viewModel: LearnMoreViewModel(
+                    url: viewModel.learnMoreURL,
+                    formatText: Localization.cashOnDeliveryLearnMore,
+                    tappedAnalyticEvent: viewModel.learnMoreEvent))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -151,14 +151,3 @@ private enum Localization {
         "Retry",
         comment: "Retry Action on error displayed when the attempt to enable a Pay in Person checkout payment option fails")
 }
-
-private extension CardPresentPaymentsPlugin {
-    var cashOnDeliveryLearnMoreURL: URL {
-        switch self {
-        case .wcPay:
-            return WooConstants.URLs.wcPayCashOnDeliveryLearnMore.asURL()
-        case .stripe:
-            return WooConstants.URLs.stripeCashOnDeliveryLearnMore.asURL()
-        }
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -156,9 +156,9 @@ private extension CardPresentPaymentsPlugin {
     var cashOnDeliveryLearnMoreURL: URL {
         switch self {
         case .wcPay:
-            return WooConstants.URLs.wcPayCashOnDeliveryLearnMoreUrl.asURL()
+            return WooConstants.URLs.wcPayCashOnDeliveryLearnMore.asURL()
         case .stripe:
-            return WooConstants.URLs.stripeCashOnDeliveryLearnMoreUrl.asURL()
+            return WooConstants.URLs.stripeCashOnDeliveryLearnMore.asURL()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -119,28 +119,33 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
 }
 
 // MARK: - Analytics
-private extension InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel {
-    typealias Event = WooAnalyticsEvent.InPersonPayments
+extension InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel {
+    private typealias Event = WooAnalyticsEvent.InPersonPayments
 
-    func trackSkipTapped() {
+    var learnMoreEvent: WooAnalyticsEvent {
+        Event.cardPresentOnboardingLearnMoreTapped(reason: analyticReason,
+                                                   countryCode: cardPresentPaymentsConfiguration.countryCode)
+    }
+
+    private func trackSkipTapped() {
         let event = Event.cardPresentOnboardingStepSkipped(reason: analyticReason,
                                                            remindLater: false,
                                                            countryCode: cardPresentPaymentsConfiguration.countryCode)
         analytics.track(event: event)
     }
 
-    func trackEnableTapped() {
+    private func trackEnableTapped() {
         let event = Event.cardPresentOnboardingCtaTapped(reason: analyticReason,
                                                          countryCode: cardPresentPaymentsConfiguration.countryCode)
         analytics.track(event: event)
     }
 
-    func trackEnableCashOnDeliverySuccess() {
+    private func trackEnableCashOnDeliverySuccess() {
         let event = Event.enableCashOnDeliverySuccess(countryCode: cardPresentPaymentsConfiguration.countryCode)
         analytics.track(event: event)
     }
 
-    func trackEnableCashOnDeliveryFailed(error: Error?) {
+    private func trackEnableCashOnDeliveryFailed(error: Error?) {
         let event = Event.enableCashOnDeliveryFailed(countryCode: cardPresentPaymentsConfiguration.countryCode,
                                                      error: error)
         analytics.track(event: event)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -81,7 +81,7 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
 
         awaitingResponse = true
 
-        let action = PaymentGatewayAction.updatePaymentGateway(defaultCashOnDeliveryGateway(siteID: siteID)) { [weak self] result in
+        let action = PaymentGatewayAction.updatePaymentGateway(PaymentGateway.defaultPayInPersonGateway(siteID: siteID)) { [weak self] result in
             guard let self = self else { return }
             guard result.isSuccess else {
                 DDLogError("💰 Could not update Payment Gateway: \(String(describing: result.failure))")
@@ -95,16 +95,6 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
             self.completion()
         }
         stores.dispatch(action)
-    }
-
-    private func defaultCashOnDeliveryGateway(siteID: Int64) -> PaymentGateway {
-        PaymentGateway(siteID: siteID,
-                       gatewayID: Constants.cashOnDeliveryGatewayID,
-                       title: Localization.cashOnDeliveryCheckoutTitle,
-                       description: Localization.cashOnDeliveryCheckoutDescription,
-                       enabled: true,
-                       features: [.products],
-                       instructions: Localization.cashOnDeliveryCheckoutInstructions)
     }
 
     private func displayEnableCashOnDeliveryFailureNotice() {
@@ -153,21 +143,6 @@ extension InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel {
 }
 
 private enum Localization {
-    static let cashOnDeliveryCheckoutTitle = NSLocalizedString(
-        "Pay in Person",
-        comment: "Customer-facing title for the payment option added to the store checkout when the merchant enables " +
-        "Pay in Person")
-
-    static let cashOnDeliveryCheckoutDescription = NSLocalizedString(
-        "Pay by card or another accepted payment method",
-        comment: "Customer-facing description showing more details about the Pay in Person option which is added to " +
-        "the store checkout when the merchant enables Pay in Person")
-
-    static let cashOnDeliveryCheckoutInstructions = NSLocalizedString(
-        "Pay by card or another accepted payment method",
-        comment: "Customer-facing instructions shown on Order Thank-you pages and confirmation emails, showing more " +
-        "details about the Pay in Person option added to the store checkout when the merchant enables Pay in Person")
-
     static let cashOnDeliveryFailureNoticeTitle = NSLocalizedString(
         "Failed to enable Pay in Person. Please try again later.",
         comment: "Error displayed when the attempt to enable a Pay in Person checkout payment option fails")
@@ -175,10 +150,6 @@ private enum Localization {
     static let cashOnDeliveryFailureNoticeRetryTitle = NSLocalizedString(
         "Retry",
         comment: "Retry Action on error displayed when the attempt to enable a Pay in Person checkout payment option fails")
-}
-
-private enum Constants {
-    static let cashOnDeliveryGatewayID = "cod"
 }
 
 private extension CardPresentPaymentsPlugin {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
@@ -29,7 +29,7 @@ struct InPersonPaymentsOnboardingError: View {
                     .padding(.bottom, 24.0)
             }
             if learnMore {
-                InPersonPaymentsLearnMore(analyticReason: analyticReason)
+                InPersonPaymentsLearnMore(viewModel: LearnMoreViewModel(tappedAnalyticEvent: learnMoreAnalyticEvent))
             }
         }.padding()
     }
@@ -43,5 +43,12 @@ extension CardPresentPaymentsPlugin {
         case .stripe:
             return .stripePlugin
         }
+    }
+}
+
+private extension InPersonPaymentsOnboardingError {
+    var learnMoreAnalyticEvent: WooAnalyticsEvent? {
+        WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingLearnMoreTapped(reason: analyticReason,
+                                                                                countryCode: CardPresentConfigurationLoader().configuration.countryCode)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -39,7 +39,7 @@ struct InPersonPaymentsPluginNotSetup: View {
             .buttonStyle(PrimaryButtonStyle())
             .padding(.bottom, 24.0)
 
-            InPersonPaymentsLearnMore(analyticReason: analyticReason)
+            InPersonPaymentsLearnMore(viewModel: LearnMoreViewModel(tappedAnalyticEvent: learnMoreAnalyticEvent))
         }
         .safariSheet(url: $presentedSetupURL, onDismiss: onRefresh)
     }
@@ -69,8 +69,16 @@ private enum Localization {
         comment: "Button to set up an in-person payments plugin after activating it"
     )
 }
+
 struct InPersonPaymentsPluginNotSetup_Previews: PreviewProvider {
     static var previews: some View {
         InPersonPaymentsPluginNotSetup(plugin: .wcPay, analyticReason: "", onRefresh: {})
+    }
+}
+
+private extension InPersonPaymentsPluginNotSetup {
+    var learnMoreAnalyticEvent: WooAnalyticsEvent? {
+        WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingLearnMoreTapped(reason: analyticReason,
+                                                                                countryCode: cardPresentConfiguration.countryCode)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTableViewCell.xib
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -15,10 +14,11 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <point key="canvasLocation" x="139" y="154"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.swift
@@ -1,0 +1,80 @@
+import UIKit
+
+
+/// Represents a regular UITableView Cell with subtitle: [Image | Text + Subtitle |  Disclosure]
+///
+class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
+
+
+    @IBOutlet weak var leftImageView: UIImageView!
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var subtitleLabel: UILabel!
+    @IBOutlet weak var toggleSwitch: UISwitch!
+
+    /// Left Image
+    ///
+    var leftImage: UIImage? {
+        get {
+            return leftImageView?.image
+        }
+        set {
+            leftImageView?.image = newValue
+        }
+    }
+
+    /// Label's Text
+    ///
+    var labelText: String? {
+        get {
+            return titleLabel?.text
+        }
+        set {
+            titleLabel?.text = newValue
+        }
+    }
+
+    /// Subtitle's text
+    ///
+    var subtitleLabelText: String? {
+        get {
+            return subtitleLabel?.text
+        }
+        set {
+            subtitleLabel?.text = newValue
+        }
+    }
+
+    // MARK: - Overridden Methods
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configureBackground()
+        leftImageView?.tintColor = .primary
+        titleLabel?.applyBodyStyle()
+        subtitleLabel?.applyFootnoteStyle()
+        toggleSwitch?.onTintColor = .primary
+    }
+
+    private func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+}
+
+// MARK: - Public Methods
+//
+extension LeftImageTitleSubtitleToggleTableViewCell {
+    func configure(image: UIImage, text: String, subtitle: String) {
+        configure(image: image, text: text, subtitle: subtitle, attributedSubtitle: nil)
+    }
+
+    func configure(image: UIImage, text: String, subtitle: NSAttributedString) {
+        configure(image: image, text: text, subtitle: nil, attributedSubtitle: subtitle)
+    }
+
+    private func configure(image: UIImage, text: String, subtitle: String?, attributedSubtitle: NSAttributedString?) {
+        leftImageView?.image = image
+        titleLabel?.text = text
+        subtitleLabel?.text = subtitle
+        subtitleLabel.attributedText = attributedSubtitle
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.swift
@@ -44,6 +44,11 @@ class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
         }
     }
 
+    private var switchAction: ((Bool) -> Void)? = nil
+
+    @IBAction func switchValueChanged(_ sender: UISwitch) {
+        switchAction?(sender.isOn)
+    }
     // MARK: - Overridden Methods
 
     override func awakeFromNib() {
@@ -63,23 +68,25 @@ class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
 // MARK: - Public Methods
 //
 extension LeftImageTitleSubtitleToggleTableViewCell {
-    func configure(image: UIImage, text: String, subtitle: String, switchState: Bool) {
-        configure(image: image, text: text, subtitle: subtitle, attributedSubtitle: nil, switchState: switchState)
+    func configure(image: UIImage, text: String, subtitle: String, switchState: Bool, switchAction: @escaping (Bool) -> Void) {
+        configure(image: image, text: text, subtitle: subtitle, attributedSubtitle: nil, switchState: switchState, switchAction: switchAction)
     }
 
-    func configure(image: UIImage, text: String, subtitle: NSAttributedString, switchState: Bool) {
-        configure(image: image, text: text, subtitle: nil, attributedSubtitle: subtitle, switchState: switchState)
+    func configure(image: UIImage, text: String, subtitle: NSAttributedString, switchState: Bool, switchAction: @escaping (Bool) -> Void) {
+        configure(image: image, text: text, subtitle: nil, attributedSubtitle: subtitle, switchState: switchState, switchAction: switchAction)
     }
 
     private func configure(image: UIImage,
                            text: String,
                            subtitle: String?,
                            attributedSubtitle: NSAttributedString?,
-                           switchState: Bool) {
+                           switchState: Bool,
+                           switchAction: @escaping (Bool) -> Void) {
         leftImageView?.image = image
         titleLabel?.text = text
         subtitleLabel?.text = subtitle
         subtitleLabel.attributedText = attributedSubtitle
         toggleSwitch.isOn = switchState
+        self.switchAction = switchAction
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.swift
@@ -63,18 +63,23 @@ class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
 // MARK: - Public Methods
 //
 extension LeftImageTitleSubtitleToggleTableViewCell {
-    func configure(image: UIImage, text: String, subtitle: String) {
-        configure(image: image, text: text, subtitle: subtitle, attributedSubtitle: nil)
+    func configure(image: UIImage, text: String, subtitle: String, switchState: Bool) {
+        configure(image: image, text: text, subtitle: subtitle, attributedSubtitle: nil, switchState: switchState)
     }
 
-    func configure(image: UIImage, text: String, subtitle: NSAttributedString) {
-        configure(image: image, text: text, subtitle: nil, attributedSubtitle: subtitle)
+    func configure(image: UIImage, text: String, subtitle: NSAttributedString, switchState: Bool) {
+        configure(image: image, text: text, subtitle: nil, attributedSubtitle: subtitle, switchState: switchState)
     }
 
-    private func configure(image: UIImage, text: String, subtitle: String?, attributedSubtitle: NSAttributedString?) {
+    private func configure(image: UIImage,
+                           text: String,
+                           subtitle: String?,
+                           attributedSubtitle: NSAttributedString?,
+                           switchState: Bool) {
         leftImageView?.image = image
         titleLabel?.text = text
         subtitleLabel?.text = subtitle
         subtitleLabel.attributedText = attributedSubtitle
+        toggleSwitch.isOn = switchState
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.swift
@@ -45,9 +45,14 @@ class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
     }
 
     private var switchAction: ((Bool) -> Void)? = nil
+    private var subtitleTapAction: (() -> Void)? = nil
 
     @IBAction func switchValueChanged(_ sender: UISwitch) {
         switchAction?(sender.isOn)
+    }
+
+    @objc private func subtitleTapped(_ sender: Any) {
+        subtitleTapAction?()
     }
     // MARK: - Overridden Methods
 
@@ -58,6 +63,7 @@ class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
         titleLabel?.applyBodyStyle()
         subtitleLabel?.applyFootnoteStyle()
         toggleSwitch?.onTintColor = .primary
+        subtitleLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(subtitleTapped)))
     }
 
     private func configureBackground() {
@@ -68,12 +74,33 @@ class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
 // MARK: - Public Methods
 //
 extension LeftImageTitleSubtitleToggleTableViewCell {
-    func configure(image: UIImage, text: String, subtitle: String, switchState: Bool, switchAction: @escaping (Bool) -> Void) {
-        configure(image: image, text: text, subtitle: subtitle, attributedSubtitle: nil, switchState: switchState, switchAction: switchAction)
+    func configure(image: UIImage,
+                   text: String,
+                   subtitle: String,
+                   switchState: Bool,
+                   switchAction: @escaping (Bool) -> Void) {
+        configure(image: image,
+                  text: text,
+                  subtitle: subtitle,
+                  attributedSubtitle: nil,
+                  switchState: switchState,
+                  switchAction: switchAction,
+                  subtitleTapAction: nil)
     }
 
-    func configure(image: UIImage, text: String, subtitle: NSAttributedString, switchState: Bool, switchAction: @escaping (Bool) -> Void) {
-        configure(image: image, text: text, subtitle: nil, attributedSubtitle: subtitle, switchState: switchState, switchAction: switchAction)
+    func configure(image: UIImage,
+                   text: String,
+                   subtitle: NSAttributedString,
+                   switchState: Bool,
+                   switchAction: @escaping (Bool) -> Void,
+                   subtitleTapAction: (() -> Void)? = nil) {
+        configure(image: image,
+                  text: text,
+                  subtitle: nil,
+                  attributedSubtitle: subtitle,
+                  switchState: switchState,
+                  switchAction: switchAction,
+                  subtitleTapAction: subtitleTapAction)
     }
 
     private func configure(image: UIImage,
@@ -81,12 +108,14 @@ extension LeftImageTitleSubtitleToggleTableViewCell {
                            subtitle: String?,
                            attributedSubtitle: NSAttributedString?,
                            switchState: Bool,
-                           switchAction: @escaping (Bool) -> Void) {
+                           switchAction: @escaping (Bool) -> Void,
+                           subtitleTapAction: (() -> Void)? = nil) {
         leftImageView?.image = image
         titleLabel?.text = text
         subtitleLabel?.text = subtitle
         subtitleLabel.attributedText = attributedSubtitle
         toggleSwitch.isOn = switchState
         self.switchAction = switchAction
+        self.subtitleTapAction = subtitleTapAction
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.xib
@@ -38,13 +38,15 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tBN-G3-N5i">
+                                            <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tBN-G3-N5i">
                                                 <rect key="frame" x="0.0" y="55.5" width="195" height="14.5"/>
+                                                <gestureRecognizers/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
+                                        <gestureRecognizers/>
                                     </stackView>
                                 </subviews>
                                 <constraints>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.xib
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="94" id="AOE-4m-edo" customClass="LeftImageTitleSubtitleToggleTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="94"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="AOE-4m-edo" id="4h9-M7-DT5">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="94"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Ur7-QP-6fZ">
+                        <rect key="frame" x="16" y="12" width="292" height="70"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="aOx-kJ-zhd">
+                                <rect key="frame" x="0.0" y="0.0" width="235" height="70"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bQv-NK-BdZ">
+                                        <rect key="frame" x="0.0" y="0.0" width="24" height="47.5"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="24" id="wgY-Gy-aWp"/>
+                                        </constraints>
+                                    </imageView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="TN7-6w-zce">
+                                        <rect key="frame" x="40" y="0.0" width="195" height="70"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zoa-lw-VWU">
+                                                <rect key="frame" x="0.0" y="0.0" width="195" height="47.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tBN-G3-N5i">
+                                                <rect key="frame" x="0.0" y="55.5" width="195" height="14.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="bQv-NK-BdZ" firstAttribute="centerY" secondItem="Zoa-lw-VWU" secondAttribute="centerY" id="Ia7-6Z-fgg"/>
+                                </constraints>
+                            </stackView>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rbD-M8-Mf4">
+                                <rect key="frame" x="243" y="19.5" width="51" height="31"/>
+                            </switch>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="Ur7-QP-6fZ" firstAttribute="top" secondItem="4h9-M7-DT5" secondAttribute="top" constant="12" id="QN6-IU-ofY"/>
+                    <constraint firstItem="Ur7-QP-6fZ" firstAttribute="leading" secondItem="4h9-M7-DT5" secondAttribute="leading" constant="16" id="Xtx-CZ-Cnu"/>
+                    <constraint firstAttribute="bottom" secondItem="Ur7-QP-6fZ" secondAttribute="bottom" constant="12" id="kwM-Fx-FlY"/>
+                    <constraint firstAttribute="trailing" secondItem="Ur7-QP-6fZ" secondAttribute="trailing" constant="12" id="rlj-R7-lWg"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="Rkv-Co-Caw"/>
+            <connections>
+                <outlet property="leftImageView" destination="bQv-NK-BdZ" id="UN9-3N-V8V"/>
+                <outlet property="subtitleLabel" destination="tBN-G3-N5i" id="BzH-tN-P9C"/>
+                <outlet property="titleLabel" destination="Zoa-lw-VWU" id="mXI-A5-hBf"/>
+                <outlet property="toggleSwitch" destination="rbD-M8-Mf4" id="Ozn-sz-T5d"/>
+            </connections>
+            <point key="canvasLocation" x="131.8840579710145" y="148.66071428571428"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.xib
@@ -53,6 +53,9 @@
                             </stackView>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rbD-M8-Mf4">
                                 <rect key="frame" x="243" y="19.5" width="51" height="31"/>
+                                <connections>
+                                    <action selector="switchValueChanged:" destination="AOE-4m-edo" eventType="valueChanged" id="ALz-qN-lId"/>
+                                </connections>
                             </switch>
                         </subviews>
                     </stackView>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -457,6 +457,7 @@
 		03AA16602719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */; };
 		03AFDE02282C0B82003B67CD /* InPersonPaymentsCompletedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */; };
 		03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */; };
+		03EF24FA28BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24F928BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift */; };
 		03FBDA9D263AD49200ACE257 /* CouponListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */; };
 		03FBDAA3263AED2F00ACE257 /* CouponListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */; };
 		03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */; };
@@ -2301,6 +2302,7 @@
 		03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinatorTests.swift; sourceTree = "<group>"; };
 		03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCompletedView.swift; sourceTree = "<group>"; };
 		03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayCardBrand+IconsTests.swift"; sourceTree = "<group>"; };
+		03EF24F928BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
 		03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewController.swift; sourceTree = "<group>"; };
 		03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CouponListViewController.xib; sourceTree = "<group>"; };
 		03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModel.swift; sourceTree = "<group>"; };
@@ -8296,6 +8298,7 @@
 				E12AF69826BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift */,
 				E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */,
 				E1906E9926C4126300CA6819 /* InPersonPaymentsMenuViewController.swift */,
+				03EF24F928BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift */,
 				E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */,
 				03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */,
 				319A626027ACAE3400BC96C3 /* InPersonPaymentsPluginChoicesView.swift */,
@@ -9957,6 +9960,7 @@
 				DECE13FB27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift in Sources */,
 				26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */,
 				0371C3682875E47B00277E2C /* FeatureAnnouncementCardViewModel.swift in Sources */,
+				03EF24FA28BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift in Sources */,
 				09EA565527C8ACEE00407D40 /* BulkUpdateViewController.swift in Sources */,
 				2602A64627BDBEBA00B347F1 /* ProductInputTransformer.swift in Sources */,
 				DE74F2A327E41D650002FE59 /* EnableAnalyticsViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -429,6 +429,7 @@
 		02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */; };
 		02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
+		0304E35E28BDC86D00A80191 /* LearnMoreViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0304E35D28BDC86D00A80191 /* LearnMoreViewModel.swift */; };
 		0313651128AB81B100EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651028AB81B100EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift */; };
 		0313651328ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651228ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift */; };
 		0313651728ACE9F400EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651628ACE9F400EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift */; };
@@ -2267,6 +2268,7 @@
 		02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsBanner.swift; sourceTree = "<group>"; };
 		02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingViewController.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
+		0304E35D28BDC86D00A80191 /* LearnMoreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreViewModel.swift; sourceTree = "<group>"; };
 		0313651028AB81B100EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift; sourceTree = "<group>"; };
 		0313651228ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsOnboardingErrorMainContentView.swift; sourceTree = "<group>"; };
 		0313651628ACE9F400EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift; sourceTree = "<group>"; };
@@ -8293,6 +8295,7 @@
 				319A626027ACAE3400BC96C3 /* InPersonPaymentsPluginChoicesView.swift */,
 				E138D4FB269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift */,
 				E15FC74426BC213500CF83E6 /* InPersonPaymentsLearnMore.swift */,
+				0304E35D28BDC86D00A80191 /* LearnMoreViewModel.swift */,
 				E107FCE226C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift */,
 				E1ABAEF628479E0300F40BB2 /* InPersonPaymentsSelectPluginView.swift */,
 				684AB8392870677F003DFDD1 /* CardReaderManualsView.swift */,
@@ -9533,6 +9536,7 @@
 				311D21ED264AF0E700102316 /* CardReaderSettingsAlerts.swift in Sources */,
 				02C0CD2A23B5BB1C00F880B1 /* ImageService.swift in Sources */,
 				26ABCE532518EAF300721CB0 /* IssueRefundTableViewCell.swift in Sources */,
+				0304E35E28BDC86D00A80191 /* LearnMoreViewModel.swift in Sources */,
 				02482A8B237BE8C7007E73ED /* LinkSettingsViewController.swift in Sources */,
 				CE227097228F152400C0626C /* WooBasicTableViewCell.swift in Sources */,
 				02C27BCE282CB52F0065471A /* CardPresentPaymentReceiptEmailCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -430,6 +430,8 @@
 		02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
 		0304E35E28BDC86D00A80191 /* LearnMoreViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0304E35D28BDC86D00A80191 /* LearnMoreViewModel.swift */; };
+		0304E36428BE1EDE00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0304E36328BE1EDE00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.xib */; };
+		0304E36628BE1EED00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0304E36528BE1EED00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.swift */; };
 		0313651128AB81B100EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651028AB81B100EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift */; };
 		0313651328ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651228ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift */; };
 		0313651728ACE9F400EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313651628ACE9F400EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift */; };
@@ -2269,6 +2271,8 @@
 		02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingViewController.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
 		0304E35D28BDC86D00A80191 /* LearnMoreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreViewModel.swift; sourceTree = "<group>"; };
+		0304E36328BE1EDE00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LeftImageTitleSubtitleToggleTableViewCell.xib; sourceTree = "<group>"; };
+		0304E36528BE1EED00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftImageTitleSubtitleToggleTableViewCell.swift; sourceTree = "<group>"; };
 		0313651028AB81B100EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpView.swift; sourceTree = "<group>"; };
 		0313651228ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsOnboardingErrorMainContentView.swift; sourceTree = "<group>"; };
 		0313651628ACE9F400EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift; sourceTree = "<group>"; };
@@ -7715,6 +7719,8 @@
 				CE1EC8EB20B8A3FF009762BF /* LeftImageTableViewCell.xib */,
 				E16058F8285876E600E471D4 /* LeftImageTitleSubtitleTableViewCell.swift */,
 				E16058F6285876DE00E471D4 /* LeftImageTitleSubtitleTableViewCell.xib */,
+				0304E36528BE1EED00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.swift */,
+				0304E36328BE1EDE00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.xib */,
 				26FE09DC24D9F3F600B9BDF5 /* LoadingView.swift */,
 				318109E725E5B8D600EE0BE7 /* NumberedListItemTableViewCell.swift */,
 				318109ED25E5B8FF00EE0BE7 /* NumberedListItemTableViewCell.xib */,
@@ -8824,6 +8830,7 @@
 				456CB50E2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib in Resources */,
 				B92FF9AE27FC7217005C34E3 /* OrderListViewController.xib in Resources */,
 				023A059B24135F2600E3FC99 /* ReviewsViewController.xib in Resources */,
+				0304E36428BE1EDE00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.xib in Resources */,
 				026CF63B237E9ABE009563D4 /* ProductVariationsViewController.xib in Resources */,
 				3F587026281B9C19004F7556 /* InfoPlist.strings in Resources */,
 				4515C88E25D6BE540099C8E3 /* ShippingLabelAddressFormViewController.xib in Resources */,
@@ -9630,6 +9637,7 @@
 				E1E125B226EB8EE80068A9B0 /* UpdateProgressImage.swift in Sources */,
 				B5A82EE7210263460053ADC8 /* UIViewController+Helpers.swift in Sources */,
 				4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */,
+				0304E36628BE1EED00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.swift in Sources */,
 				CE1F512B206985DF00C6C810 /* PaddedLabel.swift in Sources */,
 				26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */,
 				26C6E8EA26E8FD3900C7BB0F /* LazyView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -459,6 +459,7 @@
 		03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */; };
 		03EF24FA28BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24F928BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift */; };
 		03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */; };
+		03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */; };
 		03FBDA9D263AD49200ACE257 /* CouponListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */; };
 		03FBDAA3263AED2F00ACE257 /* CouponListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */; };
 		03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */; };
@@ -2305,6 +2306,7 @@
 		03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayCardBrand+IconsTests.swift"; sourceTree = "<group>"; };
 		03EF24F928BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
 		03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift; sourceTree = "<group>"; };
+		03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardPresentPaymentsPlugin+CashOnDelivery.swift"; sourceTree = "<group>"; };
 		03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewController.swift; sourceTree = "<group>"; };
 		03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CouponListViewController.xib; sourceTree = "<group>"; };
 		03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModel.swift; sourceTree = "<group>"; };
@@ -8315,6 +8317,7 @@
 				68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */,
 				68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */,
 				03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */,
+				03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */,
 			);
 			path = "In-Person Payments";
 			sourceTree = "<group>";
@@ -10042,6 +10045,7 @@
 				FE28F7182684EE6A004465C7 /* RoleErrorViewModel.swift in Sources */,
 				02C0CD2C23B5BC9600F880B1 /* DefaultImageService.swift in Sources */,
 				CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */,
+				03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */,
 				DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,
 				4572641927F1EB27004E1F95 /* AddEditCouponViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -458,6 +458,7 @@
 		03AFDE02282C0B82003B67CD /* InPersonPaymentsCompletedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */; };
 		03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */; };
 		03EF24FA28BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24F928BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift */; };
+		03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */; };
 		03FBDA9D263AD49200ACE257 /* CouponListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */; };
 		03FBDAA3263AED2F00ACE257 /* CouponListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */; };
 		03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */; };
@@ -2303,6 +2304,7 @@
 		03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCompletedView.swift; sourceTree = "<group>"; };
 		03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayCardBrand+IconsTests.swift"; sourceTree = "<group>"; };
 		03EF24F928BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
+		03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift; sourceTree = "<group>"; };
 		03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewController.swift; sourceTree = "<group>"; };
 		03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CouponListViewController.xib; sourceTree = "<group>"; };
 		03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModel.swift; sourceTree = "<group>"; };
@@ -8312,6 +8314,7 @@
 				68E952CB287536010095A23D /* SafariView.swift */,
 				68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */,
 				68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */,
+				03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */,
 			);
 			path = "In-Person Payments";
 			sourceTree = "<group>";
@@ -9151,6 +9154,7 @@
 				4592A54B24BF58DD00BC3DE0 /* ProductTagsViewController.swift in Sources */,
 				D817585E22BB5E8700289CFE /* OrderEmailComposer.swift in Sources */,
 				D8815ADF26383EE700EDAD62 /* CardPresentPaymentsModalViewController.swift in Sources */,
+				03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */,
 				57896D6625362B0C000E8C4D /* TitleAndEditableValueTableViewCellViewModel.swift in Sources */,
 				0205021E27C8B6C600FB1C6B /* InboxEligibilityUseCase.swift in Sources */,
 				26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7591 
Closes: #7570

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In 10.1, we added the ability for a merchant to turn on the `Cash on Delivery` payment gateway in the In-Person Payments Onboarding flow. There is currently no way to undo that choice in the app, nor to turn it on at a later date if the merchant chose to skip the initial onboarding prompt.

For iteration 2 of the project, we'll add a toggle to the In-Person Payments settings so that a user can see the current state of the gateway, and change it outside of the onboarding flow.

This PR tackles the UI of this new row:
- [x] Adds a new row to the IPP settings, including a title, descriptive text, help link* and toggle switch
- [x] Reflects the `enabled` state of the `cod` gateway on app launch, and after it's changed in the onboarding flow**.

*The help link is not tappable in this PR
**The switch itself can't be used to change the setting, and the PaymentGateways aren't refreshed except on app launch or change of site.

N.B. I've realised that we'll probably show this for every store, regardless of location or payment gateway status. I'll address that in a follow-up PR, we _probably_ don't want to show it to everyone even though it does have a valid use for non-IPP stores.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a US store with Cash on Delivery disabled (see wc-admin > Payments > All Payment Methods)

1. Go to the Menu tab, tap Payments
2. Observe that the new toggle shows as off
3. Tap `Continue Setup` and then `Enable Pay in Person`.
4. Observe when you go back to the menu, the toggle is on.

Turn Cash on Delivery back off using wc-admin.

1. Relaunch the app
2. Go to the Menu tab, tap Payments
3. Observe that the new toggle shows as off
4. Tap `Continue Setup` and then `Skip`.
5. Observe when you go back to the menu, the toggle is still off.

Turn Cash on Delivery back on using wc-admin.

1. Relaunch the app
2. Go to the Menu tab, tap Payments
3. Observe that the new toggle shows as on

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/2472348/187671499-a19cf3ee-fd35-409e-a167-a1f817dcd707.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
