### PR TITLE
Simplified login: Apply A/B test

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -17,6 +17,7 @@ public enum ABTest: String, CaseIterable {
     case aaTestLoggedOut = "woocommerceios_explat_aa_test_logged_out_202211"
 
     /// A/B test to measure the sign-in success rate when only WPCom login is enabled.
+    /// Experiment ref: pbxNRc-27s-p2
     ///
     case abTestLoginWithWPComOnly = "woocommerceios_login_wpcom_only"
 

--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -16,6 +16,10 @@ public enum ABTest: String, CaseIterable {
     /// Experiment ref: pbxNRc-1S0-p2
     case aaTestLoggedOut = "woocommerceios_explat_aa_test_logged_out_202211"
 
+    /// A/B test to measure the sign-in success rate when only WPCom login is enabled.
+    ///
+    case abTestLoginWithWPComOnly = "woocommerceios_login_wpcom_only"
+
     /// Returns a variation for the given experiment
     public var variation: Variation {
         ExPlat.shared?.experiment(rawValue) ?? .control
@@ -28,7 +32,7 @@ public enum ABTest: String, CaseIterable {
         switch self {
         case .aaTestLoggedIn202210:
             return .loggedIn
-        case .aaTestLoggedOut:
+        case .aaTestLoggedOut, .abTestLoginWithWPComOnly:
             return .loggedOut
         case .null:
             return .none

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -36,16 +36,10 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .orderCreationSearchCustomers:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .wpcomSignup:
-            guard isFeatureFlagEnabled(.simplifiedLoginFlowI1) else {
-                return buildConfig == .localDeveloper || buildConfig == .alpha
-            }
-            // To disable automatically sending signup link for unknown email IDs
             return false
         case .inAppPurchases:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .storeCreationMVP:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .simplifiedLoginFlowI1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .justInTimeMessagesOnDashboard:
             return buildConfig == .localDeveloper || buildConfig == .alpha

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -86,11 +86,6 @@ public enum FeatureFlag: Int {
     ///
     case storeCreationMVP
 
-    /// Temporary feature flag for the simplified login flow.
-    /// TODO: replace with A/B testing.
-    ///
-    case simplifiedLoginFlowI1
-
     /// Just In Time Messages on Dashboard
     ///
     case justInTimeMessagesOnDashboard

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -56,9 +56,7 @@ class AuthenticationManager: Authentication {
         let isWPComMagicLinkPreferredToPassword = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasis)
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasisM2)
         let isFeatureCarouselShown = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginPrologueOnboarding) == false
-        || (loggedOutAppSettings.hasFinishedOnboarding == true &&
-            ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifiedLoginFlowI1) == false)
-        let isSimplifiedLoginI1Enabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifiedLoginFlowI1)
+        let isSimplifiedLoginI1Enabled = ABTest.abTestLoginWithWPComOnly.variation != .control
         let isStoreCreationMVPEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
@@ -84,9 +82,9 @@ class AuthenticationManager: Authentication {
                                                                 enableWPComLoginOnlyInPrologue: isSimplifiedLoginI1Enabled,
                                                                 enableSiteCreation: isStoreCreationMVPEnabled,
                                                                 enableSocialLogin: !isSimplifiedLoginI1Enabled,
-                                                                emphasizeEmailForWPComPassword: isSimplifiedLoginI1Enabled,
-                                                                wpcomPasswordInstructions: isSimplifiedLoginI1Enabled ?
-                                                                AuthenticationConstants.wpcomPasswordInstructions : nil)
+                                                                emphasizeEmailForWPComPassword: true,
+                                                                wpcomPasswordInstructions:
+                                                                AuthenticationConstants.wpcomPasswordInstructions)
 
         let systemGray3LightModeColor = UIColor(red: 199/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1)
         let systemLabelLightModeColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -50,7 +50,7 @@ final class NotWPAccountViewModel: ULErrorViewModel {
          analytics: Analytics = ServiceLocator.analytics,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.analytics = analytics
-        self.isSimplifiedLoginI1Enabled = featureFlagService.isFeatureFlagEnabled(.simplifiedLoginFlowI1)
+        self.isSimplifiedLoginI1Enabled = ABTest.abTestLoginWithWPComOnly.variation != .control
         if let error = error as? SignInError,
            case let .invalidWPComEmail(source) = error,
            source == .wpComSiteAddress {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -21,9 +21,7 @@ final class NotWPAccountViewModel: ULErrorViewModel {
 
     let isPrimaryButtonHidden: Bool
 
-    var secondaryButtonTitle: String {
-        isSimplifiedLoginI1Enabled ? Localization.tryAnotherAddress : Localization.restartLogin
-    }
+    let secondaryButtonTitle = Localization.tryAnotherAddress
     let isSecondaryButtonHidden: Bool
 
     private weak var viewController: UIViewController?
@@ -42,7 +40,6 @@ final class NotWPAccountViewModel: ULErrorViewModel {
         return button
     }()
 
-    private let isSimplifiedLoginI1Enabled: Bool
     private let analytics: Analytics
     private var storePickerCoordinator: StorePickerCoordinator?
 
@@ -50,7 +47,6 @@ final class NotWPAccountViewModel: ULErrorViewModel {
          analytics: Analytics = ServiceLocator.analytics,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.analytics = analytics
-        self.isSimplifiedLoginI1Enabled = ABTest.abTestLoginWithWPComOnly.variation != .control
         if let error = error as? SignInError,
            case let .invalidWPComEmail(source) = error,
            source == .wpComSiteAddress {
@@ -60,23 +56,14 @@ final class NotWPAccountViewModel: ULErrorViewModel {
         } else {
             isSecondaryButtonHidden = false
 
-            if isSimplifiedLoginI1Enabled {
-                primaryButtonTitle = Localization.createAnAccount
-                isPrimaryButtonHidden = !featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
-            } else {
-                primaryButtonTitle = Localization.loginWithSiteAddress
-                isPrimaryButtonHidden = false
-            }
+            primaryButtonTitle = Localization.createAnAccount
+            isPrimaryButtonHidden = !featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
         }
     }
 
     // MARK: - Actions
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        if isSimplifiedLoginI1Enabled {
-            createAnAccountButtonTapped(in: viewController)
-        } else {
-            loginWithSiteAddressButtonTapped()
-        }
+        createAnAccountButtonTapped(in: viewController)
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
@@ -110,11 +97,6 @@ private extension NotWPAccountViewModel {
         viewController?.present(fancyAlert, animated: true)
     }
 
-    func loginWithSiteAddressButtonTapped() {
-        let popCommand = NavigateToEnterSite()
-        popCommand.execute(from: viewController)
-    }
-
     func createAnAccountButtonTapped(in viewController: UIViewController?) {
         analytics.track(.createAccountOnInvalidEmailScreenTapped)
         guard let viewController,
@@ -140,10 +122,6 @@ private extension NotWPAccountViewModel {
         static let needHelpFindingEmail = NSLocalizedString("Need help finding the required email?",
                                                             comment: "Button linking to webview that explains what Jetpack is"
                                                             + "Presented when logging in with a site address that does not have a valid Jetpack installation")
-
-        static let loginWithSiteAddress = NSLocalizedString("Log in with your store address",
-                                                            comment: "Action button linking to instructions for enter another store."
-                                                            + "Presented when logging in with an email address that is not a WordPress.com account")
 
         static let createAnAccount = NSLocalizedString("Create An Account",
                                                        comment: "Action button linking to create WooCommerce store flow."

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -12,6 +12,7 @@ final class LoginPrologueViewController: UIViewController {
     private let isFeatureCarouselShown: Bool
     private let analytics: Analytics
     private let featureFlagService: FeatureFlagService
+    private let isSimplifiedLogin: Bool
 
     /// Background View, to be placed surrounding the bottom area.
     ///
@@ -44,6 +45,7 @@ final class LoginPrologueViewController: UIViewController {
         self.isFeatureCarouselShown = isFeatureCarouselShown
         self.analytics = analytics
         self.featureFlagService = featureFlagService
+        self.isSimplifiedLogin = ABTest.abTestLoginWithWPComOnly.variation != .control
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -97,7 +99,7 @@ private extension LoginPrologueViewController {
         let pageTypes: [LoginProloguePageType] = {
             if isFeatureCarouselShown {
                 return [.stats, .orderManagement, .products, .reviews]
-            } else if featureFlagService.isFeatureFlagEnabled(.simplifiedLoginFlowI1) {
+            } else if isSimplifiedLogin {
                 return [.simplifiedLoginI1Intro]
             } else {
                 return [.getStarted]
@@ -125,7 +127,7 @@ private extension LoginPrologueViewController {
         guard isNewToWooCommerceButtonShown else {
             return newToWooCommerceButton.isHidden = true
         }
-        let title = featureFlagService.isFeatureFlagEnabled(.simplifiedLoginFlowI1) ? Localization.learnMoreAboutWoo : Localization.newToWooCommerce
+        let title = isSimplifiedLogin ? Localization.learnMoreAboutWoo : Localization.newToWooCommerce
         newToWooCommerceButton.setTitle(title, for: .normal)
         newToWooCommerceButton.applyLinkButtonStyle()
         newToWooCommerceButton.titleLabel?.numberOfLines = 0

--- a/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
@@ -67,24 +67,9 @@ final class NotWPAccountViewModelTests: XCTestCase {
         XCTAssertEqual(auxiliaryButtonTitle, AuthenticationConstants.whatIsWPComLinkTitle)
     }
 
-    func test_viewmodel_provides_expected_title_for_primary_button_when_simplified_login_feature_flag_is_off() {
+    func test_viewmodel_provides_expected_title_for_primary_button() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: false)
-        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
-                                               featureFlagService: featureFlagService)
-
-        // When
-        let primaryButtonTitle = viewModel.primaryButtonTitle
-
-        // Then
-        XCTAssertEqual(primaryButtonTitle, Expectations.loginWithSiteAddressTitle)
-    }
-
-    func test_viewmodel_provides_expected_title_for_primary_button_when_simplified_login_feature_flag_is_on() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true)
-        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
-                                               featureFlagService: featureFlagService)
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom))
         // When
         let primaryButtonTitle = viewModel.primaryButtonTitle
 
@@ -105,23 +90,9 @@ final class NotWPAccountViewModelTests: XCTestCase {
         XCTAssertEqual(primaryButtonTitle, Expectations.restartLoginTitle)
     }
 
-    func test_primary_button_title_is_login_with_site_address_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_feature_flag_is_off() {
+    func test_primary_button_title_is_create_an_account_for_invalidWPComEmail_from_wpCom_error() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: false)
-        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
-                                              featureFlagService: featureFlagService)
-        // When
-        let primaryButtonTitle = viewModel.primaryButtonTitle
-
-        // Then
-        XCTAssertEqual(primaryButtonTitle, Expectations.loginWithSiteAddressTitle)
-    }
-
-    func test_primary_button_title_is_create_an_account_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_feature_flag_is_on() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true)
-        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
-                                              featureFlagService: featureFlagService)
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom))
         // When
         let primaryButtonTitle = viewModel.primaryButtonTitle
 
@@ -139,29 +110,18 @@ final class NotWPAccountViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isPrimaryButtonHidden)
     }
 
