### PR TITLE
Bulk Update: Add analytics for bulk update variation prices feature

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -222,6 +222,11 @@ extension WooAnalyticsEvent {
             static let variationID = "product_variation_id"
             static let serverTime = "time"
             static let errorDescription = "error_description"
+            static let field = "field"
+        }
+
+        enum BulkUpdateField: String {
+            case regularPrice = "regular_price"
         }
 
         static func addFirstVariationButtonTapped(productID: Int64) -> WooAnalyticsEvent {
@@ -288,6 +293,22 @@ extension WooAnalyticsEvent {
         static func editVariationAttributeOptionsDoneButtonTapped(productID: Int64, variationID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .editProductVariationAttributeOptionsDoneButtonTapped, properties: [Keys.productID: "\(productID)",
                                                                                                             Keys.variationID: "\(variationID)"])
+        }
+
+        static func variationBulkUpdateSectionTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productVariationBulkUpdateSectionTapped, properties: [:])
+        }
+
+        static func variationBulkUpdateFieldTapped(field: BulkUpdateField) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productVariationBulkUpdateFieldTapped, properties: [Keys.field: field.rawValue])
+        }
+
+        static func variationBulkUpdateFieldSuccess(field: BulkUpdateField) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productVariationBulkUpdateFieldSuccess, properties: [Keys.field: field.rawValue])
+        }
+
+        static func variationBulkUpdateRegularPriceFailed(field: BulkUpdateField, error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productVariationBulkUpdateFieldFail, properties: [Keys.field: field.rawValue], error: error)
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -295,19 +295,19 @@ extension WooAnalyticsEvent {
                                                                                                             Keys.variationID: "\(variationID)"])
         }
 
-        static func variationBulkUpdateSectionTapped() -> WooAnalyticsEvent {
+        static func bulkUpdateSectionTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productVariationBulkUpdateSectionTapped, properties: [:])
         }
 
-        static func variationBulkUpdateFieldTapped(field: BulkUpdateField) -> WooAnalyticsEvent {
+        static func bulkUpdateFieldTapped(field: BulkUpdateField) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productVariationBulkUpdateFieldTapped, properties: [Keys.field: field.rawValue])
         }
 
-        static func variationBulkUpdateFieldSuccess(field: BulkUpdateField) -> WooAnalyticsEvent {
+        static func bulkUpdateFieldSuccess(field: BulkUpdateField) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productVariationBulkUpdateFieldSuccess, properties: [Keys.field: field.rawValue])
         }
 
-        static func variationBulkUpdateRegularPriceFailed(field: BulkUpdateField, error: Error) -> WooAnalyticsEvent {
+        static func bulkUpdateRegularPriceFailed(field: BulkUpdateField, error: Error) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productVariationBulkUpdateFieldFail, properties: [Keys.field: field.rawValue], error: error)
         }
     }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -307,7 +307,7 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productVariationBulkUpdateFieldSuccess, properties: [Keys.field: field.rawValue])
         }
 
-        static func bulkUpdateRegularPriceFailed(field: BulkUpdateField, error: Error) -> WooAnalyticsEvent {
+        static func bulkUpdateFieldFailed(field: BulkUpdateField, error: Error) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productVariationBulkUpdateFieldFail, properties: [Keys.field: field.rawValue], error: error)
         }
     }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -456,6 +456,11 @@ public enum WooAnalyticsStat: String {
     case productVariationDetailUpdateSuccess = "product_variation_update_success"
     case productVariationDetailUpdateError = "product_variation_update_error"
 
+    case productVariationBulkUpdateSectionTapped = "product_variation_bulk_update_section_tapped"
+    case productVariationBulkUpdateFieldTapped = "product_variation_bulk_update_field_tapped"
+    case productVariationBulkUpdateFieldSuccess = "product_variation_bulk_update_field_success"
+    case productVariationBulkUpdateFieldFail = "product_variation_bulk_update_field_fail"
+
     // MARK: Product Images Events
     //
     case productImageSettingsDoneButtonTapped = "product_image_settings_done_button_tapped"

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -583,6 +583,8 @@ private extension ProductVariationsViewController {
             })
             let navigationController = WooNavigationController(rootViewController: BulkUpdateViewController(viewModel: viewModel))
             self.present(navigationController, animated: true)
+
+            self.analytics.track(event: .Variations.bulkUpdateSectionTapped())
         }
 
         actionSheet.addCancelActionWithTitle(ActionSheetStrings.cancel)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7815 

# Why

This PR adds the relevant analytics events to properly measure if the bulk update variation prices feature is being properly discovered and used.

The events added are.

- [`*_product_variation_bulk_update_section_tapped`](https://github.com/Automattic/tracks-events-registration/pull/1099)
- [`*_product_variation_bulk_update_field_tapped` (field -> Enum(regular_price))](https://github.com/Automattic/tracks-events-registration/pull/1100)
- [`*_product_variation_update_field_success` (field -> Enum(regular_price))](https://github.com/Automattic/tracks-events-registration/pull/1101)
- [`*_product_variation_update_field_fail` (field -> Enum(regular_price), error)](https://github.com/Automattic/tracks-events-registration/pull/1102)

# Screenshot

<img width="1689" alt="Screen Shot 2022-10-05 at 5 26 01 PM" src="https://user-images.githubusercontent.com/562080/194179221-3c32a4d9-feb0-4884-a391-d7a5d96d3498.png">

# Testing Steps

- Go to into a variable product
- Tap on the variations row
- Tap on the Bulk Update button on the top right
- See the `*_product_variation_bulk_update_section_tapped` event fire
- Update the variations price
- See the `_product_variation_bulk_update_field_tapped` and `_product_variation_update_field_success` events being fired
- Update the price again but without internet.
- See the `_product_variation_update_field_fail` event fire.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
