### PR TITLE
Remove coupons view/create/edit/delete feature flag references

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -7,8 +7,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         switch featureFlag {
         case .barcodeScanner:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .couponView:
-            return true
         case .productSKUInputScanner:
             return true
         case .inbox:

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -17,8 +17,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .couponDeletion:
             return true
-        case .couponEditing:
-            return true
         case .updateOrderOptimistically:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsOnboardingM1:

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -15,8 +15,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .splitViewInOrdersTab:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .couponDeletion:
-            return true
         case .updateOrderOptimistically:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsOnboardingM1:

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -19,8 +19,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .couponEditing:
             return true
-        case .couponCreation:
-            return true
         case .updateOrderOptimistically:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsOnboardingM1:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -38,10 +38,6 @@ public enum FeatureFlag: Int {
     ///
     case couponEditing
 
-    /// Displays the option to create a coupon
-    ///
-    case couponCreation
-
     /// Enable optimistic updates for orders
     ///
     case updateOrderOptimistically

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -34,10 +34,6 @@ public enum FeatureFlag: Int {
     ///
     case couponDeletion
 
-    /// Displays the option to edit a coupon
-    ///
-    case couponEditing
-
     /// Enable optimistic updates for orders
     ///
     case updateOrderOptimistically

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -30,10 +30,6 @@ public enum FeatureFlag: Int {
     ///
     case splitViewInOrdersTab
 
-    /// Displays the option to delete coupons
-    ///
-    case couponDeletion
-
     /// Enable optimistic updates for orders
     ///
     case updateOrderOptimistically

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -14,10 +14,6 @@ public enum FeatureFlag: Int {
     ///
     case reviews
 
-    /// Displays the option to view coupons
-    ///
-    case couponView
-
     /// Barcode scanner for product SKU input
     ///
     case productSKUInputScanner

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -86,12 +86,11 @@ struct CouponDetails: View {
             ])
         }
 
-        if viewModel.isDeletingEnabled {
-            buttons.append(.destructive(Text(Localization.deleteCoupon), action: {
-                ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "tapped_delete"])
-                showingDeletionConfirmAlert = true
-            }))
-        }
+        buttons.append(.destructive(Text(Localization.deleteCoupon), action: {
+            ServiceLocator.analytics.track(.couponDetails, withProperties: ["action": "tapped_delete"])
+            showingDeletionConfirmAlert = true
+        }))
+
 
         buttons.append(.cancel())
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -128,7 +128,6 @@ final class CouponDetailsViewModel: ObservableObject {
     private let currencySettings: CurrencySettings
 
     let isEditingEnabled: Bool
-    let isDeletingEnabled: Bool
 
     // Closure to be triggered when the coupon is updated successfully
     let onUpdate: () -> Void
@@ -150,7 +149,6 @@ final class CouponDetailsViewModel: ObservableObject {
         self.onUpdate = onUpdate
 
         isEditingEnabled = coupon.discountType != .other
-        isDeletingEnabled = featureFlags.isFeatureFlagEnabled(.couponDeletion)
         populateDetails()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -149,7 +149,7 @@ final class CouponDetailsViewModel: ObservableObject {
         self.onDeletion = onDeletion
         self.onUpdate = onUpdate
 
-        isEditingEnabled = featureFlags.isFeatureFlagEnabled(.couponEditing) && coupon.discountType != .other
+        isEditingEnabled = coupon.discountType != .other
         isDeletingEnabled = featureFlags.isFeatureFlagEnabled(.couponDeletion)
         populateDetails()
     }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -253,13 +253,9 @@ private extension CouponListViewController {
 
     func configureNavigationBarItems(hasCoupons: Bool) {
         if hasCoupons {
-            navigationItem.rightBarButtonItems = viewModel.isCreationEnabled
-            ? [createCouponButtonItem, searchBarButtonItem]
-            : [searchBarButtonItem]
+            navigationItem.rightBarButtonItems = [createCouponButtonItem, searchBarButtonItem]
         } else {
-            navigationItem.rightBarButtonItems = viewModel.isCreationEnabled
-            ? [createCouponButtonItem]
-            : []
+            navigationItem.rightBarButtonItems = [createCouponButtonItem]
         }
     }
 
@@ -382,21 +378,14 @@ private extension CouponListViewController {
     }
 
     func buildNoResultConfig() -> EmptyStateViewController.Config {
-        if viewModel.isCreationEnabled {
-            return .withButton(
-                    message: .init(string: Localization.couponCreationSuggestionMessage),
-                    image: .emptyCouponsImage,
-                    details: Localization.emptyStateDetails,
-                    buttonTitle: Localization.createCouponAction
-            ) { [weak self] button in
-                guard let self = self else { return }
-                self.displayCouponTypeBottomSheet()
-            }
-        } else {
-            return .simple(
-                    message: .init(string: Localization.emptyStateMessage),
-                    image: .emptyCouponsImage
-            )
+        return .withButton(
+            message: .init(string: Localization.couponCreationSuggestionMessage),
+            image: .emptyCouponsImage,
+            details: Localization.emptyStateDetails,
+            buttonTitle: Localization.createCouponAction
+        ) { [weak self] button in
+            guard let self = self else { return }
+            self.displayCouponTypeBottomSheet()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
@@ -61,9 +61,6 @@ final class CouponListViewModel {
     ///
     private let storageManager: StorageManagerType
 
-    /// Marks if the Coupon Creation feature is enabled or not
-    let isCreationEnabled: Bool
-
     // MARK: - Initialization and setup
     //
     init(siteID: Int64,
@@ -78,7 +75,6 @@ final class CouponListViewModel {
         self.resultsController = Self.createResultsController(siteID: siteID,
                                                               storageManager: storageManager)
 
-        isCreationEnabled = featureFlags.isFeatureFlagEnabled(.couponCreation)
         configureSyncingCoordinator()
         configureResultsController()
         configureFeedbackBannerVisibility()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -94,11 +94,7 @@ private extension BetaFeaturesViewController {
     }
 
     func couponManagementSection() -> Section? {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.couponView) else {
-            return nil
-        }
-        return Section(rows: [.couponManagement,
-                              .couponManagementDescription])
+        Section(rows: [.couponManagement, .couponManagementDescription])
     }
 
     /// Register table cells.


### PR DESCRIPTION
### Description
As part of https://github.com/woocommerce/woocommerce-ios/issues/7605, this PR removes the feature flags related to coupons view/create/edit/delete, as well as logic that relies on this feature flag.

I'm having troubles building trunk (p1662721891666259?thread_ts=1662360868.863829&cid=CC7L49W13-slack-CC7L49W13) so as are very little changes, I'll merge it into `7605-remove-bgProductImageUpload-feature-flag` which is ready as well 😬 

### Changes
Removed feature flags. There's not much logic to be removed involving those, mainly around rendering within `CouponListViewController`.

### Testing instructions
Run unit tests