-    func test_primary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_feature_flag_is_off() {
+    func test_primary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error_when_store_creation_is_on() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: false)
+        let featureFlagService = MockFeatureFlagService(isStoreCreationMVPEnabled: true)
         let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
                                               featureFlagService: featureFlagService)
         // Then
         XCTAssertFalse(viewModel.isPrimaryButtonHidden)
     }
 
-    func test_primary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_is_on_and_store_creation_is_on() {
+    func test_primary_button_is_hidden_for_invalidWPComEmail_from_wpCom_error_when_store_creation_is_off() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true,
-                                                        isStoreCreationMVPEnabled: true)
-        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
-                                              featureFlagService: featureFlagService)
-        // Then
-        XCTAssertFalse(viewModel.isPrimaryButtonHidden)
-    }
-
-    func test_primary_button_is_hidden_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_is_on_and_store_creation_is_off() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true,
-                                                        isStoreCreationMVPEnabled: false)
+        let featureFlagService = MockFeatureFlagService(isStoreCreationMVPEnabled: false)
         let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
                                               featureFlagService: featureFlagService)
         // Then
@@ -188,24 +148,9 @@ final class NotWPAccountViewModelTests: XCTestCase {
 
     // MARK: - `secondaryButtonTitle`
 
-    func test_viewmodel_provides_expected_title_for_secondary_button_when_simplified_login_feature_flag_is_off() {
+    func test_viewmodel_provides_expected_title_for_secondary_button() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: false)
-        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
-                                               featureFlagService: featureFlagService)
-
-        // When
-        let secondaryButtonTitle = viewModel.secondaryButtonTitle
-
-        // Then
-        XCTAssertEqual(secondaryButtonTitle, Expectations.restartLoginTitle)
-    }
-
-    func test_viewmodel_provides_expected_title_for_secondary_button_when_simplified_login_feature_flag_is_on() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true)
-        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
-                                               featureFlagService: featureFlagService)
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom))
         // When
         let secondaryButtonTitle = viewModel.secondaryButtonTitle
 
