### PR TITLE
Simplified login: Launch account creation flow from unrecognized email error screen.

### DIFF
--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -114,12 +114,14 @@ private extension NotWPAccountViewModel {
 
     func createAnAccountButtonTapped(in viewController: UIViewController?) {
         analytics.track(.createAccountOnInvalidEmailScreenTapped)
-        guard let viewController else {
+        guard let viewController,
+              let navigationController = viewController.navigationController else {
+            DDLogWarn("⚠️ Unable to proceed with account creation as view controller/navigation controller is nil.")
             return
         }
 
         let accountCreationController = AccountCreationFormHostingController(viewModel: .init()) { [weak self] in
-            guard let self, let navigationController = viewController.navigationController else { return }
+            guard let self else { return }
             self.launchStorePicker(from: navigationController)
         }
         viewController.show(accountCreationController, sender: self)

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -11,7 +11,7 @@ final class NotWPAccountViewModel: ULErrorViewModel {
     // MARK: - Data and configuration
     let image: UIImage = .loginNoWordPressError
 
-    let text: NSAttributedString = .init(string: Localization.errorMessage)
+    let text: NSAttributedString = .init(string: Localization.errorMessage, attributes: [.font: UIFont.title3SemiBold])
 
     let isAuxiliaryButtonHidden = false
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -60,7 +60,7 @@ final class NotWPAccountViewModel: ULErrorViewModel {
     // MARK: - Actions
     func didTapPrimaryButton(in viewController: UIViewController?) {
         if isSimplifiedLoginI1Enabled {
-            createAnAccountButtonTapped()
+            createAnAccountButtonTapped(in: viewController)
         } else {
             loginWithSiteAddressButtonTapped()
         }
@@ -102,9 +102,17 @@ private extension NotWPAccountViewModel {
         popCommand.execute(from: viewController)
     }
 
-    func createAnAccountButtonTapped() {
-        // TODO: 7903 - Navigate to create store flow.
-        // analytics.track(.createAccountOnInvalidEmailScreenTapped)
+    func createAnAccountButtonTapped(in viewController: UIViewController?) {
+        analytics.track(.createAccountOnInvalidEmailScreenTapped)
+        guard let viewController else {
+            return
+        }
+
+        let accountCreationController = AccountCreationFormHostingController(viewModel: .init()) { [weak self] in
+            guard let self, let navigationController = viewController.navigationController else { return }
+            self.startStoreCreation(in: navigationController)
+        }
+        viewController.show(accountCreationController, sender: self)
     }
 
     func startStoreCreation(in navigationController: UINavigationController) {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -110,12 +110,12 @@ private extension NotWPAccountViewModel {
 
         let accountCreationController = AccountCreationFormHostingController(viewModel: .init()) { [weak self] in
             guard let self, let navigationController = viewController.navigationController else { return }
-            self.startStoreCreation(in: navigationController)
+            self.launchStorePicker(from: navigationController)
         }
         viewController.show(accountCreationController, sender: self)
     }
 
-    func startStoreCreation(in navigationController: UINavigationController) {
+    func launchStorePicker(from navigationController: UINavigationController) {
         storePickerCoordinator = StorePickerCoordinator(navigationController, config: .listStores)
         storePickerCoordinator?.start()
     }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -19,6 +19,8 @@ final class NotWPAccountViewModel: ULErrorViewModel {
 
     let primaryButtonTitle: String
 
+    let isPrimaryButtonHidden: Bool
+
     var secondaryButtonTitle: String {
         isSimplifiedLoginI1Enabled ? Localization.tryAnotherAddress : Localization.restartLogin
     }
@@ -51,9 +53,17 @@ final class NotWPAccountViewModel: ULErrorViewModel {
            source == .wpComSiteAddress {
             isSecondaryButtonHidden = true
             primaryButtonTitle = Localization.restartLogin
+            isPrimaryButtonHidden = false
         } else {
             isSecondaryButtonHidden = false
-            primaryButtonTitle = isSimplifiedLoginI1Enabled ? Localization.createAnAccount : Localization.loginWithSiteAddress
+
+            if isSimplifiedLoginI1Enabled {
+                primaryButtonTitle = Localization.createAnAccount
+                isPrimaryButtonHidden = !featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
+            } else {
+                primaryButtonTitle = Localization.loginWithSiteAddress
+                isPrimaryButtonHidden = false
+            }
         }
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -39,6 +39,7 @@ final class NotWPAccountViewModel: ULErrorViewModel {
 
     private let isSimplifiedLoginI1Enabled: Bool
     private let analytics: Analytics
+    private var storePickerCoordinator: StorePickerCoordinator?
 
     init(error: Error,
          analytics: Analytics = ServiceLocator.analytics,
@@ -104,6 +105,11 @@ private extension NotWPAccountViewModel {
     func createAnAccountButtonTapped() {
         // TODO: 7903 - Navigate to create store flow.
         // analytics.track(.createAccountOnInvalidEmailScreenTapped)
+    }
+
+    func startStoreCreation(in navigationController: UINavigationController) {
+        storePickerCoordinator = StorePickerCoordinator(navigationController, config: .listStores)
+        storePickerCoordinator?.start()
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -110,9 +110,7 @@ private extension ULErrorViewController {
     }
 
     func configureErrorMessage() {
-        errorMessage.adjustsFontForContentSizeCategory = true
-        errorMessage.font = .title3SemiBold
-        errorMessage.textColor = .text
+        errorMessage.applyBodyStyle()
         errorMessage.attributedText = viewModel.text
     }
 

--- a/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
@@ -129,6 +129,45 @@ final class NotWPAccountViewModelTests: XCTestCase {
         XCTAssertEqual(primaryButtonTitle, Expectations.createAnAccountTitle)
     }
 
+    // MARK: - `isPrimaryButtonHidden`
+
+    func test_primary_button_is_not_hidden_for_invalidWPComEmail_from_site_address_error() {
+        // Given
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpComSiteAddress))
+
+        // Then
+        XCTAssertFalse(viewModel.isPrimaryButtonHidden)
+    }
+
+    func test_primary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_feature_flag_is_off() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: false)
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
+                                              featureFlagService: featureFlagService)
+        // Then
+        XCTAssertFalse(viewModel.isPrimaryButtonHidden)
+    }
+
+    func test_primary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_is_on_and_store_creation_is_on() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true,
+                                                        isStoreCreationMVPEnabled: true)
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
+                                              featureFlagService: featureFlagService)
+        // Then
+        XCTAssertFalse(viewModel.isPrimaryButtonHidden)
+    }
+
+    func test_primary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_is_on_and_store_creation_is_off() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true,
+                                                        isStoreCreationMVPEnabled: false)
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
+                                              featureFlagService: featureFlagService)
+        // Then
+        XCTAssertTrue(viewModel.isPrimaryButtonHidden)
+    }
+
     // MARK: - `isSecondaryButtonHidden`
 
     func test_secondary_button_is_hidden_for_invalidWPComEmail_from_site_address_error() {

--- a/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
@@ -135,22 +135,16 @@ final class NotWPAccountViewModelTests: XCTestCase {
         // Given
         let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpComSiteAddress))
 
-        // When
-        let isPrimaryButtonHidden = viewModel.isSecondaryButtonHidden
-
         // Then
-        XCTAssertTrue(isPrimaryButtonHidden)
+        XCTAssertTrue(viewModel.isSecondaryButtonHidden)
     }
 
     func test_secondary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error() {
         // Given
         let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom))
 
-        // When
-        let isPrimaryButtonHidden = viewModel.isSecondaryButtonHidden
-
         // Then
-        XCTAssertFalse(isPrimaryButtonHidden)
+        XCTAssertFalse(viewModel.isSecondaryButtonHidden)
     }
 
     // MARK: - `secondaryButtonTitle`

--- a/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
@@ -158,7 +158,7 @@ final class NotWPAccountViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isPrimaryButtonHidden)
     }
 
