### PR TITLE
Widgets: Update UI for Dark Mode

### DIFF
--- a/WooCommerce/StoreWidgets/StoreInfoViewModifiers.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoViewModifiers.swift
@@ -7,7 +7,7 @@ public struct StoreNameStyle: ViewModifier {
     public func body(content: Content) -> some View {
         content
             .font(.footnote.weight(.bold))
-            .foregroundColor(Color(.textInverted))
+            .foregroundColor(Color(.white))
     }
 }
 
@@ -31,7 +31,7 @@ public struct StatValueStyle: ViewModifier {
     public func body(content: Content) -> some View {
         content
             .font(.title2)
-            .foregroundColor(Color(.textInverted))
+            .foregroundColor(Color(.white))
     }
 }
 


### PR DESCRIPTION
# Why

The Store Info Widget did not render some labels with the correct color on Dark Mode, this PR makes sure that the widget values are always rendered as white.

# Screenshots

Before | After
---- | ----
![before](https://user-images.githubusercontent.com/562080/188496365-62c5e571-73e2-41b6-b468-9f5d84b77f39.jpeg) | ![after](https://user-images.githubusercontent.com/562080/188496364-af01e70d-d7ea-49bd-bd74-3a037fd3d77b.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
