### PR TITLE
[Mobile Payments] Signed-in card reader purchase

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Dashboard: the last selected time range tab (Today/This Week/This Month/This Year) is persisted for the site and shown on the next site launch (app launch or switching stores). [https://github.com/woocommerce/woocommerce-ios/pull/7638]
 - [*] In-Person Payments: Fixed an issue where the Pay in Person toggle could be out of sync with the setting on the website. [https://github.com/woocommerce/woocommerce-ios/pull/7656]
+- [*] In-Person Payments: Removed the need to sign in when purchasing a card reader [https://github.com/woocommerce/woocommerce-ios/pull/7670]
 
 10.2
 -----

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -62,8 +62,19 @@ private extension AuthenticatedWebViewController {
             view.leadingAnchor.constraint(equalTo: webView.leadingAnchor),
             view.trailingAnchor.constraint(equalTo: webView.trailingAnchor),
             view.safeTopAnchor.constraint(equalTo: webView.topAnchor),
-            view.bottomAnchor.constraint(equalTo: webView.bottomAnchor),
+            view.safeBottomAnchor.constraint(equalTo: webView.bottomAnchor),
         ])
+
+        extendContentUnderSafeAreas()
+    }
+
+    func extendContentUnderSafeAreas() {
+        webView.scrollView.clipsToBounds = false
+        if #available(iOS 15.0, *) {
+            view.backgroundColor = webView.underPageBackgroundColor
+        } else {
+            view.backgroundColor = webView.backgroundColor
+        }
     }
 
     func configureProgressBar() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -74,6 +74,7 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         registerTableViewCells()
         configureTableReload()
         runCardPresentPaymentsOnboarding()
+        configureWebViewPresentation()
         viewModel.viewDidLoad()
     }
 }
@@ -321,6 +322,16 @@ private extension InPersonPaymentsMenuViewController {
             self?.tableView.reloadData()
         }.store(in: &cancellables)
     }
+
+    private func configureWebViewPresentation() {
+        viewModel.$showWebView.sink { viewModel in
+            guard let viewModel = viewModel else {
+                return
+            }
+            let connectionController = AuthenticatedWebViewController(viewModel: viewModel)
+            self.navigationController?.show(connectionController, sender: nil)
+        }.store(in: &cancellables)
+    }
 }
 
 // MARK: - Convenience methods
@@ -335,8 +346,7 @@ private extension InPersonPaymentsMenuViewController {
 //
 extension InPersonPaymentsMenuViewController {
     func orderCardReaderWasPressed() {
-        ServiceLocator.analytics.track(.paymentsMenuOrderCardReaderTapped)
-        WebviewHelper.launch(configurationLoader.configuration.purchaseCardReaderUrl(), with: self)
+        viewModel.orderCardReaderPressed()
     }
 
     func manageCardReaderWasPressed() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
@@ -2,14 +2,42 @@ import Foundation
 import Yosemite
 
 final class InPersonPaymentsMenuViewModel {
-    private let stores: StoresManager
+    // MARK: - Dependencies
+    struct Dependencies {
+        let stores: StoresManager
+        let analytics: Analytics
 
+        init(stores: StoresManager = ServiceLocator.stores,
+             analytics: Analytics = ServiceLocator.analytics) {
+            self.stores = stores
+            self.analytics = analytics
+        }
+    }
+
+    private let dependencies: Dependencies
+
+    private var stores: StoresManager {
+        dependencies.stores
+    }
+
+    private var analytics: Analytics {
+        dependencies.analytics
+    }
+
+    // MARK: - Output properties
+    @Published var showWebView: AuthenticatedWebViewModel? = nil
+
+    // MARK: - Configuration properties
     private var siteID: Int64? {
         return stores.sessionManager.defaultStoreID
     }
 
-    init(stores: StoresManager = ServiceLocator.stores) {
-        self.stores = stores
+    private let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
+
+    init(dependencies: Dependencies = Dependencies(),
+         cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration) {
+        self.dependencies = dependencies
+        self.cardPresentPaymentsConfiguration = cardPresentPaymentsConfiguration
     }
 
     func viewDidLoad() {
@@ -19,5 +47,13 @@ final class InPersonPaymentsMenuViewModel {
 
         let action = PaymentGatewayAction.synchronizePaymentGateways(siteID: siteID, onCompletion: { _ in })
         stores.dispatch(action)
+    }
+
+    func orderCardReaderPressed() {
+        analytics.track(.paymentsMenuOrderCardReaderTapped)
+        showWebView = PurchaseCardReaderWebViewViewModel(configuration: cardPresentPaymentsConfiguration,
+                                                         onDismiss: { [weak self] in
+            self?.showWebView = nil
+        })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/PurchaseCardReaderWebViewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/PurchaseCardReaderWebViewViewModel.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Yosemite
+import WebKit
+
+struct PurchaseCardReaderWebViewViewModel: AuthenticatedWebViewModel {
+    var title: String
+
+    var initialURL: URL?
+
+    let onDismiss: () -> Void
+
+    init(configuration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
+         onDismiss: @escaping () -> Void) {
+        self.title = Localization.title
+        self.initialURL = configuration.purchaseCardReaderUrl()
+        self.onDismiss = onDismiss
+    }
+
+    func handleDismissal() {
+        onDismiss()
+    }
+
+    func handleRedirect(for url: URL?) {
+
+    }
+
+    func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy {
+        return .allow
+    }
+}
+
+private enum Localization {
+    static let title = NSLocalizedString(
+        "Order Card Reader",
+        comment: "Title for the webview used by merchants to place an order for a card reader, for use with " +
+        "In-Person Payments.")
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -463,6 +463,7 @@
 		03EF250028C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FF28C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift */; };
 		03EF250228C615A5006A033E /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF250128C615A5006A033E /* InPersonPaymentsMenuViewModel.swift */; };
 		03EF250428C6283B006A033E /* InPersonPaymentsMenuViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF250328C6283B006A033E /* InPersonPaymentsMenuViewModelTests.swift */; };
+		03EF250628C75838006A033E /* PurchaseCardReaderWebViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF250528C75838006A033E /* PurchaseCardReaderWebViewViewModel.swift */; };
 		03FBDA9D263AD49200ACE257 /* CouponListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */; };
 		03FBDAA3263AED2F00ACE257 /* CouponListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */; };
 		03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */; };