-    func test_primary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_is_on_and_store_creation_is_off() {
+    func test_primary_button_is_hidden_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_is_on_and_store_creation_is_off() {
         // Given
         let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true,
                                                         isStoreCreationMVPEnabled: false)

--- a/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
@@ -211,11 +211,6 @@ final class NotWPAccountViewModelTests: XCTestCase {
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "what_is_wordpress_com_on_invalid_email_screen" }))
     }
 
-    /*
-     TODO: 7903 - Navigate to create store flow
-
-     Uncomment these tests after added create store navigation and analytics code.
-
     func test_tapping_primary_button_does_not_track_create_account_event_when_simplified_login_feature_flag_is_off() {
         // Given
         let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: false)
@@ -243,7 +238,6 @@ final class NotWPAccountViewModelTests: XCTestCase {
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "create_account_on_invalid_email_screen" }))
     }
-    */
 }
 
 

--- a/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
@@ -36,7 +36,7 @@ final class NotWPAccountViewModelTests: XCTestCase {
     func test_viewmodel_provides_expected_error_message() {
         // Given
         let viewModel = NotWPAccountViewModel()
-        let expectation = NSAttributedString(string: Expectations.errorMessage)
+        let expectation = NSAttributedString(string: Expectations.errorMessage, attributes: [.font: UIFont.title3SemiBold])
 
         // When
         let errorMessage = viewModel.text

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -8,19 +8,22 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let shippingLabelsOnboardingM1: Bool
     private let isLoginPrologueOnboardingEnabled: Bool
     private let isSimplifiedLoginFlowI1Enabled: Bool
+    private let isStoreCreationMVPEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
          isUpdateOrderOptimisticallyOn: Bool = false,
          shippingLabelsOnboardingM1: Bool = false,
          isLoginPrologueOnboardingEnabled: Bool = false,
-         isSimplifiedLoginFlowI1Enabled: Bool = false) {
+         isSimplifiedLoginFlowI1Enabled: Bool = false,
+         isStoreCreationMVPEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
         self.isLoginPrologueOnboardingEnabled = isLoginPrologueOnboardingEnabled
         self.isSimplifiedLoginFlowI1Enabled = isSimplifiedLoginFlowI1Enabled
+        self.isStoreCreationMVPEnabled = isStoreCreationMVPEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -37,6 +40,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isLoginPrologueOnboardingEnabled
         case .simplifiedLoginFlowI1:
             return isSimplifiedLoginFlowI1Enabled
+        case .storeCreationMVP:
+            return isStoreCreationMVPEnabled
         default:
             return false
         }


### PR DESCRIPTION
Closes #7903

### Description
As part of the simplified login flow iteration 1, this PR launches the account creation flow upon tapping "Create An 
Account" from the following unrecognized email error screen.

<img width="300" alt="Screenshot 2022-10-27 at 1 26 37 PM" src="https://user-images.githubusercontent.com/524475/198224676-ae6c22a0-fde4-40a8-99fb-988a62784acb.png">


**Changes**
- Navigate to "Account creation" flow upon tapping "Create An Account" button (When simplified login is ON)
- Add analytics for the "Create An Account" button.
- Hide the "Create An Account" button when the store creation feature flag is OFF.

### Testing instructions

**Feature flag `simplifiedLoginFlowI1` ON and `storeCreationMVP` ON**

- Launch the app and skip the prologue
- Tap `Continue With WordPress.com` button
- Enter an email which doesn't have a WPCOM account and tap `Continue`
- You will land on the unrecognized email screen. 
- Tap"Create An Account" button
  - Check logs and ensure that the following event is tracked
  ```
  Tracked create_account_on_invalid_email_screen, properties: [:]
  ```
- You will land in the create account screen from which you can create a WPCOM account.
- After creating an account you should be navigated to an empty store picker screen. 

**Feature flag `simplifiedLoginFlowI1` ON and `storeCreationMVP` OFF**

- Launch the app and skip the prologue
- Tap `Continue With WordPress.com` button
- Enter an email which doesn't have a WPCOM account and tap `Continue`
- You will land on the unrecognized email screen. 
- Ensure that "Create An Account" button is hidden. 

**Feature flag `simplifiedLoginFlowI1` OFF**

- With the feature flag `simplifiedLoginFlowI1` off, there should be no changes to the current flow.

### Screenshots

https://user-images.githubusercontent.com/524475/198228423-29351143-d510-4349-bd78-7c14685a453d.mp4


**Unregognized email screen when simplified login feature flag is turned ON**
| Store creation ON | Store creation OFF |
| --- | --- |
| ![Simulator Screen Shot - iPhone 12 Pro - 2022-10-27 at 18 24 20](https://user-images.githubusercontent.com/524475/198290254-f5b79f5b-63ed-46ef-ad9d-ff6cfe0bca4e.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2022-10-27 at 18 25 39](https://user-images.githubusercontent.com/524475/198290284-8b3a57e4-8293-42e4-9933-552d21bef0fe.png) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.