### PR TITLE
[Mobile Payments] Analytics for Pay in Person toggle on Payments Menu

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Help center: Added help center web page with FAQs for "Enter Store Credentials" and "Enter WordPress.com email "screens. [https://github.com/woocommerce/woocommerce-ios/pull/7588, https://github.com/woocommerce/woocommerce-ios/pull/7590]
 - [*] In-Person Payments: Fixed the Learn More link from the `Enable Pay in Person` onboarding screen for WCPay [https://github.com/woocommerce/woocommerce-ios/pull/7598]
+- [**] In-Person Payments: Added a switch for the Pay in Person payment method on the Payments menu. This allows you to accept In-Person Payments for website orders [https://github.com/woocommerce/woocommerce-ios/pull/7613]
 
 10.1
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1226,6 +1226,37 @@ extension WooAnalyticsEvent {
                               error: error)
         }
 
+        /// Tracked when the Cash on Delivery Payment Gateway is successfully disabled, e.g. from the toggle on the Payments hub menu.
+        ///
+        /// - Parameters:
+        ///   - countryCode: the country code of the store.
+        ///   - source: the screen which the disable attempt was made on
+        ///
+        static func disableCashOnDeliverySuccess(countryCode: String, source: CashOnDeliverySource) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .disableCashOnDeliverySuccess,
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.source: source.rawValue
+                              ])
+        }
+
+        /// Tracked when the Cash on Delivery Payment Gateway disabling fails,  e.g. from the toggle on the Payments hub menu.
+        ///
+        /// - Parameters:
+        ///   - countryCode: the country code of the store.
+        ///   - source: the screen which the disable attempt was made on
+        ///
+        static func disableCashOnDeliveryFailed(countryCode: String,
+                                               error: Error?,
+                                               source: CashOnDeliverySource) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .disableCashOnDeliveryFailed,
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.source: source.rawValue
+                              ],
+                              error: error)
+        }
+
         /// Tracked when the user taps on the "See Receipt" button to view a receipt.
         /// - Parameter countryCode: the country code of the store.
         ///

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1199,6 +1199,7 @@ extension WooAnalyticsEvent {
         ///
         /// - Parameters:
         ///   - countryCode: the country code of the store.
+        ///   - source: the screen which the enable attempt was made on     
         ///
         static func enableCashOnDeliverySuccess(countryCode: String, source: CashOnDeliverySource) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .enableCashOnDeliverySuccess,
@@ -1212,6 +1213,7 @@ extension WooAnalyticsEvent {
         ///
         /// - Parameters:
         ///   - countryCode: the country code of the store.
+        ///   - source: the screen which the enable attempt was made on
         ///
         static func enableCashOnDeliveryFailed(countryCode: String,
                                                error: Error?,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -752,6 +752,7 @@ extension WooAnalyticsEvent {
             static let paymentMethodType = "payment_method_type"
             static let softwareUpdateType = "software_update_type"
             static let source = "source"
+            static let enabled = "enabled"
         }
 
         static let unknownGatewayID = "unknown"
@@ -1240,7 +1241,7 @@ extension WooAnalyticsEvent {
                               ])
         }
 
-        /// Tracked when the Cash on Delivery Payment Gateway disabling fails,  e.g. from the toggle on the Payments hub menu.
+        /// Tracked when the Cash on Delivery Payment Gateway disabling fails, e.g. from the toggle on the Payments hub menu.
         ///
         /// - Parameters:
         ///   - countryCode: the country code of the store.
@@ -1255,6 +1256,20 @@ extension WooAnalyticsEvent {
                                 Keys.source: source.rawValue
                               ],
                               error: error)
