### PR TITLE
[Mobile Payments] Use AuthenticatedWebView from Upsell Card Reader Feature Cards

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [***] Stats: Now you can add a Today's Stats Widget to your lock screen (iOS 16 only) to monitor your sales. [https://github.com/woocommerce/woocommerce-ios/pull/7839]
 - [internal] In-Person Payments: add UTM parameters to card reader purchase URLs to allow attribution [https://github.com/woocommerce/woocommerce-ios/pull/7858]
+- [*] In-Person Payments: the Purchase card reader links now all open in authenticated web views, to make it easier to log in to woocommerce.com. [https://github.com/woocommerce/woocommerce-ios/pull/7862]
 
 10.7
 -----

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/UpsellCardReadersCampaign.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/UpsellCardReadersCampaign.swift
@@ -51,6 +51,14 @@ extension UpsellCardReadersCampaign {
         static let dismissMessage = NSLocalizedString(
             "No worries! You can always get started with In-Person Payments in Settings",
             comment: "Message for a dismissal alert on the upsell card reader feature announcement banner")
+
+        static let cardReaderWebViewTitle = NSLocalizedString(
+            "Purchase Card Reader",
+            comment: "Title for the WebView opened to upsell card readers")
+
+        static let cardReaderWebViewDoneButtonTitle = NSLocalizedString(
+            "Done",
+            comment: "Title for the Done button on the WebView opened to upsell card readers")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -440,7 +440,7 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
     }
 
     private func makeCardReaderProductPageWebView(url: URL) -> some View {
-        let nav = NavigationView {
+        return NavigationView {
             AuthenticatedWebView(isPresented: .constant(true),
                                  url: url)
             .navigationTitle(UpsellCardReadersCampaign.Localization.cardReaderWebViewTitle)
@@ -456,7 +456,6 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
             }
         }
         .wooNavigationBarStyle()
-        return nav
     }
 
     func updateUpsellCardReaderTopBannerVisibility(with newCollection: UITraitCollection) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -104,7 +104,21 @@ struct PaymentMethodsView: View {
             }
         }
         .sheet(isPresented: $showingPurchaseCardReaderView) {
-            SafariView(url: viewModel.purchaseCardReaderUrl)
+            NavigationView {
+                AuthenticatedWebView(isPresented: .constant(true),
+                                     url: viewModel.purchaseCardReaderUrl)
+                .navigationTitle(Text(UpsellCardReadersCampaign.Localization.cardReaderWebViewTitle))
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button(UpsellCardReadersCampaign.Localization.cardReaderWebViewDoneButtonTitle) {
+                            showingPurchaseCardReaderView = false
+                        }
+                    }
+                }
+            }
+            .wooNavigationBarStyle()
+            .navigationViewStyle(.stack)
         }
         .shareSheet(isPresented: $sharingPaymentLink) {
             // If paymentLink is available it already contains a valid URL.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7859
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Upsell card reader promotion via feature cards on the Order List and Payment Methods screen should have been subject to the same improvements as when the `Order card reader` row is tapped in Payment settings.

This commit changes the other two locations to use AuthenticatedWebView in order that they are preloaded with the user’s wpcom credentials, to speed up the login flow on WooCommerce.com

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

With a US or CA site,

1. Open the Order List and tap `Purchase card reader` in the feature card
2. If you have 2FA enabled, you will need to complete the 2FA challenge.
3. Observe that you're taken to the product page for the M2 or WisePad card reader, as appropriate.
4. Add the reader to your cart, and go through to checkout.
5. Tap Log in
6. Observe that you're already logged in to WordPress.com, so you only need to tap `Authorize` to complete log in.

Repeat for the `Payment Methods` card (`Menu > Payments > Collect Payment > Enter amount > Take payment`)

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/195848168-c6a2f9a8-ddb9-4249-b7d5-7115be4f486c.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
