### PR TITLE
[In-app Purchases] Send app receipt instead of transaction when creating order

### DIFF
--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -381,6 +381,7 @@
 		DEFD6D972644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */; };
 		E109876C284F6EEB002EBB05 /* CardPresentPaymentsPluginState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E109876B284F6EEB002EBB05 /* CardPresentPaymentsPluginState.swift */; };
 		E138D4FA269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */; };
+		E16B1BB02906C54C000F683D /* InAppPurchaseReceiptRefreshRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16B1BAF2906C54C000F683D /* InAppPurchaseReceiptRefreshRequest.swift */; };
 		E16C59BB28F9393E007D55BB /* InAppPurchaseStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16C59BA28F9393E007D55BB /* InAppPurchaseStore.swift */; };
 		E16C59BD28F9394F007D55BB /* InAppPurchaseAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16C59BC28F9394F007D55BB /* InAppPurchaseAction.swift */; };
 		E18FDAFE28F97EB9008519BA /* AppAccountToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18FDAFD28F97EB9008519BA /* AppAccountToken.swift */; };
@@ -798,6 +799,7 @@
 		DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SitePlugin+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		E109876B284F6EEB002EBB05 /* CardPresentPaymentsPluginState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsPluginState.swift; sourceTree = "<group>"; };
 		E138D4F9269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsOnboardingState.swift; sourceTree = "<group>"; };
+		E16B1BAF2906C54C000F683D /* InAppPurchaseReceiptRefreshRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchaseReceiptRefreshRequest.swift; sourceTree = "<group>"; };
 		E16C59BA28F9393E007D55BB /* InAppPurchaseStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchaseStore.swift; sourceTree = "<group>"; };
 		E16C59BC28F9394F007D55BB /* InAppPurchaseAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchaseAction.swift; sourceTree = "<group>"; };
 		E18FDAFD28F97EB9008519BA /* AppAccountToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAccountToken.swift; sourceTree = "<group>"; };
@@ -1675,6 +1677,7 @@
 			isa = PBXGroup;
 			children = (
 				E18FDAFD28F97EB9008519BA /* AppAccountToken.swift */,
+				E16B1BAF2906C54C000F683D /* InAppPurchaseReceiptRefreshRequest.swift */,
 			);
 			path = InAppPurchases;
 			sourceTree = "<group>";
@@ -1912,6 +1915,7 @@
 				45E18632237046CB009241F3 /* ShippingLine+ReadOnlyConvertible.swift in Sources */,
 				7493750A22498700007D85D1 /* ProductCategory+ReadOnlyConvertible.swift in Sources */,
 				D8C11A5622DFB0BE00D4A88D /* OrderStatsV4Totals+ReadOnlyConvertible.swift in Sources */,
+				E16B1BB02906C54C000F683D /* InAppPurchaseReceiptRefreshRequest.swift in Sources */,
 				CC2C0372262F32D800928C9C /* ShippingLabelPaymentMethod+ReadonlyConvertible.swift in Sources */,
 				74685D4E20F7EFA7008958C1 /* OrderItem+ReadOnlyConvertible.swift in Sources */,
 				7471401121877668009A11CC /* NotificationAction.swift in Sources */,

--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -111,13 +111,14 @@ private extension InAppPurchaseStore {
         }
 
         logInfo("Sending transaction to API for site \(siteID)")
-        _ = try await remote.createOrder(
+        let orderID = try await remote.createOrder(
             for: siteID,
             price: priceInCents,
             productIdentifier: product.id,
             appStoreCountryCode: countryCode,
             receiptData: transaction.jsonRepresentation
         )
+        logInfo("Successfully registered purchase with Order ID \(orderID)")
     }
 
     func getProductIdentifiers() async throws -> [String] {

--- a/Yosemite/Yosemite/Tools/InAppPurchases/InAppPurchaseReceiptRefreshRequest.swift
+++ b/Yosemite/Yosemite/Tools/InAppPurchases/InAppPurchaseReceiptRefreshRequest.swift
@@ -1,0 +1,41 @@
+import StoreKit
+
+class InAppPurchaseReceiptRefreshRequest: NSObject, SKRequestDelegate {
+    let refreshReceiptRequest: SKReceiptRefreshRequest
+    let completion: (Result<Void, Error>) -> Void
+
+    init(completion: @escaping (Result<Void, Error>) -> Void) {
+        refreshReceiptRequest = SKReceiptRefreshRequest()
+        self.completion = completion
+        super.init()
+        refreshReceiptRequest.delegate = self
+    }
+
+    func requestDidFinish(_ request: SKRequest) {
+        complete(.success(()))
+    }
+
+    func request(_ request: SKRequest, didFailWithError error: Error) {
+        complete(.failure(error))
+    }
+
+    func start() {
+        refreshReceiptRequest.start()
+    }
+
+    func complete(_ result: Result<Void, Error>) {
+        DispatchQueue.main.async { [completion] in
+            completion(result)
+        }
+    }
+
+    static func request() async throws {
+        var request: InAppPurchaseReceiptRefreshRequest?
+        try await withCheckedThrowingContinuation { continuation in
+            request = InAppPurchaseReceiptRefreshRequest { result in
+                continuation.resume(with: result)
+            }
+            request?.start()
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7931 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We're supposed to send the app receipt for validation instead of the encoded transaction. This PR does that, ensuring that we refresh the app receipt if missing, since sometimes it won't be there.

I also noticed that we were not handling updates correctly when a transaction was expired/refunded, so I fixed that here as well.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Hub > IAP Debug
2. Wait for the list of products to load
3. Tap on "1 Month of Debug Woo" and complete the purchase process

The UI is not very helpful, but you should see no errors in the console, and a message like `Successfully registered purchase with Order ID ###`.

![Screenshot 2022-10-26 at 10 49 24](https://user-images.githubusercontent.com/8739/197980366-150d0b15-50c6-4df0-abdd-884807075cd3.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
