### PR TITLE
Store creation MVP - account creation: form UI

### DIFF
--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -20,10 +20,10 @@ public struct Credentials: Equatable {
 
     /// Designated Initializer
     ///
-    public init(username: String, authToken: String, siteAddress: String) {
+    public init(username: String, authToken: String, siteAddress: String? = nil) {
         self.username = username
         self.authToken = authToken
-        self.siteAddress = siteAddress
+        self.siteAddress = siteAddress ?? Constants.placeholderSiteAddress
     }
 
     /// Convenience initializer. Assigns a UUID as a placeholder for the username.

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -130,15 +130,16 @@ private extension LoginPrologueViewController {
                     navigationController.popViewController(animated: true)
                 }
                 self.show(accountCreationController, sender: self)
-            } else {
-                self.analytics.track(.loginNewToWooButtonTapped)
-
-                guard let url = URL(string: Constants.newToWooCommerceURL) else {
-                    return assertionFailure("Cannot generate URL.")
-                }
-
-                WebviewHelper.launch(url, with: self)
+                return
             }
+
+            self.analytics.track(.loginNewToWooButtonTapped)
+
+            guard let url = URL(string: Constants.newToWooCommerceURL) else {
+                return assertionFailure("Cannot generate URL.")
+            }
+
+            WebviewHelper.launch(url, with: self)
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -122,13 +122,23 @@ private extension LoginPrologueViewController {
         newToWooCommerceButton.on(.touchUpInside) { [weak self] _ in
             guard let self = self else { return }
 
-            self.analytics.track(.loginNewToWooButtonTapped)
+            // TODO-7891: update prologue entry point.
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.storeCreationMVP) {
+                let accountCreationController = AccountCreationFormHostingController(viewModel: .init()) { [weak self] in
+                    guard let self, let navigationController = self.navigationController else { return }
+                    // TODO-7879 & TODO-7891: navigate to store creation after account creation.
+                    navigationController.popViewController(animated: true)
+                }
+                self.show(accountCreationController, sender: self)
+            } else {
+                self.analytics.track(.loginNewToWooButtonTapped)
 
-            guard let url = URL(string: Constants.newToWooCommerceURL) else {
-                return assertionFailure("Cannot generate URL.")
+                guard let url = URL(string: Constants.newToWooCommerceURL) else {
+                    return assertionFailure("Cannot generate URL.")
+                }
+
+                WebviewHelper.launch(url, with: self)
             }
-
-            WebviewHelper.launch(url, with: self)
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
@@ -49,28 +49,36 @@ final class AccountCreationFormViewModel: ObservableObject {
     /// - Returns: async result of account creation.
     @MainActor
     func createAccount() async -> Result<Void, Error> {
-        await withCheckedContinuation { continuation in
-            let action = AccountCreationAction.createAccount(email: email, password: password) { [weak self] result in
-                guard let self else { return }
-                switch result {
-                case .success(let data):
-                    self.handleSuccess(data: data)
-                    continuation.resume(returning: .success(()))
-                case .failure(let error):
-                    self.handleFailure(error: error)
-                    continuation.resume(returning: .failure(error))
-                }
+        let result: Result<CreateAccountResult, CreateAccountError> = await withCheckedContinuation { continuation in
+            let action = AccountCreationAction.createAccount(email: email, password: password) { result in
+                continuation.resume(returning: result)
             }
             stores.dispatch(action)
+        }
+
+        switch result {
+        case .success(let data):
+            await handleSuccess(data: data)
+            return .success(())
+        case .failure(let error):
+            handleFailure(error: error)
+            return .failure(error)
         }
     }
 }
 
 private extension AccountCreationFormViewModel {
-    func handleSuccess(data: CreateAccountResult) {
-        stores.authenticate(credentials: .init(username: data.username, authToken: data.authToken))
+    @MainActor
+    func handleSuccess(data: CreateAccountResult) async {
+        await withCheckedContinuation { continuation in
+            stores.authenticate(credentials: .init(username: data.username, authToken: data.authToken))
+                .synchronizeEntities(onCompletion: {
+                    continuation.resume(returning: ())
+                })
+        }
     }
 
+    @MainActor
     func handleFailure(error: CreateAccountError) {
         switch error {
         case .emailExists:

--- a/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
@@ -31,12 +31,14 @@ final class AccountCreationFormViewModel: ObservableObject {
         self.stores = stores
 
         $email
+            .removeDuplicates()
             .debounce(for: .seconds(Constants.fieldDebounceDuration), scheduler: DispatchQueue.main)
             .sink { [weak self] email in
                 self?.validateEmail(email)
             }.store(in: &subscriptions)
 
         $password
+            .removeDuplicates()
             .debounce(for: .seconds(Constants.fieldDebounceDuration), scheduler: DispatchQueue.main)
             .sink { [weak self] password in
                 self?.validatePassword(password)
@@ -86,10 +88,12 @@ private extension AccountCreationFormViewModel {
 private extension AccountCreationFormViewModel {
     func validateEmail(_ email: String) {
         isEmailValid = EmailFormatValidator.validate(string: email)
+        emailErrorMessage = nil
     }
 
     func validatePassword(_ password: String) {
         isPasswordValid = password.count >= 6
+        passwordErrorMessage = nil
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
@@ -1,0 +1,111 @@
+import Combine
+import Foundation
+import struct Yosemite.CreateAccountResult
+import struct Yosemite.Credentials
+import enum Yosemite.AccountAction
+import enum Yosemite.AccountCreationAction
+import enum Yosemite.CreateAccountError
+import protocol Yosemite.StoresManager
+import class WordPressShared.EmailFormatValidator
+
+/// View model for `AccountCreationForm` view.
+final class AccountCreationFormViewModel: ObservableObject {
+    /// Email input.
+    @Published var email: String = ""
+    /// An error can come from the WPCOM backend, when the email is invalid or already exists.
+    @Published private(set) var emailErrorMessage: String?
+    /// Local validation on the email field.
+    @Published private(set) var isEmailValid: Bool = false
+
+    /// Password input.
+    @Published var password: String = ""
+    /// An error can come from the WPCOM backend, when the password is too simple.
+    @Published private(set) var passwordErrorMessage: String?
+    /// Local validation on the password field.
+    @Published private(set) var isPasswordValid: Bool = false
+
+    private let stores: StoresManager
+    private var subscriptions: Set<AnyCancellable> = []
+
+    init(stores: StoresManager = ServiceLocator.stores) {
+        self.stores = stores
+
+        $email
+            .debounce(for: .seconds(Constants.fieldDebounceDuration), scheduler: DispatchQueue.main)
+            .sink { [weak self] email in
+                self?.validateEmail(email)
+            }.store(in: &subscriptions)
+
+        $password
+            .debounce(for: .seconds(Constants.fieldDebounceDuration), scheduler: DispatchQueue.main)
+            .sink { [weak self] password in
+                self?.validatePassword(password)
+            }.store(in: &subscriptions)
+    }
+
+    /// Creates a WPCOM account with the email and password.
+    /// - Returns: async result of account creation.
+    @MainActor
+    func createAccount() async -> Result<Void, Error> {
+        await withCheckedContinuation { continuation in
+            let action = AccountCreationAction.createAccount(email: email, password: password) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case .success(let data):
+                    self.handleSuccess(data: data)
+                    continuation.resume(returning: .success(()))
+                case .failure(let error):
+                    self.handleFailure(error: error)
+                    continuation.resume(returning: .failure(error))
+                }
+            }
+            stores.dispatch(action)
+        }
+    }
+}
+
+private extension AccountCreationFormViewModel {
+    func handleSuccess(data: CreateAccountResult) {
+        stores.authenticate(credentials: .init(username: data.username, authToken: data.authToken))
+    }
+
+    func handleFailure(error: CreateAccountError) {
+        switch error {
+        case .emailExists:
+            emailErrorMessage = Localization.emailExistsError
+        case .invalidEmail:
+            emailErrorMessage = Localization.invalidEmailError
+        case .invalidPassword(let message):
+            passwordErrorMessage = message ?? Localization.passwordError
+        default:
+            break
+        }
+    }
+}
+
+private extension AccountCreationFormViewModel {
+    func validateEmail(_ email: String) {
+        isEmailValid = EmailFormatValidator.validate(string: email)
+    }
+
+    func validatePassword(_ password: String) {
+        isPasswordValid = password.count >= 6
+    }
+}
+
+private extension AccountCreationFormViewModel {
+    enum Constants {
+        static let fieldDebounceDuration = 0.3
+    }
+
+    enum Localization {
+        static let emailExistsError = NSLocalizedString("An account with this email already exists.",
+                                                        comment: "Account creation error when the email is already associated with an existing WP.com account.")
+        static let invalidEmailError = NSLocalizedString("Use a working email address, so you can receive our messages.",
+                                                         comment: "Account creation error when the email is invalid.")
+        static let passwordError = NSLocalizedString("Password must be at least 6 characters.",
+                                                     comment: "Account creation error when the password is invalid.")
+        static let otherError = NSLocalizedString("Please try again.",
+                                                  comment: "Account creation error when an unexpected error occurs.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -46,15 +46,15 @@ struct AccountCreationForm: View {
                 // Form fields.
                 VStack(spacing: Layout.verticalSpacingBetweenFields) {
                     AccountCreationFormFieldView(viewModel: .init(header: Localization.emailFieldTitle,
-                                                              placeholder: Localization.emailFieldPlaceholder,
-                                                              text: $viewModel.email,
-                                                              isSecure: false,
-                                                              errorMessage: viewModel.emailErrorMessage))
+                                                                  placeholder: Localization.emailFieldPlaceholder,
+                                                                  text: $viewModel.email,
+                                                                  isSecure: false,
+                                                                  errorMessage: viewModel.emailErrorMessage))
                     AccountCreationFormFieldView(viewModel: .init(header: Localization.passwordFieldTitle,
-                                                              placeholder: Localization.passwordFieldPlaceholder,
-                                                              text: $viewModel.password,
-                                                              isSecure: true,
-                                                              errorMessage: viewModel.passwordErrorMessage))
+                                                                  placeholder: Localization.passwordFieldPlaceholder,
+                                                                  text: $viewModel.password,
+                                                                  isSecure: true,
+                                                                  errorMessage: viewModel.passwordErrorMessage))
                     AttributedText(tosAttributedText)
                         .onTapGesture {
                             customOpenURL?(Constants.tosURL)
@@ -80,7 +80,6 @@ struct AccountCreationForm: View {
             }
             .padding(.init(top: 0, leading: Layout.horizontalSpacing, bottom: 0, trailing: Layout.horizontalSpacing))
         }
-        .ignoresSafeArea(.container, edges: [.horizontal])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -132,5 +132,10 @@ private extension AccountCreationForm {
 struct AccountCreationForm_Previews: PreviewProvider {
     static var previews: some View {
         AccountCreationForm(viewModel: .init())
+            .preferredColorScheme(.light)
+
+        AccountCreationForm(viewModel: .init())
+            .preferredColorScheme(.dark)
+            .dynamicTypeSize(.xxxLarge)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -56,7 +56,7 @@ struct AccountCreationForm: View {
                                                                   isSecure: true,
                                                                   errorMessage: viewModel.passwordErrorMessage))
                     AttributedText(tosAttributedText)
-                        .attributedTextLinkColor(Color(.label))
+                        .attributedTextLinkColor(Color(.textLink))
                 }
 
                 // CTA to submit the form.

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+/// Hosting controller that wraps an `AccountCreationForm`.
+final class AccountCreationFormHostingController: UIHostingController<AccountCreationForm> {
+    init(viewModel: AccountCreationFormViewModel, completion: @escaping () -> Void) {
+        super.init(rootView: AccountCreationForm(viewModel: viewModel))
+
+        // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController.
+        rootView.completion = {
+            completion()
+        }
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// A form that allows the user to create a WPCOM account with an email and password.
+struct AccountCreationForm: View {
+    @Environment(\.customOpenURL) var customOpenURL
+
+    /// Triggered when the account is created and the app is authenticated.
+    var completion: (() -> Void) = {}
+
+    @ObservedObject private var viewModel: AccountCreationFormViewModel
+
+    @State private var isPerformingTask = false
+
+    init(viewModel: AccountCreationFormViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
+                // Header.
+                VStack(alignment: .leading, spacing: Layout.horizontalSpacing) {
+                    Text(Localization.title)
+                        .largeTitleStyle()
+                    Text(Localization.subtitle)
+                        .foregroundColor(Color(.secondaryLabel))
+                        .bodyStyle()
+                }
+
+                // Form fields.
+                VStack(spacing: Layout.verticalSpacingBetweenFields) {
+                    AccountCreationFormFieldView(viewModel: .init(header: Localization.emailFieldTitle,
+                                                              placeholder: Localization.emailFieldPlaceholder,
+                                                              text: $viewModel.email,
+                                                              isSecure: false,
+                                                              errorMessage: viewModel.emailErrorMessage))
+                    AccountCreationFormFieldView(viewModel: .init(header: Localization.passwordFieldTitle,
+                                                              placeholder: Localization.passwordFieldPlaceholder,
+                                                              text: $viewModel.password,
+                                                              isSecure: true,
+                                                              errorMessage: viewModel.passwordErrorMessage))
+                    AttributedText(tosAttributedText)
+                        .onTapGesture {
+                            customOpenURL?(Constants.tosURL)
+                        }
+                }
+
+                // CTA to submit the form.
+                Button(Localization.submitButtonTitle) {
+                    Task { @MainActor in
+                        isPerformingTask = true
+                        let result = await viewModel.createAccount()
+                        isPerformingTask = false
+                        switch result {
+                        case .success:
+                            completion()
+                        case .failure:
+                            break
+                        }
+                    }
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .disabled(!(viewModel.isEmailValid && viewModel.isPasswordValid) || isPerformingTask)
+            }
+            .padding(.init(top: 0, leading: Layout.horizontalSpacing, bottom: 0, trailing: Layout.horizontalSpacing))
+        }
+        .ignoresSafeArea(.container, edges: [.horizontal])
+    }
+}
+
+private extension AccountCreationForm {
+    var tosAttributedText: NSAttributedString {
+        let result = NSMutableAttributedString(
+            string: .localizedStringWithFormat(Localization.tosFormat, Localization.tos),
+            attributes: [
+                .foregroundColor: UIColor.label,
+                .font: UIFont.body
+            ]
+        )
+        result.replaceFirstOccurrence(
+            of: Localization.tos,
+            with: NSAttributedString(
+                string: Localization.tos,
+                attributes: [
+                    .underlineStyle: 1, // `NSUnderlineStyle.single` does not work.
+                    .foregroundColor: UIColor.label,
+                    .font: UIFont.body
+                ]
+            ))
+        return result
+    }
+
+    enum Constants {
+        static let tosURL = WooConstants.URLs.termsOfService.asURL()
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString("Get started in minutes", comment: "Title for the account creation form.")
+        // TODO-7891: support login navigation.
+        static let subtitle = NSLocalizedString("First, let’s create your account.", comment: "Subtitle for the account creation form.")
+        static let emailFieldTitle = NSLocalizedString("Your email address", comment: "Title of the email field on the account creation form.")
+        static let emailFieldPlaceholder = NSLocalizedString("Email address", comment: "Placeholder of the email field on the account creation form.")
+        static let passwordFieldTitle = NSLocalizedString("Choose a password", comment: "Title of the password field on the account creation form.")
+        static let passwordFieldPlaceholder = NSLocalizedString("Password", comment: "Placeholder of the password field on the account creation form.")
+        static let tosFormat = NSLocalizedString("By continuing, you agree to our %1$@.", comment: "Terms of service format on the account creation form.")
+        static let tos = NSLocalizedString("Terms of Service", comment: "Terms of service link on the account creation form.")
+        static let submitButtonTitle = NSLocalizedString("Get started", comment: "Title of the submit button on the account creation form.")
+    }
+
+    enum Layout {
+        static let verticalSpacing: CGFloat = 40
+        static let verticalSpacingBetweenFields: CGFloat = 16
+        static let horizontalSpacing: CGFloat = 16
+    }
+}
+
+struct AccountCreationForm_Previews: PreviewProvider {
+    static var previews: some View {
+        AccountCreationForm(viewModel: .init())
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -56,9 +56,7 @@ struct AccountCreationForm: View {
                                                                   isSecure: true,
                                                                   errorMessage: viewModel.passwordErrorMessage))
                     AttributedText(tosAttributedText)
-                        .onTapGesture {
-                            customOpenURL?(Constants.tosURL)
-                        }
+                        .attributedTextLinkColor(Color(.label))
                 }
 
                 // CTA to submit the form.
@@ -97,9 +95,8 @@ private extension AccountCreationForm {
             with: NSAttributedString(
                 string: Localization.tos,
                 attributes: [
-                    .underlineStyle: 1, // `NSUnderlineStyle.single` does not work.
-                    .foregroundColor: UIColor.label,
-                    .font: UIFont.body
+                    .font: UIFont.body,
+                    .link: Constants.tosURL
                 ]
             ))
         return result

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -47,11 +47,13 @@ struct AccountCreationForm: View {
                 VStack(spacing: Layout.verticalSpacingBetweenFields) {
                     AccountCreationFormFieldView(viewModel: .init(header: Localization.emailFieldTitle,
                                                                   placeholder: Localization.emailFieldPlaceholder,
+                                                                  keyboardType: .emailAddress,
                                                                   text: $viewModel.email,
                                                                   isSecure: false,
                                                                   errorMessage: viewModel.emailErrorMessage))
                     AccountCreationFormFieldView(viewModel: .init(header: Localization.passwordFieldTitle,
                                                                   placeholder: Localization.passwordFieldPlaceholder,
+                                                                  keyboardType: .default,
                                                                   text: $viewModel.password,
                                                                   isSecure: true,
                                                                   errorMessage: viewModel.passwordErrorMessage))

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -51,12 +51,14 @@ struct AccountCreationForm: View {
                                                                   text: $viewModel.email,
                                                                   isSecure: false,
                                                                   errorMessage: viewModel.emailErrorMessage))
+                    .disabled(isPerformingTask)
                     AccountCreationFormFieldView(viewModel: .init(header: Localization.passwordFieldTitle,
                                                                   placeholder: Localization.passwordFieldPlaceholder,
                                                                   keyboardType: .default,
                                                                   text: $viewModel.password,
                                                                   isSecure: true,
                                                                   errorMessage: viewModel.passwordErrorMessage))
+                    .disabled(isPerformingTask)
                     AttributedText(tosAttributedText)
                         .attributedTextLinkColor(Color(.textLink))
                 }
@@ -75,7 +77,7 @@ struct AccountCreationForm: View {
                         }
                     }
                 }
-                .buttonStyle(PrimaryButtonStyle())
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isPerformingTask))
                 .disabled(!(viewModel.isEmailValid && viewModel.isPasswordValid) || isPerformingTask)
             }
             .padding(.init(top: 0, leading: Layout.horizontalSpacing, bottom: 0, trailing: Layout.horizontalSpacing))

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
@@ -6,6 +6,8 @@ struct AccountCreationFormFieldViewModel {
     let header: String
     /// Placeholder of the text field.
     let placeholder: String
+    /// The type of keyboard.
+    let keyboardType: UIKeyboardType
     /// Text binding for the text field.
     let text: Binding<String>
     /// Whether the content in the text field is secure, like password.
@@ -29,9 +31,11 @@ struct AccountCreationFormFieldView: View {
             if viewModel.isSecure {
                 SecureField(viewModel.placeholder, text: viewModel.text)
                     .textFieldStyle(.roundedBorder)
+                    .keyboardType(viewModel.keyboardType)
             } else {
                 TextField(viewModel.placeholder, text: viewModel.text)
                     .textFieldStyle(.roundedBorder)
+                    .keyboardType(viewModel.keyboardType)
             }
             if let errorMessage = viewModel.errorMessage {
                 Text(errorMessage)
@@ -51,11 +55,13 @@ struct AccountCreationFormField_Previews: PreviewProvider {
     static var previews: some View {
         AccountCreationFormFieldView(viewModel: .init(header: "Your email address",
                                                       placeholder: "Email address",
+                                                      keyboardType: .emailAddress,
                                                       text: .constant(""),
                                                       isSecure: false,
                                                       errorMessage: nil))
         AccountCreationFormFieldView(viewModel: .init(header: "Choose a password",
                                                       placeholder: "Password",
+                                                      keyboardType: .default,
                                                       text: .constant("w"),
                                                       isSecure: true,
                                                       errorMessage: "Too simple"))

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// Necessary data for the account creation form field.
+struct AccountCreationFormFieldViewModel {
+    /// Title of the field.
+    let header: String
+    /// Placeholder of the text field.
+    let placeholder: String
+    /// Text binding for the text field.
+    let text: Binding<String>
+    /// Whether the content in the text field is secure, like password.
+    let isSecure: Bool
+    /// Optional error message shown below the text field.
+    let errorMessage: String?
+}
+
+/// A field in the account creation form. Currently, there are two fields - email and password.
+struct AccountCreationFormFieldView: View {
+    private let viewModel: AccountCreationFormFieldViewModel
+
+    init(viewModel: AccountCreationFormFieldViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
+            Text(viewModel.header)
+                .bodyStyle()
+            if viewModel.isSecure {
+                SecureField(viewModel.placeholder, text: viewModel.text)
+                    .textFieldStyle(.roundedBorder)
+            } else {
+                TextField(viewModel.placeholder, text: viewModel.text)
+                    .textFieldStyle(.roundedBorder)
+            }
+            if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+                    .footnoteStyle(isEnabled: true, isError: true)
+            }
+        }
+    }
+}
+
+private extension AccountCreationFormFieldView {
+    enum Layout {
+        static let verticalSpacing: CGFloat = 8
+    }
+}
+
+struct AccountCreationFormField_Previews: PreviewProvider {
+    static var previews: some View {
+        AccountCreationFormFieldView(viewModel: .init(header: "Your email address",
+                                                      placeholder: "Email address",
+                                                      text: .constant(""),
+                                                      isSecure: false,
+                                                      errorMessage: nil))
+        AccountCreationFormFieldView(viewModel: .init(header: "Choose a password",
+                                                      placeholder: "Password",
+                                                      text: .constant("w"),
+                                                      isSecure: true,
+                                                      errorMessage: "Too simple"))
+    }
+}

--- a/WooCommerce/Classes/Yosemite/DeauthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/DeauthenticatedState.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import class Networking.AlamofireNetwork
 
 // MARK: - DeauthenticatedState
 //
@@ -13,7 +14,15 @@ class DeauthenticatedState: StoresManagerState {
     private let services: [DeauthenticatedStore]
 
     init() {
-        services = [JetpackConnectionStore(dispatcher: dispatcher)]
+        // Used for logged-out state without a WPCOM auth token.
+        let network = AlamofireNetwork(credentials: .init(authToken: ""))
+        services = [
+            JetpackConnectionStore(dispatcher: dispatcher),
+            AccountCreationStore(dotcomClientID: ApiCredentials.dotcomAppId,
+                                 dotcomClientSecret: ApiCredentials.dotcomSecret,
+                                 network: network,
+                                 dispatcher: dispatcher)
+        ]
     }
 
     /// NO-OP: Executed when current state is activated.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -392,6 +392,9 @@
 		02DFECE725EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */; };
 		02E19B9C284743A40010B254 /* ProductImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E19B9B284743A40010B254 /* ProductImageUploader.swift */; };
 		02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift */; };
+		02E3B62829026C8F007E0F13 /* AccountCreationForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B62729026C8F007E0F13 /* AccountCreationForm.swift */; };
+		02E3B62D290631B3007E0F13 /* AccountCreationFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B62C290631B3007E0F13 /* AccountCreationFormViewModel.swift */; };
+		02E3B62F2906322B007E0F13 /* AccountCreationFormFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B62E2906322B007E0F13 /* AccountCreationFormFieldView.swift */; };
 		02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */; };
 		02E4AF7126FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4AF7026FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift */; };
 		02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */; };
@@ -2310,6 +2313,9 @@
 		02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationInfoViewController.swift; sourceTree = "<group>"; };
 		02E19B9B284743A40010B254 /* ProductImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageUploader.swift; sourceTree = "<group>"; };
 		02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatusListSelectorCommand.swift; sourceTree = "<group>"; };
+		02E3B62729026C8F007E0F13 /* AccountCreationForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationForm.swift; sourceTree = "<group>"; };
+		02E3B62C290631B3007E0F13 /* AccountCreationFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationFormViewModel.swift; sourceTree = "<group>"; };
+		02E3B62E2906322B007E0F13 /* AccountCreationFormFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationFormFieldView.swift; sourceTree = "<group>"; };
 		02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		02E4AF7026FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewFromNoteParcelFactory.swift; sourceTree = "<group>"; };
 		02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Chart.swift"; sourceTree = "<group>"; };
@@ -4782,6 +4788,23 @@
 			path = "List Selector Data Source";
 			sourceTree = "<group>";
 		};
+		02E3B62629026C83007E0F13 /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				02E3B62729026C8F007E0F13 /* AccountCreationForm.swift */,
+				02E3B62E2906322B007E0F13 /* AccountCreationFormFieldView.swift */,
+			);
+			path = Authentication;
+			sourceTree = "<group>";
+		};
+		02E3B62B290631A5007E0F13 /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				02E3B62C290631B3007E0F13 /* AccountCreationFormViewModel.swift */,
+			);
+			path = Authentication;
+			sourceTree = "<group>";
+		};
 		02E4FD7F2306AA770049610C /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
