### PR TITLE
Custom help content for "Wrong WordPress.com account error" screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 10.5
 -----
-
+- [*] Help center: Added help center web page with FAQs for "Wrong WordPress.com account error" screen. [https://github.com/woocommerce/woocommerce-ios/pull/7747]
 
 10.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,9 +2,8 @@
 
 10.5
 -----
-- [*] Help center: Added help center web page with FAQs for "Wrong WordPress.com account error" screen. [https://github.com/woocommerce/woocommerce-ios/pull/7747]
 - [**] Products: Now you can duplicate products from the More menu of the product detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/7727]
-
+- [*] Help center: Added help center web page with FAQs for "Wrong WordPress.com account error" screen. [https://github.com/woocommerce/woocommerce-ios/pull/7747]
 
 10.4
 -----

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -75,6 +75,16 @@ final class ULAccountMismatchViewController: UIViewController {
 
 // MARK: - View configuration
 private extension ULAccountMismatchViewController {
+    func configureRightBarButtonItem() {
+        guard let rightBarButtonTitle = viewModel.rightBarButtonItemTitle else {
+            return
+        }
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: rightBarButtonTitle,
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(didTapRightBarButtonItem))
+    }
+
     func configureAccountHeader() {
         configureGravatar()
         configureUserNameLabel()
@@ -183,6 +193,10 @@ private extension ULAccountMismatchViewController {
 
     func didTapLogOutButton() {
         viewModel.didTapLogOutButton(in: self)
+    }
+
+    @objc func didTapRightBarButtonItem() {
+        viewModel.didTapRightBarButtonItem(in: self)
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -52,6 +52,7 @@ final class ULAccountMismatchViewController: UIViewController {
         super.viewDidLoad()
 
         configureAccountHeader()
+        configureRightBarButtonItem()
         configureImageView()
         configureErrorMessage()
         configureExtraInfoButton()

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewModel.swift
@@ -44,4 +44,27 @@ protocol ULAccountMismatchViewModel {
     /// Executes action associated to a tap in the view controller auxiliary button
     /// - Parameter viewController: usually the view controller sending the tap
     func didTapAuxiliaryButton(in viewController: UIViewController?)
+
+    // MARK: Navigation bar - right bar button item
+    //
+
+    /// Title of the right bar button item in the navigation bar
+    ///  return `nil` if you don't want a `rightBarButtonItem`
+    ///
+    var rightBarButtonItemTitle: String? { get }
+
+    /// Executes action associated to a tap on the right bar button item in the navigation bar
+    /// - Parameter viewController: usually the view controller sending the tap
+    ///
+    func didTapRightBarButtonItem(in viewController: UIViewController?)
+}
+
+// MARK: Default implementation for optional right bar button item
+//
+extension ULAccountMismatchViewModel {
+    var rightBarButtonItemTitle: String? { nil }
+
+    func didTapRightBarButtonItem(in viewController: UIViewController?) {
+        // NO-OP
+    }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -11,17 +11,20 @@ final class WrongAccountErrorViewModel: ULAccountMismatchViewModel {
     private let showsConnectedStores: Bool
     private let defaultAccount: Account?
     private let storesManager: StoresManager
+    private let authentication: Authentication
 
     private var storePickerCoordinator: StorePickerCoordinator?
 
     init(siteURL: String?,
          showsConnectedStores: Bool,
          sessionManager: SessionManagerProtocol =  ServiceLocator.stores.sessionManager,
-         storesManager: StoresManager = ServiceLocator.stores) {
+         storesManager: StoresManager = ServiceLocator.stores,
+         authentication: Authentication = ServiceLocator.authenticationManager) {
         self.siteURL = siteURL ?? Localization.yourSite
         self.showsConnectedStores = showsConnectedStores
         self.defaultAccount = sessionManager.defaultAccount
         self.storesManager = storesManager
+        self.authentication = authentication
     }
 
     // MARK: - Data and configuration
@@ -82,6 +85,11 @@ final class WrongAccountErrorViewModel: ULAccountMismatchViewModel {
 
     var isPrimaryButtonHidden: Bool { !showsConnectedStores }
 
+    // Configures `Help` button title
+    var rightBarButtonItemTitle: String? {
+        Localization.helpBarButtonItemTitle
+    }
+
     // MARK: - Actions
     func didTapPrimaryButton(in viewController: UIViewController?) {
         guard let navigationController = viewController?.navigationController else {
@@ -103,6 +111,13 @@ final class WrongAccountErrorViewModel: ULAccountMismatchViewModel {
         // Log out and pop
         storesManager.deauthenticate()
         viewController?.navigationController?.popToRootViewController(animated: true)
+    }
+
+    func didTapRightBarButtonItem(in viewController: UIViewController?) {
+        guard let viewController = viewController else {
+            return
+        }
+        authentication.presentSupport(from: viewController, screen: .wrongAccountError)
     }
 }
 
@@ -139,6 +154,8 @@ private extension WrongAccountErrorViewModel {
                                                            comment: "Prompt asking users if the logged in to the wrong account."
                                                                + "Presented when logging in with a store address that does not match the account entered.")
 
+        static let helpBarButtonItemTitle = NSLocalizedString("Help",
+                                                       comment: "Help button on account mismatch error screen.")
     }
 
     enum Strings {

--- a/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
+++ b/WooCommerce/Classes/Model/CustomHelpCenterContent.swift
@@ -69,6 +69,10 @@ extension CustomHelpCenterContent {
         /// Store picker screen - `StorePickerViewController`
         ///
         case storePicker
+
+        /// Account mismatch / Wrong WordPress.com account screen - `WrongAccountErrorViewModel`
+        ///
+        case wrongAccountError
     }
 
     init(screen: Screen, flow: AuthenticatorAnalyticsTracker.Flow) {
@@ -80,6 +84,9 @@ extension CustomHelpCenterContent {
         case .storePicker:
             step = "site_list" // Matching Android `Step` value
             url = WooConstants.URLs.helpCenterForStorePicker.asURL()
+        case .wrongAccountError:
+            step = "wrong_wordpress_account" // Matching Android `Step` value
+            url = WooConstants.URLs.helpCenterForWrongAccountError.asURL()
         }
 
         trackingProperties = [

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -123,6 +123,10 @@ extension WooConstants {
         ///
         case helpCenterForJetpackRequiredError = "https://woocommerce.com/document/android-ios-apps-login-help-faq/#jetpack-required"
 
+        /// Help Center for "Wrong Account error" screen
+        ///
+        case helpCenterForWrongAccountError = "https://woocommerce.com/document/android-ios-apps-login-help-faq/#wrong-account"
+
         /// Help Center for "Store picker" screen
         ///
         case helpCenterForStorePicker = "https://woocommerce.com/document/android-ios-apps-login-help-faq/#pick-store-after-entering-password"

--- a/WooCommerce/WooCommerceTests/Authentication/JetpackErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/JetpackErrorViewModelTests.swift
@@ -136,6 +136,18 @@ final class JetpackErrorViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(mockAuthentication.presentSupportFromScreenInvoked)
     }
+
+    func test_viewModel_sends_correct_screen_value_in_present_support_method() throws {
+        // Given
+        let mockAuthentication = MockAuthentication()
+        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, authentication: mockAuthentication) { _ in }
+
+        // When
+        viewModel.didTapRightBarButtonItem(in: UIViewController())
+
+        // Then
+        XCTAssertEqual(mockAuthentication.presentSupportFromScreen, .jetpackRequired)
+    }
 }
 
 

--- a/WooCommerce/WooCommerceTests/Authentication/ULAccountMismatchViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/ULAccountMismatchViewControllerTests.swift
@@ -172,10 +172,13 @@ private final class MismatchViewModel: ULAccountMismatchViewModel {
 
     let primaryButtonTitle: String = "Primary"
 
+    var rightBarButtonItemTitle: String?
+
     let isPrimaryButtonHidden: Bool = false
     var primaryButtonTapped: Bool = false
     var logOutButtonTapped: Bool = false
     var auxiliaryButtonTapped: Bool = false
+    var rightBarButtonItemTapped = false
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
         primaryButtonTapped = true
@@ -187,5 +190,9 @@ private final class MismatchViewModel: ULAccountMismatchViewModel {
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {
         auxiliaryButtonTapped = true
+    }
+
+    func didTapRightBarButtonItem(in viewController: UIViewController?) {
+        rightBarButtonItemTapped = true
     }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/ULAccountMismatchViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/ULAccountMismatchViewControllerTests.swift
@@ -150,6 +150,50 @@ final class ULAccountMismatchViewControllerTests: XCTestCase {
         // Then
         XCTAssertEqual(primaryButton.isHidden, viewModel.isPrimaryButtonHidden)
     }
+
+    func test_viewcontroller_does_not_have_right_bar_button_item_when_rightBarButtonItemTitle_is_nil_in_viewmodel() throws {
+        // Given
+        let viewModel = MismatchViewModel()
+        viewModel.rightBarButtonItemTitle = nil
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+
+        // Then
+        XCTAssertNil(viewController.navigationItem.rightBarButtonItem)
+    }
+
+    func test_viewcontroller_shows_right_bar_button_item_when_rightBarButtonItemTitle_provided_by_viewmodel() throws {
+        // Given
+        let title = "Title"
+        let viewModel = MismatchViewModel()
+        viewModel.rightBarButtonItemTitle = title
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let rightBarButtonItem = try XCTUnwrap(viewController.navigationItem.rightBarButtonItem)
+
+        // Then
+        XCTAssertEqual(rightBarButtonItem.title, title)
+    }
+
+    func test_viewcontroller_hits_viewmodel_when_right_bar_button_item_is_tapped() throws {
+        // Given
+        let viewModel = MismatchViewModel()
+        viewModel.rightBarButtonItemTitle = "Button"
+        let viewController = ULAccountMismatchViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let rightBarButtonItem = try XCTUnwrap(viewController.navigationItem.rightBarButtonItem)
+
+        _ = rightBarButtonItem.target?.perform(rightBarButtonItem.action)
+
+        // Then
+        XCTAssertTrue(viewModel.rightBarButtonItemTapped)
+    }
 }
 
 

--- a/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
@@ -69,6 +69,18 @@ final class WrongAccountErrorViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(mockAuthentication.presentSupportFromScreenInvoked)
     }
+
+    func test_viewModel_sends_correct_screen_value_in_present_support_method() throws {
+        // Given
+        let mockAuthentication = MockAuthentication()
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url, showsConnectedStores: false, authentication: mockAuthentication)
+
+        // When
+        viewModel.didTapRightBarButtonItem(in: UIViewController())
+
+        // Then
+        XCTAssertEqual(mockAuthentication.presentSupportFromScreen, .wrongAccountError)
+    }
 }
 
 

--- a/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
@@ -57,6 +57,18 @@ final class WrongAccountErrorViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(visibility)
     }
+
+    func test_viewModel_invokes_present_support_when_the_help_button_is_tapped() throws {
+        // Given
+        let mockAuthentication = MockAuthentication()
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url, showsConnectedStores: false, authentication: mockAuthentication)
+
+        // When
+        viewModel.didTapRightBarButtonItem(in: UIViewController())
+
+        // Then
+        XCTAssertTrue(mockAuthentication.presentSupportFromScreenInvoked)
+    }
 }
 
 

--- a/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
@@ -36,6 +36,14 @@ final class WrongAccountErrorViewModelTests: XCTestCase {
         XCTAssertEqual(primaryButtonTitle, Expectations.primaryButtonTitle)
     }
 
+    func test_viewmodel_provides_expected_title_for_right_bar_button_item() {
+        // Given
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url, showsConnectedStores: false)
+
+        // Then
+        XCTAssertEqual(viewModel.rightBarButtonItemTitle, Expectations.helpBarButtonItemTitle)
+    }
+
     func test_viewmodel_provides_expected_title_for_log_out_button() {
         // Given
         let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url, showsConnectedStores: false)
@@ -100,5 +108,8 @@ private extension WrongAccountErrorViewModelTests {
         static let findYourConnectedEmail = NSLocalizedString("Find your connected email",
                                                      comment: "Button linking to webview explaining how to find your connected email"
                                                         + "Presented when logging in with a store address that does not match the account entered")
+
+        static let helpBarButtonItemTitle = NSLocalizedString("Help",
+                                                       comment: "Help button on account mismatch error screen.")
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockAuthentication.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAuthentication.swift
@@ -4,9 +4,11 @@ import WordPressKit
 
 final class MockAuthentication: Authentication {
     private(set) var presentSupportFromScreenInvoked = false
+    private(set) var presentSupportFromScreen: CustomHelpCenterContent.Screen?
 
     func presentSupport(from sourceViewController: UIViewController, screen: CustomHelpCenterContent.Screen) {
         presentSupportFromScreenInvoked = true
+        presentSupportFromScreen = screen
     }
 
     func presentSupport(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag) {

--- a/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/CustomHelpCenterContentTests.swift
@@ -249,4 +249,24 @@ final class CustomHelpCenterContentTests: XCTestCase {
         XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.flow.rawValue], flow.rawValue)
         XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.url.rawValue], helpContentURL.absoluteString)
     }
+
+    // MARK: Account mismatch / Wrong WordPress.com account screen - `WrongAccountErrorViewModel`
+    //
+    func test_init_screen_returns_valid_instance_for_wrong_account_error_screen() throws {
+        // Given
+        let step = "wrong_wordpress_account"
+        let flow: AuthenticatorAnalyticsTracker.Flow = .loginWithPasswordWithMagicLinkEmphasis
+
+        // When
+        let sut = CustomHelpCenterContent(screen: .wrongAccountError, flow: flow)
+
+        // Then
+        let helpContentURL = WooConstants.URLs.helpCenterForWrongAccountError.asURL()
+        XCTAssertEqual(sut.url, helpContentURL)
+
+        // Test the `trackingProperties` dictionary values
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.step.rawValue], step)
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.flow.rawValue], flow.rawValue)
+        XCTAssertEqual(sut.trackingProperties[CustomHelpCenterContent.Key.url.rawValue], helpContentURL.absoluteString)
+    }
 }


