### PR TITLE
Revert badge refresh removal from OrdersRootViewController

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] In-Person Payments: Improvements to the card reader connection flow UI [https://github.com/woocommerce/woocommerce-ios/pull/7687]
 - [*] Login: Users can now set up the Jetpack connection between a self-hosted site and their WP.com account. [https://github.com/woocommerce/woocommerce-ios/pull/7608]
 - [*] Product list: the "Draft" blue color is fixed to be more readable for a draft product row in the product list. [https://github.com/woocommerce/woocommerce-ios/pull/7724]
+- [*] Notifications: App icon badge is now cleared correctly after visiting the orders tab. [https://github.com/woocommerce/woocommerce-ios/pull/7735]
 
 10.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -105,6 +105,7 @@ final class OrdersRootViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
+        // Clears application icon badge and requests new reports/orders/totals data
         ServiceLocator.pushNotesManager.resetBadgeCount(type: .storeOrder)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -102,6 +102,12 @@ final class OrdersRootViewController: UIViewController {
         }
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        ServiceLocator.pushNotesManager.resetBadgeCount(type: .storeOrder)
+    }
+
     override var shouldShowOfflineBanner: Bool {
         if featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
             return false


### PR DESCRIPTION
Related: #5703

## Description

This PR brings back badge refresh logic in `OrdersRootViewController`. It was cleaned up in an effort to reduce the number of API calls, but this particular call is the only one that clears `applicationIconBadgeNumber`.

Maybe we shouldn't trigger extra data reload in [loadNotificationCountAndUpdateApplicationBadgeNumberAndPostNotifications](https://github.com/woocommerce/woocommerce-ios/blob/c457ff03b5ce36ae442d23bb571039cd37d181df/WooCommerce/Classes/Notifications/PushNotificationsManager.swift#L375-L378)? That's a consideration for a future improvement, now the goal is to fix inconsistent state for many users.

## Testing instructions

1. Allow notifications to display a badge on app icon
2. Place an order to trigger app icon badge update (always "1" for any number of orders)
3. Go to the orders tab and confirm that application badge is cleared

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.