### PR TITLE
[Just In Time Messages] GET JITM network request

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -261,6 +261,40 @@ extension JetpackUser {
         )
     }
 }
+extension JustInTimeMessage {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> JustInTimeMessage {
+        .init(
+            siteID: .fake(),
+            messageID: .fake(),
+            featureClass: .fake(),
+            ttl: .fake(),
+            content: .fake(),
+            cta: .fake()
+        )
+    }
+}
+extension JustInTimeMessage.CTA {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> JustInTimeMessage.CTA {
+        .init(
+            message: .fake(),
+            link: .fake()
+        )
+    }
+}
+extension JustInTimeMessage.Content {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> JustInTimeMessage.Content {
+        .init(
+            message: .fake(),
+            description: .fake()
+        )
+    }
+}
 extension Leaderboard {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -103,6 +103,9 @@
 		0359EA2527AAF7D60048DE2D /* wcpay-charge-card.json in Resources */ = {isa = PBXBuildFile; fileRef = 0359EA2427AAF7D60048DE2D /* wcpay-charge-card.json */; };
 		0359EA2927AC2AAD0048DE2D /* wcpay-charge-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 0359EA2827AC2AAD0048DE2D /* wcpay-charge-error.json */; };
 		036563DB2906938600D84BFD /* JustInTimeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036563DA2906938600D84BFD /* JustInTimeMessage.swift */; };
+		036563DD29069BE400D84BFD /* JustInTimeMessageListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036563DC29069BE400D84BFD /* JustInTimeMessageListMapper.swift */; };
+		036563DF29069C8F00D84BFD /* JustInTimeMessageListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036563DE29069C8F00D84BFD /* JustInTimeMessageListMapperTests.swift */; };
+		036563E129069D3500D84BFD /* just-in-time-message-list.json in Resources */ = {isa = PBXBuildFile; fileRef = 036563E029069D3500D84BFD /* just-in-time-message-list.json */; };
 		03DCB72626244B9B00C8953D /* Coupon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB72526244B9B00C8953D /* Coupon.swift */; };
 		03DCB7402624AD7D00C8953D /* CouponListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */; };
 		03DCB7442624AD9B00C8953D /* CouponListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */; };
@@ -824,6 +827,9 @@
 		0359EA2427AAF7D60048DE2D /* wcpay-charge-card.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-card.json"; sourceTree = "<group>"; };
 		0359EA2827AC2AAD0048DE2D /* wcpay-charge-error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-error.json"; sourceTree = "<group>"; };
 		036563DA2906938600D84BFD /* JustInTimeMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessage.swift; sourceTree = "<group>"; };
+		036563DC29069BE400D84BFD /* JustInTimeMessageListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessageListMapper.swift; sourceTree = "<group>"; };
+		036563DE29069C8F00D84BFD /* JustInTimeMessageListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessageListMapperTests.swift; sourceTree = "<group>"; };
+		036563E029069D3500D84BFD /* just-in-time-message-list.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "just-in-time-message-list.json"; sourceTree = "<group>"; };
 		03DCB72526244B9B00C8953D /* Coupon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coupon.swift; sourceTree = "<group>"; };
 		03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapper.swift; sourceTree = "<group>"; };
 		03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapperTests.swift; sourceTree = "<group>"; };
@@ -2167,6 +2173,7 @@
 				45CCFCE927A2E59B0012E8CB /* inbox-note-list.json */,
 				4513382727A96DE700AE5E78 /* inbox-note.json */,
 				0205021B27C86B9700FB1C6B /* inbox-note-without-isRead.json */,
+				036563E029069D3500D84BFD /* just-in-time-message-list.json */,
 				68C87B332862D40E00A99054 /* setting-all-except-countries.json */,
 				68CB801528D8A39700E169F8 /* customer.json */,
 				68F48B1228E3E5750045C15B /* wc-analytics-customers.json */,
@@ -2195,6 +2202,7 @@
 				E16C59B428F8640B007D55BB /* InAppPurchaseOrderResultMapper.swift */,
 				4513382327A951B300AE5E78 /* InboxNoteMapper.swift */,
 				45CCFCE527A2E3710012E8CB /* InboxNoteListMapper.swift */,
+				036563DC29069BE400D84BFD /* JustInTimeMessageListMapper.swift */,
 				26B2F74424C5573F0065CCC8 /* LeaderboardListMapper.swift */,
 				020D07BD23D8570800FD9580 /* MediaListMapper.swift */,
 				D823D904223746CE00C90817 /* NewShipmentTrackingMapper.swift */,
@@ -2346,6 +2354,7 @@
 				E1A5C27128F93ED900081046 /* InAppPurchaseOrderResultMapperTests.swift */,
 				4513382527A96DB700AE5E78 /* InboxNoteMapperTests.swift */,
 				45CCFCE727A2E5020012E8CB /* InboxNoteListMapperTests.swift */,
