### PR TITLE
Login Prologue: feature carousel should not be shown right after onboarding

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -43,10 +43,12 @@ class AuthenticationManager: Authentication {
 
     /// Initializes the WordPress Authenticator.
     ///
-    func initialize() {
+    func initialize(loggedOutAppSettings: LoggedOutAppSettingsProtocol) {
         let isWPComMagicLinkPreferredToPassword = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasis)
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasisM2)
         let continueWithSiteAddressFirst = ABTest.loginPrologueButtonOrder.variation == .control
+        let isFeatureCarouselShown = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding) == false
+        || loggedOutAppSettings.hasFinishedOnboarding == true
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
                                                                 wpcomScheme: ApiCredentials.dotcomAuthScheme,
@@ -97,7 +99,8 @@ class AuthenticationManager: Authentication {
                                                 navBarImage: StyleManager.navBarImage,
                                                 navBarBadgeColor: .primary,
                                                 navBarBackgroundColor: .appBar,
-                                                prologueTopContainerChildViewController: LoginPrologueViewController(),
+                                                prologueTopContainerChildViewController:
+                                                    LoginPrologueViewController(isFeatureCarouselShown: isFeatureCarouselShown),
                                                 statusBarStyle: .default)
 
         let displayStrings = WordPressAuthenticatorDisplayStrings(emailLoginInstructions: AuthenticationConstants.emailInstructions,

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -8,7 +8,8 @@ import Experiments
 ///
 final class LoginPrologueViewController: UIViewController {
     private let isNewToWooCommerceButtonShown: Bool
-    private let isOnboardingFeatureShown: Bool
+    /// The feature carousel is not shown right after finishing the onboarding.
+    private let isFeatureCarouselShown: Bool
     private let analytics: Analytics
 
     /// Background View, to be placed surrounding the bottom area.
@@ -36,10 +37,10 @@ final class LoginPrologueViewController: UIViewController {
     // MARK: - Overridden Methods
 
     init(analytics: Analytics = ServiceLocator.analytics,
-         loggedOutAppSettings: LoggedOutAppSettingsProtocol = LoggedOutAppSettings(userDefaults: .standard),
+         isFeatureCarouselShown: Bool,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         isNewToWooCommerceButtonShown = featureFlagService.isFeatureFlagEnabled(.newToWooCommerceLinkInLoginPrologue)
-        isOnboardingFeatureShown = featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding) && loggedOutAppSettings.hasFinishedOnboarding == false
+        self.isFeatureCarouselShown = isFeatureCarouselShown
         self.analytics = analytics
         super.init(nibName: nil, bundle: nil)
     }
@@ -91,8 +92,8 @@ private extension LoginPrologueViewController {
     /// This is contained in a child view so that this view's background doesn't scroll.
     ///
     func setupCarousel(isNewToWooCommerceButtonShown: Bool) {
-        let pageTypes: [LoginProloguePageType] = isOnboardingFeatureShown ? [.getStarted] : [.stats, .orderManagement, .products, .reviews]
-        let carousel = LoginProloguePageViewController(pageTypes: pageTypes, showsSubtitle: isOnboardingFeatureShown)
+        let pageTypes: [LoginProloguePageType] = isFeatureCarouselShown ? [.stats, .orderManagement, .products, .reviews]: [.getStarted]
+        let carousel = LoginProloguePageViewController(pageTypes: pageTypes, showsSubtitle: !isFeatureCarouselShown)
         carousel.view.translatesAutoresizingMaskIntoConstraints = false
 
         addChild(carousel)

--- a/WooCommerce/Classes/ServiceLocator/Authentication.swift
+++ b/WooCommerce/Classes/ServiceLocator/Authentication.swift
@@ -28,7 +28,7 @@ protocol Authentication {
 
     /// Initializes the WordPress Authenticator.
     ///
-    func initialize()
+    func initialize(loggedOutAppSettings: LoggedOutAppSettingsProtocol)
 
     /// Injects `loggedOutAppSettings`
     ///

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -155,7 +155,7 @@ private extension AppCoordinator {
 
     /// Configures the WPAuthenticator for usage in both logged-in and logged-out states.
     func configureAuthenticator() {
-        authenticationManager.initialize()
+        authenticationManager.initialize(loggedOutAppSettings: loggedOutAppSettings)
         appleIDCredentialChecker.observeLoggedInStateForAppleIDObservations()
     }
 

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -23,7 +23,7 @@ final class AppCoordinatorTests: XCTestCase {
         stores = MockStoresManager(sessionManager: sessionManager)
         storageManager = MockStorageManager()
         authenticationManager = AuthenticationManager()
-        authenticationManager.initialize()
+        authenticationManager.initialize(loggedOutAppSettings: MockLoggedOutAppSettings())
     }
 
     override func tearDown() {

--- a/WooCommerce/WooCommerceTests/Mocks/MockAuthentication.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAuthentication.swift
@@ -23,7 +23,7 @@ final class MockAuthentication: Authentication {
         UIViewController()
     }
 
-    func initialize() {
+    func initialize(loggedOutAppSettings: LoggedOutAppSettingsProtocol) {
         // no-op
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewControllerTests.swift
@@ -5,7 +5,7 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         // The NUX buttons require WordPressAuthenticator to be initialized
-        AuthenticationManager().initialize()
+        AuthenticationManager().initialize(loggedOutAppSettings: MockLoggedOutAppSettings())
     }
 
     func test_viewcontroller_presents_top_title_provided_by_viewmodel() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7758 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Joe mentioned that the feature carousel on the prologue screen is shown right after onboarding, while it doesn't do so in Android. I was able to reproduce and confirm this bug. In the login prologue screen, the feature carousel is supposed to be hidden right after the user finishes onboarding and then shown again anytime after. The reason for this bug is because `LoginPrologueViewController` is only initialized when the authenticator UI is about to show it async (in the authenticator root view's UI setup), and the feature carousel visibility is determined by `LoggedOutAppSettingsProtocol.hasFinishedOnboarding`, where we change the value right after configuring and calling to show the authenticator UI.

In order to always have the correct `LoggedOutAppSettingsProtocol.hasFinishedOnboarding`, I moved the value retrieval from `LoginPrologueViewController.init` to `Authentication.initialize` with a new parameter `LoggedOutAppSettingsProtocol` to read the value before it's toggled.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Steps to reproduce the behavior:
- Reinstall the app if needed in order to see the onboarding
- Skip or complete the onboarding --> the prologue screen **shouldn't show** the feature carousel
- Relaunch the app --> the prologue screen **should show** the feature carousel

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

right after onboarding | any other time
-- | --
![Simulator Screen Shot - iPhone 13 - 2022-09-27 at 13 06 59](https://user-images.githubusercontent.com/1945542/192436772-e7f689b2-de2d-47cc-aaca-e9bc595debc9.png) |  ![Simulator Screen Shot - iPhone 13 - 2022-09-27 at 13 06 40](https://user-images.githubusercontent.com/1945542/192436761-a52bfb66-e1aa-445a-ae6a-307492559222.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
