### PR TITLE
Products Onboarding: Adds feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -41,6 +41,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .storeCreationMVP:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .productsOnboarding:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -85,4 +85,8 @@ public enum FeatureFlag: Int {
     /// Store creation MVP.
     ///
     case storeCreationMVP
+
+    /// Hides products onboarding development.
+    ///
+    case productsOnboarding
 }


### PR DESCRIPTION
closes #7912 

# Description

This PR adds the `productsOnboarding` feature flag, so we can use it to hide development from release cycles.

No significant logic is added.