### PR TITLE
Fix an issue where UI tests for iPad isn't running on iPad

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -79,7 +79,7 @@ steps:
           context: "UI Tests (iPhone)"
 
   - label: "🔬 UI Tests (iPad)"
-    command: .buildkite/commands/run-ui-tests.sh UITests "iPad Air (4th generation)" 15.0
+    command: .buildkite/commands/run-ui-tests.sh UITests "iPad Air (5th generation)" 15.0
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins


### PR DESCRIPTION
### Description

The iPad UI tests are running on iPhone, probably because the selected Simulator "iPad Air 4th generation" doesn't exist on CI.

<img width="728" alt="Screen Shot 2022-09-06 at 12 15 22 PM" src="https://user-images.githubusercontent.com/1101828/188522904-25ab0682-693b-4136-abd1-19e0d13749f2.png">

### Testing instructions
[The logs in "UI Test (iPad)" step](https://buildkite.com/automattic/woocommerce-ios/builds/7712#0183102a-7bbd-4588-a32f-17c4bd455cba/788-856) for this PR shows an iPad was picked up.

### Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
