### PR TITLE
Widget:  Analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -216,7 +216,7 @@ private extension WooAnalytics {
         return updatedProperties
     }
 
-    /// Buildes the necesary properties for the `application_opened` event.
+    /// Builds the necesary properties for the `application_opened` event.
     ///
     func applicationOpenedProperties(_ configurationResult: Result<[WidgetInfo], Error>) -> [String: [String]] {
         guard let installedWidgets = try? configurationResult.get() else {

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import WordPressShared
+import WidgetKit
 
 public class WooAnalytics: Analytics {
 
@@ -180,7 +181,10 @@ private extension WooAnalytics {
     }
 
     @objc func trackApplicationOpened() {
-        track(.applicationOpened)
+        WidgetCenter.shared.getCurrentConfigurations { [weak self] configurationResult in
+            guard let self = self else { return }
+            self.track(.applicationOpened, withProperties: self.applicationOpenedProperties(configurationResult))
+        }
         applicationOpenedTime = Date()
     }
 
@@ -210,6 +214,27 @@ private extension WooAnalytics {
         updatedProperties[PropertyKeys.blogIDKey] = site?.siteID
         updatedProperties[PropertyKeys.wpcomStoreKey] = site?.isWordPressStore
         return updatedProperties
+    }
+
+    /// Buildes the necesary properties for the `application_opened` event.
+    ///
+    func applicationOpenedProperties(_ configurationResult: Result<[WidgetInfo], Error>) -> [String: [String]] {
+        guard let installedWidgets = try? configurationResult.get() else {
+            return ["widgets": []]
+        }
+
+        // Translate the widget kind into a name recognized by tracks.
+        let widgetAnalyticNames: [String] = installedWidgets.map { widgetInfo in
+            switch widgetInfo.kind {
+            case WooConstants.storeInfoWidgetKind:
+                return WooAnalyticsEvent.Widgets.Name.todayStats.rawValue
+            default:
+                DDLogWarn("⚠️ Make sure the widget: \(widgetInfo.kind), has the correct tracks name.")
+                return widgetInfo.kind
+            }
+        }
+
+        return ["widgets": widgetAnalyticNames]
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1605,3 +1605,22 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - Widgets {
+extension WooAnalyticsEvent {
+    enum Widgets {
+        enum Key: String {
+            case name = "name"
+        }
+
+        enum Name: String {
+            case todayStats = "today_stats"
+        }
+
+        /// Event when a widget is tapped and opens the app.
+        ///
+        static func widgetTapped(name: Name) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .widgetTapped, properties: [Key.name.rawValue: name.rawValue])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -688,6 +688,9 @@ public enum WooAnalyticsStat: String {
     case loginJetpackConnectDismissed = "login_jetpack_connect_dismissed"
     case loginJetpackConnectionURLFetchFailed = "login_jetpack_connection_url_fetch_failed"
     case loginJetpackConnectionVerificationFailed = "login_jetpack_connection_verification_failed"
+
+    // MARK: Widgets
+    case widgetTapped = "widget_tapped"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -180,6 +180,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             handleWebActivity(userActivity)
         }
 
+        trackWidgetTappedIfNeeded(userActivity: userActivity)
+
         return true
     }
 }
@@ -373,6 +375,17 @@ private extension AppDelegate {
     ///
     func startABTesting() async {
         await ABTest.start()
+    }
+
+    /// Tracks if the application was opened via a widget tap.
+    ///
+    func trackWidgetTappedIfNeeded(userActivity: NSUserActivity) {
+        switch userActivity.activityType {
+        case WooConstants.storeInfoWidgetKind:
+            ServiceLocator.analytics.track(event: .Widgets.widgetTapped(name: .todayStats))
+        default:
+            break
+        }
     }
 }
 


### PR DESCRIPTION
Closes: #7714 

# Why 

This PR implements the analytic events proposed in #7714 

Specifically it:

- Adds a new event `widget_tapped` to measure how the widget is driving app usage.
- Updates the `application_opened` event to include a list of installed widgets to know how many users are adding them.

# Logs

<img width="1174" alt="Screen Shot 2022-09-13 at 4 48 18 PM" src="https://user-images.githubusercontent.com/562080/190016516-1bf06dcc-f9de-44d0-9c82-a139d2e95584.png">

[Event Registration](https://mc.a8c.com/tracks/events/event.php?eventname=woocommerceios_widget_tapped#)



### Testing instruction

- When launching the app from the widget see that the `widget_tapped` is fired.
- When launching the app while the widget is added, see the `widgets` property of the `application_opened` event populated.
- When launching the app while the widget is not added, see the `widgets` property of the `application_opened` event empty.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
