### PR TITLE
Store creation MVP - account creation: networking layer changes

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		0272E3FB254AABB800436277 /* order-with-line-item-attributes-before-API-support.json in Resources */ = {isa = PBXBuildFile; fileRef = 0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */; };
 		028296F7237D588700E84012 /* ProductVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296F6237D588700E84012 /* ProductVariation.swift */; };
 		0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */ = {isa = PBXBuildFile; fileRef = 0282DD90233A120A006A5FDB /* products-search-photo.json */; };
+		028CB718290223CB00331C09 /* account-username-suggestions.json in Resources */ = {isa = PBXBuildFile; fileRef = 028CB714290223CB00331C09 /* account-username-suggestions.json */; };
 		028FA473257E110700F88A48 /* shipping-label-refund-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 028FA471257E110700F88A48 /* shipping-label-refund-error.json */; };
 		028FA474257E110700F88A48 /* shipping-label-refund-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 028FA472257E110700F88A48 /* shipping-label-refund-success.json */; };
 		029BA4F0255D7282006171FD /* ShippingLabelRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */; };
@@ -758,6 +759,7 @@
 		0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-with-line-item-attributes-before-API-support.json"; sourceTree = "<group>"; };
 		028296F6237D588700E84012 /* ProductVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariation.swift; sourceTree = "<group>"; };
 		0282DD90233A120A006A5FDB /* products-search-photo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-search-photo.json"; sourceTree = "<group>"; };
+		028CB714290223CB00331C09 /* account-username-suggestions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "account-username-suggestions.json"; sourceTree = "<group>"; };
 		028FA471257E110700F88A48 /* shipping-label-refund-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-refund-error.json"; sourceTree = "<group>"; };
 		028FA472257E110700F88A48 /* shipping-label-refund-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-refund-success.json"; sourceTree = "<group>"; };
 		029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRemote.swift; sourceTree = "<group>"; };
@@ -1916,6 +1918,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				028CB714290223CB00331C09 /* account-username-suggestions.json */,
 				DE50295F28C609A300551736 /* jetpack-connected-user.json */,
 				DE34051A28BDF12C00CF0D97 /* jetpack-connection-url.json */,
 				DE50296228C609DE00551736 /* jetpack-user-not-connected.json */,
@@ -2592,6 +2595,7 @@
 				B5A24179217F98F600595DEF /* notifications-load-all.json in Resources */,
 				314EDF2927C02CC100A56B6F /* stripe-account-complete-empty-descriptor.json in Resources */,
 				31A451CE27863A2E00FE81AA /* stripe-account-wrong-json.json in Resources */,
+				028CB718290223CB00331C09 /* account-username-suggestions.json in Resources */,
 				0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */,
 				45152825257A8B740076B03C /* product-attribute-update.json in Resources */,
 				68C87B342862D40E00A99054 /* setting-all-except-countries.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -44,7 +44,6 @@
 		0272E3FB254AABB800436277 /* order-with-line-item-attributes-before-API-support.json in Resources */ = {isa = PBXBuildFile; fileRef = 0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */; };
 		028296F7237D588700E84012 /* ProductVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296F6237D588700E84012 /* ProductVariation.swift */; };
 		0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */ = {isa = PBXBuildFile; fileRef = 0282DD90233A120A006A5FDB /* products-search-photo.json */; };
-		028CB7112901899E00331C09 /* CreateAccountResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028CB7102901899E00331C09 /* CreateAccountResponse.swift */; };
 		028CB716290223CB00331C09 /* create-account-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 028CB712290223CB00331C09 /* create-account-success.json */; };
 		028CB717290223CB00331C09 /* create-account-error-password.json in Resources */ = {isa = PBXBuildFile; fileRef = 028CB713290223CB00331C09 /* create-account-error-password.json */; };
 		028CB718290223CB00331C09 /* account-username-suggestions.json in Resources */ = {isa = PBXBuildFile; fileRef = 028CB714290223CB00331C09 /* account-username-suggestions.json */; };
