### PR TITLE
[Review Replies] Send product review reply to remote

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -389,7 +389,8 @@ private extension ReviewDetailsViewController {
                 return
             }
 
-            let reviewReplyViewController = ReviewReplyHostingController(viewModel: ReviewReplyViewModel())
+            let reviewReplyViewModel = ReviewReplyViewModel(siteID: self.siteID, reviewID: self.productReview.reviewID)
+            let reviewReplyViewController = ReviewReplyHostingController(viewModel: reviewReplyViewModel)
             self.present(reviewReplyViewController, animated: true)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewReply.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewReply.swift
@@ -49,6 +49,7 @@ final class ReviewReplyHostingController: UIHostingController<ReviewReply>, UIAd
                 case .success:
                     self?.systemNoticePresenter.enqueue(notice: Notice(title: Localization.success, feedbackType: .success))
                 case .error:
+                    // Include a notice identifier so the the error can be presented as a system notification even if the app is closed.
                     let noticeIdentifier = UUID().uuidString
                     let notice = Notice(title: Localization.error,
                                         feedbackType: .error,

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewReply.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewReply.swift
@@ -12,6 +12,11 @@ final class ReviewReplyHostingController: UIHostingController<ReviewReply>, UIAd
             self?.dismiss(animated: true, completion: nil)
         }
 
+        // This notice presenter is needed to display an error notice without closing the modal if the network request fails.
+        let errorNoticePresenter = DefaultNoticePresenter()
+        errorNoticePresenter.presentingViewController = self
+        viewModel.modalNoticePresenter = errorNoticePresenter
+
         // Set presentation delegate to track the user dismiss flow event
         presentationController?.delegate = self
     }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewReply.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewReply.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import Combine
 
 /// Hosting controller that wraps a `ReviewDetailsReply` view.
 ///
@@ -7,8 +8,32 @@ final class ReviewReplyHostingController: UIHostingController<ReviewReply>, UIAd
 
     private let viewModel: ReviewReplyViewModel
 
-    init(viewModel: ReviewReplyViewModel) {
+    /// Presents notices in the tab bar context.
+    ///
+    private let systemNoticePresenter: NoticePresenter
+
+    /// Presents notices in the current modal presentation context.
+    ///
+    private lazy var modalNoticePresenter: NoticePresenter = {
+        let presenter = DefaultNoticePresenter()
+        presenter.presentingViewController = self
+        return presenter
+    }()
+
+    /// Emits the intent to present a `ReviewReplyNotice`
+    ///
+    private lazy var presentNoticePublisher = {
+        viewModel.presentNoticeSubject.eraseToAnyPublisher()
+    }()
+
+    /// References to keep the Combine subscriptions alive within the lifecycle of the object.
+    ///
+    private var subscriptions: Set<AnyCancellable> = []
+
+    init(viewModel: ReviewReplyViewModel,
+         noticePresenter: NoticePresenter = ServiceLocator.noticePresenter) {
         self.viewModel = viewModel
+        self.systemNoticePresenter = noticePresenter
         super.init(rootView: ReviewReply(viewModel: viewModel))
 
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
@@ -16,10 +41,30 @@ final class ReviewReplyHostingController: UIHostingController<ReviewReply>, UIAd
             self?.dismiss(animated: true, completion: nil)
         }
 
-        // This notice presenter is needed to display an error notice without closing the modal if the network request fails.
-        let errorNoticePresenter = DefaultNoticePresenter()
-        errorNoticePresenter.presentingViewController = self
-        viewModel.modalNoticePresenter = errorNoticePresenter
+        // Observe the present notice intent.
+        presentNoticePublisher
+            .compactMap { $0 }
+            .sink { [weak self] notice in
+                switch notice {
+                case .success:
+                    self?.systemNoticePresenter.enqueue(notice: Notice(title: Localization.success, feedbackType: .success))
+                case .error:
+                    let noticeIdentifier = UUID().uuidString
+                    let notice = Notice(title: Localization.error,
+                                        feedbackType: .error,
+                                        notificationInfo: NoticeNotificationInfo(identifier: noticeIdentifier),
+                                        actionTitle: Localization.retry) { [weak self] in
+                        self?.viewModel.sendReply(onCompletion: { [weak self] success in
+                            if success {
+                                self?.dismiss(animated: true, completion: nil)
+                            }
+                        })
+                    }
+
+                    self?.modalNoticePresenter.enqueue(notice: notice)
+                }
+            }
+            .store(in: &subscriptions)
 
         // Set presentation delegate to track the user dismiss flow event
         presentationController?.delegate = self
@@ -83,9 +128,19 @@ struct ReviewReply: View {
     }
 }
 
