### PR TITLE
Widgets: Use correct conversion localized key

### DIFF
--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -191,7 +191,7 @@ private extension StoreInfoView {
             comment: "Orders title label for the store info widget"
         )
         static let conversion = AppLocalizedString(
-            "storeWidgets.infoView.orders",
+            "storeWidgets.infoView.conversion",
             value: "Conversion",
             comment: "Conversion title label for the store info widget"
         )


### PR DESCRIPTION
Closes: #7753 

# Description

When the localization support was added to the widgets project. We made a mistake and use the wrong key for the "conversion" text. 

This PR makes sure the correct key is used.

Before | After
--- | ---
<img width="550" alt="before" src="https://user-images.githubusercontent.com/562080/191606511-7da5b0d6-f449-479e-a6c1-76e7abf7c53d.png"> | <img width="357" alt="after" src="https://user-images.githubusercontent.com/562080/191606518-99ec4d08-588b-42be-a87a-499b785013b7.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
