### PR TITLE
[Universal Links] Do not enter undetermined state if the user does not have access to the passed blog Id

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -39,7 +39,7 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
         }
     }
 
-    /// Switches to store with the given id if it was previously synced and stored.
+    /// Switches the to store with the given id if it was previously synced and stored.
     /// This is done to check whether the user has access to that store, avoiding undetermined states if we log out
     /// from the current one and try to switch to a store they don't have access to.
     ///

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -47,9 +47,9 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
     /// - Returns: a boolean that indicates whether the site was changed.
     ///
     func switchToStoreIfSiteIsStored(with storeID: Int64, onCompletion: @escaping (Bool) -> Void) {
-        self.refreshStoredSites()
+        refreshStoredSites()
 
-        let siteWasStored = self.wooCommerceSites.first(where: { $0.siteID == storeID }) != nil
+        let siteWasStored = wooCommerceSites.first(where: { $0.siteID == storeID }) != nil
 
         guard siteWasStored else {
             return onCompletion(false)

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -46,7 +46,7 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
     /// - Parameter storeID: target store ID.
     /// - Returns: a boolean that indicates whether the site was changed.
     ///
-    func switchToStoreIfPreviouslyStored(with storeID: Int64, onCompletion: @escaping (Bool) -> Void) {
+    func switchToStoreIfSiteIsStored(with storeID: Int64, onCompletion: @escaping (Bool) -> Void) {
         self.refreshStoredSites()
 
         let siteWasStored = self.wooCommerceSites.first(where: { $0.siteID == storeID }) != nil

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -370,7 +370,7 @@ extension MainTabBarController {
     }
 
     private static func switchToStore(with siteID: Int64, onCompletion: @escaping (Bool) -> Void) {
-        SwitchStoreUseCase(stores: ServiceLocator.stores).switchToStoreIfPreviouslyStored(with: siteID) { siteChanged in
+        SwitchStoreUseCase(stores: ServiceLocator.stores).switchToStoreIfSiteIsStored(with: siteID) { siteChanged in
             guard siteChanged else {
                 return onCompletion(false)
             }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -370,7 +370,7 @@ extension MainTabBarController {
     }
 
     private static func switchToStore(with siteID: Int64, onCompletion: @escaping (Bool) -> Void) {
-        SwitchStoreUseCase(stores: ServiceLocator.stores).switchStore(with: siteID) { siteChanged in
+        SwitchStoreUseCase(stores: ServiceLocator.stores).switchToStoreIfPreviouslyStored(with: siteID) { siteChanged in
             guard siteChanged else {
                 return onCompletion(false)
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7864
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Before, when the user tapped on "order details" universal link with a blog Id parameter value they couldn't access, the app opened and switched to an undetermined state where data couldn't be loaded (see video below).
The reason is that, when switching to the new store, we logged out from the previous one without checking if the user could actually access the new site. Once we do that, the app cannot load any data (stats, orders, products ...) of the new site because the user doesn't have access.
With this PR we check first if the switching store was previously synced and stored in CoreData, which means the user has access to it. Since we synchronize the sites remotely on every startup and we want the navigation to be quick, I consider enough checking locally for the store instead of syncing remotely after opening the app following a universal link.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Add a link to the Notes app with a blog id you don't have access to E.g https://woocommerce.com/mobile/orders/details?blog_id=1&order_id=240
2. Tap on the Link
3a. Before: App opens, the order load fails and the app cannot retrieve data anymore until you switch store again in settings.
3b. After: App opens and navigates to orders.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

#### Before

https://user-images.githubusercontent.com/1864060/195874181-59005dd0-2675-4903-8f42-9af7aee8c5f4.MP4

#### After

https://user-images.githubusercontent.com/1864060/195874227-02817e66-be96-4a8d-b72a-f13cd7e31206.MP4

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
