### PR TITLE
Widgets: Fetch today data

### DIFF
--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -1,0 +1,92 @@
+import Networking
+
+/// Orchestrator class that fetches today store stats data.
+///
+final class StoreInfoDataService {
+
+    /// Data extracted from networking types.
+    ///
+    struct Stats {
+        let revenue: Decimal
+        let totalOrders: Int
+        let totalVisitors: Int
+        let conversion: Double
+    }
+
+    /// Revenue & Orders remote source.
+    ///
+    private var orderStatsRemoteV4: OrderStatsRemoteV4
+
+    /// Visitors remoute source
+    ///
+    private var siteVisitStatsRemote: SiteVisitStatsRemote
+
+    /// Network helper.
+    ///
+    private var network: AlamofireNetwork
+
+    init(authToken: String) {
+        network = AlamofireNetwork(credentials: Credentials(authToken: authToken))
+        orderStatsRemoteV4 = OrderStatsRemoteV4(network: network)
+        siteVisitStatsRemote = SiteVisitStatsRemote(network: network)
+    }
+
+    /// Async function that fetches todays stats data.
+    ///
+    func fetchTodayStats(for storeID: Int64) async throws -> Stats {
+        // Prepare them to run in parallel
+        async let revenueAndOrdersRequest = fetchTodaysRevenueAndOrders(for: storeID)
+        async let visitorsRequest = fetchTodaysVisitors(for: storeID)
+
+        // Wait for for response
+        let (revenueAndOrders, visitors) = try await (revenueAndOrdersRequest, visitorsRequest)
+
+        // Assemble stats data
+        let conversion: Double = visitors.totalVisitors > 0 ? Double(revenueAndOrders.totals.totalOrders / visitors.totalVisitors) : 0
+        return Stats(revenue: revenueAndOrders.totals.netRevenue,
+                     totalOrders: revenueAndOrders.totals.totalOrders,
+                     totalVisitors: visitors.totalVisitors,
+                     conversion: conversion)
+    }
+}
+
+/// Async Wrappers
+///
+private extension StoreInfoDataService {
+
+    /// Async wrapper that fetches todays revenues & orders.
+    /// TODO: Update dates with the correct timezone.
+    ///
+    func fetchTodaysRevenueAndOrders(for storeID: Int64) async throws -> OrderStatsV4 {
+        try await withCheckedThrowingContinuation { continuation in
+            // `WKWebView` is accessed internally, we are foreced to dispatch the call in the main thread.
+            Task { @MainActor in
+                orderStatsRemoteV4.loadOrderStats(for: storeID,
+                                                  unit: .hourly,
+                                                  earliestDateToInclude: Calendar.current.startOfDay(for: Date()),
+                                                  latestDateToInclude: Date(),
+                                                  quantity: 24,
+                                                  forceRefresh: true) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+    /// Async wrapper that fetches todays visitors.
+    /// TODO: Update dates with the correct timezone.
+    ///
+    func fetchTodaysVisitors(for storeID: Int64) async throws -> SiteVisitStats {
+        try await withCheckedThrowingContinuation { continuation in
+            // `WKWebView` is accessed internally, we are foreced to dispatch the call in the main thread.
+            Task { @MainActor in
+                siteVisitStatsRemote.loadSiteVisitorStats(for: storeID,
+                                                          unit: .day,
+                                                          latestDateToInclude: Date(),
+                                                          quantity: 1) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -43,7 +43,7 @@ final class StoreInfoDataService {
 
         // Assemble stats data
         let conversion: Double = visitors.totalVisitors > 0 ? Double(revenueAndOrders.totals.totalOrders / visitors.totalVisitors) : 0
-        return Stats(revenue: revenueAndOrders.totals.netRevenue,
+        return Stats(revenue: revenueAndOrders.totals.grossRevenue,
                      totalOrders: revenueAndOrders.totals.totalOrders,
                      totalVisitors: visitors.totalVisitors,
                      conversion: conversion)

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -42,7 +42,7 @@ final class StoreInfoDataService {
         let (revenueAndOrders, visitors) = try await (revenueAndOrdersRequest, visitorsRequest)
 
         // Assemble stats data
-        let conversion: Double = visitors.totalVisitors > 0 ? Double(revenueAndOrders.totals.totalOrders / visitors.totalVisitors) : 0
+        let conversion = visitors.totalVisitors > 0 ? Double(revenueAndOrders.totals.totalOrders) / Double(visitors.totalVisitors) * 100 : 0
         return Stats(revenue: revenueAndOrders.totals.grossRevenue,
                      totalOrders: revenueAndOrders.totals.totalOrders,
                      totalVisitors: visitors.totalVisitors,

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -63,8 +63,8 @@ private extension StoreInfoDataService {
             Task { @MainActor in
                 orderStatsRemoteV4.loadOrderStats(for: storeID,
                                                   unit: .hourly,
-                                                  earliestDateToInclude: Calendar.current.startOfDay(for: Date()),
-                                                  latestDateToInclude: Date(),
+                                                  earliestDateToInclude: Date.startOfToday,
+                                                  latestDateToInclude: Date.endOfToday,
                                                   quantity: 24,
                                                   forceRefresh: true) { result in
                     continuation.resume(with: result)
@@ -82,11 +82,32 @@ private extension StoreInfoDataService {
             Task { @MainActor in
                 siteVisitStatsRemote.loadSiteVisitorStats(for: storeID,
                                                           unit: .day,
-                                                          latestDateToInclude: Date(),
+                                                          latestDateToInclude: Date.endOfToday,
                                                           quantity: 1) { result in
                     continuation.resume(with: result)
                 }
             }
         }
+    }
+}
+
+// TEMP: Update dates with the correct timezones mimic the app behaviour
+private extension Date {
+
+    /// Temporary function to get the start of day in the device timezone.
+    ///
+    static var startOfToday: Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .current
+        return calendar.startOfDay(for: Date())
+    }
+
+    /// Temporary function to get the end of day in the device timezone.
+    ///
+    static var endOfToday: Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .current
+        let startDate = calendar.startOfDay(for: Date())
+        return calendar.date(byAdding: .day, value: 1, to: startDate) ?? Date()
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -82,7 +82,7 @@ private extension StoreInfoDataService {
             Task { @MainActor in
                 siteVisitStatsRemote.loadSiteVisitorStats(for: storeID,
                                                           unit: .day,
-                                                          latestDateToInclude: Date.endOfToday,
+                                                          latestDateToInclude: Date.startOfToday,
                                                           quantity: 1) { result in
                     continuation.resume(with: result)
                 }
@@ -108,6 +108,7 @@ private extension Date {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = .current
         let startDate = calendar.startOfDay(for: Date())
-        return calendar.date(byAdding: .day, value: 1, to: startDate) ?? Date()
+        let components = DateComponents(day: 1, second: -1)
+        return calendar.date(byAdding: components, to: startDate) ?? Date()
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -81,7 +81,7 @@ final class StoreInfoProvider: TimelineProvider {
                                            revenue: "$\(todayStats.revenue)",
                                            visitors: "\(todayStats.totalVisitors)",
                                            orders: "\(todayStats.totalOrders)",
-                                           conversion: "\(todayStats.conversion)")
+                                           conversion: "\(todayStats.conversion)%")
                 let timeline = Timeline<StoreInfoEntry>(entries: [entry], policy: .never)
                 completion(timeline)
 

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -82,7 +82,9 @@ final class StoreInfoProvider: TimelineProvider {
                                            visitors: "\(todayStats.totalVisitors)",
                                            orders: "\(todayStats.totalOrders)",
                                            conversion: "\(todayStats.conversion)%")
-                let timeline = Timeline<StoreInfoEntry>(entries: [entry], policy: .never)
+
+                let reloadDate = Date(timeIntervalSinceNow: 15 * 60) // Ask for a 15 minutes reload.
+                let timeline = Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
                 completion(timeline)
 
             } catch {

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -83,7 +83,7 @@ final class StoreInfoProvider: TimelineProvider {
                                            orders: "\(todayStats.totalOrders)",
                                            conversion: "\(todayStats.conversion)%")
 
-                let reloadDate = Date(timeIntervalSinceNow: 15 * 60) // Ask for a 15 minutes reload.
+                let reloadDate = Date(timeIntervalSinceNow: 30 * 60) // Ask for a 15 minutes reload.
                 let timeline = Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
                 completion(timeline)
 

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -35,7 +35,12 @@ struct StoreInfoEntry: TimelineEntry {
 
 /// Type that provides data entries to the widget system.
 ///
-struct StoreInfoProvider: TimelineProvider {
+final class StoreInfoProvider: TimelineProvider {
+
+    /// Holds a reference to the service while a network request is being performed.
+    ///
+    private var networkService: StoreInfoDataService?
+
     /// Redacted entry with sample data.
     ///
     func placeholder(in context: Context) -> StoreInfoEntry {
@@ -61,6 +66,12 @@ struct StoreInfoProvider: TimelineProvider {
     func getTimeline(in context: Context, completion: @escaping (Timeline<StoreInfoEntry>) -> Void) {
         // TODO: Temp store name to check dependency status while we fetch real data.
         let dependencies = Self.fetchDependencies()
+
+        networkService = StoreInfoDataService(authToken: dependencies?.authToken ?? "")
+        networkService?.fetchData(for: dependencies?.storeID ?? 0, completion: { result in
+            // No Op
+        })
+
         let authStatus = dependencies?.authToken != nil ? "Authenticated" : "Non Authenticated"
         let storeName = dependencies?.storeName ?? "Undefined Shop"
         let entry = StoreInfoEntry(date: Date(),

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -506,6 +506,8 @@
 		260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */; };
 		260C31622524EEB200157BC2 /* IssueRefundViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 260C31612524EEB200157BC2 /* IssueRefundViewController.xib */; };
 		260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */; };
+		260DE20A28CA7CFE009ECD7C /* StoreInfoDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260DE20828CA7CE2009ECD7C /* StoreInfoDataService.swift */; };
+		260DE20C28CA8F31009ECD7C /* Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 260DE20B28CA8F31009ECD7C /* Networking.framework */; };
 		26100B202722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26100B1F2722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift */; };
 		2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */; };
 		2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */; };
@@ -2403,6 +2405,8 @@
 		260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewController.swift; sourceTree = "<group>"; };
 		260C31612524EEB200157BC2 /* IssueRefundViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueRefundViewController.xib; sourceTree = "<group>"; };
 		260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewModel.swift; sourceTree = "<group>"; };
+		260DE20828CA7CE2009ECD7C /* StoreInfoDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreInfoDataService.swift; sourceTree = "<group>"; };
+		260DE20B28CA8F31009ECD7C /* Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26100B1F2722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentPaymentsOnboardingUseCase.swift; sourceTree = "<group>"; };
 		2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
 		2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewTests.swift; sourceTree = "<group>"; };
@@ -3754,6 +3758,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				260DE20C28CA8F31009ECD7C /* Networking.framework in Frameworks */,
 				3F1FA84328B60125009E246C /* SwiftUI.framework in Frameworks */,
 				26D9E54428C107F80098DF26 /* WooFoundation.framework in Frameworks */,
 				3F1FA84228B60125009E246C /* WidgetKit.framework in Frameworks */,
@@ -5339,6 +5344,7 @@
 				3F1FA84528B60125009E246C /* StoreWidgets.swift */,
 				265C99E028B9BA43005E6117 /* StoreInfoWidget.swift */,
 				265C99E328B9C834005E6117 /* StoreInfoProvider.swift */,
+				260DE20828CA7CE2009ECD7C /* StoreInfoDataService.swift */,
 				265C99E528B9CB8E005E6117 /* StoreInfoViewModifiers.swift */,
 				3F1FA84728B60125009E246C /* StoreWidgets.intentdefinition */,
 				3F1FA84828B60126009E246C /* Assets.xcassets */,
@@ -6369,6 +6375,7 @@
 		88A44ABE866401E6DB03AC60 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				260DE20B28CA8F31009ECD7C /* Networking.framework */,
 				26D9E54728C10A3B0098DF26 /* Experiments.framework */,
 				26D9E54328C107F80098DF26 /* WooFoundation.framework */,
 				B9151B3E2840EB330036180F /* WooFoundation.framework */,
@@ -9297,6 +9304,7 @@
 				2608C50728C941D600C9DFC0 /* UserDefaults+Woo.swift in Sources */,
 				265C99E628B9CB8E005E6117 /* StoreInfoViewModifiers.swift in Sources */,
 				2608C50628C93AB700C9DFC0 /* WooConstants.swift in Sources */,
+				260DE20A28CA7CFE009ECD7C /* StoreInfoDataService.swift in Sources */,
 				3F1FA84B28B60126009E246C /* StoreWidgets.intentdefinition in Sources */,
 				265C99E228B9BCD0005E6117 /* StoreInfoWidget.swift in Sources */,
 				265C99E428B9C834005E6117 /* StoreInfoProvider.swift in Sources */,


### PR DESCRIPTION
 part of #7564

# Why 

Continuing with the widgets development, this PR fetches todays stats data from network and renders it directly to the widget. 

Things this PR doesn't do and are pending:
- Use the correct timezone code
- Use correct currency settings
- Properly replay errors


# How

- Adds a new `StoreInfoDataService` type that orchestrates between the different remote sources to get the todays data.
- Updates the widget provider to consume the new `StoreInfoDataService` type.

# Demo

https://user-images.githubusercontent.com/562080/189234517-03db962a-f78f-4cc1-a5ed-9dfc2ceef900.MP4


### Testing instructions
- Launch the the app in the device and make sure you have some todays stats
- Launch the widget extension and see that the values are correct.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
