### PR TITLE
Products Onboarding: Add analytics for onboarding banner

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1632,3 +1632,21 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - Products Onboarding
+//
+extension WooAnalyticsEvent {
+    enum ProductsOnboarding {
+        /// Tracks when a store is eligible for products onboarding
+        ///
+        static func storeIsEligible() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productsOnboardingEligible, properties: [:])
+        }
+
+        /// Tracks when the call to action is tapped on the products onboarding banner
+        ///
+        static func bannerCTATapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productsOnboardingCTATapped, properties: [:])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -111,9 +111,10 @@ public enum WooAnalyticsStat: String {
     case dashboardNewStatsRevertedBannerLearnMoreTapped = "dashboard_new_stats_reverted_banner_learn_more_tapped"
     case usedAnalytics = "used_analytics"
 
-    // MARK: Onboarding Events
+    // MARK: Products Onboarding Events
     //
     case productsOnboardingEligible = "products_onboarding_store_is_eligible"
+    case productsOnboardingCTATapped = "products_onboarding_cta_tapped"
 
     // MARK: Site picker. Can be triggered by login epilogue or settings.
     //

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
@@ -23,7 +23,7 @@ struct ProductsOnboardingAnnouncementCardViewModel: AnnouncementCardViewModelPro
     let onCTATapped: (() -> Void)?
 
     func ctaTapped() {
-        ServiceLocator.analytics.track(.productsOnboardingCTATapped)
+        ServiceLocator.analytics.track(event: .ProductsOnboarding.bannerCTATapped())
         onCTATapped?()
     }
 

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
@@ -23,6 +23,7 @@ struct ProductsOnboardingAnnouncementCardViewModel: AnnouncementCardViewModelPro
     let onCTATapped: (() -> Void)?
 
     func ctaTapped() {
+        ServiceLocator.analytics.track(.productsOnboardingCTATapped)
         onCTATapped?()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -120,7 +120,7 @@ final class DashboardViewModel {
             switch result {
             case .success(let isEligible):
                 if isEligible {
-                    ServiceLocator.analytics.track(.productsOnboardingEligible)
+                    ServiceLocator.analytics.track(event: .ProductsOnboarding.storeIsEligible())
 
                     if self?.featureFlagService.isFeatureFlagEnabled(.productsOnboarding) == true {
                         let viewModel = ProductsOnboardingAnnouncementCardViewModel(onCTATapped: { [weak self] in


### PR DESCRIPTION
Closes: #7979
⚠️ Depends on #7988 ⚠️ 

## Description

Adds a new analytics event for the products onboarding banner when the call to action is tapped:

* `*_products_onboarding_cta_tapped` (Event registration: 1155-gh-tracks-events-registration )

## Testing

1. Build and run the app in debug/alpha mode.
2. Select a store with no products.
3. When the onboarding banner appears on the My Store dashboard, tap the "Add a Product" call to action. Confirm the event is triggered.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