@@ -232,10 +177,8 @@ final class NotWPAccountViewModelTests: XCTestCase {
 
     func test_tapping_auxiliary_button_tracks_what__is_wordpress_com_event() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true)
         let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
-                                              analytics: analytics,
-                                              featureFlagService: featureFlagService)
+                                              analytics: analytics)
 
         // When
         viewModel.didTapAuxiliaryButton(in: nil)
@@ -244,26 +187,10 @@ final class NotWPAccountViewModelTests: XCTestCase {
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "what_is_wordpress_com_on_invalid_email_screen" }))
     }
 
-    func test_tapping_primary_button_does_not_track_create_account_event_when_simplified_login_feature_flag_is_off() {
+    func test_tapping_primary_button_tracks_create_account_event() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: false)
         let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
-                                              analytics: analytics,
-                                              featureFlagService: featureFlagService)
-
-        // When
-        viewModel.didTapPrimaryButton(in: nil)
-
-        // Then
-        XCTAssertNil(analyticsProvider.receivedEvents.first(where: { $0 == "create_account_on_invalid_email_screen" }))
-    }
-
-    func test_tapping_primary_button_tracks_create_account_event_when_simplified_login_feature_flag_is_on() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true)
-        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
-                                              analytics: analytics,
-                                              featureFlagService: featureFlagService)
+                                              analytics: analytics)
 
         // When
         viewModel.didTapPrimaryButton(in: nil)

