### PR TITLE
[Review Replies] Remove feature flag to release replying to product reviews

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -39,8 +39,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .lockscreenWidgets:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .replyToProductReviews:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -81,8 +81,4 @@ public enum FeatureFlag: Int {
     /// Enables lock screen widgets
     ///
     case lockscreenWidgets
-
-    /// Enables replying to product reviews
-    ///
-    case replyToProductReviews
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] Settings: Display the WooCommerce version and available updates in Settings [https://github.com/woocommerce/woocommerce-ios/pull/7779]
 - [*] Show suggestion for logging in to a WP.com site with a mismatched WP.com account. [https://github.com/woocommerce/woocommerce-ios/pull/7773]
 - [*] Help center: Added help center web page with FAQs for "Not a WooCommerce site" and "Wrong WordPress.com account" error screens. [https://github.com/woocommerce/woocommerce-ios/pull/7767, https://github.com/woocommerce/woocommerce-ios/pull/7769]
+- [**] Reviews: Now you can reply to product reviews using the Reply button while viewing a product review. [https://github.com/woocommerce/woocommerce-ios/pull/7799]
 
 10.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 import Yosemite
 import Gridicons
 import SafariServices
-import Experiments
 
 
 // MARK: - ReviewDetailsViewController
@@ -45,16 +44,13 @@ final class ReviewDetailsViewController: UIViewController {
     ///
     private var rows = [Row]()
 
-    private let featureFlagService: FeatureFlagService
-
     /// Designated Initializer
     ///
-    init(productReview: ProductReview, product: Product?, notification: Note?, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+    init(productReview: ProductReview, product: Product?, notification: Note?) {
         self.productReview = productReview
         self.siteID = productReview.siteID
         self.product = product
         self.notification = notification
-        self.featureFlagService = featureFlagService
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -336,7 +332,7 @@ private extension ReviewDetailsViewController {
         commentCell.isTrashEnabled    = true
         commentCell.isSpamEnabled     = true
         commentCell.isApproveSelected = productReview.status == .approved
-        commentCell.isReplyEnabled    = featureFlagService.isFeatureFlagEnabled(.replyToProductReviews)
+        commentCell.isReplyEnabled    = true
 
         let reviewID = productReview.reviewID
         let reviewSiteID = productReview.siteID


### PR DESCRIPTION
Closes: #7777

## Description

This PR removes the feature flag for replying to product reviews, releasing it to all users.

## Changes

* Removes `replyToProductReviews` feature flag.
* Removes the feature flag check in `ReviewDetailsViewController`.

## Testing

1. Build and run the app.
2. Tap "Menu" in the bottom navigation bar.
3. Select "Reviews" in the hub menu.
4. Select any product review from the list of reviews.
5. Tap the "Reply" button in the product review detail.
6. Enter a reply in the "Reply to Product Review" screen and tap "Send."
7. Confirm you see a success/error notice after the reply is sent.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
