### PR TITLE
[Engage] Universal Links: Handle mobile segment

### DIFF
--- a/WooCommerce/Classes/Universal Links/RouteMatcher.swift
+++ b/WooCommerce/Classes/Universal Links/RouteMatcher.swift
@@ -16,6 +16,7 @@ struct MatchedRoute {
 /// and extracts parameters from the URL.
 ///
 class RouteMatcher {
+    private let mobilePathSegment = "/mobile"
     let routes: [Route]
 
     /// - parameter routes: A collection of routes to match against.
@@ -23,9 +24,22 @@ class RouteMatcher {
         self.routes = routes
     }
 
+    /// Validates, compares and matches the given URL with the routes previously passed.
+    /// If the URL doesn't have the mobile path segment (universal link is not mobile) nil is returned.
+    ///
+    /// - Parameter url: The universal link URL to be analyzed
+    ///
+    /// - Returns: The MatchedRoute object with the Route and url query parameters
+    ///
     func firstRouteMatching(_ url: URL) -> MatchedRoute? {
         guard let components = URLComponents(string: url.absoluteString),
-              let firstRoute = routes.first(where: { $0.path == components.path }) else {
+              components.path.hasPrefix(mobilePathSegment) else {
+            return nil
+        }
+
+        let routeSubPath = String(components.path.dropFirst(mobilePathSegment.count))
+
+        guard let firstRoute = routes.first(where: { $0.subPath == routeSubPath }) else {
             return nil
         }
 

--- a/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/OrderDetailsRoute.swift
@@ -4,7 +4,7 @@ import Yosemite
 /// Shows order details from a given universal link that matches the right path
 ///
 struct OrderDetailsRoute: Route {
-    let path = "/orders/details"
+    let subPath: String = "/orders/details"
 
     func perform(with parameters: [String: String]) -> Bool {
         guard let storeIdString = parameters[ParametersKeys.blogId],

--- a/WooCommerce/Classes/Universal Links/Routes/PaymentsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/PaymentsRoute.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Links an URL with a /payments path to the Payments Hub Menu
 /// 
 struct PaymentsRoute: Route {
-    let path = "/payments"
+    let subPath = "/payments"
 
     func perform(with parameters: [String: String]) -> Bool {
         MainTabBarController.presentPayments()

--- a/WooCommerce/Classes/Universal Links/Routes/Route.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/Route.swift
@@ -4,9 +4,9 @@ import Foundation
 /// A universal link route, used to encapsulate a URL path and action
 /// 
 protocol Route {
-    /// The url path to match so this route can perform its navigation
+    /// The universal link subpath (without the /mobile segment) to be matched so this route can perform its navigation
     ///
-    var path: String { get }
+    var subPath: String { get }
 
     /// Performs the action related to this route, usually a navigation.
     /// - Parameter parameters: The parameters dictionary that was contained in the URL

--- a/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
+++ b/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
@@ -36,6 +36,6 @@ struct UniversalLinkRouter {
             return bouncingURLOpener.open(url)
         }
 
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.universalLinkOpened(with: matchedRoute.route.path))
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.universalLinkOpened(with: matchedRoute.route.subPath))
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockRoute.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockRoute.swift
@@ -1,11 +1,11 @@
 @testable import WooCommerce
 
 final class MockRoute: Route {
-    let path: String
+    let subPath: String
     let performAction: ([String: String]) -> Bool
 
-    init(path: String, performAction: @escaping ([String: String]) -> Bool) {
-        self.path = path
+    init(subPath: String, performAction: @escaping ([String: String]) -> Bool) {
+        self.subPath = subPath
         self.performAction = performAction
     }
 


### PR DESCRIPTION
+++ Note: The functionality contained in this PR has some unfinished dependencies and thus is not ready for testing as part of the release.  +++

<!-- Remember about a good descriptive title. -->

Closes: #7668 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After realizing that there are conflicts between our agreed universal links URLs and some pre-existing pages in woocommerce.com (e.g https://woocommerce.com/payments/) we decided to append the segment `/mobile` to all our universal links to determine those that should open the mobile app.
With this PR we refactor the existing universal links implementation to validate the passed URLs, and extract the subpath following `/mobile` to match the routes.

### Changes
- RouteMatcher validates the URL and extracts the subpath following `/mobile` to match the routes.
- Rename the Route protocol `path` property to `subPath` to make it more exact.
- Adapt tests to the new implementation and add test case for a link without the `/mobile` segment
### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
At the moment there is no easy way to test it as the domain verification is not yet implemented in woocommerce.com, so either you can wait for the domain verification to be added, or the next steps to test it now:

1. Add applinks:thelinkswootester.mystagingwebsite.com to the Associated Domains in the WooCommerce target screen. 
<img width="915" alt="Screenshot 2022-08-23 at 18 28 17" src="https://user-images.githubusercontent.com/1864060/186211830-d2a37a93-0e41-4082-8a76-92a6121ce8af.png">
This is my dummy pressable test site. (We do not have domain verification ready in woocommerce.com) I uploaded the [`apple-app-site-association`](https://thelinkswootester.mystagingwebsite.com/apple-app-site-association) with paths:

```
"paths":[
               "/mobile/*",
            ]
```
2. Send yourself an email containing a link with the format 
https://thelinkswootester.mystagingwebsite.com/mobile/payments or 
https://thelinkswootester.mystagingwebsite.com/mobile/orders/details?blog_id={your storeID}&order_id={an existing orderID} Tap on it

3. Verify that the app opens and navigates accordingly.

### Error case
1. Send your self an email containing a link with the wrong format 
2. https://thelinkswootester.mystagingwebsite.com/mobile/orders/details?blog_id={your storeID}&**test_id**={an existing orderID}
(This will fail because the parameter is test_id instead of order_id)
3. Verify that the app opens and bounces to Safari.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
