### PR TITLE
[Review Replies] Add a "Reply to Product View" screen in Product Review detail.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -385,9 +385,7 @@ private extension ReviewDetailsViewController {
         }
 
         commentCell.onReply = { [weak self] in
-            guard let self = self else {
-                return
-            }
+            guard let self else { return }
 
             let reviewReplyViewController = ReviewReplyHostingController(viewModel: ReviewReplyViewModel())
             self.present(reviewReplyViewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -384,8 +384,13 @@ private extension ReviewDetailsViewController {
             self.moderateReview(siteID: reviewSiteID, reviewID: reviewID, doneStatus: .spam, undoStatus: .unspam)
         }
 
-        commentCell.onReply = {
-            // TODO: Open a text view to send a comment reply to the product review
+        commentCell.onReply = { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            let reviewReplyViewController = ReviewReplyHostingController(viewModel: ReviewReplyViewModel())
+            self.present(reviewReplyViewController, animated: true)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewReply.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewReply.swift
@@ -1,0 +1,82 @@
+import Foundation
+import SwiftUI
+
+/// Hosting controller that wraps a `ReviewDetailsReply` view.
+///
+final class ReviewReplyHostingController: UIHostingController<ReviewReply>, UIAdaptivePresentationControllerDelegate {
+    init(viewModel: ReviewReplyViewModel) {
+        super.init(rootView: ReviewReply(viewModel: viewModel))
+
+        // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
+        rootView.dismiss = { [weak self] in
+            self?.dismiss(animated: true, completion: nil)
+        }
+
+        // Set presentation delegate to track the user dismiss flow event
+        presentationController?.delegate = self
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// Allows merchant to reply to a product review.
+///
+struct ReviewReply: View {
+
+    /// Set this closure with UIKit dismiss code. Needed because we need access to the UIHostingController `dismiss` method.
+    ///
+    var dismiss: (() -> Void) = {}
+
+    /// View Model for the view
+    ///
+    @ObservedObject private(set) var viewModel: ReviewReplyViewModel
+
+    var body: some View {
+        NavigationView {
+            TextEditor(text: $viewModel.newReply)
+                .focused()
+                .padding()
+                .navigationTitle(Localization.title)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button(Localization.cancel, action: {
+                            dismiss()
+                        })
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        navigationBarTrailingItem()
+                    }
+                }
+        }
+        .wooNavigationBarStyle()
+        .navigationViewStyle(.stack)
+    }
+
+    /// Decides if the navigation trailing item should be a send button or a loading indicator.
+    ///
+    @ViewBuilder private func navigationBarTrailingItem() -> some View {
+        switch viewModel.navigationTrailingItem {
+        case .send(let enabled):
+            Button(Localization.send) {
+                viewModel.sendReply { success in
+                    if success {
+                        dismiss()
+                    }
+                }
+            }
+            .disabled(!enabled)
+        case .loading:
+            ProgressView()
+        }
+    }
+}
+
+// MARK: Constants
+private enum Localization {
+    static let title = NSLocalizedString("Reply to Product Review", comment: "Title for the product review reply screen")
+    static let send = NSLocalizedString("Send", comment: "Text for the send button in the product review reply screen")
+    static let cancel = NSLocalizedString("Cancel", comment: "Text for the cancel button in the product review reply screen")
+}

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewReply.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewReply.swift
@@ -4,7 +4,11 @@ import SwiftUI
 /// Hosting controller that wraps a `ReviewDetailsReply` view.
 ///
 final class ReviewReplyHostingController: UIHostingController<ReviewReply>, UIAdaptivePresentationControllerDelegate {
+
+    private let viewModel: ReviewReplyViewModel
+
     init(viewModel: ReviewReplyViewModel) {
+        self.viewModel = viewModel
         super.init(rootView: ReviewReply(viewModel: viewModel))
 
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewReplyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewReplyViewModel.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Combine
+import Yosemite
+
+/// View model for the `ReviewReply` screen.
+///
+final class ReviewReplyViewModel: ObservableObject {
+
+    /// New reply to send
+    ///
+    @Published var newReply: String = ""
+
+    /// Defaults to a disabled send button.
+    ///
+    @Published private(set) var navigationTrailingItem: ReviewReplyNavigationItem = .send(enabled: false)
+
+    /// Tracks if a network request is being performed.
+    ///
+    private let performingNetworkRequest: CurrentValueSubject<Bool, Never> = .init(false)
+
+    init() {
+        bindNavigationTrailingItemPublisher()
+    }
+
+    /// Called when the user taps on the Send button.
+    ///
+    /// Use this method to send the reply and invoke a completion block when finished
+    ///
+    func sendReply(onCompletion: @escaping (Bool) -> Void) {
+        // TODO: Call CommentAction.replyToComment to send the reply to remote
+        // Set `performingNetworkRequest` to true while the request is being performed
+    }
+}
+
+// MARK: Helper Methods
+private extension ReviewReplyViewModel {
+    /// Calculates what navigation trailing item should be shown depending on our internal state.
+    ///
+    func bindNavigationTrailingItemPublisher() {
+        Publishers.CombineLatest($newReply, performingNetworkRequest)
+            .map { newReply, performingNetworkRequest in
+                guard !performingNetworkRequest else {
+                    return .loading
+                }
+                return .send(enabled: newReply.isNotEmpty)
+            }
+            .assign(to: &$navigationTrailingItem)
+    }
+}
+
+/// Representation of possible navigation bar trailing buttons
+///
+enum ReviewReplyNavigationItem: Equatable {
+    case send(enabled: Bool)
+    case loading
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1355,6 +1355,8 @@
 		CC2A08062863222500510C4B /* orders_3337_add_fee.json in Resources */ = {isa = PBXBuildFile; fileRef = CC2A08052863222500510C4B /* orders_3337_add_fee.json */; };
 		CC2A0808286337A300510C4B /* CustomerNoteScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2A0807286337A300510C4B /* CustomerNoteScreen.swift */; };
 		CC2E72F727B6BFB800A62872 /* ProductVariationFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2E72F627B6BFB800A62872 /* ProductVariationFormatterTests.swift */; };
+		CC3B35DB28E5A6830036B097 /* ReviewReply.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3B35DA28E5A6830036B097 /* ReviewReply.swift */; };
+		CC3B35DD28E5A6EA0036B097 /* ReviewReplyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3B35DC28E5A6EA0036B097 /* ReviewReplyViewModel.swift */; };
 		CC440E1E2770C6AF0074C264 /* ProductInOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */; };
 		CC4A4E962655273D00B75DCD /* ShippingLabelPaymentMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */; };
 		CC4A4ED82655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4ED72655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift */; };
