### PR TITLE
Lock Screen Widgets: Add app link widget

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -37,6 +37,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .orderCreationSearchCustomers:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .lockscreenWidgets:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -77,4 +77,8 @@ public enum FeatureFlag: Int {
     /// Enables the Search Customers functionality in the Order Creation screen
     ///
     case orderCreationSearchCustomers
+
+    /// Enables lock screen widgets
+    ///
+    case lockscreenWidgets
 }

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -53,6 +53,10 @@ enum WooConstants {
     /// Store Info Widget Identifier.
     ///
     static let storeInfoWidgetKind = "StoreInfoWidget"
+
+    /// App link Widget Identifier.
+    ///
+    static let appLinkWidgetKind = "AppLinkWidget"
 }
 
 // MARK: URLs

--- a/WooCommerce/StoreWidgets/Lockscreen/AppLinkWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/AppLinkWidget.swift
@@ -5,8 +5,10 @@ import Experiments
 /// Static widget - app launch button
 ///
 struct AppLinkWidget: Widget {
+    private let enableLockscreenWidgets = DefaultFeatureFlagService().isFeatureFlagEnabled(.lockscreenWidgets)
+
     private var supportedFamilies: [WidgetFamily] {
-        if #available(iOSApplicationExtension 16.0, *) {
+        if #available(iOSApplicationExtension 16.0, *), enableLockscreenWidgets {
             return [.accessoryCircular]
         } else {
             return []

--- a/WooCommerce/StoreWidgets/Lockscreen/AppLinkWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/AppLinkWidget.swift
@@ -1,0 +1,91 @@
+import WidgetKit
+import SwiftUI
+import Experiments
+
+/// Static widget - app launch button
+///
+struct AppLinkWidget: Widget {
+    private var supportedFamilies: [WidgetFamily] {
+        if #available(iOSApplicationExtension 16.0, *) {
+            return [.accessoryCircular]
+        } else {
+            return []
+        }
+    }
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: WooConstants.appLinkWidgetKind, provider: AppLinkProvider()) { _ in
+            AppButtonView()
+        }
+        .configurationDisplayName(Localization.title)
+        .description(Localization.description)
+        .supportedFamilies(supportedFamilies)
+    }
+}
+
+private struct AppLinkProvider: TimelineProvider {
+    /// Type that represents the all the possible Widget states
+    ///
+    enum AppLinkEntry: TimelineEntry {
+        // Single possible state
+        case appLink
+
+        // Current date, needed by the `TimelineEntry` protocol.
+        var date: Date { Date() }
+    }
+
+    func placeholder(in context: Context) -> AppLinkEntry {
+        return .appLink
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (AppLinkEntry) -> Void) {
+        completion(.appLink)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<AppLinkEntry>) -> Void) {
+        let timeline = Timeline<AppLinkEntry>(entries: [.appLink], policy: .never)
+        completion(timeline)
+    }
+}
+
+private struct AppButtonView: View {
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(Color.black)
+            Image(uiImage: .wooLogoWhite)
+                .resizable()
+                .scaledToFit()
+                .padding(10)
+        }
+    }
+}
+
+// MARK: Constants
+
+/// Constants definition
+///
+private extension AppLinkWidget {
+    enum Localization {
+        static let title = AppLocalizedString(
+            "appLinkWidget.displayName",
+            value: "Icon",
+            comment: "Widget title, displayed when selecting which widget to add"
+        )
+        static let description = AppLocalizedString(
+            "appLinkWidget.description",
+            value: "Quickly Launch WooCommerce",
+            comment: "Widget description, displayed when selecting which widget to add"
+        )
+    }
+}
+
+// MARK: Previews
+
+@available(iOSApplicationExtension 16.0, *)
+struct AppLinkWidget_Previews: PreviewProvider {
+    static var previews: some View {
+        AppButtonView()
+            .previewContext(WidgetPreviewContext(family: .accessoryCircular))
+    }
+}

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -1,7 +1,6 @@
 import WidgetKit
 import SwiftUI
 import WooFoundation
-import Experiments
 
 /// Main StoreInfo Widget type.
 ///
@@ -325,11 +324,14 @@ struct StoreWidgets_Previews: PreviewProvider {
         )
         .previewContext(WidgetPreviewContext(family: .systemMedium))
         .environment(\.sizeCategory, .extraExtraLarge)
+        .previewDisplayName("XXL font")
 
         NotLoggedInView()
             .previewContext(WidgetPreviewContext(family: .systemMedium))
+            .previewDisplayName("Not logged in")
 
         UnableToFetchView()
             .previewContext(WidgetPreviewContext(family: .systemMedium))
+            .previewDisplayName("Unable to fetch data")
     }
 }

