### PR TITLE
Bring back legacy customer note & addresses editing

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 10.5
 -----
 - [**] Products: Now you can duplicate products from the More menu of the product detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/7727]
-
+- [*] Orders: We are bringing back the ability to add/edit customer notes and addresses from the main order screen [https://github.com/woocommerce/woocommerce-ios/pull/7750]
 
 10.4
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -458,12 +458,16 @@ private extension OrderDetailsDataSource {
         cell.selectionStyle = .none
         if customerNote.isNotEmpty {
             cell.body = customerNote.quoted
+            cell.onEditTapped = { [weak self] in
+                self?.onCellAction?(.editCustomerNote, nil)
+            }
         } else {
             cell.body = nil
+            cell.onAddTapped = { [weak self] in
+                self?.onCellAction?(.editCustomerNote, nil)
+            }
         }
 
-        cell.onEditTapped = nil
-        cell.onAddTapped = nil
         cell.addButtonTitle = NSLocalizedString("Add Customer Note", comment: "Title for the button to add the Customer Provided Note in Order Details")
         cell.editButtonAccessibilityLabel = NSLocalizedString(
             "Update Note",
@@ -890,12 +894,16 @@ private extension OrderDetailsDataSource {
 
         if let formattedPostalAddress = shippingAddress?.formattedPostalAddress {
             cell.address = formattedPostalAddress
+            cell.onEditTapped = { [weak self] in
+                self?.onCellAction?(.editShippingAddress, nil)
+            }
         } else {
             cell.address = nil
+            cell.onAddTapped = { [weak self] in
+                self?.onCellAction?(.editShippingAddress, nil)
+            }
         }
 
-        cell.onEditTapped = nil
-        cell.onAddTapped = nil
         cell.addButtonTitle = NSLocalizedString("Add Shipping Address", comment: "Title for the button to add the Shipping Address in Order Details")
         cell.editButtonAccessibilityLabel = NSLocalizedString(
             "Update Address",
@@ -1095,12 +1103,17 @@ extension OrderDetailsDataSource {
             var rows: [Row] = []
 
             /// Customer Note
-            if order.customerNote?.isNotEmpty == true {
-                rows.append(.customerNote)
-            }
+            /// Always visible to allow adding & editing.
+            rows.append(.customerNote)
 
             /// Shipping Address
-            if order.shippingAddress?.isEmpty == false {
+            /// Almost always visible to allow editing.
+            let orderContainsOnlyVirtualProducts = self.products.filter { (product) -> Bool in
+                return items.first(where: { $0.productID == product.productID}) != nil
+            }.allSatisfy { $0.virtual == true }
+
+
+            if order.shippingAddress != nil && orderContainsOnlyVirtualProducts == false {
                 rows.append(.shippingAddress)
             }
 
@@ -1110,9 +1123,8 @@ extension OrderDetailsDataSource {
             }
 
             /// Billing Address
-            if order.billingAddress?.isEmpty == false {
-                rows.append(.billingDetail)
-            }
+            /// Always visible to allow editing.
+            rows.append(.billingDetail)
 
             /// Return `nil` if there is no rows to display.
             guard rows.isNotEmpty else {
@@ -1599,6 +1611,8 @@ extension OrderDetailsDataSource {
         case createShippingLabel
         case shippingLabelTrackingMenu(shippingLabel: ShippingLabel, sourceView: UIView)
         case viewAddOns(addOns: [OrderItemAttribute])
+        case editCustomerNote
+        case editShippingAddress
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -395,7 +395,7 @@ extension OrderDetailsViewModel {
             viewController.show(productListVC, sender: nil)
         case .billingDetail:
             ServiceLocator.analytics.track(.orderDetailShowBillingTapped)
-            let billingInformationViewController = BillingInformationViewController(order: order, editingEnabled: false)
+            let billingInformationViewController = BillingInformationViewController(order: order, editingEnabled: true)
             viewController.navigationController?.pushViewController(billingInformationViewController, animated: true)
         case .customFields:
             ServiceLocator.analytics.track(.orderViewCustomFieldsTapped)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.swift
@@ -29,6 +29,7 @@ final class CustomerNoteTableViewCell: UITableViewCell {
         }
         set {
             bodyTextView.text = newValue
+            bodyTextView.isHidden = newValue == nil || newValue?.isEmpty == true
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -386,6 +386,10 @@ private extension OrderDetailsViewController {
             shippingLabelTrackingMoreMenuTapped(shippingLabel: shippingLabel, sourceView: sourceView)
         case let .viewAddOns(addOns):
             itemAddOnsButtonTapped(addOns: addOns)
+        case .editCustomerNote:
+            editCustomerNoteTapped()
+        case .editShippingAddress:
+            editShippingAddressTapped()
         }
     }
 
@@ -540,6 +544,20 @@ private extension OrderDetailsViewController {
         popoverController?.sourceView = sourceView
 
         present(actionSheet, animated: true)
+    }
+
+    func editCustomerNoteTapped() {
+        let editNoteViewController = EditCustomerNoteHostingController(viewModel: viewModel.editNoteViewModel)
+        present(editNoteViewController, animated: true)
+
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.OrderDetailsEdit.orderDetailEditFlowStarted(subject: .customerNote))
+    }
+
+    func editShippingAddressTapped() {
+        let viewModel = EditOrderAddressFormViewModel(order: viewModel.order, type: .shipping)
+        let editAddressViewController = EditOrderAddressHostingController(viewModel: viewModel)
+        let navigationController = WooNavigationController(rootViewController: editAddressViewController)
+        present(navigationController, animated: true, completion: nil)
     }
 
     @objc private func collectPaymentTapped() {


### PR DESCRIPTION
# Why

As reflected on pe5pgL-JG-p2, we noticed that upon releasing the Unified Order Editing feature, merchants started editing fewer customer notes & addresses.

To mitigate the downward trend we are re-introducing the old customer note & addresses editing experience merchants used to have.

# How

Revert code deleted on #7532

# Demo

### Add custome notes & Addresses

https://user-images.githubusercontent.com/562080/191379454-26287780-40d4-4265-8335-2de0a0e17bc1.mov

### Edit custome notes & Addresses

https://user-images.githubusercontent.com/562080/191379446-19f119bc-4566-4275-a6c1-bbc21ec478b5.mov

# Testing Steps

- Navigate to an order / create an order
- Make sure you can add & edit customer notes & addresses as it was previously possible.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
