### PR TITLE
Widget: Reload widget when App stats are reloaded.

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -49,6 +49,10 @@ enum WooConstants {
     /// before an app review prompt appears
     ///
     static let systemEventCount = 10
+
+    /// Store Info Widget Identifier.
+    ///
+    static let storeInfoWidgetKind = "StoreInfoWidget"
 }
 
 // MARK: URLs

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -304,7 +304,6 @@ private extension StoreStatsAndTopPerformersViewController {
                     if vc.timeRange == .today {
                         WidgetCenter.shared.reloadTimelines(ofKind: WooConstants.storeInfoWidgetKind)
                     }
-                    
                 } else {
                     syncError = periodSyncError
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -2,6 +2,7 @@ import Combine
 import UIKit
 import XLPagerTabStrip
 import Yosemite
+import class WidgetKit.WidgetCenter
 
 /// Top-level stats container view controller that consists of a button bar with 4 time ranges.
 /// Each time range tab is managed by a `StoreStatsAndTopPerformersPeriodViewController`.
@@ -298,6 +299,12 @@ private extension StoreStatsAndTopPerformersViewController {
                 // Update last successful data sync timestamp
                 if periodSyncError == nil {
                     vc.lastFullSyncTimestamp = Date()
+
+                    // Reload the Store Info Widget after syncing the today's stats.
+                    if vc.timeRange == .today {
+                        WidgetCenter.shared.reloadTimelines(ofKind: WooConstants.storeInfoWidgetKind)
+                    }
+                    
                 } else {
                     syncError = periodSyncError
                 }

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -22,7 +22,7 @@ struct StoreInfoWidget: Widget {
                 }
             }
         }
-        .configurationDisplayName("Store Info")
+        .configurationDisplayName(Localization.storeInfo)
         .supportedFamilies(enableWidgets ? [.systemMedium] : [])
     }
 }
@@ -150,6 +150,18 @@ private struct UnableToFetchView: View {
 }
 
 // MARK: Constants
+
+/// Constants definition
+///
+private extension StoreInfoWidget {
+    enum Localization {
+        static let storeInfo = AppLocalizedString(
+            "storeWidgets.displayName",
+            value: "Store Info",
+            comment: "Widget title, displayed when selecting which widget to add"
+        )
+    }
+}
 
 /// Constants definition
 ///

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -10,7 +10,7 @@ struct StoreInfoWidget: Widget {
     let enableWidgets = DefaultFeatureFlagService().isFeatureFlagEnabled(.storeWidgets)
 
     var body: some WidgetConfiguration {
-        StaticConfiguration(kind: "StoreInfoWidget", provider: StoreInfoProvider()) { entry in
+        StaticConfiguration(kind: WooConstants.storeInfoWidgetKind, provider: StoreInfoProvider()) { entry in
             Group {
                 switch entry {
                 case .notConnected:


### PR DESCRIPTION
Closes: #7709 

# Why

In order to the widget as up-to-date as possible, this PR makes sure that the widget timeline is reloaded after a successful today's stats refresh is done on the app.

# How

- Update widget ID to be shared from `WooConstants`
- Reload the today's widget when the today's stat finishes syncing.
- Localize one missing widget string.

# Demo

https://user-images.githubusercontent.com/562080/189960264-68bcbed8-49d3-40da-a754-19ae8e23b586.mov

# Testing Steps

- Launch the app
- Create an order & collect cash payment 
- Refresh the today's stats until the new order gets reflected in the stats view.
- Minimize the app and see that the widget has updated information.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