--- a/WooCommerce/StoreWidgets/StoreWidgets.swift
+++ b/WooCommerce/StoreWidgets/StoreWidgets.swift
@@ -8,5 +8,6 @@ struct StoreWidgetsBundle: WidgetBundle {
     var body: some Widget {
         // Add here any widget you want to be available
         StoreInfoWidget()
+        AppLinkWidget()
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1153,6 +1153,7 @@
 		AEC95D432774D07B001571F5 /* CreateOrderAddressFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC95D422774D07B001571F5 /* CreateOrderAddressFormViewModel.swift */; };
 		AECD57D226DFDF7500A3B580 /* EditOrderAddressForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */; };
 		AED089F227C794BC0020AE10 /* View+CurrencySymbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED089F127C794BC0020AE10 /* View+CurrencySymbol.swift */; };
+		AED9012D28E5F517002B4572 /* AppLinkWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED9012C28E5F517002B4572 /* AppLinkWidget.swift */; };
 		AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */; };
 		AEDDDA1A25CAB2170077F9B2 /* AttributePickerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */; };
 		AEE085B52897C871007ACE20 /* LinkedProductsPromoCampaign.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE085B42897C871007ACE20 /* LinkedProductsPromoCampaign.swift */; };
@@ -3041,6 +3042,7 @@
 		AEC95D422774D07B001571F5 /* CreateOrderAddressFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateOrderAddressFormViewModel.swift; sourceTree = "<group>"; };
 		AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditOrderAddressForm.swift; sourceTree = "<group>"; };
 		AED089F127C794BC0020AE10 /* View+CurrencySymbol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+CurrencySymbol.swift"; sourceTree = "<group>"; };
+		AED9012C28E5F517002B4572 /* AppLinkWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLinkWidget.swift; sourceTree = "<group>"; };
 		AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewController.swift; sourceTree = "<group>"; };
 		AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AttributePickerViewController.xib; sourceTree = "<group>"; };
 		AEE085B42897C871007ACE20 /* LinkedProductsPromoCampaign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedProductsPromoCampaign.swift; sourceTree = "<group>"; };
@@ -5353,6 +5355,7 @@
 			children = (
 				3F50FE4028C8319A00C89201 /* Entitlements */,
 				26FFD32828C6A0E4002E5E5E /* Images */,
+				AED9012B28E5F27B002B4572 /* Lockscreen */,
 				3F1FA84528B60125009E246C /* StoreWidgets.swift */,
 				265C99E028B9BA43005E6117 /* StoreInfoWidget.swift */,
 				265C99E328B9C834005E6117 /* StoreInfoProvider.swift */,
@@ -6474,6 +6477,14 @@
 				26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */,
 			);
 			path = "Address Edit";
+			sourceTree = "<group>";
+		};
+		AED9012B28E5F27B002B4572 /* Lockscreen */ = {
+			isa = PBXGroup;
+			children = (
+				AED9012C28E5F517002B4572 /* AppLinkWidget.swift */,
+			);
+			path = Lockscreen;
 			sourceTree = "<group>";
 		};
 		AEDDDA0825CA9C0A0077F9B2 /* Edit Attributes */ = {
@@ -9338,6 +9349,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AED9012D28E5F517002B4572 /* AppLinkWidget.swift in Sources */,
 				2608C50728C941D600C9DFC0 /* UserDefaults+Woo.swift in Sources */,
 				265C99E628B9CB8E005E6117 /* StoreInfoViewModifiers.swift in Sources */,
 				2608C50628C93AB700C9DFC0 /* WooConstants.swift in Sources */,


### PR DESCRIPTION
# Description
Since we have app extension fully set up for homescreen widgets, we can rely on existing data structure to add iOS 16 lock screen widgets support.
This is a first step, adding a static widget/button to quickly open Woo app from the lock screen. Inspired by Pocket Casts.

# How

- Adds feature flag.
- Adds `AppLinkWidget` with its own static `AppLinkProvider`.

# Testing Steps

1. Use iOS 16 device/simulator.
2. Build and run the app in debug mode (to ensure the feature flag is enabled).
3. Long press on lock screen.
4. Tap "Customize".
5. Tap on a bottom line of widgets.
6. In "Add Widgets" panel scroll to "Woo" app and tap it.
7. Tap the icon widget to add it on the lock screen.
8. Close widgets panel, tap "Done" in top right corner.
9. From lock screen tap newly added widget and confirm it launches the parent app.

Bonus: try app on iOS 15 device and verify it works (validate released home screen widget functionality).

# Screenshots

<img width=350 src="https://user-images.githubusercontent.com/3132438/193090612-c0054d6a-c254-4740-a830-b7d2a200c5f8.jpeg">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
