### PR TITLE
Update Automattic-Tracks-iOS library to latest beta version.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -27,7 +27,7 @@ def aztec
 end
 
 def tracks
-  pod 'Automattic-Tracks-iOS', '~> 0.12.0'
+  pod 'Automattic-Tracks-iOS', '~> 0.12.1-beta.2'
   # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => ''
   # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => ''
   # pod 'Automattic-Tracks-iOS', :path => '../Automattic-Tracks-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,8 +6,8 @@ PODS:
   - AppAuth/Core (1.5.0)
   - AppAuth/ExternalUserAgent (1.5.0):
     - AppAuth/Core
-  - Automattic-Tracks-iOS (0.12.0):
-    - Sentry (~> 6)
+  - Automattic-Tracks-iOS (0.12.1-beta.2):
+    - Sentry (~> 7.24.1)
     - Sodium (>= 0.9.1)
     - UIDeviceIdentifier (~> 2.0)
   - CocoaLumberjack (3.7.4):
@@ -31,9 +31,9 @@ PODS:
   - Kingfisher (7.2.2)
   - NSObject-SafeExpectations (0.0.4)
   - "NSURL+IDN (0.4)"
-  - Sentry (6.2.1):
-    - Sentry/Core (= 6.2.1)
-  - Sentry/Core (6.2.1)
+  - Sentry (7.24.1):
+    - Sentry/Core (= 7.24.1)
+  - Sentry/Core (7.24.1)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
   - StripeTerminal (2.7.0)
@@ -83,7 +83,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 4.8)
-  - Automattic-Tracks-iOS (~> 0.12.0)
+  - Automattic-Tracks-iOS (~> 0.12.1-beta.2)
   - CocoaLumberjack (~> 3.7.4)
   - CocoaLumberjack/Swift (~> 3.7.4)
   - Gridicons (~> 1.2.0)
@@ -144,7 +144,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
-  Automattic-Tracks-iOS: dae8787ffc2c74493a3a908abc48aed527686131
+  Automattic-Tracks-iOS: 5833147f99e8fbcfc3a2c3f340d7cccd9471dc8e
   CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
   FormatterKit: 184db51bf120b633693a73624a4cede89ec51a41
   GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
@@ -155,7 +155,7 @@ SPEC CHECKSUMS:
   Kingfisher: 184d4d1a8c36666e663caf8e08abe87898595c53
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
-  Sentry: 9b922b396b0e0bca8516a10e36b0ea3ebea5faf7
+  Sentry: 1ed2d3f2973658bf6ab7ed43857c8e321a1625dd
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
   StripeTerminal: 237b759168a00c7f55b97c743cd8a4921866c46b
@@ -179,6 +179,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 777d68ac2ad78e410f8930be0fecb3b38338c2ae
+PODFILE CHECKSUM: 0b413ca49ed0793630b6cffce7d1dabbaf0d2886
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Part of: #7711

### Description
As a part of enabling suspect commits in Sentry, we have to start using a newer version of Sentry (`7.24.1`).

This PR updates the `Automattic-Tracks-iOS` pod to version `0.12.1-beta.2` which uses the newer version of Sentry. 

### Testing instructions
CI passing should be enough. 

### Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
