### PR TITLE
Remove ios_version parameter from test_without_building lane

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -2,7 +2,6 @@
 
 TEST_NAME=$1
 DEVICE=$2
-IOS_VERSION=$3
 
 echo "Running $TEST_NAME on $DEVICE for iOS $IOS_VERSION"
 
@@ -36,7 +35,7 @@ echo "--- 🧪 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &
 set +e
-bundle exec fastlane test_without_building name:"$TEST_NAME" device:"$DEVICE" ios_version:"$IOS_VERSION"
+bundle exec fastlane test_without_building name:"$TEST_NAME" device:"$DEVICE"
 TESTS_EXIT_STATUS=$?
 set -e
 

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -3,7 +3,7 @@
 TEST_NAME=$1
 DEVICE=$2
 
-echo "Running $TEST_NAME on $DEVICE for iOS $IOS_VERSION"
+echo "Running $TEST_NAME on $DEVICE"
 
 # Run this at the start to fail early if value not available
 echo '--- :test-analytics: Configuring Test Analytics'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,7 +68,7 @@ steps:
   # UI Tests
   #################
   - label: "🔬 UI Tests (iPhone)"
-    command: .buildkite/commands/run-ui-tests.sh UITests 'iPhone 11' 15.0
+    command: .buildkite/commands/run-ui-tests.sh UITests 'iPhone 11'
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins
@@ -79,7 +79,7 @@ steps:
           context: "UI Tests (iPhone)"
 
   - label: "🔬 UI Tests (iPad)"
-    command: .buildkite/commands/run-ui-tests.sh UITests "iPad Air (5th generation)" 15.0
+    command: .buildkite/commands/run-ui-tests.sh UITests "iPad Air (5th generation)"
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1075,7 +1075,6 @@ lane :test_without_building do |options|
     workspace: 'WooCommerce.xcworkspace',
     scheme: TEST_SCHEME,
     device: options[:device],
-    deployment_target_version: options[:ios_version],
     test_without_building: true,
     xctestrun: xctestrun_path,
     result_bundle: true,


### PR DESCRIPTION
### Description

Follow-up PR for https://github.com/woocommerce/woocommerce-ios/pull/7662#discussion_r963473908. This PR removes the `ios_version` parameter since it doesn't have any affect. The current value 15.0 is ignored by fastlane, as it doesn't exist on CI. Fastlane falls back to the available simulator runtime instead.

### Testing instructions
We are good as long as CI jobs pass.

### Screenshots
N/A


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
