### PR TITLE
[Engage] Universal Links: Handle Payments universal links

### DIFF
--- a/WooCommerce/Classes/Universal Links/Routes/PaymentsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/PaymentsRoute.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// Links an URL with a /payments path to the Payments Hub Menu
+/// 
 struct PaymentsRoute: Route {
     let path = "/payments"
 

--- a/WooCommerce/Classes/Universal Links/Routes/PaymentsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/PaymentsRoute.swift
@@ -3,5 +3,7 @@ import Foundation
 struct PaymentsRoute: Route {
     let path = "/payments"
 
-    func perform(with parameters: [String: String]) {}
+    func perform(with parameters: [String: String]) {
+        MainTabBarController.presentPayments()
+    }
 }

--- a/WooCommerce/Classes/Universal Links/Routes/PaymentsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/PaymentsRoute.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct PaymentsRoute: Route {
+    let path = "/payments"
+
+    func perform(with parameters: [String: String]) {}
+}

--- a/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
+++ b/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
@@ -25,7 +25,8 @@ struct UniversalLinkRouter {
     /// As we only perform one action to avoid conflicts, order matters (only the first matched route will be called to perform its action)
     ///
     private static let defaultRoutes: [Route] = [
-        OrderDetailsRoute()
+        OrderDetailsRoute(),
+        PaymentsRoute()
     ]
 
     func handle(url: URL) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -55,13 +55,11 @@ final class InPersonPaymentsMenuViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        setupNavigationBar()
         configureSections()
         configureTableView()
         registerTableViewCells()
         runCardPresentPaymentsOnboarding()
-
-        navigationController?.setNavigationBarHidden(false, animated: true)
-        navigationItem.title = "In-Person Payments"
     }
 }
 
@@ -141,6 +139,11 @@ private extension InPersonPaymentsMenuViewController {
 // MARK: - View configuration
 //
 private extension InPersonPaymentsMenuViewController {
+    func setupNavigationBar() {
+        navigationController?.setNavigationBarHidden(false, animated: true)
+        navigationItem.title = InPersonPaymentsView.Localization.title
+    }
+
     func configureSections() {
         sections = [
             actionsSection,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -59,6 +59,9 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         configureTableView()
         registerTableViewCells()
         runCardPresentPaymentsOnboarding()
+
+        navigationController?.setNavigationBarHidden(false, animated: true)
+        navigationItem.title = "In-Person Payments"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -27,6 +27,10 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
     func pushReviewDetailsViewController(using parcel: ProductReviewFromNoteParcel) {
         viewModel.showReviewDetails(using: parcel)
     }
+
+    func showPaymentsMenu() {
+        show(InPersonPaymentsMenuViewController(), sender: self)
+    }
 }
 
 private extension HubMenuViewController {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -420,6 +420,16 @@ extension MainTabBarController {
             (childViewController() as? OrdersRootViewController)?.presentDetails(for: orderID, siteID: siteID)
         }
     }
+
+    static func presentPayments() {
+        switchToHubMenuTab()
+
+        guard let hubMenuViewController: HubMenuViewController = childViewController() else {
+            return
+        }
+
+        hubMenuViewController.showPaymentsMenu()
+    }
 }
 
 // MARK: - Site ID observation for updating tab view controllers

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1273,6 +1273,7 @@
 		B92FF9AE27FC7217005C34E3 /* OrderListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B92FF9AD27FC7217005C34E3 /* OrderListViewController.xib */; };
 		B92FF9B027FC7821005C34E3 /* ProductsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B92FF9AF27FC7821005C34E3 /* ProductsViewController.xib */; };
 		B94403C9289ABB4D00323FC2 /* SimplePaymentsAmountFlowOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = B94403C8289ABB4D00323FC2 /* SimplePaymentsAmountFlowOpener.swift */; };
