### PR TITLE
Widgets: Set up User Defaults Sharing

### DIFF
--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -27,9 +27,9 @@ extension UserDefaults {
 }
 
 extension UserDefaults {
-    // User defaults intance ready to be shared between extensions of the same group.
-    //
-    static let sharedDefaults = UserDefaults(suiteName: WooConstants.sharedUserDefaultsSuiteName)
+    /// User defaults intance ready to be shared between extensions of the same group.
+    //.
+    static let group = UserDefaults(suiteName: WooConstants.sharedUserDefaultsSuiteName)
 }
 
 

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -27,8 +27,8 @@ extension UserDefaults {
 }
 
 extension UserDefaults {
-    /// User defaults intance ready to be shared between extensions of the same group.
-    //.
+    /// User defaults instance ready to be shared between extensions of the same group.
+    ///
     static let group = UserDefaults(suiteName: WooConstants.sharedUserDefaultsSuiteName)
 }
 

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -10,6 +10,7 @@ extension UserDefaults {
         case defaultUsername
         case defaultSiteAddress
         case defaultStoreID
+        case defaultSiteName
         case defaultAnonymousID
         case defaultRoles
         case deviceID
@@ -23,6 +24,12 @@ extension UserDefaults {
         case notificationsLastSeenTime
         case notificationsMarkAsReadCount
     }
+}
+
+extension UserDefaults {
+    // User defaults intance ready to be shared between extensions of the same group.
+    //
+    static let sharedDefaults = UserDefaults(suiteName: WooConstants.sharedUserDefaultsSuiteName)
 }
 
 

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -10,7 +10,7 @@ extension UserDefaults {
         case defaultUsername
         case defaultSiteAddress
         case defaultStoreID
-        case defaultSiteName
+        case defaultStoreName
         case defaultAnonymousID
         case defaultRoles
         case deviceID

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -29,6 +29,10 @@ enum WooConstants {
     ///
     static let authToken = "authToken"
 
+    /// Shared UsersDefaults Suite Name
+    ///
+    static let sharedUserDefaultsSuiteName = "group.com.automattic.woocommerce"
+
     /// Push Notifications ApplicationID
     ///
 #if DEBUG

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -467,7 +467,7 @@ private extension DefaultStoresManager {
             return
         }
 
-        updateAndReloadWidgetInformation()
+        updateAndReloadWidgetInformation(with: siteID)
         restoreSessionSiteAndSynchronizeIfNeeded(with: siteID)
         synchronizeSettings(with: siteID) {
             ServiceLocator.selectedSiteSettings.refresh()
@@ -501,9 +501,13 @@ private extension DefaultStoresManager {
     /// Updates the necesary dependencies for the widget to function correctly.
     /// Reloads widgets timelines.
     ///
-    func updateAndReloadWidgetInformation() {
+    func updateAndReloadWidgetInformation(with siteID: Int64) {
         // Token to fire network requests
         keychain.currentAuthToken = sessionManager.defaultCredentials?.authToken
+
+        // Non-critical store info
+        UserDefaults.group?[.defaultStoreID] = siteID
+        UserDefaults.group?[.defaultSiteName] = sessionManager.defaultSite?.name
 
         // Reload widgets UI
         WidgetCenter.shared.reloadAllTimelines()

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -467,7 +467,6 @@ private extension DefaultStoresManager {
             return
         }
 
-        updateAndReloadWidgetInformation(with: siteID)
         restoreSessionSiteAndSynchronizeIfNeeded(with: siteID)
         synchronizeSettings(with: siteID) {
             ServiceLocator.selectedSiteSettings.refresh()
@@ -494,6 +493,7 @@ private extension DefaultStoresManager {
                 return
             }
             self.sessionManager.defaultSite = site
+            self.updateAndReloadWidgetInformation(with: siteID)
         }
         dispatch(action)
     }
@@ -507,7 +507,7 @@ private extension DefaultStoresManager {
 
         // Non-critical store info
         UserDefaults.group?[.defaultStoreID] = siteID
-        UserDefaults.group?[.defaultSiteName] = sessionManager.defaultSite?.name
+        UserDefaults.group?[.defaultStoreName] = sessionManager.defaultSite?.name
 
         // Reload widgets UI
         WidgetCenter.shared.reloadAllTimelines()

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -46,7 +46,7 @@ struct StoreInfoProvider: TimelineProvider {
                               revenue: "$132.234",
                               visitors: "67",
                               orders: "23",
-                              conversion: "37%")
+                              conversion: "34%")
     }
 
     /// Quick Snapshot. Required when previewing the widget.
@@ -78,7 +78,7 @@ struct StoreInfoProvider: TimelineProvider {
 private extension StoreInfoProvider {
 
     /// Dependencies needed by the `StoreInfoProvider`
-    /// //
+    ///
     struct Dependencies {
         let authToken: String
         let storeID: Int64

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -39,40 +39,61 @@ struct StoreInfoProvider: TimelineProvider {
     /// Redacted entry with sample data.
     ///
     func placeholder(in context: Context) -> StoreInfoEntry {
-        StoreInfoEntry(date: Date(),
-                       range: "Today",
-                       name: "Ernest Shop",
-                       revenue: "$132.234",
-                       visitors: "67",
-                       orders: "23",
-                       conversion: "37%")
+        let dependencies = Self.fetchDependencies()
+        return StoreInfoEntry(date: Date(),
+                              range: "Today",
+                              name: dependencies?.storeName ?? "My Shop", // TODO: Localize
+                              revenue: "$132.234",
+                              visitors: "67",
+                              orders: "23",
+                              conversion: "37%")
     }
 
     /// Quick Snapshot. Required when previewing the widget.
-    /// TODO: Update with real data.
     ///
     func getSnapshot(in context: Context, completion: @escaping (StoreInfoEntry) -> Void) {
-        completion(StoreInfoEntry(date: Date(),
-                                  range: "Today",
-                                  name: "Ernest Shop",
-                                  revenue: "$132.234",
-                                  visitors: "67",
-                                  orders: "23",
-                                  conversion: "37%"))
+        completion(placeholder(in: context))
     }
 
     /// Real data widget.
     /// TODO: Update with real data.
     ///
     func getTimeline(in context: Context, completion: @escaping (Timeline<StoreInfoEntry>) -> Void) {
+        // TODO: Temp store name to check dependency status while we fetch real data.
+        let dependencies = Self.fetchDependencies()
+        let authStatus = dependencies?.authToken != nil ? "Authenticated" : "Non Authenticated"
+        let storeName = dependencies?.storeName ?? "Undefined Shop"
         let entry = StoreInfoEntry(date: Date(),
                                    range: "Today",
-                                   name: "Ernest Shop",
+                                   name: "\(authStatus) - \(storeName)",
                                    revenue: "$132.234",
                                    visitors: "67",
                                    orders: "23",
                                    conversion: "37%")
         let timeline = Timeline<StoreInfoEntry>(entries: [entry], policy: .never)
         completion(timeline)
+    }
+}
+
+private extension StoreInfoProvider {
+
+    /// Dependencies needed by the `StoreInfoProvider`
+    /// //
+    struct Dependencies {
+        let authToken: String
+        let storeID: Int64
+        let storeName: String
+    }
+
+    /// Fetches the required dependencies from the keychain and the shared users default.
+    ///
+    static func fetchDependencies() -> Dependencies? {
+        let keychain = Keychain(service: WooConstants.keychainServiceName)
+        guard let authToken = keychain[WooConstants.authToken],
+              let storeID = UserDefaults.group?[.defaultStoreID] as? Int64,
+              let storeName = UserDefaults.group?[.defaultStoreName] as? String else {
+            return nil
+        }
+        return Dependencies(authToken: authToken, storeID: storeID, storeName: storeName)
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -42,7 +42,7 @@ struct StoreInfoProvider: TimelineProvider {
         let dependencies = Self.fetchDependencies()
         return StoreInfoEntry(date: Date(),
                               range: "Today",
-                              name: dependencies?.storeName ?? "My Shop", // TODO: Localize
+                              name: dependencies?.storeName ?? Localization.myShop,
                               revenue: "$132.234",
                               visitors: "67",
                               orders: "23",
@@ -95,5 +95,11 @@ private extension StoreInfoProvider {
             return nil
         }
         return Dependencies(authToken: authToken, storeID: storeID, storeName: storeName)
+    }
+}
+
+private extension StoreInfoProvider {
+    enum Localization {
+        static let myShop = NSLocalizedString("My Shop", comment: "Generic store name for the store info widget preview")
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -2,7 +2,6 @@ import WidgetKit
 import SwiftUI
 import WooFoundation
 import Experiments
-import KeychainAccess // TODO: Temp - Delete once token is used for fetching data.
 
 /// Main StoreInfo Widget type.
 ///
@@ -26,9 +25,6 @@ private struct StoreInfoView: View {
     // Entry to render
     let entry: StoreInfoEntry
 
-    // TODO: Temp - Delete once token is used for fetching data.
-    let keychain = Keychain(service: WooConstants.keychainServiceName)
-
     var body: some View {
         ZStack {
             // Background
@@ -38,11 +34,6 @@ private struct StoreInfoView: View {
 
                 // Store Name
                 HStack {
-
-                    // TODO: Temp - Delete once token is used for fetching data.
-                    Text(keychain[WooConstants.authToken] != nil ? "Authenticated -" : "Not Authenticated -")
-                        .storeNameStyle()
-
                     Text(entry.name)
                         .storeNameStyle()
 
@@ -93,7 +84,6 @@ private struct StoreInfoView: View {
                             .statValueStyle()
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
-
                 }
             }
             .padding(.horizontal)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -501,6 +501,7 @@
 		2602A64827BDBF8000B347F1 /* ProductInputTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A64727BDBF8000B347F1 /* ProductInputTransformerTests.swift */; };
 		2602A64A27BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A64927BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift */; };
 		2608C50628C93AB700C9DFC0 /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */; };
+		2608C50728C941D600C9DFC0 /* UserDefaults+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AA7B3E20ED81C2004DA14F /* UserDefaults+Woo.swift */; };
 		260C315E2523CC4000157BC2 /* RefundProductsTotalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */; };
 		260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */; };
 		260C31622524EEB200157BC2 /* IssueRefundViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 260C31612524EEB200157BC2 /* IssueRefundViewController.xib */; };
@@ -9293,6 +9294,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2608C50728C941D600C9DFC0 /* UserDefaults+Woo.swift in Sources */,
 				265C99E628B9CB8E005E6117 /* StoreInfoViewModifiers.swift in Sources */,
 				2608C50628C93AB700C9DFC0 /* WooConstants.swift in Sources */,
 				3F1FA84B28B60126009E246C /* StoreWidgets.intentdefinition in Sources */,


### PR DESCRIPTION
part of #7564 

# Why

In order to pass non-sensitive data from the app to the widget, like the store id and the store name, we need to share them using the app groups functionality, in this particular scenario we have chosen to use a custom suite for user defaults.

# How

- Add a new `UserDefaults.group` property that uses the `group.com.automattic.woocommerce` suite name.
- Store `siteID` and `storeName` when the app finishes synching the site information
- Read those values from the widget extension and render them temporarily via the provider.

# Demo

https://user-images.githubusercontent.com/562080/188994959-bb9d8cb1-23dc-4b09-83ef-7a80a1b87c53.MP4

# Testing Steps

- Launch the app.
- Launch the widget extension
- See that the widget show the correct store name

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
