### PR TITLE
[Just In Time Messages] Dismiss JITM

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		0359EA2127AAE58C0048DE2D /* wcpay-charge-card-present.json in Resources */ = {isa = PBXBuildFile; fileRef = 0359EA2027AAE58C0048DE2D /* wcpay-charge-card-present.json */; };
 		0359EA2527AAF7D60048DE2D /* wcpay-charge-card.json in Resources */ = {isa = PBXBuildFile; fileRef = 0359EA2427AAF7D60048DE2D /* wcpay-charge-card.json */; };
 		0359EA2927AC2AAD0048DE2D /* wcpay-charge-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 0359EA2827AC2AAD0048DE2D /* wcpay-charge-error.json */; };
+		035BA3AA29113CBD0056F0AD /* DataBoolMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035BA3A929113CBD0056F0AD /* DataBoolMapper.swift */; };
 		036563DB2906938600D84BFD /* JustInTimeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036563DA2906938600D84BFD /* JustInTimeMessage.swift */; };
 		036563DD29069BE400D84BFD /* JustInTimeMessageListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036563DC29069BE400D84BFD /* JustInTimeMessageListMapper.swift */; };
 		036563DF29069C8F00D84BFD /* JustInTimeMessageListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036563DE29069C8F00D84BFD /* JustInTimeMessageListMapperTests.swift */; };
@@ -835,6 +836,7 @@
 		0359EA2027AAE58C0048DE2D /* wcpay-charge-card-present.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-card-present.json"; sourceTree = "<group>"; };
 		0359EA2427AAF7D60048DE2D /* wcpay-charge-card.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-card.json"; sourceTree = "<group>"; };
 		0359EA2827AC2AAD0048DE2D /* wcpay-charge-error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wcpay-charge-error.json"; sourceTree = "<group>"; };
+		035BA3A929113CBD0056F0AD /* DataBoolMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBoolMapper.swift; sourceTree = "<group>"; };
 		036563DA2906938600D84BFD /* JustInTimeMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessage.swift; sourceTree = "<group>"; };
 		036563DC29069BE400D84BFD /* JustInTimeMessageListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessageListMapper.swift; sourceTree = "<group>"; };
 		036563DE29069C8F00D84BFD /* JustInTimeMessageListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessageListMapperTests.swift; sourceTree = "<group>"; };
@@ -2219,6 +2221,7 @@
 				03DCB785262739D200C8953D /* CouponMapper.swift */,
 				DE2095BE279583A100171F1C /* CouponReportListMapper.swift */,
 				45150A9D26836A57006922EA /* CountryListMapper.swift */,
+				035BA3A929113CBD0056F0AD /* DataBoolMapper.swift */,
 				B524193E21AC5FE400D6FC0A /* DotcomDeviceMapper.swift */,
 				2676F4CD290AE6BB00C7A15B /* EntityIDMapper.swift */,
 				24F98C572502EA8800F49B68 /* FeatureFlagMapper.swift */,
@@ -3161,6 +3164,7 @@
 				B963A5CC2853870000EFADA0 /* OrderItemRefundMetaData.swift in Sources */,
 				E18152BE28F85B5B0011A0EC /* InAppPurchasesRemote.swift in Sources */,
 				0329CF9B27A82E19008AFF91 /* WCPayCharge.swift in Sources */,
+				035BA3AA29113CBD0056F0AD /* DataBoolMapper.swift in Sources */,
 				74749B97224134FF005C4CF2 /* ProductMapper.swift in Sources */,
 				26455E2A25F669F0008A1D32 /* ProductAttributeTermMapper.swift in Sources */,
 				0359EA1127AAC6740048DE2D /* WCPayPaymentMethodType.swift in Sources */,

--- a/Networking/Networking/Mapper/DataBoolMapper.swift
+++ b/Networking/Networking/Mapper/DataBoolMapper.swift
@@ -1,23 +1,19 @@
 import Foundation
 
