### PR TITLE
CustomerSearchResults to Customer mapping logic

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -108,7 +108,7 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
             keyword: "hello") { result in
                 switch result {
                 case .success():
-                    print("Step 1 - SearchResults: Success!")
+                    print("Step 1.3 - SearchResults: Completed!")
                 case .failure(let error):
                     print(error)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -103,12 +103,13 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
     /// https://github.com/woocommerce/woocommerce-ios/issues/7741
     ///
     func customerSearchTapped() {
+        print("1 - SearchResults: Start")
         let action = CustomerAction.searchCustomers(
             siteID: siteID,
             keyword: "hello") { result in
                 switch result {
                 case .success():
-                    print("Step 1.3 - SearchResults: Completed!")
+                    print("9 - SearchResults: End")
                 case .failure(let error):
                     print(error)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -108,7 +108,7 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
             keyword: "hello") { result in
                 switch result {
                 case .success():
-                    print("Success!")
+                    print("Step 1 - SearchResults: Success!")
                 case .failure(let error):
                     print(error)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -107,7 +107,7 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
             siteID: siteID,
             keyword: "hello") { result in
                 switch result {
-                case .success():
+                case .success(_):
                     print("Success!")
                 case .failure(let error):
                     print(error)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -103,13 +103,12 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
     /// https://github.com/woocommerce/woocommerce-ios/issues/7741
     ///
     func customerSearchTapped() {
-        print("1 - SearchResults: Start")
         let action = CustomerAction.searchCustomers(
             siteID: siteID,
             keyword: "hello") { result in
                 switch result {
                 case .success():
-                    print("9 - SearchResults: End")
+                    print("Success!")
                 case .failure(let error):
                     print(error)
                 }

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -27,11 +27,4 @@ public enum CustomerAction: Action {
         customerID: Int64,
         onCompletion: (Result<Customer, Error>) -> Void
     )
-
-    /// Maps CustomerSearchResult to Customer objects
-    case mapSearchResultsToCustomerObject(
-        siteID: Int64,
-        searchResults: [WCAnalyticsCustomer],
-        onCompletion: (Result<Customer, Error>) -> Void
-    )
 }

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -25,7 +25,8 @@ public enum CustomerAction: Action {
     case retrieveCustomer(
         siteID: Int64,
         customerID: Int64,
-        onCompletion: (Result<Customer, Error>) -> Void)
+        onCompletion: (Result<Customer, Error>) -> Void
+    )
 
     /// Inserts or updates CustomerSearchResults in Storage
     case upsertSearchResults(
@@ -34,9 +35,17 @@ public enum CustomerAction: Action {
         onCompletion: () -> Void
     )
 
-    /// Inserts or updates Customers in Storage
-    case upsertCustomers(
-        readOnlyCustomers: [Customer],
+    /// Inserts or updates a Customer in Storage
+    case upsertCustomer(
+        siteID: Int64,
+        readOnlyCustomer: Customer,
         onCompletion: () -> Void
+    )
+
+    /// Maps CustomerSearchResult to Customer objects
+    case mapSearchResultsToCustomerObject(
+        siteID: Int64,
+        searchResults: [WCAnalyticsCustomer],
+        onCompletion: (Result<Customer, Error>) -> Void
     )
 }

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -25,6 +25,5 @@ public enum CustomerAction: Action {
     case retrieveCustomer(
         siteID: Int64,
         customerID: Int64,
-        onCompletion: (Result<Customer, Error>) -> Void
-    )
+        onCompletion: (Result<Customer, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -26,4 +26,17 @@ public enum CustomerAction: Action {
         siteID: Int64,
         customerID: Int64,
         onCompletion: (Result<Customer, Error>) -> Void)
+
+    /// Inserts or updates CustomerSearchResults in Storage
+    case upsertSearchResults(
+        siteID: Int64,
+        readOnlySearchResults: [WCAnalyticsCustomer],
+        onCompletion: () -> Void
+    )
+
+    /// Inserts or updates Customers in Storage
+    case upsertCustomers(
+        readOnlyCustomers: [Customer],
+        onCompletion: () -> Void
+    )
 }

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -8,12 +8,12 @@ public enum CustomerAction: Action {
     ///- `siteID`: The site for which we will perform the search.
     ///- `keyword`: Keyword to perform the search. Only searches by name.
     ///- `onCompletion`: Invoked when the operation finishes.
-    ///     - `result.success()`:  On success, the Customers found will be loaded in Core Data.
+    ///     - `result.success([Customer])`:  On success, the Customers found will be loaded in Core Data.
     ///     - `result.failure(Error)`: Error fetching data
     case searchCustomers(
         siteID: Int64,
         keyword: String,
-        onCompletion: (Result<Void, Error>) -> Void)
+        onCompletion: (Result<[Customer], Error>) -> Void)
 
     /// Retrieves a single Customer from a site
     ///

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -28,20 +28,6 @@ public enum CustomerAction: Action {
         onCompletion: (Result<Customer, Error>) -> Void
     )
 
-    /// Inserts or updates CustomerSearchResults in Storage
-    case upsertSearchResults(
-        siteID: Int64,
-        readOnlySearchResults: [WCAnalyticsCustomer],
-        onCompletion: () -> Void
-    )
-
-    /// Inserts or updates a Customer in Storage
-    case upsertCustomer(
-        siteID: Int64,
-        readOnlyCustomer: Customer,
-        onCompletion: () -> Void
-    )
-
     /// Maps CustomerSearchResult to Customer objects
     case mapSearchResultsToCustomerObject(
         siteID: Int64,

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -147,7 +147,6 @@ public typealias PrintingResult = Hardware.PrintingResult
 public typealias CardPresentReceiptParameters = Hardware.CardPresentReceiptParameters
 public typealias CardPresentTransactionDetails = Hardware.CardPresentTransactionDetails
 public typealias StripeAccount = Networking.StripeAccount
-public typealias WCAnalyticsCustomer = Networking.WCAnalyticsCustomer
 public typealias WCPayAccount = Networking.WCPayAccount
 public typealias WCPayAccountStatusEnum = Networking.WCPayAccountStatusEnum
 public typealias WCPayPaymentMethodType = Networking.WCPayPaymentMethodType

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -147,6 +147,7 @@ public typealias PrintingResult = Hardware.PrintingResult
 public typealias CardPresentReceiptParameters = Hardware.CardPresentReceiptParameters
 public typealias CardPresentTransactionDetails = Hardware.CardPresentTransactionDetails
 public typealias StripeAccount = Networking.StripeAccount
+public typealias WCAnalyticsCustomer = Networking.WCAnalyticsCustomer
 public typealias WCPayAccount = Networking.WCPayAccount
 public typealias WCPayAccountStatusEnum = Networking.WCPayAccountStatusEnum
 public typealias WCPayPaymentMethodType = Networking.WCPayPaymentMethodType

--- a/Yosemite/Yosemite/Stores/CustomerStore.swift
+++ b/Yosemite/Yosemite/Stores/CustomerStore.swift
@@ -70,7 +70,7 @@ public final class CustomerStore: Store {
                 switch result {
                 case .success(let customers):
                     print("1 - Successfully got [WCAnalyticsCustomer] array")
-                    self.mapSearchResultsToCustomerObject(for: siteID, with: customers)
+                    self.mapSearchResultsToCustomerObject(for: siteID, with: customers, onCompletion: onCompletion)
                 case .failure(let error):
                     onCompletion(.failure(error))
                 }
@@ -109,7 +109,8 @@ public final class CustomerStore: Store {
     ///   - searchResults: A WCAnalyticsCustomer collection that represents the matches we've got from the API based in our keyword search
     ///
     private func mapSearchResultsToCustomerObject(for siteID: Int64,
-                                          with searchResults: [WCAnalyticsCustomer]) {
+                                          with searchResults: [WCAnalyticsCustomer],
+                                                  onCompletion: @escaping (Result<Void, Error>) -> Void) {
         let group = DispatchGroup()
         print("2 - For each WCAnalyticsCustomer in [WCAnalyticsCustomer]...")
         for result in searchResults {
@@ -122,6 +123,7 @@ public final class CustomerStore: Store {
         group.notify(queue: .main) {
             self.upsertSearchCustomerResults(siteID: siteID, readOnlySearchResults: searchResults, onCompletion: {})
             print("Mapping done!")
+            onCompletion(.success(()))
         }
     }
 

--- a/Yosemite/Yosemite/Stores/CustomerStore.swift
+++ b/Yosemite/Yosemite/Stores/CustomerStore.swift
@@ -67,7 +67,11 @@ public final class CustomerStore: Store {
             searchRemote.searchCustomers(for: siteID, name: keyword) { result in
                 switch result {
                 case .success(let data):
-                    self.mapSearchResultsToCustomerObject(for: siteID, with: data, onCompletion: { _ in })
+                    print("Step 1.1 - SearchResults: Success!")
+                    self.upsertSearchResults(siteID: siteID, readOnlySearchResults: data, onCompletion: {
+                        print("Step 1.2 - Upsert SearchResults to Storage: Success!")
+                    })
+                    //self.mapSearchResultsToCustomerObject(for: siteID, with: data, onCompletion: { _ in })
                     onCompletion(.success(()))
                 case .failure(let error):
                     onCompletion(.failure(error))
@@ -115,19 +119,28 @@ public final class CustomerStore: Store {
                 case .failure(_):
                     break
                 }
-                self.upsert(readOnlyCustomers: temp_customersHolder, onCompletion: {
-                    print("Step 4 - Process completed")
+                self.upsertCustomers(readOnlyCustomers: temp_customersHolder, onCompletion: {
+                    print("Step 3 - Upsert Customer to Storage: Success!")
                 })
             }
         }
     }
 
-    func upsert(readOnlyCustomers: [Networking.Customer], onCompletion: @escaping () -> Void) {
+    func upsertSearchResults(siteID: Int64, readOnlySearchResults: [Networking.WCAnalyticsCustomer], onCompletion: @escaping () -> Void) {
+        // Logic for inserting or updating in Storage will go here.
+        for eachCustomer in readOnlySearchResults {
+            print("Upserting SearchResults: \(eachCustomer.userID) in Storage. Name: \(eachCustomer.name ?? "Name not found")")
+        }
+        onCompletion()
+        self.mapSearchResultsToCustomerObject(for: siteID, with: readOnlySearchResults, onCompletion: { _ in })
+    }
+
+    func upsertCustomers(readOnlyCustomers: [Networking.Customer], onCompletion: @escaping () -> Void) {
         // Logic for inserting or updating in Storage will go here.
         for eachCustomer in readOnlyCustomers {
             print("Upserting customer ID: \(eachCustomer.customerID) in Storage. Name: \(eachCustomer.firstName ?? "Name not found")")
-            print("Step 3 - Upsert to Storage: Success!")
         }
         onCompletion()
+        print("Step 4 - Process completed")
     }
 }

--- a/Yosemite/Yosemite/Stores/CustomerStore.swift
+++ b/Yosemite/Yosemite/Stores/CustomerStore.swift
@@ -49,8 +49,6 @@ public final class CustomerStore: Store {
             searchCustomers(for: siteID, keyword: keyword, onCompletion: onCompletion)
         case .retrieveCustomer(siteID: let siteID, customerID: let customerID, onCompletion: let onCompletion):
             retrieveCustomer(for: siteID, with: customerID, onCompletion: onCompletion)
-        case .mapSearchResultsToCustomerObject(siteID: let siteID, searchResults: let searchResults, onCompletion: let onCompletion):
-            mapSearchResultsToCustomerObject(for: siteID, with: searchResults, onCompletion: onCompletion)
         }
     }
 
@@ -67,16 +65,15 @@ public final class CustomerStore: Store {
         for siteID: Int64,
         keyword: String,
         onCompletion: @escaping (Result<Void, Error>) -> Void) {
-            searchRemote.searchCustomers(for: siteID, name: keyword) { result in
+            searchRemote.searchCustomers(for: siteID, name: keyword) { [weak self] result in
+                guard let self else { return }
                 switch result {
                 case .success(let customers):
-                    print("2 - Hit analytics endpoint")
-                    self.upsertSearchResults(siteID: siteID, readOnlySearchResults: customers) {
-                        print("4 - Saved SearchResults")
-                        self.mapSearchResultsToCustomerObject(for: siteID, with: customers) { _ in
-                            print("8 - Mapped SearchResults to Customer objects")
-                            onCompletion(.success(()))
-                        }
+                    self.upsertSearchCustomerResults(siteID: siteID, readOnlySearchResults: customers) {
+                        // We'll be saving the search results to Core Data. Not implemented yet.
+                    }
+                    self.mapSearchResultsToCustomerObject(for: siteID, with: customers) { customer in
+                        onCompletion(.success(()))
                     }
                 case .failure(let error):
                     onCompletion(.failure(error))
@@ -96,10 +93,13 @@ public final class CustomerStore: Store {
         for siteID: Int64,
         with customerID: Int64,
         onCompletion: @escaping (Result<Customer, Error>) -> Void) {
-            customerRemote.retrieveCustomer(for: siteID, with: customerID) { result in
+            customerRemote.retrieveCustomer(for: siteID, with: customerID) { [weak self] result in
+                guard let self else { return }
                 switch result {
                 case .success(let customer):
-                    onCompletion(.success(customer))
+                    self.upsertCustomer(siteID: siteID, readOnlyCustomer: customer) {
+                        onCompletion(.success(customer))
+                    }
                 case .failure(let error):
                     onCompletion(.failure(error))
                 }
@@ -113,32 +113,29 @@ public final class CustomerStore: Store {
     ///   - searchResults: A WCAnalyticsCustomer collection that represents the matches we've got from the API based in our keyword search
     ///   - onCompletion: Invoked when the operation finishes, returns a Customer object, which we'll be upserting into Core Data, or an Error.
     ///
-    func mapSearchResultsToCustomerObject(for siteID: Int64,
+    private func mapSearchResultsToCustomerObject(for siteID: Int64,
                                           with searchResults: [WCAnalyticsCustomer],
                                           onCompletion: @escaping (Result<Customer, Error>) -> Void) {
-            for result in searchResults {
-                self.retrieveCustomer(for: siteID, with: result.userID) { customer in
-                    switch customer {
-                    case .success(let customer):
-                        print("5 - Map SearchResults to Customer objects")
-                        self.upsertCustomer(siteID: siteID, readOnlyCustomer: customer) {
-                            print("7 - Saved Customer")
-                            onCompletion(.success(customer))
-                        }
-                    case .failure(let error):
-                        onCompletion(.failure(error))
-                    }
+        for result in searchResults {
+            self.retrieveCustomer(for: siteID, with: result.userID) { customer in
+                switch customer {
+                case .success(let customer):
+                    self.upsertSearchCustomerResults(siteID: siteID, readOnlySearchResults: searchResults, onCompletion: {})
+                    onCompletion(.success(customer))
+                case .failure(let error):
+                    onCompletion(.failure(error))
                 }
             }
+        }
     }
 
     /// Inserts or updates CustomerSearchResults in Storage
     ///
-    private func upsertSearchResults(siteID: Int64, readOnlySearchResults: [Networking.WCAnalyticsCustomer], onCompletion: @escaping () -> Void) {
+    private func upsertSearchCustomerResults(siteID: Int64, readOnlySearchResults: [Networking.WCAnalyticsCustomer], onCompletion: @escaping () -> Void) {
 
         for searchResult in readOnlySearchResults {
             // Logic for inserting or updating in Storage will go here.
-            print("3 - Saving SearchResults: \(searchResult.userID) in Storage. Name: \(searchResult.name ?? "Name not found")")
+            print("Saving SearchResults: \(searchResult.userID) in Storage. Name: \(searchResult.name ?? "Name not found")")
         }
         onCompletion()
     }
@@ -147,7 +144,7 @@ public final class CustomerStore: Store {
     ///
     private func upsertCustomer(siteID: Int64, readOnlyCustomer: Networking.Customer, onCompletion: @escaping () -> Void) {
             // Logic for inserting or updating in Storage will go here.
-            print("6 - Saving Customer: \(readOnlyCustomer.customerID) in Storage. Name: \(readOnlyCustomer.firstName ?? "Name not found")")
+            print("Saving Customer: \(readOnlyCustomer.customerID) in Storage. Name: \(readOnlyCustomer.firstName ?? "Name not found")")
         onCompletion()
     }
 }

--- a/Yosemite/Yosemite/Stores/CustomerStore.swift
+++ b/Yosemite/Yosemite/Stores/CustomerStore.swift
@@ -49,6 +49,10 @@ public final class CustomerStore: Store {
             searchCustomers(for: siteID, keyword: keyword, onCompletion: onCompletion)
         case .retrieveCustomer(siteID: let siteID, customerID: let customerID, onCompletion: let onCompletion):
             retrieveCustomer(for: siteID, with: customerID, onCompletion: onCompletion)
+        case .upsertSearchResults(siteID: let siteID, readOnlySearchResults: let readOnlySearchResults, onCompletion: let onCompletion):
+            upsertSearchResults(siteID: siteID, readOnlySearchResults: readOnlySearchResults, onCompletion: onCompletion)
+        case .upsertCustomers(readOnlyCustomers: let readOnlyCustomers, onCompletion: let onCompletion):
+            upsertCustomers(readOnlyCustomers: readOnlyCustomers, onCompletion: onCompletion)
         }
     }
 

--- a/Yosemite/Yosemite/Stores/CustomerStore.swift
+++ b/Yosemite/Yosemite/Stores/CustomerStore.swift
@@ -70,13 +70,10 @@ public final class CustomerStore: Store {
         onCompletion: @escaping (Result<Void, Error>) -> Void) {
             searchRemote.searchCustomers(for: siteID, name: keyword) { result in
                 switch result {
-                case .success(let data):
-                    print("Step 1.1 - SearchResults: Success!")
-                    self.upsertSearchResults(siteID: siteID, readOnlySearchResults: data, onCompletion: {
-                        print("Step 1.2 - Upsert SearchResults to Storage: Success!")
-                    })
-                    //self.mapSearchResultsToCustomerObject(for: siteID, with: data, onCompletion: { _ in })
-                    onCompletion(.success(()))
+                case .success(let customers):
+                    self.upsertSearchResults(siteID: siteID, readOnlySearchResults: customers) {
+                        onCompletion(.success(()))
+                    }
                 case .failure(let error):
                     onCompletion(.failure(error))
                 }
@@ -96,15 +93,15 @@ public final class CustomerStore: Store {
         onCompletion: @escaping (Result<Customer, Error>) -> Void) {
             customerRemote.retrieveCustomer(for: siteID, with: customerID) { result in
                 switch result {
-                case .failure(let error):
-                    onCompletion(.failure(error))
                 case .success(let customer):
                     onCompletion(.success(customer))
+                case .failure(let error):
+                    onCompletion(.failure(error))
                 }
             }
         }
 
-    /// Maps SearchResult (/analytics/customer endpoint) to customer (/wp/v3/customer endpoint) objects
+    /// Maps CustomerSearchResult to Customer objects
     ///
     /// - Parameters:
     ///   - siteID: The site for which customers should be fetched.
@@ -119,32 +116,30 @@ public final class CustomerStore: Store {
                 switch customer {
                 case .success(let customer):
                     temp_customersHolder.append(customer)
-                    print("Step 2 - Map SearchResults to Customer: Success!")
                 case .failure(_):
                     break
                 }
-                self.upsertCustomers(readOnlyCustomers: temp_customersHolder, onCompletion: {
-                    print("Step 3 - Upsert Customer to Storage: Success!")
-                })
             }
         }
     }
 
+    /// Inserts or updates CustomerSearchResults in Storage
+    ///
     func upsertSearchResults(siteID: Int64, readOnlySearchResults: [Networking.WCAnalyticsCustomer], onCompletion: @escaping () -> Void) {
-        // Logic for inserting or updating in Storage will go here.
-        for eachCustomer in readOnlySearchResults {
-            print("Upserting SearchResults: \(eachCustomer.userID) in Storage. Name: \(eachCustomer.name ?? "Name not found")")
+
+        for searchResult in readOnlySearchResults {
+            // Logic for inserting or updating in Storage will go here.
+            print("Upserting SearchResults: \(searchResult.userID) in Storage. Name: \(searchResult.name ?? "Name not found")")
         }
-        onCompletion()
-        self.mapSearchResultsToCustomerObject(for: siteID, with: readOnlySearchResults, onCompletion: { _ in })
     }
 
+    /// Inserts or updates Customers in Storage
+    ///
     func upsertCustomers(readOnlyCustomers: [Networking.Customer], onCompletion: @escaping () -> Void) {
-        // Logic for inserting or updating in Storage will go here.
-        for eachCustomer in readOnlyCustomers {
-            print("Upserting customer ID: \(eachCustomer.customerID) in Storage. Name: \(eachCustomer.firstName ?? "Name not found")")
+
+        for customer in readOnlyCustomers {
+            // Logic for inserting or updating in Storage will go here.
+            print("Upserting customer ID: \(customer.customerID) in Storage. Name: \(customer.firstName ?? "Name not found")")
         }
-        onCompletion()
-        print("Step 4 - Process completed")
     }
 }

--- a/Yosemite/Yosemite/Stores/CustomerStore.swift
+++ b/Yosemite/Yosemite/Stores/CustomerStore.swift
@@ -49,10 +49,6 @@ public final class CustomerStore: Store {
             searchCustomers(for: siteID, keyword: keyword, onCompletion: onCompletion)
         case .retrieveCustomer(siteID: let siteID, customerID: let customerID, onCompletion: let onCompletion):
             retrieveCustomer(for: siteID, with: customerID, onCompletion: onCompletion)
-        case .upsertSearchResults(siteID: let siteID, readOnlySearchResults: let readOnlySearchResults, onCompletion: let onCompletion):
-            upsertSearchResults(siteID: siteID, readOnlySearchResults: readOnlySearchResults, onCompletion: onCompletion)
-        case .upsertCustomer(siteID: let siteID, readOnlyCustomer: let readOnlyCustomer, onCompletion: let onCompletion):
-            upsertCustomer(siteID: siteID, readOnlyCustomer: readOnlyCustomer, onCompletion: onCompletion)
         case .mapSearchResultsToCustomerObject(siteID: let siteID, searchResults: let searchResults, onCompletion: let onCompletion):
             mapSearchResultsToCustomerObject(for: siteID, with: searchResults, onCompletion: onCompletion)
         }
@@ -138,7 +134,7 @@ public final class CustomerStore: Store {
 
     /// Inserts or updates CustomerSearchResults in Storage
     ///
-    func upsertSearchResults(siteID: Int64, readOnlySearchResults: [Networking.WCAnalyticsCustomer], onCompletion: @escaping () -> Void) {
+    private func upsertSearchResults(siteID: Int64, readOnlySearchResults: [Networking.WCAnalyticsCustomer], onCompletion: @escaping () -> Void) {
 
         for searchResult in readOnlySearchResults {
             // Logic for inserting or updating in Storage will go here.
@@ -149,7 +145,7 @@ public final class CustomerStore: Store {
 
     /// Inserts or updates Customers in Storage
     ///
-    func upsertCustomer(siteID: Int64, readOnlyCustomer: Networking.Customer, onCompletion: @escaping () -> Void) {
+    private func upsertCustomer(siteID: Int64, readOnlyCustomer: Networking.Customer, onCompletion: @escaping () -> Void) {
             // Logic for inserting or updating in Storage will go here.
             print("6 - Saving Customer: \(readOnlyCustomer.customerID) in Storage. Name: \(readOnlyCustomer.firstName ?? "Name not found")")
         onCompletion()

--- a/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
@@ -81,11 +81,12 @@ class CustomerStoreTests: XCTestCase {
         XCTAssertEqual(result.failure as? NetworkError, expectedError)
     }
 
-    func test_searchCustomers_returns_Success_upon_success() {
+    func test_searchCustomers_returns_success() {
         // Given
         network.simulateResponse(requestUrlSuffix: "customers", filename: "wc-analytics-customers")
         network.simulateResponse(requestUrlSuffix: "customers/25", filename: "customer")
 
+        // When
         let result: Result<Void, Error> = waitFor { promise in
             let action = CustomerAction.searchCustomers(
                 siteID: self.dummySiteID,
@@ -94,6 +95,8 @@ class CustomerStoreTests: XCTestCase {
                 }
             self.store.onAction(action)
         }
+
+        // Then
         XCTAssertTrue(result.isSuccess)
     }
 

--- a/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
@@ -11,7 +11,7 @@ class CustomerStoreTests: XCTestCase {
     private var searchRemote: WCAnalyticsCustomerRemote!
     private var store: CustomerStore!
     private let dummySiteID: Int64 = 12345
-    private let dummyCustomerID: Int64 = 1
+    private let dummyCustomerID: Int64 = 25
     private let dummyKeyword: String = "John"
 
     override func setUp() {
@@ -30,7 +30,7 @@ class CustomerStoreTests: XCTestCase {
         )
     }
 
-    func test_retrieveCustomer_returns_Customer_upon_success() {
+    func test_retrieveCustomer_returns_Customer_upon_success() throws {
         // Given
         network.simulateResponse(requestUrlSuffix: "", filename: "customer")
 
@@ -44,6 +44,23 @@ class CustomerStoreTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
+        let customer = try result.get()
+        XCTAssertEqual(customer.customerID, 25)
+        XCTAssertEqual(customer.firstName, "John")
+        XCTAssertEqual(customer.lastName, "Doe")
+        XCTAssertEqual(customer.email, "john.doe@example.com")
+        XCTAssertEqual(customer.billing?.firstName, "John" )
+        XCTAssertEqual(customer.billing?.lastName, "Doe" )
+        XCTAssertEqual(customer.billing?.address1, "969 Market" )
+        XCTAssertEqual(customer.billing?.address2, "" )
+        XCTAssertEqual(customer.billing?.city, "San Francisco" )
+        XCTAssertEqual(customer.billing?.state, "CA" )
+        XCTAssertEqual(customer.billing?.postcode, "94103" )
+        XCTAssertEqual(customer.billing?.country, "US" )
+        XCTAssertEqual(customer.billing?.email, "john.doe@example.com" )
+        XCTAssertEqual(customer.billing?.phone, "(555) 555-5555" )
+        XCTAssertEqual(customer.shipping?.firstName, "John" )
+        XCTAssertEqual(customer.shipping?.lastName, "Doe" )
     }
 
     func test_retrieveCustomer_returns_Error_upon_failure() {
@@ -64,29 +81,20 @@ class CustomerStoreTests: XCTestCase {
         XCTAssertEqual(result.failure as? NetworkError, expectedError)
     }
 
-    func test_mapSearchResultsToCustomerObject_returns_Customer_upon_success() throws {
+    func test_searchCustomers_returns_Success_upon_success() {
         // Given
-        //network.simulateResponse(requestUrlSuffix: "", filename: "wc-analytics-customers")
-        // Mock instead?
-        let searchResults = [
-            Networking.WCAnalyticsCustomer(userID: 1, name: "John"),
-            Networking.WCAnalyticsCustomer(userID: 2, name: "Paul"),
-            Networking.WCAnalyticsCustomer(userID: 3, name: "John.Merch")
-        ]
+        network.simulateResponse(requestUrlSuffix: "customers", filename: "wc-analytics-customers")
+        network.simulateResponse(requestUrlSuffix: "customers/25", filename: "customer")
 
-        // When
-        let result: Result<Customer, Error> = waitFor { promise in
-            let action = CustomerAction.mapSearchResultsToCustomerObject(
+        let result: Result<Void, Error> = waitFor { promise in
+            let action = CustomerAction.searchCustomers(
                 siteID: self.dummySiteID,
-                searchResults: searchResults) { result in
+                keyword: self.dummyKeyword) { result in
                     promise(result)
                 }
             self.store.onAction(action)
         }
-
-        // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertEqual(searchResults[0].name, try result.get().firstName)
     }
 
     func test_searchCustomers_returns_Error_upon_failure() {


### PR DESCRIPTION
Part of #7741 

### Description
This PR adds support to mapping our `CustomerSearchResult` entities, that we get from the `/wc-analytics/customers` endpoint to `Customer` entities that we find in the `/wc/v3/customers/` endpoint by:

- Creating a `[WCAnalyticsCustomer]` entity from endpoint 1
- Loop through each entity, retrieving a `Customer` object from endpoint 2, and saving them into a `[Customer]` array in memory. Later we will attempt to save this to Storage (not implemented)
- When the process finishes, we will attempt to save the `[WCAnalyticsCustomer]` to Storage as well (not implemented).

## Testing:

1. The current implementation assumes that you have at least one customer in your store, and that customer name contains the word "hello", if that's not the case, you can change this line to the keyword you prefer:

https://github.com/woocommerce/woocommerce-ios/blob/0e33748fcdb9cf46506b6ddef2e6f923a5e6e04a/WooCommerce/Classes/ViewRelated/Orders/Order%20Creation/CustomerSection/CreateOrderAddressFormViewModel.swift#L108

2. Go to "Orders" > "+" > "Create new Order" > "+ "Add Customer" and tap in the "Magnifying glass" icon at the top of the screen:

<img width=400 src="https://user-images.githubusercontent.com/3812076/192192292-26a940ff-353f-4c1b-99ba-54d443c0a91d.png">

3. In Proxyman, or any other networking tool, you should see 2+ requests: One initial request hitting the `/wc-analytics/customers&_method=get` endpoint, and subsequent requests (one per customer found) that hits the `/wc/v3/customers/{customerID}&_method=get` endpoint. 

This is an example of a Store with 2 customers that has "hello" in their names:

1st Request:
```
path=/wc-analytics/customers&_method=get
query={"search":"hello"}

{
  "data": [
    {
      "id": 100,
      "user_id": 5,
      "username": "hello.maldon",
      "name": "Hello maldon",
      "email": "gabriel.maldonado+testuser20221007@automattic.com",
      "country": "US",
      "city": "Soll",
      "state": "CA",
      "postcode": "10020",
... continues
```

Subsequent requests:
```
json=true
path=/wc/v3/customers/4&_method=get

{
  "data": {
    "id": 4,
    "date_created": "2022-10-04T08:36:49",
    "date_created_gmt": "2022-10-04T08:36:49",
    "date_modified": "2022-10-04T08:36:54",
    "date_modified_gmt": "2022-10-04T08:36:54",
    "email": "gabriel.maldonado+testuser20221004@automattic.com",
    "first_name": "hello",
    "last_name": "merch",
    "role": "customer",
    "username": "hello.merch",
    "billing": {
... continues
```
```
json=true
path=/wc/v3/customers/5&_method=get

{
  "data": {
    "id": 5,
    "date_created": "2022-10-07T09:06:43",
    "date_created_gmt": "2022-10-07T09:06:43",
    "date_modified": "2022-10-07T09:06:47",
    "date_modified_gmt": "2022-10-07T09:06:47",
    "email": "gabriel.maldonado+testuser20221007@automattic.com",
    "first_name": "Hello",
    "last_name": "maldon",
    "role": "customer",
    "username": "hello.maldon",
    "billing": {
... continues
```