### PR TITLE
[In-app Purchases] Cancel receipt refresh when complete

### DIFF
--- a/Yosemite/Yosemite/Tools/InAppPurchases/InAppPurchaseReceiptRefreshRequest.swift
+++ b/Yosemite/Yosemite/Tools/InAppPurchases/InAppPurchaseReceiptRefreshRequest.swift
@@ -24,8 +24,11 @@ class InAppPurchaseReceiptRefreshRequest: NSObject, SKRequestDelegate {
     }
 
     func complete(_ result: Result<Void, Error>) {
-        DispatchQueue.main.async { [completion] in
+        DispatchQueue.main.async { [completion, refreshReceiptRequest] in
             completion(result)
+            // It's not clear why this is necessary, but iOS keeps complaining about an internal
+            // lingering Background Task if we don't explicitly cancel the request.
+            refreshReceiptRequest.cancel()
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #7931 
Continuation of #7937 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When reviewing #7937, it was pointed out that there was this warning in the console:

> [BackgroundTask] Background Task 22 ("SKReceiptRefreshRequest"), was created over 30 seconds ago. In applications running in the background, this creates a risk of termination. Remember to call UIApplication.endBackgroundTask(_:) for your task in a timely manner to avoid this.

I thought it might be a retain cycle, but the memory graph inspector didn't show that. The only thing holding a reference to the `SKReceiptRefreshRequest` was the background task itself. It seems like an internal StoreKit bug, but searching for answers it seems most people who encounter this got around it by calling `cancel` in the completion block. This seems to be working for us too 😌 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You need to test with a fresh install of the app to ensure there is no receipt. Just in case, I also ensured there was no current subscription and cleared all purchases from App Store Connect.

1. Install the app
2. Enable IAP in Settings > Experimental Features
3. Go to Hub menu > IAP Debug
4. Wait for the list of products to load
5. Purchase one of the products. Make sure there is a `No app receipt found, refreshing` in the console.
6. Once the flow is complete, wait for a bit and make sure the background task warning doesn't appear in the console

Also, you can bring up the memory graph debugger and see that there's no `SKReceiptRefreshRequest` in memory after the refresh has been completed.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
