### PR TITLE
Widgets: Improve Widget Accessibility

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [**] Products: Now you can duplicate products from the More menu of the product detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/7727]
 - [*] Help center: Added help center web page with FAQs for "Wrong WordPress.com account error" screen. [https://github.com/woocommerce/woocommerce-ios/pull/7747]
+- [*] Widgets: The Today's Stat Widget adds support for bigger fonts. [https://github.com/woocommerce/woocommerce-ios/pull/7752]
 
 10.4
 -----

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -40,15 +40,22 @@ private struct StoreInfoView: View {
 
             VStack(spacing: Layout.sectionSpacing) {
 
-                // Store Name
-                HStack {
-                    Text(entry.name)
-                        .storeNameStyle()
+                VStack(spacing: Layout.cardSpacing) {
+                    // Store Name
+                    HStack {
+                        Text(entry.name)
+                            .storeNameStyle()
 
-                    Spacer()
+                        Spacer()
 
-                    Text(entry.range)
+                        Text(entry.range)
+                            .statRangeStyle()
+                    }
+
+                    // Updated at
+                    Text(Localization.updatedAt(entry.updatedTime))
                         .statRangeStyle()
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
                 // Revenue & Visitors
@@ -93,10 +100,6 @@ private struct StoreInfoView: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
-
-                Text(Localization.updatedAt(entry.updatedTime))
-                    .statRangeStyle()
-                    .frame(maxWidth: .infinity, alignment: .leading)
             }
             .padding(.horizontal)
         }

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -33,14 +33,17 @@ private struct StoreInfoView: View {
     // Entry to render
     let entry: StoreInfoData
 
+    // Current size category
+    @Environment(\.sizeCategory) var category
+
     var body: some View {
         ZStack {
             // Background
             Color(.brand)
 
-            VStack(spacing: Layout.sectionSpacing) {
+            VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
 
-                VStack(spacing: Layout.cardSpacing) {
+                VStack(alignment: .leading, spacing: Layout.cardSpacing) {
                     // Store Name
                     HStack {
                         Text(entry.name)
@@ -55,53 +58,93 @@ private struct StoreInfoView: View {
                     // Updated at
                     Text(Localization.updatedAt(entry.updatedTime))
                         .statRangeStyle()
-                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
-                // Revenue & Visitors
-                HStack() {
-                    VStack(alignment: .leading, spacing: Layout.cardSpacing) {
-                        Text(Localization.revenue)
-                            .statTitleStyle()
-
-                        Text(entry.revenue)
-                            .statValueStyle()
-
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                    VStack(alignment: .leading, spacing: Layout.cardSpacing) {
-                        Text(Localization.visitors)
-                            .statTitleStyle()
-
-                        Text(entry.visitors)
-                            .statValueStyle()
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-
-                // Orders & Conversion
-                HStack {
-                    VStack(alignment: .leading, spacing: Layout.cardSpacing) {
-                        Text(Localization.orders)
-                            .statTitleStyle()
-
-                        Text(entry.orders)
-                            .statValueStyle()
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                    VStack(alignment: .leading, spacing: Layout.cardSpacing) {
-                        Text(Localization.conversion)
-                            .statTitleStyle()
-
-                        Text(entry.conversion)
-                            .statValueStyle()
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                if category.isAccessibilityCategory {
+                    AccessibilityStatsCard(entry: entry)
+                } else {
+                    StatsCard(entry: entry)
                 }
             }
             .padding(.horizontal)
+        }
+    }
+}
+
+/// Stats card sub view.
+/// To be used inside `StoreInfoView`.
+///
+private struct StatsCard: View {
+    // Entry to render
+    let entry: StoreInfoData
+
+    var body: some View {
+        Group {
+            // Revenue & Visitors
+            HStack() {
+                VStack(alignment: .leading, spacing: StoreInfoView.Layout.cardSpacing) {
+                    Text(StoreInfoView.Localization.revenue)
+                        .statTitleStyle()
+
+                    Text(entry.revenue)
+                        .statValueStyle()
+
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                VStack(alignment: .leading, spacing: StoreInfoView.Layout.cardSpacing) {
+                    Text(StoreInfoView.Localization.visitors)
+                        .statTitleStyle()
+
+                    Text(entry.visitors)
+                        .statValueStyle()
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            // Orders & Conversion
+            HStack {
+                VStack(alignment: .leading, spacing: StoreInfoView.Layout.cardSpacing) {
+                    Text(StoreInfoView.Localization.orders)
+                        .statTitleStyle()
+
+                    Text(entry.orders)
+                        .statValueStyle()
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                VStack(alignment: .leading, spacing: StoreInfoView.Layout.cardSpacing) {
+                    Text(StoreInfoView.Localization.conversion)
+                        .statTitleStyle()
+
+                    Text(entry.conversion)
+                        .statValueStyle()
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+}
+
+/// Accessibility card sub view.
+/// To be used inside `StoreInfoView`.
+///
+private struct AccessibilityStatsCard: View {
+    // Entry to render
+    let entry: StoreInfoData
+
+    var body: some View {
+        Group {
+            VStack(alignment: .leading, spacing: StoreInfoView.Layout.cardSpacing) {
+                Text(StoreInfoView.Localization.revenue)
+                    .statTitleStyle()
+
+                Text(entry.revenue)
+                    .statValueStyle()
+            }
+
+            Text(StoreInfoView.Localization.viewMore)
+                .statButtonStyle()
         }
     }
 }
@@ -198,6 +241,11 @@ private extension StoreInfoView {
             value: "Conversion",
             comment: "Conversion title label for the store info widget"
         )
+        static let viewMore = AppLocalizedString(
+            "storeWidgets.infoView.viewMore",
+            value: "View More",
+            comment: "Title for the button indicator to display more stats in the Today's Stat widget when using accessibility fonts."
+        )
         static func updatedAt(_ updatedTime: String) -> LocalizedString {
             let format = AppLocalizedString("storeWidgets.infoView.updatedAt",
                                             value: "As of %1$@",
@@ -265,6 +313,18 @@ struct StoreWidgets_Previews: PreviewProvider {
                                  updatedTime: "10:24 PM")
         )
         .previewContext(WidgetPreviewContext(family: .systemMedium))
+
+        StoreInfoView(
+            entry: StoreInfoData(range: "Today",
+                                 name: "Ernest Shop",
+                                 revenue: "$132.234",
+                                 visitors: "67",
+                                 orders: "23",
+                                 conversion: "37%",
+                                 updatedTime: "10:24 PM")
+        )
+        .previewContext(WidgetPreviewContext(family: .systemMedium))
+        .environment(\.sizeCategory, .accessibilityMedium)
 
         NotLoggedInView()
             .previewContext(WidgetPreviewContext(family: .systemMedium))

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -126,7 +126,7 @@ private struct StatsCard: View {
     }
 }
 
-/// Accessibility card sub view.
+/// Accessibility card sub view. Shows only revenue and a `View More` button.
 /// To be used inside `StoreInfoView`.
 ///
 private struct AccessibilityStatsCard: View {

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -60,7 +60,7 @@ private struct StoreInfoView: View {
                         .statRangeStyle()
                 }
 
-                if category.isAccessibilityCategory {
+                if category > .extraLarge {
                     AccessibilityStatsCard(entry: entry)
                 } else {
                     StatsCard(entry: entry)
@@ -324,7 +324,7 @@ struct StoreWidgets_Previews: PreviewProvider {
                                  updatedTime: "10:24 PM")
         )
         .previewContext(WidgetPreviewContext(family: .systemMedium))
-        .environment(\.sizeCategory, .accessibilityMedium)
+        .environment(\.sizeCategory, .extraExtraLarge)
 
         NotLoggedInView()
             .previewContext(WidgetPreviewContext(family: .systemMedium))


### PR DESCRIPTION
# Why

Widgets have a fixed canvas, so we need to adjust the widget layout when the user decides to use an accessibility font.

This PR changes the layout of the widget when the user chooses a font greater than `.extraLarge`

# Screenshot

Normal | Accessibility
---- | ----
![normal](https://user-images.githubusercontent.com/562080/191557849-0a419acf-5c88-40a2-b69b-093294a9933f.png) | ![accessbility](https://user-images.githubusercontent.com/562080/191557865-e0b75ad4-a3dc-4aaf-a6de-518968d5c385.png)


# Testing instructions
- Launch the app & add the widget
- Change your device to use the biggest accessibility font
- See that the widgets use the accessibility layout.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
