### PR TITLE
[Mobile Payments] Learn more link from Payments Menu Pay in Person toggle

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -52,7 +52,7 @@ class AuthenticationManager: Authentication {
                                                                 wpcomScheme: ApiCredentials.dotcomAuthScheme,
                                                                 wpcomTermsOfServiceURL: WooConstants.URLs.termsOfService.rawValue,
                                                                 wpcomAPIBaseURL: Settings.wordpressApiBaseURL,
-                                                                whatIsWPComURL: WooConstants.URLs.whatIsWPComURL.rawValue,
+                                                                whatIsWPComURL: WooConstants.URLs.whatIsWPCom.rawValue,
                                                                 googleLoginClientId: ApiCredentials.googleClientId,
                                                                 googleLoginServerClientId: ApiCredentials.googleServerId,
                                                                 googleLoginScheme: ApiCredentials.googleAuthScheme,

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -73,7 +73,7 @@ private extension NotWPAccountViewModel {
             return
         }
         ServiceLocator.analytics.track(.whatIsWPComOnInvalidEmailScreenTapped)
-        WebviewHelper.launch(WooConstants.URLs.whatIsWPComURL.asURL(), with: viewController)
+        WebviewHelper.launch(WooConstants.URLs.whatIsWPCom.asURL(), with: viewController)
     }
 
     func needHelpFindingEmailButtonTapped() {

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -55,7 +55,7 @@ extension WooConstants {
         ///
         /// Displayed by the Authenticator in the Continue with WordPress.com flow.
         ///
-        case whatIsWPComURL = "https://woocommerce.com/document/what-is-a-wordpress-com-account/"
+        case whatIsWPCom = "https://woocommerce.com/document/what-is-a-wordpress-com-account/"
 
         /// Terms of Service Website. Displayed by the Authenticator (when / if needed).
         ///
@@ -182,11 +182,11 @@ extension WooConstants {
 #endif
         /// URL for the Enable Cash on Delivery (or Pay in Person) onboarding step's learn more link using the Stripe plugin
         /// 
-        case stripeCashOnDeliveryLearnMoreUrl = "https://woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/#section-8"
+        case stripeCashOnDeliveryLearnMore = "https://woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/#section-8"
 
         /// URL for the Enable Cash on Delivery (or Pay in Person) onboarding step's learn more link using the WCPay plugin
         ///
-        case wcPayCashOnDeliveryLearnMoreUrl =
+        case wcPayCashOnDeliveryLearnMore =
                 "https://woocommerce.com/document/payments/getting-started-with-in-person-payments-with-woocommerce-payments/#add-cod-payment-method"
 
         /// Returns the URL version of the receiver

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsPlugin+CashOnDelivery.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsPlugin+CashOnDelivery.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Yosemite
+
+extension CardPresentPaymentsPlugin {
+    var cashOnDeliveryLearnMoreURL: URL {
+        switch self {
+        case .wcPay:
+            return WooConstants.URLs.wcPayCashOnDeliveryLearnMore.asURL()
+        case .stripe:
+            return WooConstants.URLs.stripeCashOnDeliveryLearnMore.asURL()
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -110,6 +110,8 @@ private extension InPersonPaymentsMenuViewController {
             showCardPresentPaymentsOnboardingNotice()
         }
 
+        updateViewModelSelectedPlugin(state: state)
+
         activityIndicator?.stopAnimating()
         configureSections()
         tableView.reloadData()
@@ -128,6 +130,17 @@ private extension InPersonPaymentsMenuViewController {
 
     func dismissCardPresentPaymentsOnboardingNoticeIfPresent() {
         permanentNoticePresenter.dismiss()
+    }
+
+    func updateViewModelSelectedPlugin(state: CardPresentPaymentOnboardingState) {
+        switch state {
+        case let .completed(pluginState):
+            inPersonPaymentsMenuViewModel.selectedPlugin = pluginState.preferred
+        case let .codPaymentGatewayNotSetUp(plugin):
+            inPersonPaymentsMenuViewModel.selectedPlugin = plugin
+        default:
+            inPersonPaymentsMenuViewModel.selectedPlugin = nil
+        }
     }
 
     func showOnboarding() {
@@ -280,7 +293,11 @@ private extension InPersonPaymentsMenuViewController {
                        text: Localization.toggleEnableCashOnDelivery,
                        subtitle: learnMoreViewModel.learnMoreAttributedString,
                        switchState: inPersonPaymentsMenuViewModel.cashOnDeliveryEnabledState,
-                       switchAction: inPersonPaymentsMenuViewModel.updateCashOnDeliverySetting(enabled:))
+                       switchAction: inPersonPaymentsMenuViewModel.updateCashOnDeliverySetting(enabled:),
+                       subtitleTapAction: { [weak self] in
+            guard let self = self else { return }
+            self.inPersonPaymentsMenuViewModel.learnMoreTapped(from: self)
+        })
     }
 
     func updateEnabledState(in cell: UITableViewCell, shouldBeEnabled: Bool = true) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -13,7 +13,7 @@ final class InPersonPaymentsMenuViewController: UIViewController {
     private let cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCase
     private var cancellables: Set<AnyCancellable> = []
     private lazy var learnMoreViewModel: LearnMoreViewModel = {
-        LearnMoreViewModel(url: WooConstants.URLs.wcPayCashOnDeliveryLearnMoreUrl.asURL(),
+        LearnMoreViewModel(url: WooConstants.URLs.wcPayCashOnDeliveryLearnMore.asURL(),
                            linkText: Localization.toggleEnableCashOnDeliveryLearnMoreLink,
                            formatText: Localization.toggleEnableCashOnDeliveryLearnMoreFormat,
                            tappedAnalyticEvent: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingLearnMoreTapped(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -88,7 +88,7 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func refreshAfterNewOnboardingState(_ state: CardPresentPaymentOnboardingState) {
-        self.pluginState = nil
+        pluginState = nil
 
         guard state != .loading else {
             self.activityIndicator?.startAnimating()
@@ -97,22 +97,22 @@ private extension InPersonPaymentsMenuViewController {
 
         switch state {
         case let .completed(newPluginState):
-            self.pluginState = newPluginState
-            self.dismissCardPresentPaymentsOnboardingNoticeIfPresent()
-            self.dismissOnboardingIfPresented()
+            pluginState = newPluginState
+            dismissCardPresentPaymentsOnboardingNoticeIfPresent()
+            dismissOnboardingIfPresented()
         case let .selectPlugin(pluginSelectionWasCleared):
             // If it was cleared it means that we triggered it manually (e.g by tapping in this view on the plugin selection row)
             // No need to show the onboarding notice
             if !pluginSelectionWasCleared {
-                self.showCardPresentPaymentsOnboardingNotice()
+                showCardPresentPaymentsOnboardingNotice()
             }
         default:
-            self.showCardPresentPaymentsOnboardingNotice()
+            showCardPresentPaymentsOnboardingNotice()
         }
 
-        self.activityIndicator?.stopAnimating()
-        self.configureSections()
-        self.tableView.reloadData()
+        activityIndicator?.stopAnimating()
+        configureSections()
+        tableView.reloadData()
     }
 
     func showCardPresentPaymentsOnboardingNotice() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
@@ -42,6 +42,8 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
 
     private let paymentGatewaysFetchedResultsController: ResultsController<StoragePaymentGateway>?
 
+    var selectedPlugin: CardPresentPaymentsPlugin?
+
     init(dependencies: Dependencies = Dependencies()) {
         self.dependencies = dependencies
         paymentGatewaysFetchedResultsController = Self.createPaymentGatewaysResultsController(
@@ -151,6 +153,16 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
                             actionHandler: disableCashOnDeliveryGateway)
 
         noticePresenter.enqueue(notice: notice)
+    }
+
+    // MARK: - Learn More
+
+    private var learnMoreURL: URL {
+        (selectedPlugin ?? .wcPay).cashOnDeliveryLearnMoreURL
+    }
+
+    func learnMoreTapped(from viewController: UIViewController) {
+        WebviewHelper.launch(learnMoreURL, with: viewController)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -151,14 +151,3 @@ private enum Localization {
         "Retry",
         comment: "Retry Action on error displayed when the attempt to enable a Pay in Person checkout payment option fails")
 }
-
-private extension CardPresentPaymentsPlugin {
-    var cashOnDeliveryLearnMoreURL: URL {
-        switch self {
-        case .wcPay:
-            return WooConstants.URLs.wcPayCashOnDeliveryLearnMore.asURL()
-        case .stripe:
-            return WooConstants.URLs.stripeCashOnDeliveryLearnMore.asURL()
-        }
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -156,9 +156,9 @@ private extension CardPresentPaymentsPlugin {
     var cashOnDeliveryLearnMoreURL: URL {
         switch self {
         case .wcPay:
-            return WooConstants.URLs.wcPayCashOnDeliveryLearnMoreUrl.asURL()
+            return WooConstants.URLs.wcPayCashOnDeliveryLearnMore.asURL()
         case .stripe:
-            return WooConstants.URLs.stripeCashOnDeliveryLearnMoreUrl.asURL()
+            return WooConstants.URLs.stripeCashOnDeliveryLearnMore.asURL()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.swift
@@ -45,9 +45,14 @@ class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
     }
 
     private var switchAction: ((Bool) -> Void)? = nil
+    private var subtitleTapAction: (() -> Void)? = nil
 
     @IBAction func switchValueChanged(_ sender: UISwitch) {
         switchAction?(sender.isOn)
+    }
+
+    @objc private func subtitleTapped(_ sender: Any) {
+        subtitleTapAction?()
     }
     // MARK: - Overridden Methods
 
@@ -58,6 +63,7 @@ class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
         titleLabel?.applyBodyStyle()
         subtitleLabel?.applyFootnoteStyle()
         toggleSwitch?.onTintColor = .primary
+        subtitleLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(subtitleTapped)))
     }
 
     private func configureBackground() {
@@ -68,12 +74,33 @@ class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
 // MARK: - Public Methods
 //
 extension LeftImageTitleSubtitleToggleTableViewCell {
-    func configure(image: UIImage, text: String, subtitle: String, switchState: Bool, switchAction: @escaping (Bool) -> Void) {
-        configure(image: image, text: text, subtitle: subtitle, attributedSubtitle: nil, switchState: switchState, switchAction: switchAction)
+    func configure(image: UIImage,
+                   text: String,
+                   subtitle: String,
+                   switchState: Bool,
+                   switchAction: @escaping (Bool) -> Void) {
+        configure(image: image,
+                  text: text,
+                  subtitle: subtitle,
+                  attributedSubtitle: nil,
+                  switchState: switchState,
+                  switchAction: switchAction,
+                  subtitleTapAction: nil)
     }
 
-    func configure(image: UIImage, text: String, subtitle: NSAttributedString, switchState: Bool, switchAction: @escaping (Bool) -> Void) {
-        configure(image: image, text: text, subtitle: nil, attributedSubtitle: subtitle, switchState: switchState, switchAction: switchAction)
+    func configure(image: UIImage,
+                   text: String,
+                   subtitle: NSAttributedString,
+                   switchState: Bool,
+                   switchAction: @escaping (Bool) -> Void,
+                   subtitleTapAction: (() -> Void)? = nil) {
+        configure(image: image,
+                  text: text,
+                  subtitle: nil,
+                  attributedSubtitle: subtitle,
+                  switchState: switchState,
+                  switchAction: switchAction,
+                  subtitleTapAction: subtitleTapAction)
     }
 
     private func configure(image: UIImage,
@@ -81,12 +108,14 @@ extension LeftImageTitleSubtitleToggleTableViewCell {
                            subtitle: String?,
                            attributedSubtitle: NSAttributedString?,
                            switchState: Bool,
-                           switchAction: @escaping (Bool) -> Void) {
+                           switchAction: @escaping (Bool) -> Void,
+                           subtitleTapAction: (() -> Void)? = nil) {
         leftImageView?.image = image
         titleLabel?.text = text
         subtitleLabel?.text = subtitle
         subtitleLabel.attributedText = attributedSubtitle
         toggleSwitch.isOn = switchState
         self.switchAction = switchAction
+        self.subtitleTapAction = subtitleTapAction
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.xib
@@ -38,13 +38,15 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tBN-G3-N5i">
+                                            <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tBN-G3-N5i">
                                                 <rect key="frame" x="0.0" y="55.5" width="195" height="14.5"/>
+                                                <gestureRecognizers/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
+                                        <gestureRecognizers/>
                                     </stackView>
                                 </subviews>
                                 <constraints>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -459,6 +459,7 @@
 		03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */; };
 		03EF24FA28BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24F928BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift */; };
 		03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */; };
+		03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */; };
 		03FBDA9D263AD49200ACE257 /* CouponListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */; };
 		03FBDAA3263AED2F00ACE257 /* CouponListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */; };
 		03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */; };
@@ -2305,6 +2306,7 @@
 		03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayCardBrand+IconsTests.swift"; sourceTree = "<group>"; };
 		03EF24F928BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
 		03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift; sourceTree = "<group>"; };
+		03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardPresentPaymentsPlugin+CashOnDelivery.swift"; sourceTree = "<group>"; };
 		03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewController.swift; sourceTree = "<group>"; };
 		03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CouponListViewController.xib; sourceTree = "<group>"; };
 		03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModel.swift; sourceTree = "<group>"; };
@@ -8315,6 +8317,7 @@
 				68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */,
 				68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */,
 				03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */,
+				03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */,
 			);
 			path = "In-Person Payments";
 			sourceTree = "<group>";
@@ -10042,6 +10045,7 @@
 				FE28F7182684EE6A004465C7 /* RoleErrorViewModel.swift in Sources */,
 				02C0CD2C23B5BC9600F880B1 /* DefaultImageService.swift in Sources */,
 				CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */,
+				03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */,
 				DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,
 				4572641927F1EB27004E1F95 /* AddEditCouponViewModel.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7627 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In 10.1, we added the ability for a merchant to turn on the `Cash on Delivery` payment gateway in the In-Person Payments Onboarding flow. There is currently no way to undo that choice in the app, nor to turn it on at a later date if the merchant chose to skip the initial onboarding prompt.

For iteration 2 of the project, we'll add a toggle to the In-Person Payments settings so that a user can see the current state of the gateway, and change it outside of the onboarding flow.

This PR adds the Learn more behaviour for the switch on this new row:
- [x] Open web view and load correct documentation page for active IPP plugin when `Learn More` is tapped:
- [x] Stripe: `https://woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/#section-8`
- [x] WCPay: `https://woocommerce.com/document/payments/getting-started-with-in-person-payments-with-woocommerce-payments/#add-cod-payment-method`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a store with only one of WCPay or Stripe installed:

1. Run the app and log in to your account, selecting the store.
2. Go to `Menu > Payments`
3. You should see the `Enable InPersonPayments` row on the screen
4. Tap the Learn More link
5. Observe that the web view opens at the Cash on Delivery section of the correct docs for the plugin you're using.

Using a US store with both WCPay and Stripe installed:

1. Delete the app to remove any saved plugin preference
2. Run the app and log in to your account, selecting the store.
3. Go to `Menu > Payments`
4. You should see the `Enable InPersonPayments` row on the screen
5. Tap the Learn More link
6. Observe that the web view opens at the Cash on Delivery section of the correct docs for WCPay.
7. Tap Done to return to the Payments Menu
8. Tap `Continue Setup` and choose Stripe, then complete onboarding, skipping the `Enable Pay in Person` step.
9. Tap the Learn More link again
10. Observe that the web view opens at the Cash on Delivery section of the correct docs for Stripe.
11. Tap Done to return to the Payments Menu
12. Tap `Payment Provider` and choose WooCommerce Payments, then tap `Confirm` to go back to the Payments Menu
13. Tap the Learn More link again
14. Observe that the web view opens at the Cash on Delivery section of the correct docs for WCPay.


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/187897651-a410bf7d-0ab6-430e-b885-bf780d6db69a.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
