### PR TITLE
Bump Automattic-Tracks-iOS to 0.12.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -27,7 +27,7 @@ def aztec
 end
 
 def tracks
-  pod 'Automattic-Tracks-iOS', '~> 0.12.0-beta.2'
+  pod 'Automattic-Tracks-iOS', '~> 0.12.0'
   # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => ''
   # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => ''
   # pod 'Automattic-Tracks-iOS', :path => '../Automattic-Tracks-iOS'


### PR DESCRIPTION
Ref: p1662360868863829-p2-CC7L49W13/

### Description
Bumps Automattic-Tracks-iOS from `0.12.0-beta.2` to `0.12.0` in consonance with the [pod version bump](https://github.com/Automattic/Automattic-Tracks-iOS/commit/e3cb450d606edb517a0e5a0164e0368034d3962c).

### Testing instructions
1. Run `bundle exec rake dependencies`
2. See that the project analyzes and downloads dependencies properly:
```
Installing Automattic-Tracks-iOS 0.12.0
```
3. The app builds normally.
