### PR TITLE
Account creation: design polishes - add a button to show/hide text field input for a secure field

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
@@ -24,14 +24,14 @@ struct AccountCreationFormFieldView: View {
 
     /// Whether the text field is *shown* as secure.
     /// When the field is secure, there is a button to show/hide the text field input.
-    @State private var isTextFieldSecure: Bool = true
+    @State private var showsSecureInput: Bool = true
 
     // Tracks the scale of the view due to accessibility changes.
     @ScaledMetric private var scale: CGFloat = 1.0
 
     init(viewModel: AccountCreationFormFieldViewModel) {
         self.viewModel = viewModel
-        self.isTextFieldSecure = viewModel.isSecure
+        self.showsSecureInput = viewModel.isSecure
     }
 
     var body: some View {
@@ -42,7 +42,7 @@ struct AccountCreationFormFieldView: View {
                 ZStack(alignment: .trailing) {
                     // Text field based on the `isTextFieldSecure` state.
                     Group {
-                        if isTextFieldSecure {
+                        if showsSecureInput {
                             SecureField(viewModel.placeholder, text: viewModel.text)
                         } else {
                             TextField(viewModel.placeholder, text: viewModel.text)
@@ -61,9 +61,9 @@ struct AccountCreationFormFieldView: View {
 
                     // Button to show/hide the text field content.
                     Button(action: {
-                        isTextFieldSecure.toggle()
+                        showsSecureInput.toggle()
                     }) {
-                        Image(systemName: isTextFieldSecure ? "eye.slash" : "eye")
+                        Image(systemName: showsSecureInput ? "eye.slash" : "eye")
                             .accentColor(.gray)
                             .frame(width: Layout.secureFieldRevealButtonDimension * scale,
                                    height: Layout.secureFieldRevealButtonDimension * scale)

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
@@ -64,7 +64,7 @@ struct AccountCreationFormFieldView: View {
                         showsSecureInput.toggle()
                     }) {
                         Image(systemName: showsSecureInput ? "eye.slash" : "eye")
-                            .accentColor(.gray)
+                            .accentColor(Color(.textSubtle))
                             .frame(width: Layout.secureFieldRevealButtonDimension * scale,
                                    height: Layout.secureFieldRevealButtonDimension * scale)
                             .padding(.leading, Layout.secureFieldRevealButtonHorizontalPadding)

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
@@ -55,8 +55,9 @@ struct AccountCreationFormFieldView: View {
                         insets: .init(top: RoundedBorderTextFieldStyle.Defaults.insets.top,
                                       leading: RoundedBorderTextFieldStyle.Defaults.insets.leading,
                                       bottom: RoundedBorderTextFieldStyle.Defaults.insets.bottom,
-                                      trailing: Layout.secureFieldRevealButtonHorizontalPadding * 2 + Layout.secureFieldRevealButtonDimension * scale))
-                    )
+                                      trailing: Layout.secureFieldRevealButtonHorizontalPadding * 2 + Layout.secureFieldRevealButtonDimension * scale),
+                        height: 44 * scale
+                    ))
                     .keyboardType(viewModel.keyboardType)
 
                     // Button to show/hide the text field content.
@@ -101,13 +102,24 @@ struct AccountCreationFormField_Previews: PreviewProvider {
                                                       isSecure: false,
                                                       errorMessage: nil,
                                                       isFocused: true))
-        AccountCreationFormFieldView(viewModel: .init(header: "Choose a password",
-                                                      placeholder: "Password",
-                                                      keyboardType: .default,
-                                                      text: .constant("wwwwwwwwwwwwwwwwwwwwwwww"),
-                                                      isSecure: true,
-                                                      errorMessage: "Too simple",
-                                                      isFocused: false))
-        .environment(\.sizeCategory, .extraExtraExtraLarge)
+        VStack {
+            AccountCreationFormFieldView(viewModel: .init(header: "Choose a password",
+                                                          placeholder: "Password",
+                                                          keyboardType: .default,
+                                                          text: .constant("wwwwwwwwwwwwwwwwwwwwwwww"),
+                                                          isSecure: true,
+                                                          errorMessage: "Too simple",
+                                                          isFocused: false))
+            .environment(\.sizeCategory, .medium)
+
+            AccountCreationFormFieldView(viewModel: .init(header: "Choose a password",
+                                                          placeholder: "Password",
+                                                          keyboardType: .default,
+                                                          text: .constant("wwwwwwwwwwwwwwwwwwwwwwww"),
+                                                          isSecure: true,
+                                                          errorMessage: "Too simple",
+                                                          isFocused: false))
+            .environment(\.sizeCategory, .extraExtraExtraLarge)
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
@@ -6,15 +6,24 @@ struct RoundedBorderTextFieldStyle: TextFieldStyle {
     private let focusedBorderColor: Color
     private let unfocusedBorderColor: Color
     private let insets: EdgeInsets
+    private let height: CGFloat?
 
+    /// - Parameters:
+    ///   - focused: Whether the field is focused or not.
+    ///   - focusedBorderColor: The border color when the field is focused.
+    ///   - unfocusedBorderColor: The border color when the field is not focused.
+    ///   - insets: The insets between the background border and the text input.
+    ///   - height: An optional fixed height for the field.
     init(focused: Bool,
          focusedBorderColor: Color = Defaults.focusedBorderColor,
          unfocusedBorderColor: Color = Defaults.unfocusedBorderColor,
-         insets: EdgeInsets = Defaults.insets) {
+         insets: EdgeInsets = Defaults.insets,
+         height: CGFloat? = nil) {
         self.focused = focused
         self.focusedBorderColor = focusedBorderColor
         self.unfocusedBorderColor = unfocusedBorderColor
         self.insets = insets
+        self.height = height
     }
 
     func _body(configuration: TextField<Self._Label>) -> some View {
@@ -24,7 +33,9 @@ struct RoundedBorderTextFieldStyle: TextFieldStyle {
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .stroke(focused ? focusedBorderColor: unfocusedBorderColor,
                             lineWidth: focused ? 2: 1)
+                    .frame(height: height)
             )
+            .frame(height: height)
     }
 }
 
@@ -51,6 +62,20 @@ struct TextFieldStyles_Previews: PreviewProvider {
             TextField("placeholder", text: .constant("custom insets"))
                 .textFieldStyle(RoundedBorderTextFieldStyle(focused: false, insets: .init(top: 20, leading: 0, bottom: 10, trailing: 50)))
                 .frame(width: 150)
+            HStack {
+                TextField("placeholder", text: .constant("text field"))
+                    .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+                SecureField("placeholder", text: .constant("secure"))
+                    .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+            }
+            .environment(\.sizeCategory, .extraExtraExtraLarge)
+            HStack {
+                TextField("placeholder", text: .constant("text field"))
+                    .textFieldStyle(RoundedBorderTextFieldStyle(focused: true, height: 100))
+                SecureField("placeholder", text: .constant("secure"))
+                    .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+            }
+            .environment(\.sizeCategory, .extraExtraExtraLarge)
         }
         .preferredColorScheme(.dark)
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TextFieldStyles.swift
@@ -2,15 +2,27 @@ import SwiftUI
 
 /// Text field has a rounded border that has a thicker border and brighter border color when the field is focused.
 struct RoundedBorderTextFieldStyle: TextFieldStyle {
-    let focused: Bool
+    private let focused: Bool
+    private let insets: EdgeInsets
+
+    init(focused: Bool, insets: EdgeInsets = Defaults.insets) {
+        self.focused = focused
+        self.insets = insets
+    }
 
     func _body(configuration: TextField<Self._Label>) -> some View {
         configuration
-            .padding(10)
+            .padding(insets)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .stroke(focused ? Color(.brand): Color.gray,
                             lineWidth: focused ? 2: 1)
             )
+    }
+}
+
+extension RoundedBorderTextFieldStyle {
+    enum Defaults {
+        static let insets = EdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7891
Based on https://github.com/woocommerce/woocommerce-ios/pull/7995 just for easier testing
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To follow the design for the password field, this PR added an 👁️ button to `AccountCreationFormFieldView` when the view model's `isSecure` is `true`. Tapping on the button shows/hides the secure input. Because of the rounded border design, the reveal button has to be added using a `ZStack` with some custom insets to the text field style and button image size using `@ScaledMetric` for dynamic type.

One minor issue I noticed is the slight height change between the shown/hidden state. Please feel free to share any suggestions to fix it!

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app
- Log out and skip onboarding if needed
- Tap `Create a Store` --> there should be an 👁️/ icon with a slash in the password field
- Enter some text into the password field
- Tap on the 👁️ / icon --> the password input should be shown, and the icon becomes 👁️ without a slash

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

secure input hidden | secure input shown
-- | --
![Simulator Screen Shot - iPhone 14 - 2022-11-02 at 09 48 59](https://user-images.githubusercontent.com/1945542/199375628-819a51c8-5283-4282-94e6-4378567275b2.png) | ![Simulator Screen Shot - iPhone 14 - 2022-11-02 at 09 49 14](https://user-images.githubusercontent.com/1945542/199375635-bd451211-f738-4fdd-b63e-0b402d80d937.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
