### PR TITLE
Lock Screen Widgets: Update analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -228,6 +228,8 @@ private extension WooAnalytics {
             switch widgetInfo.kind {
             case WooConstants.storeInfoWidgetKind:
                 return WooAnalyticsEvent.Widgets.Name.todayStats.rawValue
+            case WooConstants.appLinkWidgetKind:
+                return WooAnalyticsEvent.Widgets.Name.appLink.rawValue
             default:
                 DDLogWarn("⚠️ Make sure the widget: \(widgetInfo.kind), has the correct tracks name.")
                 return widgetInfo.kind

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -227,7 +227,7 @@ private extension WooAnalytics {
         let widgetAnalyticNames: [String] = installedWidgets.map { widgetInfo in
             switch widgetInfo.kind {
             case WooConstants.storeInfoWidgetKind:
-                return WooAnalyticsEvent.Widgets.Name.todayStats.rawValue
+                return "\(WooAnalyticsEvent.Widgets.Name.todayStats.rawValue)-\(widgetInfo.family)"
             case WooConstants.appLinkWidgetKind:
                 return WooAnalyticsEvent.Widgets.Name.appLink.rawValue
             default:

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1620,8 +1620,14 @@ extension WooAnalyticsEvent {
 
         /// Event when a widget is tapped and opens the app.
         ///
-        static func widgetTapped(name: Name) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .widgetTapped, properties: [Key.name.rawValue: name.rawValue])
+        static func widgetTapped(name: Name, family: String? = nil) -> WooAnalyticsEvent {
+            let properties: [String: WooAnalyticsEventPropertyType]
+            if let family {
+                properties = [Key.name.rawValue: "\(name.rawValue)-\(family)"]
+            } else {
+                properties = [Key.name.rawValue: name.rawValue]
+            }
+            return WooAnalyticsEvent(statName: .widgetTapped, properties: properties)
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1614,7 +1614,7 @@ extension WooAnalyticsEvent {
         }
 
         enum Name: String {
-            case todayStats = "stats-today"
+            case todayStats = "today-stats"
             case appLink = "app-link"
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1614,7 +1614,7 @@ extension WooAnalyticsEvent {
         }
 
         enum Name: String {
-            case todayStats = "today-stats"
+            case todayStats = "stats-today"
             case appLink = "app-link"
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1615,6 +1615,7 @@ extension WooAnalyticsEvent {
 
         enum Name: String {
             case todayStats = "today-stats"
+            case appLink = "app-link"
         }
 
         /// Event when a widget is tapped and opens the app.

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -383,6 +383,8 @@ private extension AppDelegate {
         switch userActivity.activityType {
         case WooConstants.storeInfoWidgetKind:
             ServiceLocator.analytics.track(event: .Widgets.widgetTapped(name: .todayStats))
+        case WooConstants.appLinkWidgetKind:
+            ServiceLocator.analytics.track(event: .Widgets.widgetTapped(name: .appLink))
         default:
             break
         }

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -3,6 +3,7 @@ import CoreData
 import Storage
 import class Networking.UserAgent
 import Experiments
+import class WidgetKit.WidgetCenter
 
 import CocoaLumberjack
 import KeychainAccess
@@ -382,7 +383,8 @@ private extension AppDelegate {
     func trackWidgetTappedIfNeeded(userActivity: NSUserActivity) {
         switch userActivity.activityType {
         case WooConstants.storeInfoWidgetKind:
-            ServiceLocator.analytics.track(event: .Widgets.widgetTapped(name: .todayStats))
+            let widgetFamily = userActivity.userInfo?[WidgetCenter.UserInfoKey.family] as? String
+            ServiceLocator.analytics.track(event: .Widgets.widgetTapped(name: .todayStats, family: widgetFamily))
         case WooConstants.appLinkWidgetKind:
             ServiceLocator.analytics.track(event: .Widgets.widgetTapped(name: .appLink))
         default:


### PR DESCRIPTION
# Description
This PR updates current analytics setup to support "app link" widget and differentiate between "today stats" widget types (there are 4 valid types now).

# How
- Adds `app-link` widget handling for both `application_opened` and `widget_tapped` events.
- Adds `widgetFamily` suffix to `today-stats` widget names.
- Updates `today-stats` to `stats-today` (in preparation to support different intervals in the future).

# Testing
- When widget is tapped to open the app - validate that the `widget_tapped` is fired with correct widget name.
- When app is launched when some widgets are added - validate the widgets property of the `application_opened` event.

Example with all types of widgets added = 1 home screen + 4 lockscreen:
Before PR:
```
🔵 Tracked widget_tapped, properties: [AnyHashable("name"): "today-stats", AnyHashable("blog_id"): 186855689, AnyHashable("is_wpcom_store"): false]
🔵 Tracked application_opened, properties: [AnyHashable("widgets"): "today-stats,today-stats,today-stats,today-stats"]
```

After:
```
🔵 Tracked widget_tapped, properties: [AnyHashable("name"): "stats-today-systemMedium", AnyHashable("blog_id"): 186855689, AnyHashable("is_wpcom_store"): false]
🔵 Tracked application_opened, properties: [AnyHashable("widgets"): "app-link,stats-today-accessoryRectangular,stats-today-accessoryInline,stats-today-systemMedium,stats-today-accessoryCircular"]
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