+				036563DE29069C8F00D84BFD /* JustInTimeMessageListMapperTests.swift */,
 				B554FA922180C17200C54DFF /* NoteHashListMapperTests.swift */,
 				B5C151BF217EE3FB00C7BDC1 /* NoteListMapperTests.swift */,
 				B5C6FCCC20A34B8300A4F8E4 /* OrderListMapperTests.swift */,
@@ -2632,6 +2641,7 @@
 				02DD6492248A3EC00082523E /* product-external.json in Resources */,
 				03DCB7522624B3BE00C8953D /* coupons-all.json in Resources */,
 				028CB716290223CB00331C09 /* create-account-success.json in Resources */,
+				036563E129069D3500D84BFD /* just-in-time-message-list.json in Resources */,
 				45A4B85C25D2FAB500776FB4 /* shipping-label-address-validation-error.json in Resources */,
 				02A26F1C2744F5FC008E4EDB /* wp-site-settings.json in Resources */,
 				31A451D027863A2E00FE81AA /* stripe-account-live-live.json in Resources */,
@@ -2895,6 +2905,7 @@
 				B50A583921AD861700617455 /* APNSDevice.swift in Sources */,
 				DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */,
 				26455E2425F66982008A1D32 /* ProductAttributeTermRemote.swift in Sources */,
+				036563DD29069BE400D84BFD /* JustInTimeMessageListMapper.swift in Sources */,
 				7426CA0D21AF27B9004E9FFC /* SiteAPIRemote.swift in Sources */,
 				451A97D1260A03900059D135 /* ShippingLabelCustomPackage.swift in Sources */,
 				DE34051328BDCA5100CF0D97 /* WordPressOrgRequest.swift in Sources */,
@@ -3237,6 +3248,7 @@
 				45E461BE26837DB900011BF2 /* DataRemoteTests.swift in Sources */,
 				CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */,
 				24F98C5E2502EDCF00F49B68 /* BundleWooTests.swift in Sources */,
+				036563DF29069C8F00D84BFD /* JustInTimeMessageListMapperTests.swift in Sources */,
 				74AB0ACA21948CE4008220CD /* CommentResultMapperTests.swift in Sources */,
 				68CB801428D8A05200E169F8 /* CustomerMapperTests.swift in Sources */,
 				02698CF824C183A5005337C4 /* ProductVariationListMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		0359EA2127AAE58C0048DE2D /* wcpay-charge-card-present.json in Resources */ = {isa = PBXBuildFile; fileRef = 0359EA2027AAE58C0048DE2D /* wcpay-charge-card-present.json */; };
 		0359EA2527AAF7D60048DE2D /* wcpay-charge-card.json in Resources */ = {isa = PBXBuildFile; fileRef = 0359EA2427AAF7D60048DE2D /* wcpay-charge-card.json */; };
 		0359EA2927AC2AAD0048DE2D /* wcpay-charge-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 0359EA2827AC2AAD0048DE2D /* wcpay-charge-error.json */; };
+		036563DB2906938600D84BFD /* JustInTimeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036563DA2906938600D84BFD /* JustInTimeMessage.swift */; };
 		03DCB72626244B9B00C8953D /* Coupon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB72526244B9B00C8953D /* Coupon.swift */; };
 		03DCB7402624AD7D00C8953D /* CouponListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */; };
 		03DCB7442624AD9B00C8953D /* CouponListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */; };
@@ -822,6 +823,7 @@
 		0359EA2027AAE58C0048DE2D /* wcpay-charge-card-present.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-card-present.json"; sourceTree = "<group>"; };
 		0359EA2427AAF7D60048DE2D /* wcpay-charge-card.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-card.json"; sourceTree = "<group>"; };
 		0359EA2827AC2AAD0048DE2D /* wcpay-charge-error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-error.json"; sourceTree = "<group>"; };
+		036563DA2906938600D84BFD /* JustInTimeMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessage.swift; sourceTree = "<group>"; };
 		03DCB72526244B9B00C8953D /* Coupon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coupon.swift; sourceTree = "<group>"; };
 		03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapper.swift; sourceTree = "<group>"; };
 		03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapperTests.swift; sourceTree = "<group>"; };
@@ -1856,11 +1858,14 @@
 				DE2095BC27956D7900171F1C /* CouponReport.swift */,
 				2685C0D1263B069500D9EE97 /* AddOnGroup.swift */,
 				45150A99268340D2006922EA /* Country.swift */,
-				45150A9B2683417A006922EA /* StateOfACountry.swift */,
+				68CB800B28D87BC800E169F8 /* Customer.swift */,
 				B53EF53721813806003E146F /* DotcomError.swift */,
