### PR TITLE
[Mobile Payments] Make the message in error onboarding view multiline.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingErrorMainContentView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingErrorMainContentView.swift
@@ -32,6 +32,7 @@ struct InPersonPaymentsOnboardingErrorMainContentView: View {
             Text(message)
                 .font(.callout)
                 .padding(.bottom, isCompact ? 12 : 24)
+                .fixedSize(horizontal: false, vertical: true)
             if supportLink {
                 InPersonPaymentsSupportLink()
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7489 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Before the message in onboarding error views used only one line, so if the text message was longer than that it was just truncated with an ellipsis. This used to happen in some smaller devices such as iPhone 13 mini. Setting the fixed size false for horizontal made the message text render in multiple lines if necessary.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Using iPhone 13 mini, and with a store based in a country where IPP is not supported:
1. Go to Menu
2. Tap on Payments
3. Wait for background onboarding to finish. When the error message shows at the bottom, tap on Continue Setup
4. See that the error message is displayed in multiline and not truncated with ellipsis.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
#### Before

![Simulator Screen Shot - iPhone 13 mini - 2022-09-08 at 18 56 59](https://user-images.githubusercontent.com/1864060/189182725-bddc05da-2dc9-43cc-ae44-a4cd3b157117.png)

#### After

![Simulator Screen Shot - iPhone 13 mini - 2022-09-08 at 18 57 53](https://user-images.githubusercontent.com/1864060/189182807-7ea3b987-480d-4295-a069-f6c7f5861290.png)


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
