### PR TITLE
Widget: Last refreshed label

### DIFF
--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -44,6 +44,10 @@ struct StoreInfoData {
     /// Conversion at the range (eg: today)
     ///
     var conversion: String
+
+    /// Time when the widget was last refreshed (eg: 10.24PM)
+    ///
+    var updatedTime: String
 }
 
 /// Type that provides data entries to the widget system.
@@ -67,7 +71,8 @@ final class StoreInfoProvider: TimelineProvider {
                                          revenue: Self.formattedAmountString(for: 132.234, with: dependencies?.storeCurrencySettings),
                                          visitors: "67",
                                          orders: "23",
-                                         conversion: Self.formattedConversionString(for: 23/67)))
+                                         conversion: Self.formattedConversionString(for: 23/67),
+                                         updatedTime: Self.currentFormattedTime()))
     }
 
     /// Quick Snapshot. Required when previewing the widget.
@@ -94,7 +99,8 @@ final class StoreInfoProvider: TimelineProvider {
                                                       revenue: Self.formattedAmountString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
                                                       visitors: "\(todayStats.totalVisitors)",
                                                       orders: "\(todayStats.totalOrders)",
-                                                      conversion: Self.formattedConversionString(for: todayStats.conversion)))
+                                                      conversion: Self.formattedConversionString(for: todayStats.conversion),
+                                                      updatedTime: Self.currentFormattedTime()))
 
                 let reloadDate = Date(timeIntervalSinceNow: reloadInterval)
                 let timeline = Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
@@ -158,6 +164,15 @@ private extension StoreInfoProvider {
         let minimumFractionDigits = floor(conversionRate * 100.0) == conversionRate * 100.0 ? 0 : 1
         numberFormatter.minimumFractionDigits = minimumFractionDigits
         return numberFormatter.string(from: conversionRate as NSNumber) ?? Constants.valuePlaceholderText
+    }
+
+    /// Returns the current time formatted as `10:24 PM` or `22:24` depending on the phone settings.
+    ///
+    static func currentFormattedTime() -> String {
+        let timeFormatter = DateFormatter()
+        timeFormatter.timeStyle = .short
+        timeFormatter.dateStyle = .none
+        return timeFormatter.string(from: Date())
     }
 
     enum Constants {

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -94,6 +94,10 @@ private struct StoreInfoView: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
+
+                Text(Localization.updatedAt("10:23 PM"))
+                    .statRangeStyle()
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
             .padding(.horizontal)
         }
@@ -187,6 +191,12 @@ private extension StoreInfoView {
             value: "Conversion",
             comment: "Conversion title label for the store info widget"
         )
+        static func updatedAt(_ updatedTime: String) -> LocalizedString {
+            let format = AppLocalizedString("storeWidgets.infoView.updatedAt",
+                                            value: "Updated at: %1$@",
+                                            comment: "Displays the time when the widget was last updated. %1$@ is the time to render.")
+            return LocalizedString.localizedStringWithFormat(format, updatedTime)
+        }
     }
 
     enum Layout {

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -193,7 +193,7 @@ private extension StoreInfoView {
         )
         static func updatedAt(_ updatedTime: String) -> LocalizedString {
             let format = AppLocalizedString("storeWidgets.infoView.updatedAt",
-                                            value: "Updated at: %1$@",
+                                            value: "as of %1$@",
                                             comment: "Displays the time when the widget was last updated. %1$@ is the time to render.")
             return LocalizedString.localizedStringWithFormat(format, updatedTime)
         }

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -95,7 +95,7 @@ private struct StoreInfoView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
-                Text(Localization.updatedAt("10:23 PM"))
+                Text(Localization.updatedAt(entry.updatedTime))
                     .statRangeStyle()
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -254,7 +254,8 @@ struct StoreWidgets_Previews: PreviewProvider {
                                  revenue: "$132.234",
                                  visitors: "67",
                                  orders: "23",
-                                 conversion: "37%")
+                                 conversion: "37%",
+                                 updatedTime: "10:24 PM")
         )
         .previewContext(WidgetPreviewContext(family: .systemMedium))
 


### PR DESCRIPTION
Closes: #7710 

# Why 
In order to provide more accurate information to the user, this PR adds a "Last Refreshed" label so the merchant can be aware of how recent the widget information is.

# Why
- Adds a new `last refreshed ` label that reads `as of {time}`
- Update `StoreInfoProvider` to provide the current formatted time to the widget entry. The format is `hh:mm`.

# Demo
https://user-images.githubusercontent.com/562080/190206874-0b16018c-70d1-40f4-96a2-a762ec92374a.MP4



# Testing 
- Launch the app or refresh the today's stats.
- See that the widget has a correct refresh time value


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
