### PR TITLE
AttributedText: fix SwiftUI issue on publishing changes from within view updates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AttributedText.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AttributedText.swift
@@ -29,7 +29,8 @@ import SwiftUI
 /// `font` and `attributedTextForegroundColor` functions do not take effect.
 /// The link color can be set with `attributedTextLinkColor`.
 struct AttributedText: View {
-    @StateObject private var textViewStore = TextViewStore()
+    private var textViewStore = TextViewStore()
+    @State private var textSize: CGSize?
 
     let attributedText: NSAttributedString
 
@@ -46,10 +47,13 @@ struct AttributedText: View {
             )
         }
         .frame(
-            idealWidth: textViewStore.intrinsicContentSize?.width,
-            idealHeight: textViewStore.intrinsicContentSize?.height
+            idealWidth: textSize?.width,
+            idealHeight: textSize?.height
         )
         .fixedSize(horizontal: false, vertical: true)
+        .onReceive(textViewStore.$intrinsicContentSize) { size in
+            textSize = size
+        }
     }
 }
 
@@ -80,7 +84,7 @@ private extension GeometryProxy {
     }
 }
 
-private final class TextViewStore: ObservableObject {
+private final class TextViewStore {
     @Published var intrinsicContentSize: CGSize?
 
     func didUpdateTextView(_ textView: TextViewWrapper.View) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7930 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In Xcode 14, a SwiftUI issue surfaced about `AttributedText`:

```
Publishing changes from within view updates is not allowed, this will cause undefined behavior.
```

On this line:

https://github.com/woocommerce/woocommerce-ios/blob/1f4293597bc534b279505c1e6f0aac56ddbb6f3a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI%20Components/AttributedText.swift#L87

Our `AttributedText` SwiftUI view is based on a third-party library https://github.com/gonzalezreal/AttributedText with some modifications to meet the requirements for the features. There's a known issue about this SwiftUI error https://github.com/gonzalezreal/AttributedText/issues/23, and I followed the fix in a PR in the repo thanks to https://github.com/woocommerce/woocommerce-ios/issues/7930#issuecomment-1291160393. This seems to fix the SwiftUI warning while maintaining the same UI, please share any unexpected UI from this change.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app
- Skip onboarding if needed
- Tap on `New to WooCommerce` button --> account creation form should be shown
- Enter some text into the email and password field --> in Xcode, there should be no SwiftUI issues. before this PR, the issues show up consistently

Bonus point: you can also test other use cases of `AttributedText` like inbox notes, IPP learn more CTA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
