### PR TITLE
[Mobile Payments] Only show IPP announcement if it's supported in the store's country

### DIFF
--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/FeatureAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/FeatureAnnouncementCardViewModel.swift
@@ -58,6 +58,10 @@ class FeatureAnnouncementCardViewModel {
     }
 
     private func updateShouldBeVisible() {
+        guard CardPresentConfigurationLoader(stores: stores).configuration.isSupportedCountry else {
+            shouldBeVisible = false
+            return
+        }
         let action = AppSettingsAction.getFeatureAnnouncementVisibility(campaign: config.campaign) { [weak self] result in
             guard let self = self else { return }
             switch result {

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/FeatureAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/FeatureAnnouncementCardViewModel.swift
@@ -58,10 +58,6 @@ class FeatureAnnouncementCardViewModel {
     }
 
     private func updateShouldBeVisible() {
-        guard CardPresentConfigurationLoader(stores: stores).configuration.isSupportedCountry else {
-            shouldBeVisible = false
-            return
-        }
         let action = AppSettingsAction.getFeatureAnnouncementVisibility(campaign: config.campaign) { [weak self] result in
             guard let self = self else { return }
             switch result {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -297,13 +297,13 @@ extension OrderListViewModel {
         let isSupportedCountryForCPP = cppConfiguration.isSupportedCountry
 
         Publishers.CombineLatest3(errorState, $hideOrdersBanners, upsellCardReadersAnnouncementViewModel.$shouldBeVisible)
-            .map { hasError, hasDismissedOrdersBanners, upsellCardReadersBannerShouldBeVisible  -> TopBanner in
+            .map { hasError, hasDismissedOrdersBanners, upsellCardReadersBannerAvailable  -> TopBanner in
 
                 if hasError {
                     return .error
                 }
 
-                if upsellCardReadersBannerShouldBeVisible && isSupportedCountryForCPP {
+                if upsellCardReadersBannerAvailable && isSupportedCountryForCPP {
                     return .upsellCardReaders
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -293,18 +293,21 @@ extension OrderListViewModel {
     ///
     private func bindTopBannerState() {
         let errorState = $hasErrorLoadingData.removeDuplicates()
+        let cppConfiguration = CardPresentConfigurationLoader(stores: stores).configuration
+        let isSupportedCountryForCPP = cppConfiguration.isSupportedCountry
+
         Publishers.CombineLatest3(errorState, $hideOrdersBanners, upsellCardReadersAnnouncementViewModel.$shouldBeVisible)
             .map { hasError, hasDismissedOrdersBanners, upsellCardReadersBannerShouldBeVisible  -> TopBanner in
 
-                guard !hasError else {
+                if hasError {
                     return .error
                 }
 
-                guard !upsellCardReadersBannerShouldBeVisible else {
+                if upsellCardReadersBannerShouldBeVisible && isSupportedCountryForCPP {
                     return .upsellCardReaders
                 }
 
-                guard !hasDismissedOrdersBanners else {
+                if hasDismissedOrdersBanners {
                     return .none
                 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7768 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, we were showing the promotion for In-Person Payments on top of the orders list, even if the store was in a country where we don't support In-Person Payments. With this PR, this banner should only appear in stores from US and Canada.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Go to orders list:
- If the store is in the US or Canada, there should be a banner promoting In-Person Payments (as long as you haven't dismissed it before)
- If the store is in any other country, there should be no In-Person Payments banner

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2022-09-27 at 10 28 33](https://user-images.githubusercontent.com/8739/192475859-0d8b6f47-80a9-4469-9b56-a3cfa94ce6a2.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-09-27 at 10 29 34](https://user-images.githubusercontent.com/8739/192475868-f1c4674b-9468-4672-adfd-418055e17579.png)


---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
