### PR TITLE
Widgets: Updates copies

### DIFF
--- a/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
+++ b/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
@@ -63,6 +63,7 @@ extension SelectedSiteSettings {
             ServiceLocator.currencySettings.updateCurrencyOptions(with: $0)
         }
 
+        // Needed to correcly format the widget data.
         UserDefaults.group?[.defaultStoreCurrencySettings] = try? JSONEncoder().encode(ServiceLocator.currencySettings)
     }
 }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -511,6 +511,8 @@ private extension DefaultStoresManager {
         UserDefaults.group?[.defaultStoreID] = siteID
         UserDefaults.group?[.defaultStoreName] = sessionManager.defaultSite?.name
 
+        // Currency Settings are stored in `SelectedSiteSettings.defaultStoreCurrencySettings`
+
         // Reload widgets UI
         WidgetCenter.shared.reloadAllTimelines()
     }

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -199,7 +199,7 @@ private extension StoreInfoView {
         )
         static func updatedAt(_ updatedTime: String) -> LocalizedString {
             let format = AppLocalizedString("storeWidgets.infoView.updatedAt",
-                                            value: "as of %1$@",
+                                            value: "As of %1$@",
                                             comment: "Displays the time when the widget was last updated. %1$@ is the time to render.")
             return LocalizedString.localizedStringWithFormat(format, updatedTime)
         }

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -22,7 +22,8 @@ struct StoreInfoWidget: Widget {
                 }
             }
         }
-        .configurationDisplayName(Localization.storeInfo)
+        .configurationDisplayName(Localization.title)
+        .description(Localization.description)
         .supportedFamilies(enableWidgets ? [.systemMedium] : [])
     }
 }
@@ -159,10 +160,15 @@ private struct UnableToFetchView: View {
 ///
 private extension StoreInfoWidget {
     enum Localization {
-        static let storeInfo = AppLocalizedString(
+        static let title = AppLocalizedString(
             "storeWidgets.displayName",
-            value: "Store Info",
+            value: "Today",
             comment: "Widget title, displayed when selecting which widget to add"
+        )
+        static let description = AppLocalizedString(
+            "storeWidgets.description",
+            value: "WooCommerce Stats Today",
+            comment: "Widget description, displayed when selecting which widget to add"
         )
     }
 }


### PR DESCRIPTION
# Why

In preparation for the Widgets Release, this PR updates the copies when adding the widget to match the Android copies.

Additionally, it adds a small comment around sharing `currency settings`.

# Screenshots

<img width="433" alt="Screen Shot 2022-09-15 at 9 19 41 AM" src="https://user-images.githubusercontent.com/562080/190433931-c392fe83-0153-4a1e-abc8-2afad7a9a849.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