+				DE50295A28C5F99700551736 /* DotcomUser.swift */,
 				24F98C552502EA4800F49B68 /* FeatureFlag.swift */,
 				45CCFCE127A2C9BF0012E8CB /* InboxNote.swift */,
 				45CCFCE327A2DC270012E8CB /* InboxAction.swift */,
+				DE50295828C5BD0200551736 /* JetpackUser.swift */,
+				036563DA2906938600D84BFD /* JustInTimeMessage.swift */,
 				B5A2417C217F9ECC00595DEF /* MetaContainer.swift */,
 				B59325C6217E22FC000B0E8E /* Note.swift */,
 				B59325D0217E4206000B0E8E /* NoteBlock.swift */,
@@ -1896,6 +1901,7 @@
 				74046E1C217A6989007DD7BF /* SiteSetting.swift */,
 				74159624224D4045003C21CF /* SiteSettingGroup.swift */,
 				CE50345F21B5799F007573C6 /* SitePlan.swift */,
+				45150A9B2683417A006922EA /* StateOfACountry.swift */,
 				311D412B2783BF7400052F64 /* StripeAccount.swift */,
 				077F39C7269F2C7E00ABEADC /* SystemPlugin.swift */,
 				3148976F27232982007A86BD /* SystemStatus.swift */,
@@ -1904,6 +1910,8 @@
 				31799AF7270508C600D78179 /* RemoteReaderLocation.swift */,
 				D8EDFE2125EE88C9003D2213 /* ReaderConnectionToken.swift */,
 				31054705262E278100C5C02B /* RemotePaymentIntent.swift */,
+				FE28F6E126840DED004465C7 /* User.swift */,
+				68F48B0828E3AF750045C15B /* WCAnalyticsCustomer.swift */,
 				3192F21F260D33BB0067FEF9 /* WCPayAccount.swift */,
 				3192F223260D34C40067FEF9 /* WCPayAccountStatusEnum.swift */,
 				0359EA1627AAC7740048DE2D /* WCPayCardFunding.swift */,
@@ -1916,11 +1924,6 @@
 				3105470B262E27F000C5C02B /* WCPayPaymentIntentStatusEnum.swift */,
 				0359EA0E27AAC6410048DE2D /* WCPayPaymentMethodDetails.swift */,
 				0359EA1027AAC6740048DE2D /* WCPayPaymentMethodType.swift */,
-				FE28F6E126840DED004465C7 /* User.swift */,
-				DE50295828C5BD0200551736 /* JetpackUser.swift */,
-				DE50295A28C5F99700551736 /* DotcomUser.swift */,
-				68CB800B28D87BC800E169F8 /* Customer.swift */,
-				68F48B0828E3AF750045C15B /* WCAnalyticsCustomer.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -3162,6 +3165,7 @@
 				45CCFCE427A2DC270012E8CB /* InboxAction.swift in Sources */,
 				B5C6FCD420A373BB00A4F8E4 /* OrderMapper.swift in Sources */,
 				D88D5A49230BC8C7007B6E01 /* ProductReviewStatus.swift in Sources */,
+				036563DB2906938600D84BFD /* JustInTimeMessage.swift in Sources */,
 				451A97C92609FF050059D135 /* ShippingLabelPackagesResponse.swift in Sources */,
 				029BA4F0255D7282006171FD /* ShippingLabelRemote.swift in Sources */,
 				B557DA0F20975E07005962F4 /* DotcomRequest.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -117,6 +117,8 @@
 		03DCB786262739D200C8953D /* CouponMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB785262739D200C8953D /* CouponMapper.swift */; };
 		03E6676927E0F62B00890E6F /* wcpay-charge-interac-present.json in Resources */ = {isa = PBXBuildFile; fileRef = 03E6676827E0F62B00890E6F /* wcpay-charge-interac-present.json */; };
 		03E8FEC427B40E3F00F5FC7D /* wcpay-charge-card-present-minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = 03E8FEC327B40E3F00F5FC7D /* wcpay-charge-card-present-minimal.json */; };
+		03EB99882906A78400F06A39 /* JustInTimeMessagesRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EB99872906A78400F06A39 /* JustInTimeMessagesRemote.swift */; };
+		03EB998A2906AB0C00F06A39 /* JustInTimeMessagesRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EB99892906AB0C00F06A39 /* JustInTimeMessagesRemoteTests.swift */; };
 		077F39C8269F2C7E00ABEADC /* SystemPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39C7269F2C7E00ABEADC /* SystemPlugin.swift */; };
 		077F39D426A58DE700ABEADC /* SystemStatusMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39D326A58DE700ABEADC /* SystemStatusMapper.swift */; };
 		077F39D626A58E4500ABEADC /* SystemStatusRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077F39D526A58E4500ABEADC /* SystemStatusRemote.swift */; };
