### PR TITLE
Products Onboarding: Integrate Template Endpoint

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -146,10 +146,12 @@ private extension AddProductCoordinator {
         let inProgressViewController = InProgressViewController(viewProperties: viewProperties)
 
         let action = ProductAction.createTemplateProduct(siteID: siteID, template: template) { result in
+
+            // Dismiss the loader
+            inProgressViewController.dismiss(animated: true)
+
             switch result {
             case .success(let product):
-                // Dismiss the loader and present the product.
-                inProgressViewController.dismiss(animated: true)
                 self.presentProduct(product, formType: .edit) // We need to strongly capture `self` because no one is retaining `AddProductCoordinator`.
 
             case .failure(let error):

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -128,7 +128,8 @@ private extension AddProductCoordinator {
 
     func createAndPresentTemplate(productType: BottomSheetProductType) {
         guard let template = Self.templateType(from: productType) else {
-            return // Handle conversion failure
+            DDLogError("⛔️ Product Type: \(productType) not supported as a template.")
+            return presentErrorNotice()
         }
 
         // Loading ViewController while the product is being created
@@ -139,10 +140,14 @@ private extension AddProductCoordinator {
         let action = ProductAction.createTemplateProduct(siteID: siteID, template: template) { result in
             switch result {
             case .success(let product):
-                inProgressViewController.dismiss(animated: true) // Dismiss Loader
+                // Dismiss the loader and present the product.
+                inProgressViewController.dismiss(animated: true)
                 self.presentProduct(product, formType: .edit) // We need to strongly capture `self` because no one is retaining `AddProductCoordinator`.
+
             case .failure(let error):
-                print(error)
+                // Log error and inform the user
+                DDLogError("⛔️ There was an error creating the template product: \(error)")
+                self.presentErrorNotice()
             }
         }
 
@@ -203,5 +208,13 @@ private extension AddProductCoordinator {
         default:
             return nil
         }
+    }
+
+    /// Presents an general error notice using the system notice presenter.
+    ///
+    private func presentErrorNotice() {
+        let notice = Notice(title: NSLocalizedString("There was a problem creating the template product.",
+                                                     comment: "Title for the error notice when creating a template product"))
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -131,9 +131,15 @@ private extension AddProductCoordinator {
             return // Handle conversion failure
         }
 
+        // Loading ViewController while the product is being created
+        let loadingTitle = NSLocalizedString("Creating Template Product...", comment: "Loading text while creating a product from a template")
+        let viewProperties = InProgressViewProperties(title: loadingTitle, message: "")
+        let inProgressViewController = InProgressViewController(viewProperties: viewProperties)
+
         let action = ProductAction.createTemplateProduct(siteID: siteID, template: template) { result in
             switch result {
             case .success(let product):
+                inProgressViewController.dismiss(animated: true) // Dismiss Loader
                 self.presentProduct(product, formType: .edit) // We need to strongly capture `self` because no one is retaining `AddProductCoordinator`.
             case .failure(let error):
                 print(error)
@@ -141,6 +147,10 @@ private extension AddProductCoordinator {
         }
 
         ServiceLocator.stores.dispatch(action)
+
+        // Present loader right after the creation action is dispatched.
+        inProgressViewController.modalPresentationStyle = .overCurrentContext
+        self.navigationController.tabBarController?.present(inProgressViewController, animated: true, completion: nil)
     }
 
     func presentProductForm(bottomSheetProductType: BottomSheetProductType) {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -130,11 +130,13 @@ private extension AddProductCoordinator {
         let action = ProductAction.createTemplateProduct(siteID: siteID, template: template) { result in
             switch result {
             case .success(let product):
-                print(product)
+                self.presentProduct(product, formType: .edit) // We need to strongly capture `self` because no one is retaining `AddProductCoordinator`.
             case .failure(let error):
                 print(error)
             }
         }
+
+        ServiceLocator.stores.dispatch(action)
     }
 
     func presentProductForm(bottomSheetProductType: BottomSheetProductType) {
@@ -144,8 +146,13 @@ private extension AddProductCoordinator {
             assertionFailure("Unable to create product of type: \(bottomSheetProductType)")
             return
         }
-        let model = EditableProductModel(product: product)
+        presentProduct(product, formType: .add)
+    }
 
+    /// Presents a product onto the current navigation stack.
+    ///
+    func presentProduct(_ product: Product, formType: ProductFormType) {
+        let model = EditableProductModel(product: product)
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
         let productImageActionHandler = productImageUploader
@@ -154,7 +161,7 @@ private extension AddProductCoordinator {
                                       isLocalID: true),
                            originalStatuses: model.imageStatuses)
         let viewModel = ProductFormViewModel(product: model,
-                                             formType: .add,
+                                             formType: formType,
                                              productImageActionHandler: productImageActionHandler)
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        eventLogger: ProductFormEventLogger(),

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -82,6 +82,8 @@ private extension AddProductCoordinator {
         isProductCreationTypeEnabled && productsResultsController.numberOfObjects < 3
     }
 
+    /// Presents a bottom sheet for users to choose if they want a create a product manually or via a template.
+    ///
     func presentProductCreationTypeBottomSheet() {
         let title = NSLocalizedString("How do you want to start?",
                                       comment: "Message title of bottom sheet for selecting a template or manual product")
@@ -94,6 +96,8 @@ private extension AddProductCoordinator {
         productTypesListPresenter.show(from: navigationController, sourceView: sourceView, sourceBarButtonItem: sourceBarButtonItem, arrowDirections: .any)
     }
 
+    /// Presents a bottom sheet for users to choose if what kind of product they want to create.
+    ///
     func presentProductTypeBottomSheet(creationType: ProductCreationType) {
         let title = NSLocalizedString("Select a product type",
                                       comment: "Message title of bottom sheet for selecting a product type to create a product")
@@ -126,6 +130,10 @@ private extension AddProductCoordinator {
                                        arrowDirections: .any)
     }
 
+    /// Creates & Fetches a template product.
+    /// If success: Navigates to the product.
+    /// If failure: Shows an error notice
+    ///
     func createAndPresentTemplate(productType: BottomSheetProductType) {
         guard let template = Self.templateType(from: productType) else {
             DDLogError("⛔️ Product Type: \(productType) not supported as a template.")
@@ -158,6 +166,8 @@ private extension AddProductCoordinator {
         self.navigationController.tabBarController?.present(inProgressViewController, animated: true, completion: nil)
     }
 
+    /// Presents a new product based on the provided bottom sheet type.
+    ///
     func presentProductForm(bottomSheetProductType: BottomSheetProductType) {
         guard let product = ProductFactory().createNewProduct(type: bottomSheetProductType.productType,
                                                               isVirtual: bottomSheetProductType.isVirtual,

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -101,8 +101,12 @@ private extension AddProductCoordinator {
         let command = ProductTypeBottomSheetListSelectorCommand(selected: nil) { selectedBottomSheetProductType in
             ServiceLocator.analytics.track(.addProductTypeSelected, withProperties: ["product_type": selectedBottomSheetProductType.productType.rawValue])
             self.navigationController.dismiss(animated: true) {
-                //self.presentProductForm(bottomSheetProductType: selectedBottomSheetProductType)
-                self.createAndPresentTemplate(productType: selectedBottomSheetProductType)
+                switch creationType {
+                case .manual:
+                    self.presentProductForm(bottomSheetProductType: selectedBottomSheetProductType)
+                case .template:
+                    self.createAndPresentTemplate(productType: selectedBottomSheetProductType)
+                }
             }
         }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -11644,6 +11644,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = PZYM8XX95Q;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
 				INFOPLIST_PREFIX_HEADER = DerivedSources/InfoPlist.h;
@@ -11658,6 +11659,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "WooCommerce Development";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "WooCommerce Development";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "WooCommerce Catalyst Development";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
Closes: #7920 

# Why

This PR makes sure that after selecting a product template the app:

- Shows a loading screen
- Cretes & fetch the template product
- Displays the template product

**Note: Refining on the product form for the template(auto-draft) product will come in a next PR #7949**

# How

- Call Yosemite action to create and fetch a template product.
- Show loading view controller while the remote request is being performed.
- Show error notice if any error occurs.
- Show product form if template creation is successful.


# Demo

https://user-images.githubusercontent.com/562080/199122386-8cd87057-c78f-466e-9db4-caccd7ea94d1.mov

https://user-images.githubusercontent.com/562080/199122394-af9fb183-f932-480a-95a6-4655a08b41d6.mov

# Testing

- On a store with less than 3 products, go to the products screen
- Tap on the add a product CTA
- Select Template & a product type
- See that you are navigated to the template product.

**Note: Updating the product and making sure it all works & looks correctly will come in a later PR**

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
