### PR TITLE
Explicitly prevent `xcodebuild` from changing the binary's build number

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,6 +41,13 @@ ALPHA_BUNDLE_IDENTIFIERS = [
   "#{ALPHA_VERSION_BUNDLE_IDENTIFIER}.storewidgets"
 ].freeze
 
+# Shared options to use when invoking `gym` / `build_app`.
+#
+# - `manageAppVersionAndBuildNumber: false` prevents `xcodebuild` from bumping
+#   the build number when extracting an archive into an IPA file. We want to
+#   use the build number we set!
+COMMON_EXPORT_OPTIONS = { manageAppVersionAndBuildNumber: false }.freeze
+
 TEST_SCHEME = 'WooCommerce'
 
 # List of `.strings` files manually maintained by developers (as opposed to being automatically extracted from the code)
@@ -447,7 +454,7 @@ platform :ios do
       workspace: './WooCommerce.xcworkspace',
       clean: true,
       export_team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
-      export_options: { method: 'app-store' }
+      export_options: { **COMMON_EXPORT_OPTIONS, method: 'app-store' }
     )
 
     testflight(
@@ -513,7 +520,11 @@ platform :ios do
       clean: true,
       output_directory: 'build',
       export_team_id: ENV.fetch('INT_EXPORT_TEAM_ID'),
-      export_options: { method: 'enterprise', iCloudContainerEnvironment: 'Production' }
+      export_options: {
+        **COMMON_EXPORT_OPTIONS,
+        method: 'enterprise',
+        iCloudContainerEnvironment: 'Production'
+      }
     )
 
     appcenter_upload(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -442,11 +442,13 @@ platform :ios do
 
     appstore_code_signing
 
-    gym(scheme: 'WooCommerce', workspace: './WooCommerce.xcworkspace',
-        clean: true, export_team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
-        export_options: {
-          method: 'app-store'
-        })
+    gym(
+      scheme: 'WooCommerce',
+      workspace: './WooCommerce.xcworkspace',
+      clean: true,
+      export_team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
+      export_options: { method: 'app-store' }
+    )
 
     testflight(
       skip_waiting_for_build_processing: true,


### PR DESCRIPTION
Without any apparent change on our side, we saw a couple of Pocket Casts builds with unexpected, and unexpectedly incrementing, build numbers on TestFlight. From 7.24.0.3, to 8, to 9.

This behavior could be replicated locally in that project by running the Fastlane automation, but not when archiving via Xcode.

I pin pointed it to the `manageAppVersionAndBuildNumber` option being true by default in the `ExportOptions.plist` that Fastlane / `xcodebuild` generates for `gym` to convert an archive into an IPA.

Explicitly setting the option to `false` solves the issue locally.

See https://github.com/Automattic/pocket-casts-ios/pull/373.

To verify the faulty behavior on this project, checkout the current tip of the release branch, 8a08294dca22a7a76f8f418faddec59c1ee8c5c4, and apply the following patch:

```diff
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -448,6 +448,8 @@ platform :ios do
         method: 'app-store'
       })

+    UI.user_error! 'Aborting before App Store Connect upload. This was only a test'
+
   testflight(
     skip_waiting_for_build_processing: true,
     api_key_path: ASC_KEY_PATH
```

Then, run:

```
build_and_upload_beta skip_confirm:true skip_prechecks:true create_release:false
```

Result below, notice `Version 10.7 (11)` instead of `Version 10.7 (10.7.0.0)`

![image](https://user-images.githubusercontent.com/1218433/194792481-eee8dd6f-ca90-423d-9e53-5fba02fb28a2.png)

---

Note, this is against `release/10.7` because that's the branch where we'll generate new builds next.