--- a/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/NotWPAccountViewModelTests.swift
@@ -67,9 +67,24 @@ final class NotWPAccountViewModelTests: XCTestCase {
         XCTAssertEqual(auxiliaryButtonTitle, AuthenticationConstants.whatIsWPComLinkTitle)
     }
 
-    func test_viewmodel_provides_expected_title_for_primary_button() {
+    func test_viewmodel_provides_expected_title_for_primary_button_when_simplified_login_feature_flag_is_off() {
         // Given
-        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom))
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: false)
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let primaryButtonTitle = viewModel.primaryButtonTitle
+
+        // Then
+        XCTAssertEqual(primaryButtonTitle, Expectations.loginWithSiteAddressTitle)
+    }
+
+    func test_viewmodel_provides_expected_title_for_primary_button_when_simplified_login_feature_flag_is_on() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true)
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
+                                               featureFlagService: featureFlagService)
         // When
         let primaryButtonTitle = viewModel.primaryButtonTitle
 
@@ -90,9 +105,23 @@ final class NotWPAccountViewModelTests: XCTestCase {
         XCTAssertEqual(primaryButtonTitle, Expectations.restartLoginTitle)
     }
 
-    func test_primary_button_title_is_create_an_account_for_invalidWPComEmail_from_wpCom_error() {
+    func test_primary_button_title_is_login_with_site_address_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_feature_flag_is_off() {
         // Given
-        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom))
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: false)
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
+                                              featureFlagService: featureFlagService)
+        // When
+        let primaryButtonTitle = viewModel.primaryButtonTitle
+
+        // Then
+        XCTAssertEqual(primaryButtonTitle, Expectations.loginWithSiteAddressTitle)
+    }
+
+    func test_primary_button_title_is_create_an_account_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_feature_flag_is_on() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true)
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
+                                              featureFlagService: featureFlagService)
         // When
         let primaryButtonTitle = viewModel.primaryButtonTitle
 