+		B95112DA28BF79CA00D9578D /* PaymentsRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95112D928BF79CA00D9578D /* PaymentsRoute.swift */; };
 		B958A7C728B3D44A00823EEF /* UniversalLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958A7C628B3D44A00823EEF /* UniversalLinkRouter.swift */; };
 		B958A7C928B3D47B00823EEF /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958A7C828B3D47B00823EEF /* Route.swift */; };
 		B958A7CB28B3D4A100823EEF /* RouteMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958A7CA28B3D4A100823EEF /* RouteMatcher.swift */; };
@@ -3125,6 +3126,7 @@
 		B92FF9AD27FC7217005C34E3 /* OrderListViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OrderListViewController.xib; sourceTree = "<group>"; };
 		B92FF9AF27FC7821005C34E3 /* ProductsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductsViewController.xib; sourceTree = "<group>"; };
 		B94403C8289ABB4D00323FC2 /* SimplePaymentsAmountFlowOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsAmountFlowOpener.swift; sourceTree = "<group>"; };
+		B95112D928BF79CA00D9578D /* PaymentsRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsRoute.swift; sourceTree = "<group>"; };
 		B958A7C628B3D44A00823EEF /* UniversalLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalLinkRouter.swift; sourceTree = "<group>"; };
 		B958A7C828B3D47B00823EEF /* Route.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
 		B958A7CA28B3D4A100823EEF /* RouteMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMatcher.swift; sourceTree = "<group>"; };
@@ -6933,6 +6935,7 @@
 			children = (
 				B958A7CC28B3DD9100823EEF /* OrderDetailsRoute.swift */,
 				B958A7C828B3D47B00823EEF /* Route.swift */,
+				B95112D928BF79CA00D9578D /* PaymentsRoute.swift */,
 			);
 			path = Routes;
 			sourceTree = "<group>";
@@ -9184,6 +9187,7 @@
 				024DF31E23743045006658FE /* TextList+AztecFormatting.swift in Sources */,
 				0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */,
 				DE4D308928507B5B00E36ADD /* CouponCreationSuccess.swift in Sources */,
+				B95112DA28BF79CA00D9578D /* PaymentsRoute.swift in Sources */,
 				7E6A019F2725CD76001668D5 /* FilterProductCategoryListViewModel.swift in Sources */,
 				CC53FB3C2757EC7200C4CA4F /* ProductSelectorViewModel.swift in Sources */,
 				4569D3C325DC008700CDC3E2 /* SiteAddress.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7538 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the second universal link route, which navigates the user to the Payment Hub Menu. As in the previous [case](https://github.com/woocommerce/woocommerce-ios/pull/7611),  we add a new route (`PaymentsRoute`) that matches the path and implement the navigation in the `MainTabBarController`.
Furthermore, since we are using strictly UIKit for the navigation, we have to setup the navigation bar in the `InPersonPaymentsMenuViewController`, by unhiding it and setting the right title.

### Changes
- Add a new `Route` for payments
- Implement navigation in `MainTabBarController` and `HubMenuViewController`
- Setup navigation bar in `InPersonPaymentsMenuViewController`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
At the moment there is no easy way to test it as the domain verification is not yet implemented in woocommerce.com, so either you can wait for the domain verification to be added, or the next steps to test it now:

1. Add applinks:thelinkswootester.mystagingwebsite.com to the Associated Domains in the WooCommerce target screen. 
<img width="915" alt="Screenshot 2022-08-23 at 18 28 17" src="https://user-images.githubusercontent.com/1864060/186211830-d2a37a93-0e41-4082-8a76-92a6121ce8af.png">
This is my dummy pressable test site. (We do not have domain verification ready in woocommerce.com) I uploaded the [`apple-app-site-association`](https://thelinkswootester.mystagingwebsite.com/apple-app-site-association) with paths:

```
"paths":[
               "/payments",
	             "/orders/details"
            ]
```

2. Send yourself an email containing a link with the format 
https://thelinkswootester.mystagingwebsite.com/payments

3. Tap on it. You can also test the switch to a different store by adding a store id to the link other than the currently selected in Woo app.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/1864060/187913313-b126a79e-0b71-4f39-86ec-8a49acbe6f02.MP4

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
