### PR TITLE
Account creation: add login CTA for existing users

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import struct WordPressAuthenticator.NavigateToEnterAccount
 
 /// Hosting controller that wraps an `AccountCreationForm`.
 final class AccountCreationFormHostingController: UIHostingController<AccountCreationForm> {
@@ -8,6 +9,12 @@ final class AccountCreationFormHostingController: UIHostingController<AccountCre
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController.
         rootView.completion = {
             completion()
+        }
+
+        rootView.loginButtonTapped = { [weak self] in
+            guard let self else { return }
+            let command = NavigateToEnterAccount()
+            command.execute(from: self)
         }
     }
 
@@ -23,6 +30,9 @@ struct AccountCreationForm: View {
     /// Triggered when the account is created and the app is authenticated.
     var completion: (() -> Void) = {}
 
+    /// Triggered when the user taps on the login CTA.
+    var loginButtonTapped: (() -> Void) = {}
+
     @ObservedObject private var viewModel: AccountCreationFormViewModel
 
     @State private var isPerformingTask = false
@@ -36,11 +46,29 @@ struct AccountCreationForm: View {
             VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
                 // Header.
                 VStack(alignment: .leading, spacing: Layout.horizontalSpacing) {
+                    // Title label.
                     Text(Localization.title)
                         .largeTitleStyle()
-                    Text(Localization.subtitle)
-                        .foregroundColor(Color(.secondaryLabel))
-                        .bodyStyle()
+                    VStack(alignment: .leading, spacing: 0) {
+                        // Subtitle label.
+                        Text(Localization.subtitle)
+                            .foregroundColor(Color(.secondaryLabel))
+                            .bodyStyle()
+                        HStack {
+                            // Login subtitle label.
+                            Text(Localization.loginSubtitle)
+                                .foregroundColor(Color(.secondaryLabel))
+                                .bodyStyle()
+
+                            // Login button.
+                            Button(Localization.loginButtonTitle) {
+                                loginButtonTapped()
+                            }
+                            .buttonStyle(TextButtonStyle())
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .disabled(isPerformingTask)
+                        }
+                    }
                 }
 
                 // Form fields.
@@ -112,8 +140,9 @@ private extension AccountCreationForm {
 
     enum Localization {
         static let title = NSLocalizedString("Get started in minutes", comment: "Title for the account creation form.")
-        // TODO-7891: support login navigation.
         static let subtitle = NSLocalizedString("First, let’s create your account.", comment: "Subtitle for the account creation form.")
+        static let loginSubtitle = NSLocalizedString("Already registered?", comment: "Subtitle for the login button on the account creation form.")
+        static let loginButtonTitle = NSLocalizedString("Log in", comment: "Title of the login button on the account creation form.")
         static let emailFieldTitle = NSLocalizedString("Your email address", comment: "Title of the email field on the account creation form.")
         static let emailFieldPlaceholder = NSLocalizedString("Email address", comment: "Placeholder of the email field on the account creation form.")
         static let passwordFieldTitle = NSLocalizedString("Choose a password", comment: "Title of the password field on the account creation form.")

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -54,7 +54,7 @@ struct AccountCreationForm: View {
                         Text(Localization.subtitle)
                             .foregroundColor(Color(.secondaryLabel))
                             .bodyStyle()
-                        HStack {
+                        HStack(alignment: .firstTextBaseline) {
                             // Login subtitle label.
                             Text(Localization.loginSubtitle)
                                 .foregroundColor(Color(.secondaryLabel))
@@ -65,7 +65,6 @@ struct AccountCreationForm: View {
                                 loginButtonTapped()
                             }
                             .buttonStyle(TextButtonStyle())
-                            .frame(maxWidth: .infinity, alignment: .leading)
                             .disabled(isPerformingTask)
                         }
                     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -34,6 +34,13 @@ struct LinkButtonStyle: ButtonStyle {
     }
 }
 
+/// Button that looks like text without the default padding and size assumption.
+struct TextButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        TextButton(configuration: configuration)
+    }
+}
+
 struct PlusButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         return PlusButton(configuration: configuration)
@@ -268,6 +275,27 @@ private struct LinkButton: View {
     }
 }
 
+private struct TextButton: View {
+    @Environment(\.isEnabled) var isEnabled
+
+    let configuration: ButtonStyleConfiguration
+
+    var body: some View {
+        configuration.label
+            .contentShape(Rectangle())
+            .foregroundColor(Color(foregroundColor))
+            .background(Color(.clear))
+    }
+
+    var foregroundColor: UIColor {
+        if isEnabled {
+            return configuration.isPressed ? .accentDark : .accent
+        } else {
+            return .buttonDisabledTitle
+        }
+    }
+}
+
 private struct PlusButton: View {
     @Environment(\.isEnabled) var isEnabled
 
@@ -343,39 +371,58 @@ struct PrimaryButton_Previews: PreviewProvider {
         .padding()
 
         VStack(spacing: 20) {
-            Button("Primary button") {}
-                .buttonStyle(PrimaryButtonStyle())
+            Group {
+                Button("Primary button") {}
+                    .buttonStyle(PrimaryButtonStyle())
 
-            Button("Primary button (disabled)") {}
-                .buttonStyle(PrimaryButtonStyle())
-                .disabled(true)
+                Button("Primary button (disabled)") {}
+                    .buttonStyle(PrimaryButtonStyle())
+                    .disabled(true)
+            }
 
-            Button("Secondary button") {}
-                .buttonStyle(SecondaryButtonStyle())
+            Group {
+                Button("Secondary button") {}
+                    .buttonStyle(SecondaryButtonStyle())
 
-            Button("Secondary button (disabled)") {}
-                .buttonStyle(SecondaryButtonStyle())
-                .disabled(true)
+                Button("Secondary button (disabled)") {}
+                    .buttonStyle(SecondaryButtonStyle())
+                    .disabled(true)
+            }
 
-            Button("Selectable secondary button (selected)") {}
-                .buttonStyle(SelectableSecondaryButtonStyle(isSelected: true))
+            Group {
+                Button("Selectable secondary button (selected)") {}
+                    .buttonStyle(SelectableSecondaryButtonStyle(isSelected: true))
 
-            Button("Selectable secondary button") {}
-                .buttonStyle(SelectableSecondaryButtonStyle(isSelected: false))
+                Button("Selectable secondary button") {}
+                    .buttonStyle(SelectableSecondaryButtonStyle(isSelected: false))
+            }
 
-            Button("Link button") {}
-                .buttonStyle(LinkButtonStyle())
+            Group {
+                Button("Link button") {}
+                    .buttonStyle(LinkButtonStyle())
 
-            Button("Link button (Disabled)") {}
-                .buttonStyle(LinkButtonStyle())
-                .disabled(true)
+                Button("Link button (Disabled)") {}
+                    .buttonStyle(LinkButtonStyle())
+                    .disabled(true)
+            }
 
-            Button("Plus button") {}
-                .buttonStyle(PlusButtonStyle())
+            Group {
+                Button("Text button") {}
+                    .buttonStyle(TextButtonStyle())
 
-            Button("Plus button (disabled)") {}
-                .buttonStyle(PlusButtonStyle())
-                .disabled(true)
+                Button("Text button (disabled)") {}
+                    .buttonStyle(TextButtonStyle())
+                    .disabled(true)
+            }
+
+            Group {
+                Button("Plus button") {}
+                    .buttonStyle(PlusButtonStyle())
+
+                Button("Plus button (disabled)") {}
+                    .buttonStyle(PlusButtonStyle())
+                    .disabled(true)
+            }
         }
         .preferredColorScheme(.dark)
         .padding()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7879 
Based on https://github.com/woocommerce/woocommerce-ios/pull/7927 for the entry point
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For existing WPCOM users, we also want to allow them to create a store from the account creation screen. Right now after login completion, we can't tell whether the user logs in from the store creation CTA or the login CTA on the prologue screen. Therefore, the user who logs also lands on the store picker and they have to tap on the store creation CTA to create a store. We'll have to make changes to the WPAuthenticator library to pass some source tag from the beginning to the end of the login flow (many view controllers), and I'm leaving it as a separate subtask in https://github.com/woocommerce/woocommerce-ios/issues/7891.

For the `Log in` button, I originally tried using `LinkButtonStyle` but that includes the default padding. I created a new button style `TextButtonStyle` for inline text buttons. In the preview, I grouped the buttons for each style to avoid unexpected errors from too many elements in the VStack.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app
- Skip the onboarding if needed
- Tap on `New to WooCommerce` CTA on the prologue screen --> a login label and button should be shown on the account creation screen
- Tap on `Log in` button --> the login screen should be shown
- Proceed to log in to the app
- Tap on `Create a new store` CTA, and continue to create a store --> after the store creation flow, it should log in to the new store

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Please note the addition of the `Already registered? Log in` UI

dark | light
-- | --
![Simulator Screen Shot - iPhone 14 Pro - 2022-10-27 at 09 42 07](https://user-images.githubusercontent.com/1945542/198190573-cf2babaa-f4f7-444c-a7bc-8a31d31d1226.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-10-27 at 12 14 18](https://user-images.githubusercontent.com/1945542/198190585-29f4e77d-8179-407c-afd9-328311c10993.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
