### PR TITLE
Account creation: design polishes - fonts, ToS link, text field focus styles

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -49,6 +49,7 @@ struct AccountCreationForm: View {
     @ObservedObject private var viewModel: AccountCreationFormViewModel
 
     @State private var isPerformingTask = false
+    @State private var tosURL: URL?
 
     @FocusState private var focusedField: Field?
 
@@ -112,6 +113,10 @@ struct AccountCreationForm: View {
                     // Terms of Service link.
                     AttributedText(tosAttributedText)
                         .attributedTextLinkColor(Color(.textLink))
+                        .environment(\.customOpenURL) { url in
+                            tosURL = url
+                        }
+                        .safariSheet(url: $tosURL)
                 }
 
                 // CTA to submit the form.

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -35,7 +35,10 @@ final class AccountCreationFormHostingController: UIHostingController<AccountCre
 
 /// A form that allows the user to create a WPCOM account with an email and password.
 struct AccountCreationForm: View {
-    @Environment(\.customOpenURL) var customOpenURL
+    private enum Field: Hashable {
+        case email
+        case password
+    }
 
     /// Triggered when the account is created and the app is authenticated.
     var completion: (() -> Void) = {}
@@ -46,6 +49,8 @@ struct AccountCreationForm: View {
     @ObservedObject private var viewModel: AccountCreationFormViewModel
 
     @State private var isPerformingTask = false
+
+    @FocusState private var focusedField: Field?
 
     init(viewModel: AccountCreationFormViewModel) {
         self.viewModel = viewModel
@@ -82,20 +87,29 @@ struct AccountCreationForm: View {
 
                 // Form fields.
                 VStack(spacing: Layout.verticalSpacingBetweenFields) {
+                    // Email field.
                     AccountCreationFormFieldView(viewModel: .init(header: Localization.emailFieldTitle,
                                                                   placeholder: Localization.emailFieldPlaceholder,
                                                                   keyboardType: .emailAddress,
                                                                   text: $viewModel.email,
                                                                   isSecure: false,
-                                                                  errorMessage: viewModel.emailErrorMessage))
+                                                                  errorMessage: viewModel.emailErrorMessage,
+                                                                  isFocused: focusedField == .email))
+                    .focused($focusedField, equals: .email)
                     .disabled(isPerformingTask)
+
+                    // Password field.
                     AccountCreationFormFieldView(viewModel: .init(header: Localization.passwordFieldTitle,
                                                                   placeholder: Localization.passwordFieldPlaceholder,
                                                                   keyboardType: .default,
                                                                   text: $viewModel.password,
                                                                   isSecure: true,
-                                                                  errorMessage: viewModel.passwordErrorMessage))
+                                                                  errorMessage: viewModel.passwordErrorMessage,
+                                                                  isFocused: focusedField == .password))
+                    .focused($focusedField, equals: .password)
                     .disabled(isPerformingTask)
+
+                    // Terms of Service link.
                     AttributedText(tosAttributedText)
                         .attributedTextLinkColor(Color(.textLink))
                 }

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
@@ -14,6 +14,8 @@ struct AccountCreationFormFieldViewModel {
     let isSecure: Bool
     /// Optional error message shown below the text field.
     let errorMessage: String?
+    /// Whether the content in the text field is focused.
+    let isFocused: Bool
 }
 
 /// A field in the account creation form. Currently, there are two fields - email and password.
@@ -30,11 +32,11 @@ struct AccountCreationFormFieldView: View {
                 .subheadlineStyle()
             if viewModel.isSecure {
                 SecureField(viewModel.placeholder, text: viewModel.text)
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(RoundedBorderTextFieldStyle(focused: viewModel.isFocused))
                     .keyboardType(viewModel.keyboardType)
             } else {
                 TextField(viewModel.placeholder, text: viewModel.text)
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(RoundedBorderTextFieldStyle(focused: viewModel.isFocused))
                     .keyboardType(viewModel.keyboardType)
             }
             if let errorMessage = viewModel.errorMessage {
@@ -58,12 +60,14 @@ struct AccountCreationFormField_Previews: PreviewProvider {
                                                       keyboardType: .emailAddress,
                                                       text: .constant(""),
                                                       isSecure: false,
-                                                      errorMessage: nil))
+                                                      errorMessage: nil,
+                                                      isFocused: true))
         AccountCreationFormFieldView(viewModel: .init(header: "Choose a password",
                                                       placeholder: "Password",
                                                       keyboardType: .default,
                                                       text: .constant("w"),
                                                       isSecure: true,
-                                                      errorMessage: "Too simple"))
+                                                      errorMessage: "Too simple",
+                                                      isFocused: false))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
@@ -27,7 +27,7 @@ struct AccountCreationFormFieldView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
             Text(viewModel.header)
