### PR TITLE
[Mobile Payments] Cancel discovery when user taps cancel

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Dashboard: swiping to another time range tab now triggers syncing for the target tab. Previously, the stats on the target tab aren't synced from the swipe gesture. [https://github.com/woocommerce/woocommerce-ios/pull/7650]
 - [*] In-Person Payments: Fixed an issue where the Pay in Person toggle could be out of sync with the setting on the website. [https://github.com/woocommerce/woocommerce-ios/pull/7656]
 - [*] In-Person Payments: Removed the need to sign in when purchasing a card reader [https://github.com/woocommerce/woocommerce-ios/pull/7670]
+- [*] In-Person Payments: Fixed a bug where canceling a reader connection could result in being unable to connect a reader in future [https://github.com/woocommerce/woocommerce-ios/pull/7678]
 
 10.2
 -----

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -461,6 +461,9 @@ private extension CardReaderConnectionController {
                 self.candidateReader = nil
                 self.pruneSkippedReaders()
                 self.state = .searching
+            },
+            cancelSearch: { [weak self] in
+                self?.state = .cancel
             })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -54,13 +54,16 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
     func foundReader(from: UIViewController,
                      name: String,
                      connect: @escaping () -> Void,
-                     continueSearch: @escaping () -> Void) {
+                     continueSearch: @escaping () -> Void,
+                     cancelSearch: @escaping () -> Void) {
         setViewModelAndPresent(from: from,
                                viewModel: foundReader(name: name,
                                                       connect: connect,
                                                       continueSearch: continueSearch,
-                                                      cancel: { from.dismiss(animated: true) }
-                               )
+                                                      cancel: {
+            cancelSearch()
+            from.dismiss(animated: true)
+        })
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
@@ -21,7 +21,8 @@ protocol CardReaderSettingsAlertsProvider {
     func foundReader(from: UIViewController,
                      name: String,
                      connect: @escaping () -> Void,
-                     continueSearch: @escaping () -> Void)
+                     continueSearch: @escaping () -> Void,
+                     cancelSearch: @escaping () -> Void)
 
     /// Defines an interactive alert indicating more than one reader has been found. The user must
     /// choose to connect to that reader or cancel searching

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -10,6 +10,7 @@ enum MockCardReaderSettingsAlertsMode {
     case connectFoundReader
     case connectFirstFound
     case cancelFoundSeveral
+    case cancelFoundReader
     case continueSearchingAfterConnectionFailure
     case cancelSearchingAfterConnectionFailure
 }
@@ -49,15 +50,22 @@ extension MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
         }
     }
 
-    func foundReader(from: UIViewController, name: String, connect: @escaping () -> Void, continueSearch: @escaping () -> Void) {
+    func foundReader(from: UIViewController,
+                     name: String,
+                     connect: @escaping () -> Void,
+                     continueSearch: @escaping () -> Void,
+                     cancelSearch: @escaping () -> Void) {
         didPresentFoundReader = true
 
-        if mode == .continueSearching {
+        switch mode {
+        case .continueSearching:
             continueSearch()
-        }
-
-        if mode == .connectFoundReader || mode == .cancelSearchingAfterConnectionFailure || mode == .continueSearchingAfterConnectionFailure {
+        case .connectFoundReader, .cancelSearchingAfterConnectionFailure, .continueSearchingAfterConnectionFailure:
             connect()
+        case .cancelFoundReader:
+            cancelSearch()
+        default:
+            break
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
@@ -415,6 +415,43 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         // Then
         XCTAssertEqual(connectionResult, .canceled)
     }
+
+    func test_cancelling_connection_calls_completion_with_success_and_canceled() throws {
+        // Given
+        let unknownReader = MockCardReader.bbposChipper2XBT()
+
+        let mockStoresManager = MockCardPresentPaymentsStoresManager(
+            connectedReaders: [],
+            discoveredReaders: [unknownReader],
+            sessionManager: SessionManager.testingInstance,
+            storageManager: storageManager
+        )
+        ServiceLocator.setStores(mockStoresManager)
+        let mockPresentingViewController = UIViewController()
+        let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
+        let mockAlerts = MockCardReaderSettingsAlerts(mode: .cancelFoundReader)
+        let controller = CardReaderConnectionController(
+            forSiteID: sampleSiteID,
+            storageManager: storageManager,
+            knownReaderProvider: mockKnownReaderProvider,
+            alertsProvider: mockAlerts,
+            configuration: Mocks.configuration,
+            analyticsTracker: .init(configuration: Mocks.configuration,
+                                    stores: mockStoresManager)
+        )
+
+        // When
+        let connectionResult: CardReaderConnectionController.ConnectionResult = waitFor { promise in
+            controller.searchAndConnect(from: mockPresentingViewController) { result in
+                if case .success(let connectionResult) = result {
+                    promise(connectionResult)
+                }
+            }
+        }
+
+        // Then
+        XCTAssertEqual(connectionResult, .canceled)
+    }
 }
 
 private extension CardReaderConnectionControllerTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7677
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When a reader is found, the user has the option to Connect, Keep Searching, or Cancel.

Previously, if they cancelled the reader connection, the prompt was dismissed, but the SDK remained in the discoverReaders mode indefinitely.

This resulted in the user being able to start a new connection attempt.

This change calls `cancel` on the Cancellable that Stripe Terminal gives us, which results in the SDK being usable again.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Menu > Payments > Manage card reader
2. Tap Connect Card Reader
3. Wait for a reader to show
4. Tap cancel, then wait a couple of seconds
5. Tap Connect Card Reader again: observe that the connection dialog reappears
6. Wait for a reader to show, observe that you can connect to it without an error.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


Before | After
---|---
![screen recording of failure to connect to a reader after cancelling the first connection attempt](https://user-images.githubusercontent.com/2472348/188914480-a96e0f61-eb49-4e5f-8477-13cbc85f7855.mp4) | ![screen recording of success connecting to a reader after cancelling the first connection attempt](https://user-images.githubusercontent.com/2472348/188914448-d467c960-9721-4691-8e63-d1e6292a9b02.mp4)




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