@@ -841,6 +843,8 @@
 		03DCB785262739D200C8953D /* CouponMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponMapper.swift; sourceTree = "<group>"; };
 		03E6676827E0F62B00890E6F /* wcpay-charge-interac-present.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-interac-present.json"; sourceTree = "<group>"; };
 		03E8FEC327B40E3F00F5FC7D /* wcpay-charge-card-present-minimal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-card-present-minimal.json"; sourceTree = "<group>"; };
+		03EB99872906A78400F06A39 /* JustInTimeMessagesRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessagesRemote.swift; sourceTree = "<group>"; };
+		03EB99892906AB0C00F06A39 /* JustInTimeMessagesRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessagesRemoteTests.swift; sourceTree = "<group>"; };
 		077F39C7269F2C7E00ABEADC /* SystemPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPlugin.swift; sourceTree = "<group>"; };
 		077F39D326A58DE700ABEADC /* SystemStatusMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusMapper.swift; sourceTree = "<group>"; };
 		077F39D526A58E4500ABEADC /* SystemStatusRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusRemote.swift; sourceTree = "<group>"; };
@@ -1653,6 +1657,7 @@
 				24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */,
 				4513382127A8409000AE5E78 /* InboxNotesRemoteTests.swift */,
 				E13BAD5228F8625600217769 /* InAppPurchasesRemoteTests.swift */,
+				03EB99892906AB0C00F06A39 /* JustInTimeMessagesRemoteTests.swift */,
 				26B2F74824C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift */,
 				020D07BF23D8587700FD9580 /* MediaRemoteTests.swift */,
 				B554FA8A2180B1D500C54DFF /* NotificationsRemoteTests.swift */,
@@ -1788,6 +1793,7 @@
 				24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */,
 				E18152BD28F85B5B0011A0EC /* InAppPurchasesRemote.swift */,
 				4513381F27A8227F00AE5E78 /* InboxNotesRemote.swift */,
+				03EB99872906A78400F06A39 /* JustInTimeMessagesRemote.swift */,
 				26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */,
 				B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */,
 				B557DA0120975500005962F4 /* OrdersRemote.swift */,
@@ -3135,6 +3141,7 @@
 				E16C59B528F8640B007D55BB /* InAppPurchaseOrderResultMapper.swift in Sources */,
 				026CF61A237D607A009563D4 /* ProductVariationAttribute.swift in Sources */,
 				D8FBFF1A22D4DF7A006E3336 /* OrderStatsV4.swift in Sources */,
+				03EB99882906A78400F06A39 /* JustInTimeMessagesRemote.swift in Sources */,
 				74A1D26B21189B8100931DFA /* SiteVisitStatsItem.swift in Sources */,
 				DE34051728BDEB6D00CF0D97 /* JetpackConnectionRemote.swift in Sources */,
 				B505F6EC20BEFDC200BB1B69 /* Loader.swift in Sources */,
@@ -3227,6 +3234,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				45551F142523E7FF007EF104 /* UserAgentTests.swift in Sources */,
+				03EB998A2906AB0C00F06A39 /* JustInTimeMessagesRemoteTests.swift in Sources */,
 				DE34051D28BDF1C900CF0D97 /* JetpackConnectionURLMapperTests.swift in Sources */,
 				451A9836260B9DF90059D135 /* ShippingLabelPackagesMapperTests.swift in Sources */,
 				02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */,

--- a/Networking/Networking/Mapper/JustInTimeMessageListMapper.swift
+++ b/Networking/Networking/Mapper/JustInTimeMessageListMapper.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Mapper: Just In Time Message
+///
+struct JustInTimeMessageListMapper: Mapper {
+
+    /// Site we're parsing `JustInTimeMessage`s for
+    /// We're injecting this field by copying it in after parsing response, because `siteID` is not returned in any of the JITM endpoints.
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert an array into a Just In Time Message.
+    ///
+    func map(response: Data) throws -> [JustInTimeMessage] {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+        return try decoder.decode(JustInTimeMessageListEnvelope.self, from: response).data
+    }
+}
+
+/// JustInTimeMessageEnvelope Disposable Entity:
+/// This entity allows us to parse JustInTimeMessage with JSONDecoder.
+///
+private struct JustInTimeMessageListEnvelope: Decodable {
+    let data: [JustInTimeMessage]
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+    }
+}

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -313,6 +313,63 @@ extension JetpackUser {
     }
 }
 
