### PR TITLE
Lock Screen Widgets: Remove feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -35,8 +35,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .orderCreationSearchCustomers:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .lockscreenWidgets:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .wpcomSignup:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -74,10 +74,6 @@ public enum FeatureFlag: Int {
     ///
     case orderCreationSearchCustomers
 
-    /// Enables lock screen widgets
-    ///
-    case lockscreenWidgets
-
     /// Enables signing up for a WP.com account.
     ///
     case wpcomSignup

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 10.8
 -----
-
+- [***] Stats: Now you can add a Today's Stats Widget to your lock screen (iOS 16 only) to monitor your sales. [https://github.com/woocommerce/woocommerce-ios/pull/7839]
 
 10.7
 -----

--- a/WooCommerce/StoreWidgets/Lockscreen/AppLinkWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/AppLinkWidget.swift
@@ -5,10 +5,8 @@ import Experiments
 /// Static widget - app launch button
 ///
 struct AppLinkWidget: Widget {
-    private let enableLockscreenWidgets = DefaultFeatureFlagService().isFeatureFlagEnabled(.lockscreenWidgets)
-
     private var supportedFamilies: [WidgetFamily] {
-        if #available(iOSApplicationExtension 16.0, *), enableLockscreenWidgets {
+        if #available(iOSApplicationExtension 16.0, *) {
             return [.accessoryCircular]
         } else {
             return []

--- a/WooCommerce/StoreWidgets/Lockscreen/AppLinkWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/AppLinkWidget.swift
@@ -1,6 +1,5 @@
 import WidgetKit
 import SwiftUI
-import Experiments
 
 /// Static widget - app launch button
 ///

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -5,10 +5,8 @@ import Experiments
 /// Main StoreInfo Widget type.
 ///
 struct StoreInfoWidget: Widget {
-    private let enableLockscreenWidgets = DefaultFeatureFlagService().isFeatureFlagEnabled(.lockscreenWidgets)
-
     private var supportedFamilies: [WidgetFamily] {
-        if #available(iOSApplicationExtension 16.0, *), enableLockscreenWidgets {
+        if #available(iOSApplicationExtension 16.0, *) {
             return [
                 .accessoryInline,
                 .accessoryRectangular,

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -1,6 +1,5 @@
 import WidgetKit
 import SwiftUI
-import Experiments
 
 /// Main StoreInfo Widget type.
 ///


### PR DESCRIPTION
Depends on https://github.com/woocommerce/woocommerce-ios/pull/7838 (analytics update)

# Description
This PR removes feature flag to release lock screen widgets to all users.

# Testing

1. Use iOS 16 device/simulator.
2. Build and run the app in debug mode (to ensure the feature flag is enabled).
3. Long press on lock screen.
4. Tap "Customize".
5. Tap on a top line to choose inline widget.
6. In "Add Widgets" panel scroll to "Woo" app section and tap on a single option.
7. Tap on a bottom line of widgets to choose circular/rectangular widgets.
8. In "Add Widgets" panel scroll to "Woo" app and tap it.
9. Tap 2 "Today" widgets to add it on the lock screen.
10. Scroll right to icon widget to tap add it on the lock screen.
11. Close widgets panel, tap "Done" in top right corner.
12. Check that all widgets on a lock screen are displaying same and correct data.
13. Tap on any newly added widgets and confirm it launches the parent app.

# Screenshots

Lock Screen | Widgets Configuration
--|--
![IMG_2448](https://user-images.githubusercontent.com/3132438/193354921-9b4d1cd6-845d-4eb4-a909-57484c27b64a.jpeg)|![IMG_2449](https://user-images.githubusercontent.com/3132438/193354834-9201b9f1-9d4d-497a-b02f-ac8826a61b20.jpeg)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.