@@ -765,7 +764,6 @@
 		0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-with-line-item-attributes-before-API-support.json"; sourceTree = "<group>"; };
 		028296F6237D588700E84012 /* ProductVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariation.swift; sourceTree = "<group>"; };
 		0282DD90233A120A006A5FDB /* products-search-photo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-search-photo.json"; sourceTree = "<group>"; };
-		028CB7102901899E00331C09 /* CreateAccountResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAccountResponse.swift; sourceTree = "<group>"; };
 		028CB712290223CB00331C09 /* create-account-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "create-account-success.json"; sourceTree = "<group>"; };
 		028CB713290223CB00331C09 /* create-account-error-password.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "create-account-error-password.json"; sourceTree = "<group>"; };
 		028CB714290223CB00331C09 /* account-username-suggestions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "account-username-suggestions.json"; sourceTree = "<group>"; };
@@ -1923,7 +1921,6 @@
 				DE50295A28C5F99700551736 /* DotcomUser.swift */,
 				68CB800B28D87BC800E169F8 /* Customer.swift */,
 				68F48B0828E3AF750045C15B /* WCAnalyticsCustomer.swift */,
-				028CB7102901899E00331C09 /* CreateAccountResponse.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -2899,7 +2896,6 @@
 				451A97D1260A03900059D135 /* ShippingLabelCustomPackage.swift in Sources */,
 				DE34051328BDCA5100CF0D97 /* WordPressOrgRequest.swift in Sources */,
 				D88D5A45230BC6F9007B6E01 /* ProductReviewsRemote.swift in Sources */,
-				028CB7112901899E00331C09 /* CreateAccountResponse.swift in Sources */,
 				B59325D4217E4206000B0E8E /* NoteBlock.swift in Sources */,
 				DEC51AF92769A212009F3DF4 /* SystemStatus+Settings.swift in Sources */,
 				D8C251D0230BD72700F49782 /* ProductReviewMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -44,7 +44,13 @@
 		0272E3FB254AABB800436277 /* order-with-line-item-attributes-before-API-support.json in Resources */ = {isa = PBXBuildFile; fileRef = 0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */; };
 		028296F7237D588700E84012 /* ProductVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296F6237D588700E84012 /* ProductVariation.swift */; };
 		0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */ = {isa = PBXBuildFile; fileRef = 0282DD90233A120A006A5FDB /* products-search-photo.json */; };
+		028CB7112901899E00331C09 /* CreateAccountResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028CB7102901899E00331C09 /* CreateAccountResponse.swift */; };
+		028CB716290223CB00331C09 /* create-account-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 028CB712290223CB00331C09 /* create-account-success.json */; };
+		028CB717290223CB00331C09 /* create-account-error-password.json in Resources */ = {isa = PBXBuildFile; fileRef = 028CB713290223CB00331C09 /* create-account-error-password.json */; };
 		028CB718290223CB00331C09 /* account-username-suggestions.json in Resources */ = {isa = PBXBuildFile; fileRef = 028CB714290223CB00331C09 /* account-username-suggestions.json */; };
+		028CB71B290224D700331C09 /* create-account-error-username.json in Resources */ = {isa = PBXBuildFile; fileRef = 028CB71A290224D700331C09 /* create-account-error-username.json */; };
+		028CB71E2902589E00331C09 /* create-account-error-email-exists.json in Resources */ = {isa = PBXBuildFile; fileRef = 028CB71C2902589E00331C09 /* create-account-error-email-exists.json */; };
+		028CB71F2902589E00331C09 /* create-account-error-invalid-email.json in Resources */ = {isa = PBXBuildFile; fileRef = 028CB71D2902589E00331C09 /* create-account-error-invalid-email.json */; };
 		028FA473257E110700F88A48 /* shipping-label-refund-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 028FA471257E110700F88A48 /* shipping-label-refund-error.json */; };
 		028FA474257E110700F88A48 /* shipping-label-refund-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 028FA472257E110700F88A48 /* shipping-label-refund-success.json */; };
 		029BA4F0255D7282006171FD /* ShippingLabelRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */; };