-import Foundation
-
-
-/// Mapper: Success Result Wrapped in `data` Key
+/// Mapper: Bool Result Wrapped in `data` Key
 ///
 struct DataBoolMapper: Mapper {
 
-    /// (Attempts) to extract the `success` flag from a given JSON Encoded response.
+    /// (Attempts) to extract the boolean flag from a given JSON Encoded response.
     ///
     func map(response: Data) throws -> Bool {
         try JSONDecoder().decode(DataBool.self, from: response).data
     }
 }
 
-
-/// SuccessDataResultEnvelope Disposable Entity
+/// DataBoolResultEnvelope Disposable Entity
 ///
-/// Some endpoints return a "success" response in the `data` key. This entity
+/// Some endpoints return a Bool response in the `data` key. This entity
 /// allows us to parse that response with JSONDecoder.
 ///
 private struct DataBool: Decodable {

--- a/Networking/Networking/Mapper/DataBoolMapper.swift
+++ b/Networking/Networking/Mapper/DataBoolMapper.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+import Foundation
+
+
+/// Mapper: Success Result Wrapped in `data` Key
+///
+struct DataBoolMapper: Mapper {
+
+    /// (Attempts) to extract the `success` flag from a given JSON Encoded response.
+    ///
+    func map(response: Data) throws -> Bool {
+        try JSONDecoder().decode(DataBool.self, from: response).data
+    }
+}
+
+
+/// SuccessDataResultEnvelope Disposable Entity
+///
+/// Some endpoints return a "success" response in the `data` key. This entity
+/// allows us to parse that response with JSONDecoder.
+///
+private struct DataBool: Decodable {
+    let data: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -639,6 +639,40 @@ extension WooAnalyticsEvent {
                                 Keys.justInTimeMessageGroup: featureClass
                               ])
         }
+
+        static func dismissTapped(source: String,
+                                  messageID: String,
+                                  featureClass: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .justInTimeMessageDismissTapped,
+                              properties: [
+                                Keys.source: source,
+                                Keys.justInTimeMessageID: messageID,
+                                Keys.justInTimeMessageGroup: featureClass
+                              ])
+        }
+
+        static func dismissSuccess(source: String,
+                                  messageID: String,
+                                  featureClass: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .justInTimeMessageDismissSuccess, properties: [
+                Keys.source: source,
+                Keys.justInTimeMessageID: messageID,
+                Keys.justInTimeMessageGroup: featureClass
+              ])
+        }
+
+        static func dismissFailure(source: String,
+                                   messageID: String,
+                                   featureClass: String,
+                                   error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .justInTimeMessageDismissFailure,
+                              properties: [
+                                Keys.source: source,
+                                Keys.justInTimeMessageID: messageID,
+                                Keys.justInTimeMessageGroup: featureClass
+                              ],
+                              error: error)
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -629,6 +629,9 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Just In Time Messages events
     case justInTimeMessageCallToActionTapped = "jitm_cta_tapped"
