### PR TITLE
[UI Tests] - Update ScreenObject version to v0.2.2

### DIFF
--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": null,
-          "revision": "e27405a65672c62e5a055697eafdeaf073ea63ff",
-          "version": "0.2.1"
+          "revision": "cb38a32bbcc733ba03e307ca7bcae63f8c5de729",
+          "version": "0.2.2"
         }
       },
       {

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
@@ -3,9 +3,6 @@ import XCTest
 
 public final class OrdersScreen: ScreenObject {
 
-    // TODO: Remove force `try` once `ScreenObject` migration is completed
-    public let tabBar = try! TabNavComponent()
-
     private let searchButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["order-search-button"]
     }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -70,7 +70,10 @@ public final class SingleOrderScreen: ScreenObject {
 
     @discardableResult
     public func goBackToOrdersScreen() throws -> OrdersScreen {
-        pop()
+        // Only needed for iPhone because iPad shows both Orders and Single Order screens on the same view
+        if XCUIDevice.isPhone {
+            pop()
+        }
         return try OrdersScreen()
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -11746,7 +11746,7 @@
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.1;
+				minimumVersion = 0.2.2;
 			};
 		};
 		3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */ = {

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -62,7 +62,8 @@ class WooCommerceScreenshots: XCTestCase {
         .goBackToOrdersScreen()
 
         // Products
-        .tabBar.goToProductsScreen()
+        try TabNavComponent()
+        .goToProductsScreen()
         .selectAddProduct()
         .thenTakeScreenshot(named: "product-add")
 


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/7526

Original PR: https://github.com/woocommerce/woocommerce-ios/pull/7654

### Description
This PR updates the ScreenObject package to latest version to get the update where we use isHittable() instead of isEnabled() on WaitForScreen()

### Testing instructions
UI Tests should pass locally and in CI

---
- [x] I have considered if this change warrants user-facing release notes and have added them to RELEASE-NOTES.txt if necessary.