### PR TITLE
[ExPlat] Update the logged-in A/A test to the new experiment

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -7,10 +7,10 @@ public enum ABTest: String, CaseIterable {
     /// `An enum with no cases cannot declare a raw type`
     case null
 
-    /// A/A test for ExPlat integration.
+    /// A/A test for ExPlat integration in the logged in state.
     /// Experiment ref: pbxNRc-1QS-p2
     ///
-    case aaTest202208 = "woocommerceios_explat_aa_test_202208"
+    case aaTest202209 = "woocommerceios_explat_aa_test_logged_in_202209"
 
     /// A/A test to make sure there is no bias in the logged out state.
     /// Experiment ref: pbxNRc-1S0-p2


### PR DESCRIPTION
Followup for #7407

## Description

We ran the first A/A test in August with the goal to verify there is no statistical bias with the ExPlat setup, so that we can run A/B experiments in the future with confidence. From the health report of the first A/A test (the experiment is linked at the top of pbxNRc-1QS-p2), it showed that there is an issue with a very high crossover rate (i.e. too many users are getting both variations, more details in the discussion on the logged-out A/A test at pbxNRc-1S0-p2#comment-3688). After the previous PR https://github.com/woocommerce/woocommerce-ios/pull/7574 to hopefully fix the crossover issue, we are going to start a brand new A/A test for logged-in users to see if the issue is addressed. If the new A/A test goes well, we can then start running A/B experiments.

See also: #7609 (corresponding new A/A test for logged-out users)

## Testing

Feel free to use a proxy service like Charles Proxy to verify the new experiment name is in the query parameter for the ExPlat assignments API request `/wpcom/v2/experiments/0.1.0/assignments`, and if you are logged in to an a8c account you see the experiment name and assignment in the response. (I already did a check.)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

h/t @jaclync, whose PR description I shamelessly copied here :)