### PR TITLE
Widgets: Unable to fetch data View

### DIFF
--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -1,6 +1,5 @@
 import WidgetKit
 import KeychainAccess
-import WooFoundation
 
 /// Type that represents the all the possible Widget states.
 ///

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -102,7 +102,7 @@ final class StoreInfoProvider: TimelineProvider {
                 // WooFoundation does not expose `DDLOG` types. Should we include them?
                 print("⛔️ Error fetching today's widget stats: \(error)")
 
-                let reloadDate = Date(timeIntervalSinceNow: 30 * 60) // Ask for a 15 minutes reload.
+                let reloadDate = Date(timeIntervalSinceNow: 30 * 60) // Ask for a 30 minutes reload.
                 let timeline = Timeline<StoreInfoEntry>(entries: [.error], policy: .after(reloadDate))
                 completion(timeline)
             }

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -1,5 +1,6 @@
 import WidgetKit
 import KeychainAccess
+import WooFoundation
 
 /// Type that represents the all the possible Widget states.
 ///
@@ -98,10 +99,14 @@ final class StoreInfoProvider: TimelineProvider {
                 completion(timeline)
 
             } catch {
-                // TODO: Dispatch network error entry.
-                print("Error: \(error)")
-            }
 
+                // WooFoundation does not expose `DDLOG` types. Should we include them?
+                print("⛔️ Error fetching today's widget stats: \(error)")
+
+                let reloadDate = Date(timeIntervalSinceNow: 30 * 60) // Ask for a 15 minutes reload.
+                let timeline = Timeline<StoreInfoEntry>(entries: [.error], policy: .after(reloadDate))
+                completion(timeline)
+            }
         }
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -16,7 +16,7 @@ struct StoreInfoWidget: Widget {
                 case .notConnected:
                     NotLoggedInView()
                 case .error:
-                    EmptyView() // TODO:
+                    UnableToFetchView()
                 case .data(let data):
                     StoreInfoView(entry: data)
                 }

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -126,6 +126,29 @@ private struct NotLoggedInView: View {
     }
 }
 
+private struct UnableToFetchView: View {
+    var body: some View {
+        ZStack {
+            // Background
+            Color(.brand)
+
+            VStack {
+                Image(uiImage: .wooLogoWhite)
+                    .resizable()
+                    .frame(width: Layout.logoSize.width, height: Layout.logoSize.height)
+
+                Spacer()
+
+                Text(Localization.unableToFetch)
+                    .statTextStyle()
+
+                Spacer()
+            }
+            .padding(.vertical, Layout.cardVerticalPadding)
+        }
+    }
+}
+
 // MARK: Constants
 
 /// Constants definition
@@ -160,6 +183,20 @@ private extension NotLoggedInView {
     }
 }
 
+/// Constants definition
+///
+private extension UnableToFetchView {
+    enum Localization {
+        static let unableToFetch = NSLocalizedString("Unable to fetch today's stats",
+                                                     comment: "Title label when the widget can't fetch data.")
+    }
+
+    enum Layout {
+        static let cardVerticalPadding = 22.0
+        static let logoSize = CGSize(width: 24, height: 16)
+    }
+}
+
 // MARK: Previews
 
 struct StoreWidgets_Previews: PreviewProvider {
@@ -175,6 +212,9 @@ struct StoreWidgets_Previews: PreviewProvider {
         .previewContext(WidgetPreviewContext(family: .systemMedium))
 
         NotLoggedInView()
+            .previewContext(WidgetPreviewContext(family: .systemMedium))
+
+        UnableToFetchView()
             .previewContext(WidgetPreviewContext(family: .systemMedium))
     }
 }


### PR DESCRIPTION
Closes: #7567

# Why 
Following the widgets development, this PR makes sure that we display a proper error view when we have problems fetching the todays stat data.

# How

- Adds a new `UnableToFetchView` view
- Dispatch an error state to the widget when an error fetching data occurs.

*Note:* We don't have proper logs inside the widget target. @ealeksandrov do you think we should expose the logging methods from `WooFoundation`?

# Demo

https://user-images.githubusercontent.com/562080/189424399-4014e564-464f-4630-8f31-884bf54114f9.MP4

# Testing Steps

- Launch the app.
- Make sure the widget is added to the home screen.
- Close the app
- Turn off wifi & cellular data
- Open the app again to trigger a refresh (and don't wait for 15 minutes)
- Close the app
- See the "Error View" widget

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
