### PR TITLE
Elevate: Remove A/B test condition for linked products promo

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -16,10 +16,6 @@ public enum ABTest: String, CaseIterable {
     /// Experiment ref: pbxNRc-1S0-p2
     case aaTestLoggedOut202209 = "woocommerceios_explat_aa_test_logged_out_202209"
 
-    /// A/B test for promoting linked products in Product Details.
-    /// Experiment ref: pbxNRc-1Pp-p2
-    case linkedProductsPromo = "woocommerceios_product_details_linked_products_banner"
-
     /// A/B test for the login button order on the prologues screen.
     /// Experiment ref: pbxNRc-1VA-p2
     case loginPrologueButtonOrder = "woocommerceios_login_prologue_button_order_202209"

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -1,5 +1,4 @@
 import Yosemite
-import Experiments
 
 /// Edit actions in the product form. Each action allows the user to edit a subset of product properties.
 enum ProductFormEditAction: Equatable {
@@ -77,8 +76,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         let shouldShowDescriptionRow = editable || product.description?.isNotEmpty == true
 
         let newLinkedProductsPromoViewModel = linkedProductsPromoViewModel
-        let shouldShowLinkedProductsPromo = ABTest.linkedProductsPromo.variation == .treatment(nil)
-        && isLinkedProductsPromoEnabled
+        let shouldShowLinkedProductsPromo = isLinkedProductsPromoEnabled
         && newLinkedProductsPromoViewModel.shouldBeVisible
         && product.upsellIDs.isEmpty
         && product.crossSellIDs.isEmpty


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/7803

## Description
This PR removes A/B test code for linked products promo banner and releases the feature to everyone.

## Testing

1. Build and run the app.
2. Open a product without any linked products.
3. Update some property and tap "Save".
4. Confirm promo banner appears.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
