### PR TITLE
Store picker - Continue button loading state

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,4 +371,4 @@ DEPENDENCIES
   xcpretty-travis-formatter
 
 BUNDLED WITH
-   2.3.22
+   2.3.23

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 10.7
 -----
 - [internal] Store picker: Show error when the role eligibility check fails while selecting a store. [https://github.com/woocommerce/woocommerce-ios/pull/7816]
+- [internal] Store picker: Add loading state to `Continue` button. [https://github.com/woocommerce/woocommerce-ios/pull/7821]
 
 
 10.6

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -119,13 +119,4 @@ private extension StorePickerCoordinator {
             self.onDismiss?()
         }
     }
-
-    /// Displays a generic error view as a modal with options to see troubleshooting tips and to contact support.
-    ///
-    func displayUnknownErrorModal() {
-        let viewController = StorePickerErrorHostingController.createWithActions(presenting: storePicker)
-        viewController.modalPresentationStyle = .custom
-        viewController.transitioningDelegate = storePicker
-        storePicker.present(viewController, animated: true)
-    }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -49,22 +49,7 @@ final class StorePickerCoordinator: Coordinator {
 extension StorePickerCoordinator: StorePickerViewControllerDelegate {
 
     func didSelectStore(with storeID: Int64, onCompletion: @escaping SelectStoreClosure) {
-        roleEligibilityUseCase.checkEligibility(for: storeID) { [weak self] result in
-            guard let self = self else { return }
-
-            switch result {
-            case .success:
-                // if user is eligible, then switch to the desired store.
-                self.switchStore(with: storeID, onCompletion: onCompletion)
-
-            case .failure(let error):
-                if case let RoleEligibilityError.insufficientRole(errorInfo) = error {
-                    self.showRoleErrorScreen(for: storeID, errorInfo: errorInfo, onCompletion: onCompletion)
-                } else {
-                    self.displayUnknownErrorModal()
-                }
-            }
-        }
+        switchStore(with: storeID, onCompletion: onCompletion)
     }
 
     /// Shows a Role Error page using the provided error information.

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -723,6 +723,32 @@ private extension StorePickerViewController {
         navigationController?.show(noWooUI, sender: nil)
         navigationController?.setNavigationBarHidden(false, animated: true)
     }
+
+    func checkRoleEligibility(for site: Site) {
+        guard let delegate = delegate else {
+            return
+        }
+
+        viewModel.checkEligibility(for: site.siteID) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success:
+                // if user is eligible, then switch to the desired store.
+                delegate.didSelectStore(with: site.siteID) { [weak self] in
+                    self?.dismiss()
+                }
+            case .failure(let error):
+                if case let RoleEligibilityError.insufficientRole(errorInfo) = error {
+                    delegate.showRoleErrorScreen(for: site.siteID, errorInfo: errorInfo) { [weak self] in
+                        self?.dismiss()
+                    }
+                } else {
+                    self.displayUnknownErrorModal()
+                }
+            }
+        }
+    }
 }
 
 private extension StorePickerViewController {

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -729,8 +729,12 @@ private extension StorePickerViewController {
             return
         }
 
+        updateActionButtonAndTableState(animating: true, enabled: false)
+
         viewModel.checkEligibility(for: site.siteID) { [weak self] result in
             guard let self = self else { return }
+
+            self.updateActionButtonAndTableState(animating: false, enabled: true)
 
             switch result {
             case .success:

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -549,16 +549,11 @@ extension StorePickerViewController {
         case .empty:
             restartAuthentication()
         default:
-            guard let delegate = delegate else {
-                return
-            }
             guard let site = currentlySelectedSite else {
                 return
             }
 
-            delegate.didSelectStore(with: site.siteID) { [weak self] in
-                self?.dismiss()
-            }
+            checkRoleEligibility(for: site)
         }
     }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -20,6 +20,11 @@ protocol StorePickerViewControllerDelegate: AnyObject {
     ///
     func didSelectStore(with storeID: Int64, onCompletion: @escaping SelectStoreClosure)
 
+    /// Shows a Role Error page using the provided error information.
+    /// The error page is pushed to the navigation stack so the user is not locked out, and can go back to select another store.
+    ///
+    func showRoleErrorScreen(for siteID: Int64, errorInfo: StorageEligibilityErrorInfo, onCompletion: @escaping SelectStoreClosure)
+
     /// Notifies the delegate to dismiss the store picker and restart authentication.
     func restartAuthentication()
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -25,6 +25,7 @@ final class StorePickerViewModel {
     private let storageManager: StorageManagerType
     private let stores: StoresManager
     private let analytics: Analytics
+    private let roleEligibilityUseCase: RoleEligibilityUseCase
 
     init(configuration: StorePickerConfiguration,
          stores: StoresManager = ServiceLocator.stores,
@@ -34,6 +35,7 @@ final class StorePickerViewModel {
         self.stores = stores
         self.storageManager = storageManager
         self.analytics = analytics
+        self.roleEligibilityUseCase = RoleEligibilityUseCase(stores: stores)
     }
 
     func trackScreenView() {
@@ -52,6 +54,17 @@ final class StorePickerViewModel {
         synchronizeSites(selectedSiteID: currentlySelectedSiteID) { [weak self] _ in
             self?.refetchSitesAndUpdateState()
         }
+    }
+
+    /// Checks whether the current authenticated session has the correct role to manage the store.
+    /// Any error returned from the block means that the user is not eligible.
+    ///
+    /// - Parameters:
+    ///   - storeID: The dotcom site ID of the store.
+    ///   - completion: The block to be called when the check completes, with an optional RoleEligibilityError.
+    ///   
+    func checkEligibility(for storeID: Int64, completion: @escaping (Result<Void, RoleEligibilityError>) -> Void) {
+        roleEligibilityUseCase.checkEligibility(for: storeID, completion: completion)
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -62,7 +62,7 @@ final class StorePickerViewModel {
     /// - Parameters:
     ///   - storeID: The dotcom site ID of the store.
     ///   - completion: The block to be called when the check completes, with an optional RoleEligibilityError.
-    ///   
+    ///
     func checkEligibility(for storeID: Int64, completion: @escaping (Result<Void, RoleEligibilityError>) -> Void) {
         roleEligibilityUseCase.checkEligibility(for: storeID, completion: completion)
     }


### PR DESCRIPTION
Part of: #7786

### Description

https://github.com/woocommerce/woocommerce-ios/pull/7816 started showing an error alert view when role eligibility check fails. During the PR review it was reported that the `Continue` button doesn't change its state properly. 

> I see that the Continue button doesn't change its state when tapped, which looks a bit confusing and I kept tapping a few times, resulting in the alert being displayed a few times afterward. Should we disable the button and show the loading indicator to indicate that some request is being made?

This PR aims to fix that by moving the role eligibility check away from coordinator.

### Testing instructions

1. Install and launch the app.
1. Tap `Skip` to reach the login prologue screen.
1. Tap the `Continue with WordPress.com` button and sign in.
1. You will land on the store picker screen from where you can select a store.
1. Tap the `Continue` button and verify that the button goes into a loading state before showing an error or navigating to the home screen. (You can turn off wifi before tapping the `Continue` button to test error flow.)

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/524475/194234161-a0435157-039f-4250-90da-2873c74a45e2.mov


https://user-images.githubusercontent.com/524475/194234264-c68d2cd6-bdbc-4d1f-b675-084fe2b41fb6.mov



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