+enum ReviewReplyNotice: Equatable {
+    case success
+    case error
+}
+
 // MARK: Constants
 private enum Localization {
     static let title = NSLocalizedString("Reply to Product Review", comment: "Title for the product review reply screen")
     static let send = NSLocalizedString("Send", comment: "Text for the send button in the product review reply screen")
     static let cancel = NSLocalizedString("Cancel", comment: "Text for the cancel button in the product review reply screen")
+
+    // Notice strings
+    static let success = NSLocalizedString("Reply sent!", comment: "Notice text after sending a reply to a product review successfully")
+    static let error = NSLocalizedString("There was an error sending the reply", comment: "Notice text after failing to send a reply to a product review")
+    static let retry = NSLocalizedString("Retry", comment: "Retry Action")
 }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewReplyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewReplyViewModel.swift
@@ -62,7 +62,12 @@ final class ReviewReplyViewModel: ObservableObject {
             self.performingNetworkRequest.send(false)
 
             switch result {
-            case .success:
+            case .success(let status):
+                // If the comment isn't approved, log it (to help support)
+                if status != .approved {
+                    DDLogInfo("Reply to product review succeeded with comment status: \(status)")
+                }
+
                 self.displayReplySuccessNotice()
                 onCompletion(true)
             case .failure(let error):

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewReplyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewReplyViewModel.swift
@@ -6,6 +6,12 @@ import Yosemite
 ///
 final class ReviewReplyViewModel: ObservableObject {
 
+    private let siteID: Int64
+
+    /// ID for the product review being replied to.
+    ///
+    private let reviewID: Int64
+
     /// New reply to send
     ///
     @Published var newReply: String = ""
@@ -18,7 +24,14 @@ final class ReviewReplyViewModel: ObservableObject {
     ///
     private let performingNetworkRequest: CurrentValueSubject<Bool, Never> = .init(false)
 
-    init() {
+    /// Action dispatcher
+    ///
+    private let stores: StoresManager
+
+    init(siteID: Int64, reviewID: Int64, stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.reviewID = reviewID
+        self.stores = stores
         bindNavigationTrailingItemPublisher()
     }
 
@@ -27,8 +40,27 @@ final class ReviewReplyViewModel: ObservableObject {
     /// Use this method to send the reply and invoke a completion block when finished
     ///
     func sendReply(onCompletion: @escaping (Bool) -> Void) {
-        // TODO: Call CommentAction.replyToComment to send the reply to remote
-        // Set `performingNetworkRequest` to true while the request is being performed
+        guard newReply.isNotEmpty else {
+            return
+        }
+
+        let action = CommentAction.replyToComment(siteID: siteID, commentID: reviewID, content: newReply) { [weak self] result in
+            guard let self = self else { return }
+
+            self.performingNetworkRequest.send(false)
+
+            switch result {
+            case .success:
+                // TODO: Show a success notice, e.g. "Reply sent!"
+                onCompletion(true)
+            case .failure(let error):
+                // TODO: Show an error notice, e.g. "There was an error sending the reply"
+                onCompletion(false)
+            }
+        }
+
+        performingNetworkRequest.send(true)
+        stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Reviews/ReviewReplyViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Reviews/ReviewReplyViewModelTests.swift
@@ -1,11 +1,16 @@
 import XCTest
 @testable import WooCommerce
+@testable import Yosemite
 
 class ReviewReplyViewModelTests: XCTestCase {
 
+    private let sampleSiteID: Int64 = 12345
+
+    private let sampleReviewID: Int64 = 7
+
     func test_send_button_is_disabled_when_reply_content_is_empty() {
         // Given
-        let viewModel = ReviewReplyViewModel()
+        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID)
 
         // When
         let navigationItem = viewModel.navigationTrailingItem
@@ -16,12 +21,110 @@ class ReviewReplyViewModelTests: XCTestCase {
 
     func test_send_button_is_enabled_when_reply_is_entered() {
         // Given
-        let viewModel = ReviewReplyViewModel()
+        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID)
 
         // When
         viewModel.newReply = "New reply"
 
         // Then
         assertEqual(viewModel.navigationTrailingItem, .send(enabled: true))
+    }
+
+    func test_loading_indicator_enabled_during_network_request() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, stores: stores)
+        viewModel.newReply = "New reply"
+
+        // When
+        let navigationItem: ReviewReplyNavigationItem = waitFor { promise in
+            stores.whenReceivingAction(ofType: CommentAction.self) { action in
+                switch action {
+                case .replyToComment:
+                    promise(viewModel.navigationTrailingItem)
+                default:
+                    XCTFail("Received unsupported action: \(action)")
+                }
+            }
+            viewModel.sendReply { _ in }
+        }
+
+        // Then
+        XCTAssertEqual(navigationItem, .loading)
+    }
+
+    func test_send_button_renabled_after_network_request_completes() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, stores: stores)
+        stores.whenReceivingAction(ofType: CommentAction.self) { action in
+            switch action {
+            case let .replyToComment(_, _, _, onCompletion):
+                onCompletion(.failure(NSError(domain: "", code: 0)))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        viewModel.newReply = "New reply"
+        let navigationItem: ReviewReplyNavigationItem = waitFor { promise in
+            viewModel.sendReply { _ in
+                promise(viewModel.navigationTrailingItem)
+            }
+        }
+
+        // Then
+        XCTAssertEqual(navigationItem, .send(enabled: true))
+    }
+
+    func test_sendReply_completion_block_returns_true_after_successful_network_request() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, stores: stores)
+        stores.whenReceivingAction(ofType: CommentAction.self) { action in
+            switch action {
+            case let .replyToComment(_, _, _, onCompletion):
+                onCompletion(.success(.approved))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        viewModel.newReply = "New reply"
+        let successResponse: Bool = waitFor { promise in
+            viewModel.sendReply { successResponse in
+                promise(successResponse)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(successResponse)
+    }
+
+    func test_sendReply_completion_block_returns_false_after_failed_network_request() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, stores: stores)
+        stores.whenReceivingAction(ofType: CommentAction.self) { action in
+            switch action {
+            case let .replyToComment(_, _, _, onCompletion):
+                onCompletion(.failure(NSError(domain: "", code: 0)))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        viewModel.newReply = "New reply"
+        let successResponse: Bool = waitFor { promise in
+            viewModel.sendReply { successResponse in
+                promise(successResponse)
+            }
+        }
+
+        // Then
+        XCTAssertFalse(successResponse)
     }
 }


### PR DESCRIPTION
Part of #7777
⚠️ Depends on #7789 ⚠️ 

## Description

This PR hooks up the network request to the UI added in #7788 and #7789, to reply to a product review. Now, the reply is sent to the remote site after tapping the "Send" button on the "Reply to Product Review" screen. A loading indicator appears while the network request is being performed, and after it completes a notice appears:

* If the request is successful, the modal is dismissed and a "Reply sent!" notice appears.
* If the request fails, the modal is not dismissed (to avoid losing the reply content) and an error notice appears with a "Retry" action.

## Changes

* Updates `ReviewReplyViewModel` to call the `CommentAction.replyToComment` action when the "Send" button is tapped, and display a notice depending on the result.
* Updates the `ReviewReply` hosting controller to include a modal notice presenter (to display the error notice without dismissing the modal).
* Adds unit tests.

## Testing

Successful reply to a review:

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Tap "Menu" in the bottom navigation bar.
3. Select "Reviews" in the hub menu.
4. Select any product review from the list of reviews.
5. Tap the "Reply" button in the product review detail.
6. Enter some text and tap the "Send" button.
7. Confirm you see the success notice and the reply appears on your store.

Failed reply to review:

1. From the product review detail, tap the "Reply" button again.
2. Disable your network connection to force a network failure.
3. Enter some text and tap the "Send" button.
4. Confirm you see an error notice with a "Retry" button.

## Screenshots

Successful reply (success notice):


https://user-images.githubusercontent.com/8658164/193072691-e36f5c00-a23a-4c09-b0db-e45e5659eefc.mp4



Failed reply (error notice):


https://user-images.githubusercontent.com/8658164/193072713-92dfcaf6-648f-4438-aa92-97fa5a53b9c3.mp4



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