@@ -3265,6 +3267,8 @@
 		CC2A08052863222500510C4B /* orders_3337_add_fee.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = orders_3337_add_fee.json; sourceTree = "<group>"; };
 		CC2A0807286337A300510C4B /* CustomerNoteScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerNoteScreen.swift; sourceTree = "<group>"; };
 		CC2E72F627B6BFB800A62872 /* ProductVariationFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormatterTests.swift; sourceTree = "<group>"; };
+		CC3B35DA28E5A6830036B097 /* ReviewReply.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReply.swift; sourceTree = "<group>"; };
+		CC3B35DC28E5A6EA0036B097 /* ReviewReplyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReplyViewModel.swift; sourceTree = "<group>"; };
 		CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInOrderViewModel.swift; sourceTree = "<group>"; };
 		CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethods.swift; sourceTree = "<group>"; };
 		CC4A4ED72655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsViewModel.swift; sourceTree = "<group>"; };
@@ -6901,6 +6905,8 @@
 				D8C2A28E231BD00500F503E9 /* ReviewsViewModel.swift */,
 				B5F8B7DF2194759100DAB7E2 /* ReviewDetailsViewController.swift */,
 				B5F8B7E4219478FA00DAB7E2 /* ReviewDetailsViewController.xib */,
+				CC3B35DA28E5A6830036B097 /* ReviewReply.swift */,
+				CC3B35DC28E5A6EA0036B097 /* ReviewReplyViewModel.swift */,
 				023A059824135F2600E3FC99 /* ReviewsViewController.swift */,
 				023A059924135F2600E3FC99 /* ReviewsViewController.xib */,
 				5718852B2465D9EC00E2486F /* ReviewsCoordinator.swift */,
@@ -10228,6 +10234,7 @@
 				45B4F0262860BD0A00F3B16E /* WCShipCTAView.swift in Sources */,
 				020BE74D23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.swift in Sources */,
 				023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */,
+				CC3B35DD28E5A6EA0036B097 /* ReviewReplyViewModel.swift in Sources */,
 				CC72BB6427BD842500837876 /* DisclosureIndicator.swift in Sources */,
 				77E53EC52510C193003D385F /* ProductDownloadListViewController+Droppable.swift in Sources */,
 				3F50FE4328CAEBA800C89201 /* AppLocalizedString.swift in Sources */,
@@ -10390,6 +10397,7 @@
 				DE3404E828B4B96800CF0D97 /* NonAtomicSiteViewModel.swift in Sources */,
 				D8815B0126385E3F00EDAD62 /* CardPresentModalTapCard.swift in Sources */,
 				773077EE251E943700178696 /* ProductDownloadFileViewController.swift in Sources */,
+				CC3B35DB28E5A6830036B097 /* ReviewReply.swift in Sources */,
 				45D1CF4523BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift in Sources */,
 				319A626127ACAE3400BC96C3 /* InPersonPaymentsPluginChoicesView.swift in Sources */,
 				6856D31F941A33BAE66F394D /* KeyboardFrameAdjustmentProvider.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1357,6 +1357,7 @@
 		CC2E72F727B6BFB800A62872 /* ProductVariationFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2E72F627B6BFB800A62872 /* ProductVariationFormatterTests.swift */; };
 		CC3B35DB28E5A6830036B097 /* ReviewReply.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3B35DA28E5A6830036B097 /* ReviewReply.swift */; };
 		CC3B35DD28E5A6EA0036B097 /* ReviewReplyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3B35DC28E5A6EA0036B097 /* ReviewReplyViewModel.swift */; };
