### PR TITLE
Custom help content for "Open mail to find magic link" screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 10.4
 -----
 - [***] Stats: Now you can add a Today's Stats Widget to your homescreen to monitor your sales. [https://github.com/woocommerce/woocommerce-ios/pull/7732]
-- [*] Help center: Added help center web page with FAQs for "Pick a WooCommerce Store" and "Enter WordPress.com password" screens. [https://github.com/woocommerce/woocommerce-ios/pull/7641, https://github.com/woocommerce/woocommerce-ios/pull/7730]
+- [*] Help center: Added help center web page with FAQs for "Pick a WooCommerce Store", "Enter WordPress.com password" and "Open mail to find magic link" screens. [https://github.com/woocommerce/woocommerce-ios/pull/7641, https://github.com/woocommerce/woocommerce-ios/pull/7730, https://github.com/woocommerce/woocommerce-ios/pull/7737]
 - [*] In-Person Payments: Fixed a bug where cancelling a card reader connection would temporarily prevent further connections [https://github.com/woocommerce/woocommerce-ios/pull/7689]
 - [*] In-Person Payments: Improvements to the card reader connection flow UI [https://github.com/woocommerce/woocommerce-ios/pull/7687]
 - [*] Login: Users can now set up the Jetpack connection between a self-hosted site and their WP.com account. [https://github.com/woocommerce/woocommerce-ios/pull/7608]

--- a/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
+++ b/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
@@ -37,6 +37,8 @@ extension CustomHelpCenterContent {
             url = WooConstants.URLs.helpCenterForWPCOMEmailScreen.asURL()
         case .usernamePassword: // Enter Store credentials screen (wp-admin creds)
             url = WooConstants.URLs.helpCenterForEnterStoreCredentials.asURL()
+        case .magicLinkAutoRequested, .magicLinkRequested: // Open magic link from email screen
+            url = WooConstants.URLs.helpCenterForOpenEmail.asURL()
         default:
             return nil
         }

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -107,6 +107,10 @@ extension WooConstants {
         // swiftlint:disable:next line_length
         case helpCenterForWPCOMEmailFromSiteAddressFlow = "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-wordpress-com-email-address-login-using-store-address-flow"
 
+        /// Help Center for "Open magic link from email " screen
+        ///
+        case helpCenterForOpenEmail = "https://woocommerce.com/document/android-ios-apps-login-help-faq/#open-mail-to-find-login-link"
+
         /// Help Center for "Enter Store Credentials" screen
         ///
         case helpCenterForEnterStoreCredentials = "https://woocommerce.com/document/android-ios-apps-login-help-faq/#enter-store-credentials"

--- a/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
@@ -149,4 +149,24 @@ final class CustomHelpCenterContentTests: XCTestCase {
         XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.flow.rawValue], flow.rawValue)
         XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.url.rawValue], helpContentURL.absoluteString)
     }
+
+    // MARK: Open email screen after requesting magic link
+    //
+    func test_init_using_step_and_flow_returns_valid_instance_for_open_email_screen() throws {
+        // Given
+        let step: AuthenticatorAnalyticsTracker.Step = .magicLinkRequested
+        let flow: AuthenticatorAnalyticsTracker.Flow = .loginWithSiteAddress
+
+        // When
+        let sut = try XCTUnwrap(CustomHelpCenterContent(step: step, flow: flow))
+
+        // Then
+        let helpContentURL = WooConstants.URLs.helpCenterForOpenEmail.asURL()
+        XCTAssertEqual(sut.url, helpContentURL)
+
+        // Test the `trackingProperties` dictionary values
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.step.rawValue], step.rawValue)
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.flow.rawValue], flow.rawValue)
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.url.rawValue], helpContentURL.absoluteString)
+    }
 }

--- a/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
@@ -169,4 +169,24 @@ final class CustomHelpCenterContentTests: XCTestCase {
         XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.flow.rawValue], flow.rawValue)
         XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.url.rawValue], helpContentURL.absoluteString)
     }
