### PR TITLE
Bulk Prices: Added success notice with bulk updating variation prices

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
@@ -128,12 +128,21 @@ final class BulkUpdateViewController: UIViewController, GhostableViewController 
         noticePresenter.enqueue(notice: notice)
     }
 
+    /// Displays the success price update `Notice`.
+    ///
+    private func displayPriceUpdatedNotice() {
+        let title = Localization.pricesUpdated
+        let notice = Notice(title: title, feedbackType: .success)
+        noticePresenter.enqueue(notice: notice)
+    }
+
     /// Called when the price option is selected
     ///
     private func navigateToEditPriceSettings() {
         let bulkUpdatePriceSettingsViewModel = viewModel.viewModelForBulkUpdatePriceOfType(.regular, priceUpdateDidFinish: { [weak self] in
             guard let self = self else { return }
             self.navigationController?.popToViewController(self, animated: true)
+            self.displayPriceUpdatedNotice()
         })
         let viewController = BulkUpdatePriceViewController(viewModel: bulkUpdatePriceSettingsViewModel)
         show(viewController, sender: nil)
@@ -256,6 +265,8 @@ private extension BulkUpdateViewController {
         static let noticeUnableToSyncVariations = NSLocalizedString("Unable to retrieve variations",
                                                                     comment: "Unable to retrieve variations for bulk update screen")
         static let noticeRetryAction = NSLocalizedString("Retry", comment: "Retry Action")
+        static let pricesUpdated = NSLocalizedString("Prices updated succesfully.",
+                                                     comment: "Notice title when updating the price via the bulk variation screen")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
@@ -265,7 +265,7 @@ private extension BulkUpdateViewController {
         static let noticeUnableToSyncVariations = NSLocalizedString("Unable to retrieve variations",
                                                                     comment: "Unable to retrieve variations for bulk update screen")
         static let noticeRetryAction = NSLocalizedString("Retry", comment: "Retry Action")
-        static let pricesUpdated = NSLocalizedString("Prices updated succesfully.",
+        static let pricesUpdated = NSLocalizedString("Prices updated successfully.",
                                                      comment: "Notice title when updating the price via the bulk variation screen")
     }
 }


### PR DESCRIPTION
Closes: #6562

# Why 

The [variations bulk update trial project](https://github.com/woocommerce/woocommerce-ios/issues/5762) has some small tasks left to be in a releasable state. 

I'm going to be submitting PRs for those tasks to wrap it up.

This PR just shows a success notice after prices are successfully updated.

# Demo

https://user-images.githubusercontent.com/562080/193067256-4ec6330b-4b1d-47be-8fe8-e2c78b9e0351.mov


# Testing Steps

- Go to a variable product
- Go to the variations section
- Tap the "bulk update" from the top right menu
- Enter a new price
- Tap Save 
- See that the success notice appears

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
