### PR TITLE
Hub menu: Fix navigation bar issue on iOS 16

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -13,6 +13,7 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        // Workaround on iOS 16: hide the navigation bar before showing the hub menu
         navigationController?.isNavigationBarHidden = true
         super.viewWillAppear(animated)
     }
@@ -29,6 +30,7 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        // Restore the visibility of the navigation bar when the view disappears.
         navigationController?.isNavigationBarHidden = false
     }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -12,6 +12,11 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
         configureTabBarItem()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.isNavigationBarHidden = true
+        super.viewWillAppear(animated)
+    }
+
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -20,6 +25,11 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
         super.viewDidAppear(animated)
 
         viewModel.viewDidAppear()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.isNavigationBarHidden = false
     }
 
     /// Present the specific Review Details View from a push notification


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7091 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
On iOS 14 and 15, hiding the navigation bar in the hub menu works thanks to `.navigationBarHidden(true)`.  

On iOS 16, this no longer works, so this PR provides a workaround to show and hide the navigation bar in `HubMenuViewController`. However, this solution doesn't work on iOS 14 and 15, so I'm keeping both solutions for now.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Build and run the change in Xcode 14 beta.
- Log in if needed and switch to Menu tab.
- Notice that the navigation bar is hidden correctly. 
- Select any menu: Notes, Coupons, Reviews and the tap Back.
- Notice that the navigation bar is displayed on the above views and then hidden when navigating back to the hub menu.

Please feel free to test again on iOS 14 and 15 to ensure it still works.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
https://user-images.githubusercontent.com/5533851/189579558-3904aed2-2deb-4c43-9060-58424d83ef80.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