@@ -110,18 +139,29 @@ final class NotWPAccountViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isPrimaryButtonHidden)
     }
 
-    func test_primary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error_when_store_creation_is_on() {
+    func test_primary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_feature_flag_is_off() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isStoreCreationMVPEnabled: true)
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: false)
         let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
                                               featureFlagService: featureFlagService)
         // Then
         XCTAssertFalse(viewModel.isPrimaryButtonHidden)
     }
 
-    func test_primary_button_is_hidden_for_invalidWPComEmail_from_wpCom_error_when_store_creation_is_off() {
+    func test_primary_button_is_not_hidden_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_is_on_and_store_creation_is_on() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isStoreCreationMVPEnabled: false)
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true,
+                                                        isStoreCreationMVPEnabled: true)
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
+                                              featureFlagService: featureFlagService)
+        // Then
+        XCTAssertFalse(viewModel.isPrimaryButtonHidden)
+    }
+
+    func test_primary_button_is_hidden_for_invalidWPComEmail_from_wpCom_error_when_simplified_login_is_on_and_store_creation_is_off() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true,
+                                                        isStoreCreationMVPEnabled: false)
         let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
                                               featureFlagService: featureFlagService)
         // Then
@@ -148,9 +188,24 @@ final class NotWPAccountViewModelTests: XCTestCase {
 
     // MARK: - `secondaryButtonTitle`
 
-    func test_viewmodel_provides_expected_title_for_secondary_button() {
+    func test_viewmodel_provides_expected_title_for_secondary_button_when_simplified_login_feature_flag_is_off() {
         // Given
-        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom))
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: false)
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let secondaryButtonTitle = viewModel.secondaryButtonTitle
+
+        // Then
+        XCTAssertEqual(secondaryButtonTitle, Expectations.restartLoginTitle)
+    }
+
+    func test_viewmodel_provides_expected_title_for_secondary_button_when_simplified_login_feature_flag_is_on() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true)
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
+                                               featureFlagService: featureFlagService)
         // When
         let secondaryButtonTitle = viewModel.secondaryButtonTitle
 
@@ -177,8 +232,10 @@ final class NotWPAccountViewModelTests: XCTestCase {
 
     func test_tapping_auxiliary_button_tracks_what__is_wordpress_com_event() {
         // Given
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true)
         let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
-                                              analytics: analytics)
+                                              analytics: analytics,
+                                              featureFlagService: featureFlagService)
 
         // When
         viewModel.didTapAuxiliaryButton(in: nil)
@@ -187,10 +244,26 @@ final class NotWPAccountViewModelTests: XCTestCase {
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "what_is_wordpress_com_on_invalid_email_screen" }))
     }
 
-    func test_tapping_primary_button_tracks_create_account_event() {
+    func test_tapping_primary_button_does_not_track_create_account_event_when_simplified_login_feature_flag_is_off() {
         // Given
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: false)
         let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
-                                              analytics: analytics)
+                                              analytics: analytics,
+                                              featureFlagService: featureFlagService)
+
+        // When
+        viewModel.didTapPrimaryButton(in: nil)
+
+        // Then
+        XCTAssertNil(analyticsProvider.receivedEvents.first(where: { $0 == "create_account_on_invalid_email_screen" }))
+    }
+
+    func test_tapping_primary_button_tracks_create_account_event_when_simplified_login_feature_flag_is_on() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isSimplifiedLoginFlowI1Enabled: true)
+        let viewModel = NotWPAccountViewModel(error: SignInError.invalidWPComEmail(source: .wpCom),
+                                              analytics: analytics,
+                                              featureFlagService: featureFlagService)
 
         // When
         viewModel.didTapPrimaryButton(in: nil)

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -7,7 +7,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isUpdateOrderOptimisticallyOn: Bool
     private let shippingLabelsOnboardingM1: Bool
     private let isLoginPrologueOnboardingEnabled: Bool
