### PR TITLE
Account creation: handle email-based username error by generating another fallback username

### DIFF
--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -233,7 +233,7 @@ public enum CreateAccountError: Error, Equatable {
                 self = .invalidEmail
             case Constants.invalidPassword:
                 self = .invalidPassword(message: message)
-            case Constants.invalidUsername:
+            case Constants.invalidUsername, Constants.usernameExists:
                 self = .invalidUsername
             default:
                 self = .unexpected(error: error)
@@ -249,6 +249,7 @@ public enum CreateAccountError: Error, Equatable {
         static let emailExists = "email_exists"
         static let invalidEmail = "email_invalid"
         static let invalidPassword = "password_invalid"
-        static let invalidUsername = "username_exists"
+        static let usernameExists = "username_exists"
+        static let invalidUsername = "username_invalid"
     }
 }

--- a/Yosemite/Yosemite/Stores/AccountCreationStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountCreationStore.swift
@@ -56,10 +56,10 @@ private extension AccountCreationStore {
             switch result {
             case .failure(let error) where error == .invalidUsername:
                 // Because the username is automatically generated based on the email,
-                // when there is an error on the username we want to auto-generate another
-                // username using a known base so that the user is not blocked on the
-                // internal bug where `remote.loadUsernameSuggestions` returns an invalid
-                // username.
+                // when there is an error on the username (e.g. when the username contains certain
+                // keywords like `wordpress`) we want to auto-generate another username using a
+                // known base so that the user is not blocked on the internal bug where
+                // `remote.loadUsernameSuggestions` returns an invalid username.
                 guard let fallbackUsername = await generateUsername(base: Constants.fallbackUsernameBase) else {
                     return completion(.failure(.invalidUsername))
                 }

--- a/Yosemite/Yosemite/Stores/AccountCreationStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountCreationStore.swift
@@ -44,9 +44,7 @@ private extension AccountCreationStore {
     func createAccount(email: String, password: String, completion: @escaping (Result<CreateAccountResult, CreateAccountError>) -> Void) {
         Task { @MainActor in
             // Auto-generates a username based on the email.
-            let usernameSuggestionsResult = await remote.loadUsernameSuggestions(from: email)
-            guard case let .success(usernameSuggestions) = usernameSuggestionsResult,
-            let username = usernameSuggestions.first else {
+            guard let username = await generateUsername(base: email) else {
                 return completion(.failure(.invalidUsername))
             }
             // Creates a WPCOM account.
@@ -55,7 +53,41 @@ private extension AccountCreationStore {
                                                     password: password,
                                                     clientID: dotcomClientID,
                                                     clientSecret: dotcomClientSecret)
-            completion(result)
+            switch result {
+            case .failure(let error) where error == .invalidUsername:
+                // Because the username is automatically generated based on the email,
+                // when there is an error on the username we want to auto-generate another
+                // username using a known base so that the user is not blocked on the
+                // internal bug where `remote.loadUsernameSuggestions` returns an invalid
+                // username.
+                guard let fallbackUsername = await generateUsername(base: Constants.fallbackUsernameBase) else {
+                    return completion(.failure(.invalidUsername))
+                }
+                // Creates a WPCOM account with the fallback username.
+                let result = await remote.createAccount(email: email,
+                                                        username: fallbackUsername,
+                                                        password: password,
+                                                        clientID: dotcomClientID,
+                                                        clientSecret: dotcomClientSecret)
+                completion(result)
+            default:
+                completion(result)
+            }
         }
+    }
+
+    func generateUsername(base: String) async -> String? {
+        let usernameSuggestionsResult = await remote.loadUsernameSuggestions(from: base)
+        guard case let .success(usernameSuggestions) = usernameSuggestionsResult,
+              let username = usernameSuggestions.first else {
+            return nil
+        }
+        return username
+    }
+}
+
+private extension AccountCreationStore {
+    enum Constants {
+        static let fallbackUsernameBase = "woomerchant"
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Edge case of #7891 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Thanks @selanthiraiyan for discovering this scenario where the user could get stuck because of an internal bug on the backend side! (More details in p1666852701302039-slack-C045CUK1Y3U)

#### Why

The account creation form currently just has two fields: email and password. Since a username is required in the account creation endpoint, we currently auto-generate a username based on the email using the WPCOM `username/suggestions` endpoint. However, as Sharma discovered earlier, if the email contains `wordpress` the suggested username often also contains `wordpress` but it's not allowed in the account creation endpoint (it feels like a bug which I'll look into reporting - the suggestions endpoint should only return valid usernames). Therefore, the merchant just gets stuck and retries would not change anything. As Corey pointed out, `wordpress` seems to be the only excluded keyword for now fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Szh%2Qcyhtvaf%2Szvfp.cuc%3Se%3Q90q00s9s%232770-og.

#### The workaround

Because the merchant can't fix any of the username error (we can't ask them to use another email), I thought it's easier to auto-generate another username using a known base `woomerchant` (feel free to suggest others). In `AccountCreationStore.createAccount`, when the app receives a username error it auto-generates another and creates an account with the new username again.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app
- Log out and skip onboarding if needed
- Tap `Learn more about WooCommerce` (temporary CTA)
- Enter an email that contains `wordpress` (e.g. `*+wordpress@domain`), and a valid password
- Tap `Get started` --> it should not fail on the username, and an account with a username like `woomerchant*` should be created

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->