### PR TITLE
[ExPlat] Update logged-in A/A test (take 3)

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -10,7 +10,7 @@ public enum ABTest: String, CaseIterable {
     /// A/A test for ExPlat integration in the logged in state.
     /// Experiment ref: pbxNRc-1QS-p2
     ///
-    case aaTest202209 = "woocommerceios_explat_aa_test_logged_in_202209"
+    case aaTestLoggedIn202210 = "woocommerceios_explat_aa_test_logged_in_202210"
 
     /// A/A test to make sure there is no bias in the logged out state.
     /// Experiment ref: pbxNRc-1S0-p2
@@ -30,7 +30,7 @@ public enum ABTest: String, CaseIterable {
     /// When adding a new experiment, add it to the appropriate case depending on its context (logged-in or logged-out experience).
     public var context: ExperimentContext {
         switch self {
-        case .aaTest202209:
+        case .aaTestLoggedIn202210:
             return .loggedIn
         case .aaTestLoggedOut202209, .loginPrologueButtonOrder:
             return .loggedOut


### PR DESCRIPTION
## Description

We fixed a remaining issue with the ExPlat integration in #7844. This PR replaces the logged-in A/A test with a new test, to check that the problems for logged-in experiments are resolved with these changes.

## Testing

Feel free to use a proxy service like Charles Proxy to verify the new experiment name is in the query parameter for the ExPlat assignments API request `/wpcom/v2/experiments/0.1.0/assignments`, and if you are logged in to an a8c account you see the experiment name and assignment in the response. (I already did a check.)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
