### PR TITLE
[ExPlat] Distinguish between logged-out and logged-in experiment assignments

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -24,6 +24,20 @@ public enum ABTest: String, CaseIterable {
     public var variation: Variation {
         ExPlat.shared?.experiment(rawValue) ?? .control
     }
+
+    /// Returns the context for the given experiment.
+    ///
+    /// When adding a new experiment, add it to the appropriate case depending on its context (logged-in or logged-out experience).
+    public var context: ExperimentContext {
+        switch self {
+        case .aaTest202209:
+            return .loggedIn
+        case .aaTestLoggedOut202209, .loginPrologueButtonOrder:
+            return .loggedOut
+        case .null:
+            return .none
+        }
+    }
 }
 
 public extension ABTest {
@@ -55,4 +69,10 @@ public extension Variation {
             return string.map { "treatment: \($0)" } ?? "treatment"
         }
     }
+}
+
+public enum ExperimentContext: Equatable {
+    case loggedOut
+    case loggedIn
+    case none // For the `null` experiment case
 }

--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -41,15 +41,17 @@ public enum ABTest: String, CaseIterable {
 }
 
 public extension ABTest {
-    /// Start the AB Testing platform if any experiment exists
+    /// Start the AB Testing platform if any experiment exists for the provided context
     ///
-    static func start() async {
+    static func start(for context: ExperimentContext) async {
+        let experiments = ABTest.allCases.filter { $0.context == context }
+
         await withCheckedContinuation { continuation in
-            guard ABTest.allCases.count > 1 else {
+            guard !experiments.isEmpty else {
                 return continuation.resume(returning: ())
             }
 
-            let experimentNames = ABTest.allCases.filter { $0 != .null }.map { $0.rawValue }
+            let experimentNames = experiments.map { $0.rawValue }
             ExPlat.shared?.register(experiments: experimentNames)
 
             ExPlat.shared?.refresh {

--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -73,6 +73,8 @@ public extension Variation {
     }
 }
 
+/// The context for an A/B testing experiment (where the experience being tested occurs).
+///
 public enum ExperimentContext: Equatable {
     case loggedOut
     case loggedIn

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -73,14 +73,12 @@ private extension TracksProvider {
                 UserDefaults.standard[.analyticsUsername] = account.username
                 tracksService.switchToAuthenticatedUser(withUsername: account.username,
                                                         userID: String(account.userID),
-                                                        anonymousID: anonymousID,
                                                         wpComToken: credentials.authToken,
                                                         skipAliasEventCreation: false)
             } else if currentAnalyticsUsername == account.username {
                 // Username did not change - just make sure Tracks client has it
                 tracksService.switchToAuthenticatedUser(withUsername: account.username,
                                                         userID: String(account.userID),
-                                                        anonymousID: anonymousID,
                                                         wpComToken: credentials.authToken,
                                                         skipAliasEventCreation: true)
             } else {
@@ -88,7 +86,6 @@ private extension TracksProvider {
                 tracksService.switchToAnonymousUser(withAnonymousID: anonymousID)
                 tracksService.switchToAuthenticatedUser(withUsername: account.username,
                                                         userID: String(account.userID),
-                                                        anonymousID: anonymousID,
                                                         wpComToken: credentials.authToken,
                                                         skipAliasEventCreation: false)
             }

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -372,7 +372,7 @@ private extension AppDelegate {
         }
     }
 
-    /// Starts the AB testing platform
+    /// Starts the AB testing platform and fetches test assignments for the current context
     ///
     func startABTesting() async {
         let context: ExperimentContext = ServiceLocator.stores.isAuthenticated ? .loggedIn : .loggedOut

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -375,7 +375,8 @@ private extension AppDelegate {
     /// Starts the AB testing platform
     ///
     func startABTesting() async {
-        await ABTest.start()
+        let context: ExperimentContext = ServiceLocator.stores.isAuthenticated ? .loggedIn : .loggedOut
+        await ABTest.start(for: context)
     }
 
     /// Tracks if the application was opened via a widget tap.

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -524,7 +524,7 @@ private extension StorePickerViewController {
             return
         }
         Task { @MainActor in
-            await ABTest.start()
+            await ABTest.start(for: .loggedIn)
         }
     }
 }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -178,6 +178,7 @@ class DefaultStoresManager: StoresManager {
 
         updateAndReloadWidgetInformation(with: nil)
 
+        // Refresh the A/B test assignments for the logged-out context
         Task { @MainActor in
             await ABTest.start(for: .loggedOut)
         }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -6,6 +6,7 @@ import class Networking.UserAgent
 import class Networking.WordPressOrgNetwork
 import KeychainAccess
 import class WidgetKit.WidgetCenter
+import Experiments
 
 // MARK: - DefaultStoresManager
 //
@@ -176,6 +177,10 @@ class DefaultStoresManager: StoresManager {
         ServiceLocator.productImageUploader.reset()
 
         updateAndReloadWidgetInformation(with: nil)
+
+        Task { @MainActor in
+            await ABTest.start(for: .loggedOut)
+        }
 
         NotificationCenter.default.post(name: .logOutEventReceived, object: nil)
 

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -27,7 +27,9 @@ In the default implementation of `FeatureFlagService`, some of the feature flags
 
 To add an ExPlat experiment to the app, add a new case to the `ABTest` enum in the `Experiments` framework.
 
-Once the experiment is added to the app, define the behavior for each variation:
+Define the experiment context (`loggedOut` or `loggedIn`) in `ABTest`, depending on whether the experience being experimented on occurs in the logged-out or logged-in context. This determines whether the test assignment prioritizes the `anonid` (for logged-out experiments) or `userid` (for logged-in experiments).
+
+Once the experiment is added to the app, define the behavior for each variation (this must be in the context specified above):
 
 ```
 if ABTest.experimentName.variation == .control {


### PR DESCRIPTION
Closes: #7843

## Description

We are still seeing some crossovers (the same users assigned to different experiment variations) in our logged-in experiments with ExPlat. These seem to be caused by users with multiple devices.

Currently, we fetch assignments for all experiments at once, and we prioritize the assignments made while users are logged out. This is fine for logged-in experiments on a single device, but it can cause crossovers if they have multiple devices and are assigned to different variations before logging in on each device.

This PR adds the distinction between logged-out and logged-in experiments. This way, we can fetch only the assignments needed for the current logged-out or logged-in context. While logged out, assignments will prioritize the `anonid` (for a consistent experiment assignment while logged out); while logged in, assignments will prioritize the `userid` (for a consistent experiment assignment while logged in across devices).

More context/discussion with @aaronyan about the problem and proposed changes: pbxNRc-1QS-p2#comment-3819

## Changes

* Adds `ExperimentContext` to specify the context (logged in or logged out) for each experiment and updates `ABTest.start` to use the `ExperimentContext` so only the assignments for experiments in the given context are fetched.
* Updates `DefaultStoresManager.deauthenticate` to refresh the test assignments any time the user is logged out. This wasn't needed before because we were fetching assignments for logged-out experiments when the app was opened, even if the user was logged in. Now when the app is opened we only fetch assignments for the current context, so we need to be sure to fetch/refresh assignments for the new context after login/logout.
* Removes the `anonid` when switching to an authenticated (logged-in) user in `TracksProvider`. This stops ExPlat from prioritizing the `anonid` when fetching experiment assignments while logged in.

## Testing

Prerequisite: In Xcode, set a breakpoint at `ExPlatService` L55 where the assignments request is defined. (Alternately, you can use a tool like CharlesProxy to check the requests/responses for the ExPlat assignments API request `/wpcom/v2/experiments/0.1.0/assignments`.)

1. Launch the app, log out if needed
2. Relaunch the app (logged-out context) --> Check that `url` (the URL for the request) includes only the logged **out** experiment names and includes the `anon_id`. Make a note of the `anon_id`.
3. Log in to the store picker screen --> Check that `url` includes only the logged **in** experiment names and does **not** include the `anon_id`.
4. Relaunch the app (logged-in context) --> Check that `url` includes only the logged **in** experiment names and does **not** include the `anon_id`.
5. Log out of the app --> Check that `url` (the URL for the request) includes only the logged **out** experiment names and includes the `anon_id`. Check that the `anon_id` is the same as before.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.