### PR TITLE
Dashboard: fix a crash from unexpected number of order stats intervals

### DIFF
--- a/WooCommerce/Classes/Extensions/Date+StartAndEnd.swift
+++ b/WooCommerce/Classes/Extensions/Date+StartAndEnd.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WooFoundation
 
 extension Date {
     // MARK: Day
@@ -17,7 +18,7 @@ extension Date {
             var components = DateComponents()
             components.day = 1
             guard let nextDay = calendar.date(byAdding: components, to: startOfDay(timezone: timezone)) else {
-                fatalError("The next day cannot be calculated for \(self) with time zone \(timezone)")
+                logErrorAndExit("The next day cannot be calculated for \(self) with time zone \(timezone)")
             }
             return nextDay.startOfDay(timezone: timezone)
         }()
@@ -26,7 +27,7 @@ extension Date {
             var components = DateComponents()
             components.second = -1
             guard let date = calendar.date(byAdding: components, to: startOfNextDay) else {
-                fatalError("The end of today cannot be calculated from the start of tomorrow \(startOfNextDay) with time zone \(timezone)")
+                logErrorAndExit("The end of today cannot be calculated from the start of tomorrow \(startOfNextDay) with time zone \(timezone)")
             }
             return date
         }()

--- a/WooCommerce/Classes/Extensions/Date+StartAndEnd.swift
+++ b/WooCommerce/Classes/Extensions/Date+StartAndEnd.swift
@@ -12,10 +12,25 @@ extension Date {
     /// Returns self's end of day in the given time zone.
     func endOfDay(timezone: TimeZone) -> Date {
         let calendar = createCalendar(timezone: timezone)
-        var components = DateComponents()
-        components.day = 1
-        components.second = -1
-        return calendar.date(byAdding: components, to: startOfDay(timezone: timezone))!
+
+        let startOfNextDay: Date = {
+            var components = DateComponents()
+            components.day = 1
+            guard let nextDay = calendar.date(byAdding: components, to: startOfDay(timezone: timezone)) else {
+                fatalError("The next day cannot be calculated for \(self) with time zone \(timezone)")
+            }
+            return nextDay.startOfDay(timezone: timezone)
+        }()
+
+        let endOfToday: Date = {
+            var components = DateComponents()
+            components.second = -1
+            guard let date = calendar.date(byAdding: components, to: startOfNextDay) else {
+                fatalError("The end of today cannot be calculated from the start of tomorrow \(startOfNextDay) with time zone \(timezone)")
+            }
+            return date
+        }()
+        return endOfToday
     }
 
     // MARK: Week

--- a/WooCommerce/WooCommerceTests/Extensions/DateStartAndEndTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/DateStartAndEndTests.swift
@@ -26,6 +26,23 @@ final class DateStartAndEndTests: XCTestCase {
         XCTAssertEqual(endOfDay, expectedDate)
     }
 
+    func test_endOfDay_is_on_the_same_day_of_dst_change() throws {
+        // Given
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "America/Santiago"))
+        // Chile time zone: 2022-09-11 01:45:44
+        // Daily saving time on 2022-09-11, therefore 0-1AM is non-existent.
+        // Please note that Chile just removed daily saving time last minute in 2022.
+        let date = Date(timeIntervalSince1970: 1662871544)
+
+        // When
+        let endOfDay = date.endOfDay(timezone: timeZone)
+
+        // Then
+        // Chile time zone: 2022-09-11 23:59:59
+        let expectedDate = Date(timeIntervalSince1970: 1662951599)
+        XCTAssertEqual(endOfDay, expectedDate)
+    }
+
     // MARK: Week
 
     func testStartOfWeekInTaipei() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7703 
Most likely also fixes #6333
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For a long time, we've been haunted by a crash from a delegate method from the Charts framework to generate the string value for an x-axis value (index of the line chart). The crash occurs on and off, often surging around days with the daylight saving time (DST) change in certain regions in the world. This time, fortunately, I was able to reproduce it on one iOS 15.4 device (I cannot reproduce it on the other iOS 15.6 test device).

### Root cause

In `StoreStatsPeriodViewController`, we currently assume the given `value` corresponds to the index of the data values on the x-axis (the index of order stats intervals):

https://github.com/woocommerce/woocommerce-ios/blob/63a3e846101740eff109068ee1807e8bd60b2e72/WooCommerce/Classes/ViewRelated/Dashboard/Stats%20v4/StoreStatsV4PeriodViewController.swift#L493-L498

On days with DST change, there was only 1 order stats interval returned from the API (which is unexpected with reason below). In this case where there is only one interval, Charts library has [this logic](https://github.com/danielgindi/Charts/blob/2c77b2b8a4ccb82a36260b44b2c794683cc6f17b/Source/Charts/Components/AxisBase.swift#L345-L353) to set the x-axis's `entries` to `[-1, 0, 1]` and then calls `StoreStatsV4PeriodViewController: AxisValueFormatter`'s `stringForValue(:axis:)` to get the value for each x-axis entry. The app crashes when the x-axis entry is `-1` (and I'm sure it will crash for value `1` as well because it's out of bound). When there is more than one order stats interval, the x-axis `entries` is set properly for each interval index.

The reason why there is only 1 order stats interval fetched/returned is because of how the end of today is calculated in `Date.endOfDay(timezone:)`. Before this PR, the end of a date is calculated by adding 1 day minus 1 second to the start of the given date:

https://github.com/woocommerce/woocommerce-ios/blob/63a3e846101740eff109068ee1807e8bd60b2e72/WooCommerce/Classes/Extensions/Date%2BStartAndEnd.swift#L13-L19

On the day with daily saving time, 0-1 AM is non-existent at least in Chile (each region might be different) and thus the start of today is actually 1 AM instead of 12 AM. After adding 1 day minus 1 second, the end of today becomes the next day at 12:59:59 AM instead of 11:59:59 PM of the same day. In the order stats API request, we then calculate the "start of today" using the "end of today", therefore only 1 interval is fetched (12-1 AM the next day). In order to fix it, the logic is updated to 1 second minus the **start of the next day**.

### Target release

I decided to target the frozen 10.3 because at least Iran and New Zealand might expect a DST change at the end of September from the [DST Wiki](https://en.wikipedia.org/wiki/Daylight_saving_time_by_country). Release 10.4 has code freeze on September 16, and might be too late for the next DST change in Iran on September 20/21.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: in device settings > General, set the Date & Time to September 11, 2022, in Santiago, Chile. Also, set the region in Language & Region to Chile. Somehow I cannot reproduce this on an iOS 15.6 device, probably because DST was [recently removed by the Chile government](https://www.ghacks.net/2022/09/07/windows-users-in-chile-could-run-into-issues-because-of-daylight-savings-time/) and not every device receives the updates. You can also test this in a simulator, but updating the Mac time might be more problematic (some websites might stop working). Make sure to revert the device time to be automatic after testing, I couldn't use mobile payment services when buying lunch due to this time hack 😅 .

- Launch the app in the logged-in state --> the app might crash on `trunk`, and does not crash anymore with the PR branch

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
