### PR TITLE
Add performance monitoring configuration behind feature flags – Off by default

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -51,6 +51,14 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .productsOnboarding:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .performanceMonitoring,
+                .performanceMonitoringCoreData,
+                .performanceMonitoringFileIO,
+                .performanceMonitoringNetworking,
+                .performanceMonitoringViewController,
+                .performanceMonitoringUserInteraction:
+            // Disabled by default to avoid costs spikes, unless in internal testing builds.
+            return buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -98,4 +98,39 @@ public enum FeatureFlag: Int {
     /// Hides products onboarding development.
     ///
     case productsOnboarding
+
+    // MARK: - Performance Monitoring
+    //
+    // These flags are not transient. That is, they are not here to help us rollout a feature,
+    // but to serve a safety switches to granularly turn off performance monitoring if it looks
+    // like we are consuming too many events.
+
+    /// Whether to enable performance monitoring.
+    ///
+    case performanceMonitoring
+
+    /// Whether to enable performance monitoring for Core Data operations.
+    ///
+    /// - Note: The app will ignore this if `performanceMonitoring` is `false`
+    case performanceMonitoringCoreData
+
+    /// Whether to enable performance monitoring for file IO operations.
+    ///
+    /// - Note: The app will ignore this if `performanceMonitoring` is `false`
+    case performanceMonitoringFileIO
+
+    /// Whether to enable performance monitoring for networking operations.
+    ///
+    /// - Note: The app will ignore this if `performanceMonitoring` is `false`
+    case performanceMonitoringNetworking
+
+    /// Whether to enable performance monitoring for user interaction events.
+    ///
+    /// - Note: The app will ignore this if `performanceMonitoring` is `false`
+    case performanceMonitoringUserInteraction
+
+    /// Whether to enable performance monitoring for `UIViewController` life-cycle events.
+    ///
+    /// - Note: The app will ignore this if `performanceMonitoring` is `false`.
+    case performanceMonitoringViewController
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 
 11.0
 -----
+- [internal] Add support for controlling performance monitoring via Sentry. **Off by default**. [https://github.com/woocommerce/woocommerce-ios/pull/7831]
 
 
 10.9

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -66,7 +66,9 @@ final class ServiceLocator {
 
     /// Crash Logging Stack
     ///
-    private static var _crashLogging: CrashLoggingStack = WooCrashLoggingStack()
+    private static var _crashLogging: CrashLoggingStack = WooCrashLoggingStack(
+        featureFlagService: featureFlagService
+    )
 
     /// Support for external Card Readers
     ///

--- a/WooCommerce/Classes/Tools/Logging/WooCrashLoggingStack.swift
+++ b/WooCommerce/Classes/Tools/Logging/WooCrashLoggingStack.swift
@@ -12,14 +12,15 @@ struct WooCrashLoggingStack: CrashLoggingStack {
     let crashLogging: AutomatticTracks.CrashLogging
     let eventLogging: EventLogging
 
-    private let crashLoggingDataProvider = WCCrashLoggingDataProvider()
+    private let crashLoggingDataProvider: WCCrashLoggingDataProvider
     private let eventLoggingDataProvider = WCEventLoggingDataSource()
     private let eventLoggingDelegate = WCEventLoggingDelegate()
 
-    init() {
+    init(featureFlagService: FeatureFlagService) {
         let eventLogging = EventLogging(dataSource: eventLoggingDataProvider, delegate: eventLoggingDelegate)
 
         self.eventLogging = eventLogging
+        self.crashLoggingDataProvider = WCCrashLoggingDataProvider(featureFlagService: featureFlagService)
         self.crashLogging = AutomatticTracks.CrashLogging(dataProvider: crashLoggingDataProvider, eventLogging: eventLogging)
 
         /// Upload any remaining files any time the app becomes active
@@ -87,7 +88,11 @@ class WCCrashLoggingDataProvider: CrashLoggingDataProvider {
     /// Indicates that app is in an inconsistent state and we don't want to start asking it for metadata
     fileprivate var appIsCrashing = false
 
-    init() {
+    let featureFlagService: FeatureFlagService
+
+    init(featureFlagService: FeatureFlagService) {
+        self.featureFlagService = featureFlagService
+
         NotificationCenter.default.addObserver(self, selector: #selector(updateCrashLoggingSystem(_:)), name: .defaultAccountWasUpdated, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateCrashLoggingSystem(_:)), name: .logOutEventReceived, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateCrashLoggingSystem(_:)), name: .StoresManagerDidUpdateDefaultSite, object: nil)

--- a/WooCommerce/Classes/Tools/Logging/WooCrashLoggingStack.swift
+++ b/WooCommerce/Classes/Tools/Logging/WooCrashLoggingStack.swift
@@ -134,6 +134,26 @@ class WCCrashLoggingDataProvider: CrashLoggingDataProvider {
             ServiceLocator.crashLogging.setNeedsDataRefresh()
         }
     }
+
+    // MARK: – Performance Monitoring
+
+    var performanceTracking: PerformanceTracking {
+        guard featureFlagService.isFeatureFlagEnabled(.performanceMonitoring) else {
+            return .disabled
+        }
+
+        return .enabled(
+            .init(
+                // FIXME: Is there a way to control this via feature flags?
+                sampler: { 0.1 },
+                trackCoreData: featureFlagService.isFeatureFlagEnabled(.performanceMonitoringCoreData),
+                trackFileIO: featureFlagService.isFeatureFlagEnabled(.performanceMonitoringFileIO),
+                trackNetwork: featureFlagService.isFeatureFlagEnabled(.performanceMonitoringNetworking),
+                trackUserInteraction: featureFlagService.isFeatureFlagEnabled(.performanceMonitoringUserInteraction),
+                trackViewControllers: featureFlagService.isFeatureFlagEnabled(.performanceMonitoringViewController)
+            )
+        )
+    }
 }
 
 struct CrashLoggingSettings {


### PR DESCRIPTION
### Description
This PR aims to enable performance monitoring, the concrete implementation of which lives in Tracks and is currently implemented via Sentry, behind feature flags.

When I started working on this, I was under the impression WooCommerce iOS already had support for remote feature flags, but that doesn't seem to be the case. _I must have applied my iOS bias to the conversations I had about remote feature flags, not realizing they were about the Android app._

~~**I'm leaving this PR here to pick back up once we'll have support for remote feature flag.** Or once someone tells me I got it wrong and it was there all along.~~

~~I used the 11.3 milestone for this PR. It's the future-most milestone at the time of creating the PR.~~

Update: Speaking with @jkmassel, we decided to get this PR to a ready-to-merge state, where all the logic is available but off, ready to build on top of once we'll be ready to tap into the remote feature toggles.

### Testing instructions

Download the installable build, then visit [the Sentry page](https://sentry.io/organizations/a8c/performance/?project=1458804&query=&statsPeriod=1h) to verify performance events from your device have been received.

<img width="1364" alt="Screen Shot 2022-10-24 at 3 44 23 pm" src="https://user-images.githubusercontent.com/1218433/197450128-18f2c57c-a971-4403-a993-de3dd519e955.png">



If instead you run the app from Xcode, you should see no events.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
