### PR TITLE
Products Onboarding: Update buttons for onboarding banner

### DIFF
--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/FeatureAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/FeatureAnnouncementCardViewModel.swift
@@ -17,6 +17,7 @@ protocol AnnouncementCardViewModelProtocol {
     func onAppear()
     func ctaTapped()
 
+    var showDismissButton: Bool { get }
     var showDismissConfirmation: Bool { get }
     var dismissAlertTitle: String { get }
     var dismissAlertMessage: String { get }
@@ -44,6 +45,8 @@ class FeatureAnnouncementCardViewModel: AnnouncementCardViewModelProtocol {
     var image: UIImage {
         config.image
     }
+
+    var showDismissButton: Bool = true
 
     var showDismissConfirmation: Bool {
         config.showDismissConfirmation

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModel.swift
@@ -22,6 +22,8 @@ struct JustInTimeMessageAnnouncementCardViewModel: AnnouncementCardViewModelProt
         // No-op
     }
 
+    var showDismissButton: Bool = true
+
     var showDismissConfirmation: Bool = false
 
     var dismissAlertTitle: String = ""

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
@@ -18,8 +18,14 @@ struct ProductsOnboardingAnnouncementCardViewModel: AnnouncementCardViewModelPro
         // No-op
     }
 
+    /// Opens the Products tab when the Call To Action button is tapped
+    ///
     func ctaTapped() {
-        // No-op
+        guard let tabBarController = AppDelegate.shared.tabBarController else {
+            return
+        }
+
+        tabBarController.navigateTo(.products)
     }
 
     // MARK: Dismiss button (disabled)

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
@@ -18,14 +18,12 @@ struct ProductsOnboardingAnnouncementCardViewModel: AnnouncementCardViewModelPro
         // No-op
     }
 
-    /// Opens the Products tab when the Call To Action button is tapped
-    ///
-    func ctaTapped() {
-        guard let tabBarController = AppDelegate.shared.tabBarController else {
-            return
-        }
+    // MARK: Call to Action
 
-        tabBarController.navigateTo(.products)
+    let onCTATapped: (() -> Void)?
+
+    func ctaTapped() {
+        onCTATapped?()
     }
 
     // MARK: Dismiss button (disabled)

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
@@ -22,6 +22,14 @@ struct ProductsOnboardingAnnouncementCardViewModel: AnnouncementCardViewModelPro
         // No-op
     }
 
+    // MARK: Dismiss button (disabled)
+
+    var showDismissButton: Bool = false
+
+    func dontShowAgainTapped() {
+        // No-op
+    }
+
     // MARK: Dismiss confirmation alert (disabled)
 
     var showDismissConfirmation: Bool = false
@@ -29,10 +37,6 @@ struct ProductsOnboardingAnnouncementCardViewModel: AnnouncementCardViewModelPro
     var dismissAlertTitle: String = ""
 
     var dismissAlertMessage: String = ""
-
-    func dontShowAgainTapped() {
-        // No-op
-    }
 
     func remindLaterTapped() {
         // No-op

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -123,7 +123,14 @@ final class DashboardViewModel {
                     ServiceLocator.analytics.track(.productsOnboardingEligible)
 
                     if self?.featureFlagService.isFeatureFlagEnabled(.productsOnboarding) == true {
-                        let viewModel = ProductsOnboardingAnnouncementCardViewModel()
+                        let viewModel = ProductsOnboardingAnnouncementCardViewModel(onCTATapped: { [weak self] in
+                            guard let tabBarController = AppDelegate.shared.tabBarController else {
+                                return
+                            }
+
+                            self?.announcementViewModel = nil // Dismiss announcement
+                            tabBarController.navigateTo(.products)
+                        })
                         self?.announcementViewModel = viewModel
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
@@ -30,7 +30,7 @@ struct FeatureAnnouncementCardView: View {
                 BadgeView(type: viewModel.badgeType)
                     .padding(.leading, Layout.padding)
                 Spacer()
-                if let dismiss = dismiss {
+                if viewModel.showDismissButton, let dismiss = dismiss {
                     Button(action: {
                         if viewModel.showDismissConfirmation {
                             showingDismissActionSheet = true


### PR DESCRIPTION
Closes: #7978
⚠️ Depends on #7980 ⚠️ 

## Description

This PR updates the buttons on the products onboarding banner:

* Removes the dismiss button
* Call to Action redirects to the Products tab (and auto-dismisses the banner)

The dismiss button is only removed for the onboarding banner. The `FeatureAnnouncementCardView` now checks the view model before showing the dismiss button.

## Testing

1. Build and run the app in debug/alpha mode.
2. Select a store with no products.
3. Confirm the products onboarding banner appears on the My Store dashboard with no visible dismiss button.
4. Tap the "Add a Product" call to action and confirm you are directed to the Products tab.
5. Go back to the My Store tab and confirm the banner does not appear. (You can force close and reopen the app and the banner will reappear, as long as you haven't added any products to the store.)

## Screenshots

Products Onboarding banner (no dismiss button)|Just In Time Message (with dismiss button)
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2022-10-31 at 12 49 09](https://user-images.githubusercontent.com/8658164/199014240-0dcf39c0-fe49-421b-968c-69769b99f22c.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-10-31 at 12 48 48](https://user-images.githubusercontent.com/8658164/199014222-cf36fc1b-00e0-47a3-993d-36c8b600660d.png)


https://user-images.githubusercontent.com/8658164/199014252-bcffff92-8383-4f29-8135-33dada1630bf.mp4



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