@@ -2360,6 +2361,7 @@
 		03EF24FF28C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift; sourceTree = "<group>"; };
 		03EF250128C615A5006A033E /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
 		03EF250328C6283B006A033E /* InPersonPaymentsMenuViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModelTests.swift; sourceTree = "<group>"; };
+		03EF250528C75838006A033E /* PurchaseCardReaderWebViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseCardReaderWebViewViewModel.swift; sourceTree = "<group>"; };
 		03FBDA9C263AD49100ACE257 /* CouponListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewController.swift; sourceTree = "<group>"; };
 		03FBDAA2263AED2F00ACE257 /* CouponListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CouponListViewController.xib; sourceTree = "<group>"; };
 		03FBDAF1263EE47C00ACE257 /* CouponListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListViewModel.swift; sourceTree = "<group>"; };
@@ -8425,6 +8427,7 @@
 				E138D4F3269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift */,
 				E1906E9926C4126300CA6819 /* InPersonPaymentsMenuViewController.swift */,
 				03EF250128C615A5006A033E /* InPersonPaymentsMenuViewModel.swift */,
+				03EF250528C75838006A033E /* PurchaseCardReaderWebViewViewModel.swift */,
 				03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */,
 				E120F63726C26B550005A029 /* InPersonPaymentsLoadingView.swift */,
 				03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */,
@@ -9925,6 +9928,7 @@
 				B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */,
 				7E6A01972725B811001668D5 /* FilterProductCategoryListViewController.swift in Sources */,
 				E10DFC7A2673595A0083AFF2 /* ShareSheet.swift in Sources */,
+				03EF250628C75838006A033E /* PurchaseCardReaderWebViewViewModel.swift in Sources */,
 				AEE085B52897C871007ACE20 /* LinkedProductsPromoCampaign.swift in Sources */,
 				933A27372222354600C2143A /* Logging.swift in Sources */,
 				0290E26F238E3CE400B5C466 /* ListSelectorViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -6,15 +6,29 @@ import Yosemite
 class InPersonPaymentsMenuViewModelTests: XCTestCase {
     private var stores: MockStoresManager!
 
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: Analytics!
+
     private var sut: InPersonPaymentsMenuViewModel!
 
     private let sampleStoreID: Int64 = 12345
+
+    private var configuration: CardPresentPaymentsConfiguration!
 
     override func setUp() {
         stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.sessionManager.setStoreId(sampleStoreID)
 
-        sut = InPersonPaymentsMenuViewModel(stores: stores)
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+
+        let dependencies = InPersonPaymentsMenuViewModel.Dependencies(stores: stores,
+                                                                      analytics: analytics)
+
+        configuration = CardPresentPaymentsConfiguration(country: "US")
+
+        sut = InPersonPaymentsMenuViewModel(dependencies: dependencies,
+                                            cardPresentPaymentsConfiguration: configuration)
     }
 
     func test_viewDidLoad_synchronizes_payment_gateways() throws {
@@ -32,5 +46,27 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
         default:
             XCTFail("viewDidLoad failed to dispatch .synchronizePaymentGateways action")
         }
+    }
+
+    func test_orderCardReaderPressed_tracks_paymentsMenuOrderCardReaderTapped() {
+        // Given
+
+        // When
+        sut.orderCardReaderPressed()
+
+        // Then
+        XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "payments_hub_order_card_reader_tapped" }))
+    }
+
+    func test_orderCardReaderPressed_presents_card_reader_purchase_web_view() throws {
+        // Given
+        XCTAssertNil(sut.showWebView)
+
+        // When
+        sut.orderCardReaderPressed()
+
+        // Then
+        let cardReaderViewModel = try XCTUnwrap(sut.showWebView)
+        assertEqual(configuration.purchaseCardReaderUrl(), cardReaderViewModel.initialURL)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7655
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We show WooCommerce.com in a web view to help a merchant to purchase a card reader. Previously, this was not authenticated, so the merchant would need to sign in to WordPress.com again in order to complete a purchase.

This PR changes the webview to be an AuthenticatedWebViewController, which authenticates with wordpress.com using the merchant's authtoken, before redirecting to woocommerce.com.

With this change, the merchant only needs to authorise the use of their WordPress.com account in order to sign in to WooCommerce.com and complete their purchase.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a US or Canada store:

1. Navigate to `Menu > Payments`
2. Tap `Order card reader`
3. Observe that the correct order card reader page is opened (M2 for US, WisePad 3 for Canada)
4. Tap through to purchase the reader
5. Observe that you're able to use your WordPress.com account without entering your card details again.

N.B. if you are using AutoProxxy, there's a good chance that you'll be asked for your 2FA again. This can be tricky to get working correctly, and is a pre-existing issue even before this change.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/188686889-81a7a57a-cf9d-481e-af89-2b36f0e6d5e5.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
