### PR TITLE
Widgets Configuration: Add time interval setting

### DIFF
--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
@@ -225,7 +225,7 @@ private extension StoreInfoView {
         static let viewMore = AppLocalizedString(
             "storeWidgets.infoView.viewMore",
             value: "View More",
-            comment: "Title for the button indicator to display more stats in the Today's Stat widget when using accessibility fonts."
+            comment: "Title for the button indicator to display more stats in the Stat widget when using accessibility fonts."
         )
         static func updatedAt(_ updatedTime: String) -> LocalizedString {
             let format = AppLocalizedString("storeWidgets.infoView.updatedAt",
@@ -247,7 +247,7 @@ private extension NotLoggedInView {
     enum Localization {
         static let notLoggedIn = AppLocalizedString(
             "storeWidgets.notLoggedInView.notLoggedIn",
-            value: "Log in to see today’s stats.",
+            value: "Log in to see store’s stats.",
             comment: "Title label when the widget does not have a logged-in store."
         )
         static let login = AppLocalizedString(
@@ -269,7 +269,7 @@ private extension UnableToFetchView {
     enum Localization {
         static let unableToFetch = AppLocalizedString(
             "storeWidgets.unableToFetchView.unableToFetch",
-            value: "Unable to fetch today's stats",
+            value: "Unable to fetch store's stats",
             comment: "Title label when the widget can't fetch data."
         )
     }

--- a/WooCommerce/StoreWidgets/StatsTimeRange.swift
+++ b/WooCommerce/StoreWidgets/StatsTimeRange.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WooFoundation
 import enum Networking.StatGranularity
+import enum Networking.StatsGranularityV4
 
 /// Represents the time range for an Order Stats v4 model.
 /// This is a local property and not in the remote response.
@@ -27,6 +28,34 @@ extension StatsTimeRange {
             self = .thisMonth
         case .thisYear:
             self = .thisYear
+        }
+    }
+
+    /// The maximum number of stats intervals a time range could have.
+    var maxNumberOfIntervals: Int {
+        switch self {
+        case .today:
+            return 24
+        case .thisWeek:
+            return 7
+        case .thisMonth:
+            return 31
+        case .thisYear:
+            return 12
+        }
+    }
+
+    /// Represents the period unit of the store stats using Stats v4 API given a time range.
+    var intervalGranularity: StatsGranularityV4 {
+        switch self {
+        case .today:
+            return .hourly
+        case .thisWeek:
+            return .daily
+        case .thisMonth:
+            return .daily
+        case .thisYear:
+            return .monthly
         }
     }
 

--- a/WooCommerce/StoreWidgets/StatsTimeRange.swift
+++ b/WooCommerce/StoreWidgets/StatsTimeRange.swift
@@ -1,3 +1,7 @@
+import Foundation
+import WooFoundation
+import enum Networking.StatGranularity
+
 /// Represents the time range for an Order Stats v4 model.
 /// This is a local property and not in the remote response.
 ///
@@ -23,6 +27,70 @@ extension StatsTimeRange {
             self = .thisMonth
         case .thisYear:
             self = .thisYear
+        }
+    }
+
+    /// Represents the period unit of the site visit stats given a time range.
+    var siteVisitStatsGranularity: StatGranularity {
+        switch self {
+        case .today, .thisWeek, .thisMonth:
+            return .day
+        case .thisYear:
+            return .month
+        }
+    }
+
+    /// The number of intervals for site visit stats to fetch given a time range.
+    /// The interval unit is in `siteVisitStatsGranularity`.
+    func siteVisitStatsQuantity(date: Date, siteTimezone: TimeZone) -> Int {
+        switch self {
+        case .today:
+            return 1
+        case .thisWeek:
+            return 7
+        case .thisMonth:
+            var calendar = Calendar.current
+            calendar.timeZone = siteTimezone
+            let daysThisMonth = calendar.range(of: .day, in: .month, for: date)
+            return daysThisMonth?.count ?? 0
+        case .thisYear:
+            return 12
+        }
+    }
+
+    /// Returns the latest date to be shown for the time range, given the current date and site time zone
+    ///
+    /// - Parameters:
+    ///   - currentDate: the date which the latest date is based on
+    ///   - siteTimezone: site time zone, which the stats data are based on
+    func latestDate(currentDate: Date, siteTimezone: TimeZone) -> Date {
+        switch self {
+        case .today:
+            return currentDate.endOfDay(timezone: siteTimezone)
+        case .thisWeek:
+            return currentDate.endOfWeek(timezone: siteTimezone)
+        case .thisMonth:
+            return currentDate.endOfMonth(timezone: siteTimezone)
+        case .thisYear:
+            return currentDate.endOfYear(timezone: siteTimezone)
+        }
+    }
+
+    /// Returns the earliest date to be shown for the time range, given the latest date and site time zone
+    ///
+    /// - Parameters:
+    ///   - latestDate: the date which the earliest date is based on
+    ///   - siteTimezone: site time zone, which the stats data are based on
+    func earliestDate(latestDate: Date, siteTimezone: TimeZone) -> Date {
+        switch self {
+        case .today:
+            return latestDate.startOfDay(timezone: siteTimezone)
+        case .thisWeek:
+            return latestDate.startOfWeek(timezone: siteTimezone)
+        case .thisMonth:
+            return latestDate.startOfMonth(timezone: siteTimezone)
+        case .thisYear:
+            return latestDate.startOfYear(timezone: siteTimezone)
         }
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -7,6 +7,7 @@ final class StoreInfoDataService {
     /// Data extracted from networking types.
     ///
     struct Stats {
+        let timeRange: StatsTimeRange
         let revenue: Decimal
         let totalOrders: Int
         let totalVisitors: Int
@@ -43,7 +44,8 @@ final class StoreInfoDataService {
 
         // Assemble stats data
         let conversion = visitors.totalVisitors > 0 ? Double(revenueAndOrders.totals.totalOrders) / Double(visitors.totalVisitors) : 0
-        return Stats(revenue: revenueAndOrders.totals.grossRevenue,
+        return Stats(timeRange: timeRange,
+                     revenue: revenueAndOrders.totals.grossRevenue,
                      totalOrders: revenueAndOrders.totals.totalOrders,
                      totalVisitors: visitors.totalVisitors,
                      conversion: min(conversion, 1))

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -1,6 +1,6 @@
 import Networking
 
-/// Orchestrator class that fetches today store stats data.
+/// Orchestrator class that fetches store stats data.
 ///
 final class StoreInfoDataService {
 
@@ -56,7 +56,7 @@ final class StoreInfoDataService {
 ///
 private extension StoreInfoDataService {
 
-    /// Async wrapper that fetches todays revenues & orders.
+    /// Async wrapper that fetches revenues & orders.
     ///
     func fetchRevenueAndOrders(for storeID: Int64, timeRange: StatsTimeRange) async throws -> OrderStatsV4 {
         try await withCheckedThrowingContinuation { continuation in

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -143,7 +143,7 @@ private extension StoreInfoProvider {
     /// Redacted entry with sample data. If dependencies are available - store name and currency settings will be used.
     ///
     static func placeholderEntry(for dependencies: Dependencies?) -> StoreInfoEntry {
-        StoreInfoEntry.data(.init(range: Localization.today,
+        StoreInfoEntry.data(.init(range: Localization.periodString(from: .today),
                                   name: dependencies?.storeName ?? Localization.myShop,
                                   revenue: Self.formattedAmountString(for: 132.234, with: dependencies?.storeCurrencySettings),
                                   revenueCompact: Self.formattedAmountCompactString(for: 132.234, with: dependencies?.storeCurrencySettings),
@@ -156,7 +156,7 @@ private extension StoreInfoProvider {
     /// Real data entry.
     ///
     static func dataEntry(for todayStats: StoreInfoDataService.Stats, with dependencies: Dependencies) -> StoreInfoEntry {
-        StoreInfoEntry.data(.init(range: Localization.today,
+        StoreInfoEntry.data(.init(range: Localization.periodString(from: todayStats.timeRange),
                                   name: dependencies.storeName,
                                   revenue: Self.formattedAmountString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
                                   revenueCompact: Self.formattedAmountCompactString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
@@ -206,10 +206,34 @@ private extension StoreInfoProvider {
             value: "My Shop",
             comment: "Generic store name for the store info widget preview"
         )
-        static let today = AppLocalizedString(
-            "storeWidgets.infoProvider.today",
-            value: "Today",
-            comment: "Range title for the today store info widget"
-        )
+
+        static func periodString(from timeRange: StatsTimeRange) -> String {
+            switch timeRange {
+            case .today:
+                return AppLocalizedString(
+                    "storeWidgets.infoProvider.today",
+                    value: "Today",
+                    comment: "Range title for the store info widget"
+                )
+            case .thisWeek:
+                return AppLocalizedString(
+                    "storeWidgets.infoProvider.thisWeek",
+                    value: "This Week",
+                    comment: "Range title for the store info widget"
+                )
+            case .thisMonth:
+                return AppLocalizedString(
+                    "storeWidgets.infoProvider.thisMonth",
+                    value: "This Month",
+                    comment: "Range title for the store info widget"
+                )
+            case .thisYear:
+                return AppLocalizedString(
+                    "storeWidgets.infoProvider.thisYear",
+                    value: "This Year",
+                    comment: "Range title for the store info widget"
+                )
+            }
+        }
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -90,14 +90,14 @@ final class StoreInfoProvider: IntentTimelineProvider {
         networkService = strongService
         Task {
             do {
-                let todayStats = try await strongService.fetchStats(for: dependencies.storeID, timeRange: StatsTimeRange(configuration.timeRange))
-                let entry = Self.dataEntry(for: todayStats, with: dependencies)
+                let stats = try await strongService.fetchStats(for: dependencies.storeID, timeRange: StatsTimeRange(configuration.timeRange))
+                let entry = Self.dataEntry(for: stats, with: dependencies)
                 let reloadDate = Date(timeIntervalSinceNow: reloadInterval)
                 let timeline = Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
                 completion(timeline)
             } catch {
                 // WooFoundation does not expose `DDLOG` types. Should we include them?
-                print("⛔️ Error fetching today's widget stats: \(error)")
+                print("⛔️ Error fetching widget stats: \(error)")
 
                 let reloadDate = Date(timeIntervalSinceNow: reloadInterval)
                 let timeline = Timeline<StoreInfoEntry>(entries: [.error], policy: .after(reloadDate))
@@ -155,14 +155,14 @@ private extension StoreInfoProvider {
 
     /// Real data entry.
     ///
-    static func dataEntry(for todayStats: StoreInfoDataService.Stats, with dependencies: Dependencies) -> StoreInfoEntry {
-        StoreInfoEntry.data(.init(range: Localization.periodString(from: todayStats.timeRange),
+    static func dataEntry(for stats: StoreInfoDataService.Stats, with dependencies: Dependencies) -> StoreInfoEntry {
+        StoreInfoEntry.data(.init(range: Localization.periodString(from: stats.timeRange),
                                   name: dependencies.storeName,
-                                  revenue: Self.formattedAmountString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
-                                  revenueCompact: Self.formattedAmountCompactString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
-                                  visitors: "\(todayStats.totalVisitors)",
-                                  orders: "\(todayStats.totalOrders)",
-                                  conversion: Self.formattedConversionString(for: todayStats.conversion),
+                                  revenue: Self.formattedAmountString(for: stats.revenue, with: dependencies.storeCurrencySettings),
+                                  revenueCompact: Self.formattedAmountCompactString(for: stats.revenue, with: dependencies.storeCurrencySettings),
+                                  visitors: "\(stats.totalVisitors)",
+                                  orders: "\(stats.totalOrders)",
+                                  conversion: Self.formattedConversionString(for: stats.conversion),
                                   updatedTime: Self.currentFormattedTime()))
     }
 
@@ -211,25 +211,25 @@ private extension StoreInfoProvider {
             switch timeRange {
             case .today:
                 return AppLocalizedString(
-                    "storeWidgets.infoProvider.today",
+                    "storeWidgets.timeRange.today",
                     value: "Today",
                     comment: "Range title for the store info widget"
                 )
             case .thisWeek:
                 return AppLocalizedString(
-                    "storeWidgets.infoProvider.thisWeek",
+                    "storeWidgets.timeRange.thisWeek",
                     value: "This Week",
                     comment: "Range title for the store info widget"
                 )
             case .thisMonth:
                 return AppLocalizedString(
-                    "storeWidgets.infoProvider.thisMonth",
+                    "storeWidgets.timeRange.thisMonth",
                     value: "This Month",
                     comment: "Range title for the store info widget"
                 )
             case .thisYear:
                 return AppLocalizedString(
-                    "storeWidgets.infoProvider.thisYear",
+                    "storeWidgets.timeRange.thisYear",
                     value: "This Year",
                     comment: "Range title for the store info widget"
                 )

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -61,12 +61,12 @@ private extension StoreInfoWidget {
     enum Localization {
         static let title = AppLocalizedString(
             "storeWidgets.displayName",
-            value: "Today",
+            value: "Stats",
             comment: "Widget title, displayed when selecting which widget to add"
         )
         static let description = AppLocalizedString(
             "storeWidgets.description",
-            value: "WooCommerce Stats Today",
+            value: "WooCommerce Stats",
             comment: "Widget description, displayed when selecting which widget to add"
         )
     }


### PR DESCRIPTION
Part of: https://github.com/woocommerce/woocommerce-ios/issues/7863
Based on: https://github.com/woocommerce/woocommerce-ios/pull/7872

## Description

This PR updates widget data provider to fetch data for user-selected time interval.
It also cleans up code for any hardcoded mention of "today" for the widget.

*Note:* configuration UI still says "Today" in 2 widget title and description, because they are overriden in `Localizable.strings`.

## Testing

1. Add a widget to home screen (long press on home screen > tap + in top left > search for Woo).
2. Configure Widget (long press on widget > tap "Edit Widget").
3. Select different time intervals and confirm that data is the same as on application's stats dashboard.
4. Confirm that time range title (in top right corner of a widget) is correct.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
