### PR TITLE
[Mobile Payments] Relabel Pay in Person toggle: remove “Enable”, mention checkout

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -474,7 +474,7 @@ private extension InPersonPaymentsMenuViewController {
         )
 
         static let toggleEnableCashOnDeliveryLearnMoreFormat = NSLocalizedString(
-            "Pay in Person lets you accept card or cash payments on collection or delivery. %1$@",
+            "The Pay in Person checkout option lets you accept payments for website orders, on collection or delivery. %1$@",
             comment: "A label prompting users to learn more about adding Pay in Person to their checkout. " +
             "%1$@ is a placeholder that always replaced with \"Learn more\" string, " +
             "which should be translated separately and considered part of this sentence.")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -469,7 +469,7 @@ private extension InPersonPaymentsMenuViewController {
         )
 
         static let toggleEnableCashOnDelivery = NSLocalizedString(
-            "Enable Pay in Person",
+            "Pay in Person",
             comment: "Title for a switch on the In-Person Payments menu to enable Cash on Delivery"
         )
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We decided that the "Enable Pay in Person" label for the new toggle on the Payments hub menu did not need the word "Enable", as it's implied by the toggle switch.

Additionally, we decided to update the description to make it clear that the toggle affects the checkout options on the user's site.

This PR updates the strings.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screen Shot - iPhone 13 mini - 2022-09-01 at 19 23 44](https://user-images.githubusercontent.com/2472348/187986266-afd3ae70-f363-4e84-8aae-9dc0db46f116.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
