### PR TITLE
Save test result as artifacts

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -36,3 +36,6 @@ echo "--- 🧪 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &
 bundle exec fastlane test_without_building name:"$TEST_NAME" device:"$DEVICE" ios_version:"$IOS_VERSION"
+
+echo "--- 📦 Zipping test results"
+cd fastlane/test_output/ && zip -rq WooCommerce.xcresult.zip WooCommerce.xcresult && cd -

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -17,3 +17,6 @@ install_gems
 
 echo "--- 🧪 Testing"
 bundle exec fastlane test_without_building name:UnitTests
+
+echo "--- 📦 Zipping test results"
+cd fastlane/test_output/ && zip -rq WooCommerce.xcresult.zip WooCommerce.xcresult && cd -

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,6 +44,8 @@ steps:
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins
+    artifact_paths:
+      - "fastlane/test_output/**"
     notify:
       - github_commit_status:
           context: "Unit Tests"
@@ -71,7 +73,7 @@ steps:
     env: *common_env
     plugins: *common_plugins
     artifact_paths:
-      - "build/results/"
+      - "fastlane/test_output/**"
     notify:
       - github_commit_status:
           context: "UI Tests (iPhone)"
@@ -82,7 +84,7 @@ steps:
     env: *common_env
     plugins: *common_plugins
     artifact_paths:
-      - "build/results/"
+      - "fastlane/test_output/**"
     notify:
       - github_commit_status:
           context: "UI Tests (iPad)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,7 +45,7 @@ steps:
     env: *common_env
     plugins: *common_plugins
     artifact_paths:
-      - "fastlane/test_output/**"
+      - "fastlane/test_output/*"
     notify:
       - github_commit_status:
           context: "Unit Tests"
@@ -73,7 +73,7 @@ steps:
     env: *common_env
     plugins: *common_plugins
     artifact_paths:
-      - "fastlane/test_output/**"
+      - "fastlane/test_output/*"
     notify:
       - github_commit_status:
           context: "UI Tests (iPhone)"
@@ -84,7 +84,7 @@ steps:
     env: *common_env
     plugins: *common_plugins
     artifact_paths:
-      - "fastlane/test_output/**"
+      - "fastlane/test_output/*"
     notify:
       - github_commit_status:
           context: "UI Tests (iPad)"


### PR DESCRIPTION
### Description
Save unit test result as artifacts.
<img width="704" alt="Screen Shot 2022-09-01 at 8 28 56 PM" src="https://user-images.githubusercontent.com/1101828/187869410-3ebb2fc6-75dd-43dd-898c-776ff58184e8.png">

### Testing instructions
No testing needed.

### Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.