+        }
+
+        /// Tracked when the Cash on Delivery Payment Gateway toggle is changed from the toggle on the Payments hub menu.
+        ///
+        /// - Parameters:
+        ///   - enabled: the reason why the onboarding step was shown (effectively the name of the step.)
+        ///   - countryCode: the country code of the store.
+        ///
+        static func paymentsHubCashOnDeliveryToggled(enabled: Bool, countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .paymentsHubCashOnDeliveryToggled,
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.enabled: enabled
+                              ])
         }
 
         /// Tracked when the user taps on the "See Receipt" button to view a receipt.

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -751,6 +751,7 @@ extension WooAnalyticsEvent {
             static let errorDescription = "error_description"
             static let paymentMethodType = "payment_method_type"
             static let softwareUpdateType = "software_update_type"
+            static let source = "source"
         }
 
         static let unknownGatewayID = "unknown"
@@ -1189,15 +1190,21 @@ extension WooAnalyticsEvent {
                               ])
         }
 
+        enum CashOnDeliverySource: String {
+            case onboarding
+            case paymentsHub = "payments_hub"
+        }
+
         /// Tracked when the Cash on Delivery Payment Gateway is successfully enabled, e.g. from the IPP onboarding flow.
         ///
         /// - Parameters:
         ///   - countryCode: the country code of the store.
         ///
-        static func enableCashOnDeliverySuccess(countryCode: String) -> WooAnalyticsEvent {
+        static func enableCashOnDeliverySuccess(countryCode: String, source: CashOnDeliverySource) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .enableCashOnDeliverySuccess,
                               properties: [
-                                Keys.countryCode: countryCode
+                                Keys.countryCode: countryCode,
+                                Keys.source: source.rawValue
                               ])
         }
 
