### PR TITLE
Account creation: design polishes - update ToS link style to an underline, font/color updates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -112,7 +112,7 @@ struct AccountCreationForm: View {
 
                     // Terms of Service link.
                     AttributedText(tosAttributedText, enablesLinkUnderline: true)
-                        .attributedTextLinkColor(Color(.label))
+                        .attributedTextLinkColor(Color(.secondaryLabel))
                         .environment(\.customOpenURL) { url in
                             tosURL = url
                         }
@@ -146,8 +146,8 @@ private extension AccountCreationForm {
         let result = NSMutableAttributedString(
             string: .localizedStringWithFormat(Localization.tosFormat, Localization.tos),
             attributes: [
-                .foregroundColor: UIColor.label,
-                .font: UIFont.body
+                .foregroundColor: UIColor.secondaryLabel,
+                .font: UIFont.caption1
             ]
         )
         result.replaceFirstOccurrence(
@@ -155,7 +155,7 @@ private extension AccountCreationForm {
             with: NSAttributedString(
                 string: Localization.tos,
                 attributes: [
-                    .font: UIFont.body,
+                    .font: UIFont.caption1,
                     .link: Constants.tosURL,
                     .underlineStyle: NSUnderlineStyle.single.rawValue
                 ]

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -111,8 +111,8 @@ struct AccountCreationForm: View {
                     .disabled(isPerformingTask)
 
                     // Terms of Service link.
-                    AttributedText(tosAttributedText)
-                        .attributedTextLinkColor(Color(.textLink))
+                    AttributedText(tosAttributedText, enablesLinkUnderline: true)
+                        .attributedTextLinkColor(Color(.label))
                         .environment(\.customOpenURL) { url in
                             tosURL = url
                         }
@@ -156,7 +156,8 @@ private extension AccountCreationForm {
                 string: Localization.tos,
                 attributes: [
                     .font: UIFont.body,
-                    .link: Constants.tosURL
+                    .link: Constants.tosURL,
+                    .underlineStyle: NSUnderlineStyle.single.rawValue
                 ]
             ))
         return result

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
@@ -29,6 +29,7 @@ struct AccountCreationFormFieldView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
             Text(viewModel.header)
+                .foregroundColor(Color(.label))
                 .subheadlineStyle()
             if viewModel.isSecure {
                 SecureField(viewModel.placeholder, text: viewModel.text)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AttributedText.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AttributedText.swift
@@ -32,10 +32,17 @@ struct AttributedText: View {
     private var textViewStore = TextViewStore()
     @State private var textSize: CGSize?
 
-    let attributedText: NSAttributedString
+    private let attributedText: NSAttributedString
 
-    init(_ attributedText: NSAttributedString) {
+    private let enablesLinkUnderline: Bool
+
+    /// - Parameters:
+    ///   - attributedText: The attributed text to be shown.
+    ///   - enablesLinkUnderline: If disabled, the underline color is set to clear to hide the underline.
+    ///     Otherwise, the link attributes in the `NSAttributedString` are used.
+    init(_ attributedText: NSAttributedString, enablesLinkUnderline: Bool = false) {
         self.attributedText = attributedText
+        self.enablesLinkUnderline = enablesLinkUnderline
     }
 
     var body: some View {
@@ -43,7 +50,8 @@ struct AttributedText: View {
             TextViewWrapper(
                 attributedText: attributedText,
                 maxLayoutWidth: geometry.maxWidth,
-                textViewStore: textViewStore
+                textViewStore: textViewStore,
+                enablesLinkUnderline: enablesLinkUnderline
             )
         }
         .frame(
@@ -124,6 +132,7 @@ private struct TextViewWrapper: UIViewRepresentable {
     let attributedText: NSAttributedString
     let maxLayoutWidth: CGFloat
     let textViewStore: TextViewStore
+    let enablesLinkUnderline: Bool
 
     func makeUIView(context: Context) -> View {
         let uiView = View()
@@ -145,7 +154,9 @@ private struct TextViewWrapper: UIViewRepresentable {
         uiView.attributedText = attributedText
 
         var linkTextAttributes = uiView.linkTextAttributes ?? [:]
-        linkTextAttributes[.underlineColor] = UIColor.clear
+        if enablesLinkUnderline == false {
+            linkTextAttributes[.underlineColor] = UIColor.clear
+        }
         if let linkColor = context.environment.linkColor.map(UIColor.init) {
             linkTextAttributes[.foregroundColor] = linkColor
         }
@@ -225,6 +236,17 @@ struct AttributedText_Previews: PreviewProvider {
                 .font(.footnote)
                 .attributedTextForegroundColor(.gray)
                 .attributedTextLinkColor(.pink)
+            AttributedText(.init(string: "Link with underline", attributes: [
+                .font: UIFont.body,
+                .link: "woocommerce.com",
+                .underlineStyle: NSUnderlineStyle.single.rawValue
+            ]), enablesLinkUnderline: true)
+            .attributedTextLinkColor(.init(UIColor.accent))
+            AttributedText(.init(string: "Link without underline", attributes: [
+                .font: UIFont.body,
+                .link: "woocommerce.com",
+                .underlineStyle: 0 // No `NSUnderlineStyle` is available.
+            ]), enablesLinkUnderline: true)
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7891 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR mainly updated the Terms of Service (ToS) link style, along with some minor font and text color changes based on the latest design HyVloP5FipZzyPVenH2euI-fi-1518%3A60333.

For links in the `NSAttributedString` passed to `AttributedText` (strings with a `.link` attribute), we currently assume the link does not have an underline. By default, an underline is shown for each link in the attributed string and thus we currently set the link underline color to `clear` for the existing use cases in the app. This is fine if we never want any underlined links in the app, but now we want to show the ToS link with an underline.

In order to support underlined links, I added an `enablesLinkUnderline: Bool` parameter to `AttributedText` to specify whether underlined links should be enabled. To not break existing use cases of `AttributedText`, the default value is set to `false`. Then, to show the ToS link with an underline in `AccountCreationForm`, I passed `enablesLinkUnderline: true` with `underlineStyle` for the link and updated the link text color to match the design.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch the app
- Log out and skip onboarding if needed
- Tap `Create a Store` --> the ToS link and text field title label should match the latest design
- Tap on the ToS link --> the webview sheet should be shown as before

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

light | dark
-- | --
![Simulator Screen Shot - iPhone 14 - 2022-11-02 at 13 59 30](https://user-images.githubusercontent.com/1945542/199410992-d27e7280-1a61-42af-9781-694290920e2e.png) | ![Simulator Screen Shot - iPhone 14 - 2022-11-02 at 13 59 58](https://user-images.githubusercontent.com/1945542/199410998-27aeabd7-89c5-473a-81af-a2029a8d7578.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
