### PR TITLE
[Mobile Payments] Refactor InPersonPaymentsMenuViewModel

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Yosemite
 import protocol Storage.StorageManagerType
 
-final class InPersonPaymentsMenuViewModel: ObservableObject {
+final class InPersonPaymentsCashOnDeliveryToggleRowViewModel: ObservableObject {
 
     // MARK: - Dependencies
     struct Dependencies {
@@ -187,7 +187,7 @@ final class InPersonPaymentsMenuViewModel: ObservableObject {
 }
 
 // MARK: - Analytics
-private extension InPersonPaymentsMenuViewModel {
+private extension InPersonPaymentsCashOnDeliveryToggleRowViewModel {
     typealias Event = WooAnalyticsEvent.InPersonPayments
 
     func trackCashOnDeliveryToggled(enabled: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -20,7 +20,7 @@ final class InPersonPaymentsMenuViewController: UIViewController {
                             reason: "reason",
                             countryCode: configurationLoader.configuration.countryCode))
     }()
-    private let inPersonPaymentsMenuViewModel: InPersonPaymentsMenuViewModel
+    private let cashOnDeliveryToggleRowViewModel: InPersonPaymentsCashOnDeliveryToggleRowViewModel
 
     /// No Manuals to be shown in a country where IPP is not supported
     /// 
@@ -53,7 +53,7 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         self.featureFlagService = featureFlagService
         self.cardPresentPaymentsOnboardingUseCase = CardPresentPaymentsOnboardingUseCase()
         configurationLoader = CardPresentConfigurationLoader()
-        self.inPersonPaymentsMenuViewModel = InPersonPaymentsMenuViewModel()
+        self.cashOnDeliveryToggleRowViewModel = InPersonPaymentsCashOnDeliveryToggleRowViewModel()
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -136,11 +136,11 @@ private extension InPersonPaymentsMenuViewController {
     func updateViewModelSelectedPlugin(state: CardPresentPaymentOnboardingState) {
         switch state {
         case let .completed(pluginState):
-            inPersonPaymentsMenuViewModel.selectedPlugin = pluginState.preferred
+            cashOnDeliveryToggleRowViewModel.selectedPlugin = pluginState.preferred
         case let .codPaymentGatewayNotSetUp(plugin):
-            inPersonPaymentsMenuViewModel.selectedPlugin = plugin
+            cashOnDeliveryToggleRowViewModel.selectedPlugin = plugin
         default:
-            inPersonPaymentsMenuViewModel.selectedPlugin = nil
+            cashOnDeliveryToggleRowViewModel.selectedPlugin = nil
         }
     }
 
@@ -298,11 +298,11 @@ private extension InPersonPaymentsMenuViewController {
         cell.configure(image: .creditCardIcon,
                        text: Localization.toggleEnableCashOnDelivery,
                        subtitle: learnMoreViewModel.learnMoreAttributedString,
-                       switchState: inPersonPaymentsMenuViewModel.cashOnDeliveryEnabledState,
-                       switchAction: inPersonPaymentsMenuViewModel.updateCashOnDeliverySetting(enabled:),
+                       switchState: cashOnDeliveryToggleRowViewModel.cashOnDeliveryEnabledState,
+                       switchAction: cashOnDeliveryToggleRowViewModel.updateCashOnDeliverySetting(enabled:),
                        subtitleTapAction: { [weak self] in
             guard let self = self else { return }
-            self.inPersonPaymentsMenuViewModel.learnMoreTapped(from: self)
+            self.cashOnDeliveryToggleRowViewModel.learnMoreTapped(from: self)
         })
     }
 
@@ -313,7 +313,7 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func configureTableReload() {
-        inPersonPaymentsMenuViewModel.$cashOnDeliveryEnabledState.sink { [weak self] _ in
+        cashOnDeliveryToggleRowViewModel.$cashOnDeliveryEnabledState.sink { [weak self] _ in
             self?.tableView.reloadData()
         }.store(in: &cancellables)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Yosemite
 import protocol Storage.StorageManagerType
 
-class InPersonPaymentsMenuViewModel: ObservableObject {
+final class InPersonPaymentsMenuViewModel: ObservableObject {
 
     // MARK: - Dependencies
     struct Dependencies {
@@ -187,35 +187,35 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
 }
 
 // MARK: - Analytics
-extension InPersonPaymentsMenuViewModel {
-    private typealias Event = WooAnalyticsEvent.InPersonPayments
+private extension InPersonPaymentsMenuViewModel {
+    typealias Event = WooAnalyticsEvent.InPersonPayments
 
-    private func trackCashOnDeliveryToggled(enabled: Bool) {
+    func trackCashOnDeliveryToggled(enabled: Bool) {
         let event = Event.paymentsHubCashOnDeliveryToggled(enabled: enabled,
                                                            countryCode: cardPresentPaymentsConfiguration.countryCode)
         analytics.track(event: event)
     }
 
-    private func trackEnableCashOnDeliverySuccess() {
+    func trackEnableCashOnDeliverySuccess() {
         let event = Event.enableCashOnDeliverySuccess(countryCode: cardPresentPaymentsConfiguration.countryCode,
                                                       source: .paymentsHub)
         analytics.track(event: event)
     }
 
-    private func trackEnableCashOnDeliveryFailed(error: Error?) {
+    func trackEnableCashOnDeliveryFailed(error: Error?) {
         let event = Event.enableCashOnDeliveryFailed(countryCode: cardPresentPaymentsConfiguration.countryCode,
                                                      error: error,
                                                      source: .paymentsHub)
         analytics.track(event: event)
     }
 
-    private func trackDisableCashOnDeliverySuccess() {
+    func trackDisableCashOnDeliverySuccess() {
         let event = Event.disableCashOnDeliverySuccess(countryCode: cardPresentPaymentsConfiguration.countryCode,
                                                        source: .paymentsHub)
         analytics.track(event: event)
     }
 
-    private func trackDisableCashOnDeliveryFailed(error: Error?) {
+    func trackDisableCashOnDeliveryFailed(error: Error?) {
         let event = Event.disableCashOnDeliveryFailed(countryCode: cardPresentPaymentsConfiguration.countryCode,
                                                       error: error,
                                                       source: .paymentsHub)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -457,10 +457,10 @@
 		03AA16602719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */; };
 		03AFDE02282C0B82003B67CD /* InPersonPaymentsCompletedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */; };
 		03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */; };
-		03EF24FA28BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24F928BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift */; };
+		03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
 		03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */; };
 		03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */; };
-		03EF250028C0E9EE006A033E /* InPersonPaymentsMenuViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FF28C0E9EE006A033E /* InPersonPaymentsMenuViewModelTests.swift */; };
+		03EF250028C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FF28C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift */; };
 		03FBDA9D263AD49200ACE257 /* CouponListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */; };
 		03FBDAA3263AED2F00ACE257 /* CouponListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */; };
 		03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */; };
@@ -2309,10 +2309,10 @@
 		03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinatorTests.swift; sourceTree = "<group>"; };
 		03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCompletedView.swift; sourceTree = "<group>"; };
 		03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayCardBrand+IconsTests.swift"; sourceTree = "<group>"; };
-		03EF24F928BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
+		03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift; sourceTree = "<group>"; };
 		03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift; sourceTree = "<group>"; };
 		03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardPresentPaymentsPlugin+CashOnDelivery.swift"; sourceTree = "<group>"; };
-		03EF24FF28C0E9EE006A033E /* InPersonPaymentsMenuViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModelTests.swift; sourceTree = "<group>"; };
+		03EF24FF28C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift; sourceTree = "<group>"; };
 		03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewController.swift; sourceTree = "<group>"; };
 		03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CouponListViewController.xib; sourceTree = "<group>"; };
 		03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModel.swift; sourceTree = "<group>"; };
@@ -4756,7 +4756,7 @@
 			isa = PBXGroup;
 			children = (
 				03A6C18228B52ADB00AADF23 /* Onboarding Errors */,
-				03EF24FF28C0E9EE006A033E /* InPersonPaymentsMenuViewModelTests.swift */,
+				03EF24FF28C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift */,
 			);
 			path = "In-Person Payments";
 			sourceTree = "<group>";
@@ -8317,7 +8317,7 @@
 				E12AF69826BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift */,
 				E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */,
 				E1906E9926C4126300CA6819 /* InPersonPaymentsMenuViewController.swift */,
-				03EF24F928BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift */,
+				03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */,
 				E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */,
 				03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */,
 				319A626027ACAE3400BC96C3 /* InPersonPaymentsPluginChoicesView.swift */,
@@ -9983,7 +9983,7 @@
 				DECE13FB27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift in Sources */,
 				26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */,
 				0371C3682875E47B00277E2C /* FeatureAnnouncementCardViewModel.swift in Sources */,
-				03EF24FA28BF5D21006A033E /* InPersonPaymentsMenuViewModel.swift in Sources */,
+				03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */,
 				09EA565527C8ACEE00407D40 /* BulkUpdateViewController.swift in Sources */,
 				2602A64627BDBEBA00B347F1 /* ProductInputTransformer.swift in Sources */,
 				DE74F2A327E41D650002FE59 /* EnableAnalyticsViewModel.swift in Sources */,
@@ -10435,7 +10435,7 @@
 				021125B82578ECF10075AD2A /* BoldableTextParserTests.swift in Sources */,
 				4569D3F425DC1BFF00CDC3E2 /* ShippingLabelFormViewModelTests.swift in Sources */,
 				57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */,
-				03EF250028C0E9EE006A033E /* InPersonPaymentsMenuViewModelTests.swift in Sources */,
+				03EF250028C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift in Sources */,
 				02A275C423FE5B64005C560F /* MockPHAssetImageLoader.swift in Sources */,
 				456738972743DE9A00743054 /* OrderDateRangeFilterTests.swift in Sources */,
 				A650BE872578E76600C655E0 /* MockStorageManager.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift
@@ -5,7 +5,7 @@ import TestKit
 import Yosemite
 import Networking
 
-final class InPersonPaymentsMenuViewModelTests: XCTestCase {
+final class InPersonPaymentsCashOnDeliveryToggleRowViewModelTests: XCTestCase {
     private var stores: MockStoresManager!
 
     private var storageManager: MockStorageManager!
@@ -17,9 +17,9 @@ final class InPersonPaymentsMenuViewModelTests: XCTestCase {
 
     private var configuration: CardPresentPaymentsConfiguration!
 
-    private var dependencies: InPersonPaymentsMenuViewModel.Dependencies!
+    private var dependencies: InPersonPaymentsCashOnDeliveryToggleRowViewModel.Dependencies!
 
-    private var sut: InPersonPaymentsMenuViewModel!
+    private var sut: InPersonPaymentsCashOnDeliveryToggleRowViewModel!
 
     private let sampleStoreID: Int64 = 12345
 
@@ -34,13 +34,13 @@ final class InPersonPaymentsMenuViewModelTests: XCTestCase {
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         configuration = CardPresentPaymentsConfiguration.init(country: "US")
 
-        dependencies = InPersonPaymentsMenuViewModel.Dependencies(
+        dependencies = InPersonPaymentsCashOnDeliveryToggleRowViewModel.Dependencies(
             stores: stores,
             storageManager: storageManager,
             noticePresenter: noticePresenter,
             analytics: analytics
         )
-        sut = InPersonPaymentsMenuViewModel(dependencies: dependencies,
+        sut = InPersonPaymentsCashOnDeliveryToggleRowViewModel(dependencies: dependencies,
                                             configuration: configuration)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a rename and minor refactor to the previous InPersonPaymentsMenuViewModel, which has been renamed to show that it's specific to the Pay in Person Toggle row.

In #7656, a new one added for the menu itself.

It's a separate PR because if done together, Github considers the files to all be new, so +400/-400 lines. The diff's much easier to read this way.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run unit tests

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