+extension JustInTimeMessage {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        messageID: CopiableProp<String> = .copy,
+        featureClass: CopiableProp<String> = .copy,
+        ttl: CopiableProp<Int64> = .copy,
+        content: CopiableProp<JustInTimeMessage.Content> = .copy,
+        cta: CopiableProp<JustInTimeMessage.CTA> = .copy
+    ) -> JustInTimeMessage {
+        let siteID = siteID ?? self.siteID
+        let messageID = messageID ?? self.messageID
+        let featureClass = featureClass ?? self.featureClass
+        let ttl = ttl ?? self.ttl
+        let content = content ?? self.content
+        let cta = cta ?? self.cta
+
+        return JustInTimeMessage(
+            siteID: siteID,
+            messageID: messageID,
+            featureClass: featureClass,
+            ttl: ttl,
+            content: content,
+            cta: cta
+        )
+    }
+}
+
+extension JustInTimeMessage.CTA {
+    public func copy(
+        message: CopiableProp<String> = .copy,
+        link: CopiableProp<String> = .copy
+    ) -> JustInTimeMessage.CTA {
+        let message = message ?? self.message
+        let link = link ?? self.link
+
+        return JustInTimeMessage.CTA(
+            message: message,
+            link: link
+        )
+    }
+}
+
+extension JustInTimeMessage.Content {
+    public func copy(
+        message: CopiableProp<String> = .copy,
+        description: CopiableProp<String> = .copy
+    ) -> JustInTimeMessage.Content {
+        let message = message ?? self.message
+        let description = description ?? self.description
+
+        return JustInTimeMessage.Content(
+            message: message,
+            description: description
+        )
+    }
+}
+
 extension Media {
     public func copy(
         mediaID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/JustInTimeMessage.swift
+++ b/Networking/Networking/Model/JustInTimeMessage.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Codegen
+
+/// Just In Time Message
+/// Also referred to as JITM, these messages are triggered on a per WPcom user basis, and can be requested for particular contexts within the app.
+/// They are generally displayed as a title, description, and CTA button
+///
+public struct JustInTimeMessage: GeneratedCopiable, GeneratedFakeable, Equatable {
+    /// Site Identifier
+    ///
+    public let siteID: Int64
+
+    /// JITM id, e.g. `woomobile_ipp_barcode_users`. Identifies a message.
+    ///
+    public let messageID: String
+
+    /// JITM feature class, groups JITMs by area, e.g. `woomobile_ipp`
+    ///
+    public let featureClass: String
+
+    /// Validity of the JITM in seconds
+    ///
+    public let ttl: Int64
+
+    /// Content of the JITM: in particular, the title and description of the message
+    ///
+    public let content: Content
+
+    /// The Call to Action for the JITM: in particular, the button text and link to open
+    ///
+    public let cta: CTA
+
+    public init(siteID: Int64,
+                messageID: String,
+                featureClass: String,
+                ttl: Int64,
+                content: JustInTimeMessage.Content,
+                cta: JustInTimeMessage.CTA) {
+        self.siteID = siteID
+        self.messageID = messageID
+        self.featureClass = featureClass
+        self.ttl = ttl
+        self.content = content
+        self.cta = cta
+    }
+}
+
+extension JustInTimeMessage: Codable {
+    enum CodingKeys: String, CodingKey {
+        case messageID = "id"
+        case featureClass = "feature_class"
+        case ttl
+        case content
+        case cta = "CTA"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: JustInTimeMessage.CodingKeys.self)
+
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw JustInTimeMessageDecodingError.missingSiteID
+        }
+
+        self.siteID = siteID
+        self.messageID = try container.decode(String.self, forKey: JustInTimeMessage.CodingKeys.messageID)
+        self.featureClass = try container.decode(String.self, forKey: JustInTimeMessage.CodingKeys.featureClass)
+        self.ttl = try container.decode(Int64.self, forKey: JustInTimeMessage.CodingKeys.ttl)
+        self.content = try container.decode(JustInTimeMessage.Content.self, forKey: JustInTimeMessage.CodingKeys.content)
+        self.cta = try container.decode(JustInTimeMessage.CTA.self, forKey: JustInTimeMessage.CodingKeys.cta)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: JustInTimeMessage.CodingKeys.self)
+
+        try container.encode(self.messageID, forKey: JustInTimeMessage.CodingKeys.messageID)
+        try container.encode(self.featureClass, forKey: JustInTimeMessage.CodingKeys.featureClass)
+        try container.encode(self.ttl, forKey: JustInTimeMessage.CodingKeys.ttl)
+        try container.encode(self.content, forKey: JustInTimeMessage.CodingKeys.content)
+        try container.encode(self.cta, forKey: JustInTimeMessage.CodingKeys.cta)
+    }
+}
+
+// MARK: - Nested Types
+extension JustInTimeMessage {
+    public struct Content: GeneratedCopiable, GeneratedFakeable, Codable, Equatable {
+        /// The message is the title for a JITM – this is localized to the store's locale by WPcom, and intended to be shown to the user.
+        ///
+        public let message: String
+
+        /// The message is the title for a JITM – this is localized to the store's locale by WPcom, and intended to be shown to the user.
+        public let description: String
+
+        enum CodingKeys: String, CodingKey {
+            case message
+            case description
+        }
+
+        public init(message: String, description: String) {
+            self.message = message
+            self.description = description
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: JustInTimeMessage.Content.CodingKeys.self)
+
+            self.message = try container.decode(String.self, forKey: JustInTimeMessage.Content.CodingKeys.message)
+            self.description = try container.decode(String.self, forKey: JustInTimeMessage.Content.CodingKeys.description)
+
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: JustInTimeMessage.Content.CodingKeys.self)
+
+            try container.encode(self.message, forKey: JustInTimeMessage.Content.CodingKeys.message)
+            try container.encode(self.description, forKey: JustInTimeMessage.Content.CodingKeys.description)
+        }
+    }
+
+    public struct CTA: GeneratedCopiable, GeneratedFakeable, Codable, Equatable {
+        /// The message is the button title for a JITM – this is localized to the store's locale by WPcom, and intended to be shown to the user.
+        ///
+        public let message: String
+
+        /// The link to be opened when a JITM button is tapped. This may be a web link, or a deeplink.
+        ///
+        public let link: String
+
+        enum CodingKeys: String, CodingKey {
+            case message
+            case link
+        }
+
+        public init(message: String, link: String) {
+            self.message = message
+            self.link = link
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: JustInTimeMessage.CTA.CodingKeys.self)
+
+            self.message = try container.decode(String.self, forKey: JustInTimeMessage.CTA.CodingKeys.message)
+            self.link = try container.decode(String.self, forKey: JustInTimeMessage.CTA.CodingKeys.link)
+
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: JustInTimeMessage.CTA.CodingKeys.self)
+
+            try container.encode(self.message, forKey: JustInTimeMessage.CTA.CodingKeys.message)
+            try container.encode(self.link, forKey: JustInTimeMessage.CTA.CodingKeys.link)
+        }
+    }
+}
+
+// MARK: - Decoding Errors
+//
+enum JustInTimeMessageDecodingError: Error {
+    case missingSiteID
+}

