### PR TITLE
Home Screen Widgets: Update widget accessibility style condition for iOS 14

### DIFF
--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
@@ -28,6 +28,16 @@ private struct StoreInfoView: View {
     // Current size category
     @Environment(\.sizeCategory) var category
 
+    var accessibilityCategory: ContentSizeCategory {
+        if #available(iOS 15.0, *) {
+            return .extraLarge
+        } else {
+            // iOS 14 has margins issue with extraLarge text size, so fallback to accessibility style earlier
+            // https://github.com/woocommerce/woocommerce-ios/issues/7797
+            return .large
+        }
+    }
+
     var body: some View {
         ZStack {
             // Background
@@ -48,7 +58,7 @@ private struct StoreInfoView: View {
                         .statRangeStyle()
                 }
 
-                if category > .extraLarge {
+                if category > accessibilityCategory {
                     AccessibilityStatsCard(entryData: entryData)
                 } else {
                     StatsCard(entryData: entryData)


### PR DESCRIPTION
Fixes: https://github.com/woocommerce/woocommerce-ios/issues/7797

## Description
iOS 14 has slightly different side margins (compared to 15 and 16) for widget when `extraLarge` text size is used.
Widget view already has different content layout for accessibility text sizes, so this PR updates it to fallback on accessibility style earlier on iOS 14.

## How

Added `accessibilityCategory` var which returns different text size for iOS 14/15+.

## Testing

1. Use iOS 14 device/simulator.
2. Increment text size (Settings > Accessibility > Display & Text Size > Larger Text) to one step from default value.
3. Add a widget to home screen (long press on home screen > tap + in top left > search for Woo).
4. Confirm it has accessibility style and correct margins.

## Screenshots

text settings|before|after
--|--|--
![1](https://user-images.githubusercontent.com/3132438/195811441-e16c4e1c-2774-432a-860a-a2f3c4c2eea9.png)|![2](https://user-images.githubusercontent.com/3132438/195811462-76b35e5e-5f54-4d33-8c45-eb279e38c449.png)|![3](https://user-images.githubusercontent.com/3132438/195811494-d45577d9-f928-4c74-9af5-1345bd96f347.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