-                .bodyStyle()
+                .subheadlineStyle()
             if viewModel.isSecure {
                 SecureField(viewModel.placeholder, text: viewModel.text)
                     .textFieldStyle(.roundedBorder)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+/// Text field has a rounded border that has a thicker border and brighter border color when the field is focused.
+struct RoundedBorderTextFieldStyle: TextFieldStyle {
+    let focused: Bool
+
+    func _body(configuration: TextField<Self._Label>) -> some View {
+        configuration
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(focused ? Color(.brand): Color.gray,
+                            lineWidth: focused ? 2: 1)
+            )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
@@ -2,15 +2,48 @@ import SwiftUI
 
 /// Text field has a rounded border that has a thicker border and brighter border color when the field is focused.
 struct RoundedBorderTextFieldStyle: TextFieldStyle {
-    let focused: Bool
+    private let focused: Bool
+    private let focusedBorderColor: Color
+    private let unfocusedBorderColor: Color
+
+    init(focused: Bool,
+         focusedBorderColor: Color = Defaults.focusedBorderColor,
+         unfocusedBorderColor: Color = Defaults.unfocusedBorderColor) {
+        self.focused = focused
+        self.focusedBorderColor = focusedBorderColor
+        self.unfocusedBorderColor = unfocusedBorderColor
+    }
 
     func _body(configuration: TextField<Self._Label>) -> some View {
         configuration
             .padding(10)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(focused ? Color(.brand): Color.gray,
+                    .stroke(focused ? focusedBorderColor: unfocusedBorderColor,
                             lineWidth: focused ? 2: 1)
             )
+    }
+}
+
+extension RoundedBorderTextFieldStyle {
+    enum Defaults {
+        static let focusedBorderColor: Color = .init(uiColor: .brand)
+        static let unfocusedBorderColor: Color = .gray
+    }
+}
+
+struct TextFieldStyles_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            TextField("placeholder", text: .constant("focused"))
+                .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+            TextField("placeholder", text: .constant("unfocused"))
+                .textFieldStyle(RoundedBorderTextFieldStyle(focused: false))
+            TextField("placeholder", text: .constant("focused with a different color"))
+                .textFieldStyle(RoundedBorderTextFieldStyle(focused: true, focusedBorderColor: .orange))
+            TextField("placeholder", text: .constant("unfocused with a different color"))
+                .textFieldStyle(RoundedBorderTextFieldStyle(focused: false, unfocusedBorderColor: .cyan))
+        }
+        .preferredColorScheme(.dark)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -414,6 +414,7 @@
 		02EA6BFA2435E92600FFF90A /* KingfisherImageDownloader+ImageDownloadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EA6BF92435E92600FFF90A /* KingfisherImageDownloader+ImageDownloadable.swift */; };
 		02EA6BFC2435EC3500FFF90A /* MockImageDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EA6BFB2435EC3500FFF90A /* MockImageDownloader.swift */; };
 		02EAA4C8290F992B00918DAB /* LoggedOutStoreCreationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAA4C7290F992B00918DAB /* LoggedOutStoreCreationCoordinator.swift */; };
