### PR TITLE
Products Onboarding: Support template products

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -152,7 +152,8 @@ private extension AddProductCoordinator {
 
             switch result {
             case .success(let product):
-                self.presentProduct(product, formType: .edit) // We need to strongly capture `self` because no one is retaining `AddProductCoordinator`.
+                let newProduct = ProductFactory().newProduct(from: product) // Transforms the auto-draft product into a new product ready to be used.
+                self.presentProduct(newProduct) // We need to strongly capture `self` because no one is retaining `AddProductCoordinator`.
 
             case .failure(let error):
                 // Log error and inform the user
@@ -177,12 +178,12 @@ private extension AddProductCoordinator {
             assertionFailure("Unable to create product of type: \(bottomSheetProductType)")
             return
         }
-        presentProduct(product, formType: .add)
+        presentProduct(product)
     }
 
     /// Presents a product onto the current navigation stack.
     ///
-    func presentProduct(_ product: Product, formType: ProductFormType) {
+    func presentProduct(_ product: Product) {
         let model = EditableProductModel(product: product)
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
@@ -192,7 +193,7 @@ private extension AddProductCoordinator {
                                       isLocalID: true),
                            originalStatuses: model.imageStatuses)
         let viewModel = ProductFormViewModel(product: model,
-                                             formType: formType,
+                                             formType: .add,
                                              productImageActionHandler: productImageActionHandler)
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        eventLogger: ProductFormEventLogger(),

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
@@ -16,6 +16,13 @@ struct ProductFactory {
             return nil
         }
     }
+
+    /// Copies a product by cleaning properties like `id, name, and statusKey` to their default state.
+    /// This is usefult to turn an existing(on core) `auto-draft` product into a new app-product ready to be saved.
+    ///
+    func newProduct(from existingProduct: Product) -> Product {
+        existingProduct.copy(productID: 0, name: "", statusKey: ProductStatus.published.rawValue)
+    }
 }
 
 private extension ProductFactory {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/ProductFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/ProductFactoryTests.swift
@@ -1,4 +1,6 @@
 import XCTest
+import Fakes
+import Networking
 @testable import WooCommerce
 
 final class ProductFactoryTests: XCTestCase {
@@ -39,5 +41,24 @@ final class ProductFactoryTests: XCTestCase {
     func test_creating_a_non_core_product_returns_nil() {
         let product = ProductFactory().createNewProduct(type: .custom("any"), isVirtual: false, siteID: siteID)
         XCTAssertNil(product)
+    }
+
+    func test_creating_new_product_removes_expected_fields() {
+        // Given
+        let product = Product.fake().copy(siteID: 123, productID: 1234, name: "Test Product", statusKey: ProductStatus.autoDraft.rawValue, price: "20.00")
+
+        // When
+        let newProduct = ProductFactory().newProduct(from: product)
+
+        // Then
+
+        // Stay the same
+        XCTAssertEqual(newProduct.siteID, product.siteID)
+        XCTAssertEqual(newProduct.price, product.price)
+
+        // Changes
+        XCTAssertEqual(newProduct.productID, 0)
+        XCTAssertEqual(newProduct.name, "")
+        XCTAssertEqual(newProduct.statusKey, ProductStatus.published.rawValue)
     }
 }


### PR DESCRIPTION
Closes:  #7949 

# Why 

This PR makes sure that a template product can be used within the product form as it was manually populated by the merchant.

# How

Instead of taking the long route and adding full auto-draft support to our product form module, I've taken a shortcut where after getting a template product, which has an `auto-draft` status, the app removes that product identity (id, name and status) so it's treated like a new product but with all the necessary content prefilled.

We can evaluate later if full auto-draft support is needed.

# Demo

https://user-images.githubusercontent.com/562080/199324991-5b039102-c35c-4a4b-a75c-cc49c6fbd5a2.mov

# Testing Steps

- On a store with less than 3 products, tap the add product button
- Select the "Template" option and a product type.
- See that you can modify, save or publish the template product.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
