### PR TITLE
Set `skip_prechecks:true` in CI release builds

### DIFF
--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -22,5 +22,6 @@ bundle exec fastlane run configure_apply
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_and_upload_itc \
   skip_confirm:true \
+  skip_prechecks:true \
   create_release:true \
   beta_release:${1:-true} # use first call param, default to true for safety


### PR DESCRIPTION
### Description

Notice this PR is against the release branch, so we can test and benefit from the improvement ASAP.

This will result in CI relying on the CocoaPods cache it just downloaded instead of reinstalling all pods from scratch.

It should save around a minute of CI time. See this build for example: https://buildkite.com/automattic/woocommerce-ios/builds/7674#01830b20-18fd-4cef-bedd-5d494da79152/1163-1249

Admittedly, one minute over a total of 26 is not that much. Still, we pay CI by the minute and, pragmatically, we shouldn't run
unnecessary operations if we can avoid it.

See also matching change and related discussion in https://github.com/wordpress-mobile/WordPress-iOS/pull/19033.

### Testing instructions

Tested in CI via https://github.com/woocommerce/woocommerce-ios/commit/3691b613797af16818d070adb26e12b340ea3b43.

**Before**

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/1218433/188364384-6308e235-6dd3-4797-82a7-a179cab07c3c.png">

**After**

![image](https://user-images.githubusercontent.com/1218433/188364279-b4d5ce4a-8782-4ae7-844a-35f960ed6ecd.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