--- a/Networking/Networking/Remote/JustInTimeMessagesRemote.swift
+++ b/Networking/Networking/Remote/JustInTimeMessagesRemote.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+public protocol JustInTimeMessagesRemoteProtocol {
+    func loadAllJustInTimeMessages(for siteID: Int64,
+                                   messagePath: JustInTimeMessagesRemote.MessagePath) async -> Result<[JustInTimeMessage], Error>
+}
+
+/// Just In Time Messages: Remote endpoints
+///
+public final class JustInTimeMessagesRemote: Remote, JustInTimeMessagesRemoteProtocol {
+    // MARK: - GET Just In Time Messages
+
+    /// Retrieves all of the `JustInTimeMessage`s from the API.
+    ///
+    /// - Parameters:
+    ///     - siteID: The site for which we'll fetch JustInTimeMessages.
+    ///     - messagePath: The location for JITMs to be displayed
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func loadAllJustInTimeMessages(for siteID: Int64,
+                                          messagePath: JustInTimeMessagesRemote.MessagePath) async -> Result<[JustInTimeMessage], Error> {
+        let request = JetpackRequest(wooApiVersion: .none,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Path.jitm,
+                                     parameters: [ParameterKey.messagePath: messagePath.requestValue])
+
+        let mapper = JustInTimeMessageListMapper(siteID: siteID)
+
+        do {
+            let result = try await enqueue(request, mapper: mapper)
+            return result
+        } catch {
+            return .failure(error)
+        }
+    }
+}
+
+// MARK: - Constants
+//
+public extension JustInTimeMessagesRemote {
+    private enum Path {
+        static let jitm = "jetpack/v4/jitm"
+    }
+
+    private enum ParameterKey {
+        static let messagePath = "message_path"
+    }
+
+    /// Message Path parameter
+    ///
+    struct MessagePath {
+        public let app: MessagePath.App
+        public let screen: String
+        public let hook: MessagePath.Hook
+
+        public init(app: MessagePath.App,
+                    screen: String,
+                    hook: MessagePath.Hook) {
+            self.app = app
+            self.screen = screen
+            self.hook = hook
+        }
+
+        public enum App: String {
+            case wooMobile = "woomobile"
+        }
+
+        public enum Hook: String {
+            case adminNotices = "admin_notices"
+        }
+
+        var requestValue: String {
+            "\(app.rawValue):\(screen):\(hook.rawValue)"
+        }
+    }
+}

