### PR TITLE
Products: Add duplicate product feature

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -407,6 +407,10 @@ public enum WooAnalyticsStat: String {
     case addProductSuccess = "add_product_success"
     case addProductFailed = "add_product_failed"
 
+    // MARK: Duplicate Product events
+    case duplicateProductSuccess = "duplicate_product_success"
+    case duplicateProductFailed = "duplicate_product_failed"
+
     // MARK: Edit Product Events
     //
     case productDetailLoaded = "product_detail_loaded"
@@ -512,6 +516,7 @@ public enum WooAnalyticsStat: String {
     // MARK: Product Settings
     //
     case productDetailViewSettingsButtonTapped = "product_detail_view_settings_button_tapped"
+    case productDetailDuplicateButtonTapped = "product_detail_duplicate_button_tapped"
     case productSettingsDoneButtonTapped = "product_settings_done_button_tapped"
     case productSettingsStatusTapped = "product_settings_status_tapped"
     case productSettingsVisibilityTapped = "product_settings_visibility_tapped"

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -31,7 +31,7 @@ final class ProductFormRemoteActionUseCase {
         addProductRemotely(product: product) { productResult in
             switch productResult {
             case .failure(let error):
-                ServiceLocator.analytics.track(successEventName, withError: error)
+                ServiceLocator.analytics.track(failureEventName, withError: error)
                 onCompletion(.failure(error))
             case .success(let product):
                 // `self` is retained because the use case is not usually strongly held.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -288,7 +288,6 @@ private extension ProductFormRemoteActionUseCase {
 
     func retrieveProduct(id: Int64, siteID: Int64) async -> Product? {
         await withCheckedContinuation { [weak self] continuation in
-            guard let self = self else { return }
             let action = ProductAction.retrieveProduct(siteID: siteID, productID: id) { result in
                 switch result {
                 case .success(let product):
@@ -305,8 +304,10 @@ private extension ProductFormRemoteActionUseCase {
 
     func retrieveProductVariation(variationID: Int64, siteID: Int64, productID: Int64) async -> ProductVariation? {
         await withCheckedContinuation { [weak self] continuation in
-            guard let self = self else { return }
-            let action = ProductVariationAction.retrieveProductVariation(siteID: siteID, productID: productID, variationID: variationID, onCompletion: { result in
+            let action = ProductVariationAction.retrieveProductVariation(siteID: siteID,
+                                                                         productID: productID,
+                                                                         variationID: variationID,
+                                                                         onCompletion: { result in
                 switch result {
                 case .success(let variation):
                     continuation.resume(returning: variation)
@@ -322,7 +323,6 @@ private extension ProductFormRemoteActionUseCase {
 
     func duplicateProductVariation(_ newVariation: CreateProductVariation, parent: EditableProductModel) async {
         await withCheckedContinuation { [weak self] continuation in
-            guard let self = self else { return }
             let createAction = ProductVariationAction.createProductVariation(
                 siteID: parent.siteID,
                 productID: parent.productID,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -290,7 +290,7 @@ private extension ProductFormRemoteActionUseCase {
             DispatchQueue.main.async { [weak self] in
                 self?.stores.dispatch(action)
             }
-        }
+        } as Product?
     }
 
     func retrieveProductVariation(id: Int64, siteID: Int64, productID: Int64) async -> ProductVariation? {
@@ -307,7 +307,7 @@ private extension ProductFormRemoteActionUseCase {
             DispatchQueue.main.async { [weak self] in
                 self?.stores.dispatch(action)
             }
-        }
+        } as ProductVariation?
     }
 
     func duplicateProductVariation(_ newVariation: CreateProductVariation, parent: EditableProductModel) async {
@@ -322,7 +322,7 @@ private extension ProductFormRemoteActionUseCase {
             DispatchQueue.main.async { [weak self] in
                 self?.stores.dispatch(createAction)
             }
-        }
+        } as Void
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -49,14 +49,14 @@ final class ProductFormRemoteActionUseCase {
         }
     }
 
-    /// Adds a copy of the input product remotely.
+    /// Adds a copy of the input product remotely. The new product will have an updated name, no SKU and its status will be Draft.
     /// - Parameters:
     ///   - originalProduct: The product to be duplicated remotely.
     ///   - onCompletion: Called when the remote process finishes.
     func duplicateProduct(originalProduct: EditableProductModel,
                           password: String?,
                           onCompletion: @escaping DuplicateProductCompletion) {
-        let productModelToSave: EditableProductModel = {
+        let productModelToSave = {
             let newName = String(format: Localization.copyProductName, originalProduct.name)
             let copiedProduct = originalProduct.product.copy(
                 productID: 0,
@@ -273,7 +273,7 @@ private extension ProductFormRemoteActionUseCase {
                 await self.duplicateProductVariation(newVariation, parent: newProduct)
             }
 
-            let updatedProduct: EditableProductModel = await {
+            let updatedProduct = await {
                 guard let productModel = await retrieveProduct(id: newProduct.productID, siteID: newProduct.siteID) else {
                     return newProduct
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -266,7 +266,7 @@ private extension ProductFormRemoteActionUseCase {
         Task { [weak self] in
             guard let self = self else { return }
             for id in variationIDs {
-                guard let variation = await self.retrieveProductVariation(id: id, siteID: newProduct.siteID, productID: oldProductID) else {
+                guard let variation = await self.retrieveProductVariation(variationID: id, siteID: newProduct.siteID, productID: oldProductID) else {
                     continue
                 }
                 let newVariation = CreateProductVariation(regularPrice: variation.regularPrice ?? "", attributes: variation.attributes)
@@ -303,10 +303,10 @@ private extension ProductFormRemoteActionUseCase {
         } as Product?
     }
 
-    func retrieveProductVariation(id: Int64, siteID: Int64, productID: Int64) async -> ProductVariation? {
+    func retrieveProductVariation(variationID: Int64, siteID: Int64, productID: Int64) async -> ProductVariation? {
         await withCheckedContinuation { [weak self] continuation in
             guard let self = self else { return }
-            let action = ProductVariationAction.retrieveProductVariation(siteID: siteID, productID: productID, variationID: id, onCompletion: { result in
+            let action = ProductVariationAction.retrieveProductVariation(siteID: siteID, productID: productID, variationID: variationID, onCompletion: { result in
                 switch result {
                 case .success(let variation):
                     continuation.resume(returning: variation)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -56,7 +56,7 @@ final class ProductFormRemoteActionUseCase {
     func duplicateProduct(originalProduct: EditableProductModel,
                           password: String?,
                           onCompletion: @escaping DuplicateProductCompletion) {
-        let productModelToSave = {
+        let productModelToSave: EditableProductModel = {
             let newName = String(format: Localization.copyProductName, originalProduct.name)
             let copiedProduct = originalProduct.product.copy(
                 productID: 0,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -35,13 +35,12 @@ extension ProductFormViewController {
     }
     /// Product Confirmation Save alert
     ///
-    func presentProductConfirmationSaveAlert(hasDuplicated: Bool) {
+    func presentProductConfirmationSaveAlert(title: String = Localization.Alert.presentProductConfirmationSaveAlert) {
         let contextNoticePresenter: NoticePresenter = {
             let noticePresenter = DefaultNoticePresenter()
             noticePresenter.presentingViewController = self
             return noticePresenter
         }()
-        let title = hasDuplicated ? Localization.Alert.presentProductCopiedAlert : Localization.Alert.presentProductConfirmationSaveAlert
         contextNoticePresenter.enqueue(notice: .init(title: title))
     }
 
@@ -129,10 +128,6 @@ private enum Localization {
         static let presentProductConfirmationSaveAlert = NSLocalizedString("Product saved",
                                                                            comment: "Title of the alert when a user is saving a product")
 
-        // Product copied
-        static let presentProductCopiedAlert = NSLocalizedString("Product copied",
-                                                                 comment: "Title of the alert when a user has copied a product")
-
         // Product type change
         static let productTypeChangeTitle = NSLocalizedString("Are you sure you want to change the product type?",
                                                               comment: "Title of the alert when a user is changing the product type")
@@ -180,7 +175,7 @@ private enum Localization {
                                                             comment: "Message of the in-progress UI while saving a Product as draft remotely")
 
         static let productDuplicatingTitle = NSLocalizedString("Duplicating your product...",
-                                                               comment: "Title of the in-progress UI while duplicated a Product remotely")
+                                                               comment: "Title of the in-progress UI while duplicating a Product remotely")
         static let productDuplicatingMessage = NSLocalizedString("Please wait while we save a copy of this product to your store",
                                                                  comment: "Message of the in-progress UI while duplicating a Product as draft remotely")
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -35,14 +35,16 @@ extension ProductFormViewController {
     }
     /// Product Confirmation Save alert
     ///
-    func presentProductConfirmationSaveAlert() {
+    func presentProductConfirmationSaveAlert(hasDuplicated: Bool) {
         let contextNoticePresenter: NoticePresenter = {
             let noticePresenter = DefaultNoticePresenter()
             noticePresenter.presentingViewController = self
             return noticePresenter
         }()
-        contextNoticePresenter.enqueue(notice: .init(title: Localization.Alert.presentProductConfirmationSaveAlert))
+        let title = hasDuplicated ? Localization.Alert.presentProductCopiedAlert : Localization.Alert.presentProductConfirmationSaveAlert
+        contextNoticePresenter.enqueue(notice: .init(title: title))
     }
+
     /// Product Confirmation Delete alert
     ///
     func presentProductConfirmationDeleteAlert(completion: @escaping (_ isConfirmed: Bool) -> ()) {
@@ -124,6 +126,11 @@ private enum Localization {
         // Product saved or updated
         static let presentProductConfirmationSaveAlert = NSLocalizedString("Product saved",
                                                                            comment: "Title of the alert when a user is saving a product")
+
+        // Product copied
+        static let presentProductCopiedAlert = NSLocalizedString("Product copied",
+                                                                 comment: "Title of the alert when a user has copied a product")
+
         // Product type change
         static let productTypeChangeTitle = NSLocalizedString("Are you sure you want to change the product type?",
                                                               comment: "Title of the alert when a user is changing the product type")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -95,6 +95,8 @@ extension ProductFormViewController {
             displayInProgressView(title: Localization.ProgressView.productSavingTitle, message: Localization.ProgressView.productSavingMessage)
         case .saveVariation:
             displayInProgressView(title: Localization.ProgressView.productVariationTitle, message: Localization.ProgressView.productVariationMessage)
+        case .duplicate:
+            displayInProgressView(title: Localization.ProgressView.productDuplicatingTitle, message: Localization.ProgressView.productDuplicatingMessage)
         }
     }
 
@@ -176,6 +178,11 @@ private enum Localization {
                                                           comment: "Title of the in-progress UI while saving a Product as draft remotely")
         static let productSavingMessage = NSLocalizedString("Please wait while we save this product to your store",
                                                             comment: "Message of the in-progress UI while saving a Product as draft remotely")
+
+        static let productDuplicatingTitle = NSLocalizedString("Duplicating your product...",
+                                                               comment: "Title of the in-progress UI while duplicated a Product remotely")
+        static let productDuplicatingMessage = NSLocalizedString("Please wait while we save a copy of this product to your store",
+                                                                 comment: "Message of the in-progress UI while duplicating a Product as draft remotely")
 
         static let productDeletionTitle = NSLocalizedString("Placing your product in the trash...",
                                                             comment: "Title of the in-progress UI while deleting the Product remotely")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -251,6 +251,13 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
             }
         }
 
+        if viewModel.canDuplicateProduct() {
+            actionSheet.addDefaultActionWithTitle(ActionSheetStrings.duplicate) { [weak self] _ in
+                // TODO: Tracks?
+                self?.duplicateProduct()
+            }
+        }
+
         if viewModel.canDeleteProduct() {
             actionSheet.addDestructiveActionWithTitle(ActionSheetStrings.delete) { [weak self] _ in
                 self?.displayDeleteProductAlert()
@@ -772,6 +779,10 @@ private extension ProductFormViewController {
         }
 
         SharingHelper.shareURL(url: url, title: product.name, from: view, in: self)
+    }
+
+    func duplicateProduct() {
+        // TODO
     }
 
     func displayDeleteProductAlert() {
@@ -1530,6 +1541,7 @@ private enum ActionSheetStrings {
     static let delete = NSLocalizedString("Delete", comment: "Button title Delete in Edit Product More Options Action Sheet")
     static let productSettings = NSLocalizedString("Product Settings", comment: "Button title Product Settings in Edit Product More Options Action Sheet")
     static let cancel = NSLocalizedString("Cancel", comment: "Button title Cancel in Edit Product More Options Action Sheet")
+    static let duplicate = NSLocalizedString("Duplicate", comment: "Button title to duplicate a product in Product More Options Action Sheet")
 }
 
 private enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -253,7 +253,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
         if viewModel.canDuplicateProduct() {
             actionSheet.addDefaultActionWithTitle(ActionSheetStrings.duplicate) { [weak self] _ in
-                // TODO: Tracks?
+                ServiceLocator.analytics.track(.productDetailDuplicateButtonTapped)
                 self?.duplicateProduct()
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -736,7 +736,7 @@ private extension ProductFormViewController {
             case .success:
                 // Dismisses the in-progress UI, then presents the confirmation alert.
                 self?.navigationController?.dismiss(animated: true, completion: nil)
-                self?.presentProductConfirmationSaveAlert(hasDuplicated: false)
+                self?.presentProductConfirmationSaveAlert()
 
                 // Show linked products promo banner after product save
                 (self?.viewModel as? ProductFormViewModel)?.isLinkedProductsPromoEnabled = true
@@ -792,7 +792,8 @@ private extension ProductFormViewController {
             case .success:
                 // Dismisses the in-progress UI, then presents the confirmation alert.
                 self?.navigationController?.dismiss(animated: true, completion: nil)
-                self?.presentProductConfirmationSaveAlert(hasDuplicated: true)
+                let alertTitle =  Localization.presentProductCopiedAlert
+                self?.presentProductConfirmationSaveAlert(title: alertTitle)
             }
         })
     }
@@ -1547,6 +1548,7 @@ private enum Localization {
         "Cannot duplicate product",
         comment: "The title of the alert when there is an error duplicating the product"
     )
+    static let presentProductCopiedAlert = NSLocalizedString("Product copied", comment: "Title of the alert when a user has copied a product")
 }
 
 private enum ActionSheetStrings {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -745,11 +745,8 @@ private extension ProductFormViewController {
         }
     }
 
-    func displayError(error: ProductUpdateError?) {
-        let title = NSLocalizedString("Cannot update product", comment: "The title of the alert when there is an error updating the product")
-
+    func displayError(error: ProductUpdateError?, title: String = Localization.updateProductError) {
         let message = error?.errorDescription
-
         displayErrorAlert(title: title, message: message)
     }
 
@@ -790,7 +787,7 @@ private extension ProductFormViewController {
 
                 // Dismisses the in-progress UI then presents the error alert.
                 self?.navigationController?.dismiss(animated: true) {
-                    self?.displayError(error: error)
+                    self?.displayError(error: error, title: Localization.duplicateProductError)
                 }
             case .success:
                 // Dismisses the in-progress UI, then presents the confirmation alert.
@@ -1545,6 +1542,11 @@ private enum Localization {
         let titleFormat = NSLocalizedString("Variation #%1$@", comment: "Navigation bar title for variation. Parameters: %1$@ - Product variation ID")
         return String.localizedStringWithFormat(titleFormat, variationID)
     }
+    static let updateProductError = NSLocalizedString("Cannot update product", comment: "The title of the alert when there is an error updating the product")
+    static let duplicateProductError = NSLocalizedString(
+        "Cannot duplicate product",
+        comment: "The title of the alert when there is an error duplicating the product"
+    )
 }
 
 private enum ActionSheetStrings {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -791,9 +791,10 @@ private extension ProductFormViewController {
                 }
             case .success:
                 // Dismisses the in-progress UI, then presents the confirmation alert.
-                self?.navigationController?.dismiss(animated: true, completion: nil)
-                let alertTitle =  Localization.presentProductCopiedAlert
-                self?.presentProductConfirmationSaveAlert(title: alertTitle)
+                self?.navigationController?.dismiss(animated: true) {
+                    let alertTitle =  Localization.presentProductCopiedAlert
+                    self?.presentProductConfirmationSaveAlert(title: alertTitle)
+                }
             }
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -782,6 +782,7 @@ private extension ProductFormViewController {
     }
 
     func duplicateProduct() {
+        showSavingProgress(.duplicate)
         viewModel.duplicateProduct(onCompletion: { [weak self] result in
             switch result {
             case .failure(let error):

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -736,7 +736,7 @@ private extension ProductFormViewController {
             case .success:
                 // Dismisses the in-progress UI, then presents the confirmation alert.
                 self?.navigationController?.dismiss(animated: true, completion: nil)
-                self?.presentProductConfirmationSaveAlert()
+                self?.presentProductConfirmationSaveAlert(hasDuplicated: false)
 
                 // Show linked products promo banner after product save
                 (self?.viewModel as? ProductFormViewModel)?.isLinkedProductsPromoEnabled = true
@@ -782,7 +782,21 @@ private extension ProductFormViewController {
     }
 
     func duplicateProduct() {
-        // TODO
+        viewModel.duplicateProduct(onCompletion: { [weak self] result in
+            switch result {
+            case .failure(let error):
+                DDLogError("⛔️ Error duplicating Product: \(error)")
+
+                // Dismisses the in-progress UI then presents the error alert.
+                self?.navigationController?.dismiss(animated: true) {
+                    self?.displayError(error: error)
+                }
+            case .success:
+                // Dismisses the in-progress UI, then presents the confirmation alert.
+                self?.navigationController?.dismiss(animated: true, completion: nil)
+                self?.presentProductConfirmationSaveAlert(hasDuplicated: true)
+            }
+        })
     }
 
     func displayDeleteProductAlert() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -472,19 +472,18 @@ extension ProductFormViewModel {
             )
             return EditableProductModel(product: copiedProduct)
         }()
-        let remoteActionUseCase = ProductFormRemoteActionUseCase()
 
-        remoteActionUseCase.addProduct(product: productModelToSave, password: password) { [weak self] result in
+        let remoteActionUseCase = ProductFormRemoteActionUseCase()
+        remoteActionUseCase.duplicateProduct(product: productModelToSave,
+                                             originalProductID: product.productID,
+                                             originalProductVariationIDs: product.product.variations) { [weak self] result in
+            guard let self = self else { return }
             switch result {
             case .failure(let error):
                 onCompletion(.failure(error))
-            case .success(let data):
-                guard let self = self else {
-                    return
-                }
-                self.resetProduct(data.product)
-                self.resetPassword(data.password)
-                onCompletion(.success(data.product))
+            case .success(let product):
+                self.resetProduct(product)
+                onCompletion(.success(product))
                 self.replaceProductID(productIDBeforeSave: productIDBeforeSave)
                 self.saveProductImagesWhenNoneIsPendingUploadAnymore()
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -462,9 +462,14 @@ extension ProductFormViewModel {
     }
 
     func duplicateProduct(onCompletion: @escaping (Result<ProductModel, ProductUpdateError>) -> Void) {
-        let productIDBeforeSave: Int64 = -1
+        let productIDBeforeSave: Int64 = 0
         let productModelToSave: EditableProductModel = {
-            let copiedProduct = product.product.copy(productID: productIDBeforeSave, name: "\(product.name) Copy")
+            let newName = String(format: Localization.copyProductName, product.name)
+            let copiedProduct = product.product.copy(
+                productID: productIDBeforeSave,
+                name: newName,
+                statusKey: ProductStatus.draft.rawValue
+            )
             return EditableProductModel(product: copiedProduct)
         }()
         let remoteActionUseCase = ProductFormRemoteActionUseCase()
@@ -640,5 +645,14 @@ private extension ProductFormViewModel {
                                                    addOnsFeatureEnabled: isAddOnsFeatureEnabled,
                                                    isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
                                                    variationsPrice: calculateVariationPriceState())
+    }
+}
+
+private extension ProductFormViewModel {
+    enum Localization {
+        static let copyProductName = NSLocalizedString(
+            "%1$@ Copy",
+            comment: "The default name for a duplicated product, with %1$@ being the original name. Reads like: Ramen Copy"
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -476,14 +476,16 @@ extension ProductFormViewModel {
         let remoteActionUseCase = ProductFormRemoteActionUseCase()
         remoteActionUseCase.duplicateProduct(product: productModelToSave,
                                              originalProductID: product.productID,
-                                             originalProductVariationIDs: product.product.variations) { [weak self] result in
+                                             originalProductVariationIDs: product.product.variations,
+                                             password: password) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .failure(let error):
                 onCompletion(.failure(error))
-            case .success(let product):
-                self.resetProduct(product)
-                onCompletion(.success(product))
+            case .success(let data):
+                self.resetProduct(data.product)
+                self.resetPassword(data.password)
+                onCompletion(.success(data.product))
                 self.replaceProductID(productIDBeforeSave: productIDBeforeSave)
                 self.saveProductImagesWhenNoneIsPendingUploadAnymore()
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -246,6 +246,10 @@ extension ProductFormViewModel {
     func canDeleteProduct() -> Bool {
         formType == .edit
     }
+
+    func canDuplicateProduct() -> Bool {
+        formType == .edit
+    }
 }
 
 // MARK: Action handling

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -462,21 +462,8 @@ extension ProductFormViewModel {
     }
 
     func duplicateProduct(onCompletion: @escaping (Result<ProductModel, ProductUpdateError>) -> Void) {
-        let productIDBeforeSave: Int64 = 0
-        let productModelToSave: EditableProductModel = {
-            let newName = String(format: Localization.copyProductName, product.name)
-            let copiedProduct = product.product.copy(
-                productID: productIDBeforeSave,
-                name: newName,
-                statusKey: ProductStatus.draft.rawValue
-            )
-            return EditableProductModel(product: copiedProduct)
-        }()
-
         let remoteActionUseCase = ProductFormRemoteActionUseCase()
-        remoteActionUseCase.duplicateProduct(product: productModelToSave,
-                                             originalProductID: product.productID,
-                                             originalProductVariationIDs: product.product.variations,
+        remoteActionUseCase.duplicateProduct(originalProduct: product,
                                              password: password) { [weak self] result in
             guard let self = self else { return }
             switch result {
@@ -486,8 +473,6 @@ extension ProductFormViewModel {
                 self.resetProduct(data.product)
                 self.resetPassword(data.password)
                 onCompletion(.success(data.product))
-                self.replaceProductID(productIDBeforeSave: productIDBeforeSave)
-                self.saveProductImagesWhenNoneIsPendingUploadAnymore()
             }
         }
     }
@@ -646,14 +631,5 @@ private extension ProductFormViewModel {
                                                    addOnsFeatureEnabled: isAddOnsFeatureEnabled,
                                                    isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
                                                    variationsPrice: calculateVariationPriceState())
-    }
-}
-
-private extension ProductFormViewModel {
-    enum Localization {
-        static let copyProductName = NSLocalizedString(
-            "%1$@ Copy",
-            comment: "The default name for a duplicated product, with %1$@ being the original name. Reads like: Ramen Copy"
-        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -139,6 +139,8 @@ protocol ProductFormViewModelProtocol {
 
     func deleteProductRemotely(onCompletion: @escaping (Result<Void, ProductUpdateError>) -> Void)
 
+    func duplicateProduct(onCompletion: @escaping (Result<ProductModel, ProductUpdateError>) -> Void)
+
     // Reset action
 
     func resetPassword(_ password: String?)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -79,6 +79,8 @@ protocol ProductFormViewModelProtocol {
 
     func canDeleteProduct() -> Bool
 
+    func canDuplicateProduct() -> Bool
+
     // Update actions
 
     func updateName(_ name: String)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -20,6 +20,7 @@ enum SaveMessageType {
     case publish
     case save
     case saveVariation
+    case duplicate
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -170,6 +170,10 @@ extension ProductVariationFormViewModel {
     func canDeleteProduct() -> Bool {
         formType == .edit
     }
+
+    func canDuplicateProduct() -> Bool {
+        false
+    }
 }
 
 // MARK: Action handling

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -323,6 +323,10 @@ extension ProductVariationFormViewModel {
         storesManager.dispatch(updateAction)
     }
 
+    func duplicateProduct(onCompletion: @escaping (Result<EditableProductVariationModel, ProductUpdateError>) -> Void) {
+        // no-op
+    }
+
     func deleteProductRemotely(onCompletion: @escaping (Result<Void, ProductUpdateError>) -> Void) {
         let deleteAction = ProductVariationAction.deleteProductVariation(productVariation: productVariation.productVariation) { [weak self] result in
             switch result {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCaseTests.swift
@@ -290,6 +290,145 @@ final class ProductFormRemoteActionUseCaseTests: XCTestCase {
         XCTAssertNotNil(storesManager.receivedActions.first as? ProductAction)
         XCTAssertEqual(result, .failure(.unexpected))
     }
+
+    // MARK: - Duplicate a product (`duplicateProduct`)
+    func test_duplicating_product_triggers_adding_copy_of_product_correctly() {
+        // Given
+        let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.published.rawValue, sku: "12356")
+        let model = EditableProductModel(product: product)
+        var copiedProductName: String?
+        var copiedProductStatusKey: String?
+        var copiedProductSKU: String?
+        let useCase = ProductFormRemoteActionUseCase(stores: storesManager)
+
+        // When
+        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case .addProduct(let product, _):
+                copiedProductName = product.name
+                copiedProductStatusKey = product.statusKey
+                copiedProductSKU = product.sku
+            default:
+                break
+            }
+        }
+        useCase.duplicateProduct(originalProduct: model, password: nil, onCompletion: { _ in })
+
+        // Then
+        assertEqual(String(format: Localization.copyProductName, product.name), copiedProductName)
+        assertEqual(ProductStatus.draft.rawValue, copiedProductStatusKey)
+        XCTAssertNil(copiedProductSKU)
+    }
+
+    func test_duplicating_product_with_a_password_unsuccessfully_returns_failure_result_with_password_error() {
+        // Given
+        let product = Product.fake()
+        let model = EditableProductModel(product: product)
+        let password = "wo0oo!"
+        let useCase = ProductFormRemoteActionUseCase(stores: storesManager)
+        mockAddProduct(result: .success(product))
+        mockUpdatePassword(result: .failure(NSError(domain: "", code: 100, userInfo: nil)))
+
+        // When
+        var result: Result<ResultData, ProductUpdateError>?
+        useCase.duplicateProduct(originalProduct: model, password: password) { aResult in
+            result = aResult
+        }
+
+        // Then
+        XCTAssertEqual(storesManager.receivedActions.count, 2)
+        XCTAssertNotNil(storesManager.receivedActions[0] as? ProductAction)
+        XCTAssertNotNil(storesManager.receivedActions[1] as? SitePostAction)
+        XCTAssertEqual(result, .failure(.passwordCannotBeUpdated))
+    }
+
+    func test_duplicating_product_without_a_password_successfully_does_not_trigger_password_action_and_returns_success_result() {
+        // Given
+        let product = Product.fake()
+        let model = EditableProductModel(product: product)
+        let useCase = ProductFormRemoteActionUseCase(stores: storesManager)
+        mockAddProduct(result: .success(product))
+
+        // When
+        var result: Result<ResultData, ProductUpdateError>?
+        useCase.duplicateProduct(originalProduct: model, password: nil) { aResult in
+            result = aResult
+        }
+
+        // Then
+        XCTAssertEqual(storesManager.receivedActions.count, 1)
+        XCTAssertNotNil(storesManager.receivedActions.first as? ProductAction)
+        XCTAssertEqual(result, .success(ResultData(product: model, password: nil)))
+    }
+
+    func test_duplicating_product_unsuccessfully_does_not_trigger_password_action_and_returns_failure_result_with_product_error() {
+        // Given
+        let product = Product.fake()
+        let model = EditableProductModel(product: product)
+        mockAddProduct(result: .failure(.invalidSKU))
+        let useCase = ProductFormRemoteActionUseCase(stores: storesManager)
+
+        // When
+        var result: Result<ResultData, ProductUpdateError>?
+        useCase.duplicateProduct(originalProduct: model, password: "test") { aResult in
+            result = aResult
+        }
+
+        // Then
+        XCTAssertEqual(storesManager.receivedActions.count, 1)
+        XCTAssertNotNil(storesManager.receivedActions.first as? ProductAction)
+        XCTAssertEqual(result, .failure(.invalidSKU))
+    }
+
+    func test_duplicating_variable_product_triggers_retrieving_original_product_variations_and_creating_new_variations_for_duplicated_product() {
+        // Given
+        let testVariationIDs: [Int64] = [11, 20, 35]
+        let product = Product.fake().copy(productID: 2, productTypeKey: ProductType.variable.rawValue, variations: testVariationIDs)
+        let model = EditableProductModel(product: product)
+
+        var retrievedVariationIDs: [Int64] = []
+        var createdVariationCount = 0
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .retrieveProductVariation(_, _, variationID, onCompletion):
+                retrievedVariationIDs.append(variationID)
+                onCompletion(.success(ProductVariation.fake().copy(productVariationID: variationID)))
+            case let .createProductVariation(_, _, _, onCompletion):
+                createdVariationCount += 1
+                let fakeVariation = ProductVariation.fake().copy(productVariationID: Int64.random(in: 99..<999))
+                onCompletion(.success(fakeVariation))
+            default:
+                break
+            }
+        }
+
+        let copiedProduct = product.copy(productID: 13)
+        let finalProduct = copiedProduct.copy(variations: testVariationIDs)
+        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case .addProduct(_, let onCompletion):
+                onCompletion(.success(copiedProduct))
+            case .retrieveProduct(_, _, let onCompletion):
+                onCompletion(.success(finalProduct))
+            default:
+                break
+            }
+        }
+
+        // When
+        let useCase = ProductFormRemoteActionUseCase(stores: storesManager)
+        var result: Result<ResultData, ProductUpdateError>?
+        useCase.duplicateProduct(originalProduct: model, password: nil) { aResult in
+            result = aResult
+        }
+        waitUntil {
+            createdVariationCount == 3
+        }
+
+        // Then
+        XCTAssertEqual(retrievedVariationIDs, testVariationIDs)
+        XCTAssertEqual(result?.isSuccess, true)
+    }
 }
 
 private extension ProductFormRemoteActionUseCaseTests {
@@ -323,5 +462,15 @@ private extension ProductFormRemoteActionUseCaseTests {
                 onCompletion(result)
             }
         }
+    }
+}
+
+
+private extension ProductFormRemoteActionUseCaseTests {
+    enum Localization {
+        static let copyProductName = NSLocalizedString(
+            "%1$@ Copy",
+            comment: "The default name for a duplicated product, with %1$@ being the original name. Reads like: Ramen Copy"
+        )
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -171,6 +171,43 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertFalse(canDeleteProduct)
     }
 
+    // MARK: `canDuplicateProduct`
+    func test_add_product_form_with_non_published_status_cannot_duplicate_product() {
+        // Arrange
+        let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.pending.rawValue)
+        let viewModel = createViewModel(product: product, formType: .add)
+
+        // Action
+        let canDuplicateProduct = viewModel.canDuplicateProduct()
+
+        // Assert
+        XCTAssertFalse(canDuplicateProduct)
+    }
+
+    func test_edit_product_form_with_non_published_status_can_duplicate_product() {
+        // Arrange
+        let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.pending.rawValue)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // Action
+        let canDuplicateProduct = viewModel.canDuplicateProduct()
+
+        // Assert
+        XCTAssertTrue(canDuplicateProduct)
+    }
+
+    func test_edit_product_form_with_published_status_can_duplicate_product() {
+        // Arrange
+        let product = Product.fake().copy(name: "Test", statusKey: ProductStatus.published.rawValue)
+        let viewModel = createViewModel(product: product, formType: .edit)
+
+        // Action
+        let canDuplicateProduct = viewModel.canDuplicateProduct()
+
+        // Assert
+        XCTAssertTrue(canDuplicateProduct)
+    }
+
     func test_update_variations_updates_original_product_while_maintaining_pending_changes() throws {
         // Given
         let product = Product.fake()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7255 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the feature to duplicate products.

This feature is available for all products that have been saved on the server, regardless of their status (published/draft).

This feature is implemented on WooCommerce Core [here](https://github.com/woocommerce/woocommerce/blob/5d7f6acbcb387f1d51d51305bf949d07fa3c4b08/includes/admin/class-wc-admin-duplicate-product.php#L97), but not available on the API.

The idea is simply to create a copy of the original product, rename it, set its status to draft, and make sure to clear the SKU value since it needs to be unique. The implementation on Core handles generating a new unique value based on the original one, but this requires checking for existing values which may take time, so I'm just resetting it to nil for simplicity.

For variable products, the original product's variations are also duplicated to the new one.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Navigate to the Products tab, and select a simple product with SKU value. 
- Tap the "..." button on the top right and select Duplicate. Notice in Xcode console: `🔵 Tracked product_detail_duplicate_button_tapped`
-  Notice that after the process completes, the view is reloaded with the copied product, with the name updated and no SKU value. The status of the product should be Draft. Most of the other values should be the same as the original one, except for reviews, rating, slug, and product ID. Xcode console should log: `🔵 Tracked duplicate_product_success`
- Repeat the test with a variable product. After duplicating, the new product should have the same variations as the original.
- Turn off the Internet connection and try duplicating product again. Xcode console should log `🔵 Tracked duplicate_product_failed` with error information in the properties.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/190574415-498989a5-e2b3-4e83-928e-94d8397c70d2.mp4



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