+		02EAA4CA2911004B00918DAB /* TextFieldStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAA4C92911004B00918DAB /* TextFieldStyles.swift */; };
 		02ECD1DF24FF48D000735BE5 /* PaginationTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ECD1DE24FF48D000735BE5 /* PaginationTracker.swift */; };
 		02ECD1E124FF496200735BE5 /* PaginationTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ECD1E024FF496200735BE5 /* PaginationTrackerTests.swift */; };
 		02ECD1E424FF5E0B00735BE5 /* AddProductCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ECD1E324FF5E0B00735BE5 /* AddProductCoordinator.swift */; };
@@ -2357,6 +2358,7 @@
 		02EA6BF92435E92600FFF90A /* KingfisherImageDownloader+ImageDownloadable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KingfisherImageDownloader+ImageDownloadable.swift"; sourceTree = "<group>"; };
 		02EA6BFB2435EC3500FFF90A /* MockImageDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageDownloader.swift; sourceTree = "<group>"; };
 		02EAA4C7290F992B00918DAB /* LoggedOutStoreCreationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedOutStoreCreationCoordinator.swift; sourceTree = "<group>"; };
+		02EAA4C92911004B00918DAB /* TextFieldStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldStyles.swift; sourceTree = "<group>"; };
 		02ECD1DE24FF48D000735BE5 /* PaginationTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationTracker.swift; sourceTree = "<group>"; };
 		02ECD1E024FF496200735BE5 /* PaginationTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationTrackerTests.swift; sourceTree = "<group>"; };
 		02ECD1E324FF5E0B00735BE5 /* AddProductCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductCoordinator.swift; sourceTree = "<group>"; };
@@ -5962,6 +5964,7 @@
 				03076D39290C22BE008EE839 /* WebView.swift */,
 				03076D35290C162E008EE839 /* WebViewSheet.swift */,
 				03076D37290C223D008EE839 /* WooNavigationSheet.swift */,
+				02EAA4C92911004B00918DAB /* TextFieldStyles.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -10321,6 +10324,7 @@
 				AE6C4FDF28A15BFE00EAC00D /* FeatureAnnouncementCardCell.swift in Sources */,
 				CE5F462723AAC8C0006B1A5C /* RefundDetailsViewModel.swift in Sources */,
 				D8815B132638686200EDAD62 /* CardPresentModalError.swift in Sources */,
+				02EAA4CA2911004B00918DAB /* TextFieldStyles.swift in Sources */,
 				453DBF8E2387F34A006762A5 /* UICollectionViewCell+Helpers.swift in Sources */,
 				45B9C63E23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift in Sources */,
 				318853362639FC9C00F66A9C /* CardReaderSettingsPresentingViewController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parts of #7891 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updated the account creation form to match the design better HyVloP5FipZzyPVenH2euI-fi-1522%3A87655:

- Fonts: updated the text field title label to `subheadline` style
- Focus state: created a `RoundedBorderTextFieldStyle: TextFieldStyle` to show a rounded border with highlighted border color when the field is focused
- URL presentation style: showed the Terms of Service link using an in-app Safari sheet by passing a `customOpenURL` environment value to `AttributedText`

I'm still working on the other two design updates on the password show/hide button, and showing the ToS link in underline style.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app
- Log out and skip onboarding if needed
- Tap `Create a Store` --> the text field header label should be subheadline style
- Tap into either text field --> the field should show a purple and thicker border when it's focused
- Tap on `Terms of Service` in the legal text --> the ToS page should be opened in the app

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light
-- | --
![Simulator Screen Shot - iPhone 14 - 2022-11-01 at 15 23 37](https://user-images.githubusercontent.com/1945542/199192155-f8c4a71a-7ba1-4b9c-85ab-801cdf28e840.png) | ![Simulator Screen Shot - iPhone 14 - 2022-11-01 at 15 23 47](https://user-images.githubusercontent.com/1945542/199192171-ddcb5ed0-6f3f-41e3-8b5a-fdc1a379bfea.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->