### PR TITLE
Search products by SKU: show SKU to search result cell, empty query optimization, analytics

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -34,7 +34,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .promptToEnableCodInIppOnboarding:
             return true
         case .searchProductsBySKU:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .orderCreationSearchCustomers:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 
 - [*] Fixed a rare crash when selecting a store in the store picker. [https://github.com/woocommerce/woocommerce-ios/pull/7765]
 - [*] Help center: Added help center web page with FAQs for "Not a WooCommerce site" and "Wrong WordPress.com account" error screens. [https://github.com/woocommerce/woocommerce-ios/pull/7767, https://github.com/woocommerce/woocommerce-ios/pull/7769]
+- [*] Products tab: products search now has an option to search products by SKU. Stores with WC version 6.6+ support partial SKU search, otherwise the product(s) with the exact SKU match is returned. [https://github.com/woocommerce/woocommerce-ios/pull/7781]
 
 10.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,9 +3,9 @@
 10.6
 -----
 
+- [**] Products tab: products search now has an option to search products by SKU. Stores with WC version 6.6+ support partial SKU search, otherwise the product(s) with the exact SKU match is returned. [https://github.com/woocommerce/woocommerce-ios/pull/7781]
 - [*] Fixed a rare crash when selecting a store in the store picker. [https://github.com/woocommerce/woocommerce-ios/pull/7765]
 - [*] Help center: Added help center web page with FAQs for "Not a WooCommerce site" and "Wrong WordPress.com account" error screens. [https://github.com/woocommerce/woocommerce-ios/pull/7767, https://github.com/woocommerce/woocommerce-ios/pull/7769]
-- [*] Products tab: products search now has an option to search products by SKU. Stores with WC version 6.6+ support partial SKU search, otherwise the product(s) with the exact SKU match is returned. [https://github.com/woocommerce/woocommerce-ios/pull/7781]
 
 10.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
@@ -31,6 +31,7 @@ struct ProductsTabProductViewModel {
          productVariation: ProductVariation? = nil,
          isSelected: Bool = false,
          isDraggable: Bool = false,
+         isSKUShown: Bool = false,
          imageService: ImageService = ServiceLocator.imageService) {
 
         imageUrl = product.images.first?.src
@@ -38,7 +39,7 @@ struct ProductsTabProductViewModel {
         self.productVariation = productVariation
         self.isSelected = isSelected
         self.isDraggable = isDraggable
-        detailsAttributedString = EditableProductModel(product: product).createDetailsAttributedString()
+        detailsAttributedString = EditableProductModel(product: product).createDetailsAttributedString(isSKUShown: isSKUShown)
 
         self.imageService = imageService
     }
@@ -57,7 +58,7 @@ struct ProductsTabProductViewModel {
 }
 
 private extension EditableProductModel {
-    func createDetailsAttributedString() -> NSAttributedString {
+    func createDetailsAttributedString(isSKUShown: Bool) -> NSAttributedString {
         let statusText = createStatusText()
         let stockText = createStockText()
         let variationsText = createVariationsText()
@@ -65,8 +66,10 @@ private extension EditableProductModel {
         let detailsText = [statusText, stockText, variationsText]
             .compactMap({ $0 })
             .joined(separator: " • ")
+        let skuText = isSKUShown ? createSKUText(): nil
+        let text = [detailsText, skuText].compactMap { $0 }.joined(separator: "\n")
 
-        let attributedString = NSMutableAttributedString(string: detailsText,
+        let attributedString = NSMutableAttributedString(string: text,
                                                          attributes: [
                                                             .foregroundColor: UIColor.textSubtle,
                                                             .font: StyleManager.footerLabelFont
@@ -97,6 +100,13 @@ private extension EditableProductModel {
                                       plural: Localization.VariationCount.plural)
         return String.localizedStringWithFormat(format, numberOfVariations)
     }
+
+    func createSKUText() -> String? {
+        guard let sku = product.sku, sku.isNotEmpty else {
+            return nil
+        }
+        return String.localizedStringWithFormat(Localization.skuFormat, sku)
+    }
 }
 
 // MARK: Localization
@@ -109,6 +119,7 @@ private extension EditableProductModel {
             static let plural = NSLocalizedString("%1$ld variations",
                                                   comment: "Label about number of variations shown on Products tab. Reads, `2 variations`")
         }
+        static let skuFormat = NSLocalizedString("SKU: %1$@", comment: "Label about the SKU of a product in the product list. Reads, `SKU: productSku`")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -86,7 +86,7 @@ final class ProductSearchUICommand: SearchUICommand {
     }
 
     func createCellViewModel(model: Product) -> ProductsTabProductViewModel {
-        return ProductsTabProductViewModel(product: model)
+        ProductsTabProductViewModel(product: model, isSKUShown: true)
     }
 
     /// Synchronizes the Products matching a given Keyword

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -19,13 +19,16 @@ final class ProductSearchUICommand: SearchUICommand {
 
     private let siteID: Int64
     private let stores: StoresManager
+    private let analytics: Analytics
     private let isSearchProductsBySKUEnabled: Bool
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics,
          isSearchProductsBySKUEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.searchProductsBySKU)) {
         self.siteID = siteID
         self.stores = stores
+        self.analytics = analytics
         self.isSearchProductsBySKUEnabled = isSearchProductsBySKUEnabled
     }
 
@@ -123,7 +126,7 @@ final class ProductSearchUICommand: SearchUICommand {
 
         stores.dispatch(action)
 
-        ServiceLocator.analytics.track(.productListSearched)
+        analytics.track(.productListSearched, withProperties: isSearchProductsBySKUEnabled ? ["filter": filter.analyticsValue]: nil)
     }
 
     func didSelectSearchResult(model: Product, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
@@ -161,6 +164,16 @@ private extension ProductSearchFilter {
             return NSLocalizedString("All Products", comment: "Title of the product search filter to search for all products.")
         case .sku:
             return NSLocalizedString("SKU", comment: "Title of the product search filter to search for products that match the SKU.")
+        }
+    }
+
+    /// The value that is set in the analytics event property.
+    var analyticsValue: String {
+        switch self {
+        case .all:
+            return "all"
+        case .sku:
+            return "sku"
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -101,6 +101,11 @@ final class ProductSearchUICommand: SearchUICommand {
                 onCompletion?(true)
                 return
             }
+            // Skips the product search API request if the keyword is empty.
+            guard keyword.isNotEmpty else {
+                onCompletion?(true)
+                return
+            }
             lastSearchQueryByFilter[filter] = keyword
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
@@ -103,8 +103,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
         let detailsText = viewModel.detailsAttributedString.string
 
         // Then
-        let skuFormat = NSLocalizedString("SKU: %1$@", comment: "Label about the SKU of a product in the product list. Reads, `SKU: productSku`")
-        let expectedSKU = String.localizedStringWithFormat(skuFormat, sku)
+        let expectedSKU = String.localizedStringWithFormat(Localization.skuFormat, sku)
         XCTAssertTrue(detailsText.contains(expectedSKU))
     }
 
@@ -118,8 +117,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
         let detailsText = viewModel.detailsAttributedString.string
 
         // Then
-        let skuFormat = NSLocalizedString("SKU: %1$@", comment: "Label about the SKU of a product in the product list. Reads, `SKU: productSku`")
-        let skuText = String.localizedStringWithFormat(skuFormat, sku)
+        let skuText = String.localizedStringWithFormat(Localization.skuFormat, sku)
         XCTAssertFalse(detailsText.contains(skuText))
     }
 }
@@ -136,5 +134,11 @@ extension ProductsTabProductViewModelTests {
                                    stockStatusKey: stockStatus.rawValue,
                                    images: images,
                                    variations: variations)
+    }
+}
+
+private extension ProductsTabProductViewModelTests {
+    enum Localization {
+        static let skuFormat = NSLocalizedString("SKU: %1$@", comment: "Label about the SKU of a product in the product list. Reads, `SKU: productSku`")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
@@ -93,6 +93,35 @@ final class ProductsTabProductViewModelTests: XCTestCase {
         XCTAssertTrue(detailsText.contains(expectedStockDetail))
     }
 
+    func test_details_contain_sku_when_isSKUShown_is_true() {
+        // Given
+        let sku = "pear"
+        let product = productMock(name: "Yay").copy(sku: sku)
+
+        // When
+        let viewModel = ProductsTabProductViewModel(product: product, isSKUShown: true)
+        let detailsText = viewModel.detailsAttributedString.string
+
+        // Then
+        let skuFormat = NSLocalizedString("SKU: %1$@", comment: "Label about the SKU of a product in the product list. Reads, `SKU: productSku`")
+        let expectedSKU = String.localizedStringWithFormat(skuFormat, sku)
+        XCTAssertTrue(detailsText.contains(expectedSKU))
+    }
+
+    func test_details_do_not_contain_sku_when_isSKUShown_is_false() {
+        // Given
+        let sku = "pear"
+        let product = productMock(name: "Yay").copy(sku: sku)
+
+        // When
+        let viewModel = ProductsTabProductViewModel(product: product, isSKUShown: false)
+        let detailsText = viewModel.detailsAttributedString.string
+
+        // Then
+        let skuFormat = NSLocalizedString("SKU: %1$@", comment: "Label about the SKU of a product in the product list. Reads, `SKU: productSku`")
+        let skuText = String.localizedStringWithFormat(skuFormat, sku)
+        XCTAssertFalse(detailsText.contains(skuText))
+    }
 }
 
 extension ProductsTabProductViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductSearchUICommandTests.swift
@@ -156,7 +156,14 @@ final class ProductSearchUICommandTests: XCTestCase {
 
     func test_productListSearched_is_tracked_when_synchronizing_models() throws {
         // Given
-        let command = ProductSearchUICommand(siteID: sampleSiteID, analytics: analytics, isSearchProductsBySKUEnabled: true)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let command = ProductSearchUICommand(siteID: sampleSiteID, stores: stores, analytics: analytics, isSearchProductsBySKUEnabled: true)
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            guard case let .searchProducts(_, _, _, _, _, _, _, _, _, _, onCompletion) = action else {
+                return XCTFail("Unexpected action: \(action)")
+            }
+            onCompletion(.success(()))
+        }
 
         // When
         waitFor { promise in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #3157 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is the last PR for searching products by SKU. The changes include:

- Shows a new line of `SKU: \(sku)` below the product details in the product cell via `ProductsTabProductViewModel`. On Android, the SKU text is shown in both the All and SKU tabs
- Adds an event property `filter: all|sku` to the Tracks event `*_product_list_searched` so that we can measure how many people search with SKU
- Empty query optimization: in `ProductSearchUICommand `, skips the `ProductAction.searchProducts` (which makes an API request) if the keyword is empty. This should improve the UX when some filters are applied to the products tab, and then tapping on the SKU tab with an empty query

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in if needed, and connect to a store with WC 6.6+
- Go to the Products tab, and apply some filters to the product list so that not all the products are shown
- Tap on the search icon --> there should be a segmented control between the search bar and the results, and the same list of filtered products from the products tab should be shown for both tabs
- Type in some query --> the results should be shown correctly for each tab, where products with a partial match on the SKU should be shown on the SKU tab. pagination should work correctly on both tabs. in the console, an event should be tracked like `🔵 Tracked product_list_searched, properties: [AnyHashable("filter"): "all|sku", ...]`

### Example screenshots

SKU | All
-- | --
![Simulator Screen Shot - iPhone 13 Pro - 2022-09-28 at 10 43 24](https://user-images.githubusercontent.com/1945542/192676027-08107b64-ed61-48fc-9c14-11604c90b35b.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-09-28 at 10 44 10](https://user-images.githubusercontent.com/1945542/192676029-15f4a5c8-6191-4d35-8eff-36a87d343992.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
