### PR TITLE
Products Onboarding: Present product template Type bottom sheet

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -1052,6 +1052,12 @@ extension UIImage {
     static var lockImage: UIImage {
         UIImage.gridicon(.lock, size: CGSize(width: 24, height: 24))
     }
+
+    /// Sites Image
+    ///
+    static var sitesImage: UIImage {
+        UIImage.gridicon(.site).imageFlippedForRightToLeftLayoutDirection()
+    }
 }
 
 private extension UIImage {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -63,9 +63,8 @@ private extension AddProductCoordinator {
                                       comment: "Message title of bottom sheet for selecting a template or manual product")
         let viewProperties = BottomSheetListSelectorViewProperties(title: title)
         let command = ProductCreationTypeSelectorCommand { selectedCreationType in
-            //ServiceLocator.analytics.track(.addProductTypeSelected, withProperties: ["product_type": selectedBottomSheetProductType.productType.rawValue])
-            self.navigationController.dismiss(animated: true)
-            //self.presentProductForm(bottomSheetProductType: selectedBottomSheetProductType)
+            // TODO: Add analytics
+            self.presentProductTypeBottomSheet()
         }
         let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
         productTypesListPresenter.show(from: navigationController, sourceView: sourceView, sourceBarButtonItem: sourceBarButtonItem, arrowDirections: .any)
@@ -77,12 +76,18 @@ private extension AddProductCoordinator {
         let viewProperties = BottomSheetListSelectorViewProperties(title: title)
         let command = ProductTypeBottomSheetListSelectorCommand(selected: nil) { selectedBottomSheetProductType in
             ServiceLocator.analytics.track(.addProductTypeSelected, withProperties: ["product_type": selectedBottomSheetProductType.productType.rawValue])
-            self.navigationController.dismiss(animated: true)
-            self.presentProductForm(bottomSheetProductType: selectedBottomSheetProductType)
+            self.navigationController.dismiss(animated: true) {
+                self.presentProductForm(bottomSheetProductType: selectedBottomSheetProductType)
+            }
         }
         command.data = [.simple(isVirtual: false), .simple(isVirtual: true), .variable, .grouped, .affiliate]
         let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
-        productTypesListPresenter.show(from: navigationController, sourceView: sourceView, sourceBarButtonItem: sourceBarButtonItem, arrowDirections: .any)
+
+        // `topmostPresentedViewController` is used because another bottom sheet could have been presented before.
+        productTypesListPresenter.show(from: navigationController.topmostPresentedViewController,
+                                       sourceView: sourceView,
+                                       sourceBarButtonItem: sourceBarButtonItem,
+                                       arrowDirections: .any)
     }
 
     func presentProductForm(bottomSheetProductType: BottomSheetProductType) {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -14,7 +14,7 @@ final class AddProductCoordinator: Coordinator {
     private let sourceBarButtonItem: UIBarButtonItem?
     private let sourceView: UIView?
     private let productImageUploader: ProductImageUploaderProtocol
-    private let shouldPresentProductCreationSheet : Bool
+    private let shouldPresentProductCreationSheet: Bool
 
     init(siteID: Int64,
          sourceBarButtonItem: UIBarButtonItem,

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -13,29 +13,33 @@ final class AddProductCoordinator: Coordinator {
     private let siteID: Int64
     private let sourceBarButtonItem: UIBarButtonItem?
     private let sourceView: UIView?
-
     private let productImageUploader: ProductImageUploaderProtocol
+    private let shouldPresentProductCreationSheet : Bool
 
     init(siteID: Int64,
          sourceBarButtonItem: UIBarButtonItem,
          sourceNavigationController: UINavigationController,
+         shouldPresentProductCreationSheet: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productsOnboarding),
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader) {
         self.siteID = siteID
         self.sourceBarButtonItem = sourceBarButtonItem
         self.sourceView = nil
         self.navigationController = sourceNavigationController
         self.productImageUploader = productImageUploader
+        self.shouldPresentProductCreationSheet = shouldPresentProductCreationSheet
     }
 
     init(siteID: Int64,
          sourceView: UIView,
          sourceNavigationController: UINavigationController,
+         shouldPresentProductCreationSheet: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productsOnboarding),
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader) {
         self.siteID = siteID
         self.sourceBarButtonItem = nil
         self.sourceView = sourceView
         self.navigationController = sourceNavigationController
         self.productImageUploader = productImageUploader
+        self.shouldPresentProductCreationSheet = shouldPresentProductCreationSheet
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -43,12 +47,30 @@ final class AddProductCoordinator: Coordinator {
     }
 
     func start() {
-        presentProductTypeBottomSheet()
+        if shouldPresentProductCreationSheet {
+            presentProductCreationTypeBottomSheet()
+        } else {
+            presentProductTypeBottomSheet()
+        }
     }
 }
 
 // MARK: Navigation
 private extension AddProductCoordinator {
+
+    func presentProductCreationTypeBottomSheet() {
+        let title = NSLocalizedString("How do you want to start?",
+                                      comment: "Message title of bottom sheet for selecting a template or manual product")
+        let viewProperties = BottomSheetListSelectorViewProperties(title: title)
+        let command = ProductCreationTypeSelectorCommand { selectedCreationType in
+            //ServiceLocator.analytics.track(.addProductTypeSelected, withProperties: ["product_type": selectedBottomSheetProductType.productType.rawValue])
+            self.navigationController.dismiss(animated: true)
+            //self.presentProductForm(bottomSheetProductType: selectedBottomSheetProductType)
+        }
+        let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
+        productTypesListPresenter.show(from: navigationController, sourceView: sourceView, sourceBarButtonItem: sourceBarButtonItem, arrowDirections: .any)
+    }
+
     func presentProductTypeBottomSheet() {
         let title = NSLocalizedString("Select a product type",
                                       comment: "Message title of bottom sheet for selecting a product type to create a product")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductCreationTypeCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductCreationTypeCommand.swift
@@ -1,0 +1,78 @@
+import Foundation
+import UIKit
+
+/// Type to allow merchant to create a template product.
+///
+public enum ProductCreationType: Equatable {
+    case template
+    case manual
+
+    /// Title shown on the action sheet.
+    ///
+    var actionSheetTitle: String {
+        switch self {
+        case .template:
+            return NSLocalizedString("Start with a template", comment: "Title for the option to create a template product")
+        case .manual:
+            return NSLocalizedString("Add manually", comment: "Title for the option to create product manually")
+        }
+    }
+
+    /// Description shown on the action sheet.
+    ///
+    var actionSheetDescription: String {
+        switch self {
+        case .template:
+            return NSLocalizedString("Use a template to create physical, digital, and variable products",
+                                     comment: "Description for the option to create a template product")
+        case .manual:
+            return NSLocalizedString("Add a product manually",
+                                     comment: "Description for the option to create product manually")
+        }
+    }
+
+    /// Image shown on the action sheet.
+    ///
+    var actionSheetImage: UIImage {
+        switch self {
+        case .template:
+            return .sitesImage
+        case .manual:
+            return .addOutlineImage
+        }
+    }
+}
+
+/// Selector command for selecting a template product.
+///
+final class ProductCreationTypeSelectorCommand: BottomSheetListSelectorCommand {
+    typealias Model = ProductCreationType
+    typealias Cell = ImageAndTitleAndTextTableViewCell
+
+    var data: [ProductCreationType] = [.template, .manual]
+
+    var selected: ProductCreationType? = nil
+
+    private let onSelection: (ProductCreationType) -> Void
+
+    init(onSelection: @escaping (ProductCreationType) -> Void) {
+        self.onSelection = onSelection
+    }
+
+    func configureCell(cell: ImageAndTitleAndTextTableViewCell, model: ProductCreationType) {
+        let viewModel = ImageAndTitleAndTextTableViewCell.ViewModel(title: model.actionSheetTitle,
+                                                                    text: model.actionSheetDescription,
+                                                                    image: model.actionSheetImage,
+                                                                    imageTintColor: .gray(.shade20),
+                                                                    numberOfLinesForText: 0)
+        cell.updateUI(viewModel: viewModel)
+    }
+
+    func handleSelectedChange(selected: ProductCreationType) {
+        onSelection(selected)
+    }
+
+    func isSelected(model: ProductCreationType) -> Bool {
+        return model == selected
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductCreationTypeCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductCreationTypeCommand.swift
@@ -23,10 +23,10 @@ public enum ProductCreationType: Equatable {
     var actionSheetDescription: String {
         switch self {
         case .template:
-            return NSLocalizedString("Use a template to create physical, digital, and variable products",
+            return NSLocalizedString("Use a template to create physical, virtual, and variable products.",
                                      comment: "Description for the option to create a template product")
         case .manual:
-            return NSLocalizedString("Add a product manually",
+            return NSLocalizedString("Add a product manually.",
                                      comment: "Description for the option to create product manually")
         }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -558,6 +558,7 @@
 		2667BFE92530ECE4008099D4 /* RefundProductsTotalViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE82530ECE4008099D4 /* RefundProductsTotalViewModelTests.swift */; };
 		2667BFEB2535FF09008099D4 /* RefundShippingCalculationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFEA2535FF09008099D4 /* RefundShippingCalculationUseCase.swift */; };
 		2667BFED25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFEC25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift */; };
+		2676F4CC2908284800C7A15B /* ProductCreationTypeCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2676F4CB2908284800C7A15B /* ProductCreationTypeCommand.swift */; };
 		26771A14256FFA8700EE030E /* IssueRefundCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26771A13256FFA8700EE030E /* IssueRefundCoordinatingController.swift */; };
 		2678897C270E6E8B00BD249E /* SimplePaymentsAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2678897B270E6E8B00BD249E /* SimplePaymentsAmount.swift */; };
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
@@ -2471,6 +2472,7 @@
 		2667BFE82530ECE4008099D4 /* RefundProductsTotalViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalViewModelTests.swift; sourceTree = "<group>"; };
 		2667BFEA2535FF09008099D4 /* RefundShippingCalculationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingCalculationUseCase.swift; sourceTree = "<group>"; };
 		2667BFEC25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingCalculationUseCaseTests.swift; sourceTree = "<group>"; };
+		2676F4CB2908284800C7A15B /* ProductCreationTypeCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCreationTypeCommand.swift; sourceTree = "<group>"; };
 		26771A13256FFA8700EE030E /* IssueRefundCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundCoordinatingController.swift; sourceTree = "<group>"; };
 		2678897B270E6E8B00BD249E /* SimplePaymentsAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsAmount.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
@@ -3987,6 +3989,7 @@
 				02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */,
 				02BAB02624D13A6400F8B06E /* ProductVariationFormActionsFactory.swift */,
 				4574745C24EA84D800CF49BC /* ProductTypeBottomSheetListSelectorCommand.swift */,
+				2676F4CB2908284800C7A15B /* ProductCreationTypeCommand.swift */,
 			);
 			path = BottomSheetListSelector;
 			sourceTree = "<group>";
@@ -10169,6 +10172,7 @@
 				B5BE75DB213F1D1E00909A14 /* OverlayMessageView.swift in Sources */,
 				31B0551E264B3C7A00134D87 /* CardPresentModalFoundReader.swift in Sources */,
 				4520A15E2722BA3E001FA573 /* OrderDateRangeFilter+Utils.swift in Sources */,
+				2676F4CC2908284800C7A15B /* ProductCreationTypeCommand.swift in Sources */,
 				45A24E5F2451DF1A0050606B /* ProductMenuOrderViewController.swift in Sources */,
 				2667BFE1252FA117008099D4 /* RefundItemQuantityListSelectorCommand.swift in Sources */,
 				261AA30C2753119E009530FE /* PaymentMethodsViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -672,4 +672,8 @@ final class IconsTests: XCTestCase {
     func test_reply_icon_is_not_nil() {
         XCTAssertNotNil(UIImage.replyImage)
     }
+
+    func test_sites_icon_is_not_nil() {
+        XCTAssertNotNil(UIImage.sitesImage)
+    }
 }


### PR DESCRIPTION
Part of #7917 

# Why 

To allow merchants to create template products, we will provide them with a bottom sheet where they can choose from template or manual options.

This PR show the bottom sheet always, the next one will update the behavior so we only show it when the store has fewer than 3 products.

# How

- Adds new `ProductCreationType` and `ProductCreationTypeSelectorCommand` types that feed the new bottom sheet.

- Update `AddProductCoordinator` to show the new bottom sheet when the feature flag is enabled.


# Testing Steps

- Go to the product list screen
- Tap the add product button
- See that the product creation type bottom sheet is present. (Both options should redirect you to the normal product type picker)
- See that you can still create any product like before

# Demo

https://user-images.githubusercontent.com/562080/197897376-bacc2aba-7dee-4547-8d15-b2a533129761.mov


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
