### PR TITLE
Widgets: Data formatting

### DIFF
--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -12,6 +12,7 @@ extension UserDefaults {
         case defaultStoreID
         case defaultStoreName
         case defaultStoreTimeZoneGMTOffset
+        case defaultStoreCurrencySettings
         case defaultAnonymousID
         case defaultRoles
         case deviceID

--- a/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
+++ b/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
@@ -62,6 +62,8 @@ extension SelectedSiteSettings {
         fetchedObjects.forEach {
             ServiceLocator.currencySettings.updateCurrencyOptions(with: $0)
         }
+
+        UserDefaults.group?[.defaultStoreCurrencySettings] = try? JSONEncoder().encode(ServiceLocator.currencySettings)
     }
 }
 

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -51,7 +51,7 @@ final class StoreInfoDataService {
         return Stats(revenue: revenueAndOrders.totals.grossRevenue,
                      totalOrders: revenueAndOrders.totals.totalOrders,
                      totalVisitors: visitors.totalVisitors,
-                     conversion: conversion)
+                     conversion: min(conversion, 100))
     }
 }
 

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -47,11 +47,11 @@ final class StoreInfoDataService {
         let (revenueAndOrders, visitors) = try await (revenueAndOrdersRequest, visitorsRequest)
 
         // Assemble stats data
-        let conversion = visitors.totalVisitors > 0 ? Double(revenueAndOrders.totals.totalOrders) / Double(visitors.totalVisitors) * 100 : 0
+        let conversion = visitors.totalVisitors > 0 ? Double(revenueAndOrders.totals.totalOrders) / Double(visitors.totalVisitors) : 0
         return Stats(revenue: revenueAndOrders.totals.grossRevenue,
                      totalOrders: revenueAndOrders.totals.totalOrders,
                      totalVisitors: visitors.totalVisitors,
-                     conversion: min(conversion, 100))
+                     conversion: min(conversion, 1))
     }
 }
 

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -1,4 +1,5 @@
 import WidgetKit
+import WooFoundation
 import KeychainAccess
 
 /// Type that represents the all the possible Widget states.
@@ -123,6 +124,7 @@ private extension StoreInfoProvider {
         let storeID: Int64
         let storeName: String
         let storeTimeZone: TimeZone
+        let storeCurrencySettings: CurrencySettings
     }
 
     /// Fetches the required dependencies from the keychain and the shared users default.
@@ -133,10 +135,16 @@ private extension StoreInfoProvider {
               let storeID = UserDefaults.group?[.defaultStoreID] as? Int64,
               let storeName = UserDefaults.group?[.defaultStoreName] as? String,
               let storeTimeZoneGMTOffset = UserDefaults.group?[.defaultStoreTimeZoneGMTOffset] as? Int,
-              let storeTimeZone = TimeZone(secondsFromGMT: storeTimeZoneGMTOffset) else {
+              let storeTimeZone = TimeZone(secondsFromGMT: storeTimeZoneGMTOffset),
+              let storeCurrencySettingsData = UserDefaults.group?[.defaultStoreCurrencySettings] as? Data,
+              let storeCurrencySettings = try? JSONDecoder().decode(CurrencySettings.self, from: storeCurrencySettingsData) else {
             return nil
         }
-        return Dependencies(authToken: authToken, storeID: storeID, storeName: storeName, storeTimeZone: storeTimeZone)
+        return Dependencies(authToken: authToken,
+                            storeID: storeID,
+                            storeName: storeName,
+                            storeTimeZone: storeTimeZone,
+                            storeCurrencySettings: storeCurrencySettings)
     }
 }
 

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -77,7 +77,6 @@ final class StoreInfoProvider: TimelineProvider {
     }
 
     /// Real data widget.
