### PR TITLE
Add docs and unit test for Model 70 CD migration

### DIFF
--- a/Storage/Storage/Model/MIGRATIONS.md
+++ b/Storage/Storage/Model/MIGRATIONS.md
@@ -6,7 +6,7 @@ This file documents changes in the WCiOS Storage data model. Please explain any 
 - @jaclync 2022-09-14
     - Added `filterKey` attribute to `ProductSearchResults` entity.
 
-## Model 71 (Release 9.6.0.0)
+## Model 72 (Release 9.6.0.0)
 - @joshheald 2022-08-19
     - Added `instructions` attribute to `PaymentGateway` entity.
 
@@ -14,6 +14,10 @@ This file documents changes in the WCiOS Storage data model. Please explain any 
 - @rachelmcr 2022-07-07
     - Added `OrderMetaData` entity.
     - Added `customFields` to-many relationship from `Order` to `OrderMetaData`.
+
+## Model 70 (Release 9.5.0.0)
+- @toupper 2022-06-22
+    - Update `OrderItemRefund` entity to include the `refundedItemID` property.
 
 ## Model 69 (Release 9.4.0.0)
 - @ecarrion 2022-06-08

--- a/Storage/StorageTests/CoreData/MigrationTests.swift
+++ b/Storage/StorageTests/CoreData/MigrationTests.swift
@@ -1203,6 +1203,27 @@ final class MigrationTests: XCTestCase {
         XCTAssertEqual(migratedOrder.value(forKey: "needsProcessing") as? Bool, false)
     }
 
+    func test_migrating_from_69_to_70_adds_refundedItemID_property_to_OrderItemRefund() throws {
+        // Given
+        let sourceContainer = try startPersistentContainer("Model 69")
+        let sourceContext = sourceContainer.viewContext
+
+        let orderItemRefund = insertOrderItemRefund(to: sourceContext)
+
+        // Confidence check:
+        // The `itemID` property already exists on Model 69, but the `refundedItemID` does not
+        XCTAssertNotNil(orderItemRefund.entity.attributesByName["itemID"])
+        XCTAssertNil(orderItemRefund.entity.attributesByName["refundedItemID"])
+
+        // When
+        let targetContainer = try migrate(sourceContainer, to: "Model 70")
+        let targetContext = targetContainer.viewContext
+        let migratedOrderItemRefund = insertOrderItemRefund(to: targetContext)
+
+        // Confirms the `refundedItemID` property now exists on Model 70
+        XCTAssertNotNil(migratedOrderItemRefund.entity.attributesByName["refundedItemID"])
+    }
+
     func test_migrating_from_70_to_71_adds_custom_fields_property_to_order() throws {
         // Given
         let sourceContainer = try startPersistentContainer("Model 70")
@@ -1524,6 +1545,13 @@ private extension MigrationTests {
             "byUserID": 456,
             "isAutomated": false,
             "createAutomated": false
+        ])
+    }
+
+    @discardableResult
+    func insertOrderItemRefund(to context: NSManagedObjectContext) -> NSManagedObject {
+        context.insert(entityName: "OrderItemRefund", properties: [
+            "itemID": 123
         ])
     }
 


### PR DESCRIPTION
### Description
This PR adds the `69_to_70` migration test between Core Data models, which checks if the `refundedItemID` property is being added to the `OrderItemRefund` property on Model 70.

### Testing instructions
Confirm that Unit Tests pass successfully.