### PR TITLE
Remove orders/totals request from notifications manager

### DIFF
--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -174,7 +174,7 @@ extension PushNotificationsManager {
             return
         }
         let action = NotificationCountAction.reset(siteID: siteID, type: type) { [weak self] in
-            self?.loadNotificationCountAndUpdateApplicationBadgeNumberAndPostNotifications(siteID: siteID, type: type)
+            self?.loadNotificationCountAndUpdateApplicationBadgeNumber(siteID: siteID, type: type, postNotifications: false)
         }
         stores.dispatch(action)
     }
@@ -193,7 +193,7 @@ extension PushNotificationsManager {
         guard let siteID = siteID else {
             return
         }
-        loadNotificationCountAndUpdateApplicationBadgeNumberAndPostNotifications(siteID: siteID, type: nil)
+        loadNotificationCountAndUpdateApplicationBadgeNumber(siteID: siteID, type: nil, postNotifications: true)
     }
 
     /// Registers the Device Token agains WordPress.com backend, if there's a default account.
@@ -372,9 +372,11 @@ private extension PushNotificationsManager {
         stores.dispatch(action)
     }
 
-    func loadNotificationCountAndUpdateApplicationBadgeNumberAndPostNotifications(siteID: Int64, type: Note.Kind?) {
+    func loadNotificationCountAndUpdateApplicationBadgeNumber(siteID: Int64, type: Note.Kind?, postNotifications: Bool) {
         loadNotificationCountAndUpdateApplicationBadgeNumber(siteID: siteID)
-        postBadgeReloadNotifications(type: type)
+        if postNotifications {
+            postBadgeReloadNotifications(type: type)
+        }
     }
 
     func loadNotificationCountAndUpdateApplicationBadgeNumber(siteID: Int64) {
@@ -450,7 +452,7 @@ private extension PushNotificationsManager {
            let siteID = siteID,
            let notificationSiteID = userInfo[APNSKey.siteID] as? Int64 {
             incrementNotificationCount(siteID: notificationSiteID, type: type, incrementCount: 1) { [weak self] in
-                self?.loadNotificationCountAndUpdateApplicationBadgeNumberAndPostNotifications(siteID: siteID, type: type)
+                self?.loadNotificationCountAndUpdateApplicationBadgeNumber(siteID: siteID, type: type, postNotifications: true)
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -105,7 +105,7 @@ final class OrdersRootViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        // Clears application icon badge and requests new reports/orders/totals data
+        // Clears application icon badge
         ServiceLocator.pushNotesManager.resetBadgeCount(type: .storeOrder)
     }
 

--- a/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
+++ b/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
@@ -1,5 +1,4 @@
 import Foundation
-import WooFoundation
 
 public extension Date {
     // MARK: Day


### PR DESCRIPTION
Follow-up to: #7735

## Description

This PR updates `PushNotificationsManager` to prevent triggering data reload notifications on each "app badge clear" action. Without it order list will trigger `orders/totals` requests on each `viewWillAppear`.

Same change was already implemented in https://github.com/woocommerce/woocommerce-ios/pull/7459, but Application Icon badge handling accidentally removed with it, so this PR now decouples one from another.

*Note:* Application icon badge != Orders tab badge. They have different logic and values (app icon can only be `1` or `nil`)

## Testing instructions

1. Allow notifications to display a badge on app icon
2. Place an order to trigger app icon badge update (always "1" for any number of orders)
3. Go to the orders tab and confirm that application badge is cleared, but `orders/totals` API request is not triggered.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.