### PR TITLE
Decode HTML in product categories names

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryViewModelBuilder.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryViewModelBuilder.swift
@@ -98,7 +98,7 @@ extension ProductCategoryListViewModel {
                                       indentationLevel: Int) -> ProductCategoryCellViewModel {
             let isSelected = selectedCategories.contains(category)
             return ProductCategoryCellViewModel(categoryID: category.categoryID,
-                                                name: category.name,
+                                                name: category.name.strippedHTML,
                                                 isSelected: isSelected,
                                                 indentationLevel: indentationLevel)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
@@ -17,7 +17,7 @@ extension Product {
             return nil
         }
 
-        let categoriesNames = categories.map { $0.name }
+        let categoriesNames = categories.map { $0.name.strippedHTML }
         let formatter = ListFormatter()
         formatter.locale = locale
         return formatter.string(from: categoriesNames)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryViewModelBuilderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryViewModelBuilderTests.swift
@@ -119,6 +119,17 @@ final class ProductCategoryViewModelBuilderTests: XCTestCase {
             _ = ProductCategoryListViewModel.CellViewModelBuilder.viewModels(from: allCategories, selectedCategories: selectedCategories)
         }
     }
+
+    func test_viewmodel_decodes_HTML_in_category_name() {
+        // Given
+        let category = ProductCategory(categoryID: 123, siteID: sampleSiteID, parentID: 0, name: "Test &amp; Test", slug: "test-test")
+
+        // When
+        let viewModels = ProductCategoryListViewModel.CellViewModelBuilder.viewModels(from: [category], selectedCategories: [])
+
+        // Then
+        XCTAssertEqual(viewModels.first?.name, "Test & Test")
+    }
 }
 
 // MARK: Helpers

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
@@ -44,6 +44,13 @@ class Product_ProductFormTests: XCTestCase {
         XCTAssertEqual(product.categoriesDescription(using: usLocale), expectedDescription)
     }
 
+    func test_category_description_decodes_HTML_in_category_name() {
+        let category = sampleCategory(name: "Test &amp; Test")
+        let product = sampleProduct(categories: [category])
+        let expectedDescription = "Test & Test"
+        XCTAssertEqual(product.categoriesDescription(), expectedDescription)
+    }
+
     // MARK: image related
 
     func testProductAllowsMultipleImages() {


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/7557

## Description
This PR adds HTML decoding for category name in Product Form and Categories List views.

## How

- `Product` extension is updated for Product Form
- `ProductCategoryCellViewModel` initializer updated for Categories List

Another solution could be updating `Decodable` initializer for `ProductCategory` object, but I'm unsure how it used and where it can be sent, so decoding on UI layer feels safer.

## Testing

1. Create a product category with "&" in its name.
2. In the app got to the Products tab.
3. Tap any product to open its details.
4. Tap "Categories".
5. Confirm the category name is displayed (decoded) correctly in the list.
6. Select the test category and tap "Done".
7. Confirm the category name is displayed (decoded) correctly in the product details.

## Screenshots

before|after
--|--
![1_1](https://user-images.githubusercontent.com/3132438/195402637-63e8c621-d2b7-4b91-aa6b-09370ed82330.png)|![2_1](https://user-images.githubusercontent.com/3132438/195402652-0375d238-5e20-45d1-b8b7-6375efb9c644.png)
![1_2](https://user-images.githubusercontent.com/3132438/195402645-4e88a0d6-4a64-4bed-be57-d6eda514110c.png)|![2_2](https://user-images.githubusercontent.com/3132438/195402655-28708227-c55f-4553-89f0-b286432d4dac.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
