### PR TITLE
[Review Replies] Add comment reply action to Yosemite layer

### DIFF
--- a/Yosemite/Yosemite/Actions/CommentAction.swift
+++ b/Yosemite/Yosemite/Actions/CommentAction.swift
@@ -21,4 +21,9 @@ public enum CommentAction: Action {
     /// The completion closure will return the updated comment status or error (if any).
     ///
     case updateTrashStatus(siteID: Int64, commentID: Int64, isTrash: Bool, onCompletion: (CommentStatus?, Error?) -> Void)
+
+    /// Creates a comment as a reply to another comment.
+    /// The completion closure will return the new comment's status or error (if any).
+    ///
+    case replyToComment(siteID: Int64, commentID: Int64, content: String, onCompletion: (Result<CommentStatus, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/CommentAction.swift
+++ b/Yosemite/Yosemite/Actions/CommentAction.swift
@@ -22,7 +22,7 @@ public enum CommentAction: Action {
     ///
     case updateTrashStatus(siteID: Int64, commentID: Int64, isTrash: Bool, onCompletion: (CommentStatus?, Error?) -> Void)
 
-    /// Creates a comment as a reply to another comment.
+    /// Creates a comment as a reply to another comment (including product reviews).
     /// The completion closure will return the new comment's status or error (if any).
     ///
     case replyToComment(siteID: Int64, commentID: Int64, content: String, onCompletion: (Result<CommentStatus, Error>) -> Void)

--- a/Yosemite/Yosemite/Stores/CommentStore.swift
+++ b/Yosemite/Yosemite/Stores/CommentStore.swift
@@ -71,7 +71,7 @@ private extension CommentStore {
         }
     }
 
-    /// Creates a comment as a reply to another comment.
+    /// Creates a comment as a reply to another comment (including product reviews).
     ///
     func replyToComment(siteID: Int64, commentID: Int64, content: String, onCompletion: @escaping (Result<CommentStatus, Error>) -> Void) {
         remote.replyToComment(siteID: siteID, commentID: commentID, content: content) { result in

--- a/Yosemite/Yosemite/Stores/CommentStore.swift
+++ b/Yosemite/Yosemite/Stores/CommentStore.swift
@@ -33,6 +33,8 @@ public class CommentStore: Store {
             updateSpamStatus(siteID: siteID, commentID: commentID, isSpam: isSpam, onCompletion: onCompletion)
         case .updateTrashStatus(let siteID, let commentID, let isTrash, let onCompletion):
             updateTrashStatus(siteID: siteID, commentID: commentID, isTrash: isTrash, onCompletion: onCompletion)
+        case .replyToComment(let siteID, let commentID, let content, let onCompletion):
+            replyToComment(siteID: siteID, commentID: commentID, content: content, onCompletion: onCompletion)
         }
     }
 }
@@ -66,6 +68,14 @@ private extension CommentStore {
     func moderateComment(siteID: Int64, commentID: Int64, status: CommentStatus, onCompletion: @escaping (CommentStatus?, Error?) -> Void) {
         remote.moderateComment(siteID: siteID, commentID: commentID, status: status) { (updatedStatus, error) in
             onCompletion(updatedStatus, error)
+        }
+    }
+
+    /// Creates a comment as a reply to another comment.
+    ///
+    func replyToComment(siteID: Int64, commentID: Int64, content: String, onCompletion: @escaping (Result<CommentStatus, Error>) -> Void) {
+        remote.replyToComment(siteID: siteID, commentID: commentID, content: content) { result in
+            onCompletion(result)
         }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/CommentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CommentStoreTests.swift
@@ -251,4 +251,43 @@ class CommentStoreTests: XCTestCase {
         store.onAction(action)
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
+
+    // MARK: - CommentAction.replyToComment
+
+    func test_replyToComment_returns_expected_comment_status() throws {
+        // Given
+        let store = CommentStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)/replies/new", filename: "comment-moderate-approved")
+
+        // When
+        let result: Result<Yosemite.CommentStatus, Error> = waitFor { promise in
+            let action = CommentAction.replyToComment(siteID: self.sampleSiteID, commentID: self.sampleCommentID, content: "Test comment") { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(try XCTUnwrap(result.get()), .approved)
+    }
+
+    func test_replyToComment_returns_error_upon_response_error() {
+        // Given
+        let store = CommentStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)/replies/new", filename: "generic_error")
+
+        // When
+        let result: Result<Yosemite.CommentStatus, Error> = waitFor { promise in
+            let action = CommentAction.replyToComment(siteID: self.sampleSiteID, commentID: self.sampleCommentID, content: "Test comment") { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
 }


### PR DESCRIPTION
Part of: #7777

## Description

This adds support to the Yosemite layer (a new action) to allow users to reply to product reviews in the app. Product reviews are a custom type of comment, so new comments can be posted as a reply to the existing product review.

## Changes

* Adds a `replyToComment` action to `CommentAction`.
* Adds `replyToComment` to `CommentStore`, which fires the call to the remote endpoint to create a new comment in reply to an existing comment (product review).
* Adds unit tests to confirm the expected response is returned.

## Testing

Confirm tests pass in CI (action is not yet used in app). You can also test firing this action with an existing product review ID and test comment to confirm it creates the comment reply as expected.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
