### PR TITLE
Login: More unit tests for WrongAccountErrorViewModel

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -537,10 +537,8 @@ private extension AuthenticationManager {
 // MARK: - Private helpers
 private extension AuthenticationManager {
     func isJetpackInvalidForSelfHostedSite(url: String) -> Bool {
-        // Checks if the site has Jetpack and it's active
-        // We can handle Jetpack connection later in the account mismatch flow.
-        if let site = currentSelfHostedSite, site.url == url,
-            (!site.hasJetpack || !site.isJetpackActive) {
+        if let site = currentSelfHostedSite,
+           site.url == url, !site.isJetpackConnected {
             return true
         }
         return false

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -679,7 +679,7 @@ private extension AuthenticationManager {
         }
 
         /// Jetpack is required. Present an error if we don't detect a valid installation.
-        guard site.hasJetpack && site.isJetpackActive else {
+        guard site.isJetpackConnected else {
             return jetpackErrorUI(for: site.url, with: matcher, in: navigationController)
         }
 

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -537,8 +537,10 @@ private extension AuthenticationManager {
 // MARK: - Private helpers
 private extension AuthenticationManager {
     func isJetpackInvalidForSelfHostedSite(url: String) -> Bool {
-        if let site = currentSelfHostedSite,
-           site.url == url, !site.isJetpackConnected {
+        // Checks if the site has Jetpack and it's active
+        // We can handle Jetpack connection later in the account mismatch flow.
+        if let site = currentSelfHostedSite, site.url == url,
+            (!site.hasJetpack || !site.isJetpackActive) {
             return true
         }
         return false

--- a/WooCommerce/Classes/Authentication/Epilogue/Authenticator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/Authenticator.swift
@@ -1,0 +1,28 @@
+import Foundation
+import WordPressAuthenticator
+
+/// An interface used for mocking `WordPressAuthenticator` in unit tests.
+/// It's not complete for now since this is used for testing `WrongAccountErrorViewModel` only at the time of writing.
+/// Update this further if necessary.
+///
+protocol Authenticator {
+    /// Used to present the site credential login flow directly from the delegate.
+    ///
+    /// - Parameters:
+    ///     - presenter: The view controller that presents the site credential login flow.
+    ///     - siteURL: The URL of the site to log in to.
+    ///     - onCompletion: The closure to be trigged when the login succeeds with the input credentials.
+    ///
+    static func showSiteCredentialLogin(from presenter: UIViewController, siteURL: String, onCompletion: @escaping (WordPressOrgCredentials) -> Void)
+
+    /// A helper method to fetch site info for a given URL.
+    /// - Parameters:
+    ///     - siteURL: The URL of the site to fetch information for.
+    ///     - onCompletion: The closure to be triggered when fetching site info is done.
+    ///
+    static func fetchSiteInfo(for siteURL: String, onCompletion: @escaping (Result<WordPressComSiteInfo, Error>) -> Void)
+}
+
+/// Makes `WordPressAuthenticator` conform to the interface for mocking.
+///
+extension WordPressAuthenticator: Authenticator {}

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -17,6 +17,7 @@ final class WrongAccountErrorViewModel: ULAccountMismatchViewModel {
     private let analytics: Analytics
     private let jetpackSetupCompletionHandler: (_ email: String, _ xmlrpc: String) -> Void
     private let authentication: Authentication
+    private let authenticatorType: Authenticator.Type
 
     private var storePickerCoordinator: StorePickerCoordinator?
     private var siteXMLRPC: String = ""
@@ -32,6 +33,7 @@ final class WrongAccountErrorViewModel: ULAccountMismatchViewModel {
     init(siteURL: String?,
          showsConnectedStores: Bool,
          siteCredentials: WordPressOrgCredentials?,
+         authenticatorType: Authenticator.Type = WordPressAuthenticator.self,
          sessionManager: SessionManagerProtocol =  ServiceLocator.stores.sessionManager,
          storesManager: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
@@ -44,6 +46,7 @@ final class WrongAccountErrorViewModel: ULAccountMismatchViewModel {
         self.analytics = analytics
         self.authentication = authentication
         self.jetpackSetupCompletionHandler = onJetpackSetupCompletion
+        self.authenticatorType = authenticatorType
 
         if let credentials = siteCredentials {
             siteUsername = credentials.username
@@ -181,7 +184,7 @@ private extension WrongAccountErrorViewModel {
     ///
     func fetchSiteInfo() {
         activityIndicatorLoadingSubject.send(true)
-        WordPressAuthenticator.fetchSiteInfo(for: siteURL) { [weak self] result in
+        authenticatorType.fetchSiteInfo(for: siteURL) { [weak self] result in
             guard let self = self else { return }
             self.activityIndicatorLoadingSubject.send(false)
 
@@ -229,7 +232,7 @@ private extension WrongAccountErrorViewModel {
     }
 
     func showSiteCredentialLoginAndJetpackConnection(from viewController: UIViewController) {
-        WordPressAuthenticator.showSiteCredentialLogin(from: viewController, siteURL: siteURL) { [weak self] credentials in
+        authenticatorType.showSiteCredentialLogin(from: viewController, siteURL: siteURL) { [weak self] credentials in
             guard let self = self else { return }
             // dismisses the site credential login flow
             viewController.dismiss(animated: true)

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -34,14 +34,13 @@ final class WrongAccountErrorViewModel: ULAccountMismatchViewModel {
          showsConnectedStores: Bool,
          siteCredentials: WordPressOrgCredentials?,
          authenticatorType: Authenticator.Type = WordPressAuthenticator.self,
-         sessionManager: SessionManagerProtocol =  ServiceLocator.stores.sessionManager,
          storesManager: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          authentication: Authentication = ServiceLocator.authenticationManager,
          onJetpackSetupCompletion: @escaping (String, String) -> Void) {
         self.siteURL = siteURL ?? Localization.yourSite
         self.showsConnectedStores = showsConnectedStores
-        self.defaultAccount = sessionManager.defaultAccount
+        self.defaultAccount = storesManager.sessionManager.defaultAccount
         self.storesManager = storesManager
         self.analytics = analytics
         self.authentication = authentication

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1669,6 +1669,7 @@
 		DE3404E828B4B96800CF0D97 /* NonAtomicSiteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */; };
 		DE3404EA28B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */; };
 		DE34771327F174C8009CA300 /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34771227F174C8009CA300 /* StatusView.swift */; };
+		DE37517C28DC5FC6000163CB /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE37517B28DC5FC6000163CB /* Authenticator.swift */; };
 		DE3877E0283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */; };
 		DE3877E2283CCBC20075D87E /* BottomSheetListSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */; };
 		DE3877E4283E35E80075D87E /* DiscountTypeBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3877E3283E35E80075D87E /* DiscountTypeBottomSheetListSelectorCommandTests.swift */; };
@@ -3587,6 +3588,7 @@
 		DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModel.swift; sourceTree = "<group>"; };
 		DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModelTests.swift; sourceTree = "<group>"; };
 		DE34771227F174C8009CA300 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
+		DE37517B28DC5FC6000163CB /* Authenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authenticator.swift; sourceTree = "<group>"; };
 		DE3877DF283B68CF0075D87E /* DiscountTypeBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountTypeBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
 		DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelector.swift; sourceTree = "<group>"; };
 		DE3877E3283E35E80075D87E /* DiscountTypeBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountTypeBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
@@ -7004,6 +7006,7 @@
 				262C922026F1370000011F92 /* StorePickerError.swift */,
 				45527A402472C6160078D609 /* SwitchStoreUseCase.swift */,
 				45A4221924ACC79C003B1E4C /* SwitchStoreNoticePresenter.swift */,
+				DE37517B28DC5FC6000163CB /* Authenticator.swift */,
 			);
 			path = Epilogue;
 			sourceTree = "<group>";
@@ -9704,6 +9707,7 @@
 				03EF250228C615A5006A033E /* InPersonPaymentsMenuViewModel.swift in Sources */,
 				0212275C244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift in Sources */,
 				DEC6C51A2747758D006832D3 /* JetpackInstallView.swift in Sources */,
+				DE37517C28DC5FC6000163CB /* Authenticator.swift in Sources */,
 				AED089F227C794BC0020AE10 /* View+CurrencySymbol.swift in Sources */,
 				D85806292642BA5400A8AB6C /* PaymentCaptureOrchestrator.swift in Sources */,
 				E1E636BB26FB467A00C9D0D7 /* Comparable+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -173,6 +173,28 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertTrue(rootController is ULErrorViewController)
     }
 
+    func test_it_shows_account_mismatch_upon_login_epilogue_if_the_site_has_active_jetpack_but_not_connected() {
+        // Given
+        let manager = AuthenticationManager()
+        let testSite = "http://test.com"
+        let siteInfo = WordPressComSiteInfo(remote: ["isWordPress": true,
+                                                     "hasJetpack": true,
+                                                     "urlAfterRedirects": testSite,
+                                                     "isJetpackActive": true,
+                                                     "isJetpackConnected": false])
+        let wpcomCredentials = WordPressComCredentials(authToken: "abc", isJetpackLogin: false, multifactor: false, siteURL: testSite)
+        let credentials = AuthenticatorCredentials(wpcom: wpcomCredentials, wporg: nil)
+        let navigationController = UINavigationController()
+
+        // When
+        manager.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { _ in })
+        manager.presentLoginEpilogue(in: navigationController, for: credentials, onDismiss: {})
+
+        // Then
+        let rootController = navigationController.viewControllers.first
+        XCTAssertTrue(rootController is ULAccountMismatchViewController)
+    }
+
     func test_it_can_display_jetpack_error_for_org_site_credentials_sign_in() {
         // Given
         let manager = AuthenticationManager()

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -173,28 +173,6 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertTrue(rootController is ULErrorViewController)
     }
 
-    func test_it_shows_account_mismatch_upon_login_epilogue_if_the_site_has_active_jetpack_but_not_connected() {
-        // Given
-        let manager = AuthenticationManager()
-        let testSite = "http://test.com"
-        let siteInfo = WordPressComSiteInfo(remote: ["isWordPress": true,
-                                                     "hasJetpack": true,
-                                                     "urlAfterRedirects": testSite,
-                                                     "isJetpackActive": true,
-                                                     "isJetpackConnected": false])
-        let wpcomCredentials = WordPressComCredentials(authToken: "abc", isJetpackLogin: false, multifactor: false, siteURL: testSite)
-        let credentials = AuthenticatorCredentials(wpcom: wpcomCredentials, wporg: nil)
-        let navigationController = UINavigationController()
-
-        // When
-        manager.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { _ in })
-        manager.presentLoginEpilogue(in: navigationController, for: credentials, onDismiss: {})
-
-        // Then
-        let rootController = navigationController.viewControllers.first
-        XCTAssertTrue(rootController is ULAccountMismatchViewController)
-    }
-
     func test_it_can_display_jetpack_error_for_org_site_credentials_sign_in() {
         // Given
         let manager = AuthenticationManager()

--- a/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
@@ -276,3 +276,34 @@ private extension WrongAccountErrorViewModelTests {
                                                        comment: "Help button on account mismatch error screen.")
     }
 }
+
+private final class MockAuthenticator: Authenticator {
+    enum AuthenticatorError: Error {
+        case serviceError
+    }
+
+    private static var credentials: WordPressOrgCredentials?
+    private static var siteInfo: WordPressComSiteInfo?
+
+    static func setMockCredentials(_ credentials: WordPressOrgCredentials) {
+        Self.credentials = credentials
+    }
+
+    static func setMockSiteInfo(_ siteInfo: WordPressComSiteInfo) {
+        Self.siteInfo = siteInfo
+    }
+
+    static func showSiteCredentialLogin(from presenter: UIViewController, siteURL: String, onCompletion: @escaping (WordPressOrgCredentials) -> Void) {
+        guard let credentials = credentials else {
+            return
+        }
+        onCompletion(credentials)
+    }
+    
+    static func fetchSiteInfo(for siteURL: String, onCompletion: @escaping (Result<WordPressComSiteInfo, Error>) -> Void) {
+        guard let siteInfo = siteInfo else {
+            return onCompletion(.failure(AuthenticatorError.serviceError))
+        }
+        onCompletion(.success(siteInfo))
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
@@ -1,4 +1,6 @@
 import XCTest
+import Yosemite
+import WordPressAuthenticator
 @testable import WooCommerce
 
 final class WrongAccountErrorViewModelTests: XCTestCase {
@@ -128,6 +130,123 @@ final class WrongAccountErrorViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(mockAuthentication.presentSupportFromScreen, .wrongAccountError)
+    }
+
+    func test_web_view_is_presented_when_tapping_primary_button_if_site_credentials_are_present() throws {
+        // Given
+        let expectedURL = try XCTUnwrap(URL(string: "http://jetpack.wordpress.com/jetpack.authorize/1/"))
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackConnectionURL(let completion):
+                completion(.success(expectedURL))
+            default:
+                break
+            }
+        }
+        let credentials = WordPressOrgCredentials(username: "test", password: "pwd", xmlrpc: "http://test.com/xmlrpc.php", options: [:])
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url,
+                                                   showsConnectedStores: false,
+                                                   siteCredentials: credentials,
+                                                   storesManager: stores,
+                                                   onJetpackSetupCompletion: { _, _ in })
+        let viewController = UIViewController()
+        let navigationController = UINavigationController(rootViewController: viewController)
+
+        // When
+        viewModel.didTapPrimaryButton(in: viewController)
+        waitUntil {
+            navigationController.viewControllers.containsMoreThanOne
+        }
+
+        // Then
+        XCTAssertTrue(navigationController.topViewController is AuthenticatedWebViewController)
+    }
+
+    func test_error_view_is_tracked_with_selfhosted_site_if_credentials_are_present() throws {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let credentials = WordPressOrgCredentials(username: "test", password: "pwd", xmlrpc: "http://test.com/xmlrpc.php", options: [:])
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url,
+                                                   showsConnectedStores: false,
+                                                   siteCredentials: credentials,
+                                                   analytics: analytics,
+                                                   onJetpackSetupCompletion: { _, _ in })
+
+        // When
+        viewModel.viewDidLoad(nil)
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "login_jetpack_connection_error_shown" }))
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(properties["is_selfhosted_site"] as? Bool, true)
+    }
+
+    func test_primary_button_tap_is_tracked() throws {
+        // Given
+        let expectedURL = try XCTUnwrap(URL(string: "http://jetpack.wordpress.com/jetpack.authorize/1/"))
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackConnectionURL(let completion):
+                completion(.success(expectedURL))
+            default:
+                break
+            }
+        }
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let credentials = WordPressOrgCredentials(username: "test", password: "pwd", xmlrpc: "http://test.com/xmlrpc.php", options: [:])
+        let viewModel = WrongAccountErrorViewModel(siteURL: Expectations.url,
+                                                   showsConnectedStores: false,
+                                                   siteCredentials: credentials,
+                                                   storesManager: stores,
+                                                   analytics: analytics,
+                                                   onJetpackSetupCompletion: { _, _ in })
+
+        // When
+        viewModel.didTapPrimaryButton(in: UIViewController())
+
+        // Then
+        XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_connect_button_tapped" }))
+    }
+
+    func test_failure_to_fetch_connection_url_is_tracked() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        var completed = false
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackConnectionURL(let completion):
+                let error = NSError(domain: "Test", code: 123)
+                completion(.failure(error))
+                completed = true
+            default:
+                break
+            }
+        }
+
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let credentials = WordPressOrgCredentials(username: "test", password: "pwd", xmlrpc: "http://test.com/xmlrpc.php", options: [:])
+
+        // When
+        _ = WrongAccountErrorViewModel(siteURL: Expectations.url,
+                                       showsConnectedStores: false,
+                                       siteCredentials: credentials,
+                                       storesManager: stores,
+                                       analytics: analytics,
+                                       onJetpackSetupCompletion: { _, _ in })
+        waitUntil {
+            completed == true
+        }
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "login_jetpack_connection_url_fetch_failed" }))
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(properties["error_code"] as? String, "123")
+        XCTAssertEqual(properties["error_domain"] as? String, "Test")
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7745 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds more unit tests for `WrongAccountErrorViewModel` since the last PR #7748 didn't cover much. Since the code has calls to the `WordPressAuthenticator` library methods, a new interface was added for mocking the authenticator for the tests.

This PR also reverts a change in [a commit](https://github.com/woocommerce/woocommerce-ios/pull/7748/commits/14d67480375a37f3f0a43b8133d3472278495366) in #7748 that causes the account mismatch error screen to be displayed when a site has Jetpack active but not connected. The connection URL doesn't work in this case so it's best to revert the change while waiting for help from the Jetpack team (pe5sF9-B9-p2#comment-985).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
All old and new unit tests should pass.

**Testing site discovery flow**:
- Create a JN site with Jetpack and Woo. Make sure not to connect Jetpack to your WP.com account.
- Log out of the app if needed and select Continue with WordPress.com.
- Log in with a test WP.com account that doesn't have any site.
- Notice that you reach the empty store picker screen. Select Enter your site address.
- Enter the test site's address and continue.
- Notice that the Jetpack required error screen is displayed instead of the Account mismatch screen.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/191893780-5858a605-363d-4337-bde3-f3369d8b34f5.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->