### PR TITLE
Customer Search: Implement UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -107,19 +107,8 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
             siteID: siteID,
             keyword: "hello") { result in
                 switch result {
-                case .success(let customers):
-                    let storage = ServiceLocator.storageManager
-                    guard let result = storage.viewStorage.loadCustomerSearchResult(siteID: self.siteID, keyword: "hello") else {
-                        return
-                    }
-                    print("Site ID: \(result.siteID), keyword: \(result.keyword), Customers: \(result.customers?.count as Any)")
-                    for eachCustomer in customers {
-                        let output = """
-                                    Customer: \(eachCustomer.customerID),
-                                    Name: \(String(describing: eachCustomer.firstName)) \(String(describing: eachCustomer.lastName))
-                                    """
-                        print(output)
-                    }
+                case .success(_):
+                    print("Success")
                 case .failure(let error):
                     print(error)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -17,15 +17,17 @@ final class CustomerSearchUICommand: SearchUICommand {
 
     var resynchronizeModels: (() -> Void) = {}
 
+    var onDidSelectSearchResult: ((Customer) -> Void)
+
     private let siteID: Int64
 
-    init(siteID: Int64) {
+    init(siteID: Int64, onDidSelectSearchResult: @escaping ((Customer) -> Void)) {
         self.siteID = siteID
+        self.onDidSelectSearchResult = onDidSelectSearchResult
     }
 
     func createResultsController() -> ResultsController<StorageCustomer> {
         let storageManager = ServiceLocator.storageManager
-        let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \StorageCustomer.customerID, ascending: false)
         return ResultsController<StorageCustomer>(storageManager: storageManager, sortedBy: [descriptor])
     }
@@ -37,7 +39,7 @@ final class CustomerSearchUICommand: SearchUICommand {
     func createCellViewModel(model: Customer) -> TitleAndSubtitleAndStatusTableViewCell.ViewModel {
         return CellViewModel(
             id: "\(model.customerID)",
-            title: "\(model.firstName ?? "") \(model.lastName ?? ""))",
+            title: "\(model.firstName ?? "") \(model.lastName ?? "")",
             subtitle: model.email,
             accessibilityLabel: "",
             status: "",
@@ -59,7 +61,10 @@ final class CustomerSearchUICommand: SearchUICommand {
 
     func didSelectSearchResult(model: Customer, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
         // Not implemented yet
-        print("Selected ID: \(model.customerID) - Name: \(String(describing: model.firstName))")
+        print("1 - Customer tapped")
+        print("2 - Customer ID: \(model.customerID) - Name: \(model.firstName ?? ""))")
+        // Customer data will go up to EditOrderAddressForm, via OrderCustomerListView completion handler
+        onDidSelectSearchResult(model)
     }
 
     func searchResultsPredicate(keyword: String) -> NSPredicate? {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -37,11 +37,11 @@ final class CustomerSearchUICommand: SearchUICommand {
     func createCellViewModel(model: Customer) -> TitleAndSubtitleAndStatusTableViewCell.ViewModel {
         return CellViewModel(
             id: "\(model.customerID)",
-            title: model.firstName ?? "",
-            subtitle: model.lastName ?? "",
+            title: "\(model.firstName ?? "") \(model.lastName ?? ""))",
+            subtitle: model.email,
             accessibilityLabel: "",
             status: "",
-            statusBackgroundColor: .accent
+            statusBackgroundColor: .clear
         )
     }
 
@@ -58,7 +58,8 @@ final class CustomerSearchUICommand: SearchUICommand {
     }
 
     func didSelectSearchResult(model: Customer, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
-
+        // Not implemented yet
+        print("Selected ID: \(model.customerID) - Name: \(String(describing: model.firstName))")
     }
 
     func searchResultsPredicate(keyword: String) -> NSPredicate? {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -46,7 +46,15 @@ final class CustomerSearchUICommand: SearchUICommand {
     }
 
     func synchronizeModels(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
-
+        let action = CustomerAction.searchCustomers(siteID: siteID, keyword: keyword) { result in
+            switch result {
+            case .success(_):
+                onCompletion?(result.isSuccess)
+            case .failure(let error):
+                DDLogError("Customer Search Failure \(error)")
+            }
+        }
+        ServiceLocator.stores.dispatch(action)
     }
 
     func didSelectSearchResult(model: Customer, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -28,8 +28,9 @@ final class CustomerSearchUICommand: SearchUICommand {
 
     func createResultsController() -> ResultsController<StorageCustomer> {
         let storageManager = ServiceLocator.storageManager
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \StorageCustomer.customerID, ascending: false)
-        return ResultsController<StorageCustomer>(storageManager: storageManager, sortedBy: [descriptor])
+        return ResultsController<StorageCustomer>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }
 
     func createStarterViewController() -> UIViewController? {
@@ -68,7 +69,7 @@ final class CustomerSearchUICommand: SearchUICommand {
     }
 
     func searchResultsPredicate(keyword: String) -> NSPredicate? {
-        return NSPredicate(format: "ANY searchResults.keyword = %@", keyword)
+        return NSPredicate(format: "siteID == %lld AND ANY searchResults.keyword = %@", siteID, keyword)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Yosemite
+
+final class CustomerSearchUICommand: SearchUICommand {
+
+    typealias Model = Customer
+    typealias CellViewModel = TitleAndSubtitleAndStatusTableViewCell.ViewModel
+    typealias ResultsControllerModel = StorageCustomer
+
+    var searchBarPlaceholder: String = ""
+
+    var searchBarAccessibilityIdentifier: String = ""
+
+    var cancelButtonAccessibilityIdentifier: String = ""
+
+    var resynchronizeModels: (() -> Void) = {}
+
+    private let siteID: Int64
+
+    init(siteID: Int64) {
+        self.siteID = siteID
+    }
+
+    func createResultsController() -> ResultsController<StorageCustomer> {
+        let storageManager = ServiceLocator.storageManager
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        let descriptor = NSSortDescriptor(keyPath: \StorageCustomer.customerID, ascending: false)
+        return ResultsController<StorageCustomer>(storageManager: storageManager, sortedBy: [descriptor])
+    }
+
+    func createStarterViewController() -> UIViewController? {
+        return nil
+    }
+
+    func createCellViewModel(model: Customer) -> TitleAndSubtitleAndStatusTableViewCell.ViewModel {
+        return CellViewModel(
+            id: "\(model.customerID)",
+            title: model.firstName ?? "",
+            subtitle: model.lastName ?? "",
+            accessibilityLabel: "",
+            status: "",
+            statusBackgroundColor: .accent
+        )
+    }
+
+    func synchronizeModels(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
+
+    }
+
+    func didSelectSearchResult(model: Customer, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
+
+    }
+
+    func searchResultsPredicate(keyword: String) -> NSPredicate? {
+        return NSPredicate(format: "ANY searchResults.keyword = %@", keyword)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -1,17 +1,19 @@
 import Foundation
 import Yosemite
 
+/// Implementation of `SearchUICommand` for Customer search.
+///
 final class CustomerSearchUICommand: SearchUICommand {
 
     typealias Model = Customer
     typealias CellViewModel = TitleAndSubtitleAndStatusTableViewCell.ViewModel
     typealias ResultsControllerModel = StorageCustomer
 
-    var searchBarPlaceholder: String = ""
+    var searchBarPlaceholder: String = Localization.searchBarPlaceHolder
 
-    var searchBarAccessibilityIdentifier: String = ""
+    var searchBarAccessibilityIdentifier: String = "customer-search-screen-search-field"
 
-    var cancelButtonAccessibilityIdentifier: String = ""
+    var cancelButtonAccessibilityIdentifier: String = "customer-search-screen-cancel-button"
 
     var resynchronizeModels: (() -> Void) = {}
 
@@ -29,7 +31,7 @@ final class CustomerSearchUICommand: SearchUICommand {
     }
 
     func createStarterViewController() -> UIViewController? {
-        return nil
+        nil
     }
 
     func createCellViewModel(model: Customer) -> TitleAndSubtitleAndStatusTableViewCell.ViewModel {
@@ -53,5 +55,12 @@ final class CustomerSearchUICommand: SearchUICommand {
 
     func searchResultsPredicate(keyword: String) -> NSPredicate? {
         return NSPredicate(format: "ANY searchResults.keyword = %@", keyword)
+    }
+}
+
+private extension CustomerSearchUICommand {
+    enum Localization {
+        static let searchBarPlaceHolder = NSLocalizedString("Search all customers",
+                                                            comment: "Customer Search Placeholder")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerListView.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Yosemite
 import SwiftUI
 
 /// `SwiftUI` wrapper for `SearchViewController` using `CustomerSearchUICommand`
@@ -7,11 +8,13 @@ struct OrderCustomerListView: UIViewControllerRepresentable {
 
     let siteID: Int64
 
+    let onCustomerTapped: ((Customer) -> Void)
+
     func makeUIViewController(context: Context) -> WooNavigationController {
 
         let viewController = SearchViewController(
             storeID: siteID,
-            command: CustomerSearchUICommand(siteID: siteID),
+            command: CustomerSearchUICommand(siteID: siteID, onDidSelectSearchResult: onCustomerTapped),
             cellType: TitleAndSubtitleAndStatusTableViewCell.self,
             // Must conform to SearchResultCell.
             // TODO: Proper cell for this cellType.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerListView.swift
@@ -1,19 +1,18 @@
 import Foundation
 import SwiftUI
 
-/// `SwiftUI` wrapper for `SearchViewController`
-///
+/// `SwiftUI` wrapper for `SearchViewController` using `CustomerSearchUICommand`
+/// TODO: Make it generic
 struct OrderCustomerListView: UIViewControllerRepresentable {
-    
-    let storeID: Int64
-    let command: CouponSearchUICommand // TODO: Make CustomerSearchUICommand
-    let cellType: UITableViewCell
-    
+
+    let siteID: Int64
+
     func makeUIViewController(context: Context) -> WooNavigationController {
-        //let vm =
+
         let viewController = SearchViewController(
-            storeID: storeID,
-            command: command,
+            storeID: siteID,
+            command: CouponSearchUICommand(siteID: siteID),
+            // TODO: replace SearchUICommand
             cellType: TitleAndSubtitleAndStatusTableViewCell.self,
             // Must conform to SearchResultCell.
             // TODO: Proper cell for this cellType.
@@ -22,6 +21,8 @@ struct OrderCustomerListView: UIViewControllerRepresentable {
         let navigationController = WooNavigationController(rootViewController: viewController)
         return navigationController
     }
-    
-    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
+
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
+        // nope
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerListView.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SwiftUI
+
+/// `SwiftUI` wrapper for `SearchViewController`
+///
+struct OrderCustomerListView: UIViewControllerRepresentable {
+    
+    let storeID: Int64
+    let command: CouponSearchUICommand // TODO: Make CustomerSearchUICommand
+    let cellType: UITableViewCell
+    
+    func makeUIViewController(context: Context) -> WooNavigationController {
+        //let vm =
+        let viewController = SearchViewController(
+            storeID: storeID,
+            command: command,
+            cellType: TitleAndSubtitleAndStatusTableViewCell.self,
+            // Must conform to SearchResultCell.
+            // TODO: Proper cell for this cellType.
+            cellSeparator: .none
+        )
+        let navigationController = WooNavigationController(rootViewController: viewController)
+        return navigationController
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerListView.swift
@@ -11,8 +11,7 @@ struct OrderCustomerListView: UIViewControllerRepresentable {
 
         let viewController = SearchViewController(
             storeID: siteID,
-            command: CouponSearchUICommand(siteID: siteID),
-            // TODO: replace SearchUICommand
+            command: CustomerSearchUICommand(siteID: siteID),
             cellType: TitleAndSubtitleAndStatusTableViewCell.self,
             // Must conform to SearchResultCell.
             // TODO: Proper cell for this cellType.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -7,6 +7,10 @@ import protocol Storage.StorageManagerType
 ///
 protocol AddressFormViewModelProtocol: ObservableObject {
 
+    /// Site ID
+    /// 
+    var siteID: Int64 { get }
+
     /// Address form fields
     ///
     var fields: AddressFormFields { get set }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -89,6 +89,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
     @ObservedObject private(set) var viewModel: ViewModel
 
     @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+    @State private var showingCustomerSearch: Bool = false
 
     let isSearchCustomersEnabled = DefaultFeatureFlagService().isFeatureFlagEnabled(.orderCreationSearchCustomers)
 
@@ -152,7 +153,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
             ToolbarItem(placement: .automatic) {
                 if isSearchCustomersEnabled {
                     Button(action: {
-                        viewModel.customerSearchTapped()
+                        showingCustomerSearch = true
                     }, label: {
                         Image(systemName: "magnifyingglass")
                     })
@@ -169,6 +170,9 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
             viewModel.onLoadTrigger.send()
         }
         .notice($viewModel.notice)
+        .sheet(isPresented: $showingCustomerSearch, content: {
+            OrderCustomerListView(siteID: viewModel.siteID)
+        })
     }
 
     /// Decides if the navigation trailing item should be a done button or a loading indicator.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -171,7 +171,11 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
         }
         .notice($viewModel.notice)
         .sheet(isPresented: $showingCustomerSearch, content: {
-            OrderCustomerListView(siteID: viewModel.siteID)
+            OrderCustomerListView(siteID: viewModel.siteID, onCustomerTapped: { customer in
+                // Not implemented yet.
+                print("3 - Customer Callback. Fill Order data with Customer details")
+                print("4 - Customer ID: \(customer.customerID) - Name: \(customer.firstName ?? ""))")
+            })
         })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -9,6 +9,9 @@ final class EditOrderAddressFormViewModel: AddressFormViewModel, AddressFormView
         case billing
     }
 
+    var siteID: Int64 {
+        order.siteID
+    }
     /// Order to be edited.
     ///
     private let order: Yosemite.Order

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -8916,7 +8916,7 @@
 				3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 				174CA86827D90A6200126524 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
 				3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */,
-				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */,
+				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject.git" */,
 				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
@@ -11887,7 +11887,7 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */ = {
+		4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/krzysztofzablocki/Inject.git";
 			requirement = {
@@ -11973,7 +11973,7 @@
 		};
 		4598298028574688003A9AFE /* Inject */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */;
+			package = 4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject.git" */;
 			productName = Inject;
 		};
 		57150E0E24F462C200E81611 /* TestKit */ = {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1001,6 +1001,7 @@
 		6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D66A1963092C34D20674 /* Calendar+Extensions.swift */; };
 		6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D1A5F72A36AB3704D19D /* AgeTests.swift */; };
 		6879B8DB287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */; };
+		68D1BEDB28FFEDC20074A29E /* OrderCustomerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D1BEDA28FFEDC20074A29E /* OrderCustomerListView.swift */; };
 		68E952CC287536010095A23D /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952CB287536010095A23D /* SafariView.swift */; };
 		68E952D0287587BF0095A23D /* CardReaderManualRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */; };
 		68E952D22875A44B0095A23D /* CardReaderType+Manual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */; };
@@ -2892,6 +2893,7 @@
 		6856D7981E11F85D5E4EFED7 /* NSMutableAttributedStringHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringHelperTests.swift; sourceTree = "<group>"; };
 		6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProviderTests.swift; sourceTree = "<group>"; };
 		6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsViewModelTests.swift; sourceTree = "<group>"; };
+		68D1BEDA28FFEDC20074A29E /* OrderCustomerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomerListView.swift; sourceTree = "<group>"; };
 		68E952CB287536010095A23D /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualRowView.swift; sourceTree = "<group>"; };
 		68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardReaderType+Manual.swift"; sourceTree = "<group>"; };
@@ -6467,6 +6469,7 @@
 			children = (
 				AE9E04742776213E003FA09E /* OrderCustomerSection.swift */,
 				AEC95D422774D07B001571F5 /* CreateOrderAddressFormViewModel.swift */,
+				68D1BEDA28FFEDC20074A29E /* OrderCustomerListView.swift */,
 			);
 			path = CustomerSection;
 			sourceTree = "<group>";
@@ -8910,7 +8913,7 @@
 				3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 				174CA86827D90A6200126524 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
 				3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */,
-				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject.git" */,
+				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */,
 				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
@@ -9661,6 +9664,7 @@
 				0313651328ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift in Sources */,
 				260C315E2523CC4000157BC2 /* RefundProductsTotalViewModel.swift in Sources */,
 				0286B27D23C7051F003D784B /* ProductImagesViewController.swift in Sources */,
+				68D1BEDB28FFEDC20074A29E /* OrderCustomerListView.swift in Sources */,
 				4569317F2653E82B009ED69D /* ShippingLabelCarriers.swift in Sources */,
 				024DF30B23742297006658FE /* AztecFormatBarCommand.swift in Sources */,
 				262AF387271114CC00E39AFF /* SimplePaymentsAmountViewModel.swift in Sources */,
@@ -11879,7 +11883,7 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject.git" */ = {
+		4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/krzysztofzablocki/Inject.git";
 			requirement = {
@@ -11965,7 +11969,7 @@
 		};
 		4598298028574688003A9AFE /* Inject */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject.git" */;
+			package = 4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */;
 			productName = Inject;
 		};
 		57150E0E24F462C200E81611 /* TestKit */ = {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1002,6 +1002,7 @@
 		6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D1A5F72A36AB3704D19D /* AgeTests.swift */; };
 		6879B8DB287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */; };
 		68D1BEDB28FFEDC20074A29E /* OrderCustomerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D1BEDA28FFEDC20074A29E /* OrderCustomerListView.swift */; };
+		68D1BEDD2900E4180074A29E /* CustomerSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D1BEDC2900E4180074A29E /* CustomerSearchUICommand.swift */; };
 		68E952CC287536010095A23D /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952CB287536010095A23D /* SafariView.swift */; };
 		68E952D0287587BF0095A23D /* CardReaderManualRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */; };
 		68E952D22875A44B0095A23D /* CardReaderType+Manual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */; };
@@ -2894,6 +2895,7 @@
 		6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProviderTests.swift; sourceTree = "<group>"; };
 		6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsViewModelTests.swift; sourceTree = "<group>"; };
 		68D1BEDA28FFEDC20074A29E /* OrderCustomerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomerListView.swift; sourceTree = "<group>"; };
+		68D1BEDC2900E4180074A29E /* CustomerSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSearchUICommand.swift; sourceTree = "<group>"; };
 		68E952CB287536010095A23D /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualRowView.swift; sourceTree = "<group>"; };
 		68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardReaderType+Manual.swift"; sourceTree = "<group>"; };
@@ -6470,6 +6472,7 @@
 				AE9E04742776213E003FA09E /* OrderCustomerSection.swift */,
 				AEC95D422774D07B001571F5 /* CreateOrderAddressFormViewModel.swift */,
 				68D1BEDA28FFEDC20074A29E /* OrderCustomerListView.swift */,
+				68D1BEDC2900E4180074A29E /* CustomerSearchUICommand.swift */,
 			);
 			path = CustomerSection;
 			sourceTree = "<group>";
@@ -9708,6 +9711,7 @@
 				D881A31B256B5CC500FE5605 /* ULErrorViewController.swift in Sources */,
 				CE22E3F72170E23C005A6BEF /* PrivacySettingsViewController.swift in Sources */,
 				021125482577CC650075AD2A /* ShippingLabelDetailsViewModel.swift in Sources */,
+				68D1BEDD2900E4180074A29E /* CustomerSearchUICommand.swift in Sources */,
 				316837DA25CCA90C00E36B2F /* OrderStatusListDataSource.swift in Sources */,
 				FE28F6F4268477C1004465C7 /* RoleEligibilityUseCase.swift in Sources */,
 				57C5FF7A25091A350074EC26 /* OrderListSyncActionUseCase.swift in Sources */,


### PR DESCRIPTION
Part of #7741
Branched from https://github.com/woocommerce/woocommerce-ios/pull/7848 , that PR needs to be merged first.

### Description
This PR implements the basic UI for searching Customers. The scope of this PR is limited to display a search view when we tap on the search icon, display Customer results matching our keyword, and pass the Customer data back to our `EditOrderAddressForm` view when we tap in any of the Customers. Filling the data to corresponding fields will be done in a future PR.

### Changes
- Adds a `OrderCustomerListView`, which is a SwiftUI wrapper for the existing `SearchViewController`.
- Adds a `CustomerSearchUICommand` class, which is the implementation of the existing `SearchUICommand` for Customer search.

### Testing instructions
1. Go to Orders > + > Create new Order > + Add Customer details > Tap on the magnifying glass icon:

<img width=400 src="https://user-images.githubusercontent.com/3812076/192192292-26a940ff-353f-4c1b-99ba-54d443c0a91d.png">

3. Search for a Customer name, and tap on it:

<img width=400 src="https://user-images.githubusercontent.com/3812076/196853445-01630412-d357-4f8d-9c51-5cef6f2c5e55.png">

4. Check if details are printed in the Xcode console. This will display steps 1 to 4, which represents the Customer data flow to `EditOrderAddressForm`, which we'll use to fill the Order with Customer details in a future PR.

```
1 - Customer tapped
2 - Customer ID: 5 - Name: Hello)
3 - Customer Callback. Fill Order data with Customer details
4 - Customer ID: 5 - Name: Hello)
```