### PR TITLE
Products Onboarding: Trigger add product flow from banner CTA

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -126,12 +126,8 @@ final class DashboardViewModel {
 
                     if self?.featureFlagService.isFeatureFlagEnabled(.productsOnboarding) == true {
                         let viewModel = ProductsOnboardingAnnouncementCardViewModel(onCTATapped: { [weak self] in
-                            guard let tabBarController = AppDelegate.shared.tabBarController else {
-                                return
-                            }
-
                             self?.announcementViewModel = nil // Dismiss announcement
-                            tabBarController.navigateTo(.products)
+                            MainTabBarController.presentAddProductFlow()
                         })
                         self?.announcementViewModel = viewModel
                     }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -416,6 +416,19 @@ extension MainTabBarController {
         }
     }
 
+    static func presentAddProductFlow() {
+        navigateTo(.products)
+
+        guard let productsViewController: ProductsViewController = childViewController() else {
+            return
+        }
+
+        // We give some time for the products tab transition to finish, so the add product button is present to start the flow
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            productsViewController.addProduct()
+        }
+    }
+
     static func presentPayments() {
         switchToHubMenuTab()
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -47,6 +47,18 @@ final class ProductsViewController: UIViewController, GhostableViewController {
         return stackView
     }()
 
+    /// The button in the navigation bar to add a product
+    ///
+    private lazy var addProductButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(image: .plusBarButtonItemImage,
+                                     style: .plain,
+                                     target: self,
+                                     action: #selector(addProduct(_:)))
+        button.accessibilityTraits = .button
+        button.accessibilityLabel = NSLocalizedString("Add a product", comment: "The action to add a product")
+        button.accessibilityIdentifier = "product-add-button"
+        return button
+    }()
 
     /// Top toolbar that shows the sort and filter CTAs.
     ///
@@ -208,6 +220,16 @@ final class ProductsViewController: UIViewController, GhostableViewController {
     }
 }
 
+// MARK: - Public API
+//
+extension ProductsViewController {
+    /// Adds a new product using the "Add Product" navigation bar button as the source
+    ///
+    func addProduct() {
+        addProduct(addProductButton)
+    }
+}
+
 // MARK: - Navigation Bar Actions
 //
 private extension ProductsViewController {
@@ -271,17 +293,7 @@ private extension ProductsViewController {
 
     func configureNavigationBarRightButtonItems() {
         var rightBarButtonItems = [UIBarButtonItem]()
-        let buttonItem: UIBarButtonItem = {
-            let button = UIBarButtonItem(image: .plusBarButtonItemImage,
-                                         style: .plain,
-                                         target: self,
-                                         action: #selector(addProduct(_:)))
-            button.accessibilityTraits = .button
-            button.accessibilityLabel = NSLocalizedString("Add a product", comment: "The action to add a product")
-            button.accessibilityIdentifier = "product-add-button"
-            return button
-        }()
-        rightBarButtonItems.append(buttonItem)
+        rightBarButtonItems.append(addProductButton)
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.barcodeScanner) && UIImagePickerController.isSourceTypeAvailable(.camera) {
             let buttonItem: UIBarButtonItem = {


### PR DESCRIPTION
Closes: #7998

## Description

Tapping the "Add a Product" CTA on the products onboarding banner now starts the add product flow, instead of just taking you to the Products tab.

## Changes

Tapping the CTA now calls `MainTabBarController.presentAddProductFlow()`; this navigates to the products tab and starts the add product flow with a new public method `ProductsViewController.addProduct()`.

This method relies on the add product nav bar button in `ProductsViewController` because the [`addProduct(sourceBarButtonItem:sourceView:)`](https://github.com/woocommerce/woocommerce-ios/blob/a9d2501b0a525084004deafc4e7235593af9587e/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift#L256) method it calls requires a source button or view, which is used as the source for the popover on iPad.

## Testing

1. Build and run app on debug/alpha mode.
2. Select a store with no products.
3. When the onboarding banner appears, tap the "Add a Product" CTA. Confirm you are redirected to the Products tab and the add product flow begins (in debug mode, the "How do you want to start?" bottom sheet appears).

## Screenshots

https://user-images.githubusercontent.com/8658164/199238902-c772eb95-0dcc-4ca0-a3be-f921b0540c06.mp4


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