@@ -6773,6 +6796,7 @@
 		B56DB3EF2049C06D00D4AA8E /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				02E3B62629026C83007E0F13 /* Authentication */,
 				E1325EF928FD543B00EC9B2A /* InAppPurchases */,
 				03FBDA9B263AD47200ACE257 /* Coupons */,
 				571B850024CF7E1600CF58A7 /* InAppFeedback */,
@@ -7809,6 +7833,7 @@
 		CE85535B209B5B6A00938BDC /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				02E3B62B290631A5007E0F13 /* Authentication */,
 				D41C9F2A26D9A04A00993558 /* WhatsNew */,
 				D8815AE526383FC200EDAD62 /* CardPresentPayments */,
 				D817585C22BB5E6900289CFE /* Order Details */,
@@ -9621,6 +9646,7 @@
 				2688643D25D470C000821BA5 /* EditAttributesViewModel.swift in Sources */,
 				31C21FA426D9949000916E2E /* SeveralReadersFoundViewController.swift in Sources */,
 				45E1482527736D1E0099CF23 /* SettingsView.swift in Sources */,
+				02E3B62829026C8F007E0F13 /* AccountCreationForm.swift in Sources */,
 				CC078531266E706300BA9AC1 /* ErrorTopBannerFactory.swift in Sources */,
 				DE8C94662646990000C94823 /* PluginListViewController.swift in Sources */,
 				B6E851F3276320C70041D1BA /* RefundFeesDetailsViewModel.swift in Sources */,