--- a/Networking/NetworkingTests/Mapper/JustInTimeMessageListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/JustInTimeMessageListMapperTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import Networking
+import TestKit
+
+final class JustInTimeMessageListMapperTests: XCTestCase {
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 1678
+
+    /// Verifies that the message is parsed.
+    ///
+    func test_JustInTimeMessageListMapper_parses_the_JustInTimeMessage_in_response() throws {
+        let justInTimeMessages = try mapLoadJustInTimeMessageListResponse()
+        XCTAssertNotNil(justInTimeMessages)
+        assertEqual(1, justInTimeMessages?.count)
+    }
+
+    /// Verifies that the fields are all parsed correctly.
+    ///
+    func test_JustInTimeMessageListMapper_parses_all_fields_in_result() throws {
+        // Given, When
+        let justInTimeMessage = try XCTUnwrap(mapLoadJustInTimeMessageListResponse()).first
+
+        // Then
+        let expectedJustInTimeMessage = JustInTimeMessage(siteID: dummySiteID,
+                                                          messageID: "woomobile_ipp_barcode_users",
+                                                          featureClass: "woomobile_ipp",
+                                                          ttl: 300,
+                                                          content: JustInTimeMessage.Content(
+                                                            message: "In-person card payments",
+                                                            description: "Sell anywhere, and take card payments using a mobile card reader."),
+                                                          cta: JustInTimeMessage.CTA(
+                                                            message: "Purchase Card Reader",
+                                                            link: "https://woocommerce.com/products/hardware/US"))
+        assertEqual(expectedJustInTimeMessage, justInTimeMessage)
+    }
+}
+
+
+// MARK: - Test Helpers
+
+private extension JustInTimeMessageListMapperTests {
+    /// Returns the JustInTimeMessageMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapJustInTimeMessageList(from filename: String) throws -> [JustInTimeMessage]? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try JustInTimeMessageListMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    /// Returns the JustInTimeMessageListMapper output from `just-in-time-message-list.json`
+    ///
+    func mapLoadJustInTimeMessageListResponse() throws -> [JustInTimeMessage]? {
+        return try mapJustInTimeMessageList(from: "just-in-time-message-list")
+    }
+}

--- a/Networking/NetworkingTests/Remote/JustInTimeMessagesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/JustInTimeMessagesRemoteTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import Networking
+import TestKit
+
+final class JustInTimeMessagesRemoteTests: XCTestCase {
+    /// Dummy Network Wrapper
+    ///
+    private var network: MockNetwork!
+
+    /// Dummy Site ID
+    ///
+    private let sampleSiteID: Int64 = 1234
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork()
+    }
+
+    override func tearDown() {
+        network = nil
+        super.tearDown()
+    }
+
+    // MARK: - Load all Just In Time Messages tests
+
+    /// Verifies that loadAllJustInTimeMessages properly parses the `just-in-time-message-list` sample response.
+    ///
+    func test_loadAllJustInTimeMessages_returns_parsed_messages() async throws {
+        // Given
+        let remote = JustInTimeMessagesRemote(network: network)
+
+        network.simulateResponse(requestUrlSuffix: "jetpack/v4/jitm", filename: "just-in-time-message-list")
+
+        // When
+        let result = await remote.loadAllJustInTimeMessages(
+                for: self.sampleSiteID,
+                messagePath: JustInTimeMessagesRemote.MessagePath(
+                    app: .wooMobile,
+                    screen: "my_store",
+                    hook: .adminNotices))
+
+        // Then
+        XCTAssert(result.isSuccess)
+        let justInTimeMessages = try XCTUnwrap(result.get())
+        assertEqual(1, justInTimeMessages.count)
+    }
+
+    /// Verifies that loadAllJustInTimeMessages uses the SiteID passed in for the request.
+    ///
+    func test_loadAllJustInTimeMessages_uses_passed_siteID_for_request() async throws {
+        // Given
+        let remote = JustInTimeMessagesRemote(network: network)
+
+        // When
+        _ = await remote.loadAllJustInTimeMessages(
+            for: self.sampleSiteID,
+            messagePath: JustInTimeMessagesRemote.MessagePath(
+                app: .wooMobile,
+                screen: "my_store",
+                hook: .adminNotices))
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.first as? JetpackRequest)
+        XCTAssertEqual(request.siteID, sampleSiteID)
+    }
+
+    /// Verifies that loadAllJustInTimeMessages uses the SiteID passed in to build the models.
+    ///
+    func test_loadAllJustInTimeMessages_uses_passed_siteID_for_model_creation() async throws {
+        // Given
+        let remote = JustInTimeMessagesRemote(network: network)
+
+        network.simulateResponse(requestUrlSuffix: "jetpack/v4/jitm", filename: "just-in-time-message-list")
+
+        // When
+        let result = await remote.loadAllJustInTimeMessages(
+                for: self.sampleSiteID,
+                messagePath: JustInTimeMessagesRemote.MessagePath(
+                    app: .wooMobile,
+                    screen: "my_store",
+                    hook: .adminNotices))
+
+        // Then
+        let justInTimeMessages = try result.get()
+        assertEqual(sampleSiteID, justInTimeMessages.first?.siteID)
+    }
+
+    /// Verifies that loadAllJustInTimeMessages uses the messagePath passed in for the request.
+    ///
+    func test_loadAllJustInTimeMessages_uses_passed_messagePath_for_request() async throws {
+        // Given
+        let remote = JustInTimeMessagesRemote(network: network)
+
+        // When
+        _ = await remote.loadAllJustInTimeMessages(
+            for: self.sampleSiteID,
+            messagePath: JustInTimeMessagesRemote.MessagePath(
+                app: .wooMobile,
+                screen: "my_store",
+                hook: .adminNotices))
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.first as? JetpackRequest)
+        let url = try XCTUnwrap(request.urlRequest?.url)
+        let queryItems = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+        let queryJson = try XCTUnwrap(queryItems.first { $0.name == "query" }?.value)
+        assertThat(queryJson, contains: "woomobile:my_store:admin_notices")
+    }
+
+    /// Verifies that loadAllJustInTimeMessages properly relays Networking Layer errors.
+    ///
+    func test_loadAllJustInTimeMessages_properly_relays_networking_errors() async throws {
+        // Given
+        let remote = JustInTimeMessagesRemote(network: network)
+
+        let error = NetworkError.unacceptableStatusCode(statusCode: 403)
+        network.simulateError(requestUrlSuffix: "jetpack/v4/jitm", error: error)
+
+        // When
+        let result = await remote.loadAllJustInTimeMessages(
+                for: self.sampleSiteID,
+                messagePath: JustInTimeMessagesRemote.MessagePath(
+                    app: .wooMobile,
+                    screen: "my_store",
+                    hook: .adminNotices))
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let resultError = try XCTUnwrap(result.failure as? NetworkError)
+        assertEqual(error, resultError)
+    }
+}