-    private let isSimplifiedLoginFlowI1Enabled: Bool
     private let isStoreCreationMVPEnabled: Bool
     private let isProductsOnboardingEnabled: Bool
 
@@ -16,7 +15,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isUpdateOrderOptimisticallyOn: Bool = false,
          shippingLabelsOnboardingM1: Bool = false,
          isLoginPrologueOnboardingEnabled: Bool = false,
-         isSimplifiedLoginFlowI1Enabled: Bool = false,
          isStoreCreationMVPEnabled: Bool = false,
          isProductsOnboardingEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
@@ -24,7 +22,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
         self.isLoginPrologueOnboardingEnabled = isLoginPrologueOnboardingEnabled
-        self.isSimplifiedLoginFlowI1Enabled = isSimplifiedLoginFlowI1Enabled
         self.isStoreCreationMVPEnabled = isStoreCreationMVPEnabled
         self.isProductsOnboardingEnabled = isProductsOnboardingEnabled
     }
@@ -41,8 +38,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return shippingLabelsOnboardingM1
         case .loginPrologueOnboarding:
             return isLoginPrologueOnboardingEnabled
-        case .simplifiedLoginFlowI1:
-            return isSimplifiedLoginFlowI1Enabled
         case .storeCreationMVP:
             return isStoreCreationMVPEnabled
         case .productsOnboarding:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7904 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new A/B test experiment for simplified login to enable only WP.com logins. Experiment details: pbxNRc-27s-p2.
Changes:
- Added new A/B test experiment.
- Replaced the temporary feature flag with A/B test.
- Removed the unnecessary checks on password screen to use the new design on all variants.
- Removed the unnecessary checks on unrecognized email error screen to use the new design on all variants.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### `control` variation

This is the default variation, and most likely the one that is shown before the experiment is launched.

- Delete the app
- Launch the app from the PR branch --> the onboarding screen should be shown, and an event is logged `🔵 Tracked application_installed, properties: [AnyHashable("after_abtest_setup"): true]`
- Finish or dismiss the onboarding --> the prologue screen should be shown with entry points to both WP.com login and site address login.
- Tap "Continue with WordPress.com", notice the email screen has entry points to social logins and a link for "What is WordPress.com".

#### Testing the `treatment` variation

It's difficult to test different variants in A/B tests because ExPlat is supposed to assign one single variant to a device. I'll shamelessly paste the guide from Jaclyn's past PR #7551 here:

Prerequisites:
- Please follow the setup in PCYsg-Fq7-p2#assignments-api for proxied sandboxed API requests: connect to sandbox via ssh, and point WP.com API to the sandbox IP address (`ifconfig`) in the local matchine's `/etc/hosts`
- In Xcode, set a breakpoint at `ExPlatService` L47 where `anon_id` is set in the URL request
- Make an API request `PATCH /wpcom/v2/experiments/0.1.0/assignments` with the following `body` and make sure it's successful:
```
{
    "variations": {
        "woocommerceios_login_wpcom_only": "treatment"
    },
    "anon_id": "anon_id_from_the_previous_step",
    "username_override": ""
}
```
- Launch the app, and let it sit for a bit
- Relaunch the app --> the treatment variation should be shown with only the CTA "Log In".
- Tap "Log In", notice that the email screen is the simplified design with no mentioning of WordPress.com.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Control | Treatment |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/199221300-16caa188-ec31-4975-a27d-accd10e5da25.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/199221377-8a0278ce-03bd-4694-be39-0f8b050df8e4.png" width=320 /> | 
| <img src="https://user-images.githubusercontent.com/5533851/199221523-8e95d602-12f0-4a1d-b104-a009412a4fa7.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/199221605-38998c22-95c9-4298-866f-5f83402747dd.png" width=320 /> |




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->