@@ -1207,10 +1214,12 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///
         static func enableCashOnDeliveryFailed(countryCode: String,
-                                               error: Error?) -> WooAnalyticsEvent {
+                                               error: Error?,
+                                               source: CashOnDeliverySource) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .enableCashOnDeliveryFailed,
                               properties: [
-                                Keys.countryCode: countryCode
+                                Keys.countryCode: countryCode,
+                                Keys.source: source.rawValue
                               ],
                               error: error)
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -193,6 +193,7 @@ public enum WooAnalyticsStat: String {
     case disableCashOnDeliverySuccess = "disable_cash_on_delivery_success"
     case disableCashOnDeliveryFailed = "disable_cash_on_delivery_failed"
     case paymentsHubCashOnDeliveryToggled = "payments_hub_cash_on_delivery_toggled"
+    case paymentsHubCashOnDeliveryToggleLearnMoreTapped = "payments_hub_cash_on_delivery_toggle_learn_more_tapped"
 
     // MARK: Payment Gateways selection
     case cardPresentPaymentGatewaySelected = "card_present_payment_gateway_selected"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -192,6 +192,7 @@ public enum WooAnalyticsStat: String {
     case enableCashOnDeliveryFailed = "enable_cash_on_delivery_failed"
     case disableCashOnDeliverySuccess = "disable_cash_on_delivery_success"
     case disableCashOnDeliveryFailed = "disable_cash_on_delivery_failed"
+    case paymentsHubCashOnDeliveryToggled = "payments_hub_cash_on_delivery_toggled"
 
     // MARK: Payment Gateways selection
     case cardPresentPaymentGatewaySelected = "card_present_payment_gateway_selected"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -190,6 +190,8 @@ public enum WooAnalyticsStat: String {
     // MARK: Cash on Delivery Enable events
     case enableCashOnDeliverySuccess = "enable_cash_on_delivery_success"
     case enableCashOnDeliveryFailed = "enable_cash_on_delivery_failed"
+    case disableCashOnDeliverySuccess = "disable_cash_on_delivery_success"
+    case disableCashOnDeliveryFailed = "disable_cash_on_delivery_failed"
 
     // MARK: Payment Gateways selection
     case cardPresentPaymentGatewaySelected = "card_present_payment_gateway_selected"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
@@ -102,6 +102,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
     // MARK: - Toggle Cash on Delivery Payment Gateway
 
     func updateCashOnDeliverySetting(enabled: Bool) {
+        trackCashOnDeliveryToggled(enabled: enabled)
         switch enabled {
         case true:
             enableCashOnDeliveryGateway()
@@ -187,6 +188,12 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
 // MARK: - Analytics
 extension InPersonPaymentsMenuViewModel {
     private typealias Event = WooAnalyticsEvent.InPersonPayments
+
+    private func trackCashOnDeliveryToggled(enabled: Bool) {
+        let event = Event.paymentsHubCashOnDeliveryToggled(enabled: enabled,
+                                                           countryCode: cardPresentPaymentsConfiguration.countryCode)
+        analytics.track(event: event)
+    }
 
     private func trackEnableCashOnDeliverySuccess() {
         let event = Event.enableCashOnDeliverySuccess(countryCode: cardPresentPaymentsConfiguration.countryCode,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
@@ -182,6 +182,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
 
     func learnMoreTapped(from viewController: UIViewController) {
         WebviewHelper.launch(learnMoreURL, with: viewController)
+        analytics.track(.paymentsHubCashOnDeliveryToggleLearnMoreTapped)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -131,13 +131,15 @@ extension InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel {
     }
 
     private func trackEnableCashOnDeliverySuccess() {
-        let event = Event.enableCashOnDeliverySuccess(countryCode: cardPresentPaymentsConfiguration.countryCode)
+        let event = Event.enableCashOnDeliverySuccess(countryCode: cardPresentPaymentsConfiguration.countryCode,
+                                                      source: .onboarding)
         analytics.track(event: event)
     }
 
     private func trackEnableCashOnDeliveryFailed(error: Error?) {
         let event = Event.enableCashOnDeliveryFailed(countryCode: cardPresentPaymentsConfiguration.countryCode,
-                                                     error: error)
+                                                     error: error,
+                                                     source: .onboarding)
         analytics.track(event: event)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTitleSubtitleToggleTableViewCell.swift
@@ -4,8 +4,6 @@ import UIKit
 /// Represents a regular UITableView Cell with subtitle: [Image | Text + Subtitle |  Disclosure]
 ///
 class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
-
-
     @IBOutlet weak var leftImageView: UIImageView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var subtitleLabel: UILabel!
@@ -15,10 +13,10 @@ class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
     ///
     var leftImage: UIImage? {
         get {
-            return leftImageView?.image
+            return leftImageView.image
         }
         set {
-            leftImageView?.image = newValue
+            leftImageView.image = newValue
         }
     }
 
@@ -26,10 +24,10 @@ class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
     ///
     var labelText: String? {
         get {
-            return titleLabel?.text
+            return titleLabel.text
         }
         set {
-            titleLabel?.text = newValue
+            titleLabel.text = newValue
         }
     }
 
@@ -37,10 +35,10 @@ class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
     ///
     var subtitleLabelText: String? {
         get {
-            return subtitleLabel?.text
+            return subtitleLabel.text
         }
         set {
-            subtitleLabel?.text = newValue
+            subtitleLabel.text = newValue
         }
     }
 
@@ -59,10 +57,10 @@ class LeftImageTitleSubtitleToggleTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBackground()
-        leftImageView?.tintColor = .primary
-        titleLabel?.applyBodyStyle()
-        subtitleLabel?.applyFootnoteStyle()
-        toggleSwitch?.onTintColor = .primary
+        leftImageView.tintColor = .primary
+        titleLabel.applyBodyStyle()
+        subtitleLabel.applyFootnoteStyle()
+        toggleSwitch.onTintColor = .primary
         subtitleLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(subtitleTapped)))
     }
 
@@ -110,9 +108,9 @@ extension LeftImageTitleSubtitleToggleTableViewCell {
                            switchState: Bool,
                            switchAction: @escaping (Bool) -> Void,
                            subtitleTapAction: (() -> Void)? = nil) {
-        leftImageView?.image = image
-        titleLabel?.text = text
-        subtitleLabel?.text = subtitle
+        leftImageView.image = image
+        titleLabel.text = text
+        subtitleLabel.text = subtitle
         subtitleLabel.attributedText = attributedSubtitle
         toggleSwitch.isOn = switchState
         self.switchAction = switchAction

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -460,6 +460,7 @@
 		03EF24FA28BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24F928BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift */; };
 		03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */; };
 		03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */; };
+		03EF250028C0E9EE006A033E /* InPersonPaymentsMenuViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FF28C0E9EE006A033E /* InPersonPaymentsMenuViewModelTests.swift */; };
 		03FBDA9D263AD49200ACE257 /* CouponListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */; };
 		03FBDAA3263AED2F00ACE257 /* CouponListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */; };
 		03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */; };
