### PR TITLE
Login: Handle cookie authentication in Authenticated web view 

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -105,10 +105,14 @@ private extension AuthenticatedWebViewController {
 
         webView.publisher(for: \.url)
             .sink { [weak self] url in
-                if url?.absoluteString.contains(WKWebView.wporgNoncePath) == true {
-                    self?.loadContent()
+                guard let self else { return }
+                let initialURL = self.viewModel.initialURL
+                // avoids infinite loop if the initial url happens to be the nonce retrieval path.
+                if url?.absoluteString.contains(WKWebView.wporgNoncePath) == true,
+                   initialURL?.absoluteString.contains(WKWebView.wporgNoncePath) != true {
+                    self.loadContent()
                 } else {
-                    self?.viewModel.handleRedirect(for: url)
+                    self.viewModel.handleRedirect(for: url)
                 }
             }
             .store(in: &subscriptions)

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -1,6 +1,7 @@
 import Combine
 import UIKit
 import WebKit
+import struct WordPressAuthenticator.WordPressOrgCredentials
 
 /// A web view which is authenticated for WordPress.com, when possible.
 ///
@@ -26,8 +27,13 @@ final class AuthenticatedWebViewController: UIViewController {
     /// Strong reference for the subscription to update progress bar
     private var subscriptions: Set<AnyCancellable> = []
 
-    init(viewModel: AuthenticatedWebViewModel) {
+    /// Optional credentials for authenticating with WP.org
+    ///
+    private let wporgCredentials: WordPressOrgCredentials?
+
+    init(viewModel: AuthenticatedWebViewModel, wporgCredentials: WordPressOrgCredentials? = nil) {
         self.viewModel = viewModel
+        self.wporgCredentials = wporgCredentials
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -107,8 +113,7 @@ private extension AuthenticatedWebViewController {
             }
             .store(in: &subscriptions)
 
-        if let wporgCredentials = viewModel.wporgCredentials,
-            let request = try? webView.authenticateForWPOrg(with: wporgCredentials) {
+        if let wporgCredentials, let request = try? webView.authenticateForWPOrg(with: wporgCredentials) {
             webView.load(request)
         } else {
             loadContent()

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
@@ -11,10 +11,6 @@ protocol AuthenticatedWebViewModel {
     /// Initial URL to be loaded on the web view
     var initialURL: URL? { get }
 
-    /// Optional credentials for authenticating with WP.org
-    ///
-    var wporgCredentials: WordPressOrgCredentials? { get }
-
     /// Triggered when the web view is dismissed
     func handleDismissal()
 
@@ -23,9 +19,4 @@ protocol AuthenticatedWebViewModel {
 
     /// Handler for a navigation URL
     func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy
-}
-
-/// Default implementation
-extension AuthenticatedWebViewModel {
-    var wporgCredentials: WordPressOrgCredentials? { nil }
 }

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WebKit
+import WordPressAuthenticator
 
 /// Abstracts different configurations and logic for web view controllers
 /// which are authenticated for WordPress.com, where possible
@@ -10,6 +11,10 @@ protocol AuthenticatedWebViewModel {
     /// Initial URL to be loaded on the web view
     var initialURL: URL? { get }
 
+    /// Optional credentials for authenticating with WP.org
+    ///
+    var wporgCredentials: WordPressOrgCredentials? { get }
+
     /// Triggered when the web view is dismissed
     func handleDismissal()
 
@@ -18,4 +23,9 @@ protocol AuthenticatedWebViewModel {
 
     /// Handler for a navigation URL
     func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy
+}
+
+/// Default implementation
+extension AuthenticatedWebViewModel {
+    var wporgCredentials: WordPressOrgCredentials? { nil }
 }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -588,7 +588,8 @@ private extension AuthenticationManager {
     }
 
     /// The error screen to be displayed when the user enters a site
-    /// without Jetpack in the site discovery flow
+    /// without Jetpack in the site discovery flow.
+    /// More about this flow: pe5sF9-mz-p2.
     ///
     func jetpackErrorUI(for siteURL: String, with matcher: ULAccountMatcher, in navigationController: UINavigationController) -> UIViewController {
         let viewModel = JetpackErrorViewModel(siteURL: siteURL,
@@ -671,6 +672,7 @@ private extension AuthenticationManager {
     }
 
     /// Appropriate error to display for a site when entered from the site discovery flow.
+    /// More about this flow: pe5sF9-mz-p2
     ///
     func errorUI(for site: WordPressComSiteInfo, in navigationController: UINavigationController) -> UIViewController {
         guard site.isWP else {

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -553,7 +553,9 @@ private extension AuthenticationManager {
                              with credentials: AuthenticatorCredentials,
                              in navigationController: UINavigationController,
                              onDismiss: @escaping () -> Void) {
-        let viewModel = JetpackErrorViewModel(siteURL: siteURL, onJetpackSetupCompletion: { [weak self] authorizedEmailAddress in
+        let viewModel = JetpackErrorViewModel(siteURL: siteURL,
+                                              siteCredentials: credentials.wporg,
+                                              onJetpackSetupCompletion: { [weak self] authorizedEmailAddress in
             guard let self = self else { return }
             // Resets the referenced site since the setup completed now.
             self.currentSelfHostedSite = nil
@@ -589,7 +591,9 @@ private extension AuthenticationManager {
     /// without Jetpack in the site discovery flow
     ///
     func jetpackErrorUI(for siteURL: String, with matcher: ULAccountMatcher, in navigationController: UINavigationController) -> UIViewController {
-        let viewModel = JetpackErrorViewModel(siteURL: siteURL, onJetpackSetupCompletion: { [weak self] authorizedEmailAddress in
+        let viewModel = JetpackErrorViewModel(siteURL: siteURL,
+                                              siteCredentials: nil,
+                                              onJetpackSetupCompletion: { [weak self] authorizedEmailAddress in
             guard let self = self else { return }
 
             // Tries re-syncing to get an updated store list

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
@@ -66,10 +66,9 @@ struct JetpackErrorViewModel: ULErrorViewModel {
         }
 
         let viewModel = JetpackSetupWebViewModel(siteURL: siteURL,
-                                                 siteCredentials: siteCredentials,
                                                  analytics: analytics,
                                                  onCompletion: jetpackSetupCompletionHandler)
-        let connectionController = AuthenticatedWebViewController(viewModel: viewModel)
+        let connectionController = AuthenticatedWebViewController(viewModel: viewModel, wporgCredentials: siteCredentials)
         viewController.navigationController?.show(connectionController, sender: nil)
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
@@ -8,15 +8,18 @@ import WordPressUI
 /// an error when Jetpack is not installed or is not connected
 struct JetpackErrorViewModel: ULErrorViewModel {
     private let siteURL: String
+    private let siteCredentials: WordPressOrgCredentials?
     private let analytics: Analytics
     private let jetpackSetupCompletionHandler: (String?) -> Void
     private let authentication: Authentication
 
     init(siteURL: String?,
+         siteCredentials: WordPressOrgCredentials?,
          analytics: Analytics = ServiceLocator.analytics,
          authentication: Authentication = ServiceLocator.authenticationManager,
          onJetpackSetupCompletion: @escaping (String?) -> Void) {
         self.siteURL = siteURL ?? Localization.yourSite
+        self.siteCredentials = siteCredentials
         self.analytics = analytics
         self.authentication = authentication
         self.jetpackSetupCompletionHandler = onJetpackSetupCompletion
@@ -62,7 +65,10 @@ struct JetpackErrorViewModel: ULErrorViewModel {
             return
         }
 
-        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: jetpackSetupCompletionHandler)
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL,
+                                                 siteCredentials: siteCredentials,
+                                                 analytics: analytics,
+                                                 onCompletion: jetpackSetupCompletionHandler)
         let connectionController = AuthenticatedWebViewController(viewModel: viewModel)
         viewController.navigationController?.show(connectionController, sender: nil)
     }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
@@ -110,8 +110,8 @@ private extension JetpackErrorViewModel {
                                                      comment: "Button linking to webview that explains what Jetpack is"
                                                         + "Presented when logging in with a site address that does not have a valid Jetpack installation")
 
-        static let primaryButtonTitle = NSLocalizedString("Install Jetpack",
-                                                          comment: "Action button for installing Jetpack."
+        static let primaryButtonTitle = NSLocalizedString("Set up Jetpack",
+                                                          comment: "Action button for setting up Jetpack."
                                                           + "Presented when logging in with a site address that does not have a valid Jetpack installation")
 
         static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewModel.swift
@@ -1,13 +1,9 @@
 import Foundation
 import WebKit
-import WordPressAuthenticator
 
 /// View model used for the web view controller to install Jetpack the plugin during the login flow.
 ///
 final class JetpackSetupWebViewModel: AuthenticatedWebViewModel {
-
-    // Site credentials if available
-    let wporgCredentials: WordPressOrgCredentials?
 
     /// The site URL to set up Jetpack for.
     private let siteURL: String
@@ -20,11 +16,9 @@ final class JetpackSetupWebViewModel: AuthenticatedWebViewModel {
     private var authorizedEmailAddress: String?
 
     init(siteURL: String,
-         siteCredentials: WordPressOrgCredentials?,
          analytics: Analytics = ServiceLocator.analytics,
          onCompletion: @escaping (String?) -> Void) {
         self.siteURL = siteURL
-        self.wporgCredentials = siteCredentials
         self.analytics = analytics
         self.completionHandler = onCompletion
     }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupWebViewModel.swift
@@ -1,9 +1,13 @@
 import Foundation
 import WebKit
+import WordPressAuthenticator
 
 /// View model used for the web view controller to install Jetpack the plugin during the login flow.
 ///
 final class JetpackSetupWebViewModel: AuthenticatedWebViewModel {
+
+    // Site credentials if available
+    let wporgCredentials: WordPressOrgCredentials?
 
     /// The site URL to set up Jetpack for.
     private let siteURL: String
@@ -15,8 +19,12 @@ final class JetpackSetupWebViewModel: AuthenticatedWebViewModel {
     /// The email address that the user uses to authorize Jetpack
     private var authorizedEmailAddress: String?
 
-    init(siteURL: String, analytics: Analytics = ServiceLocator.analytics, onCompletion: @escaping (String?) -> Void) {
+    init(siteURL: String,
+         siteCredentials: WordPressOrgCredentials?,
+         analytics: Analytics = ServiceLocator.analytics,
+         onCompletion: @escaping (String?) -> Void) {
         self.siteURL = siteURL
+        self.wporgCredentials = siteCredentials
         self.analytics = analytics
         self.completionHandler = onCompletion
     }

--- a/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
+++ b/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
@@ -1,12 +1,29 @@
 import Alamofire
 import Foundation
 import WebKit
+import WordPressAuthenticator
 import struct Yosemite.Credentials
 import class Networking.UserAgent
 
 /// An extension to authenticate WPCom automatically
 ///
 extension WKWebView {
+    static let wporgNoncePath = "/admin-ajax.php?action=rest-nonce"
+
+    func authenticateForWPOrg(with credentials: WordPressOrgCredentials) throws -> URLRequest {
+        var request = try URLRequest(url: credentials.loginURL.asURL(), method: .post)
+        request.httpShouldHandleCookies = true
+
+        let redirectLink = (credentials.adminURL + Self.wporgNoncePath)
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+
+        let parameters = ["log": credentials.username,
+                          "pwd": credentials.password,
+                          "redirect_to": redirectLink ?? ""]
+
+        return try URLEncoding.default.encode(request, with: parameters)
+    }
+
     func authenticateForWPComAndRedirect(to url: URL, credentials: Credentials?) {
         customUserAgent = UserAgent.defaultUserAgent
         do {

--- a/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
+++ b/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
@@ -10,6 +10,9 @@ import class Networking.UserAgent
 extension WKWebView {
     static let wporgNoncePath = "/admin-ajax.php?action=rest-nonce"
 
+    /// Cookie authentication following WordPressKit implementation:
+    /// https://github.com/wordpress-mobile/WordPressKit-iOS/blob/trunk/WordPressKit/Authenticator.swift
+    ///
     func authenticateForWPOrg(with credentials: WordPressOrgCredentials) throws -> URLRequest {
         var request = try URLRequest(url: credentials.loginURL.asURL(), method: .post)
         request.httpShouldHandleCookies = true

--- a/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
+++ b/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
@@ -1,7 +1,7 @@
 import Alamofire
 import Foundation
 import WebKit
-import WordPressAuthenticator
+import struct WordPressAuthenticator.WordPressOrgCredentials
 import struct Yosemite.Credentials
 import class Networking.UserAgent
 

--- a/WooCommerce/WooCommerceTests/Authentication/JetpackErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/JetpackErrorViewModelTests.swift
@@ -22,7 +22,7 @@ final class JetpackErrorViewModelTests: XCTestCase {
 
     func test_viewmodel_provides_expected_image() {
         // Given
-        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url) { _ in }
+        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, siteCredentials: nil) { _ in }
 
         // When
         let image = viewModel.image
@@ -33,7 +33,7 @@ final class JetpackErrorViewModelTests: XCTestCase {
 
     func test_viewmodel_provides_expected_visibility_for_auxiliary_button() {
         // Given
-        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url) { _ in }
+        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, siteCredentials: nil) { _ in }
 
         // When
         let isVisible = viewModel.isAuxiliaryButtonHidden
@@ -44,7 +44,7 @@ final class JetpackErrorViewModelTests: XCTestCase {
 
     func test_viewmodel_provides_expected_title_for_auxiliary_button() {
         // Given
-        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url) { _ in }
+        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, siteCredentials: nil) { _ in }
 
         // When
         let auxiliaryButtonTitle = viewModel.auxiliaryButtonTitle
@@ -55,7 +55,7 @@ final class JetpackErrorViewModelTests: XCTestCase {
 
     func test_viewmodel_provides_expected_title_for_primary_button() {
         // Given
-        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url) { _ in }
+        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, siteCredentials: nil) { _ in }
 
         // When
         let primaryButtonTitle = viewModel.primaryButtonTitle
@@ -66,7 +66,7 @@ final class JetpackErrorViewModelTests: XCTestCase {
 
     func test_viewmodel_provides_expected_title_for_secondary_button() {
         // Given
-        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url) { _ in }
+        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, siteCredentials: nil) { _ in }
 
         // When
         let secondaryButtonTitle = viewModel.secondaryButtonTitle
@@ -77,7 +77,7 @@ final class JetpackErrorViewModelTests: XCTestCase {
 
     func test_viewmodel_provides_expected_title_for_right_bar_button_item() {
         // Given
-        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url) { _ in }
+        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, siteCredentials: nil) { _ in }
 
         // Then
         XCTAssertEqual(viewModel.rightBarButtonItemTitle, Expectations.helpBarButtonItemTitle)
@@ -85,7 +85,7 @@ final class JetpackErrorViewModelTests: XCTestCase {
 
     func test_viewModel_logs_an_event_when_viewDidLoad_is_triggered() throws {
         // Given
-        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, analytics: analytics) { _ in }
+        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, siteCredentials: nil, analytics: analytics) { _ in }
 
         assertEmpty(analyticsProvider.receivedEvents)
 
@@ -99,7 +99,7 @@ final class JetpackErrorViewModelTests: XCTestCase {
 
     func test_viewModel_logs_an_event_when_install_jetpack_button_is_tapped() throws {
         // Given
-        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, analytics: analytics) { _ in }
+        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, siteCredentials: nil, analytics: analytics) { _ in }
 
         assertEmpty(analyticsProvider.receivedEvents)
 
@@ -113,7 +113,7 @@ final class JetpackErrorViewModelTests: XCTestCase {
 
     func test_viewModel_logs_an_event_when_the_what_is_jetpack_button_is_tapped() throws {
         // Given
-        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, analytics: analytics) { _ in }
+        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, siteCredentials: nil, analytics: analytics) { _ in }
 
         assertEmpty(analyticsProvider.receivedEvents)
 
@@ -128,7 +128,7 @@ final class JetpackErrorViewModelTests: XCTestCase {
     func test_viewModel_invokes_present_support_when_the_help_button_is_tapped() throws {
         // Given
         let mockAuthentication = MockAuthentication()
-        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, authentication: mockAuthentication) { _ in }
+        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, siteCredentials: nil, authentication: mockAuthentication) { _ in }
 
         // When
         viewModel.didTapRightBarButtonItem(in: UIViewController())
@@ -140,7 +140,7 @@ final class JetpackErrorViewModelTests: XCTestCase {
     func test_viewModel_sends_correct_screen_value_in_present_support_method() throws {
         // Given
         let mockAuthentication = MockAuthentication()
-        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, authentication: mockAuthentication) { _ in }
+        let viewModel = JetpackErrorViewModel(siteURL: Expectations.url, siteCredentials: nil, authentication: mockAuthentication) { _ in }
 
         // When
         viewModel.didTapRightBarButtonItem(in: UIViewController())

--- a/WooCommerce/WooCommerceTests/Authentication/JetpackErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/JetpackErrorViewModelTests.swift
@@ -158,8 +158,8 @@ private extension JetpackErrorViewModelTests {
         static let whatIsJetpack = NSLocalizedString("What is Jetpack?",
                                                      comment: "Button linking to webview that explains what Jetpack is"
                                                         + "Presented when logging in with a site address that does not have a valid Jetpack installation")
-        static let primaryButtonTitle = NSLocalizedString("Install Jetpack",
-                                                          comment: "Action button for installing Jetpack."
+        static let primaryButtonTitle = NSLocalizedString("Set up Jetpack",
+                                                          comment: "Action button for setting up Jetpack."
                                                           + "Presented when logging in with a site address that does not have a valid Jetpack installation")
 
         static let secondaryButtonTitle = NSLocalizedString("Log In With Another Account",

--- a/WooCommerce/WooCommerceTests/Authentication/JetpackSetupWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/JetpackSetupWebViewModelTests.swift
@@ -6,7 +6,7 @@ final class JetpackSetupWebViewModelTests: XCTestCase {
     func test_initial_url_is_correct() {
         // Given
         let siteURL = "https://test.com"
-        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, onCompletion: {_ in })
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, siteCredentials: nil, onCompletion: {_ in })
 
         // Then
         let expectedURL = "https://wordpress.com/jetpack/connect?url=https://test.com&mobile_redirect=woocommerce://jetpack-connected&from=mobile"
@@ -20,7 +20,7 @@ final class JetpackSetupWebViewModelTests: XCTestCase {
         let completionHandler: (String?) -> Void = { _ in
             triggeredCompletion = true
         }
-        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, onCompletion: completionHandler)
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, siteCredentials: nil, onCompletion: completionHandler)
 
         // When
         let url = try XCTUnwrap(URL(string: "woocommerce://jetpack-connected"))
@@ -39,7 +39,7 @@ final class JetpackSetupWebViewModelTests: XCTestCase {
         let completionHandler: (String?) -> Void = { email in
             authorizedEmail = email
         }
-        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, onCompletion: completionHandler)
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, siteCredentials: nil, onCompletion: completionHandler)
 
         // When
         let authorizeURL = try XCTUnwrap(URL(string: "https://jetpack.wordpress.com/jetpack.authorize?user_email=\(expectedEmail)"))
@@ -57,7 +57,7 @@ final class JetpackSetupWebViewModelTests: XCTestCase {
         let siteURL = "https://test.com"
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: { _ in })
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, siteCredentials: nil, analytics: analytics, onCompletion: { _ in })
 
         // When
         viewModel.handleDismissal()
@@ -73,7 +73,7 @@ final class JetpackSetupWebViewModelTests: XCTestCase {
         let siteURL = "https://test.com"
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: { _ in })
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, siteCredentials: nil, analytics: analytics, onCompletion: { _ in })
 
         // When
         let url = try XCTUnwrap(URL(string: "woocommerce://jetpack-connected"))

--- a/WooCommerce/WooCommerceTests/Authentication/JetpackSetupWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/JetpackSetupWebViewModelTests.swift
@@ -6,7 +6,7 @@ final class JetpackSetupWebViewModelTests: XCTestCase {
     func test_initial_url_is_correct() {
         // Given
         let siteURL = "https://test.com"
-        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, siteCredentials: nil, onCompletion: {_ in })
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, onCompletion: {_ in })
 
         // Then
         let expectedURL = "https://wordpress.com/jetpack/connect?url=https://test.com&mobile_redirect=woocommerce://jetpack-connected&from=mobile"
@@ -20,7 +20,7 @@ final class JetpackSetupWebViewModelTests: XCTestCase {
         let completionHandler: (String?) -> Void = { _ in
             triggeredCompletion = true
         }
-        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, siteCredentials: nil, onCompletion: completionHandler)
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, onCompletion: completionHandler)
 
         // When
         let url = try XCTUnwrap(URL(string: "woocommerce://jetpack-connected"))
@@ -39,7 +39,7 @@ final class JetpackSetupWebViewModelTests: XCTestCase {
         let completionHandler: (String?) -> Void = { email in
             authorizedEmail = email
         }
-        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, siteCredentials: nil, onCompletion: completionHandler)
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, onCompletion: completionHandler)
 
         // When
         let authorizeURL = try XCTUnwrap(URL(string: "https://jetpack.wordpress.com/jetpack.authorize?user_email=\(expectedEmail)"))
@@ -57,7 +57,7 @@ final class JetpackSetupWebViewModelTests: XCTestCase {
         let siteURL = "https://test.com"
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, siteCredentials: nil, analytics: analytics, onCompletion: { _ in })
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: { _ in })
 
         // When
         viewModel.handleDismissal()
@@ -73,7 +73,7 @@ final class JetpackSetupWebViewModelTests: XCTestCase {
         let siteURL = "https://test.com"
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, siteCredentials: nil, analytics: analytics, onCompletion: { _ in })
+        let viewModel = JetpackSetupWebViewModel(siteURL: siteURL, analytics: analytics, onCompletion: { _ in })
 
         // When
         let url = try XCTUnwrap(URL(string: "woocommerce://jetpack-connected"))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7370 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, when a user enters the site address login flow and chooses to enter site credentials, if they reach the Jetpack installation flow, they have to enter their site credentials again before proceeding to install Jetpack.

This PR improves this experience by sending the input site credentials to the web view to handle authentication and get the nonce before proceeding to load the web view. This helps shorten the flow a bit and removes duplicated login flow.

Another minor update: The "Install Jetpack" button on the Jetpack error screen is updated to "Set up Jetpack" to avoid confusion.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Create a JN site without Jetpack.
- Erase all data in your simulator if needed to ensure any existing cookies and caches are cleared.
- Install the app, skip onboarding and select Enter your site address.
- Enter the test site address and select Continue.
- Select Log in with site credentials and enter your credentials to the site.
- When the login succeeds, notice that the Jetpack required error screen is displayed. 
- Select Set up Jetpack. In the presented web view, follow the steps to set up Jetpack in your site. Notice that you don't have to enter site credentials again.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/192941273-486dbe61-51fa-4671-a7bc-668192d0e627.mp4





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
