### PR TITLE
Widgets: Show Not logged in view

### DIFF
--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -175,6 +175,8 @@ class DefaultStoresManager: StoresManager {
         ServiceLocator.storageManager.reset()
         ServiceLocator.productImageUploader.reset()
 
+        updateAndReloadWidgetInformation(with: 0)
+
         NotificationCenter.default.post(name: .logOutEventReceived, object: nil)
 
         return self
@@ -501,7 +503,7 @@ private extension DefaultStoresManager {
     /// Updates the necesary dependencies for the widget to function correctly.
     /// Reloads widgets timelines.
     ///
-    func updateAndReloadWidgetInformation(with siteID: Int64) {
+    func updateAndReloadWidgetInformation(with siteID: Int64?) {
         // Token to fire network requests
         keychain.currentAuthToken = sessionManager.defaultCredentials?.authToken
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -175,7 +175,7 @@ class DefaultStoresManager: StoresManager {
         ServiceLocator.storageManager.reset()
         ServiceLocator.productImageUploader.reset()
 
-        updateAndReloadWidgetInformation(with: 0)
+        updateAndReloadWidgetInformation(with: nil)
 
         NotificationCenter.default.post(name: .logOutEventReceived, object: nil)
 

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -11,7 +11,16 @@ struct StoreInfoWidget: Widget {
 
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: "StoreInfoWidget", provider: StoreInfoProvider()) { entry in
-            StoreInfoView(entry: entry)
+            Group {
+                switch entry {
+                case .notConnected:
+                    NotLoggedInView()
+                case .error:
+                    EmptyView() // TODO:
+                case .data(let data):
+                    StoreInfoView(entry: data)
+                }
+            }
         }
         .configurationDisplayName("Store Info")
         .supportedFamilies(enableWidgets ? [.systemMedium] : [])
@@ -23,7 +32,7 @@ struct StoreInfoWidget: Widget {
 private struct StoreInfoView: View {
 
     // Entry to render
-    let entry: StoreInfoEntry
+    let entry: StoreInfoData
 
     var body: some View {
         ZStack {
@@ -156,13 +165,12 @@ private extension NotLoggedInView {
 struct StoreWidgets_Previews: PreviewProvider {
     static var previews: some View {
         StoreInfoView(
-            entry: StoreInfoEntry(date: Date(),
-                                  range: "Today",
-                                  name: "Ernest Shop",
-                                  revenue: "$132.234",
-                                  visitors: "67",
-                                  orders: "23",
-                                  conversion: "37%")
+            entry: StoreInfoData(range: "Today",
+                                 name: "Ernest Shop",
+                                 revenue: "$132.234",
+                                 visitors: "67",
+                                 orders: "23",
+                                 conversion: "37%")
         )
         .previewContext(WidgetPreviewContext(family: .systemMedium))
 


### PR DESCRIPTION
Closes: #7566

# Why

This PR Makes sure that the "Not Logged In" widget view is displayed when there is not connected store.

# How

- Make sure the widget dependencies are updated upon logout.
- Update `StoreInfoEntry` to have 3 states: `notConnected`, `error`, and `data`.
- Update `StoreInfoWidget` to render the `NotLoggedInView` when required.


# Demo

https://user-images.githubusercontent.com/562080/189393594-f6c3b435-41ee-4e28-9263-1b46d5e19166.mov


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
