### PR TITLE
Bulk Prices: Shows API limit warning

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
@@ -77,6 +77,7 @@ final class BulkUpdateViewController: UIViewController, GhostableViewController 
                 self.sections = sections
                 self.removeGhostContent()
                 self.tableView.reloadData()
+                self.displayTooManyVariationsWarningIfNeeded()
             case .error:
                 self.removeGhostContent()
                 self.displaySyncingError()
@@ -146,6 +147,26 @@ final class BulkUpdateViewController: UIViewController, GhostableViewController 
         })
         let viewController = BulkUpdatePriceViewController(viewModel: bulkUpdatePriceSettingsViewModel)
         show(viewController, sender: nil)
+    }
+
+    /// Displays a warning informing the user that only the first 100 variations would be editted.
+    /// This is due to API limitations.
+    ///
+    private func displayTooManyVariationsWarningIfNeeded() {
+        guard viewModel.shouldShowVariationLimitWarning else {
+            return
+        }
+
+        let bannerViewModel = TopBannerViewModel(title: nil,
+                                    infoText: Localization.tooManyVariations,
+                                    icon: .noticeImage,
+                                    iconTintColor: .warning,
+                                    isExpanded: false,
+                                    topButton: .none,
+                                    type: .warning)
+        let banner = TopBannerView(viewModel: bannerViewModel)
+        tableView.tableHeaderView = banner
+        tableView.updateHeaderHeight()
     }
 }
 