--- a/Networking/NetworkingTests/Responses/just-in-time-message-list.json
+++ b/Networking/NetworkingTests/Responses/just-in-time-message-list.json
@@ -1,0 +1,35 @@
+{
+  "data": [
+    {
+      "content": {
+        "message": "In-person card payments",
+        "icon": "",
+        "iconPath": null,
+        "list": [],
+        "description": "Sell anywhere, and take card payments using a mobile card reader.",
+        "classes": "",
+        "title": "",
+        "disclaimer": []
+      },
+      "CTA": {
+        "message": "Purchase Card Reader",
+        "hook": "",
+        "newWindow": true,
+        "primary": true,
+        "link": "https:\/\/woocommerce.com\/products\/hardware\/US"
+      },
+      "template": "default",
+      "ttl": 300,
+      "id": "woomobile_ipp_barcode_users",
+      "feature_class": "woomobile_ipp",
+      "expires": 3628800,
+      "max_dismissal": 2,
+      "activate_module": null,
+      "is_dismissible": true,
+      "is_user_created_by_partner": null,
+      "message_expiration": null,
+      "url": "https:\/\/jetpack.com\/redirect\/?source=jitm-woomobile_ipp_barcode_users&#038;site=taxbugcheck.mystagingwebsite.com&#038;u=1",
+      "jitm_stats_url": "https:\/\/pixel.wp.com\/b.gif?v=wpcom2&rand=b8ec47eefac4b8f64b70cd379dc573dd&x_jetpack-jitm=woomobile_ipp_barcode_users"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7908 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We will display a Just In Time Message, when available, at the top of the My Store tab.

When the tab is loaded, we will request the messages for this location. To do this, we will make a GET request from `path=jetpack/v4/jitm` with `query={"message_path": "woomobile:my_store:admin_notices"}`

This PR covers the networking layer for that request.

### PR length
Apologies that this is over 500 lines. I could split it into two if that would be helpful, but I haven't because I think it would be more difficult to review. Please let me know if you'd prefer me to do it though, it's no problem at all. I would split it into:
1. [The model and mapper and associated tests](https://github.com/woocommerce/woocommerce-ios/pull/7910/files/322ae1d7a894dbb6e0d9283abcc45ff71dcbcb13)
2. [The remote and associated tests](https://github.com/woocommerce/woocommerce-ios/pull/7910/files/322ae1d7a894dbb6e0d9283abcc45ff71dcbcb13..2a035788eaed26a177740b80b91f123e41a31d4b)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Not independently testable, since it's a currently-unused network request. Unit tests should pass.

To test it, add the following to a store's implementation of existing action, and trigger it, e.g. the top of `OrderStore.fetchFilteredOrders`, then open the Orders tab:

```
        Task {
            do {
                let result = try await jitmRemote.loadAllJustInTimeMessages(for: siteID, messagePath: .init(app: .wooMobile, screen: "my_store", hook: .adminNotices))
                switch result {
                case .success(let messages):
                    print("JITM: recieved \(messages)")
                case .failure(let error):
                    print("JITM: failure \(error)")
                }
            }
        }
```

N.B. see pdfdoF-1uc-p2#comment-2581 for details of setting up your store to be eligible for the test JITM

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="754" alt="Debugger `print()` output showing a parsed JITM" src="https://user-images.githubusercontent.com/2472348/197544869-d7f04186-eebe-4639-89e4-847389172317.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
