### PR TITLE
Products: Draft product preview (WIP)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -795,6 +795,15 @@ private extension ProductFormViewController {
     }
 
     func displayProductPreview() {
+        var permalink = URLComponents(string: product.permalink)
+        var updatedQueryItems = permalink?.queryItems ?? []
+        updatedQueryItems.append(.init(name: "preview", value: "true"))
+        permalink?.queryItems = updatedQueryItems
+        guard let url = permalink?.url else {
+            return
+        }
+
+        WebviewHelper.launch(url, with: self)
     }
 
     func duplicateProduct() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -716,14 +716,14 @@ private extension ProductFormViewController {
 // MARK: Navigation actions
 //
 private extension ProductFormViewController {
-    func saveProduct(status: ProductStatus? = nil) {
+    func saveProduct(status: ProductStatus? = nil, onCompletion: @escaping (Result<Void, ProductUpdateError>) -> Void = { _ in }) {
         let productStatus = status ?? product.status
         let messageType = viewModel.saveMessageType(for: productStatus)
         showSavingProgress(messageType)
-        saveProductRemotely(status: status)
+        saveProductRemotely(status: status, onCompletion: onCompletion)
     }
 
-    func saveProductRemotely(status: ProductStatus?) {
+    func saveProductRemotely(status: ProductStatus?, onCompletion: @escaping (Result<Void, ProductUpdateError>) -> Void = { _ in }) {
         viewModel.saveProductRemotely(status: status) { [weak self] result in
             switch result {
             case .failure(let error):
@@ -732,6 +732,7 @@ private extension ProductFormViewController {
                 // Dismisses the in-progress UI then presents the error alert.
                 self?.navigationController?.dismiss(animated: true) {
                     self?.displayError(error: error)
+                    onCompletion(.failure(error))
                 }
             case .success:
                 // Dismisses the in-progress UI, then presents the confirmation alert.
@@ -741,6 +742,7 @@ private extension ProductFormViewController {
                 // Show linked products promo banner after product save
                 (self?.viewModel as? ProductFormViewModel)?.isLinkedProductsPromoEnabled = true
                 self?.reloadLinkedPromoCellAnimated()
+                onCompletion(.success(()))
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -229,6 +229,20 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
             }
         }
 
+        if viewModel.canSaveAsDraft() || viewModel.productModel.status == .draft {
+            actionSheet.addDefaultActionWithTitle(ActionSheetStrings.previewProduct) { [weak self] _ in
+                if self?.viewModel.canSaveAsDraft() == true || self?.viewModel.hasUnsavedChanges() == true {
+                    self?.saveProduct(status: .draft) { result in
+                        if result.isSuccess {
+                            self?.displayProductPreview()
+                        }
+                    }
+                } else {
+                    self?.displayProductPreview()
+                }
+            }
+        }
+
         /// The "View product in store" action will be shown only if the product is published.
         if viewModel.canViewProductInStore() {
             actionSheet.addDefaultActionWithTitle(ActionSheetStrings.viewProduct) { [weak self] _ in
@@ -778,6 +792,9 @@ private extension ProductFormViewController {
         }
 
         SharingHelper.shareURL(url: url, title: product.name, from: view, in: self)
+    }
+
+    func displayProductPreview() {
     }
 
     func duplicateProduct() {
@@ -1557,6 +1574,8 @@ private enum Localization {
 private enum ActionSheetStrings {
     static let saveProductAsDraft = NSLocalizedString("Save as draft",
                                                       comment: "Button title to save a product as draft in Product More Options Action Sheet")
+    static let previewProduct = NSLocalizedString("Preview",
+                                                  comment: "Button title to open preview link for a product in Product More Options Action Sheet")
     static let viewProduct = NSLocalizedString("View Product in Store",
                                                comment: "Button title View product in store in Edit Product More Options Action Sheet")
     static let share = NSLocalizedString("Share", comment: "Button title Share in Edit Product More Options Action Sheet")


### PR DESCRIPTION
## Description

This is a draft of "product preview" functionality.
It adds "preview" option in action sheet on product form. It appears for new product flow and existing drafts.
On button tap it saves the product as a draft and opens URL in SafariVC.

*Known issue:* because session in SafariVC is not authenticated, preview links for drafts can't be directly accessed at this time. Links work when opened in previously authenticated Safari.

## Video

https://user-images.githubusercontent.com/3132438/196533178-1e87c745-067f-4d50-bc08-6aaca68501d7.mp4

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
