### PR TITLE
Products: fix the draft status blue text color in the product row

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] In-Person Payments: Fixed a bug where cancelling a card reader connection would temporarily prevent further connections [https://github.com/woocommerce/woocommerce-ios/pull/7689]
 - [*] In-Person Payments: Improvements to the card reader connection flow UI [https://github.com/woocommerce/woocommerce-ios/pull/7687]
 - [*] Login: Users can now set up the Jetpack connection between a self-hosted site and their WP.com account. [https://github.com/woocommerce/woocommerce-ios/pull/7608]
+- [*] Product list: the "Draft" blue color is fixed to be more readable for a draft product row in the product list. [https://github.com/woocommerce/woocommerce-ios/pull/7724]
 
 10.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
@@ -5,7 +5,7 @@ private extension ProductStatus {
     var descriptionColor: UIColor {
         switch self {
         case .draft:
-            return .blue
+            return .wooBlue
         case .pending:
             return .orange
         default:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7723 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When we moved the semantic colors (`UIColor` extensions) from the main app to WooFoundation framework, we had to rename some of the color extensions that conflict with the native colors including `UIColor.blue`. In https://github.com/woocommerce/woocommerce-ios/pull/7604, we fixed most of the blue color and there's just one case left in this PR. Also did a quick pass, and I don't see any other `UIColor.blue` references anymore.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Go to the Products tab
- Create a product in draft status if your store doesn't have one yet (ellipsis menu > Product Settings > Status) --> the product row should have a "Draft" text, and in the Woo blue color instead of the native blue as in `trunk`

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light
-- | --
![Simulator Screen Shot - iPhone 13 Pro - 2022-09-15 at 11 58 17](https://user-images.githubusercontent.com/1945542/190327982-ee09cba8-a980-449a-ad70-a51d4f8011c7.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-09-15 at 11 58 26](https://user-images.githubusercontent.com/1945542/190328000-b0481f4d-1223-401c-b778-24f341af49db.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