@@ -759,7 +765,13 @@
 		0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-with-line-item-attributes-before-API-support.json"; sourceTree = "<group>"; };
 		028296F6237D588700E84012 /* ProductVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariation.swift; sourceTree = "<group>"; };
 		0282DD90233A120A006A5FDB /* products-search-photo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-search-photo.json"; sourceTree = "<group>"; };
+		028CB7102901899E00331C09 /* CreateAccountResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAccountResponse.swift; sourceTree = "<group>"; };
+		028CB712290223CB00331C09 /* create-account-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "create-account-success.json"; sourceTree = "<group>"; };
+		028CB713290223CB00331C09 /* create-account-error-password.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "create-account-error-password.json"; sourceTree = "<group>"; };
 		028CB714290223CB00331C09 /* account-username-suggestions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "account-username-suggestions.json"; sourceTree = "<group>"; };
+		028CB71A290224D700331C09 /* create-account-error-username.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "create-account-error-username.json"; sourceTree = "<group>"; };
+		028CB71C2902589E00331C09 /* create-account-error-email-exists.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "create-account-error-email-exists.json"; sourceTree = "<group>"; };
+		028CB71D2902589E00331C09 /* create-account-error-invalid-email.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "create-account-error-invalid-email.json"; sourceTree = "<group>"; };
 		028FA471257E110700F88A48 /* shipping-label-refund-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-refund-error.json"; sourceTree = "<group>"; };
 		028FA472257E110700F88A48 /* shipping-label-refund-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-refund-success.json"; sourceTree = "<group>"; };
 		029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRemote.swift; sourceTree = "<group>"; };
@@ -1911,6 +1923,7 @@
 				DE50295A28C5F99700551736 /* DotcomUser.swift */,
 				68CB800B28D87BC800E169F8 /* Customer.swift */,
 				68F48B0828E3AF750045C15B /* WCAnalyticsCustomer.swift */,
+				028CB7102901899E00331C09 /* CreateAccountResponse.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1919,6 +1932,11 @@
 			isa = PBXGroup;
 			children = (
 				028CB714290223CB00331C09 /* account-username-suggestions.json */,
+				028CB71C2902589E00331C09 /* create-account-error-email-exists.json */,
+				028CB71D2902589E00331C09 /* create-account-error-invalid-email.json */,
+				028CB713290223CB00331C09 /* create-account-error-password.json */,
+				028CB71A290224D700331C09 /* create-account-error-username.json */,
+				028CB712290223CB00331C09 /* create-account-success.json */,
 				DE50295F28C609A300551736 /* jetpack-connected-user.json */,
 				DE34051A28BDF12C00CF0D97 /* jetpack-connection-url.json */,
 				DE50296228C609DE00551736 /* jetpack-user-not-connected.json */,
@@ -2594,6 +2612,7 @@
 				CC9A253C26442C71005DE56E /* shipping-label-eligibility-success.json in Resources */,
 				B5A24179217F98F600595DEF /* notifications-load-all.json in Resources */,
 				314EDF2927C02CC100A56B6F /* stripe-account-complete-empty-descriptor.json in Resources */,
+				028CB71F2902589E00331C09 /* create-account-error-invalid-email.json in Resources */,
 				31A451CE27863A2E00FE81AA /* stripe-account-wrong-json.json in Resources */,
 				028CB718290223CB00331C09 /* account-username-suggestions.json in Resources */,
 				0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */,
@@ -2612,6 +2631,7 @@
 				DE5CA111288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json in Resources */,
 				02DD6492248A3EC00082523E /* product-external.json in Resources */,
 				03DCB7522624B3BE00C8953D /* coupons-all.json in Resources */,
+				028CB716290223CB00331C09 /* create-account-success.json in Resources */,
 				45A4B85C25D2FAB500776FB4 /* shipping-label-address-validation-error.json in Resources */,
 				02A26F1C2744F5FC008E4EDB /* wp-site-settings.json in Resources */,
 				31A451D027863A2E00FE81AA /* stripe-account-live-live.json in Resources */,
@@ -2668,6 +2688,7 @@
 				B5C6FCD620A3768900A4F8E4 /* order.json in Resources */,
 				3158FE7426129D9F00E566B9 /* wcpay-account-rejected-other.json in Resources */,
 				CC0786C7267BB10700BA9AC1 /* shipping-label-status-success.json in Resources */,
