### PR TITLE
[Mobile Payments] Delay dismissing connection modal until cancellation is fully complete

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -63,7 +63,6 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
         cancelAction()
-        viewController?.dismiss(animated: true, completion: nil)
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -532,7 +532,6 @@ private extension CardReaderConnectionController {
     /// End the search for a card reader
     ///
     func onCancel() {
-        alerts.dismiss()
         let action = CardPresentPaymentAction.cancelCardReaderDiscovery() { [weak self] _ in
             self?.returnSuccess(result: .canceled)
         }
@@ -764,8 +763,8 @@ private extension CardReaderConnectionController {
     /// Calls the completion with a success result
     ///
     private func returnSuccess(result: ConnectionResult) {
-        alerts.dismiss()
         onCompletion?(.success(result))
+        alerts.dismiss()
         state = .idle
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7685 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, if you cancelled a card reader search and then started a new one too quickly, the SDK would not be ready to perform further actions and would show an error.

Cancellation of SDK actions is asynchronous in its own right. We had multiple calls to `dismiss` fired by different parts of the modal, so in some cases we risked dismissing extra alerts if they were presented (though I don't have any concrete examples of how that could happen.)

This PR removes, and moves, some `dismiss` calls, to handle them after the cancellation and any completion handlers have run.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Navigate to `Menu > Payments`
2. Tap `Manage card reader`
3. Tap `Connect Card Reader`
4. Tap `Cancel` on the `Scanning for reader` modal
5. Immediately tap `Connect Card Reader` again
6. Observe that you do not see the `Connecting reader failed` error
7. Observe that the connection flow continues as expected.

Repeat the above and similar steps, tapping cancel at different places in the flow.

The flow can also be accessed when taking a payment without a connected reader: see `Payments > Collect payment`, `Orders > + > Create Order`, and `Orders > Order details > Collect Payment` for these flows.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
