### PR TITLE
Update logged-out A/A test name, and remove completed A/B experiment

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -14,11 +14,7 @@ public enum ABTest: String, CaseIterable {
 
     /// A/A test to make sure there is no bias in the logged out state.
     /// Experiment ref: pbxNRc-1S0-p2
-    case aaTestLoggedOut202209 = "woocommerceios_explat_aa_test_logged_out_202209"
-
-    /// A/B test for the login button order on the prologues screen.
-    /// Experiment ref: pbxNRc-1VA-p2
-    case loginPrologueButtonOrder = "woocommerceios_login_prologue_button_order_202209"
+    case aaTestLoggedOut = "woocommerceios_explat_aa_test_logged_out_202211"
 
     /// Returns a variation for the given experiment
     public var variation: Variation {
@@ -32,7 +28,7 @@ public enum ABTest: String, CaseIterable {
         switch self {
         case .aaTestLoggedIn202210:
             return .loggedIn
-        case .aaTestLoggedOut202209, .loginPrologueButtonOrder:
+        case .aaTestLoggedOut:
             return .loggedOut
         case .null:
             return .none

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -405,8 +405,7 @@ private extension AppDelegate {
         if versionOfLastRun == nil {
             // First run after a fresh install
             ServiceLocator.analytics.track(.applicationInstalled,
-                                           withProperties: ["after_abtest_setup": true,
-                                                            "prologue_experiment_variant": ABTest.loginPrologueButtonOrder.variation.analyticsValue])
+                                           withProperties: ["after_abtest_setup": true])
         } else if versionOfLastRun != currentVersion {
             // App was upgraded
             ServiceLocator.analytics.track(.applicationUpgraded, withProperties: ["previous_version": versionOfLastRun ?? String()])

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -52,7 +52,6 @@ class AuthenticationManager: Authentication {
     func initialize(loggedOutAppSettings: LoggedOutAppSettingsProtocol) {
         let isWPComMagicLinkPreferredToPassword = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasis)
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasisM2)
-        let continueWithSiteAddressFirst = ABTest.loginPrologueButtonOrder.variation == .control
         let isFeatureCarouselShown = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding) == false
         || loggedOutAppSettings.hasFinishedOnboarding == true
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
@@ -70,7 +69,7 @@ class AuthenticationManager: Authentication {
                                                                 enableSignInWithApple: true,
                                                                 enableSignupWithGoogle: false,
                                                                 enableUnifiedAuth: true,
-                                                                continueWithSiteAddressFirst: continueWithSiteAddressFirst,
+                                                                continueWithSiteAddressFirst: false,
                                                                 enableSiteCredentialsLoginForSelfHostedSites: true,
                                                                 isWPComLoginRequiredForSiteCredentialsLogin: true,
                                                                 isWPComMagicLinkPreferredToPassword: isWPComMagicLinkPreferredToPassword,

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -150,7 +150,7 @@ private extension AppCoordinator {
             guard let self = self else { return }
             self.tabBarController.removeViewControllers()
         }
-        ServiceLocator.analytics.track(.openedLogin, withProperties: ["prologue_experiment_variant": ABTest.loginPrologueButtonOrder.variation.analyticsValue])
+        ServiceLocator.analytics.track(.openedLogin)
     }
 
     /// Configures the WPAuthenticator for usage in both logged-in and logged-out states.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Related to #7435 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The previous A/A test showed a bias toward the control variant, and we're hoping this is just an exception since we couldn't spot anything obvious in the setup. I created another A/A test 20877-explat-experiment for November based on the decision pbxNRc-1QS-p2#comment-3890, and also remove the previous A/B experiment on swapping buttons on the prologue screen by going with the treatment variant like in Android pe5sF9-vK-p2#comment-1036. The iOS result wasn't as clear as Android, the treatment variant was ahead for some time but then flattened out.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

The A/A test doesn't have any visual changes, please just test the update on the prologue button order. Please note that after https://github.com/woocommerce/woocommerce-ios/pull/7929 which removes the site address login button, you can disable the `simplifiedLoginFlowI1` feature flag to test this PR.

- Launch the app
- Log out if needed
- Skip onboarding if needed --> the prologue should show the `Continue With WordPress.com` CTA above the `Enter Your Store Address` CTA

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://user-images.githubusercontent.com/1945542/198228707-b8cd1898-fbe7-454d-9e7e-3744284a6c2d.png" width="300" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->