### PR TITLE
[Review Replies] Add comment reply endpoint to Networking layer

### DIFF
--- a/Networking/Networking/Remote/CommentRemote.swift
+++ b/Networking/Networking/Remote/CommentRemote.swift
@@ -56,6 +56,24 @@ public class CommentRemote: Remote {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters)
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Reply to a comment (including product reviews)
+    ///
+    /// - Parameters:
+    ///    - siteID: site ID which contains the comment
+    ///    - commentID: ID of the comment to reply to
+    ///    - content: the text of the comment reply
+    ///    - completion: callback to be executed on completion
+    ///
+    public func replyToComment(siteID: Int64, commentID: Int64, content: String, completion: @escaping (Result<CommentStatus, Error>) -> Void) {
+        let path = "\(Paths.sites)/" + String(siteID) + "/" + "\(Paths.comments)/" + String(commentID) + "/\(Paths.commentReply)"
+        let parameters = [
+            ParameterKeys.content: content
+        ]
+        let mapper = CommentResultMapper()
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 
@@ -65,11 +83,13 @@ private extension CommentRemote {
     enum Paths {
         static let sites: String        = "sites"
         static let comments: String     = "comments"
+        static let commentReply: String = "replies/new"
     }
 
     enum ParameterKeys {
         static let status: String       = "status"
         static let context: String      = "context"
+        static let content: String      = "content"
     }
 
     enum ParameterValues {


### PR DESCRIPTION
Part of: #7777

## Description

This adds support to the Networking layer to allow users to reply to product reviews in the app. Product reviews are a custom type of comment, and merchants can reply to them using the WordPress.com REST API [comment reply endpoint](https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/comments/%24comment_ID/replies/new/).

## Changes

* Adds the comment reply endpoint to `CommentRemote`.
* Adds tests to confirm the response is parsed as expected.
 
Note: This endpoint returns full details about the new comment in its response, but we don't need the full comment data at this point, so I used the existing `CommentResultMapper` to map the response. This extracts just the status of the new comment (e.g. `approved`). In the future if we want to handle more of the new comment's details we could add a `Comment` model and mapper, but that seemed overkill for what we need now.

## Testing

Confirm tests pass in CI (endpoint is not yet used in app) and method matches documented API behavior.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
