### PR TITLE
[Mobile Payments] Rename PluginWebView to AuthenticatedWebView

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -2,7 +2,7 @@ import Combine
 import UIKit
 import WebKit
 
-/// The web view to handle plugin setup in the login flow.
+/// A web view which is authenticated for WordPress.com, when possible.
 ///
 final class AuthenticatedWebViewController: UIViewController {
 

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -4,9 +4,9 @@ import WebKit
 
 /// The web view to handle plugin setup in the login flow.
 ///
-final class PluginSetupWebViewController: UIViewController {
+final class AuthenticatedWebViewController: UIViewController {
 
-    private let viewModel: PluginSetupWebViewModel
+    private let viewModel: AuthenticatedWebViewModel
 
     /// Main web view
     private lazy var webView: WKWebView = {
@@ -26,7 +26,7 @@ final class PluginSetupWebViewController: UIViewController {
     /// Strong reference for the subscription to update progress bar
     private var subscriptions: Set<AnyCancellable> = []
 
-    init(viewModel: PluginSetupWebViewModel) {
+    init(viewModel: AuthenticatedWebViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
@@ -51,7 +51,7 @@ final class PluginSetupWebViewController: UIViewController {
     }
 }
 
-private extension PluginSetupWebViewController {
+private extension AuthenticatedWebViewController {
     func configureNavigationBar() {
         title = viewModel.title
     }
@@ -104,7 +104,7 @@ private extension PluginSetupWebViewController {
     }
 }
 
-extension PluginSetupWebViewController: WKNavigationDelegate {
+extension AuthenticatedWebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
         guard let navigationURL = navigationAction.request.url else {
             return .allow

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
@@ -2,8 +2,8 @@ import Foundation
 import WebKit
 
 /// Abstracts different configurations and logic for web view controllers
-/// used for setting up plugins during the login flow
-protocol PluginSetupWebViewModel {
+/// which are authenticated for WordPress.com, where possible
+protocol AuthenticatedWebViewModel {
     /// Title for the view
     var title: String { get }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
@@ -63,7 +63,7 @@ struct JetpackErrorViewModel: ULErrorViewModel {
         }
 
         let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: jetpackSetupCompletionHandler)
-        let connectionController = PluginSetupWebViewController(viewModel: viewModel)
+        let connectionController = AuthenticatedWebViewController(viewModel: viewModel)
         viewController.navigationController?.show(connectionController, sender: nil)
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewModel.swift
@@ -3,7 +3,7 @@ import WebKit
 
 /// View model used for the web view controller to install Jetpack the plugin during the login flow.
 ///
-final class JetpackSetupWebViewModel: PluginSetupWebViewModel {
+final class JetpackSetupWebViewModel: AuthenticatedWebViewModel {
 
     /// The site URL to set up Jetpack for.
     private let siteURL: String

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -70,7 +70,7 @@ final class NoWooErrorViewModel: ULErrorViewModel {
         }, onDismiss: {
             viewController.navigationController?.popViewController(animated: true)
         })
-        let setupViewController = PluginSetupWebViewController(viewModel: viewModel)
+        let setupViewController = AuthenticatedWebViewController(viewModel: viewModel)
         viewController.navigationController?.show(setupViewController, sender: nil)
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WooSetupWebViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WebKit
 
-final class WooSetupWebViewModel: PluginSetupWebViewModel {
+final class WooSetupWebViewModel: AuthenticatedWebViewModel {
     private let siteURL: String
     private let analytics: Analytics
     private let completionHandler: () -> Void

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1732,8 +1732,8 @@
 		DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437726D8DAD900888A75 /* InProgressView.swift */; };
 		DEF3300C270444070073AE29 /* ShippingLabelSelectedRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF3300B270444060073AE29 /* ShippingLabelSelectedRate.swift */; };
 		DEF36DE82898D3CF00178AC2 /* JetpackSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE52898D3CF00178AC2 /* JetpackSetupWebViewModel.swift */; };
-		DEF36DE92898D3CF00178AC2 /* PluginSetupWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE62898D3CF00178AC2 /* PluginSetupWebViewController.swift */; };
-		DEF36DEA2898D3CF00178AC2 /* PluginSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */; };
+		DEF36DE92898D3CF00178AC2 /* AuthenticatedWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE62898D3CF00178AC2 /* AuthenticatedWebViewController.swift */; };
+		DEF36DEA2898D3CF00178AC2 /* AuthenticatedWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE72898D3CF00178AC2 /* AuthenticatedWebViewModel.swift */; };
 		DEF36DEC2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */; };
 		DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */; };
 		DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */; };
@@ -3640,8 +3640,8 @@
 		DEE6437726D8DAD900888A75 /* InProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressView.swift; sourceTree = "<group>"; };
 		DEF3300B270444060073AE29 /* ShippingLabelSelectedRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSelectedRate.swift; sourceTree = "<group>"; };
 		DEF36DE52898D3CF00178AC2 /* JetpackSetupWebViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackSetupWebViewModel.swift; sourceTree = "<group>"; };
-		DEF36DE62898D3CF00178AC2 /* PluginSetupWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginSetupWebViewController.swift; sourceTree = "<group>"; };
-		DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginSetupWebViewModel.swift; sourceTree = "<group>"; };
+		DEF36DE62898D3CF00178AC2 /* AuthenticatedWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewController.swift; sourceTree = "<group>"; };
+		DEF36DE72898D3CF00178AC2 /* AuthenticatedWebViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewModel.swift; sourceTree = "<group>"; };
 		DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupWebViewModelTests.swift; sourceTree = "<group>"; };
 		DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModel.swift; sourceTree = "<group>"; };
 		DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModel.swift; sourceTree = "<group>"; };
@@ -6559,6 +6559,8 @@
 				027A2E152513356100DA6ACB /* AppleIDCredentialChecker.swift */,
 				FE28F6F3268477C1004465C7 /* RoleEligibilityUseCase.swift */,
 				D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */,
+				DEF36DE62898D3CF00178AC2 /* AuthenticatedWebViewController.swift */,
+				DEF36DE72898D3CF00178AC2 /* AuthenticatedWebViewModel.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -8126,8 +8128,6 @@
 				FE28F7112684CA29004465C7 /* RoleErrorViewController.xib */,
 				FE28F7172684EE6A004465C7 /* RoleErrorViewModel.swift */,
 				DEF36DE52898D3CF00178AC2 /* JetpackSetupWebViewModel.swift */,
-				DEF36DE62898D3CF00178AC2 /* PluginSetupWebViewController.swift */,
-				DEF36DE72898D3CF00178AC2 /* PluginSetupWebViewModel.swift */,
 				DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */,
 				DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */,
 				DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */,
@@ -9759,7 +9759,7 @@
 				021125A52578E5730075AD2A /* BoldableTextView.swift in Sources */,
 				CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */,
 				CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */,
-				DEF36DE92898D3CF00178AC2 /* PluginSetupWebViewController.swift in Sources */,
+				DEF36DE92898D3CF00178AC2 /* AuthenticatedWebViewController.swift in Sources */,
 				74334F36214AB130006D6AC5 /* ProductTableViewCell.swift in Sources */,
 				D8610D762570AE1F00A5DF27 /* NotWPErrorViewModel.swift in Sources */,
 				0245465B24EE7637004F531C /* ProductFormEventLoggerProtocol.swift in Sources */,
@@ -10277,7 +10277,7 @@
 				B541B21A2189F3A2008FE7C1 /* StringFormatter.swift in Sources */,
 				0279F0DF252DC12D0098D7DE /* ProductLoaderViewControllerModel+Init.swift in Sources */,
 				26B9875D273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift in Sources */,
-				DEF36DEA2898D3CF00178AC2 /* PluginSetupWebViewModel.swift in Sources */,
+				DEF36DEA2898D3CF00178AC2 /* AuthenticatedWebViewModel.swift in Sources */,
 				45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */,
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
 				311F827426CD897900DF5BAD /* CardReaderSettingsAlertsProvider.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The PluginSetupWebViewController was not specific to plugins, and will be useful for anywhere we need a WKWebView with a WPcom auth token.

This PR renames it to make it reusable for, initially, card reader purchases in #7655 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