@@ -2307,6 +2308,7 @@
 		03EF24F928BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
 		03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift; sourceTree = "<group>"; };
 		03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardPresentPaymentsPlugin+CashOnDelivery.swift"; sourceTree = "<group>"; };
+		03EF24FF28C0E9EE006A033E /* InPersonPaymentsMenuViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModelTests.swift; sourceTree = "<group>"; };
 		03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewController.swift; sourceTree = "<group>"; };
 		03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CouponListViewController.xib; sourceTree = "<group>"; };
 		03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModel.swift; sourceTree = "<group>"; };
@@ -4745,6 +4747,7 @@
 			isa = PBXGroup;
 			children = (
 				03A6C18228B52ADB00AADF23 /* Onboarding Errors */,
+				03EF24FF28C0E9EE006A033E /* InPersonPaymentsMenuViewModelTests.swift */,
 			);
 			path = "In-Person Payments";
 			sourceTree = "<group>";
@@ -10417,6 +10420,7 @@
 				021125B82578ECF10075AD2A /* BoldableTextParserTests.swift in Sources */,
 				4569D3F425DC1BFF00CDC3E2 /* ShippingLabelFormViewModelTests.swift in Sources */,
 				57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */,
+				03EF250028C0E9EE006A033E /* InPersonPaymentsMenuViewModelTests.swift in Sources */,
 				02A275C423FE5B64005C560F /* MockPHAssetImageLoader.swift in Sources */,
 				456738972743DE9A00743054 /* OrderDateRangeFilterTests.swift in Sources */,
 				A650BE872578E76600C655E0 /* MockStorageManager.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -45,6 +45,34 @@ final class InPersonPaymentsMenuViewModelTests: XCTestCase {
     }
 
     // MARK: - Analytics tests
+    func test_updateCashOnDeliverySetting_enabled_tracks_paymentsHubCashOnDeliveryToggled_event() throws {
+        // Given
+
+        // When
+        sut.updateCashOnDeliverySetting(enabled: true)
+
+        // Then
+        assertNotEmpty(analyticsProvider.receivedEvents)
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == AnalyticEvents.paymentsHubCashOnDeliveryToggled }))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        assertEqual("US", eventProperties[AnalyticProperties.countryCodeKey] as? String)
+        assertEqual(true, eventProperties[AnalyticProperties.enabledKey] as? Bool)
+    }
+
+    func test_updateCashOnDeliverySetting_disabled_tracks_paymentsHubCashOnDeliveryToggled_event() throws {
+        // Given
+
+        // When
+        sut.updateCashOnDeliverySetting(enabled: false)
+
+        // Then
+        assertNotEmpty(analyticsProvider.receivedEvents)
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == AnalyticEvents.paymentsHubCashOnDeliveryToggled }))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        assertEqual("US", eventProperties[AnalyticProperties.countryCodeKey] as? String)
+        assertEqual(false, eventProperties[AnalyticProperties.enabledKey] as? Bool)
+    }
+
     func test_updateCashOnDeliverySetting_enabled_success_logs_enable_success_event() throws {
         // Given
         assertEmpty(analyticsProvider.receivedEvents)
@@ -143,10 +171,12 @@ private enum AnalyticEvents {
     static let enableCashOnDeliveryFailed = "enable_cash_on_delivery_failed"
     static let disableCashOnDeliverySuccess = "disable_cash_on_delivery_success"
     static let disableCashOnDeliveryFailed = "disable_cash_on_delivery_failed"
+    static let paymentsHubCashOnDeliveryToggled = "payments_hub_cash_on_delivery_toggled"
 }
 
 private enum AnalyticProperties {
     static let countryCodeKey = "country"
     static let errorDescriptionKey = "error_description"
     static let sourceKey = "source"
+    static let enabledKey = "enabled"
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+import TestKit
+
+@testable import WooCommerce
+import Yosemite
+import Networking
+
+final class InPersonPaymentsMenuViewModelTests: XCTestCase {
+    private var stores: MockStoresManager!
+
+    private var noticePresenter: MockNoticePresenter!
+
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: Analytics!
+
+    private var configuration: CardPresentPaymentsConfiguration!
+
+    private var dependencies: InPersonPaymentsMenuViewModel.Dependencies!
+
+    private var sut: InPersonPaymentsMenuViewModel!
+
+    override func setUp() {
+        stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.sessionManager.setStoreId(12345)
+        noticePresenter = MockNoticePresenter()
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        configuration = CardPresentPaymentsConfiguration.init(country: "US")
+        dependencies = InPersonPaymentsMenuViewModel.Dependencies(
+            stores: stores,
+            noticePresenter: noticePresenter,
+            analytics: analytics
+        )
+        sut = InPersonPaymentsMenuViewModel(dependencies: dependencies,
+                                            configuration: configuration)
+    }
+
+    // MARK: - Analytics tests
+    func test_updateCashOnDeliverySetting_enabled_success_logs_enable_success_event() throws {
+        // Given
+        assertEmpty(analyticsProvider.receivedEvents)
+        stores.whenReceivingAction(ofType: PaymentGatewayAction.self) { action in
+            switch action {
+            case let .updatePaymentGateway(paymentGateway, onCompletion):
+                onCompletion(.success(paymentGateway))
+            default:
+                break
+            }
+        }
+
+        // When
+        sut.updateCashOnDeliverySetting(enabled: true)
+
+        // Then
+        assertNotEmpty(analyticsProvider.receivedEvents)
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == AnalyticEvents.enableCashOnDeliverySuccess }))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        assertEqual("US", eventProperties[AnalyticProperties.countryCodeKey] as? String)
+        assertEqual("payments_hub", eventProperties[AnalyticProperties.sourceKey] as? String)
+    }
+
+    func test_updateCashOnDeliverySetting_enabled_failure_logs_enable_failure_event() throws {
+        // Given
+        stores.whenReceivingAction(ofType: PaymentGatewayAction.self) { action in
+            switch action {
+            case let .updatePaymentGateway(_, onCompletion):
+                onCompletion(.failure(DotcomError.noRestRoute))
+            default:
+                break
+            }
+        }
+
+        // When
+        sut.updateCashOnDeliverySetting(enabled: true)
+
+        // Then
+        assertNotEmpty(analyticsProvider.receivedEvents)
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == AnalyticEvents.enableCashOnDeliveryFailed }))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        assertEqual("US", eventProperties[AnalyticProperties.countryCodeKey] as? String)
+        assertEqual("Dotcom Invalid REST Route", eventProperties[AnalyticProperties.errorDescriptionKey] as? String)
+        assertEqual("payments_hub", eventProperties[AnalyticProperties.sourceKey] as? String)
+    }
+}
+
+private enum AnalyticEvents {
+    static let enableCashOnDeliverySuccess = "enable_cash_on_delivery_success"
+    static let enableCashOnDeliveryFailed = "enable_cash_on_delivery_failed"
+}
+
+private enum AnalyticProperties {
+    static let countryCodeKey = "country"
+    static let errorDescriptionKey = "error_description"
+    static let sourceKey = "source"
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -164,6 +164,17 @@ final class InPersonPaymentsMenuViewModelTests: XCTestCase {
         assertEqual("Dotcom Invalid REST Route", eventProperties[AnalyticProperties.errorDescriptionKey] as? String)
         assertEqual("payments_hub", eventProperties[AnalyticProperties.sourceKey] as? String)
     }
+
+    func test_learnMoreTapped_tracks_paymentsHubCashOnDeliveryToggleLearnMoreTapped_event() throws {
+        // Given
+
+        // When
+        sut.learnMoreTapped(from: UIViewController())
+
+        // Then
+        let event = try XCTUnwrap(analyticsProvider.receivedEvents.first(where: { $0 == AnalyticEvents.paymentsHubCashOnDeliveryToggleLearnMoreTapped } ))
+        XCTAssertNotNil(event)
+    }
 }
 
 private enum AnalyticEvents {
@@ -172,6 +183,7 @@ private enum AnalyticEvents {
     static let disableCashOnDeliverySuccess = "disable_cash_on_delivery_success"
     static let disableCashOnDeliveryFailed = "disable_cash_on_delivery_failed"
     static let paymentsHubCashOnDeliveryToggled = "payments_hub_cash_on_delivery_toggled"
+    static let paymentsHubCashOnDeliveryToggleLearnMoreTapped = "payments_hub_cash_on_delivery_toggle_learn_more_tapped"
 }
 
 private enum AnalyticProperties {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift
@@ -189,6 +189,7 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests: 
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == AnalyticEvents.enableCashOnDeliverySuccess }))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
         assertEqual("US", eventProperties[AnalyticProperties.countryCodeKey] as? String)
+        assertEqual("onboarding", eventProperties[AnalyticProperties.sourceKey] as? String)
     }
 
     func test_enable_failure_logs_enable_failure_event() throws {
@@ -211,6 +212,7 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests: 
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
         assertEqual("US", eventProperties[AnalyticProperties.countryCodeKey] as? String)
         assertEqual("Dotcom Invalid REST Route", eventProperties[AnalyticProperties.errorDescriptionKey] as? String)
+        assertEqual("onboarding", eventProperties[AnalyticProperties.sourceKey] as? String)
     }
 }
 
@@ -227,4 +229,5 @@ private enum AnalyticProperties {
     static let remindLaterKey = "remind_later"
     static let countryCodeKey = "country"
     static let errorDescriptionKey = "error_description"
+    static let sourceKey = "source"
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7628 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
In 10.1, we added the ability to enable Cash on Delivery, renamed to Pay in Person, as part of In-Person Payments onboarding.

Merchants can skip that (permanently), and may want to enable it at a later date. Alternatively, they may enable it during Onboarding and then change their mind.

This issue covers the analytics required in the new Pay in Person row.

- [x] Track new `payments_hub_cash_on_delivery_toggled` event when the toggle value is changed, with the property `enabled: Bool`
- [x] Add a `source` property to the existing `enable_cash_on_delivery_success` and `enable_cash_on_delivery_failed` events: values `onboarding` or `payments_hub`
- [x] Track new `payments_hub_cash_on_delivery_toggle_learn_more_tapped` for taps on the Learn More link.
- [x] Track new `disable_cash_on_delivery_success` event
- [x] Track new `disable_cash_on_delivery_failed` event
- [x] Track `enable_cash_on_delivery_success`
- [x] Track `enable_cash_on_delivery_failed`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a store with WCPay

#### Happy path

1. Open the app, and go to `Menu > Payments`
2. Tap the `Learn more` on the toggle switch row: observe that the `payments_hub_cash_on_delivery_toggle_learn_more_tapped` event is tracked
3. Toggle the switch: observe that the `enable_cash_on_delivery_success` or `disable_cash_on_delivery_success` events are tracked, including the `source: payments_hub` property
4. Observe that the `payments_hub_cash_on_delivery_toggled` event is also tracked, including the `enabled: true/false` property.

#### Network failures

Set a breakpoint in Proxyman or Charles on `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/*/rest-api/`

1. Open the app, and go to `Menu > Payments`
2. Toggle the switch, and abort the request in Proxyman/Charles
3. Observe that the `enable_cash_on_delivery_failed` or `disable_cash_on_delivery_failed` events are tracked

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

```
🔵 Tracked payments_hub_cash_on_delivery_toggle_learn_more_tapped, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("blog_id"): 197448330]
```

```
🔵 Tracked payments_hub_cash_on_delivery_toggled, properties: [AnyHashable("enabled"): false, AnyHashable("is_wpcom_store"): false, AnyHashable("country"): "US", AnyHashable("blog_id"): 197448330]
```
#### `{en/dis}able_cash_on_delivery_*` Source: payments_hub
```
🔵 Tracked disable_cash_on_delivery_success, properties: [AnyHashable("blog_id"): 197448330, AnyHashable("country"): "US", AnyHashable("is_wpcom_store"): false, AnyHashable("source"): "payments_hub"]
```

```
🔵 Tracked enable_cash_on_delivery_success, properties: [AnyHashable("country"): "US", AnyHashable("source"): "payments_hub", AnyHashable("blog_id"): 197448330, AnyHashable("is_wpcom_store"): false]
```

```
🔵 Tracked disable_cash_on_delivery_failed, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("country"): "US", AnyHashable("error_code"): "4864", AnyHashable("blog_id"): 197448330, AnyHashable("error_description"): "Swift.DecodingError.dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: \"The given data was not valid JSON.\", underlyingError: Optional(Error Domain=NSCocoaErrorDomain Code=3840 \"Unable to parse empty data.\" UserInfo={NSDebugDescription=Unable to parse empty data.})))", AnyHashable("source"): "payments_hub", AnyHashable("error_domain"): "NSCocoaErrorDomain"]
```

```
🔵 Tracked enable_cash_on_delivery_failed, properties: [AnyHashable("country"): "US", AnyHashable("error_code"): "4864", AnyHashable("error_domain"): "NSCocoaErrorDomain", AnyHashable("is_wpcom_store"): false, AnyHashable("blog_id"): 197448330, AnyHashable("error_description"): "Swift.DecodingError.dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: \"The given data was not valid JSON.\", underlyingError: Optional(Error Domain=NSCocoaErrorDomain Code=3840 \"Unable to parse empty data.\" UserInfo={NSDebugDescription=Unable to parse empty data.})))", AnyHashable("source"): "payments_hub"]
```

#### `enable_cash_on_delivery_*` Source: onboarding
```
🔵 Tracked enable_cash_on_delivery_failed, properties: [AnyHashable("country"): "US", AnyHashable("source"): "onboarding", AnyHashable("error_code"): "4864", AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 200370280, AnyHashable("error_description"): "Swift.DecodingError.dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: \"The given data was not valid JSON.\", underlyingError: Optional(Error Domain=NSCocoaErrorDomain Code=3840 \"No value.\" UserInfo={NSDebugDescription=No value.})))", AnyHashable("error_domain"): "NSCocoaErrorDomain"]
```

```
🔵 Tracked enable_cash_on_delivery_success, properties: [AnyHashable("source"): "onboarding", AnyHashable("blog_id"): 200370280, AnyHashable("country"): "US", AnyHashable("is_wpcom_store"): true]
```

<img width="641" alt="Tracks events live view screenshot showing Cash on Delivery events" src="https://user-images.githubusercontent.com/2472348/187964446-fa0cc4c0-36cd-4bd8-95f9-29ee50c88db2.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
