### PR TITLE
Products Onboarding: Restrict product types based on the creation type

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -66,7 +66,7 @@ final class AddProductCoordinator: Coordinator {
         if shouldPresentProductCreationBottomSheet() {
             presentProductCreationTypeBottomSheet()
         } else {
-            presentProductTypeBottomSheet()
+            presentProductTypeBottomSheet(creationType: .manual)
         }
     }
 }
@@ -87,13 +87,13 @@ private extension AddProductCoordinator {
         let viewProperties = BottomSheetListSelectorViewProperties(title: title)
         let command = ProductCreationTypeSelectorCommand { selectedCreationType in
             // TODO: Add analytics
-            self.presentProductTypeBottomSheet()
+            self.presentProductTypeBottomSheet(creationType: selectedCreationType)
         }
         let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
         productTypesListPresenter.show(from: navigationController, sourceView: sourceView, sourceBarButtonItem: sourceBarButtonItem, arrowDirections: .any)
     }
 
-    func presentProductTypeBottomSheet() {
+    func presentProductTypeBottomSheet(creationType: ProductCreationType) {
         let title = NSLocalizedString("Select a product type",
                                       comment: "Message title of bottom sheet for selecting a product type to create a product")
         let viewProperties = BottomSheetListSelectorViewProperties(title: title)
@@ -103,7 +103,14 @@ private extension AddProductCoordinator {
                 self.presentProductForm(bottomSheetProductType: selectedBottomSheetProductType)
             }
         }
-        command.data = [.simple(isVirtual: false), .simple(isVirtual: true), .variable, .grouped, .affiliate]
+
+        switch creationType {
+        case .template:
+            command.data = [.simple(isVirtual: false), .simple(isVirtual: true), .variable]
+        case .manual:
+            command.data = [.simple(isVirtual: false), .simple(isVirtual: true), .variable, .grouped, .affiliate]
+        }
+
         let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
 
         // `topmostPresentedViewController` is used because another bottom sheet could have been presented before.


### PR DESCRIPTION
Closes: #7942 

# Why

To reduce the number of options for new merchants, this PR modifies the product types when selecting the template option to only `Physical, Virtual, and Variable` products.

# Demo

https://user-images.githubusercontent.com/562080/198079573-967e393e-5a8c-49ae-8ef9-b13951b81e00.mov

# Testing Steps

- On a store with less than 3 products
- Navigate to the product list screen
- Tap add product button
- Tap template option
- See that only Physical, Digital, and Variable products are available. 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
