### PR TITLE
[Review Replies] Add reply button to product review detail

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -37,6 +37,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .orderCreationSearchCustomers:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .replyToProductReviews:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -77,4 +77,8 @@ public enum FeatureFlag: Int {
     /// Enables the Search Customers functionality in the Order Creation screen
     ///
     case orderCreationSearchCustomers
+
+    /// Enables replying to product reviews
+    ///
+    case replyToProductReviews
 }

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -804,6 +804,12 @@ extension UIImage {
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
+    /// Reply Icon
+    ///
+    static var replyImage: UIImage {
+        return UIImage.gridicon(.reply)
+    }
+
     /// Search Icon - used in `UIBarButtonItem`
     ///
     static var searchBarButtonItemImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Reviews/Cells/NoteDetailsCommentTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/Cells/NoteDetailsCommentTableViewCell.swift
@@ -131,6 +131,17 @@ final class NoteDetailsCommentTableViewCell: UITableViewCell {
         }
     }
 
+    /// Indicates if the Reply Button is enabled (or not!)
+    ///
+    var isReplyEnabled: Bool {
+        get {
+            return replyButton.isHidden
+        }
+        set {
+            replyButton.isHidden = !newValue
+        }
+    }
+
     /// Title: Usually displays the Author's Name.
     ///
     var titleText: String? {

--- a/WooCommerce/Classes/ViewRelated/Reviews/Cells/NoteDetailsCommentTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/Cells/NoteDetailsCommentTableViewCell.swift
@@ -56,6 +56,10 @@ final class NoteDetailsCommentTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var approvalButton: UIButton!
 
+    /// Button: Reply
+    ///
+    @IBOutlet var replyButton: UIButton!
+
     /// Custom UIView: Rating star view
     ///
     @IBOutlet private var starRatingView: RatingView!
@@ -75,6 +79,10 @@ final class NoteDetailsCommentTableViewCell: UITableViewCell {
     /// Closure to be executed whenever the Unapprove Button is pressed.
     ///
     var onUnapprove: (() -> Void)?
+
+    /// Closure to be executed whenever the Reply Button is pressed.
+    ///
+    var onReply: (() -> Void)?
 
 
     /// Indicates if the Spam Button is enabled (or not!)
@@ -222,6 +230,10 @@ private extension NoteDetailsCommentTableViewCell {
         approvalButton.accessibilityLabel = Approve.normalLabel
         approvalButton.accessibilityIdentifier = "single-review-approval-button"
 
+        replyButton.applyNoteDetailsActionStyle(icon: .replyImage)
+        replyButton.setTitle(Reply.normalTitle, for: .normal)
+        replyButton.accessibilityLabel = Reply.normalLabel
+        replyButton.accessibilityIdentifier = "single-review-reply-button"
     }
 
     func configureTitleLabel() {
@@ -240,7 +252,7 @@ private extension NoteDetailsCommentTableViewCell {
     /// Setup: Default Action(s) Style
     ///
     func configureDefaultAppearance() {
-        let buttons = [spamButton, trashButton, approvalButton].compactMap { $0 }
+        let buttons = [spamButton, trashButton, approvalButton, replyButton].compactMap { $0 }
 
         for button in buttons {
             refreshAppearance(button: button)
@@ -299,6 +311,13 @@ private extension NoteDetailsCommentTableViewCell {
 
         onClick?()
     }
+
+    /// Reply Button Callback
+    ///
+    @IBAction func replyWasPressed(_ sender: UIButton) {
+        sender.animateImageOverlay(style: .explosion)
+        onReply?()
+    }
 }
 
 
@@ -325,6 +344,14 @@ private struct Approve {
     static let selectedTitle    = NSLocalizedString("Approved", comment: "Unapprove a comment")
     static let normalLabel      = NSLocalizedString("Approves the comment", comment: "Approves a comment. Spoken Hint.")
     static let selectedLabel    = NSLocalizedString("Unapproves the comment", comment: "Unapproves a comment. Spoken Hint.")
+}
+
+
+// MARK: - Reply Button: Strings!
+//
+private struct Reply {
+    static let normalTitle      = NSLocalizedString("Reply", comment: "Reply to a comment")
+    static let normalLabel      = NSLocalizedString("Opens a text view to reply to the comment", comment: "Reply to a comment. Spoken Hint.")
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/Cells/NoteDetailsCommentTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Reviews/Cells/NoteDetailsCommentTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -49,13 +49,13 @@
                                         <rect key="frame" x="56" y="0.0" width="232" height="40"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="249" horizontalCompressionResistancePriority="250" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MB2-nk-Fuo">
-                                                <rect key="frame" x="0.0" y="0.0" width="232" height="24"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="232" height="25.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6d4-9R-dcK">
-                                                <rect key="frame" x="0.0" y="24" width="232" height="16"/>
+                                                <rect key="frame" x="0.0" y="25.5" width="232" height="14.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -98,7 +98,7 @@
                                 <rect key="frame" x="0.0" y="160" width="288" height="52"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qUJ-uA-W4N" customClass="VerticalButton" customModule="WooCommerce" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="89.5" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="64.5" height="52"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <state key="normal" title="Spam"/>
                                         <connections>
@@ -106,7 +106,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6As-Iw-caM" customClass="VerticalButton" customModule="WooCommerce" customModuleProvider="target">
-                                        <rect key="frame" x="99.5" y="0.0" width="89" height="52"/>
+                                        <rect key="frame" x="74.5" y="0.0" width="64.5" height="52"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <state key="normal" title="Trash">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -116,11 +116,20 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uc0-Kk-Npt" customClass="VerticalButton" customModule="WooCommerce" customModuleProvider="target">
-                                        <rect key="frame" x="198.5" y="0.0" width="89.5" height="52"/>
+                                        <rect key="frame" x="149" y="0.0" width="64.5" height="52"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <state key="normal" title="Approve"/>
                                         <connections>
                                             <action selector="approveWasPressed:" destination="ba1-rz-4HV" eventType="touchUpInside" id="XrG-F9-l5a"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jZy-9J-G3f" userLabel="Reply Button" customClass="VerticalButton" customModule="WooCommerce" customModuleProvider="target">
+                                        <rect key="frame" x="223.5" y="0.0" width="64.5" height="52"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="Reply"/>
+                                        <connections>
+                                            <action selector="replyWasPressed:" destination="ba1-rz-4HV" eventType="touchUpInside" id="jZu-dE-X4p"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -143,6 +152,7 @@
                 <outlet property="approvalButton" destination="uc0-Kk-Npt" id="tZL-iM-Q2H"/>
                 <outlet property="detailsLabel" destination="6d4-9R-dcK" id="pCn-M7-He8"/>
                 <outlet property="gravatarImageView" destination="qcp-iw-3SL" id="e8j-K5-3V4"/>
+                <outlet property="replyButton" destination="jZy-9J-G3f" id="uvH-7W-9fm"/>
                 <outlet property="spamButton" destination="qUJ-uA-W4N" id="Gbe-6K-KhN"/>
                 <outlet property="starRatingView" destination="1Iy-55-tos" id="bcq-5i-2Gp"/>
                 <outlet property="textView" destination="FpQ-yp-a6e" id="qCC-ZC-o7p"/>

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -383,6 +383,10 @@ private extension ReviewDetailsViewController {
 
             self.moderateReview(siteID: reviewSiteID, reviewID: reviewID, doneStatus: .spam, undoStatus: .unspam)
         }
+
+        commentCell.onReply = {
+            // TODO: Open a text view to send a comment reply to the product review
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import Yosemite
 import Gridicons
 import SafariServices
+import Experiments
 
 
 // MARK: - ReviewDetailsViewController
@@ -44,13 +45,16 @@ final class ReviewDetailsViewController: UIViewController {
     ///
     private var rows = [Row]()
 
+    private let featureFlagService: FeatureFlagService
+
     /// Designated Initializer
     ///
-    init(productReview: ProductReview, product: Product?, notification: Note?) {
+    init(productReview: ProductReview, product: Product?, notification: Note?, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.productReview = productReview
         self.siteID = productReview.siteID
         self.product = product
         self.notification = notification
+        self.featureFlagService = featureFlagService
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -332,6 +336,7 @@ private extension ReviewDetailsViewController {
         commentCell.isTrashEnabled    = true
         commentCell.isSpamEnabled     = true
         commentCell.isApproveSelected = productReview.status == .approved
+        commentCell.isReplyEnabled    = featureFlagService.isFeatureFlagEnabled(.replyToProductReviews)
 
         let reviewID = productReview.reviewID
         let reviewSiteID = productReview.siteID

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -668,4 +668,8 @@ final class IconsTests: XCTestCase {
     func test_lock_icon_is_not_nil() {
         XCTAssertNotNil(UIImage.lockImage)
     }
+
+    func test_reply_icon_is_not_nil() {
+        XCTAssertNotNil(UIImage.replyImage)
+    }
 }


### PR DESCRIPTION
Part of #7777

## Description

This adds a "Reply" button to the Product Review detail screen, behind a feature flag.

The button is currently inactive, but the idea is to eventually open a new text view when the Reply button is tapped. This will allow the user to enter and send a reply to the review. That text view will be added in a separate PR.

## Changes

* Adds a new feature flag `replyToProductReviews` enabled in debug/alpha.
* Adds the reply gridicon (`replyImage`) and unit test.
* Adds a reply button to the buttons displayed in `NoteDetailsCommentTableViewCell` (used for the Product Review detail screen). 
* Sets the reply button visibility in `ReviewDetailsViewController`, based on the feature flag.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Tap "Menu" in the bottom navigation bar.
3. Select "Reviews" in the hub menu.
4. Select any product review from the list of reviews.
5. Confirm you see all of the expected buttons in the product review detail: Spam, Trash, Approved, and Reply.

## Screenshots

Before|After
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-09-29 at 10 19 55](https://user-images.githubusercontent.com/8658164/193015567-a5533916-2ccf-4f71-a93e-ce172bb99c66.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-09-29 at 11 50 32](https://user-images.githubusercontent.com/8658164/193015586-bbfb07a8-0dc4-45c3-b090-a8b8cedb227e.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