+				028CB71B290224D700331C09 /* create-account-error-username.json in Resources */,
 				68F48B1328E3E5750045C15B /* wc-analytics-customers.json in Resources */,
 				D88D5A41230BC5DA007B6E01 /* reviews-all.json in Resources */,
 				74C947862193A6C70024CB60 /* comment-moderate-unapproved.json in Resources */,
@@ -2727,6 +2748,7 @@
 				31A451D427863A2E00FE81AA /* stripe-account-rejected-listed.json in Resources */,
 				74A1D265211898F000931DFA /* site-visits-month.json in Resources */,
 				31799AFC2705189200D78179 /* wcpay-location.json in Resources */,
+				028CB71E2902589E00331C09 /* create-account-error-email-exists.json in Resources */,
 				74159623224D2C86003C21CF /* settings-product.json in Resources */,
 				266C7F9225AD3C88006ED243 /* attribute-term.json in Resources */,
 				D865CE6E278CC19A002C8520 /* stripe-location.json in Resources */,
@@ -2782,6 +2804,7 @@
 				457FC68C2382B2FD00B41B02 /* product-update.json in Resources */,
 				CE19CB11222486A600E8AF7A /* order-statuses.json in Resources */,
 				02F096C22406691100C0C1D5 /* media-library.json in Resources */,
+				028CB717290223CB00331C09 /* create-account-error-password.json in Resources */,
 				D800DA0E25EFEC21001E13CE /* wcpay-connection-token.json in Resources */,
 				74159628224D63CE003C21CF /* settings-product-alt.json in Resources */,
 				45AB8B2024AB3E1F00B5B36E /* product-tags-empty.json in Resources */,
@@ -2876,6 +2899,7 @@
 				451A97D1260A03900059D135 /* ShippingLabelCustomPackage.swift in Sources */,
 				DE34051328BDCA5100CF0D97 /* WordPressOrgRequest.swift in Sources */,
 				D88D5A45230BC6F9007B6E01 /* ProductReviewsRemote.swift in Sources */,
+				028CB7112901899E00331C09 /* CreateAccountResponse.swift in Sources */,
 				B59325D4217E4206000B0E8E /* NoteBlock.swift in Sources */,
 				DEC51AF92769A212009F3DF4 /* SystemStatus+Settings.swift in Sources */,
 				D8C251D0230BD72700F49782 /* ProductReviewMapper.swift in Sources */,

--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -28,7 +28,7 @@ public protocol AccountRemoteProtocol {
                        username: String,
                        password: String,
                        clientID: String,
-                       clientSecret: String) async -> Result<CreateAccountData, CreateAccountError>
+                       clientSecret: String) async -> Result<CreateAccountResult, CreateAccountError>
 }
 
 /// Account: Remote Endpoints