+    case justInTimeMessageDismissTapped = "jitm_dismissed"
+    case justInTimeMessageDismissSuccess = "jitm_dismiss_success"
+    case justInTimeMessageDismissFailure = "jitm_dismiss_failure"
 
     // MARK: Simple Payments events
     //

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModel.swift
@@ -102,8 +102,10 @@ final class JustInTimeMessageAnnouncementCardViewModel: AnnouncementCardViewMode
                                                                 featureClass: featureClass))
         let action = JustInTimeMessageAction.dismissMessage(justInTimeMessage,
                                                             siteID: siteID,
-                                                            completion: { [weak self] result in
-            guard let self = self else { return }
+                                                            completion: { result in
+            // We deliberately strongly capture self here: the owning reference to the VM may have been
+            // set to nil by now, in order to stop displaying the Just In Time Message.
+            // [weak self] will result in these two analytics never being logged.
             switch result {
             case .success(_):
                 self.analytics.track(event: .JustInTimeMessage.dismissSuccess(

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModel.swift
@@ -9,6 +9,10 @@ final class JustInTimeMessageAnnouncementCardViewModel: AnnouncementCardViewMode
 
     private let analytics: Analytics
 
+    private let stores: StoresManager
+
+    private let justInTimeMessage: YosemiteJustInTimeMessage
+
     // MARK: - Message properties
     let title: String
 
@@ -27,9 +31,11 @@ final class JustInTimeMessageAnnouncementCardViewModel: AnnouncementCardViewMode
     init(justInTimeMessage: YosemiteJustInTimeMessage,
          screenName: String,
          siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.analytics = analytics
+        self.stores = stores
         let utmProvider = WooCommerceComUTMProvider(
             campaign: "jitm_group_\(justInTimeMessage.featureClass)",
             source: screenName,
@@ -38,6 +44,7 @@ final class JustInTimeMessageAnnouncementCardViewModel: AnnouncementCardViewMode
         self.url = utmProvider.urlWithUtmParams(string: justInTimeMessage.url)
         self.messageID = justInTimeMessage.messageID
         self.featureClass = justInTimeMessage.featureClass
+        self.justInTimeMessage = justInTimeMessage
         self.screenName = screenName
         self.title = justInTimeMessage.title
         self.message = justInTimeMessage.detail
@@ -91,7 +98,10 @@ final class JustInTimeMessageAnnouncementCardViewModel: AnnouncementCardViewMode
     }
 
     func dontShowAgainTapped() {
-        // No-op
+        let action = JustInTimeMessageAction.dismissMessage(justInTimeMessage,
+                                                            siteID: siteID,
+                                                            completion: { _ in })
+        stores.dispatch(action)
     }
 
     func remindLaterTapped() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -317,9 +317,12 @@ private extension DashboardViewController {
                 return
             }
 
-            let cardView = FeatureAnnouncementCardView(viewModel: viewModel,
-                                                       dismiss: {},
-                                                       callToAction: {})
+            let cardView = FeatureAnnouncementCardView(
+                viewModel: viewModel,
+                dismiss: { [weak self] in
+                    self?.viewModel.announcementViewModel = nil
+                },
+                callToAction: {})
 
             self.showAnnouncement(AnnouncementCardWrapper(cardView: cardView))
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -8,7 +8,7 @@ final class DashboardViewModel {
     /// Stats v4 is shown by default, then falls back to v3 if store stats are unavailable.
     @Published private(set) var statsVersion: StatsVersion = .v4
 
-    @Published private(set) var announcementViewModel: AnnouncementCardViewModelProtocol? = nil
+    @Published var announcementViewModel: AnnouncementCardViewModelProtocol? = nil
 
     @Published private(set) var showWebViewSheet: WebViewSheetViewModel? = nil
 

--- a/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModelTests.swift
@@ -178,11 +178,14 @@ final class JustInTimeMessageAnnouncementCardViewModelTests: XCTestCase {
     }
 
     private func assertAnalyticEventLogged(name: String, expectedProperties: [String: String]) {
-        guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: name)
+        guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: name),
+              let properties = analyticsProvider.receivedProperties[eventIndex] as? [String: AnyHashable]
         else {
             return XCTFail("Analytics not logged")
         }
-        let properties = analyticsProvider.receivedProperties[eventIndex] as? [String: String]
-        assertEqual(expectedProperties, properties)
+
+        for property in expectedProperties {
+            XCTAssert(properties.contains(where: { $0 == property }))
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModelTests.swift
@@ -3,6 +3,7 @@ import TestKit
 import Fakes
 import Yosemite
 import Combine
+import Networking
 
 @testable import WooCommerce
 
@@ -11,6 +12,7 @@ final class JustInTimeMessageAnnouncementCardViewModelTests: XCTestCase {
     private var webviewPublishes: [WebViewSheetViewModel]!
     private var analyticsProvider: MockAnalyticsProvider!
     private var analytics: Analytics!
+    private var stores: MockStoresManager!
     private var sut: JustInTimeMessageAnnouncementCardViewModel!
 
     override func setUp() {
@@ -18,12 +20,14 @@ final class JustInTimeMessageAnnouncementCardViewModelTests: XCTestCase {
         webviewPublishes = [WebViewSheetViewModel]()
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        stores = MockStoresManager(sessionManager: .makeForTesting())
     }
 
     func setUp(with message: YosemiteJustInTimeMessage) {
         sut = JustInTimeMessageAnnouncementCardViewModel(justInTimeMessage: message,
                                                          screenName: "my_store",
                                                          siteID: 1234,
+                                                         stores: stores,
                                                          analytics: analytics)
 
         sut.$showWebViewSheet
@@ -90,21 +94,95 @@ final class JustInTimeMessageAnnouncementCardViewModelTests: XCTestCase {
     }
 
     func test_ctaTapped_tracks_jitm_cta_tapped_event() {
-        // Given
-        setUp(with: YosemiteJustInTimeMessage.fake().copy(messageID: "test-message-id", featureClass: "test-feature-class"))
+        let message = YosemiteJustInTimeMessage.fake().copy(messageID: "test-message-id", featureClass: "test-feature-class")
+        setUp(with: message)
 
         // When
         sut.ctaTapped()
 
         // Then
-        guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: "jitm_cta_tapped")
+        assertAnalyticEventLogged(name: "jitm_cta_tapped", message: message)
+    }
+
+    func test_dismiss_tracks_jitm_dismissed_event() {
+        // Given
+        let message = YosemiteJustInTimeMessage.fake().copy(messageID: "test-message-id", featureClass: "test-feature-class")
+        setUp(with: message)
+
+        // When
+        sut.dontShowAgainTapped()
+
+        // Then
+        assertAnalyticEventLogged(name: "jitm_dismissed", message: message)
+    }
+
+    func test_success_response_on_dismissal_tracks_jitm_dismiss_success_event() {
+        // Given
+        let message = YosemiteJustInTimeMessage.fake().copy(messageID: "test-message-id", featureClass: "test-feature-class")
+        setUp(with: message)
+
+        stores.whenReceivingAction(ofType: JustInTimeMessageAction.self) { action in
+            switch action {
+            case .dismissMessage(_, _, let completion):
+                completion(Result.success(true))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        sut.dontShowAgainTapped()
+
+        // Then
+        assertAnalyticEventLogged(name: "jitm_dismiss_success", message: message)
+    }
+
+    func test_failed_response_on_dismissal_tracks_jitm_dismiss_failed_event() {
+        // Given
+        let message = YosemiteJustInTimeMessage.fake().copy(messageID: "test-message-id", featureClass: "test-feature-class")
+        setUp(with: message)
+        let expectedError = DotcomError.resourceDoesNotExist as NSError
+
+        stores.whenReceivingAction(ofType: JustInTimeMessageAction.self) { action in
+            switch action {
+            case .dismissMessage(_, _, let completion):
+                completion(Result.failure(expectedError))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+
+        // When
+        sut.dontShowAgainTapped()
+
+        // Then
+        assertAnalyticEventLogged(name: "jitm_dismiss_failure", message: message, error: expectedError)
+    }
+
+    private func assertAnalyticEventLogged(name: String, message: YosemiteJustInTimeMessage) {
+        let expectedProperties = ["jitm_id": message.messageID,
+                                  "jitm_group": message.featureClass,
+                                  "source": "my_store"]
+        assertAnalyticEventLogged(name: name, expectedProperties: expectedProperties)
+    }
+
+    private func assertAnalyticEventLogged(name: String, message: YosemiteJustInTimeMessage, error: Error) {
+        let error = error as NSError
+        let expectedProperties = ["jitm_id": message.messageID,
+                                  "jitm_group": message.featureClass,
+                                  "source": "my_store",
+                                  "error_domain": String(error.domain),
+                                  "error_description": error.debugDescription,
+                                  "error_code": String(error.code)]
+        assertAnalyticEventLogged(name: name, expectedProperties: expectedProperties)
+    }
+
+    private func assertAnalyticEventLogged(name: String, expectedProperties: [String: String]) {
+        guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: name)
         else {
             return XCTFail("Analytics not logged")
         }
         let properties = analyticsProvider.receivedProperties[eventIndex] as? [String: String]
-        let expectedProperties = ["jitm_id": "test-message-id",
-                                  "jitm_group": "test-feature-class",
-                                  "source": "my_store"]
         assertEqual(expectedProperties, properties)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -96,6 +96,8 @@ final class DashboardViewModelTests: XCTestCase {
             switch action {
             case let .loadMessage(_, _, _, completion):
                 completion(.success(YosemiteJustInTimeMessage.fake()))
+            default:
+                XCTFail("Received unsupported action: \(action)")
             }
         }
         let viewModel = DashboardViewModel(stores: stores)
@@ -122,6 +124,8 @@ final class DashboardViewModelTests: XCTestCase {
             switch action {
             case let .loadMessage(_, _, _, completion):
                 completion(.success(YosemiteJustInTimeMessage.fake().copy(title: "JITM Message")))
+            default:
+                XCTFail("Received unsupported action: \(action)")
             }
         }
         let viewModel = DashboardViewModel(stores: stores)
@@ -148,6 +152,8 @@ final class DashboardViewModelTests: XCTestCase {
             switch action {
             case let .loadMessage(_, _, _, completion):
                 completion(.success(nil))
+            default:
+                XCTFail("Received unsupported action: \(action)")
             }
         }
         let viewModel = DashboardViewModel(stores: stores)
@@ -174,6 +180,8 @@ final class DashboardViewModelTests: XCTestCase {
             switch action {
             case let .loadMessage(_, _, _, completion):
                 completion(.success(YosemiteJustInTimeMessage.fake()))
+            default:
+                XCTFail("Received unsupported action: \(action)")
             }
         }
         let viewModel = DashboardViewModel(stores: stores, featureFlags: MockFeatureFlagService())

--- a/Yosemite/Yosemite/Actions/JustInTimeMessageAction.swift
+++ b/Yosemite/Yosemite/Actions/JustInTimeMessageAction.swift
@@ -9,4 +9,10 @@ public enum JustInTimeMessageAction: Action {
                      screen: String,
                      hook: JustInTimeMessageHook,
                      completion: (Result<YosemiteJustInTimeMessage?, Error>) -> ())
+
+    /// Dismisses a `JustInTimeMessage` and others for the same `featureClass`
+    ///
+    case dismissMessage(_ message: YosemiteJustInTimeMessage,
+                        siteID: Int64,
+                        completion: (Result<Bool, Error>) -> ())
 }

--- a/Yosemite/Yosemite/Stores/JustInTimeMessageStore.swift
+++ b/Yosemite/Yosemite/Stores/JustInTimeMessageStore.swift
@@ -30,6 +30,8 @@ public class JustInTimeMessageStore: Store {
         switch action {
         case .loadMessage(let siteID, let screen, let hook, let completion):
             loadMessage(for: siteID, screen: screen, hook: hook, completion: completion)
+        case .dismissMessage(let message, let siteID, let completion):
+            dismissMessage(message, for: siteID, completion: completion)
         }
     }
 }
@@ -56,10 +58,23 @@ private extension JustInTimeMessageStore {
         }
     }
 
-    private func topDisplayMessage(_ messages: [Networking.JustInTimeMessage]) -> YosemiteJustInTimeMessage? {
+    func topDisplayMessage(_ messages: [Networking.JustInTimeMessage]) -> YosemiteJustInTimeMessage? {
         guard let topMessage = messages.first else {
             return nil
         }
         return YosemiteJustInTimeMessage(message: topMessage)
+    }
+
+    func dismissMessage(_ message: YosemiteJustInTimeMessage,
+                        for siteID: Int64,
+                        completion: @escaping (Result<Bool, Error>) -> ()) {
+        Task {
+            let result = await remote.dismissJustInTimeMessage(for: siteID,
+                                                               messageID: message.messageID,
+                                                               featureClass: message.featureClass)
+            await MainActor.run {
+                completion(result)
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7854
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We've added the ability to show a Just In Time Message at the top of the dashboard in #7853. Just In Time Messages can be dismissed; when they are, that should be communicated back to Jetpack via the REST API, and the dismissal is noted there.

After a message has been dismissed, the rules for whether it should be displayed will take that in to account. The message can have a number of dismissals defined, and a duration between those dismissals. By default, after being dismissed a message will be shown again six weeks later, and if it's dismissed a second time, it won't be shown again.

This PR implements the dismiss behaviour and analytics on our JITM.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

N.B. see pdfdoF-1uc-p2#comment-2581 for details of setting up your store to be eligible for the test JITM

The test JITM uses unrealistic dismissal rules to make testing easier. There are 1000 dismissals possible, and the dismissal only lasts 30 seconds. With this JITM it's not really possible to check that the JITM isn't shown again after the dismissal limit is reached, but that isn't the app's responsibility. We can test this once we make the JITM production-ready and set the dismissal limit to a sensible value.

With a US store that is eligible for the test JITM, on a debug/alpha build of the app

### Dismissal request is sent
1. Set up Proxyman or Charles to observe network requests
2. Open the app
3. Observe that the message is shown
4. Tap the `x`
5. Observe that the message is removed
6. Observe in Proxyman/Charles that a POST request has been made to the correct store ID with the following payload:
```
body={"feature_class":"woomobile_ipp","id":"woomobile_ipp_barcode_users"}
json=true
path=/jetpack/v4/jitm&_method=post
```

### Dismissal is effective
1. Repeat the above steps up to 5
2. Quit and relaunch the app by flicking it out of the app switcher, within 30 seconds of dismissing
3. Observe that the message is not shown
4. Quit and relaunch again after 30s has passed
5. Observe that the message is shown again.

### Analytics

1. Repeat the steps to dismiss the JITM
2. Observe in the debug output that the `woocommerceios_jitm_dismiss_success` and `woocommerceios_jitm_dismissed` events are tracked with the following properties:

- [ ] `*_jitm_dismissed` event with props `jitm_group: woomobile_ipp`, `jitm_id: woomobile_ipp_barcode_users`, `source: my_store`
- [ ] Track `*_jitm_dismiss_success` event with props `jitm_group: woomobile_ipp`, `jitm_id: woomobile_ipp_barcode_users`, `source: my_store`

1. Set up Proxyman or Charles with a breakpoint on `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{siteid}/rest-api/`, for POST requests only.
2. Repeat the steps to dismiss the JITM
3. When you reach your Proxyman/Charles breakpoint, abort the request
4. Observe that the failure event below is tracked correctly.

- [ ] `*_jitm_dismiss_failure` event with props `jitm_group: woomobile_ipp`, `jitm_id: woomobile_ipp_barcode_users`, `source: my_store` and error props

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="847" alt="Analytics debug print output" src="https://user-images.githubusercontent.com/2472348/199287403-9bee283c-80f3-449c-8095-43f4bdb6156c.png">

https://user-images.githubusercontent.com/2472348/199293020-ffe840c7-9f93-4e79-82fd-3aa9474f6f98.mp4

<img width="542" alt="Dismissed event in Tracks live view" src="https://user-images.githubusercontent.com/2472348/199298713-951a9cda-dd00-4ac3-9ef2-f48303cc90f6.png">

<img width="614" alt="Dismiss success event in Tracks live view" src="https://user-images.githubusercontent.com/2472348/199298720-55518570-8acf-4bc7-b593-fe973a706b42.png">

<img width="1376" alt="Dismiss failure event in Tracks live view" src="https://user-images.githubusercontent.com/2472348/199298702-3536d1ce-782d-4321-be0b-0d31522b582d.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
