### PR TITLE
Fix "Linking against a dylib which is not safe for use in application extensions" warnings

### DIFF
--- a/Experiments/Experiments.xcodeproj/project.pbxproj
+++ b/Experiments/Experiments.xcodeproj/project.pbxproj
@@ -463,6 +463,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2B7FCE683D4058A7A16F7946 /* Pods-Experiments.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -489,6 +490,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = AF72D9DB7771E7A5105C88B0 /* Pods-Experiments.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -611,6 +613,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8CB554DFAAD3EF41D17099C4 /* Pods-Experiments.release-alpha.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -3293,6 +3293,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9BD9C6C44CAC220B3C3B90B7 /* Pods-Networking.release-alpha.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -3466,6 +3467,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 753D6504FF01F09F6A33B73E /* Pods-Networking.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -3495,6 +3497,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C8F9A8CC6F90A8C9B5EF2EE2 /* Pods-Networking.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -548,6 +548,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 81B8569CD52D20EAE64EE737 /* Pods-WooFoundation.release-alpha.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -709,6 +710,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 99861FECBD0975C25DA03D80 /* Pods-WooFoundation.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -741,6 +743,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D64F2A76E9373989B3F181FC /* Pods-WooFoundation.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
### Description

After adding the store widgets extension (#7558) we noticed a few new warnings of the type:

```
warning build:
Linking against a dylib which is not safe for use in application extensions:
/path/to/DerivedData/WooCommerce/Build/Products/Debug-iphonesimulator/Networking.framework/Networking
```

This PR addresses all but one or two of those warnings. The remaining ones are:

**1. The Networking framework importing the unsafe Codegen framework**

<img width="795" alt="image" src="https://user-images.githubusercontent.com/1218433/190072835-c01aebd8-d55f-4a15-9b94-7b60f1ad7721.png">

Codegen as a local Swift package, meaning it doesn't have the same configuration as frameworks. The only solution I found so far is to silence it (see [this](https://danielsaidi.com/blog/2022/05/18/how-to-suppress-linking-warning)). I'd like to find a proper solution and would like to take some extra time to look into it.

**2. The WooFoundation framework importing the unsafe CocoaLumberjack framework**

I actually only saw this warning once and I can't get it to come up anymore. So, it's possible it was just another Xcode brain fart. I [looked in the CocoaLumberjack repo](https://github.com/CocoaLumberjack/CocoaLumberjack/search?q=APPLICATION_EXTENSION_API_ONLY) and confirmed the framework builds with the app-extension-safe APIs only, so I can't explain why we'd get that warning.

### Testing instructions

Checkout this branch and build locally (maybe after purging `DerivedData`) and verify the dylib warnings are gone.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – N.A.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
