### PR TITLE
[Mobile Payments] Revert `needsPayment` use for showing the `Collect Payment` button

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] In-Person Payments: Fixed an issue where the Pay in Person toggle could be out of sync with the setting on the website. [https://github.com/woocommerce/woocommerce-ios/pull/7656]
 - [*] In-Person Payments: Removed the need to sign in when purchasing a card reader [https://github.com/woocommerce/woocommerce-ios/pull/7670]
 - [*] In-Person Payments: Fixed a bug where canceling a reader connection could result in being unable to connect a reader in future [https://github.com/woocommerce/woocommerce-ios/pull/7678]
+- [*] In-Person Payments: Fixed a bug which prevented the Collect Payment button from being shown for Cash on Delivery orders  [https://github.com/woocommerce/woocommerce-ios/pull/7694]
 
 10.2
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -999,17 +999,17 @@ extension OrderDetailsDataSource {
 
             var rows: [Row] = Array(repeating: .aggregateOrderItem, count: aggregateOrderItemCount)
 
-            switch (shouldShowShippingLabelCreation, isProcessingStatus, isRefundedStatus) {
-            case (true, false, false):
+            switch (shouldShowShippingLabelCreation, isProcessingStatus, isRefundedStatus, isEligibleForPayment) {
+            case (true, false, false, false):
                 // Order completed and eligible for shipping label creation:
                 rows.append(.shippingLabelCreateButton)
                 rows.append(.shippingLabelCreationInfo(showsSeparator: false))
-            case (true, true, false):
+            case (true, true, false, false):
                 // Order processing shippable:
                 rows.append(.shippingLabelCreateButton)
                 rows.append(.markCompleteButton(style: .secondary, showsBottomSpacing: false))
                 rows.append(.shippingLabelCreationInfo(showsSeparator: false))
-            case (false, true, false):
+            case (false, true, false, false):
                 // Order processing digital:
                 rows.append(.markCompleteButton(style: .primary, showsBottomSpacing: true))
             default:

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -47,7 +47,7 @@ final class OrderDetailsDataSource: NSObject {
     /// Whether the order is eligible for card present payment.
     ///
     var isEligibleForPayment: Bool {
-        order.needsPayment
+        return order.datePaid == nil
     }
 
     var isEligibleForRefund: Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -256,7 +256,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
     func test_reloadSections_when_isEligibleForPayment_is_true_then_collect_payment_button_is_visible() throws {
         //Given
-        let order = makeOrder().copy(needsPayment: true) // Unpaid orders are eligible for payment
+        let order = makeOrder().copy(datePaid: .some(nil)) // Unpaid orders are eligible for payment
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
@@ -337,7 +337,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
 
     func test_create_shipping_label_button_is_not_visible_when_order_is_eligible_for_payment() throws {
         // Given
-        let order = makeOrder().copy(needsPayment: true, status: .pending)
+        let order = makeOrder().copy(status: .processing, datePaid: .some(nil), total: "100")
         let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
         dataSource.isEligibleForShippingLabelCreation = true
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7696 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We discovered an issue where Cash on Delivery orders placed on the web did not get the `Collect Payment` button in the iOS app any more.

This was traced back to the change we made to use `order.needsPayment == true` as the check for whether to show the `Collect Payment` button. The response from the API for Cash on Delivery orders has that property as `false`, even though they are unpaid.

The quickest safe fix is to revert to the old way of determining payment eligibility: whether `order.datePaid == nil`. This PR makes that revert, and also adds the `isEligibleToPayment` into the decision for showing the `Mark Order Complete` button, which otherwise shows up for Cash on Delivery orders [in the case for `// Order processing digital:`, i.e. intended for non-physical goods in the processing status.](https://github.com/woocommerce/woocommerce-ios/blob/14e758871a536a54a9bf3a1820a2a738eb4eea4c/WooCommerce/Classes/ViewModels/Order%20Details/OrderDetailsDataSource.swift#L1014)



### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a store with Cash on Delivery enabled,

1. Place an order on the web, selecting Pay in Person/Cash on delivery
2. Open the app and navigate to `Orders > Order Details` for your order
3. Observe that the order is in the `Processing` status, shows the `Awaiting payment via Pay in Person` line, and the `Collect Payment` button is available
4. Observe that the `Mark Order Complete` button is not shown
5. Tap `Collect Payment` and observe that you can collect payment for the order.

Additionally test that the Collect Payment flow for other orders, originating from the phone, work as expected too.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/189333302-ff3e8e41-3baf-4a73-8b99-eaced6937004.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