@@ -267,6 +288,8 @@ private extension BulkUpdateViewController {
         static let noticeRetryAction = NSLocalizedString("Retry", comment: "Retry Action")
         static let pricesUpdated = NSLocalizedString("Prices updated successfully.",
                                                      comment: "Notice title when updating the price via the bulk variation screen")
+        static let tooManyVariations = NSLocalizedString("Only the first 100 variations will be updated.",
+                                                         comment: "Warning when trying to bulk edit more than 100 variations")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
@@ -26,6 +26,10 @@ final class BulkUpdateViewModel {
     private let currencyFormatter: CurrencyFormatter
     private var onCancelButtonTapped: () -> Void
 
+    /// Returns `true` if there are more than 100 variations to edit.
+    ///
+    let shouldShowVariationLimitWarning: Bool
+
     /// Product Variations Controller.
     ///
     private lazy var resultsController: ResultsController<StorageProductVariation> = {
@@ -48,6 +52,7 @@ final class BulkUpdateViewModel {
 
     init(siteID: Int64,
          productID: Int64,
+         variationCount: Int,
          onCancelButtonTapped: @escaping () -> Void,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          storesManager: StoresManager = ServiceLocator.stores,
@@ -59,6 +64,7 @@ final class BulkUpdateViewModel {
         self.storesManager = storesManager
         self.currencySettings = currencySettings
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        self.shouldShowVariationLimitWarning = variationCount > Constants.numberOfObjects
         syncState = .notStarted
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -575,7 +575,10 @@ private extension ProductVariationsViewController {
         actionSheet.addDefaultActionWithTitle(ActionSheetStrings.bulkUpdate) { [weak self] _ in
             guard let self = self else { return }
 
-            let viewModel = BulkUpdateViewModel(siteID: self.siteID, productID: self.productID, onCancelButtonTapped: { [weak self] in
+            let viewModel = BulkUpdateViewModel(siteID: self.siteID,
+                                                productID: self.productID,
+                                                variationCount: self.product.variations.count,
+                                                onCancelButtonTapped: { [weak self] in
                 self?.dismiss(animated: true)
             })
             let navigationController = WooNavigationController(rootViewController: BulkUpdateViewController(viewModel: viewModel))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewControllerTests.swift
@@ -14,7 +14,12 @@ final class BulkUpdateViewControllerTests: XCTestCase {
         let storageManager =  MockStorageManager()
         let storesManager = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         let noticePresenter = MockNoticePresenter()
-        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 0,
+                                            productID: 0,
+                                            variationCount: 10,
+                                            onCancelButtonTapped: {},
+                                            storageManager: storageManager,
+                                            storesManager: storesManager)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
@@ -33,6 +33,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         let expectedPageNumber = 1
         let viewModel = BulkUpdateViewModel(siteID: expectedSiteID,
                                             productID: expectedProductID,
+                                            variationCount: 10,
                                             onCancelButtonTapped: {},
                                             storageManager: storageManager,
                                             storesManager: storesManager)
@@ -56,7 +57,12 @@ final class BulkUpdateViewModelTests: XCTestCase {
 
     func test_initial_sync_state() throws {
         // Given
-        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 0,
+                                            productID: 0,
+                                            variationCount: 10,
+                                            onCancelButtonTapped: {},
+                                            storageManager: storageManager,
+                                            storesManager: storesManager)
 
         // Then
         XCTAssertEqual(viewModel.syncState, .notStarted)
@@ -64,7 +70,12 @@ final class BulkUpdateViewModelTests: XCTestCase {
 
     func test_sync_state_updates_to_loading_when_product_variations_syncing_starts() {
         // Given
-        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 0,
+                                            productID: 0,
+                                            variationCount: 10,
+                                            onCancelButtonTapped: {},
+                                            storageManager: storageManager,
+                                            storesManager: storesManager)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { _ in
             // do nothing to stay in "syncing" state
         }
@@ -78,7 +89,12 @@ final class BulkUpdateViewModelTests: XCTestCase {
 
     func test_sync_state_updates_to_syncerror_when_product_variations_syncing_fails() {
         // Given
-        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 0,
+                                            productID: 0,
+                                            variationCount: 10,
+                                            onCancelButtonTapped: {},
+                                            storageManager: storageManager,
+                                            storesManager: storesManager)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
@@ -97,7 +113,12 @@ final class BulkUpdateViewModelTests: XCTestCase {
 
     func test_sync_state_updates_to_syncResults_when_product_variations_syncing_is_successful() {
         // Given
-        let viewModel = BulkUpdateViewModel(siteID: 0, productID: 0, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 0,
+                                            productID: 0,
+                                            variationCount: 10,
+                                            onCancelButtonTapped: {},
+                                            storageManager: storageManager,
+                                            storesManager: storesManager)
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
@@ -128,7 +149,12 @@ final class BulkUpdateViewModelTests: XCTestCase {
                 XCTFail("Unsupported Action")
             }
         }
-        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 1,
+                                            productID: 1,
+                                            variationCount: 10,
+                                            onCancelButtonTapped: {},
+                                            storageManager: storageManager,
+                                            storesManager: storesManager)
 
         // When
         viewModel.syncVariations()
@@ -161,6 +187,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         }
         let viewModel = BulkUpdateViewModel(siteID: 1,
                                             productID: 1,
+                                            variationCount: 10,
                                             onCancelButtonTapped: {},
                                             storageManager: storageManager,
                                             storesManager: storesManager,
@@ -196,7 +223,12 @@ final class BulkUpdateViewModelTests: XCTestCase {
                 XCTFail("Unsupported Action")
             }
         }
-        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 1,
+                                            productID: 1,
+                                            variationCount: 10,
+                                            onCancelButtonTapped: {},
+                                            storageManager: storageManager,
+                                            storesManager: storesManager)
 
         // When
         viewModel.syncVariations()
@@ -228,7 +260,12 @@ final class BulkUpdateViewModelTests: XCTestCase {
                 XCTFail("Unsupported Action")
             }
         }
-        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 1,
+                                            productID: 1,
+                                            variationCount: 10,
+                                            onCancelButtonTapped: {},
+                                            storageManager: storageManager,
+                                            storesManager: storesManager)
 
         // When
         viewModel.syncVariations()
@@ -260,7 +297,12 @@ final class BulkUpdateViewModelTests: XCTestCase {
                 XCTFail("Unsupported Action")
             }
         }
-        let viewModel = BulkUpdateViewModel(siteID: 1, productID: 1, onCancelButtonTapped: {}, storageManager: storageManager, storesManager: storesManager)
+        let viewModel = BulkUpdateViewModel(siteID: 1,
+                                            productID: 1,
+                                            variationCount: 10,
+                                            onCancelButtonTapped: {},
+                                            storageManager: storageManager,
+                                            storesManager: storesManager)
 
         // When
         viewModel.syncVariations()
@@ -281,6 +323,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         var onCancelButtonTappedInvoked = false
         let viewModel = BulkUpdateViewModel(siteID: 0,
                                             productID: 0,
+                                            variationCount: 10,
                                             onCancelButtonTapped: {
                                                 onCancelButtonTappedInvoked = true
                                             },
@@ -292,6 +335,32 @@ final class BulkUpdateViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(onCancelButtonTappedInvoked)
+    }
+
+    func test_less_than_100_variations_shows_warning() throws {
+        // Given
+        let viewModel = BulkUpdateViewModel(siteID: 0,
+                                            productID: 0,
+                                            variationCount: 10,
+                                            onCancelButtonTapped: {},
+                                            storageManager: storageManager,
+                                            storesManager: storesManager)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowVariationLimitWarning)
+    }
+
+    func test_more_than_100_variations_does_not_shows_warning() throws {
+        // Given
+        let viewModel = BulkUpdateViewModel(siteID: 0,
+                                            productID: 0,
+                                            variationCount: 101,
+                                            onCancelButtonTapped: {},
+                                            storageManager: storageManager,
+                                            storesManager: storesManager)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowVariationLimitWarning)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
@@ -337,7 +337,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         XCTAssertTrue(onCancelButtonTappedInvoked)
     }
 
-    func test_less_than_100_variations_shows_warning() throws {
+    func test_less_than_100_variations_does_not_shows_warning() throws {
         // Given
         let viewModel = BulkUpdateViewModel(siteID: 0,
                                             productID: 0,
@@ -350,7 +350,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldShowVariationLimitWarning)
     }
 
-    func test_more_than_100_variations_does_not_shows_warning() throws {
+    func test_more_than_100_variations_shows_shows_warning() throws {
         // Given
         let viewModel = BulkUpdateViewModel(siteID: 0,
                                             productID: 0,


### PR DESCRIPTION
Closes: #6309

# Why 

One of our API limitations is that we can't batch update more than 100 product variations. Currently, the bulk update variation view model was capping the update to 100 records without notifying the merchant.

This PR makes sure a propper warning is presented when the merchant tries to bulk edit a product that has more than 100 variations. 

# How

- Expose a new `shouldShowVariationLimitWarning` view model property.
- Update VC to show a warning top banner when necessary.

# Screenshots

Less than 100 | More than 100
---- | ----
<img width="437" alt="less" src="https://user-images.githubusercontent.com/562080/193310594-95ec1b08-f36d-4232-aa3d-70acac38e52d.png"> | <img width="436" alt="more" src="https://user-images.githubusercontent.com/562080/193310590-9e3ec46c-db34-4487-8aa8-b03fc6717768.png">

# Testings

Note: As you may not have a product with 100 variations you can just hardcode the [`variationCount`](https://github.com/woocommerce/woocommerce-ios/pull/7802/files#diff-61c28dceef078ec1124d12c1208911ecac0ec73275b36242deafd4990519d460R580) to `101` before testing the PR.

- Go to a variable product
- Go to the variations section
- Tap the "bulk update" from the top right menu
- See the warning banner.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