@@ -9989,6 +10015,7 @@
 				E1E125B226EB8EE80068A9B0 /* UpdateProgressImage.swift in Sources */,
 				B5A82EE7210263460053ADC8 /* UIViewController+Helpers.swift in Sources */,
 				4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */,
+				02E3B62D290631B3007E0F13 /* AccountCreationFormViewModel.swift in Sources */,
 				0304E36628BE1EED00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.swift in Sources */,
 				CE1F512B206985DF00C6C810 /* PaddedLabel.swift in Sources */,
 				26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */,
@@ -10390,6 +10417,7 @@
 				FE28F7182684EE6A004465C7 /* RoleErrorViewModel.swift in Sources */,
 				02C0CD2C23B5BC9600F880B1 /* DefaultImageService.swift in Sources */,
 				CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */,
+				02E3B62F2906322B007E0F13 /* AccountCreationFormFieldView.swift in Sources */,
 				03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */,
 				DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Form UI for #7891 
Based on design HyVloP5FipZzyPVenH2euI-fi-1518%3A60333
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR includes the UI work for the new account creation form to create a WPCOM account in SwiftUI, `AccountCreationForm` and `AccountCreationFormFieldView` with their corresponding view model. I'm deferring unit tests on `AccountCreationFormViewModel` for later due to the tight timeline. The view model dispatches `AccountCreationAction.createAccount` to create a WPCOM account. For easier testing during development & code review, the account creation form is shown from the `New to WooCommerce?` CTA on the prologue screen.

