### PR TITLE
Update Tracks to 0.13.0-beta.2 to address verbose Sentry logs

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -27,7 +27,7 @@ def aztec
 end
 
 def tracks
-  pod 'Automattic-Tracks-iOS', '~> 0.12.1-beta.2'
+  pod 'Automattic-Tracks-iOS', '~> 0.13.0-beta.2'
   # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => ''
   # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => ''
   # pod 'Automattic-Tracks-iOS', :path => '../Automattic-Tracks-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,8 +6,8 @@ PODS:
   - AppAuth/Core (1.5.0)
   - AppAuth/ExternalUserAgent (1.5.0):
     - AppAuth/Core
-  - Automattic-Tracks-iOS (0.12.1-beta.2):
-    - Sentry (~> 7.24.1)
+  - Automattic-Tracks-iOS (0.13.0-beta.2):
+    - Sentry (~> 7.25)
     - Sodium (>= 0.9.1)
     - UIDeviceIdentifier (~> 2.0)
   - CocoaLumberjack (3.7.4):
@@ -31,9 +31,9 @@ PODS:
   - Kingfisher (7.2.2)
   - NSObject-SafeExpectations (0.0.4)
   - "NSURL+IDN (0.4)"
-  - Sentry (7.24.1):
-    - Sentry/Core (= 7.24.1)
-  - Sentry/Core (7.24.1)
+  - Sentry (7.25.1):
+    - Sentry/Core (= 7.25.1)
+  - Sentry/Core (7.25.1)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
   - StripeTerminal (2.7.0)
@@ -83,7 +83,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 4.8)
-  - Automattic-Tracks-iOS (~> 0.12.1-beta.2)
+  - Automattic-Tracks-iOS (~> 0.13.0-beta.2)
   - CocoaLumberjack (~> 3.7.4)
   - CocoaLumberjack/Swift (~> 3.7.4)
   - Gridicons (~> 1.2.0)
@@ -144,7 +144,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
-  Automattic-Tracks-iOS: 5833147f99e8fbcfc3a2c3f340d7cccd9471dc8e
+  Automattic-Tracks-iOS: 22ba583f388b4db28393d5735121633d37285939
   CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
   FormatterKit: 184db51bf120b633693a73624a4cede89ec51a41
   GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
@@ -155,7 +155,7 @@ SPEC CHECKSUMS:
   Kingfisher: 184d4d1a8c36666e663caf8e08abe87898595c53
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
-  Sentry: 1ed2d3f2973658bf6ab7ed43857c8e321a1625dd
+  Sentry: dd29c18c32b0af9269949f079cf631d581ca76ca
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
   StripeTerminal: 237b759168a00c7f55b97c743cd8a4921866c46b
@@ -179,6 +179,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 3e746ecbe69d5cf22e0377beba8d803003558dd6
+PODFILE CHECKSUM: c2e2c47533bbece8fb5b4500107ca34638d56293
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
### Description
@jaclync reported internally an onslaught of Sentry logs in the console, in the form of:

```
Sentry - debug:: Add breadcrumb: <SentryBreadcrumb: 0x60000390cbc0, {
    category = http;
    data =     {
        ...
        url = "https://public-api.wordpress.com/wpcom/...";
    };
    level = info;
    timestamp = "2022-09-14T08:34:30.845Z";
    type = http;
}>
```

This PR updates Tracks to a version that set the Sentry logging level to `.error` (the only level above it is `.fatal`).

_I expect this PR to raise conflicts with #7062. Ideally, we'd merge that one first, then I'll handle the conflict here. For that reason, I haven't enabled auto-merge._

### Testing instructions
Running the app in the Simulator should no show Sentry logs. I guess one could also try to trigger something that would log with `.error` level, but I didn't go that far.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