@@ -144,7 +144,7 @@ public class AccountRemote: Remote, AccountRemoteProtocol {
                               username: String,
                               password: String,
                               clientID: String,
-                              clientSecret: String) async -> Result<CreateAccountData, CreateAccountError> {
+                              clientSecret: String) async -> Result<CreateAccountResult, CreateAccountError> {
         let path = Path.accountCreation
         let parameters: [String: Any] = [
             "client_id": clientID,
@@ -159,7 +159,7 @@ public class AccountRemote: Remote, AccountRemoteProtocol {
             "send_verification_email": true
         ]
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters)
-        let result: Result<CreateAccountData, Error> = await enqueue(request)
+        let result: Result<CreateAccountResult, Error> = await enqueue(request)
         switch result {
         case .success(let data):
             return .success(data)
@@ -192,7 +192,7 @@ private extension AccountRemote {
 }
 
 /// Necessary data for account credentials.
-public struct CreateAccountData: Decodable {
+public struct CreateAccountResult: Decodable {
     public let authToken: String
     public let username: String
 

--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -13,6 +13,7 @@ public protocol AccountRemoteProtocol {
     func checkIfWooCommerceIsActive(for siteID: Int64) -> AnyPublisher<Result<Bool, Error>, Never>
     func fetchWordPressSiteSettings(for siteID: Int64) -> AnyPublisher<Result<WordPressSiteSettings, Error>, Never>
     func loadSitePlan(for siteID: Int64, completion: @escaping (Result<SitePlan, Error>) -> Void)
+    func loadUsernameSuggestions(from text: String) async -> [String]
 }
 
 /// Account: Remote Endpoints
@@ -114,6 +115,15 @@ public class AccountRemote: Remote, AccountRemoteProtocol {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    public func loadUsernameSuggestions(from text: String) async -> [String] {
+        let path = Path.usernameSuggestions
+        let parameters = [ParameterKey.name: text]
+        let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .get, path: path, parameters: parameters)
+        let result: Result<[String: [String]], Error> = await enqueue(request)
+        let suggestions = (try? result.get())?["suggestions"] ?? []
+        return suggestions
+    }
 }
 
 // MARK: - Constants
@@ -121,5 +131,15 @@ public class AccountRemote: Remote, AccountRemoteProtocol {
 private extension AccountRemote {
     enum Constants {
         static let wooCommerceSiteSettingsPath: String = "settings"
+    }
+
+    enum ParameterKey {
+        static let name = "name"
+    }
+
+    enum Path {
+        static let settings = "me/settings"
+        static let username = "me/username"
+        static let usernameSuggestions = "wpcom/v2/users/username/suggestions"
     }
 }

--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -159,6 +159,9 @@ public class AccountRemote: Remote, AccountRemoteProtocol {
             "password": password,
             "email": email,
             "username": username,
+            // Passing `validate=false` always creates an account (if input data is valid) and sends an email
+            // to the user that the account was created successfully.
+            // Otherwise, email validation is required before an account is created.
             "validate": false,
             "send_verification_email": true
         ]

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -26,7 +26,7 @@ public class Remote: NSObject {
     ///
     /// - Parameter request: Request that should be performed.
     /// - Returns: The result from the JSON parsed response for the expected type.
-    func enqueue<T>(_ request: URLRequestConvertible) async -> Result<T, Error> {
+    func enqueue<T: Decodable>(_ request: URLRequestConvertible) async -> Result<T, Error> {
         await withCheckedContinuation { continuation in
             network.responseData(for: request) { [weak self] result in
                 guard let self else { return }
@@ -40,9 +40,7 @@ public class Remote: NSObject {
                     }
 
                     do {
-                        guard let document = try JSONSerialization.jsonObject(with: data, options: []) as? T else {
-                            return continuation.resume(returning: .failure(RemoteError.unexpectedResponseData))
-                        }
+                        let document = try JSONDecoder().decode(T.self, from: data)
                         continuation.resume(returning: .success(document))
                     } catch {
                         continuation.resume(returning: .failure(error))

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -29,9 +29,7 @@ public class Remote: NSObject {
     func enqueue<T>(_ request: URLRequestConvertible) async -> Result<T, Error> {
         await withCheckedContinuation { continuation in
             network.responseData(for: request) { [weak self] result in
-                guard let self = self else {
-                    return
-                }
+                guard let self else { return }
 
                 switch result {
                 case .success(let data):

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -267,8 +267,3 @@ public extension NSNotification.Name {
     ///
     static let RemoteDidReceiveJetpackTimeoutError = NSNotification.Name(rawValue: "RemoteDidReceiveJetpackTimeoutError")
 }
-
-enum RemoteError: Error {
-    /// The response data does not match the expected type.
-    case unexpectedResponseData
-}

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -145,27 +145,29 @@ final class AccountRemoteTests: XCTestCase {
 
     // MARK: - `loadUsernameSuggestions`
 
-    func test_loadUsernameSuggestions_returns_suggestions_on_success() async {
+    func test_loadUsernameSuggestions_returns_suggestions_on_success() async throws {
         // Given
         let remote = AccountRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "username/suggestions", filename: "account-username-suggestions")
 
         // When
-        let suggestions = await remote.loadUsernameSuggestions(from: "woo")
+        let result = await remote.loadUsernameSuggestions(from: "woo")
 
         // Then
+        let suggestions = try XCTUnwrap(result.get())
         XCTAssertEqual(suggestions, ["woowriter", "woowoowoo", "woodaily"])
     }
 
-    func test_loadUsernameSuggestions_returns_empty_suggestions_on_empty_response() async {
+    func test_loadUsernameSuggestions_returns_empty_suggestions_on_empty_response() async throws {
         // Given
         let remote = AccountRemote(network: network)
 
         // When
-        let suggestions = await remote.loadUsernameSuggestions(from: "woo")
+        let result = await remote.loadUsernameSuggestions(from: "woo")
 
         // Then
-        XCTAssertEqual(suggestions, [])
+        let error = try XCTUnwrap(result.failure as? NetworkError)
+        XCTAssertEqual(error, .notFound)
     }
 
     // MARK: - `createAccount`

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -179,8 +179,9 @@ final class AccountRemoteTests: XCTestCase {
         let result = await remote.createAccount(email: "coffee@woo.com", username: "", password: "", clientID: "", clientSecret: "")
 
         // Then
-        let authToken = try XCTUnwrap(result.get())
-        XCTAssertEqual(authToken, "🐻")
+        let data = try XCTUnwrap(result.get())
+        XCTAssertEqual(data.authToken, "🐻")
+        XCTAssertEqual(data.username, "wootest")
     }
 
     func test_createAccount_returns_emailExists_error_on_email_exists_error() async throws {

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -142,4 +142,29 @@ final class AccountRemoteTests: XCTestCase {
         let siteSettings = try XCTUnwrap(result.get())
         XCTAssertEqual(siteSettings.name, "Zucchini recipes")
     }
+
+    // MARK: - `loadUsernameSuggestions`
+
+    func test_loadUsernameSuggestions_returns_success_when_response_is_valid() async {
+        // Given
+        let remote = AccountRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "username/suggestions", filename: "account-username-suggestions")
+
+        // When
+        let suggestions = await remote.loadUsernameSuggestions(from: "woo")
+
+        // Then
+        XCTAssertEqual(suggestions, ["woowriter", "woowoowoo", "woodaily"])
+    }
+
+    func test_loadUsernameSuggestions_returns_empty_suggestions_on_empty_response() async {
+        // Given
+        let remote = AccountRemote(network: network)
+
+        // When
+        let suggestions = await remote.loadUsernameSuggestions(from: "woo")
+
+        // Then
+        XCTAssertEqual(suggestions, [])
+    }
 }

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -145,7 +145,7 @@ final class AccountRemoteTests: XCTestCase {
 
     // MARK: - `loadUsernameSuggestions`
 
-    func test_loadUsernameSuggestions_returns_success_when_response_is_valid() async {
+    func test_loadUsernameSuggestions_returns_suggestions_on_success() async {
         // Given
         let remote = AccountRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "username/suggestions", filename: "account-username-suggestions")
@@ -166,5 +166,73 @@ final class AccountRemoteTests: XCTestCase {
 
         // Then
         XCTAssertEqual(suggestions, [])
+    }
+
+    // MARK: - `createAccount`
+
+    func test_createAccount_returns_auth_token_on_success() async throws {
+        // Given
+        let remote = AccountRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "users/new", filename: "create-account-success")
+
+        // When
+        let result = await remote.createAccount(email: "coffee@woo.com", username: "", password: "", clientID: "", clientSecret: "")
+
+        // Then
+        let authToken = try XCTUnwrap(result.get())
+        XCTAssertEqual(authToken, "🐻")
+    }
+
+    func test_createAccount_returns_emailExists_error_on_email_exists_error() async throws {
+        // Given
+        let remote = AccountRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "users/new", filename: "create-account-error-email-exists")
+
+        // When
+        let result = await remote.createAccount(email: "coffee@woo.com", username: "", password: "", clientID: "", clientSecret: "")
+
+        // Then
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error, .emailExists)
+    }
+
+    func test_createAccount_returns_invalidEmail_error_on_invalid_email_error() async throws {
+        // Given
+        let remote = AccountRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "users/new", filename: "create-account-error-invalid-email")
+
+        // When
+        let result = await remote.createAccount(email: "coffee@woo.com", username: "", password: "", clientID: "", clientSecret: "")
+
+        // Then
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error, .invalidEmail)
+    }
+
+    func test_createAccount_returns_password_error_on_invalid_password_error() async throws {
+        // Given
+        let remote = AccountRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "users/new", filename: "create-account-error-password")
+
+        // When
+        let result = await remote.createAccount(email: "coffee@woo.com", username: "", password: "", clientID: "", clientSecret: "")
+
+        // Then
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error, .invalidPassword(message:
+                                                "Your password is too short. Please pick a password that has at least 6 characters."))
+    }
+
+    func test_createAccount_returns_invalidUsername_error_on_invalid_username_error() async throws {
+        // Given
+        let remote = AccountRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "users/new", filename: "create-account-error-username")
+
+        // When
+        let result = await remote.createAccount(email: "coffee@woo.com", username: "", password: "", clientID: "", clientSecret: "")
+
+        // Then
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error, .invalidUsername)
     }
 }

--- a/Networking/NetworkingTests/Remote/RemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/RemoteTests.swift
@@ -180,10 +180,12 @@ final class RemoteTests: XCTestCase {
         let expectationForNotification = expectation(forNotification: .RemoteDidReceiveJetpackTimeoutError, object: nil, handler: nil)
         network.simulateResponse(requestUrlSuffix: "something", filename: "timeout_error")
 
-        let result: Result<String, Error> = await remote.enqueue(request)
-        XCTAssertTrue(result.isFailure)
-        let error = try XCTUnwrap(result.failure as? DotcomError)
-        XCTAssertEqual(error, .requestFailed)
+        do {
+            let _: String = try await remote.enqueue(request)
+        } catch {
+            let error = try XCTUnwrap(error as? DotcomError)
+            XCTAssertEqual(error, .requestFailed)
+        }
 
         wait(for: [expectationForNotification], timeout: Constants.expectationTimeout)
     }

--- a/Networking/NetworkingTests/Remote/RemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/RemoteTests.swift
@@ -7,6 +7,7 @@ import Fakes
 
 /// Remote UnitTests
 ///
+@MainActor
 final class RemoteTests: XCTestCase {
 
     /// Sample Request
@@ -172,22 +173,19 @@ final class RemoteTests: XCTestCase {
     /// Verifies that `enqueue:` posts a `RemoteDidReceiveJetpackTimeoutError` Notification whenever the backend returns a
     /// Request Timeout error.
     ///
-    func testEnqueueRequestWithoutMapperPostJetpackTimeoutNotificationWhenTheResponseContainsTimeoutError() {
+    func testEnqueueRequestWithoutMapperPostJetpackTimeoutNotificationWhenTheResponseContainsTimeoutError() async throws {
         let network = MockNetwork()
         let remote = Remote(network: network)
 
         let expectationForNotification = expectation(forNotification: .RemoteDidReceiveJetpackTimeoutError, object: nil, handler: nil)
-        let expectationForRequest = expectation(description: "Request")
-
         network.simulateResponse(requestUrlSuffix: "something", filename: "timeout_error")
 
-        remote.enqueue(request) { (payload, error) in
-            XCTAssertNil(payload)
-            XCTAssert(error is DotcomError)
-            expectationForRequest.fulfill()
-        }
+        let result: Result<Void, Error> = await remote.enqueue(request)
+        XCTAssertTrue(result.isFailure)
+        let error = try XCTUnwrap(result.failure as? DotcomError)
+        XCTAssertEqual(error, .requestFailed)
 
-        wait(for: [expectationForNotification, expectationForRequest], timeout: Constants.expectationTimeout)
+        wait(for: [expectationForNotification], timeout: Constants.expectationTimeout)
     }
 
     /// Verifies that `enqueue:mapper:` posts a `RemoteDidReceiveJetpackTimeoutError` Notification whenever the backend returns a

--- a/Networking/NetworkingTests/Remote/RemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/RemoteTests.swift
@@ -180,7 +180,7 @@ final class RemoteTests: XCTestCase {
         let expectationForNotification = expectation(forNotification: .RemoteDidReceiveJetpackTimeoutError, object: nil, handler: nil)
         network.simulateResponse(requestUrlSuffix: "something", filename: "timeout_error")
 
-        let result: Result<Void, Error> = await remote.enqueue(request)
+        let result: Result<String, Error> = await remote.enqueue(request)
         XCTAssertTrue(result.isFailure)
         let error = try XCTUnwrap(result.failure as? DotcomError)
         XCTAssertEqual(error, .requestFailed)

--- a/Networking/NetworkingTests/Responses/account-username-suggestions.json
+++ b/Networking/NetworkingTests/Responses/account-username-suggestions.json
@@ -1,0 +1,3 @@
+{
+    "suggestions": ["woowriter", "woowoowoo", "woodaily"]
+}

--- a/Networking/NetworkingTests/Responses/create-account-error-email-exists.json
+++ b/Networking/NetworkingTests/Responses/create-account-error-email-exists.json
@@ -1,0 +1,4 @@
+{
+    "error": "email_exists",
+    "message": "Invalid email input"
+}

--- a/Networking/NetworkingTests/Responses/create-account-error-invalid-email.json
+++ b/Networking/NetworkingTests/Responses/create-account-error-invalid-email.json
@@ -1,0 +1,4 @@
+{
+    "error": "email_invalid",
+    "message": "Invalid email input"
+}

--- a/Networking/NetworkingTests/Responses/create-account-error-password.json
+++ b/Networking/NetworkingTests/Responses/create-account-error-password.json
@@ -1,0 +1,4 @@
+{
+    "error": "password_invalid",
+    "message": "Your password is too short. Please pick a password that has at least 6 characters."
+}

--- a/Networking/NetworkingTests/Responses/create-account-error-username.json
+++ b/Networking/NetworkingTests/Responses/create-account-error-username.json
@@ -1,0 +1,4 @@
+{
+    "error": "username_exists",
+    "message": "Invalid user input"
+}

--- a/Networking/NetworkingTests/Responses/create-account-success.json
+++ b/Networking/NetworkingTests/Responses/create-account-success.json
@@ -1,0 +1,8 @@
+{
+    "success": true,
+    "bearer_token": "🐻",
+    "username": "wootest",
+    "user_id": 134863,
+    "marketing_price_group": false,
+    "plans_reorder_abtest_variation": "control"
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
@@ -85,4 +85,12 @@ extension MockAccountRemote: AccountRemoteProtocol {
     func loadUsernameSuggestions(from text: String) async -> [String] {
         []
     }
+
+    func createAccount(email: String,
+                       username: String,
+                       password: String,
+                       clientID: String,
+                       clientSecret: String) async -> Result<String, Networking.CreateAccountError> {
+        .success("someAuthToken")
+    }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
@@ -90,7 +90,7 @@ extension MockAccountRemote: AccountRemoteProtocol {
                        username: String,
                        password: String,
                        clientID: String,
-                       clientSecret: String) async -> Result<String, Networking.CreateAccountError> {
-        .success("someAuthToken")
+                       clientSecret: String) async -> Result<CreateAccountData, CreateAccountError> {
+        .success(.init(authToken: "someAuthToken", username: "user"))
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
@@ -82,8 +82,8 @@ extension MockAccountRemote: AccountRemoteProtocol {
         // no-op
     }
 
-    func loadUsernameSuggestions(from text: String) async -> [String] {
-        []
+    func loadUsernameSuggestions(from text: String) async -> Result<[String], Error> {
+        .success([])
     }
 
     func createAccount(email: String,

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
@@ -81,4 +81,8 @@ extension MockAccountRemote: AccountRemoteProtocol {
     func loadSitePlan(for siteID: Int64, completion: @escaping (Result<SitePlan, Error>) -> Void) {
         // no-op
     }
+
+    func loadUsernameSuggestions(from text: String) async -> [String] {
+        []
+    }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
@@ -90,7 +90,7 @@ extension MockAccountRemote: AccountRemoteProtocol {
                        username: String,
                        password: String,
                        clientID: String,
-                       clientSecret: String) async -> Result<CreateAccountData, CreateAccountError> {
+                       clientSecret: String) async -> Result<CreateAccountResult, CreateAccountError> {
         .success(.init(authToken: "someAuthToken", username: "user"))
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Networking layer for #7891
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR includes the networking layer changes for store creation MVP with two endpoints:

- Fetch username suggestions - only the first one is used for store creation (there's no parameter to only fetch one)
- Create a WPCOM account with an email and password - a few possible errors that we're handling have their corresponding JSON files for unit testing

In `Remote.enqueue`, I updated an existing unused function to return an async result of an expected `Decodable` type using `JSONDecoder`. This way, we can use it for network requests that return a simple type like a string/array/free-form dictionary without a heavy-weight mapper.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just CI for now, the new functions aren't used in the app yet.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
