### PR TITLE
Widgets: Fix analytics events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -234,7 +234,7 @@ private extension WooAnalytics {
             }
         }
 
-        return ["widgets": widgetAnalyticNames.description]
+        return ["widgets": widgetAnalyticNames.joined(separator: ",")]
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -218,9 +218,9 @@ private extension WooAnalytics {
 
     /// Builds the necesary properties for the `application_opened` event.
     ///
-    func applicationOpenedProperties(_ configurationResult: Result<[WidgetInfo], Error>) -> [String: [String]] {
+    func applicationOpenedProperties(_ configurationResult: Result<[WidgetInfo], Error>) -> [String: String] {
         guard let installedWidgets = try? configurationResult.get() else {
-            return ["widgets": []]
+            return ["widgets": ""]
         }
 
         // Translate the widget kind into a name recognized by tracks.
@@ -234,7 +234,7 @@ private extension WooAnalytics {
             }
         }
 
-        return ["widgets": widgetAnalyticNames]
+        return ["widgets": widgetAnalyticNames.description]
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1614,7 +1614,7 @@ extension WooAnalyticsEvent {
         }
 
         enum Name: String {
-            case todayStats = "today_stats"
+            case todayStats = "today-stats"
         }
 
         /// Event when a widget is tapped and opens the app.


### PR DESCRIPTION
# Why

We recently introduced the `widgets` property to the `application_opened` event whose value can be an array of widget names. 

I failed to notice that our tracks event doesn't support arrays and we have to send the list as a string representation of the array.

This is causing that the `application_opened` events that contain widgets information are getting rejected/filtered by tracks.

Property as Array | Error Message
---- | ----
<img width="520" alt="error-ios-1" src="https://user-images.githubusercontent.com/562080/192822391-0835d13d-9e9d-4bd9-8dca-eaef72216452.png"> | <img width="684" alt="error-ios-2" src="https://user-images.githubusercontent.com/562080/192822388-4a387aeb-3c89-47cf-a45f-9e0857bc8435.png">

# How 

This PR fixes that by sending the widgets name list as a string. Additionally, it updates the widget name to match the android one. `today_stats` to `today-stats`

Android | iOS
---- | ----
<img width="500" alt="android" src="https://user-images.githubusercontent.com/562080/192823763-93351868-b2d5-49ec-9666-945eb87e502d.png"> | <img width="512" alt="ios" src="https://user-images.githubusercontent.com/562080/192823766-a80fd787-7ef5-4389-9566-c2348b6557e0.png">



### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
