### PR TITLE
[Products Onboarding] Check for and track products onboarding eligibility

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -109,6 +109,10 @@ public enum WooAnalyticsStat: String {
     case dashboardNewStatsRevertedBannerLearnMoreTapped = "dashboard_new_stats_reverted_banner_learn_more_tapped"
     case usedAnalytics = "used_analytics"
 
+    // MARK: Onboarding Events
+    //
+    case productsOnboardingEligible = "products_onboarding_store_is_eligible"
+
     // MARK: Site picker. Can be triggered by login epilogue or settings.
     //
     case sitePickerContinueTapped = "site_picker_continue_tapped"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -116,7 +116,7 @@ final class DashboardViewController: UIViewController {
         observeBottomJetpackBenefitsBannerVisibilityUpdates()
         observeNavigationBarHeightForStoreNameLabelVisibility()
         observeStatsVersionForDashboardUIUpdates()
-        checkProductsOnboardingEligibility()
+        trackProductsOnboardingEligibility()
         Task { @MainActor in
             await reloadDashboardUIStatsVersion(forced: true)
         }
@@ -245,9 +245,9 @@ private extension DashboardViewController {
         }
     }
 
-    /// Checks if the store has any existing products, to determine whether it is eligible for products onboarding.
+    /// Tracks if the store is eligible for products onboarding (if the store has no existing products)
     ///
-    func checkProductsOnboardingEligibility() {
+    func trackProductsOnboardingEligibility() {
         let action = ProductAction.checkForProducts(siteID: siteID) { result in
             switch result {
             case .success(let hasProducts):


### PR DESCRIPTION
Closes: #7914

## Description

This PR adds a check when the My Store dashboard loads. It checks if a store is eligible for products onboarding (if the store has no products) and triggers a new event if it is eligible:

* `*_products_onboarding_store_is_eligible` (event registration: 1152-gh-Automattic/tracks-events-registration)

## Changes

* Adds the check using `ProductAction.checkForProducts` when `DashboardViewController` loads, and fires the Tracks event if the store has no products yet.

## Testing

1. Build and run the app.
2. Log in or select a store with no products and confirm the new event is tracked when the My Store dashboard loads.
3. Log in or select a store with existing products and confirm the new event is **not** tracked.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
