### PR TITLE
Widgets: Remove Feature Flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -33,8 +33,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .promptToEnableCodInIppOnboarding:
             return true
-        case .storeWidgets:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -69,8 +69,4 @@ public enum FeatureFlag: Int {
     /// Whether to include the Cash on Delivery enable step in In-Person Payment onboarding
     ///
     case promptToEnableCodInIppOnboarding
-
-    /// Enables home screen store widgets.
-    ///
-    case storeWidgets
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 10.4
 -----
+- [***] Stats: Now you can add a Today's Stats Widget to your homescreen to monitor your sales. [https://github.com/woocommerce/woocommerce-ios/pull/7732]
 - [*] Help center: Added help center web page with FAQs for "Pick a WooCommerce Store" screen. [https://github.com/woocommerce/woocommerce-ios/pull/7641]
 - [*] In-Person Payments: Fixed a bug where cancelling a card reader connection would temporarily prevent further connections [https://github.com/woocommerce/woocommerce-ios/pull/7689]
 - [*] In-Person Payments: Improvements to the card reader connection flow UI [https://github.com/woocommerce/woocommerce-ios/pull/7687]

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -7,8 +7,6 @@ import Experiments
 ///
 struct StoreInfoWidget: Widget {
 
-    let enableWidgets = DefaultFeatureFlagService().isFeatureFlagEnabled(.storeWidgets)
-
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: WooConstants.storeInfoWidgetKind, provider: StoreInfoProvider()) { entry in
             Group {
@@ -23,7 +21,7 @@ struct StoreInfoWidget: Widget {
             }
         }
         .configurationDisplayName(Localization.storeInfo)
-        .supportedFamilies(enableWidgets ? [.systemMedium] : [])
+        .supportedFamilies([.systemMedium])
     }
 }
 


### PR DESCRIPTION
**Please be sure that https://github.com/woocommerce/woocommerce-ios/pull/7721 and https://github.com/woocommerce/woocommerce-ios/pull/7731 are merged first** 

# Why

In order to release the Today's Stats Widget, this PR removes the feature flag associated to it! 😁 

[Test Plan](https://wooengage.wordpress.com/2022/09/10/widgets-mini-test-plan/)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
