### PR TITLE
Upgrade `bash-cache` plugin to version 2.8.0

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -13,7 +13,7 @@ common_params:
         repo: "woocommerce/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-13.4.1
+    IMAGE_ID: xcode-14
 
 steps:
 

--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -8,7 +8,7 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/bash-cache#2.8.0
-    - automattic/git-s3-cache#v1.1.0:
+    - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         repo: "woocommerce/woocommerce-ios/"
   # Common environment values to use with the `env` key.

--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -7,7 +7,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#v1.5.0
+    - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.0:
         bucket: "a8c-repo-mirrors"
         repo: "woocommerce/woocommerce-ios/"
@@ -25,10 +25,6 @@ steps:
   #################
   - label: ":cocoapods: Rebuild CocoaPods cache"
     command: |
-      # Workaround for https://github.com/Automattic/buildkite-ci/issues/79
-      echo "--- :rubygems: Fixing Ruby Setup"
-      gem install bundler
-
       echo "--- :rubygems: Setting up Gems"
       install_gems
 

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :rubygems: Setting up Gems"
 restore_cache "$(hash_file .ruby-version)-$(hash_file Gemfile.lock)"
 install_gems

--- a/.buildkite/commands/installable-build.sh
+++ b/.buildkite/commands/installable-build.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 # FIXIT-13.1: Installable Builds want the latest version of Sentry CLI
 brew update
 brew upgrade sentry-cli

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :arrow_down: Installing Release Dependencies"
 brew update # Update homebrew to temporarily fix a bintray issue
 brew install imagemagick

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -13,10 +13,6 @@ else
   export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPAD
 fi
 
-# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 # FIXIT-13.1: Temporary fix until all VMs have a JVM
 brew install openjdk@11
 sudo ln -sfn /usr/local/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -8,10 +8,6 @@ echo "--- 📦 Downloading Build Artifacts"
 buildkite-agent artifact download build-products.tar .
 tar -xf build-products.tar
 
-# Workaround for https://github.com/Automattic/buildkite-ci/issues/79
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :rubygems: Setting up Gems"
 install_gems
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/bash-cache#2.8.0
-    - automattic/git-s3-cache#v1.1.0:
+    - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         repo: "woocommerce/woocommerce-ios/"
   # Common environment values to use with the `env` key.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#v1.5.0
+    - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.0:
         bucket: "a8c-repo-mirrors"
         repo: "woocommerce/woocommerce-ios/"

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -10,7 +10,7 @@ common_params:
         repo: "woocommerce/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-13.4.1
+    IMAGE_ID: xcode-14
 
 steps:
 

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -5,7 +5,7 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/bash-cache#2.8.0
-    - automattic/git-s3-cache#v1.1.0:
+    - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         repo: "woocommerce/woocommerce-ios/"
   # Common environment values to use with the `env` key.

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,7 +4,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#v1.5.0
+    - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.0:
         bucket: "a8c-repo-mirrors"
         repo: "woocommerce/woocommerce-ios/"


### PR DESCRIPTION
### Description

This version includes a fix that allows us to remove the `gem install workaround`.

While I was at it, I also update the `git-s3-cache` plugin and the cache builder and release pipeline to use Xcode 14.

### Testing instructions
If CI is green, we're good. I also opened a PR that hacked the CI pipeline to test the steps outside the default pipeline #7811. [It passed](https://buildkite.com/automattic/woocommerce-ios/builds/8184#_).

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – N.A.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