### PR DESCRIPTION
Part of: #7547 

### Description
As a part of improving the help center content, this PR adds custom content with FAQs and Answers for the "Wrong WordPress.com account error" screen at the following URL.

https://woocommerce.com/document/android-ios-apps-login-help-faq/#wrong-account

Internal ref - pe5sF9-sZ-p2

### Testing instructions

1. Install and launch the app.
1. Tap `Skip` to reach the login prologue screen.
1. Tap the `Enter Your Store Address` button and enter store address.
1. Tap `Continue`, and you will land in the "Enter WordPress.com account email" screen.
1. Sign in using a WordPress.com account email which isn't connected with the store's Jetpack.
1. You will land in the following wrong account error screen. 

<img src="https://user-images.githubusercontent.com/524475/191195745-48a47392-cd55-44a0-b230-9b0eb54617e6.png" width="300"/>

7. Tap `Help` -> `Help Center`
1. Observe that you are directed to https://woocommerce.com/document/android-ios-apps-login-help-faq/#wrong-account in a web view
1. In Xcode debug console observe that the following event is tracked. Note that the `source_flow` value will differ based on the flow you selected to login.
```
Tracked support_help_center_viewed, properties: [AnyHashable("source_flow"): "login_password_magic_link_emphasis", AnyHashable("help_content_url"): "https://woocommerce.com/document/android-ios-apps-login-help-faq/#wrong-account", AnyHashable("source_step"): "wrong_wordpress_account"]
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.