+		CC3B35DF28E5BE6F0036B097 /* ReviewReplyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3B35DE28E5BE6F0036B097 /* ReviewReplyViewModelTests.swift */; };
 		CC440E1E2770C6AF0074C264 /* ProductInOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */; };
 		CC4A4E962655273D00B75DCD /* ShippingLabelPaymentMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */; };
 		CC4A4ED82655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A4ED72655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift */; };
@@ -3269,6 +3270,7 @@
 		CC2E72F627B6BFB800A62872 /* ProductVariationFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormatterTests.swift; sourceTree = "<group>"; };
 		CC3B35DA28E5A6830036B097 /* ReviewReply.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReply.swift; sourceTree = "<group>"; };
 		CC3B35DC28E5A6EA0036B097 /* ReviewReplyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReplyViewModel.swift; sourceTree = "<group>"; };
+		CC3B35DE28E5BE6F0036B097 /* ReviewReplyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReplyViewModelTests.swift; sourceTree = "<group>"; };
 		CC440E1D2770C6AF0074C264 /* ProductInOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInOrderViewModel.swift; sourceTree = "<group>"; };
 		CC4A4E952655273D00B75DCD /* ShippingLabelPaymentMethods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethods.swift; sourceTree = "<group>"; };
 		CC4A4ED72655478D00B75DCD /* ShippingLabelPaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsViewModel.swift; sourceTree = "<group>"; };
@@ -7118,6 +7120,7 @@
 			isa = PBXGroup;
 			children = (
 				BAA34C1F2787494300846F3C /* ReviewsViewControllerTests.swift */,
+				CC3B35DE28E5BE6F0036B097 /* ReviewReplyViewModelTests.swift */,
 			);
 			path = Reviews;
 			sourceTree = "<group>";
@@ -10619,6 +10622,7 @@
 				020C908424C84652001E2BEB /* ProductListMultiSelectorSearchUICommandTests.swift in Sources */,
 				746FC23D2200A62B00C3096C /* DateWooTests.swift in Sources */,
 				31F21B5A263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift in Sources */,
+				CC3B35DF28E5BE6F0036B097 /* ReviewReplyViewModelTests.swift in Sources */,
 				02F5F80E246102240000613A /* FilterProductListViewModel+numberOfActiveFiltersTests.swift in Sources */,
 				021AEF9C2407B07300029D28 /* ProductImageStatus+HelpersTests.swift in Sources */,
 				024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Reviews/ReviewReplyViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Reviews/ReviewReplyViewModelTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import WooCommerce
+
+class ReviewReplyViewModelTests: XCTestCase {
+
+    func test_send_button_is_disabled_when_reply_content_is_empty() {
+        // Given
+        let viewModel = ReviewReplyViewModel()
+
+        // When
+        let navigationItem = viewModel.navigationTrailingItem
+
+        // Then
+        assertEqual(navigationItem, .send(enabled: false))
+    }
+
+    func test_send_button_is_enabled_when_reply_is_entered() {
+        // Given
+        let viewModel = ReviewReplyViewModel()
+
+        // When
+        viewModel.newReply = "New reply"
+
+        // Then
+        assertEqual(viewModel.navigationTrailingItem, .send(enabled: true))
+    }
+}


### PR DESCRIPTION
Part of #7777
⚠️ Depends on #7788 ⚠️ 

## Description

This PR adds a "Reply to Product Review" screen, which is presented after tapping the "Reply" button in the Product Review detail screen.

You can enter a plain text comment reply on this screen. The "Send" button becomes active when text is entered, but for now the button doesn't do anything.

## Changes

* Adds a `ReviewReply` SwiftUI view and hosting controller. (This new view is similar to our existing `EditCustomerNote` view, for a similar/consistent UX for adding and submitting plain text.)
* Adds a view model for the `ReviewReply` view. Currently this view model handles changes to the entered text and enabling the "Send" button. It is also set up to handle changing the navigation button to a loading spinner when the reply is being sent to remote (after tapping "Send"), which will be implemented in an upcoming PR.
* Adds unit tests for the new view model.
* Updates `ReviewDetailsViewController` to present the `ReviewReply` view when the Reply button is tapped in the Product Review detail screen.

## Testing

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Tap "Menu" in the bottom navigation bar.
3. Select "Reviews" in the hub menu.
4. Select any product review from the list of reviews.
5. Tap the "Reply" button in the product detail and confirm a "Reply to Product Review" screen appears with the "Send" button disabled.
6. Enter some text and confirm the "Send" button is enabled.
7. Tap "Cancel" and confirm the view is dismissed.

## Screenshots

<img src="https://user-images.githubusercontent.com/8658164/193027515-6e4b4614-1581-4a62-98db-50375aa9c6c4.gif" width="300px">


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