-    /// TODO: Update with real data.
     ///
     func getTimeline(in context: Context, completion: @escaping (Timeline<StoreInfoEntry>) -> Void) {
         guard let dependencies = Self.fetchDependencies() else {
@@ -90,10 +89,9 @@ final class StoreInfoProvider: TimelineProvider {
             do {
                 let todayStats = try await strongService.fetchTodayStats(for: dependencies.storeID)
 
-                // TODO: Use proper store formatting.
                 let entry = StoreInfoEntry.data(.init(range: Localization.today,
                                                       name: dependencies.storeName,
-                                                      revenue: "$\(todayStats.revenue)",
+                                                      revenue: formattedAmountString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
                                                       visitors: "\(todayStats.totalVisitors)",
                                                       orders: "\(todayStats.totalOrders)",
                                                       conversion: formattedConversionString(for: todayStats.conversion)))
@@ -149,6 +147,11 @@ private extension StoreInfoProvider {
 }
 
 private extension StoreInfoProvider {
+
+    func formattedAmountString(for amountValue: Decimal, with currencySettings: CurrencySettings?) -> String {
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings ?? CurrencySettings())
+        return currencyFormatter.formatAmount(amountValue) ?? Constants.valuePlaceholderText
+    }
 
     func formattedConversionString(for conversionRate: Double) -> String {
         let numberFormatter = NumberFormatter()

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -95,7 +95,7 @@ final class StoreInfoProvider: TimelineProvider {
                                                       revenue: "$\(todayStats.revenue)",
                                                       visitors: "\(todayStats.totalVisitors)",
                                                       orders: "\(todayStats.totalOrders)",
-                                                      conversion: "\(todayStats.conversion)%"))
+                                                      conversion: formattedConversionString(for: todayStats.conversion)))
 
                 let reloadDate = Date(timeIntervalSinceNow: reloadInterval)
                 let timeline = Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
@@ -141,6 +141,22 @@ private extension StoreInfoProvider {
 }
 
 private extension StoreInfoProvider {
+
+    func formattedConversionString(for conversionRate: Double) -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .percent
+        numberFormatter.minimumFractionDigits = 1
+
+        // do not add 0 fraction digit if the percentage is round
+        let minimumFractionDigits = floor(conversionRate * 100.0) == conversionRate * 100.0 ? 0 : 1
+        numberFormatter.minimumFractionDigits = minimumFractionDigits
+        return numberFormatter.string(from: conversionRate as NSNumber) ?? Constants.valuePlaceholderText
+    }
+
+    enum Constants {
+        static let valuePlaceholderText = "-"
+    }
+
     enum Localization {
         static let myShop = NSLocalizedString("My Shop", comment: "Generic store name for the store info widget preview")
         static let today = NSLocalizedString("Today", comment: "Range title for the today store info widget")

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -53,6 +53,10 @@ final class StoreInfoProvider: TimelineProvider {
     ///
     private var networkService: StoreInfoDataService?
 
+    /// Desired data reload interval provided to system = 30 minutes.
+    ///
+    private let reloadInterval: TimeInterval = 30 * 60
+
     /// Redacted entry with sample data.
     ///
     func placeholder(in context: Context) -> StoreInfoEntry {
@@ -93,7 +97,7 @@ final class StoreInfoProvider: TimelineProvider {
                                                       orders: "\(todayStats.totalOrders)",
                                                       conversion: "\(todayStats.conversion)%"))
 
-                let reloadDate = Date(timeIntervalSinceNow: 30 * 60) // Ask for a 15 minutes reload.
+                let reloadDate = Date(timeIntervalSinceNow: reloadInterval)
                 let timeline = Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
                 completion(timeline)
 
@@ -102,7 +106,7 @@ final class StoreInfoProvider: TimelineProvider {
                 // WooFoundation does not expose `DDLOG` types. Should we include them?
                 print("⛔️ Error fetching today's widget stats: \(error)")
 
-                let reloadDate = Date(timeIntervalSinceNow: 30 * 60) // Ask for a 30 minutes reload.
+                let reloadDate = Date(timeIntervalSinceNow: reloadInterval)
                 let timeline = Timeline<StoreInfoEntry>(entries: [.error], policy: .after(reloadDate))
                 completion(timeline)
             }

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -64,10 +64,10 @@ final class StoreInfoProvider: TimelineProvider {
         let dependencies = Self.fetchDependencies()
         return StoreInfoEntry.data(.init(range: Localization.today,
                                          name: dependencies?.storeName ?? Localization.myShop,
-                                         revenue: "$132.234",
+                                         revenue: formattedAmountString(for: 132.234, with: dependencies?.storeCurrencySettings),
                                          visitors: "67",
                                          orders: "23",
-                                         conversion: "34%"))
+                                         conversion: formattedConversionString(for: 23/67)))
     }
 
     /// Quick Snapshot. Required when previewing the widget.

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -64,10 +64,10 @@ final class StoreInfoProvider: TimelineProvider {
         let dependencies = Self.fetchDependencies()
         return StoreInfoEntry.data(.init(range: Localization.today,
                                          name: dependencies?.storeName ?? Localization.myShop,
-                                         revenue: formattedAmountString(for: 132.234, with: dependencies?.storeCurrencySettings),
+                                         revenue: Self.formattedAmountString(for: 132.234, with: dependencies?.storeCurrencySettings),
                                          visitors: "67",
                                          orders: "23",
-                                         conversion: formattedConversionString(for: 23/67)))
+                                         conversion: Self.formattedConversionString(for: 23/67)))
     }
 
     /// Quick Snapshot. Required when previewing the widget.
