### PR TITLE
Store picker: Fix crash when selecting a store in the store picker

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+10.6
+-----
+- [*] Fixed a rare crash when selecting a store in the store picker. [https://github.com/woocommerce/woocommerce-ios/pull/7765]
+
 10.5
 -----
 - [**] Products: Now you can duplicate products from the More menu of the product detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/7727]

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -406,36 +406,6 @@ private extension StorePickerViewController {
         dismissButton.isEnabled = enabled
     }
 
-    /// This method will reload the [Selected Row]
-    ///
-    func reloadSelectedStoreRows(afterRunning block: () -> Void) {
-        /// Preserve: Selected and Checked Rows
-        ///
-        var rowsToReload = [IndexPath]()
-
-        if let oldSiteID = currentlySelectedSite?.siteID,
-           let oldCheckedRow = viewModel.indexPath(for: oldSiteID) {
-            rowsToReload.append(oldCheckedRow)
-        }
-
-        if let oldSelectedRow = tableView.indexPathForSelectedRow {
-            rowsToReload.append(oldSelectedRow)
-        }
-
-        /// Update the Default Store
-        ///
-        block()
-
-        if let newSiteID = currentlySelectedSite?.siteID,
-           let selectedRow = viewModel.indexPath(for: newSiteID) {
-            rowsToReload.append(selectedRow)
-        }
-
-        /// Refresh: Selected and Checked Rows
-        ///
-        tableView.reloadRows(at: rowsToReload, with: .none)
-    }
-
     /// Re-initializes the Login Flow, forcing a logout. This may be required if the WordPress.com Account has no Stores available.
     ///
     func restartAuthentication() {
@@ -699,12 +669,8 @@ extension StorePickerViewController: UITableViewDelegate {
             return tableView.deselectRow(at: indexPath, animated: true)
         }
 
-        reloadSelectedStoreRows() {
-            currentlySelectedSite = site
-        }
-
-        tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
-        tableView.deselectRow(at: indexPath, animated: true)
+        currentlySelectedSite = site
+        tableView.reloadData()
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -146,21 +146,6 @@ extension StorePickerViewModel {
         }
         return resultsController.safeObject(at: indexPath)
     }
-
-    /// Returns the IndexPath for the specified Site.
-    ///
-    func indexPath(for siteID: Int64) -> IndexPath? {
-        guard resultsController.numberOfObjects > 0 else {
-            return nil
-        }
-
-        for (sectionIndex, section) in resultsController.sections.enumerated() {
-            if let rowIndex = section.objects.firstIndex(where: { $0.siteID == siteID }) {
-                return IndexPath(row: rowIndex, section: sectionIndex)
-            }
-        }
-        return nil
-    }
 }
 
 private extension StorePickerViewModel {

--- a/WooCommerce/WooCommerceTests/Authentication/StorePickerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/StorePickerViewModelTests.swift
@@ -109,7 +109,6 @@ final class StorePickerViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.titleForSection(at: 0), Localization.connectedStore)
         XCTAssertEqual(viewModel.numberOfRows(inSection: 0), 1)
         XCTAssertEqual(viewModel.site(at: IndexPath(row: 0, section: 0))?.siteID, testSite1.siteID)
-        XCTAssertEqual(viewModel.indexPath(for: testSite1.siteID), IndexPath(row: 0, section: 0))
     }
 
     func test_table_view_configs_are_correct_for_list_with_both_woo_and_non_woo_sites() {
@@ -143,7 +142,6 @@ final class StorePickerViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.numberOfRows(inSection: 1), 1)
         XCTAssertEqual(viewModel.site(at: IndexPath(row: 1, section: 0))?.siteID, testSite2.siteID)
         XCTAssertEqual(viewModel.site(at: IndexPath(row: 0, section: 1))?.siteID, testSite3.siteID)
-        XCTAssertEqual(viewModel.indexPath(for: testSite3.siteID), IndexPath(row: 0, section: 1))
     }
 
     func test_trackScreenView_tracks_both_number_of_woo_and_non_woo_sites() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Potentially fixes: #7612 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
There's a rare crash in the store picker happening when selecting a store in the store picker. According to the crash log, this happens when the number of rows or sections changes when the selection occur. 

We're reloading only specific rows when selecting a new row, and this method will cause a crash when the table view detects any change in the data source. This can probably happen when [site synchronization](https://github.com/woocommerce/woocommerce-ios/blob/78ef6c857e6745ffdc272060e30c644792fd7681/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift#L49-L56) causes some changes to the data source.

Since the number of stores is most often not too large for most merchants, using `reloadRows` may not be necessary and complicates the code more. The solution is to switch to using the simple `reloadData` when there's any change to the selected store.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
I can't reproduce the crash, so verifying that this PR fixes it concretely is hard. We can only ensure that the store selection works as before and observe the crash in the next releases.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
