### PR TITLE
Widgets: Update deployment target

### DIFF
--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -62,12 +62,7 @@ final class StoreInfoProvider: TimelineProvider {
     ///
     func placeholder(in context: Context) -> StoreInfoEntry {
         let dependencies = Self.fetchDependencies()
-        return StoreInfoEntry.data(.init(range: Localization.today,
-                                         name: dependencies?.storeName ?? Localization.myShop,
-                                         revenue: Self.formattedAmountString(for: 132.234, with: dependencies?.storeCurrencySettings),
-                                         visitors: "67",
-                                         orders: "23",
-                                         conversion: Self.formattedConversionString(for: 23/67)))
+        return Self.placeholderEntry(for: dependencies)
     }
 
     /// Quick Snapshot. Required when previewing the widget.
@@ -88,20 +83,11 @@ final class StoreInfoProvider: TimelineProvider {
         Task {
             do {
                 let todayStats = try await strongService.fetchTodayStats(for: dependencies.storeID)
-
-                let entry = StoreInfoEntry.data(.init(range: Localization.today,
-                                                      name: dependencies.storeName,
-                                                      revenue: Self.formattedAmountString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
-                                                      visitors: "\(todayStats.totalVisitors)",
-                                                      orders: "\(todayStats.totalOrders)",
-                                                      conversion: Self.formattedConversionString(for: todayStats.conversion)))
-
+                let entry = Self.dataEntry(for: todayStats, with: dependencies)
                 let reloadDate = Date(timeIntervalSinceNow: reloadInterval)
                 let timeline = Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
                 completion(timeline)
-
             } catch {
-
                 // WooFoundation does not expose `DDLOG` types. Should we include them?
                 print("⛔️ Error fetching today's widget stats: \(error)")
 
@@ -142,7 +128,31 @@ private extension StoreInfoProvider {
     }
 }
 
+/// Data configuration
+///
 private extension StoreInfoProvider {
+
+    /// Redacted entry with sample data. If dependencies are available - store name and currency settings will be used.
+    ///
+    static func placeholderEntry(for dependencies: Dependencies?) -> StoreInfoEntry {
+        StoreInfoEntry.data(.init(range: Localization.today,
+                                  name: dependencies?.storeName ?? Localization.myShop,
+                                  revenue: Self.formattedAmountString(for: 132.234, with: dependencies?.storeCurrencySettings),
+                                  visitors: "67",
+                                  orders: "23",
+                                  conversion: Self.formattedConversionString(for: 23/67)))
+    }
+
+    /// Real data entry.
+    ///
+    static func dataEntry(for todayStats: StoreInfoDataService.Stats, with dependencies: Dependencies) -> StoreInfoEntry {
+        StoreInfoEntry.data(.init(range: Localization.today,
+                                  name: dependencies.storeName,
+                                  revenue: Self.formattedAmountString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
+                                  visitors: "\(todayStats.totalVisitors)",
+                                  orders: "\(todayStats.totalOrders)",
+                                  conversion: Self.formattedConversionString(for: todayStats.conversion)))
+    }
 
     static func formattedAmountString(for amountValue: Decimal, with currencySettings: CurrencySettings?) -> String {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings ?? CurrencySettings())

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -11100,7 +11100,6 @@
 				INFOPLIST_FILE = StoreWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgets;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Automattic. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -11135,7 +11134,6 @@
 				INFOPLIST_FILE = StoreWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgets;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Automattic. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -11169,7 +11167,6 @@
 				INFOPLIST_FILE = StoreWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgets;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Automattic. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
Closes #7722.

## Description

Widgets target has been set up with default value for deployment target = 15.5.
We don't have any blockers to deploy it at minimum supported version by main app = 14.0.

## How

- Removes deployment target setting in extension, so it derives iOS 14 from the project level.
- Refactors some `StoreInfoProvider` code in attempt to add unit tests. Easy attempt failed, we need to extract code to be tested in shared library, out of scope for now. Refactoring left in place to separate data formatting away from wdigets/networking.

## Testing Steps

- Compile and run.

@mokagio pinging you as the target creator to take second look at settings update.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