@@ -91,10 +91,10 @@ final class StoreInfoProvider: TimelineProvider {
 
                 let entry = StoreInfoEntry.data(.init(range: Localization.today,
                                                       name: dependencies.storeName,
-                                                      revenue: formattedAmountString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
+                                                      revenue: Self.formattedAmountString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
                                                       visitors: "\(todayStats.totalVisitors)",
                                                       orders: "\(todayStats.totalOrders)",
-                                                      conversion: formattedConversionString(for: todayStats.conversion)))
+                                                      conversion: Self.formattedConversionString(for: todayStats.conversion)))
 
                 let reloadDate = Date(timeIntervalSinceNow: reloadInterval)
                 let timeline = Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
@@ -148,12 +148,12 @@ private extension StoreInfoProvider {
 
 private extension StoreInfoProvider {
 
-    func formattedAmountString(for amountValue: Decimal, with currencySettings: CurrencySettings?) -> String {
+    static func formattedAmountString(for amountValue: Decimal, with currencySettings: CurrencySettings?) -> String {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings ?? CurrencySettings())
         return currencyFormatter.formatAmount(amountValue) ?? Constants.valuePlaceholderText
     }
 
-    func formattedConversionString(for conversionRate: Double) -> String {
+    static func formattedConversionString(for conversionRate: Double) -> String {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .percent
         numberFormatter.minimumFractionDigits = 1

--- a/WooFoundation/WooFoundation/Currency/CurrencyCode.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencyCode.swift
@@ -1,6 +1,6 @@
 /// The 3-letter country code for supported currencies
 ///
-public enum CurrencyCode: String, CaseIterable {
+public enum CurrencyCode: String, CaseIterable, Codable {
     // A
     case AED, AFN, ALL, AMD, ANG, AOA, ARS, AUD, AWG, AZN,
     // B

--- a/WooFoundation/WooFoundation/Currency/CurrencySettings.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencySettings.swift
@@ -2,13 +2,13 @@ import Foundation
 
 /// Site-wide settings for displaying prices/money
 ///
-public class CurrencySettings {
+public class CurrencySettings: Codable {
 
     // MARK: - Enums
 
     /// Designates where the currency symbol is located on a formatted price
     ///
-    public enum CurrencyPosition: String {
+    public enum CurrencyPosition: String, Codable {
         case left = "left"
         case right = "right"
         case leftSpace = "left_space"
@@ -393,5 +393,33 @@ public class CurrencySettings {
         case .ZMW:
             return "ZK"
         }
+    }
+
+    // MARK: - Codable implementation
+
+    enum CodingKeys: CodingKey {
+        case currencyCode
+        case currencyPosition
+        case groupingSeparator
+        case decimalSeparator
+        case fractionDigits
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        currencyCode = try container.decode(CurrencyCode.self, forKey: .currencyCode)
+        currencyPosition = try container.decode(CurrencyPosition.self, forKey: .currencyPosition)
+        groupingSeparator = try container.decode(String.self, forKey: .groupingSeparator)
+        decimalSeparator = try container.decode(String.self, forKey: .decimalSeparator)
+        fractionDigits = try container.decode(Int.self, forKey: .fractionDigits)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(currencyCode, forKey: .currencyCode)
+        try container.encode(currencyPosition, forKey: .currencyPosition)
+        try container.encode(groupingSeparator, forKey: .groupingSeparator)
+        try container.encode(decimalSeparator, forKey: .decimalSeparator)
+        try container.encode(fractionDigits, forKey: .fractionDigits)
     }
 }

--- a/WooFoundation/WooFoundation/Currency/CurrencySettings.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencySettings.swift
@@ -396,6 +396,10 @@ public class CurrencySettings: Codable {
     }
 
     // MARK: - Codable implementation
+    // Used for serialization in UserDefaults to share settings between app and widgets extension
+    //
+    // No custom logic, but it is required because `@Published` property prevents automatic Codable synthesis
+    // (currencyCode type is Published<CurrencyCode> instead of CurrencyCode)
 
     enum CodingKeys: CodingKey {
         case currencyCode


### PR DESCRIPTION
Closes: #7565
Depends on #7707 (not logic, it's just to prevent merge conflicts in same files).

# Description
We need store currency setting to correctly display amount field. This PR also fixes conversion field from overflow over 100%.

# How

- Updates conversion rate value to behave the same way as on dashboard.
- Adds Codable conformance to `CurrencySettings` and shares it between app and extension.
- Uses shared settings to correctly format Amount value.

# Testing Steps

- Set currency settings to be very different from normal. In `wp-admin` it's in WooCommerce -> Settings -> Currency Options.
- Launch the app.
- Compare amount field formatting on app dashboard and widget.

# Screenshots

USD | EUR
--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/189726949-130c699d-0cda-450c-a97d-a2e6e0779ec2.png)|![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/189726974-bb4571f7-e22d-445d-b272-d507aad392bd.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