In a later PR, account creation completion will navigate to the store creation flow.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Feature flag on

- Launch the app
- Log out if needed
- Tap on the `New to WooCommerce?` CTA on the prologue screen --> it should navigate to a form to create a WPCOM account as in the screenshot
  - Please note that the design isn't using existing components like the font size and color, so I used existing SwiftUI styles for now. If you have any suggestions on the UX, please feel free to comment on any improvements!
- Tap on the Terms of Service link --> it should open the ToS page in the browser
- Try entering an email linked to an existing WPCOM account, and a password with >= 6 characters --> the submit CTA should be enabled
- Tap on the submit CTA --> an error should be shown under the email field about the existing account
- Change the email to a new one that isn't linked to an existing account, and update the password to be a simple one like `wooooo`
- Tap on the submit CTA --> an error should be shown under the email field about the password being too simple
- Update the password to be more complex, then tap on the submit CTA again --> it should navigate back to the prologue screen (since store creation flow hasn't been integrated), and you should receive an email to activate the account

#### Feature flag off

- In code, return `false` for `storeCreationMVP` feature flag in `DefaultFeatureFlagService`
- Launch the app

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

light | dark
-- | --
![Simulator Screen Shot - iPhone 14 Pro - 2022-10-24 at 16 36 04](https://user-images.githubusercontent.com/1945542/197483964-45b3ebc3-ba9e-4adb-bde7-d03376d432c9.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-10-24 at 16 35 57](https://user-images.githubusercontent.com/1945542/197483957-fe84f5ce-784e-40e4-9e3e-80deee1834f6.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->