### PR TITLE
Reload product when review notification received

### DIFF
--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -453,6 +453,10 @@ private extension PushNotificationsManager {
            let notificationSiteID = userInfo[APNSKey.siteID] as? Int64 {
             incrementNotificationCount(siteID: notificationSiteID, type: type, incrementCount: 1) { [weak self] in
                 self?.loadNotificationCountAndUpdateApplicationBadgeNumber(siteID: siteID, type: type, postNotifications: true)
+
+                if let productID = userInfo[APNSKey.postID] as? Int64 {
+                    self?.updateProduct(productID, siteID: notificationSiteID)
+                }
             }
         }
 
@@ -482,6 +486,16 @@ private extension PushNotificationsManager {
         presentDetails(for: notification)
 
         inactiveNotificationsSubject.send(notification)
+    }
+
+    /// Reload related product when review notification received
+    ///
+    func updateProduct(_ productID: Int64, siteID: Int64) {
+        let action = ProductAction.retrieveProduct(siteID: siteID,
+                                                   productID: productID) { _ in
+            // ResultsController<StorageProduct> will reload the Product List (ProductsViewController)
+        }
+        stores.dispatch(action)
     }
 }
 
@@ -657,6 +671,7 @@ private enum APNSKey {
     static let identifier = "note_id"
     static let type = "type"
     static let siteID = "blog"
+    static let postID = "post_id"
 }
 
 private enum AnalyticKey {

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -454,7 +454,7 @@ private extension PushNotificationsManager {
             incrementNotificationCount(siteID: notificationSiteID, type: type, incrementCount: 1) { [weak self] in
                 self?.loadNotificationCountAndUpdateApplicationBadgeNumber(siteID: siteID, type: type, postNotifications: true)
 
-                if let productID = userInfo[APNSKey.postID] as? Int64 {
+                if type == .comment, let productID = userInfo[APNSKey.postID] as? Int64 {
                     self?.updateProduct(productID, siteID: notificationSiteID)
                 }
             }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -446,11 +446,11 @@ private extension PushNotificationsManager {
     func handleRemoteNotificationInAllAppStates(_ userInfo: [AnyHashable: Any]) {
         DDLogVerbose("📱 Push Notification Received: \n\(userInfo)\n")
 
-        // Badge: Update
         if let typeString = userInfo.string(forKey: APNSKey.type),
            let type = Note.Kind(rawValue: typeString),
            let siteID = siteID,
            let notificationSiteID = userInfo[APNSKey.siteID] as? Int64 {
+            // Badge: Update
             incrementNotificationCount(siteID: notificationSiteID, type: type, incrementCount: 1) { [weak self] in
                 self?.loadNotificationCountAndUpdateApplicationBadgeNumber(siteID: siteID, type: type, postNotifications: true)
             }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -453,10 +453,11 @@ private extension PushNotificationsManager {
            let notificationSiteID = userInfo[APNSKey.siteID] as? Int64 {
             incrementNotificationCount(siteID: notificationSiteID, type: type, incrementCount: 1) { [weak self] in
                 self?.loadNotificationCountAndUpdateApplicationBadgeNumber(siteID: siteID, type: type, postNotifications: true)
+            }
 
-                if type == .comment, let productID = userInfo[APNSKey.postID] as? Int64 {
-                    self?.updateProduct(productID, siteID: notificationSiteID)
-                }
+            // Update related product when review notification is received
+            if type == .comment, let productID = userInfo[APNSKey.postID] as? Int64 {
+                updateProduct(productID, siteID: notificationSiteID)
             }
         }
 
@@ -488,7 +489,7 @@ private extension PushNotificationsManager {
         inactiveNotificationsSubject.send(notification)
     }
 
-    /// Reload related product when review notification received
+    /// Reload related product when review notification is received
     ///
     func updateProduct(_ productID: Int64, siteID: Int64) {
         let action = ProductAction.retrieveProduct(siteID: siteID,


### PR DESCRIPTION
Fixes: https://github.com/woocommerce/woocommerce-ios/issues/7823

## Description
This PR adds product refresh when new product review push notification is received.
It provides correct review information when product details is opened.

## How

`ProductAction` is dispatched with a product ID from push notification. `ProductsViewController` picks up updated data automatically through `ResultsController<StorageProduct>`.

## Testing

1. Test on device with enabled push notifications.
2. Open products list.
3. Go to the web and publish a new review.
4. Open product details and confirm that the number of reviews is correct.

## Screenshots

before|after
--|--
![IMG_2536](https://user-images.githubusercontent.com/3132438/195634759-6ecac0ff-70ce-41f2-8c9c-1bc5d29ca931.PNG)|![IMG_2538](https://user-images.githubusercontent.com/3132438/195634772-b432db7f-e175-44c4-bdb0-9d1f64781149.PNG)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