+
+    // MARK: Open email screen after magic link has been auto requested
+    //
+    func test_init_using_step_and_flow_returns_valid_instance_for_open_email_screen_after_magic_link_auto_request() throws {
+        // Given
+        let step: AuthenticatorAnalyticsTracker.Step = .magicLinkAutoRequested
+        let flow: AuthenticatorAnalyticsTracker.Flow = .loginWithSiteAddress
+
+        // When
+        let sut = try XCTUnwrap(CustomHelpCenterContent(step: step, flow: flow))
+
+        // Then
+        let helpContentURL = WooConstants.URLs.helpCenterForOpenEmail.asURL()
+        XCTAssertEqual(sut.url, helpContentURL)
+
+        // Test the `trackingProperties` dictionary values
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.step.rawValue], step.rawValue)
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.flow.rawValue], flow.rawValue)
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.url.rawValue], helpContentURL.absoluteString)
+    }
 }

--- a/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
@@ -24,7 +24,7 @@ final class CustomHelpCenterContentTests: XCTestCase {
     // MARK: Invalid `Step` and `Flow`
     //
     func test_init_using_invalid_step_and_flow_returns_nil() {
-        let step: AuthenticatorAnalyticsTracker.Step = .magicLinkRequested
+        let step: AuthenticatorAnalyticsTracker.Step = .twoFactorAuthentication
         let flow: AuthenticatorAnalyticsTracker.Flow = .prologue
 
         XCTAssertNil(CustomHelpCenterContent(step: step, flow: flow))


### PR DESCRIPTION
Part of: #7547 

### Description
As a part of improving the help center content, this PR adds custom content with FAQs and Answers for the "Open mail to find magic link" screen at the following URL.

https://woocommerce.com/document/android-ios-apps-login-help-faq/#open-mail-to-find-login-link

Internal ref - pe5sF9-sZ-p2

### Testing instructions

**When magic link is auto requested**
1. Install and launch the app.
1. Tap `Skip` to reach the login prologue screen.
1. Tap the `Continue with WordPress.com` button.
1. Enter a non A8C email with magic link option, and you will land on the following screen, which has instructions to open mail to find the magic link

<img src="https://user-images.githubusercontent.com/524475/190569642-c65c83f6-1e7f-4e25-8435-9abb72b2499d.png" width="300"/>

5. Tap `Help` -> `Help Center`
1. Observe that you are directed to https://woocommerce.com/document/android-ios-apps-login-help-faq/#open-mail-to-find-login-link in a web view
1. In Xcode debug console observe that the following event is tracked. 
```
Tracked support_help_center_viewed, properties: [AnyHashable("help_content_url"): "https://woocommerce.com/document/android-ios-apps-login-help-faq/#open-mail-to-find-login-link", AnyHashable("source_step"): "magic_link_auto_requested", AnyHashable("source_flow"): "login_magic_link"]
```

**When user requests magic link manually**
1. Install and launch the app.
1. Tap `Skip` to reach the login prologue screen.
1. Tap the `Continue with WordPress.com` button.
1. Enter a non A8C email with magic link option, and you will land in a screen which has instructions to open mail to find the magic link
1. Tap on "Use password to sign in" button
1. In the "Enter password" screen tap on "Or log in with magic link" button to manually request magic link
1. Once the loading indicator finishes you will land in the following screen

<img src="https://user-images.githubusercontent.com/524475/190570266-456a4f7b-6475-4c84-9d1c-3fc9b6e8861f.png" width="300"/>

8. Tap `Help` -> `Help Center`
1. Observe that you are directed to https://woocommerce.com/document/android-ios-apps-login-help-faq/#open-mail-to-find-login-link in a web view
1. In Xcode debug console observe that the following event is tracked. Note that the `source_flow` property will differ based on the login method used. 
```
Tracked support_help_center_viewed, properties: [AnyHashable("help_content_url"): "https://woocommerce.com/document/android-ios-apps-login-help-faq/#open-mail-to-find-login-link", AnyHashable("source_step"): "magic_link_requested", AnyHashable("source_flow"): "login_magic_link"]

```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.