### PR TITLE
Mock an action response to prevent the test case sending HTTP request

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
@@ -163,7 +163,20 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
     func test_loading_indicator_gets_disabled_after_the_network_operation_completes() {
         // Given
-        let viewModel = EditOrderAddressFormViewModel(order: order(withShippingAddress: sampleAddress()), type: .shipping, storageManager: testingStorage)
+        let viewModel = EditOrderAddressFormViewModel(
+            order: order(withShippingAddress: sampleAddress()),
+            type: .shipping,
+            storageManager: testingStorage,
+            stores: testingStores
+        )
+        testingStores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .updateOrder(_, _, _, onCompletion):
+                onCompletion(.failure(NSError(domain: "", code: 0)))
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
 
         // When
         viewModel.onLoadTrigger.send()


### PR DESCRIPTION
### Description
This test case has been pretty flaky. In case where it passed, it took more than 2 seconds to finish. It seems to me that this test case is making an actual HTTP request from `saveAddress` function. Other similar test cases in this test class use `testingStores.whenReceivingAction` as a way to stub HTTP response, this PR adds the same code to this test case.

### Testing instructions
CI jobs passes, and `test_loading_indicator_gets_disabled_after_the_network_operation_completes` test case takes less than 1 seconds to finish.

### Screenshots
N/A


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
