### PR TITLE
[Mobile Payments] Moooore IPP: Remove all references to IPP from settings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -130,8 +130,6 @@ private extension SettingsViewController {
             configurePlugins(cell: cell)
         case let cell as HostingTableViewCell<FeatureAnnouncementCardView> where row == .upsellCardReadersFeatureAnnouncement:
             configureUpsellCardReadersFeatureAnnouncement(cell: cell)
-        case let cell as BasicTableViewCell where row == .inPersonPayments:
-            configureInPersonPayments(cell: cell)
         case let cell as BasicTableViewCell where row == .installJetpack:
             configureInstallJetpack(cell: cell)
         case let cell as BasicTableViewCell where row == .support:
@@ -188,12 +186,6 @@ private extension SettingsViewController {
         })
         cell.host(view, parent: self)
         cell.selectionStyle = .none
-    }
-
-    func configureInPersonPayments(cell: BasicTableViewCell) {
-        cell.accessoryType = .disclosureIndicator
-        cell.selectionStyle = .default
-        cell.textLabel?.text = Localization.inPersonPayments
     }
 
     func configureInstallJetpack(cell: BasicTableViewCell) {
@@ -336,13 +328,6 @@ private extension SettingsViewController {
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: HelpAndSupportViewController.self) else {
             fatalError("Cannot instantiate `HelpAndSupportViewController` from Dashboard storyboard")
         }
-        show(viewController, sender: self)
-    }
-
-    func inPersonPaymentsWasPressed() {
-        let viewModel = InPersonPaymentsViewModel()
-        viewModel.refresh()
-        let viewController = InPersonPaymentsViewController(viewModel: viewModel)
         show(viewController, sender: self)
     }
 
@@ -529,8 +514,6 @@ extension SettingsViewController: UITableViewDelegate {
             sitePluginsWasPressed()
         case .support:
             supportWasPressed()
-        case .inPersonPayments:
-            inPersonPaymentsWasPressed()
         case .installJetpack:
             installJetpackWasPressed()
         case .privacy:
@@ -606,7 +589,6 @@ extension SettingsViewController {
 
         // Store settings
         case upsellCardReadersFeatureAnnouncement
-        case inPersonPayments
         case installJetpack
 
         // Help & Feedback
@@ -652,8 +634,6 @@ extension SettingsViewController {
                 return BasicTableViewCell.self
             case .upsellCardReadersFeatureAnnouncement:
                 return HostingTableViewCell<FeatureAnnouncementCardView>.self
-            case .inPersonPayments:
-                return BasicTableViewCell.self
             case .installJetpack:
                 return BasicTableViewCell.self
             case .logout, .removeAppleIDAccess:


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Part of: #7363
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With https://github.com/woocommerce/woocommerce-ios/pull/7450 and https://github.com/woocommerce/woocommerce-ios/pull/7473 we wanted to get rid of all the references to IPP from the settings codebase, because we have a new IPP menu screen. While we removed most of these, there were some remaining pieces in `SettingsViewController`. These are taken out with this PR.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Project builds and tests run.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
