### PR TITLE
[Review Replies] Add analytics for replying to product reviews

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -385,6 +385,9 @@ public enum WooAnalyticsStat: String {
     case reviewsMarkAllReadFailed = "reviews_mark_all_read_failed"
     case reviewsProductsLoaded = "reviews_products_loaded"
     case reviewsProductsLoadFailed = "reviews_products_load_failed"
+    case reviewReplySend = "review_reply_send"
+    case reviewReplySendSuccess = "review_reply_send_success"
+    case reviewReplySendFailed = "review_reply_send_failed"
 
     // MARK: Product List Events
     //


### PR DESCRIPTION
Part of #7777

## Description

Adds three new analytics events, to track when a reply to a product review is sent:

* `review_reply_send` triggered when the "Send" button is tapped (1086-gh-tracks-events-registration)
* `review_reply_send_success` triggered if the remote request succeeds (1087-gh-tracks-events-registration)
* `review_reply_send_failed` triggered if the remote request fails (1088-gh-tracks-events-registration)

## Changes

* Adds the new events to `WooAnalyticsStat`.
* Calls the three events in `ReviewReplyViewModel` when the reply is sent, and when the remote response is received.

## Testing

Successful reply to a review:

1. Build and run the app in debug mode (to ensure the feature flag is enabled).
2. Tap "Menu" in the bottom navigation bar.
3. Select "Reviews" in the hub menu.
4. Select any product review from the list of reviews.
5. Tap the "Reply" button in the product review detail.
6. Enter some text and tap the "Send" button. Confirm the `review_reply_send` event is triggered.
7. Confirm that when the reply is sent successfully, the `review_reply_send_success` event is triggered.

Failed reply to review:

1. From the product review detail, tap the "Reply" button again.
2. Disable your network connection to force a network failure.
3. Enter some text and tap the "Send" button. Confirm the `review_reply_send` event is triggered.
4. Confirm that when the reply fails, the `review_reply_send_failed` event is triggered.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
