### PR TITLE
Store creation MVP: analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -1,0 +1,84 @@
+extension WooAnalyticsEvent {
+    enum StoreCreation {
+        /// Event property keys.
+        private enum Key {
+            static let source = "source"
+            static let url = "url"
+        }
+
+        /// Tracked when the user taps on the CTA in store picker (logged in to WPCOM) to create a store.
+        static func sitePickerCreateSiteTapped(source: StorePickerSource) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .sitePickerCreateSiteTapped,
+                              properties: [Key.source: source.rawValue])
+        }
+
+        /// Tracked when a site is created from the store creation flow.
+        static func siteCreated(source: Source, siteURL: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .siteCreated,
+                              properties: [Key.source: source.rawValue, Key.url: siteURL])
+        }
+
+        /// Tracked when site creation fails.
+        static func siteCreationFailed(source: Source, error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .siteCreationFailed,
+                              properties: [Key.source: source.rawValue],
+                              error: error)
+        }
+
+        /// Tracked when the user dismisses the store creation flow before the flow is complete.
+        static func siteCreationDismissed(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .siteCreationDismissed,
+                              properties: [Key.source: source.rawValue])
+        }
+
+        /// Tracked when the user taps on the CTA in login prologue (logged out) to create a store.
+        static func loginPrologueCreateSiteTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginPrologueCreateSiteTapped,
+                              properties: [:])
+        }
+
+        /// Tracked when the user taps on the CTA in the account creation form to log in instead.
+        static func signupFormLoginTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .signupFormLoginTapped,
+                              properties: [:])
+        }
+
+        /// Tracked when the user taps to submit the WPCOM signup form.
+        static func signupSubmitted() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .signupSubmitted,
+                              properties: [:])
+        }
+
+        /// Tracked when WPCOM signup succeeds.
+        static func signupSuccess() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .signupSuccess,
+                              properties: [:])
+        }
+
+        /// Tracked when WPCOM signup fails.
+        static func signupFailed(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .signupFailed,
+                              properties: [:],
+                              error: error)
+        }
+    }
+}
+
+extension WooAnalyticsEvent.StoreCreation {
+    enum StorePickerSource: String {
+        /// From switching stores.
+        case switchStores = "switching_stores"
+        /// From the login flow.
+        case login
+        /// The store creation flow is originally initiated from login prologue and dismissed,
+        /// which lands on the store picker.
+        case loginPrologue = "prologue"
+        /// Other sources like from any error screens during the login flow.
+        case other
+    }
+
+    enum Source: String {
+        case loginPrologue = "prologue"
+        case storePicker = "store_picker"
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -82,6 +82,7 @@ extension WooAnalyticsEvent.StoreCreation {
     enum Source: String {
         case loginPrologue = "prologue"
         case storePicker = "store_picker"
+        case loginEmailError = "login_email_error"
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -86,7 +86,7 @@ extension WooAnalyticsEvent.StoreCreation {
     }
 }
 
-extension CreateAccountError {
+private extension CreateAccountError {
     var analyticsValue: String {
         switch self {
         case .emailExists:

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -1,9 +1,12 @@
+import enum Yosemite.CreateAccountError
+
 extension WooAnalyticsEvent {
     enum StoreCreation {
         /// Event property keys.
         private enum Key {
             static let source = "source"
             static let url = "url"
+            static let errorType = "error_type"
         }
 
         /// Tracked when the user taps on the CTA in store picker (logged in to WPCOM) to create a store.
@@ -56,10 +59,9 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when WPCOM signup fails.
-        static func signupFailed(error: Error) -> WooAnalyticsEvent {
+        static func signupFailed(error: CreateAccountError) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .signupFailed,
-                              properties: [:],
-                              error: error)
+                              properties: [Key.errorType: error.analyticsValue])
         }
     }
 }
@@ -80,5 +82,20 @@ extension WooAnalyticsEvent.StoreCreation {
     enum Source: String {
         case loginPrologue = "prologue"
         case storePicker = "store_picker"
+    }
+}
+
+extension CreateAccountError {
+    var analyticsValue: String {
+        switch self {
+        case .emailExists:
+            return "EMAIL_EXIST"
+        case .invalidEmail:
+            return "EMAIL_INVALID"
+        case .invalidPassword:
+            return "PASSWORD_INVALID"
+        default:
+            return "\(self)"
+        }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -125,6 +125,18 @@ public enum WooAnalyticsStat: String {
     case sitePickerSiteDiscovery = "site_picker_site_discovery"
     case sitePickerNewToWooTapped = "site_picker_new_to_woo_tapped"
 
+    // MARK: Site creation
+    //
+    case sitePickerCreateSiteTapped = "site_picker_create_site_tapped"
+    case siteCreated = "login_woocommerce_site_created"
+    case siteCreationFailed = "site_creation_failed"
+    case siteCreationDismissed = "site_creation_dismissed"
+    case loginPrologueCreateSiteTapped = "login_prologue_create_site_tapped"
+    case signupFormLoginTapped = "signup_login_button_tapped"
+    case signupSubmitted = "signup_submitted"
+    case signupSuccess = "signup_success"
+    case signupFailed = "signup_failed"
+
     // MARK: Help & Support Events
     //
     case supportHelpCenterViewed = "support_help_center_viewed"

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -543,8 +543,13 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
     // Navigate to store creation
     func showSiteCreation(in navigationController: UINavigationController) {
-        // TODO: add tracks
-        // Navigate to store creation
+        let accountCreationController = AccountCreationFormHostingController(
+            viewModel: .init(),
+            signInSource: .custom(source: StoreCreationCoordinator.Source.prologue.rawValue)
+        ) { [weak self] in
+            self?.startStoreCreation(in: navigationController)
+        }
+        navigationController.show(accountCreationController, sender: nil)
     }
 }
 
@@ -641,6 +646,13 @@ private extension AuthenticationManager {
         } else {
             storePickerCoordinator?.start()
         }
+    }
+
+    func startStoreCreation(in navigationController: UINavigationController) {
+        // Shows the store picker first, so that after dismissal of the store creation view it goes back to the store picker.
+        let coordinator = StorePickerCoordinator(navigationController, config: .storeCreationFromLoginPrologue)
+        storePickerCoordinator = coordinator
+        coordinator.start()
     }
 
     /// The error screen to be displayed when the user enters a site

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -543,6 +543,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
     // Navigate to store creation
     func showSiteCreation(in navigationController: UINavigationController) {
+        ServiceLocator.analytics.track(event: .StoreCreation.loginPrologueCreateSiteTapped())
         let accountCreationController = AccountCreationFormHostingController(
             viewModel: .init(),
             signInSource: .custom(source: StoreCreationCoordinator.Source.prologue.rawValue)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -86,8 +86,6 @@ extension StorePickerCoordinator: StorePickerViewControllerDelegate {
     }
 
     func createStore() {
-        // TODO-7879: analytics
-
         let source: StoreCreationCoordinator.Source
         switch selectedConfiguration {
         case .storeCreationFromLoginPrologue:

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -88,8 +88,8 @@ extension StorePickerCoordinator: StorePickerViewControllerDelegate {
     func createStore() {
         let source: StoreCreationCoordinator.Source
         switch selectedConfiguration {
-        case .storeCreationFromLoginPrologue:
-            source = .prologue
+        case .storeCreationFromLogin(let loggedOutSource):
+            source = .loggedOut(source: loggedOutSource)
         default:
             source = .storePicker
         }
@@ -122,7 +122,7 @@ private extension StorePickerCoordinator {
     func showStorePicker() {
         showStorePicker(presentationStyle: selectedConfiguration.presentationStyle)
         switch selectedConfiguration {
-        case .storeCreationFromLoginPrologue:
+        case .storeCreationFromLogin:
             createStore()
         default:
             break
@@ -184,7 +184,7 @@ private extension StorePickerConfiguration {
             return .fullscreen
         case .switchingStores:
             return .modally
-        case .storeCreationFromLoginPrologue:
+        case .storeCreationFromLogin:
             return .navigationStack(animated: false)
         default:
             return .navigationStack(animated: true)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -35,7 +35,7 @@ protocol StorePickerViewControllerDelegate: AnyObject {
 
 /// Configuration option enum for the StorePickerViewController
 ///
-enum StorePickerConfiguration {
+enum StorePickerConfiguration: Equatable {
 
     /// Setup the store picker for use in the login flow
     ///
@@ -43,7 +43,7 @@ enum StorePickerConfiguration {
 
     /// Setup the store picker for store creation initiated from login prologue
     ///
-    case storeCreationFromLoginPrologue
+    case storeCreationFromLogin(source: LoggedOutStoreCreationCoordinator.Source)
 
     /// Setup the store picker for use in the store switching flow
     ///
@@ -617,8 +617,13 @@ private extension StorePickerViewController {
                 return .switchStores
             case .login, .standard:
                 return .login
-            case .storeCreationFromLoginPrologue:
-                return .loginPrologue
+            case .storeCreationFromLogin(let loggedOutSource):
+                switch loggedOutSource {
+                case .prologue:
+                    return .loginPrologue
+                case .loginEmailError:
+                    return .other
+                }
             default:
                 return .other
             }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -41,7 +41,7 @@ enum StorePickerConfiguration: Equatable {
     ///
     case login
 
-    /// Setup the store picker for store creation initiated from login prologue
+    /// Setup the store picker for store creation initiated from the logged out state
     ///
     case storeCreationFromLogin(source: LoggedOutStoreCreationCoordinator.Source)
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -611,6 +611,20 @@ private extension StorePickerViewController {
     }
 
     func createStoreButtonPressed() {
+        let source: WooAnalyticsEvent.StoreCreation.StorePickerSource = {
+            switch configuration {
+            case .switchingStores:
+                return .switchStores
+            case .login, .standard:
+                return .login
+            case .storeCreationFromLoginPrologue:
+                return .loginPrologue
+            default:
+                return .other
+            }
+        }()
+        ServiceLocator.analytics.track(event: .StoreCreation.sitePickerCreateSiteTapped(source: source))
+
         delegate?.createStore()
     }
 }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -28,6 +28,9 @@ final class NotWPAccountViewModel: ULErrorViewModel {
 
     private weak var viewController: UIViewController?
 
+    /// Store creation coordinator in the logged-out state.
+    private var loggedOutStoreCreationCoordinator: LoggedOutStoreCreationCoordinator?
+
     private(set) lazy var auxiliaryView: UIView? = {
         let button = UIButton(type: .custom)
         button.applyLinkButtonStyle(enableMultipleLines: true)
@@ -120,19 +123,10 @@ private extension NotWPAccountViewModel {
             return
         }
 
-        let accountCreationController = AccountCreationFormHostingController(
-            viewModel: .init(),
-            signInSource: .custom(source: StoreCreationCoordinator.Source.prologue.rawValue)
-        ) { [weak self] in
-            guard let self else { return }
-            self.launchStorePicker(from: navigationController)
-        }
-        viewController.show(accountCreationController, sender: self)
-    }
-
-    func launchStorePicker(from navigationController: UINavigationController) {
-        storePickerCoordinator = StorePickerCoordinator(navigationController, config: .listStores)
-        storePickerCoordinator?.start()
+        let coordinator = LoggedOutStoreCreationCoordinator(source: .loginEmailError,
+                                                            navigationController: navigationController)
+        self.loggedOutStoreCreationCoordinator = coordinator
+        coordinator.start()
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -28,8 +28,6 @@ final class LoginPrologueViewController: UIViewController {
     /// Button for users who are new to WooCommerce to learn more about WooCommerce.
     @IBOutlet private weak var newToWooCommerceButton: UIButton!
 
-    private var storePickerCoordinator: StorePickerCoordinator?
-
     // MARK: - Overridden Properties
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -135,19 +133,6 @@ private extension LoginPrologueViewController {
         newToWooCommerceButton.on(.touchUpInside) { [weak self] _ in
             guard let self = self else { return }
 
-            // TODO-7891: update prologue entry point.
-            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.storeCreationMVP) {
-                let accountCreationController = AccountCreationFormHostingController(
-                    viewModel: .init(),
-                    signInSource: .custom(source: StoreCreationCoordinator.Source.prologue.rawValue)
-                ) { [weak self] in
-                    guard let self, let navigationController = self.navigationController else { return }
-                    self.startStoreCreation(in: navigationController)
-                }
-                self.show(accountCreationController, sender: self)
-                return
-            }
-
             self.analytics.track(.loginNewToWooButtonTapped)
 
             guard let url = URL(string: Constants.newToWooCommerceURL) else {
@@ -156,13 +141,6 @@ private extension LoginPrologueViewController {
 
             WebviewHelper.launch(url, with: self)
         }
-    }
-
-    func startStoreCreation(in navigationController: UINavigationController) {
-        // Shows the store picker first, so that after dismissal of the store creation view it goes back to the store picker.
-        let coordinator = StorePickerCoordinator(navigationController, config: .storeCreationFromLoginPrologue)
-        self.storePickerCoordinator = coordinator
-        coordinator.start()
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/LoggedOutStoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/LoggedOutStoreCreationCoordinator.swift
@@ -1,0 +1,49 @@
+import UIKit
+
+/// Coordinates navigation for store creation flow in logged-out state that starts with WPCOM authentication.
+final class LoggedOutStoreCreationCoordinator: Coordinator {
+    /// Navigation source to store creation.
+    enum Source: String, Equatable {
+        /// Initiated from the login prologue in logged-out state.
+        case prologue
+        /// Initiated from the login email error screen in logged-out state.
+        case loginEmailError
+    }
+
+    /// Mutable to conform to `Coordinator` protocol.
+    var navigationController: UINavigationController
+
+    private var storePickerCoordinator: StorePickerCoordinator?
+
+    private let analytics: Analytics
+    private let source: Source
+
+    init(source: Source,
+         navigationController: UINavigationController,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.source = source
+        self.navigationController = navigationController
+        self.analytics = analytics
+    }
+
+    func start() {
+        let accountCreationController = AccountCreationFormHostingController(
+            viewModel: .init(),
+            signInSource: .custom(source: source.rawValue),
+            analytics: analytics
+        ) { [weak self] in
+            guard let self else { return }
+            self.startStoreCreation(in: self.navigationController)
+        }
+        navigationController.show(accountCreationController, sender: self)
+    }
+}
+
+private extension LoggedOutStoreCreationCoordinator {
+    func startStoreCreation(in navigationController: UINavigationController) {
+        // Shows the store picker first, so that after dismissal of the store creation view it goes back to the store picker.
+        let coordinator = StorePickerCoordinator(navigationController, config: .storeCreationFromLogin(source: source))
+        storePickerCoordinator = coordinator
+        coordinator.start()
+    }
+}

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -6,9 +6,9 @@ import protocol Storage.StorageManagerType
 /// Coordinates navigation for store creation flow, with the assumption that the app is already authenticated with a WPCOM user.
 final class StoreCreationCoordinator: Coordinator {
     /// Navigation source to store creation.
-    enum Source: String {
+    enum Source {
         /// Initiated from the login prologue in logged-out state.
-        case prologue
+        case loggedOut(source: LoggedOutStoreCreationCoordinator.Source)
         /// Initiated from the store picker in logged-in state.
         case storePicker
     }
@@ -152,8 +152,13 @@ private extension StoreCreationCoordinator.Source {
         switch self {
         case .storePicker:
             return .storePicker
-        case .prologue:
-            return .loginPrologue
+        case .loggedOut(let source):
+            switch source {
+            case .prologue:
+                return .loginPrologue
+            case .loginEmailError:
+                return .loginEmailError
+            }
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -40,8 +40,6 @@ final class StoreCreationCoordinator: Coordinator {
     }
 
     func start() {
-        // TODO-7879: analytics
-
         observeSiteURLsFromStoreCreation()
 
         let viewModel = StoreCreationWebViewModel { [weak self] result in

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -7,7 +7,7 @@ import protocol Storage.StorageManagerType
 final class StoreCreationCoordinator: Coordinator {
     /// Navigation source to store creation.
     enum Source {
-        /// Initiated from the login prologue in logged-out state.
+        /// Initiated from the logged-out state.
         case loggedOut(source: LoggedOutStoreCreationCoordinator.Source)
         /// Initiated from the store picker in logged-in state.
         case storePicker

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -4,9 +4,13 @@ import struct WordPressAuthenticator.NavigateToEnterAccount
 
 /// Hosting controller that wraps an `AccountCreationForm`.
 final class AccountCreationFormHostingController: UIHostingController<AccountCreationForm> {
+    private let analytics: Analytics
+
     init(viewModel: AccountCreationFormViewModel,
          signInSource: SignInSource,
+         analytics: Analytics = ServiceLocator.analytics,
          completion: @escaping () -> Void) {
+        self.analytics = analytics
         super.init(rootView: AccountCreationForm(viewModel: viewModel))
 
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController.
@@ -16,6 +20,9 @@ final class AccountCreationFormHostingController: UIHostingController<AccountCre
 
         rootView.loginButtonTapped = { [weak self] in
             guard let self else { return }
+
+            self.analytics.track(event: .StoreCreation.signupFormLoginTapped())
+
             let command = NavigateToEnterAccount(signInSource: signInSource)
             command.execute(from: self)
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -413,6 +413,7 @@
 		02EA6BF82435E80600FFF90A /* ImageDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EA6BF72435E80600FFF90A /* ImageDownloader.swift */; };
 		02EA6BFA2435E92600FFF90A /* KingfisherImageDownloader+ImageDownloadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EA6BF92435E92600FFF90A /* KingfisherImageDownloader+ImageDownloadable.swift */; };
 		02EA6BFC2435EC3500FFF90A /* MockImageDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EA6BFB2435EC3500FFF90A /* MockImageDownloader.swift */; };
+		02EAA4C8290F992B00918DAB /* LoggedOutStoreCreationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAA4C7290F992B00918DAB /* LoggedOutStoreCreationCoordinator.swift */; };
 		02ECD1DF24FF48D000735BE5 /* PaginationTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ECD1DE24FF48D000735BE5 /* PaginationTracker.swift */; };
 		02ECD1E124FF496200735BE5 /* PaginationTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ECD1E024FF496200735BE5 /* PaginationTrackerTests.swift */; };
 		02ECD1E424FF5E0B00735BE5 /* AddProductCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ECD1E324FF5E0B00735BE5 /* AddProductCoordinator.swift */; };
@@ -2342,6 +2343,7 @@
 		02EA6BF72435E80600FFF90A /* ImageDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloader.swift; sourceTree = "<group>"; };
 		02EA6BF92435E92600FFF90A /* KingfisherImageDownloader+ImageDownloadable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KingfisherImageDownloader+ImageDownloadable.swift"; sourceTree = "<group>"; };
 		02EA6BFB2435EC3500FFF90A /* MockImageDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageDownloader.swift; sourceTree = "<group>"; };
+		02EAA4C7290F992B00918DAB /* LoggedOutStoreCreationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedOutStoreCreationCoordinator.swift; sourceTree = "<group>"; };
 		02ECD1DE24FF48D000735BE5 /* PaginationTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationTracker.swift; sourceTree = "<group>"; };
 		02ECD1E024FF496200735BE5 /* PaginationTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationTrackerTests.swift; sourceTree = "<group>"; };
 		02ECD1E324FF5E0B00735BE5 /* AddProductCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductCoordinator.swift; sourceTree = "<group>"; };
@@ -4447,6 +4449,7 @@
 			children = (
 				02759B9028FFA09600918176 /* StoreCreationWebViewModel.swift */,
 				02E3B63029066858007E0F13 /* StoreCreationCoordinator.swift */,
+				02EAA4C7290F992B00918DAB /* LoggedOutStoreCreationCoordinator.swift */,
 			);
 			path = "Store Creation";
 			sourceTree = "<group>";
@@ -10522,6 +10525,7 @@
 				D8B4D5EE26C2C26C00F34E94 /* InPersonPaymentsStripeAcountReviewView.swift in Sources */,
 				CC593A6B26EA640800EF0E04 /* PackageCreationError+UI.swift in Sources */,
 				CE1F512920697F0100C6C810 /* UIFont+Helpers.swift in Sources */,
+				02EAA4C8290F992B00918DAB /* LoggedOutStoreCreationCoordinator.swift in Sources */,
 				2687165A24D350C20042F6AE /* SurveyCoordinatingController.swift in Sources */,
 				02C88775245036D400E4470F /* FilterProductListViewModel.swift in Sources */,
 				4590B6A8261F0F8300A6FCE0 /* SegmentedView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		0262DA5823A23AC80029AF30 /* ProductShippingSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0262DA5623A23AC80029AF30 /* ProductShippingSettingsViewController.swift */; };
 		0262DA5923A23AC80029AF30 /* ProductShippingSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0262DA5723A23AC80029AF30 /* ProductShippingSettingsViewController.xib */; };
 		0262DA5B23A244830029AF30 /* Product+ShippingSettingsViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0262DA5A23A244830029AF30 /* Product+ShippingSettingsViewModels.swift */; };
+		0263E3BB290BB21800E5F88F /* WooAnalyticsEvent+StoreCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0263E3BA290BB21800E5F88F /* WooAnalyticsEvent+StoreCreation.swift */; };
 		02645D7D27BA027B0065DC68 /* Inbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D7927BA027B0065DC68 /* Inbox.swift */; };
 		02645D7E27BA027B0065DC68 /* InboxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D7A27BA027B0065DC68 /* InboxViewModel.swift */; };
 		02645D8227BA20A30065DC68 /* InboxViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645D8127BA20A30065DC68 /* InboxViewModelTests.swift */; };
@@ -2143,6 +2144,7 @@
 		0262DA5623A23AC80029AF30 /* ProductShippingSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingSettingsViewController.swift; sourceTree = "<group>"; };
 		0262DA5723A23AC80029AF30 /* ProductShippingSettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductShippingSettingsViewController.xib; sourceTree = "<group>"; };
 		0262DA5A23A244830029AF30 /* Product+ShippingSettingsViewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ShippingSettingsViewModels.swift"; sourceTree = "<group>"; };
+		0263E3BA290BB21800E5F88F /* WooAnalyticsEvent+StoreCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+StoreCreation.swift"; sourceTree = "<group>"; };
 		02645D7927BA027B0065DC68 /* Inbox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Inbox.swift; sourceTree = "<group>"; };
 		02645D7A27BA027B0065DC68 /* InboxViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InboxViewModel.swift; sourceTree = "<group>"; };
 		02645D8127BA20A30065DC68 /* InboxViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxViewModelTests.swift; sourceTree = "<group>"; };
@@ -6297,6 +6299,7 @@
 				0247F511286F73EA009C177E /* WooAnalyticsEvent+ImageUpload.swift */,
 				02AC30CE2888EC8100146A25 /* WooAnalyticsEvent+LoginOnboarding.swift */,
 				53284FB62FF7F94F18F0D3FF /* WaitingTimeTracker.swift */,
+				0263E3BA290BB21800E5F88F /* WooAnalyticsEvent+StoreCreation.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -10127,6 +10130,7 @@
 				B5D1AFB820BC510200DB0E8C /* UIImage+Woo.swift in Sources */,
 				B5980A6121AC878900EBF596 /* UIDevice+Woo.swift in Sources */,
 				EEADF624281A421A001B40F1 /* DefaultShippingValueLocalizer.swift in Sources */,
+				0263E3BB290BB21800E5F88F /* WooAnalyticsEvent+StoreCreation.swift in Sources */,
 				174CA86E27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift in Sources */,
 				262C921F26EEF8B100011F92 /* Binding.swift in Sources */,
 				DE4FB7732812AE96003D20D6 /* FilterListView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7879 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For store/account creation analytics, there are 9 new events in total. A few variables were added in `WooAnalyticsEvent` extension for the new events, so that the app doesn't track in place with raw strings. This PR also updated the login prologue screen entry point from the temporary `New to WooCommerce` link to one of the bottom buttons. In order to consolidate the navigation from account creation to store creation, I created another coordinator `LoggedOutStoreCreationCoordinator` to wrap these two flows with 3 entry points:

entry point | StoreCreationCoordinator.Source | Tracks source event property value
-- | -- | --
Login prologue | `loggedOut(source: .prologue)` | prologue
Login email error | `loggedOut(source: .loginEmailError)` | login_email_error
Store picker | `storePicker` | store_picker

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Login prologue entry point

- Launch the app
- Log out and skip onboarding if needed
- Tap `Create a Store` —> in the console, you should see `🔵 Tracked login_prologue_create_site_tapped, properties: [:]`
- On the account creation form, enter an email and password that results in any type of error (e.g. existing email, password too simple), and submit the form —> in the console, you should fist see `🔵 Tracked signup_submitted, properties: [:]` followed by a failure event like ` 🔵 Tracked signup_failed, properties: [AnyHashable("error_type"): "EMAIL_EXIST"]`
- Update the email/password to a valid one, and submit the form —> in the console, you should fist see `🔵 Tracked signup_submitted, properties: [:]` followed by a success event like ` 🔵 Tracked signup_success, properties: [:]`
- When the store creation view is shown, tap the X button to dismiss the view —> in the console, you should fist see `🔵 Tracked site_creation_dismissed, properties: [AnyHashable("source"): "prologue”]`

#### Store picker entry point

- On the store picker, tap `Create a new store` to create a store —> `🔵 Tracked site_picker_create_site_tapped, properties: [AnyHashable("source"): "prologue”]` should be tracked
- When the store creation view is shown, tap the X button to dismiss the view —> in the console, you should fist see `🔵 Tracked site_creation_dismissed, properties: [AnyHashable("source"): “prologue”]`

#### Login email error entry point - login

- Go back to the prologue screen
- Tap `Log in`
- Enter an invalid email —> a no WP account error screen should be shown
- Tap `Create An Account` —> account creation form should be shown
- Tap `Log in` to log in —> `🔵 Tracked signup_login_button_tapped, properties: [:]` should be tracked
- Continue to log in with an existing account —> store creation view should be shown at the end
- When the store creation view is shown, tap the X button to dismiss the view —> `🔵 Tracked site_creation_dismissed, properties: [AnyHashable("source"): "login_email_error”]` should be tracked
- On the store picker, tap `Create a new store` to create a store —> `🔵 Tracked site_picker_create_site_tapped, properties: [AnyHashable("source"): "other”]` should be tracked
- Continue to create a store —> after a few ` jetpack_cp_sites_fetched` events, it should log in to the newly created store with `🔵 Tracked login_woocommerce_site_created, properties: [AnyHashable("source"): "login_email_error", AnyHashable("url"): "URL"]` tracked

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
