### PR TITLE
Add support for force-refreshing the server-side analytics cache

### DIFF
--- a/Networking/Networking/Remote/LeaderboardsRemote.swift
+++ b/Networking/Networking/Remote/LeaderboardsRemote.swift
@@ -78,10 +78,10 @@ private extension LeaderboardsRemote {
     }
 
     enum ParameterKeys {
-        static let interval: String = "interval"
-        static let after: String    = "after"
-        static let before: String   = "before"
-        static let quantity: String = "per_page"
-        static let forceRefresh: String = "force_cache_refresh"
+        static let interval = "interval"
+        static let after = "after"
+        static let before = "before"
+        static let quantity = "per_page"
+        static let forceRefresh = "force_cache_refresh"
     }
 }

--- a/Networking/Networking/Remote/LeaderboardsRemote.swift
+++ b/Networking/Networking/Remote/LeaderboardsRemote.swift
@@ -12,6 +12,7 @@ public class LeaderboardsRemote: Remote {
     ///   - earliestDateToInclude: The earliest date to include in the results. This string is ISO8601 compliant
     ///   - latestDateToInclude: The latest date to include in the results. This string is ISO8601 compliant
     ///   - quantity: Number of results to fetch
+    ///   - forceRefresh: Whether to enforce the data being refreshed.
     ///   - completion: Closure to be executed upon completion.
     ///
     public func loadLeaderboards(for siteID: Int64,
@@ -19,11 +20,15 @@ public class LeaderboardsRemote: Remote {
                                  earliestDateToInclude: String,
                                  latestDateToInclude: String,
                                  quantity: Int,
+                                 forceRefresh: Bool,
                                  completion: @escaping (Result<[Leaderboard], Error>) -> Void) {
-        let parameters = [ParameterKeys.interval: unit.rawValue,
-                          ParameterKeys.after: earliestDateToInclude,
-                          ParameterKeys.before: latestDateToInclude,
-                          ParameterKeys.quantity: String(quantity)]
+        let parameters: [String: Any] = [
+            ParameterKeys.interval: unit.rawValue,
+            ParameterKeys.after: earliestDateToInclude,
+            ParameterKeys.before: latestDateToInclude,
+            ParameterKeys.quantity: String(quantity),
+            ParameterKeys.forceRefresh: forceRefresh
+        ]
 
         let request = JetpackRequest(wooApiVersion: .wcAnalytics, method: .get, siteID: siteID, path: Constants.path, parameters: parameters)
         let mapper = LeaderboardListMapper()
@@ -39,6 +44,7 @@ public class LeaderboardsRemote: Remote {
     ///   - earliestDateToInclude: The earliest date to include in the results. This string is ISO8601 compliant
     ///   - latestDateToInclude: The latest date to include in the results. This string is ISO8601 compliant
     ///   - quantity: Number of results to fetch
+    ///   - forceRefresh: Whether to enforce the data being refreshed
     ///   - completion: Closure to be executed upon completion
     ///
     public func loadLeaderboardsDeprecated(for siteID: Int64,
@@ -46,11 +52,15 @@ public class LeaderboardsRemote: Remote {
                                            earliestDateToInclude: String,
                                            latestDateToInclude: String,
                                            quantity: Int,
+                                           forceRefresh: Bool,
                                            completion: @escaping (Result<[Leaderboard], Error>) -> Void) {
-        let parameters = [ParameterKeys.interval: unit.rawValue,
-                          ParameterKeys.after: earliestDateToInclude,
-                          ParameterKeys.before: latestDateToInclude,
-                          ParameterKeys.quantity: String(quantity)]
+        let parameters: [String: Any] = [
+            ParameterKeys.interval: unit.rawValue,
+            ParameterKeys.after: earliestDateToInclude,
+            ParameterKeys.before: latestDateToInclude,
+            ParameterKeys.quantity: String(quantity),
+            ParameterKeys.forceRefresh: forceRefresh
+        ]
 
         let request = JetpackRequest(wooApiVersion: .wcAnalytics, method: .get, siteID: siteID, path: Constants.pathDeprecated, parameters: parameters)
         let mapper = LeaderboardListMapper()
@@ -72,5 +82,6 @@ private extension LeaderboardsRemote {
         static let after: String    = "after"
         static let before: String   = "before"
         static let quantity: String = "per_page"
+        static let forceRefresh: String = "force_cache_refresh"
     }
 }

--- a/Networking/Networking/Remote/OrderStatsRemoteV4.swift
+++ b/Networking/Networking/Remote/OrderStatsRemoteV4.swift
@@ -6,9 +6,12 @@ public final class OrderStatsRemoteV4: Remote {
     /// Fetch the order stats for a given site, depending on the given granularity of the `unit` parameter.
     ///
     /// - Parameters:
-    ///   - siteID: The site ID
-    ///   - unit: Defines the granularity of the stats we are fetching (one of 'hourly', 'daily', 'weekly', 'monthly', or 'yearly')
+    ///   - siteID: The site ID.
+    ///   - unit: Defines the granularity of the stats we are fetching (one of 'hourly', 'daily', 'weekly', 'monthly', or 'yearly').
+    ///   - earliestDateToInclude: The earliest date to include in the results.
     ///   - latestDateToInclude: The latest date to include in the results.
+    ///   - quantity: The number of intervals to fetch the order stats.
+    ///   - forceRefresh: Whether to enforce the data being refreshed.
     ///   - completion: Closure to be executed upon completion.
     ///
     /// Note: by limiting the return values with the `_fields` param, we shrink the response size by over 90%! (~40kb to ~3kb)
@@ -18,13 +21,17 @@ public final class OrderStatsRemoteV4: Remote {
                                earliestDateToInclude: Date,
                                latestDateToInclude: Date,
                                quantity: Int,
+                               forceRefresh: Bool,
                                completion: @escaping (Result<OrderStatsV4, Error>) -> Void) {
         let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
 
-        let parameters = [ParameterKeys.interval: unit.rawValue,
-                          ParameterKeys.after: dateFormatter.string(from: earliestDateToInclude),
-                          ParameterKeys.before: dateFormatter.string(from: latestDateToInclude),
-                          ParameterKeys.quantity: String(quantity)]
+        let parameters: [String: Any] = [
+            ParameterKeys.interval: unit.rawValue,
+            ParameterKeys.after: dateFormatter.string(from: earliestDateToInclude),
+            ParameterKeys.before: dateFormatter.string(from: latestDateToInclude),
+            ParameterKeys.quantity: String(quantity),
+            ParameterKeys.forceRefresh: forceRefresh
+        ]
 
         let request = JetpackRequest(wooApiVersion: .wcAnalytics, method: .get, siteID: siteID, path: Constants.orderStatsPath, parameters: parameters)
         let mapper = OrderStatsV4Mapper(siteID: siteID, granularity: unit)
@@ -45,5 +52,6 @@ private extension OrderStatsRemoteV4 {
         static let after: String    = "after"
         static let before: String   = "before"
         static let quantity: String = "per_page"
+        static let forceRefresh: String = "force_cache_refresh"
     }
 }

--- a/Networking/Networking/Remote/OrderStatsRemoteV4.swift
+++ b/Networking/Networking/Remote/OrderStatsRemoteV4.swift
@@ -48,10 +48,10 @@ private extension OrderStatsRemoteV4 {
     }
 
     enum ParameterKeys {
-        static let interval: String = "interval"
-        static let after: String    = "after"
-        static let before: String   = "before"
-        static let quantity: String = "per_page"
-        static let forceRefresh: String = "force_cache_refresh"
+        static let interval = "interval"
+        static let after = "after"
+        static let before = "before"
+        static let quantity = "per_page"
+        static let forceRefresh = "force_cache_refresh"
     }
 }

--- a/Networking/NetworkingTests/Remote/LeaderboardsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/LeaderboardsRemoteTests.swift
@@ -24,7 +24,8 @@ final class LeaderboardsRemoteV4Tests: XCTestCase {
                                     unit: .yearly,
                                     earliestDateToInclude: "2020-01-01T00:00:00",
                                     latestDateToInclude: "2020-12-31T23:59:59",
-                                    quantity: 3) { result in
+                                    quantity: 3,
+                                    forceRefresh: false) { result in
                 promise(result)
             }
         }
@@ -62,7 +63,8 @@ final class LeaderboardsRemoteV4Tests: XCTestCase {
                                               unit: .yearly,
                                               earliestDateToInclude: "2020-01-01T00:00:00",
                                               latestDateToInclude: "2020-12-31T23:59:59",
-                                              quantity: 3) { result in
+                                              quantity: 3,
+                                              forceRefresh: false) { result in
                 promise(result)
             }
         }
@@ -100,7 +102,8 @@ final class LeaderboardsRemoteV4Tests: XCTestCase {
                                     unit: .yearly,
                                     earliestDateToInclude: "2020-01-01T00:00:00",
                                     latestDateToInclude: "2020-12-31T23:59:59",
-                                    quantity: 3) { result in
+                                    quantity: 3,
+                                    forceRefresh: false) { result in
                                         remoteResult = result
                                         exp.fulfill()
             }

--- a/Networking/NetworkingTests/Remote/OrderStatsRemoteV4Tests.swift
+++ b/Networking/NetworkingTests/Remote/OrderStatsRemoteV4Tests.swift
@@ -33,7 +33,8 @@ final class OrderStatsRemoteV4Tests: XCTestCase {
                                   unit: .hourly,
                                   earliestDateToInclude: Date(),
                                   latestDateToInclude: Date(),
-                                  quantity: 24) { result in
+                                  quantity: 24,
+                                  forceRefresh: false) { result in
                 promise(result)
             }
         }
@@ -58,7 +59,8 @@ final class OrderStatsRemoteV4Tests: XCTestCase {
                                   unit: .weekly,
                                   earliestDateToInclude: Date(),
                                   latestDateToInclude: Date(),
-                                  quantity: 2) { result in
+                                  quantity: 2,
+                                  forceRefresh: false) { result in
                 promise(result)
             }
         }
@@ -81,7 +83,8 @@ final class OrderStatsRemoteV4Tests: XCTestCase {
                                   unit: .daily,
                                   earliestDateToInclude: Date(),
                                   latestDateToInclude: Date(),
-                                  quantity: 31) { result in
+                                  quantity: 31,
+                                  forceRefresh: false) { result in
                 promise(result)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -18,6 +18,7 @@ final class DashboardViewModel {
                    siteTimezone: TimeZone,
                    timeRange: StatsTimeRangeV4,
                    latestDateToInclude: Date,
+                   forceRefresh: Bool,
                    onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
         let waitingTracker = WaitingTimeTracker(trackScenario: .dashboardMainStats)
         let earliestDateToInclude = timeRange.earliestDate(latestDate: latestDateToInclude, siteTimezone: siteTimezone)
@@ -26,6 +27,7 @@ final class DashboardViewModel {
                                                  earliestDateToInclude: earliestDateToInclude,
                                                  latestDateToInclude: latestDateToInclude,
                                                  quantity: timeRange.maxNumberOfIntervals,
+                                                 forceRefresh: forceRefresh,
                                                  onCompletion: { [weak self] result in
             guard let self = self else { return }
             switch result {
@@ -69,6 +71,7 @@ final class DashboardViewModel {
                              siteTimezone: TimeZone,
                              timeRange: StatsTimeRangeV4,
                              latestDateToInclude: Date,
+                             forceRefresh: Bool,
                              onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
         let waitingTracker = WaitingTimeTracker(trackScenario: .dashboardTopPerformers)
         let earliestDateToInclude = timeRange.earliestDate(latestDate: latestDateToInclude, siteTimezone: siteTimezone)
@@ -77,6 +80,7 @@ final class DashboardViewModel {
                                                           earliestDateToInclude: earliestDateToInclude,
                                                           latestDateToInclude: latestDateToInclude,
                                                           quantity: Constants.topEarnerStatsLimit,
+                                                          forceRefresh: forceRefresh,
                                                           onCompletion: { result in
             switch result {
             case .success:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -160,6 +160,8 @@ private extension StoreStatsAndTopPerformersViewController {
                 return
             }
 
+            let forceRefresh = forced || vc.lastFullSyncTimestamp == nil
+
             // local var to catch sync error for period
             var periodSyncError: Error? = nil
 
@@ -181,7 +183,8 @@ private extension StoreStatsAndTopPerformersViewController {
             self.dashboardViewModel.syncStats(for: siteID,
                                               siteTimezone: timezoneForSync,
                                               timeRange: vc.timeRange,
-                                              latestDateToInclude: latestDateToInclude) { [weak self] result in
+                                              latestDateToInclude: latestDateToInclude,
+                                              forceRefresh: forceRefresh) { [weak self] result in
                 switch result {
                 case .success:
                     self?.trackStatsLoaded(for: vc.timeRange)
@@ -215,7 +218,8 @@ private extension StoreStatsAndTopPerformersViewController {
             self.dashboardViewModel.syncTopEarnersStats(for: siteID,
                                                         siteTimezone: timezoneForSync,
                                                         timeRange: vc.timeRange,
-                                                        latestDateToInclude: latestDateToInclude) { result in
+                                                        latestDateToInclude: latestDateToInclude,
+                                                        forceRefresh: forceRefresh) { result in
                 if case let .failure(error) = result {
                     DDLogError("⛔️ Error synchronizing top earners stats: \(error)")
                     periodSyncError = error

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -160,6 +160,9 @@ private extension StoreStatsAndTopPerformersViewController {
                 return
             }
 
+            // We want to make sure the latest data are fetched (force-refreshing the cache on the server side) when:
+            // - The `forced` parameter is `true` (e.g. when the user pulls to refresh)
+            // - The stats for the time range tab are being synced for the first time (`lastFullSyncTimestamp` is `nil`)
             let forceRefresh = forced || vc.lastFullSyncTimestamp == nil
 
             // local var to catch sync error for period

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -16,7 +16,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
-            if case let .retrieveStats(_, _, _, _, _, completion) = action {
+            if case let .retrieveStats(_, _, _, _, _, _, completion) = action {
                 completion(.failure(DotcomError.noRestRoute))
             }
         }
@@ -24,7 +24,7 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.statsVersion, .v4)
 
         // When
-        viewModel.syncStats(for: 122, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init())
+        viewModel.syncStats(for: 122, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init(), forceRefresh: false)
 
         // Then
         XCTAssertEqual(viewModel.statsVersion, .v3)
@@ -34,11 +34,11 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
-            if case let .retrieveStats(_, _, _, _, _, completion) = action {
+            if case let .retrieveStats(_, _, _, _, _, _, completion) = action {
                 completion(.failure(DotcomError.empty))
             } else if case let .retrieveSiteVisitStats(_, _, _, _, completion) = action {
                 completion(.failure(DotcomError.noRestRoute))
-            } else if case let .retrieveTopEarnerStats(_, _, _, _, _, completion) = action {
+            } else if case let .retrieveTopEarnerStats(_, _, _, _, _, _, completion) = action {
                 completion(.failure(DotcomError.noRestRoute))
             }
         }
@@ -46,9 +46,9 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.statsVersion, .v4)
 
         // When
-        viewModel.syncStats(for: 122, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init())
+        viewModel.syncStats(for: 122, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init(), forceRefresh: false)
         viewModel.syncSiteVisitStats(for: 122, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init())
-        viewModel.syncTopEarnersStats(for: 122, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init())
+        viewModel.syncTopEarnersStats(for: 122, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init(), forceRefresh: false)
 
         // Then
         XCTAssertEqual(viewModel.statsVersion, .v4)
@@ -60,17 +60,17 @@ final class DashboardViewModelTests: XCTestCase {
         // `DotcomError.noRestRoute` error indicates the stats are unavailable.
         var storeStatsResult: Result<Void, Error> = .failure(DotcomError.noRestRoute)
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
-            if case let .retrieveStats(_, _, _, _, _, completion) = action {
+            if case let .retrieveStats(_, _, _, _, _, _, completion) = action {
                 completion(storeStatsResult)
             }
         }
         let viewModel = DashboardViewModel(stores: stores)
-        viewModel.syncStats(for: 122, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init())
+        viewModel.syncStats(for: 122, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init(), forceRefresh: false)
         XCTAssertEqual(viewModel.statsVersion, .v3)
 
         // When
         storeStatsResult = .success(())
-        viewModel.syncStats(for: 122, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init())
+        viewModel.syncStats(for: 122, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init(), forceRefresh: false)
 
         // Then
         XCTAssertEqual(viewModel.statsVersion, .v4)

--- a/Yosemite/Yosemite/Actions/StatsActionV4.swift
+++ b/Yosemite/Yosemite/Actions/StatsActionV4.swift
@@ -16,6 +16,7 @@ public enum StatsActionV4: Action {
         earliestDateToInclude: Date,
         latestDateToInclude: Date,
         quantity: Int,
+        forceRefresh: Bool,
         onCompletion: (Result<Void, Error>) -> Void)
 
     /// Synchronizes `SiteVisitStats` for the provided siteID, time range, and date.
@@ -33,5 +34,6 @@ public enum StatsActionV4: Action {
                                 earliestDateToInclude: Date,
                                 latestDateToInclude: Date,
                                 quantity: Int,
+                                forceRefresh: Bool,
                                 onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
@@ -10,11 +10,11 @@ struct MockStatsActionV4Handler: MockActionHandler {
 
     func handle(action: ActionType) {
         switch action {
-            case .retrieveStats(let siteID, let timeRange, _, _, _, let onCompletion):
+            case .retrieveStats(let siteID, let timeRange, _, _, _, _, let onCompletion):
                 retrieveStats(siteID: siteID, timeRange: timeRange, onCompletion: onCompletion)
             case .retrieveSiteVisitStats(let siteID, _, let timeRange, _, let onCompletion):
                 retrieveSiteVisitStats(siteID: siteID, timeRange: timeRange, onCompletion: onCompletion)
-            case .retrieveTopEarnerStats(let siteID, let timeRange, _, _, _, let onCompletion):
+            case .retrieveTopEarnerStats(let siteID, let timeRange, _, _, _, _, let onCompletion):
                 retrieveTopEarnerStats(siteID: siteID, timeRange: timeRange, onCompletion: onCompletion)
             default: unimplementedAction(action: action)
         }

--- a/Yosemite/Yosemite/Stores/AvailabilityStore.swift
+++ b/Yosemite/Yosemite/Stores/AvailabilityStore.swift
@@ -43,7 +43,8 @@ private extension AvailabilityStore {
                               unit: .yearly,
                               earliestDateToInclude: Date(),
                               latestDateToInclude: Date(),
-                              quantity: 1) { result in
+                              quantity: 1,
+                                        forceRefresh: false) { result in
             switch result {
             case .failure(let error) where error as? DotcomError == .noRestRoute:
                 onCompletion(false)

--- a/Yosemite/YosemiteTests/Mocks/MockNetwork+Path.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockNetwork+Path.swift
@@ -17,9 +17,9 @@ extension MockNetwork {
 
         guard let queryString = parameters?.first(where: { $0.name == "query" })?.value,
               let queryData = queryString.data(using: .utf8),
-              let queryDictionary = try? JSONSerialization.jsonObject(with: queryData) as? [String: String] else {
+              let queryDictionary = try? JSONSerialization.jsonObject(with: queryData) as? [String: Any] else {
             return nil
         }
-        return queryDictionary.map({ $0.0 + "=" + $0.1 })
+        return queryDictionary.map { "\($0.0)=\($0.1)" }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -53,7 +53,8 @@ final class StatsStoreV4Tests: XCTestCase {
                                                      timeRange: .thisYear,
                                                      earliestDateToInclude: DateFormatter.dateFromString(with: "2018-06-23T17:06:55"),
                                                      latestDateToInclude: DateFormatter.dateFromString(with: "2018-06-23T17:06:55"),
-                                                     quantity: 2) { result in
+                                                     quantity: 2,
+                                                     forceRefresh: false) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -80,7 +81,8 @@ final class StatsStoreV4Tests: XCTestCase {
                                                      timeRange: .thisYear,
                                                      earliestDateToInclude: DateFormatter.dateFromString(with: "2018-06-23T17:06:55"),
                                                      latestDateToInclude: DateFormatter.dateFromString(with: "2018-06-23T17:06:55"),
-                                                     quantity: 2) { result in
+                                                     quantity: 2,
+                                                     forceRefresh: false) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -102,7 +104,8 @@ final class StatsStoreV4Tests: XCTestCase {
                                                      timeRange: .thisYear,
                                                      earliestDateToInclude: DateFormatter.dateFromString(with: "2018-06-23T17:06:55"),
                                                      latestDateToInclude: DateFormatter.dateFromString(with: "2018-06-23T17:06:55"),
-                                                     quantity: 2) { result in
+                                                     quantity: 2,
+                                                     forceRefresh: false) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -266,7 +269,8 @@ final class StatsStoreV4Tests: XCTestCase {
                                                               timeRange: .thisYear,
                                                               earliestDateToInclude: DateFormatter.dateFromString(with: "2020-01-01T00:00:00"),
                                                               latestDateToInclude: DateFormatter.dateFromString(with: "2020-07-22T12:00:00"),
-                                                              quantity: 3) { result in
+                                                              quantity: 3,
+                                                              forceRefresh: false) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -294,7 +298,8 @@ final class StatsStoreV4Tests: XCTestCase {
                                                               timeRange: .thisYear,
                                                               earliestDateToInclude: DateFormatter.dateFromString(with: "2020-01-01T00:00:00"),
                                                               latestDateToInclude: DateFormatter.dateFromString(with: "2020-07-22T12:00:00"),
-                                                              quantity: quantity) { _ in
+                                                              quantity: quantity,
+                                                              forceRefresh: false) { _ in
                 promise(())
             }
             store.onAction(action)
@@ -320,7 +325,8 @@ final class StatsStoreV4Tests: XCTestCase {
                                                               timeRange: .thisYear,
                                                               earliestDateToInclude: DateFormatter.dateFromString(with: "2020-01-01T00:00:00"),
                                                               latestDateToInclude: DateFormatter.dateFromString(with: "2020-07-22T12:00:00"),
-                                                              quantity: 3) { result in
+                                                              quantity: 3,
+                                                              forceRefresh: false) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -349,7 +355,8 @@ final class StatsStoreV4Tests: XCTestCase {
                                                               timeRange: .thisYear,
                                                               earliestDateToInclude: DateFormatter.dateFromString(with: "2020-01-01T00:00:00"),
                                                               latestDateToInclude: DateFormatter.dateFromString(with: "2020-07-22T12:00:00"),
-                                                              quantity: 3) { result in
+                                                              quantity: 3,
+                                                              forceRefresh: false) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -377,7 +384,8 @@ final class StatsStoreV4Tests: XCTestCase {
                                                               timeRange: .thisMonth,
                                                               earliestDateToInclude: Date(),
                                                               latestDateToInclude: Date(),
-                                                              quantity: 3) { result in
+                                                              quantity: 3,
+                                                              forceRefresh: false) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -399,7 +407,8 @@ final class StatsStoreV4Tests: XCTestCase {
                                                               timeRange: .thisMonth,
                                                               earliestDateToInclude: Date(),
                                                               latestDateToInclude: Date(),
-                                                              quantity: 3) { result in
+                                                              quantity: 3,
+                                                              forceRefresh: false) { result in
                 promise(result)
             }
             store.onAction(action)

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -310,6 +310,54 @@ final class StatsStoreV4Tests: XCTestCase {
         XCTAssertEqual(network.queryParameters?.contains(expectedQuantityParam), true)
     }
 
+    /// Verifies that `StatsActionV4.retrieveTopEarnerStats` makes a network request with the given `force_cache_refresh` parameter.
+    ///
+    func test_retrieveTopEarnerStats_makes_network_request_with_given_force_cache_rerefresh_parameter() {
+        // Given
+        let store = StatsStoreV4(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let _: Void = waitFor { promise in
+            let action = StatsActionV4.retrieveTopEarnerStats(siteID: self.sampleSiteID,
+                                                              timeRange: .thisYear,
+                                                              earliestDateToInclude: DateFormatter.dateFromString(with: "2020-01-01T00:00:00"),
+                                                              latestDateToInclude: DateFormatter.dateFromString(with: "2020-07-22T12:00:00"),
+                                                              quantity: 1,
+                                                              forceRefresh: true) { _ in
+                promise(())
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let expectedParam = "force_cache_refresh=1"
+        XCTAssertEqual(network.queryParameters?.contains(expectedParam), true)
+    }
+
+    /// Verifies that `StatsActionV4.retrieveStats` makes a network request with the given `force_cache_refresh` parameter.
+    ///
+    func test_retrieveStats_makes_network_request_with_given_force_cache_rerefresh_parameter() {
+        // Given
+        let store = StatsStoreV4(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let _: Void = waitFor { promise in
+            let action = StatsActionV4.retrieveStats(siteID: self.sampleSiteID,
+                                                     timeRange: .thisMonth,
+                                                     earliestDateToInclude: .init(),
+                                                     latestDateToInclude: .init(),
+                                                     quantity: 1,
+                                                     forceRefresh: false) { _ in
+                promise(())
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let expectedParam = "force_cache_refresh=0"
+        XCTAssertEqual(network.queryParameters?.contains(expectedParam), true)
+    }
+
     /// Verifies that `StatsActionV4.retrieveTopEarnerStats` effectively persists any updated TopEarnerStatsItems.
     ///
     func test_retrieveTopEarnerStats_effectively_persists_updated_items() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7055 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

On the server side, our API team [has a plan](https://github.com/woocommerce/woocommerce/issues/33315) to update how the analytics cache is invalidated so that it's invalidated less often to potentially improve site performance. This means that after the changes on the cache, the data in the wc-analytics API response could be outdated more often. This is fine for API requests triggered like when switching a time range tab, but there are times when we still want to always fetch the latest data like when the user pulls to refresh or on the first view of a stats time range tab. In order to distinguish whether a "force-refresh" is required, a new parameter `force_cache_refresh` was added in WC 6.7.0 https://github.com/woocommerce/woocommerce/pull/33325 and we need to implement this parameter before the API team can make any changes to the cache.

This PR thus added the new parameter `force_cache_refresh` to two API requests: order stats and leaderboards. The parameter doesn't make a difference right now, but will be necessary when the cache changes are implemented in a future WC version.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

I don't think there's a way to verify the new param works, asked about this in peaMlT-X-p2#comment-47 but haven't got a response.

Please just make sure the stats are loaded correctly before for all 4 time range tabs in the My store tab, for sites with WC version 6.7.0+.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->