### PR TITLE
Order creation: Add orderCreationSearchCustomers feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -33,6 +33,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .promptToEnableCodInIppOnboarding:
             return true
+        case .orderCreationSearchCustomers:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -69,4 +69,8 @@ public enum FeatureFlag: Int {
     /// Whether to include the Cash on Delivery enable step in In-Person Payment onboarding
     ///
     case promptToEnableCodInIppOnboarding
+
+    /// Enables the Search Customers functionality in the Order Creation screen
+    ///
+    case orderCreationSearchCustomers
 }


### PR DESCRIPTION
Part of #7741

### Description
As part of the initial work to add the ability to search existing customers within the Order Creation screen( pe5pgL-9t-p2 ), we're adding a feature flag to hide the work behind it.

### Changes
- Adds the `.orderCreationSearchCustomers` feature flag
