### PR TITLE
Remove `SKUInputScanner` feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -9,8 +9,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .couponView:
             return true
-        case .productSKUInputScanner:
-            return true
         case .inbox:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .bulkEditProductVariations:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -85,7 +85,7 @@ private extension BetaFeaturesViewController {
     }
 
     func productSKUInputScannerSection() -> Section? {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productSKUInputScanner), UIImagePickerController.isSourceTypeAvailable(.camera) else {
+        guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -285,7 +285,7 @@ private extension ProductInventorySettingsViewController {
         cell.configure(viewModel: cellViewModel)
 
         // Configures accessory view for adding SKU from barcode scanner by fetching switch's state from app settings.
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productSKUInputScanner) && UIImagePickerController.isSourceTypeAvailable(.camera) else {
+        guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
             return
         }
         let action = AppSettingsAction.loadProductSKUInputScannerFeatureSwitchState() { [weak cell, self] result in


### PR DESCRIPTION
* We may not want to remove this flag for now, as per https://github.com/woocommerce/woocommerce-ios/pull/5695

> Created a new feature flag productSKUInputScanner that always returns true, which is used for product SKU input scanner CTA. Since the more complicated inventory scanner (CTA on the Products tab) is still WIP, we want to release two features separately with two feature flags

### Description
As part of https://github.com/woocommerce/woocommerce-ios/issues/7605 (removing feature-flag-related code that has been in production for a while) this PR removes the `.productSKUInputScanner` feature flag, as well as logic that relies on it.
