### PR TITLE
Login: Add tracks for Jetpack connection flow

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1591,3 +1591,17 @@ extension WooAnalyticsEvent {
         WooAnalyticsEvent(statName: .universalLinkFailed, properties: [Key.url.rawValue: url.absoluteString])
     }
 }
+
+// MARK: - Jetpack connection
+//
+extension WooAnalyticsEvent {
+    enum LoginJetpackConnection {
+        enum Key: String {
+            case selfHosted = "is_selfhosted_site"
+        }
+
+        static func jetpackConnectionErrorShown(selfHostedSite: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginJetpackConnectionErrorShown, properties: [Key.selfHosted.rawValue: selfHostedSite])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -680,6 +680,14 @@ public enum WooAnalyticsStat: String {
     // MARK: Universal Links
     case universalLinkOpened = "universal_link_opened"
     case universalLinkFailed = "universal_link_failed"
+
+    // MARK: Login Jetpack Connection
+    case loginJetpackConnectionErrorShown = "login_jetpack_connection_error_shown"
+    case loginJetpackConnectButtonTapped = "login_jetpack_connect_button_tapped"
+    case loginJetpackConnectCompleted = "login_jetpack_connect_completed"
+    case loginJetpackConnectDismissed = "login_jetpack_connect_dismissed"
+    case loginJetpackConnectionURLFetchFailed = "login_jetpack_connection_url_fetch_failed"
+    case loginJetpackConnectionVerificationFailed = "login_jetpack_connection_verification_failed"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackConnectionErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackConnectionErrorViewModel.swift
@@ -8,15 +8,18 @@ final class JetpackConnectionErrorViewModel: ULErrorViewModel {
     private let siteURL: String
     private var jetpackConnectionURL: URL?
     private let stores: StoresManager
+    private let analytics: Analytics
     private let isPrimaryButtonLoadingSubject = CurrentValueSubject<Bool, Never>(false)
     private let jetpackSetupCompletionHandler: (String) -> Void
 
     init(siteURL: String,
          credentials: WordPressOrgCredentials,
          stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics,
          onJetpackSetupCompletion: @escaping (String) -> Void) {
         self.siteURL = siteURL
         self.stores = stores
+        self.analytics = analytics
         self.jetpackSetupCompletionHandler = onJetpackSetupCompletion
         authenticate(with: credentials)
         fetchJetpackConnectionURL()
@@ -51,7 +54,7 @@ final class JetpackConnectionErrorViewModel: ULErrorViewModel {
     let secondaryButtonTitle = Localization.secondaryButtonTitle
 
     func viewDidLoad(_ viewController: UIViewController?) {
-        // TODO: Tracks?
+        analytics.track(event: .LoginJetpackConnection.jetpackConnectionErrorShown(selfHostedSite: true))
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackConnectionErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackConnectionErrorViewModel.swift
@@ -58,6 +58,7 @@ final class JetpackConnectionErrorViewModel: ULErrorViewModel {
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
+        analytics.track(.loginJetpackConnectButtonTapped)
         showJetpackConnectionWebView(from: viewController)
     }
 
@@ -111,6 +112,7 @@ private extension JetpackConnectionErrorViewModel {
             case .success(let url):
                 self.jetpackConnectionURL = url
             case .failure(let error):
+                self.analytics.track(.loginJetpackConnectionURLFetchFailed, withError: error)
                 DDLogWarn("⚠️ Error fetching Jetpack connection URL: \(error)")
             }
         }
@@ -130,11 +132,13 @@ private extension JetpackConnectionErrorViewModel {
             case .success(let user):
                 guard let emailAddress = user.wpcomUser?.email else {
                     DDLogWarn("⚠️ Cannot find connected WPcom user")
+                    self.analytics.track(.loginJetpackConnectionVerificationFailed)
                     return self.showSetupErrorNotice(in: viewController)
                 }
                 self.jetpackSetupCompletionHandler(emailAddress)
             case .failure(let error):
                 DDLogWarn("⚠️ Error fetching Jetpack user: \(error)")
+                self.analytics.track(.loginJetpackConnectionVerificationFailed, withError: error)
                 self.showSetupErrorNotice(in: viewController)
             }
         }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackConnectionWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackConnectionWebViewModel.swift
@@ -10,14 +10,20 @@ final class JetpackConnectionWebViewModel: AuthenticatedWebViewModel {
     let siteURL: String
     let completionHandler: () -> Void
 
-    init(initialURL: URL, siteURL: String, completion: @escaping () -> Void) {
+    private let analytics: Analytics
+
+    init(initialURL: URL,
+         siteURL: String,
+         analytics: Analytics = ServiceLocator.analytics,
+         completion: @escaping () -> Void) {
+        self.analytics = analytics
         self.initialURL = initialURL
         self.siteURL = siteURL
         self.completionHandler = completion
     }
 
     func handleDismissal() {
-        // TODO: tracks?
+        analytics.track(.loginJetpackConnectDismissed)
     }
 
     func handleRedirect(for url: URL?) {
@@ -40,7 +46,7 @@ final class JetpackConnectionWebViewModel: AuthenticatedWebViewModel {
     }
 
     private func handleSetupCompletion() {
-        // TODO: tracks?
+        analytics.track(.loginJetpackConnectCompleted)
         completionHandler()
     }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/JetpackConnectionWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/JetpackConnectionWebViewModelTests.swift
@@ -25,4 +25,36 @@ final class JetpackConnectionWebViewModelTests: XCTestCase {
         XCTAssertTrue(completionTriggered)
     }
 
+    func test_dismissal_is_tracked() throws {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+
+        let siteURL = "https://test.com"
+        let initialURL = try XCTUnwrap(URL(string: "https://jetpack.wordpress.com/jetpack.authorize/1/"))
+        let viewModel = JetpackConnectionWebViewModel(initialURL: initialURL, siteURL: siteURL, analytics: analytics, completion: {})
+
+        // When
+        viewModel.handleDismissal()
+
+        // Then
+        XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_connect_dismissed" }))
+    }
+
+    func test_completion_is_tracked() async throws {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+
+        let siteURL = "https://test.com"
+        let initialURL = try XCTUnwrap(URL(string: "https://jetpack.wordpress.com/jetpack.authorize/1/"))
+        let viewModel = JetpackConnectionWebViewModel(initialURL: initialURL, siteURL: siteURL, analytics: analytics, completion: {})
+
+        // When
+        let finalUrl = try XCTUnwrap(URL(string: siteURL + "/wp-admin"))
+        _ = await viewModel.decidePolicy(for: finalUrl)
+
+        // Then
+        XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_connect_completed" }))
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7597 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds tracking to the Jetpack connection flow following the proposal in pe5sF9-AL-p2#comment-864.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Create a JN site with Jetpack and Woo.
- Invite a test account to your site.
- Build and run the app, log out if necessary.
- On the prologue screen, select Enter your site address and enter the JN site address.
- Select Sign in with site credentials and input the credentials for the test account.
- Notice that the Jetpack connection error screen is displayed, in Xcode console there's a log: `🔵 Tracked login_jetpack_connection_error_shown, properties: [AnyHashable("is_selfhosted_site"): true]`.
- Quickly turn off the internet connection, after a while, notice in the Xcode console: `🔵 Tracked login_jetpack_connection_url_fetch_failed, properties: [AnyHashable("error_description"): "Error Domain=NSURLErrorDomain Code=-1001 \"The request timed out.\"...", AnyHashable("error_code"): "-1001", AnyHashable("error_domain"): "NSURLErrorDomain"]`
- Turn the connection on again, tap Back and retry from the credential login screen.
- Select Connect Jetpack to your account, notice in Xcode console: `🔵 Tracked login_jetpack_connect_button_tapped`.
- Dismiss the Connect Jetpack screen, notice in Xcode console: `🔵 Tracked login_jetpack_connect_dismissed`.
- Select the Connect Jetpack button again and approve the Jetpack connection with your WP.com account. After the flow completes, notice in Xcode console: `🔵 Tracked login_jetpack_connect_completed`.
- When the progress view is displayed while verifying the connection, quickly turn the connection off again. Notice in Xcode console: `🔵 Tracked login_jetpack_connection_verification_failed, properties: [AnyHashable("error_description"): "Error Domain=NSURLErrorDomain Code=-1001 \"The request timed out.\"...", AnyHashable("error_code"): "-1001", AnyHashable("error_domain"): "NSURLErrorDomain"]`


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->