### PR TITLE
Add `fake()` method to DotcomUser and JetpackUser entities

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -188,6 +188,19 @@ extension DotcomError {
         .empty
     }
 }
+extension DotcomUser {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> DotcomUser {
+        .init(
+            id: .fake(),
+            username: .fake(),
+            email: .fake(),
+            displayName: .fake(),
+            avatar: .fake()
+        )
+    }
+}
 extension InboxAction {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -217,6 +230,19 @@ extension InboxNote {
             isRemoved: .fake(),
             isRead: .fake(),
             dateCreated: .fake()
+        )
+    }
+}
+extension JetpackUser {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> JetpackUser {
+        .init(
+            isConnected: .fake(),
+            isPrimary: .fake(),
+            username: .fake(),
+            wpcomUser: .fake(),
+            gravatar: .fake()
         )
     }
 }


### PR DESCRIPTION
Ref: p1663681651496369-slack-CGPNUU63E

### Description
This PR adds the `fake()` method to both `DotcomUser` and `JetpackUser` entities via `Fakes.generated` type extensions , as these types conform to `GeneratedFakeable` but are missing that [automatically-generated](https://github.com/woocommerce/woocommerce-ios/blob/1e8ea98e0587761e2795a8a70481c73b782201c2/docs/fakeable.md) method.

### Changes
- Updated the `Fakes.generated` file with the new `fake()` method by running `rake generate`

### Testing instructions
- Confirm that Unit Test pass
