### PR TITLE
Help button in fancy alert in "Wrong WordPress.com account error" screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 10.6
 -----
 - [*] Fixed a rare crash when selecting a store in the store picker. [https://github.com/woocommerce/woocommerce-ios/pull/7765]
-- [*] Help center: Added help center web page with FAQs for "Not a WooCommerce site" error screen. [https://github.com/woocommerce/woocommerce-ios/pull/7767]
+- [*] Help center: Added help center web page with FAQs for "Not a WooCommerce site" and "Wrong WordPress.com account"  error screens. [https://github.com/woocommerce/woocommerce-ios/pull/7767, https://github.com/woocommerce/woocommerce-ios/pull/7769]
 
 10.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 10.6
 -----
 - [*] Fixed a rare crash when selecting a store in the store picker. [https://github.com/woocommerce/woocommerce-ios/pull/7765]
-- [*] Help center: Added help center web page with FAQs for "Not a WooCommerce site" and "Wrong WordPress.com account"  error screens. [https://github.com/woocommerce/woocommerce-ios/pull/7767, https://github.com/woocommerce/woocommerce-ios/pull/7769]
+- [*] Help center: Added help center web page with FAQs for "Not a WooCommerce site" and "Wrong WordPress.com account" error screens. [https://github.com/woocommerce/woocommerce-ios/pull/7767, https://github.com/woocommerce/woocommerce-ios/pull/7769]
 
 10.5
 -----

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -156,7 +156,7 @@ final class WrongAccountErrorViewModel: ULAccountMismatchViewModel {
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {
-        let fancyAlert = FancyAlertViewController.makeNeedHelpFindingEmailAlertController()
+        let fancyAlert = FancyAlertViewController.makeNeedHelpFindingEmailAlertController(screen: .wrongAccountError)
         fancyAlert.modalPresentationStyle = .custom
         fancyAlert.transitioningDelegate = AppDelegate.shared.tabBarController
         viewController?.present(fancyAlert, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
@@ -24,7 +24,12 @@ extension FancyAlertViewController {
 
     static func makeNeedHelpFindingEmailAlertController(screen: CustomHelpCenterContent.Screen? = nil) -> FancyAlertViewController {
         let dismissButton = makeDismissButtonConfig()
-        let moreHelpButton = makeNeedMoreHelpButton()
+        var customHelpCenterContent: CustomHelpCenterContent?
+        if let screen = screen {
+            customHelpCenterContent = CustomHelpCenterContent(screen: screen,
+                                                              flow: AuthenticatorAnalyticsTracker.shared.state.lastFlow)
+        }
+        let moreHelpButton = makeNeedMoreHelpButton(customHelpCenterContent: customHelpCenterContent)
         let config = FancyAlertViewController.Config(titleText: Localization.whatEmailDoIUse,
                                                      bodyText: Localization.whatEmailDoIUseLongDescription,
                                                      headerImage: nil,

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
@@ -22,7 +22,7 @@ extension FancyAlertViewController {
         return controller
     }
 
-    static func makeNeedHelpFindingEmailAlertController() -> FancyAlertViewController {
+    static func makeNeedHelpFindingEmailAlertController(screen: CustomHelpCenterContent.Screen? = nil) -> FancyAlertViewController {
         let dismissButton = makeDismissButtonConfig()
         let moreHelpButton = makeNeedMoreHelpButton()
         let config = FancyAlertViewController.Config(titleText: Localization.whatEmailDoIUse,

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
@@ -1,5 +1,6 @@
 import WordPressUI
 import SafariServices
+import WordPressAuthenticator
 
 extension FancyAlertViewController {
     static func makeWhatIsJetpackAlertController(analytics: Analytics) -> FancyAlertViewController {
@@ -108,14 +109,20 @@ private extension FancyAlertViewController {
         }
     }
 
-    static func makeNeedMoreHelpButton() -> FancyAlertViewController.Config.ButtonConfig {
+    static func makeNeedMoreHelpButton(customHelpCenterContent: CustomHelpCenterContent? = nil) -> FancyAlertViewController.Config.ButtonConfig {
         return FancyAlertViewController.Config.ButtonConfig(Localization.needMoreHelp) { controller, _ in
             let identifier = HelpAndSupportViewController.classNameWithoutNamespaces
-            guard let supportViewController = UIStoryboard
-                    .dashboard
-                    .instantiateViewController(withIdentifier: identifier) as? HelpAndSupportViewController else {
-                return
-            }
+            let supportViewController = UIStoryboard.dashboard.instantiateViewController(identifier: identifier,
+                                                                                         creator: { coder -> HelpAndSupportViewController? in
+                guard let customHelpCenterContent = customHelpCenterContent else {
+                    /// Returning nil as we don't need to customise the HelpAndSupportViewController
+                    /// In this case `instantiateViewController` method will use the default `HelpAndSupportViewController` created from storyboard.
+                    ///
+                    return nil
+                }
+
+                return HelpAndSupportViewController(customHelpCenterContent: customHelpCenterContent, coder: coder)
+            })
 
             supportViewController.displaysDismissAction = true
 

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
@@ -24,11 +24,7 @@ extension FancyAlertViewController {
 
     static func makeNeedHelpFindingEmailAlertController(screen: CustomHelpCenterContent.Screen? = nil) -> FancyAlertViewController {
         let dismissButton = makeDismissButtonConfig()
-        var customHelpCenterContent: CustomHelpCenterContent?
-        if let screen = screen {
-            customHelpCenterContent = CustomHelpCenterContent(screen: screen,
-                                                              flow: AuthenticatorAnalyticsTracker.shared.state.lastFlow)
-        }
+        let customHelpCenterContent = screen.map { CustomHelpCenterContent(screen: $0, flow: AuthenticatorAnalyticsTracker.shared.state.lastFlow) }
         let moreHelpButton = makeNeedMoreHelpButton(customHelpCenterContent: customHelpCenterContent)
         let config = FancyAlertViewController.Config(titleText: Localization.whatEmailDoIUse,
                                                      bodyText: Localization.whatEmailDoIUseLongDescription,


### PR DESCRIPTION
Part of: #7547 

### Description
This PR makes the "Need more help?" button from the "Wrong WordPress.com account error" screen to open a help center which has customised help content. 

We originally added custom help content for this screen in https://github.com/woocommerce/woocommerce-ios/pull/7747 This PR aims to link the same help center page for the "Need more help?" button as well.


### Testing instructions

1. Install and launch the app.
1. Tap `Skip` to reach the login prologue screen.
1. Tap the `Enter Your Store Address` button and enter store address.
1. Tap `Continue`, and you will land in the "Enter WordPress.com account email" screen.
1. Sign in using a WordPress.com account email which isn't connected with the store's Jetpack.
1. You will land in the following wrong account error screen. 

<img src="https://user-images.githubusercontent.com/524475/191195745-48a47392-cd55-44a0-b230-9b0eb54617e6.png" width="300"/>
7. Tap on the "Find your connected email" button, which will show an alert like the following.

<img src="https://user-images.githubusercontent.com/524475/192250518-2344180c-df9d-4112-a5db-6079ff593122.png" width="300"/>

8. Tap `Need more help?` -> `Help Center`
1. Observe that you are directed to https://woocommerce.com/document/android-ios-apps-login-help-faq/#wrong-account in a web view
1. In Xcode debug console observe that the following event is tracked. Note that the `source_flow` value will differ based on the flow you selected to login.
```
Tracked support_help_center_viewed, properties: [AnyHashable("source_flow"): "login_password_magic_link_emphasis", AnyHashable("help_content_url"): "https://woocommerce.com/document/android-ios-apps-login-help-faq/#wrong-account", AnyHashable("source_step"): "wrong_wordpress_account"]
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.