### PR TITLE
Add IPP plugin status tags to ZenDesk

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -12,7 +12,7 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
 
     private let stores: StoresManager
     private let storageManager: StorageManagerType
-    private let ZendeskShared: ZendeskManagerProtocol = ZendeskProvider.shared
+    private let zendeskShared: ZendeskManagerProtocol = ZendeskProvider.shared
 
     private lazy var resultsController: ResultsController<StorageSite> = {
         return ResultsController(storageManager: storageManager, sortedBy: [])
@@ -73,9 +73,9 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
         // https://github.com/woocommerce/woocommerce-ios/pull/2013#discussion_r454620804
         logOutOfCurrentStore {
             self.finalizeStoreSelection(storeID)
-            // Inform ZD that the site has changed
+            // Inform the Zendesk shared instance that the Store has been switched
             // https://github.com/woocommerce/woocommerce-ios/pull/8008/
-            self.ZendeskShared.test_listenToSiteSwitchChanges()
+            self.zendeskShared.observeStoreSwitch()
             onCompletion(true)
         }
     }

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -12,6 +12,7 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
 
     private let stores: StoresManager
     private let storageManager: StorageManagerType
+    private let ZendeskShared: ZendeskManagerProtocol = ZendeskProvider.shared
 
     private lazy var resultsController: ResultsController<StorageSite> = {
         return ResultsController(storageManager: storageManager, sortedBy: [])
@@ -72,7 +73,9 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
         // https://github.com/woocommerce/woocommerce-ios/pull/2013#discussion_r454620804
         logOutOfCurrentStore {
             self.finalizeStoreSelection(storeID)
-
+            // Inform ZD that the site has changed
+            // https://github.com/woocommerce/woocommerce-ios/pull/8008/
+            self.ZendeskShared.test_listenToSiteSwitchChanges()
             onCompletion(true)
         }
     }

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -147,7 +147,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
 
     /// IPP plugin statuses
     ///
-    private var ippPluginstatuses: [String]? {
+    private var ippPluginstatuses: [String] {
         var ippTags = [PluginStatus]()
         if let stripe = pluginResultsController.fetchedObjects.first(where: { $0.plugin == PluginSlug.stripe }) {
             if stripe.status == .active {
@@ -371,11 +371,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     /// The SDK tag is used in a trigger and displays tickets in Woo > Mobile Apps New.
     ///
     func getTags(supportSourceTag: String?) -> [String] {
-        var tags = [Constants.platformTag, Constants.sdkTag, Constants.jetpackTag]
-
-        // Get IPP plugin statuses
-        tags.append(contentsOf: ippPluginstatuses ?? [])
-
+        var tags = [Constants.platformTag, Constants.sdkTag, Constants.jetpackTag] + ippPluginstatuses
         return decorateTags(tags: tags, supportSourceTag: supportSourceTag)
     }
 

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -358,6 +358,23 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         if let sourceTagOrigin = supportSourceTag, sourceTagOrigin.isEmpty == false {
             decoratedTags.append(sourceTagOrigin)
         }
+        // WIP
+        let action = SitePluginAction.getPluginDetails(siteID: site.siteID, pluginName: "WooCommerce Stripe Gateway") { result in
+            switch result {
+            case .success(let plugin):
+                if plugin.status == .inactive {
+                    decoratedTags.append(Constants.woo_mobile_stripe_installed_and_not_activated)
+                } else if plugin.status == .active {
+                    decoratedTags.append(Constants.woo_mobile_stripe_installed_and_activated)
+                } else {
+                    decoratedTags.append(Constants.woo_mobile_stripe_not_installed)
+                }
+            case .failure(let error):
+                DDLogError("Unable to fetch plugin details: \(error)")
+                break
+            }
+        }
+        ServiceLocator.stores.dispatch(action)
 
         return decoratedTags
     }
@@ -1012,6 +1029,16 @@ private extension ZendeskManager {
         static let paymentsSubcategory = "payment"
         static let paymentsProduct = "woocommerce_payments"
         static let paymentsProductArea = "product_area_woo_payment_gateway"
+        // WIP
+        static let stripePluginName = "WooCommerce Stripe Gateway"
+        static let wcPayPluginName = "WooCommerce Payments"
+        static let woo_mobile_stripe_not_installed = "woo_mobile_stripe_not_installed"
+        static let woo_mobile_stripe_installed_and_not_activated = "woo_mobile_stripe_installed_and_not_activated"
+        static let woo_mobile_stripe_installed_and_activated = "woo_mobile_stripe_installed_and_activated"
+        static let woo_mobile_wcpay_not_installed = "woo_mobile_wcpay_not_installed"
+        static let woo_mobile_wcpay_installed_and_not_activated = "woo_mobile_wcpay_installed_and_not_activated"
+        static let woo_mobile_wcpay_installed_and_activated = "woo_mobile_wcpay_installed_and_activated"
+        static let woo_mobile_site_plugins_fetching_error = "woo_mobile_site_plugins_fetching_error"
     }
 
     // Zendesk expects these as NSNumber. However, they are defined as UInt64 to satisfy 32-bit devices (ex: iPhone 5).

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -152,18 +152,16 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         do {
             try resultsController.performFetch()
         } catch {
+            ippTags.append(Constants.woo_mobile_site_plugins_fetching_error)
             DDLogError("⛔️ Error fetching plugin list!")
         }
         return resultsController
     }()
 
     func observePlugins(onDataChanged: @escaping () -> Void) {
-        let stripePluginSlug = "woocommerce-gateway-stripe/woocommerce-gateway-stripe"
-        let wcPayPluginSlug = "woocommerce-payments/woocommerce-payments"
-
         resultsController.onDidResetContent = onDataChanged
 
-        if let stripe = resultsController.fetchedObjects.first(where: { $0.plugin == stripePluginSlug } ) {
+        if let stripe = resultsController.fetchedObjects.first(where: { $0.plugin == Constants.stripe_plugin_slug } ) {
             if stripe.status == .inactive {
                 ippTags.append(Constants.woo_mobile_stripe_installed_and_not_activated)
             } else if stripe.status == .active {
@@ -172,7 +170,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
                 ippTags.append(Constants.woo_mobile_stripe_not_installed)
             }
         }
-        if let wcPay = resultsController.fetchedObjects.first(where: { $0.plugin == wcPayPluginSlug } ) {
+        if let wcPay = resultsController.fetchedObjects.first(where: { $0.plugin == Constants.wcpay_plugin_slug } ) {
             if wcPay.status == .inactive {
                 ippTags.append(Constants.woo_mobile_wcpay_installed_and_not_activated)
             } else if wcPay.status == .active {
@@ -1073,6 +1071,8 @@ private extension ZendeskManager {
         static let paymentsSubcategory = "payment"
         static let paymentsProduct = "woocommerce_payments"
         static let paymentsProductArea = "product_area_woo_payment_gateway"
+        static let stripe_plugin_slug = "woocommerce-gateway-stripe/woocommerce-gateway-stripe"
+        static let wcpay_plugin_slug = "woocommerce-payments/woocommerce-payments"
         static let woo_mobile_stripe_not_installed = "woo_mobile_stripe_not_installed"
         static let woo_mobile_stripe_installed_and_not_activated = "woo_mobile_stripe_installed_and_not_activated"
         static let woo_mobile_stripe_installed_and_activated = "woo_mobile_stripe_installed_and_activated"

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -22,6 +22,8 @@ extension NSNotification.Name {
 protocol ZendeskManagerProtocol: SupportManagerAdapter {
     typealias onUserInformationCompletion = (_ success: Bool, _ email: String?) -> Void
 
+    func test_listenToSiteSwitchChanges()
+
     /// Displays the Zendesk New Request view from the given controller, for users to submit new tickets.
     ///
     func showNewRequestIfPossible(from controller: UIViewController, with sourceTag: String?)
@@ -44,6 +46,10 @@ protocol ZendeskManagerProtocol: SupportManagerAdapter {
 }
 
 struct NoZendeskManager: ZendeskManagerProtocol {
+    func test_listenToSiteSwitchChanges() {
+        // no-op
+    }
+
     func showNewRequestIfPossible(from controller: UIViewController) {
         // no-op
     }
@@ -155,6 +161,15 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         return ResultsController(storageManager: storageManager,
                                  matching: sitePredicate,
                                  sortedBy: pluginStatusDescriptor)
+    }
+
+    func test_listenToSiteSwitchChanges() {
+        print("Changed! SiteID: ")
+        do {
+            try pluginResultsController.performFetch()
+        } catch {
+            DDLogError(":(")
+        }
     }
 
     /// IPP plugin statuses
@@ -368,7 +383,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     /// The SDK tag is used in a trigger and displays tickets in Woo > Mobile Apps New.
     ///
     func getTags(supportSourceTag: String?) -> [String] {
-        var tags = [Constants.platformTag, Constants.sdkTag, Constants.jetpackTag] + ippPluginstatuses
+        let tags = [Constants.platformTag, Constants.sdkTag, Constants.jetpackTag] + ippPluginstatuses
         return decorateTags(tags: tags, supportSourceTag: supportSourceTag)
     }
 

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -168,7 +168,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         else {
             ippTags.append(.wcpayNotInstalled)
         }
-        return ippTags.map{ $0.rawValue }
+        return ippTags.map { $0.rawValue }
     }
 
     func showNewRequestIfPossible(from controller: UIViewController) {

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -158,7 +158,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         return resultsController
     }()
 
-    func observePlugins(onDataChanged: @escaping () -> Void) {
+    private func observePlugins(onDataChanged: @escaping () -> Void) {
         resultsController.onDidResetContent = onDataChanged
 
         if let stripe = resultsController.fetchedObjects.first(where: { $0.plugin == Constants.stripe_plugin_slug } ) {
@@ -375,7 +375,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         return decorateTags(tags: tags, supportSourceTag: supportSourceTag)
     }
 
-    func getWCPayTags(supportSourceTag: String?) -> [String] {
+    private func getWCPayTags(supportSourceTag: String?) -> [String] {
         let tags = [Constants.platformTag,
                     Constants.sdkTag,
                     Constants.paymentsProduct,
@@ -386,7 +386,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         return decorateTags(tags: tags, supportSourceTag: supportSourceTag)
     }
 
-    func appendIPPstatusTagsIfNeeded(decoratedTags: [String]) -> [String] {
+    private func appendIPPstatusTagsIfNeeded(decoratedTags: [String]) -> [String] {
         var tags = decoratedTags
         observePlugins(onDataChanged: {
             tags.append(contentsOf: self.ippTags)
@@ -394,7 +394,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         return tags
     }
 
-    func decorateTags(tags: [String], supportSourceTag: String?) -> [String] {
+    private func decorateTags(tags: [String], supportSourceTag: String?) -> [String] {
         guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
             return tags
         }

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -148,27 +148,27 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     /// IPP plugin statuses
     ///
     private var ippPluginstatuses: [String]? {
-        var ippTags = [String]()
-        if let stripe = pluginResultsController.fetchedObjects.first(where: { $0.plugin == IPPPluginStatus.stripe_plugin_slug }) {
+        var ippTags = [PluginStatus]()
+        if let stripe = pluginResultsController.fetchedObjects.first(where: { $0.plugin == PluginSlug.stripe }) {
             if stripe.status == .active {
-                ippTags.append(IPPPluginStatus.woo_mobile_stripe_installed_and_activated)
+                ippTags.append(.stripeInstalledAndActivated)
             } else if stripe.status == .inactive {
-                ippTags.append(IPPPluginStatus.woo_mobile_stripe_installed_and_not_activated)
+                ippTags.append(.stripeInstalledButNotActivated)
             }
         } else {
-            ippTags.append(IPPPluginStatus.woo_mobile_stripe_not_installed)
+            ippTags.append(.stripeNotInstalled)
         }
-        if let wcpay = pluginResultsController.fetchedObjects.first(where: { $0.plugin == IPPPluginStatus.wcpay_plugin_slug }) {
+        if let wcpay = pluginResultsController.fetchedObjects.first(where: { $0.plugin == PluginSlug.wcpay }) {
             if wcpay.status == .active {
-                ippTags.append(IPPPluginStatus.woo_mobile_wcpay_installed_and_activated)
+                ippTags.append(.wcpayInstalledAndActivated)
             } else if wcpay.status == .inactive {
-                ippTags.append(IPPPluginStatus.woo_mobile_wcpay_installed_and_not_activated)
+                ippTags.append(.wcpayInstalledButNotActivated)
             }
         }
         else {
-            ippTags.append(IPPPluginStatus.woo_mobile_wcpay_not_installed)
+            ippTags.append(.wcpayNotInstalled)
         }
-        return ippTags
+        return ippTags.map{ $0.rawValue }
     }
 
     func showNewRequestIfPossible(from controller: UIViewController) {
@@ -1117,16 +1117,17 @@ private extension ZendeskManager {
 }
 
 private extension ZendeskManager {
-    enum IPPPluginStatus {
-        static let stripe_plugin_slug = "woocommerce-gateway-stripe/woocommerce-gateway-stripe"
-        static let wcpay_plugin_slug = "woocommerce-payments/woocommerce-payments"
-        static let woo_mobile_stripe_not_installed = "woo_mobile_stripe_not_installed"
-        static let woo_mobile_stripe_installed_and_not_activated = "woo_mobile_stripe_installed_and_not_activated"
-        static let woo_mobile_stripe_installed_and_activated = "woo_mobile_stripe_installed_and_activated"
-        static let woo_mobile_wcpay_not_installed = "woo_mobile_wcpay_not_installed"
-        static let woo_mobile_wcpay_installed_and_not_activated = "woo_mobile_wcpay_installed_and_not_activated"
-        static let woo_mobile_wcpay_installed_and_activated = "woo_mobile_wcpay_installed_and_activated"
-        static let woo_mobile_site_plugins_fetching_error = "woo_mobile_site_plugins_fetching_error"
+    enum PluginSlug {
+        static let stripe = "woocommerce-gateway-stripe/woocommerce-gateway-stripe"
+        static let wcpay = "woocommerce-payments/woocommerce-payments"
+    }
+    enum PluginStatus: String {
+        case stripeNotInstalled = "woo_mobile_stripe_not_installed"
+        case stripeInstalledAndActivated = "woo_mobile_stripe_installed_and_activated"
+        case stripeInstalledButNotActivated = "woo_mobile_stripe_installed_and_not_activated"
+        case wcpayNotInstalled = "woo_mobile_wcpay_not_installed"
+        case wcpayInstalledAndActivated = "woo_mobile_wcpay_installed_and_activated"
+        case wcpayInstalledButNotActivated = "woo_mobile_wcpay_installed_and_not_activated"
     }
 }
 

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -157,7 +157,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         }
     }
 
-    private lazy var settingsVM = SettingsViewModel()
+    private lazy var settingsViewModel = SettingsViewModel()
 
     private var unreadNotificationsCount = 0
 
@@ -326,7 +326,9 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     ///
     func getTags(supportSourceTag: String?) -> [String] {
         var tags = [Constants.platformTag, Constants.sdkTag, Constants.jetpackTag]
-        if let ippTags = settingsVM.ippPluginTags {
+
+        // Get IPP plugin statuses
+        if let ippTags = settingsViewModel.ippPluginstatuses {
             tags.append(contentsOf: ippTags)
         }
 

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -162,11 +162,24 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         let wcPayPluginSlug = "woocommerce-payments/woocommerce-payments"
 
         resultsController.onDidResetContent = onDataChanged
-        if let _ = resultsController.fetchedObjects.first(where: { $0.plugin == stripePluginSlug } ) {
-            ippTags.append(stripePluginSlug)
+
+        if let stripe = resultsController.fetchedObjects.first(where: { $0.plugin == stripePluginSlug } ) {
+            if stripe.status == .inactive {
+                ippTags.append(Constants.woo_mobile_stripe_installed_and_not_activated)
+            } else if stripe.status == .active {
+                ippTags.append(Constants.woo_mobile_stripe_installed_and_activated)
+            } else {
+                ippTags.append(Constants.woo_mobile_stripe_not_installed)
+            }
         }
-        if let _ = resultsController.fetchedObjects.first(where: { $0.plugin == wcPayPluginSlug } ) {
-            ippTags.append(wcPayPluginSlug)
+        if let wcPay = resultsController.fetchedObjects.first(where: { $0.plugin == wcPayPluginSlug } ) {
+            if wcPay.status == .inactive {
+                ippTags.append(Constants.woo_mobile_wcpay_installed_and_not_activated)
+            } else if wcPay.status == .active {
+                ippTags.append(Constants.woo_mobile_wcpay_installed_and_activated)
+            } else {
+                ippTags.append(Constants.woo_mobile_wcpay_not_installed)
+            }
         }
     }
 
@@ -400,10 +413,9 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
             decoratedTags.append(sourceTagOrigin)
         }
 
-        // Adds specific plugin status tags for Stripe and WCPay:
         decoratedTags = appendIPPstatusTagsIfNeeded(decoratedTags: decoratedTags)
         
-        print("Tags: \(decoratedTags)")
+        print("All tags: \(decoratedTags)")
         return decoratedTags
     }
 }

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -191,8 +191,6 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         }
     }
 
-    private lazy var settingsViewModel = SettingsViewModel()
-
     private var unreadNotificationsCount = 0
 
     var showSupportNotificationIndicator: Bool {

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -217,7 +217,6 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     private var userEmail: String?
     private var haveUserIdentity = false
     private var alertNameField: UITextField?
-    private var supportRequestTags = [String]()
     private var ippTags = [String]()
     private var getSitePlugins: ()
 
@@ -683,7 +682,6 @@ private extension ZendeskManager {
         var defaultTags = getTags(supportSourceTag: supportSourceTag)
         let ippTags = self.ippTags
         var allTags = defaultTags + ippTags
-        print(allTags)
 
         requestConfig.tags = allTags
 
@@ -1075,9 +1073,6 @@ private extension ZendeskManager {
         static let paymentsSubcategory = "payment"
         static let paymentsProduct = "woocommerce_payments"
         static let paymentsProductArea = "product_area_woo_payment_gateway"
-        // WIP
-        static let stripePluginName = "WooCommerce Stripe Gateway"
-        static let wcPayPluginName = "WooCommerce Payments"
         static let woo_mobile_stripe_not_installed = "woo_mobile_stripe_not_installed"
         static let woo_mobile_stripe_installed_and_not_activated = "woo_mobile_stripe_installed_and_not_activated"
         static let woo_mobile_stripe_installed_and_activated = "woo_mobile_stripe_installed_and_activated"

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -146,11 +146,13 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     private let stores = ServiceLocator.stores
     private let storageManager = ServiceLocator.storageManager
 
-    /// Loads Plugins from the Storage Layer.
+    /// Controller for fetching site plugins from Storage
     ///
-    private lazy var pluginResultsController: ResultsController<StorageSitePlugin> = updatePluginResultsController()
-
-    private func updatePluginResultsController() -> ResultsController<StorageSitePlugin> {
+    private lazy var pluginResultsController: ResultsController<StorageSitePlugin> = createPluginResultsController()
+    
+    /// Returns a `pluginResultsController` using the latest selected site ID for predicate
+    ///
+    private func createPluginResultsController() -> ResultsController<StorageSitePlugin> {
         var sitePredicate: NSPredicate? = nil
         if let siteID = stores.sessionManager.defaultSite?.siteID {
             sitePredicate = NSPredicate(format: "siteID == %lld", siteID)
@@ -166,7 +168,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     }
 
     func observeStoreSwitch() {
-        pluginResultsController = updatePluginResultsController()
+        pluginResultsController = createPluginResultsController()
         do {
             try pluginResultsController.performFetch()
         } catch {
@@ -174,9 +176,9 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         }
     }
 
-    /// IPP plugin statuses
+    /// List of tags that reflect Stripe and WCPay plugin statuses
     ///
-    private var ippPluginstatuses: [String] {
+    private var ippPluginStatuses: [String] {
         var ippTags = [PluginStatus]()
         if let stripe = pluginResultsController.fetchedObjects.first(where: { $0.plugin == PluginSlug.stripe }) {
             if stripe.status == .active {
@@ -386,7 +388,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     /// The SDK tag is used in a trigger and displays tickets in Woo > Mobile Apps New.
     ///
     func getTags(supportSourceTag: String?) -> [String] {
-        let tags = [Constants.platformTag, Constants.sdkTag, Constants.jetpackTag] + ippPluginstatuses
+        let tags = [Constants.platformTag, Constants.sdkTag, Constants.jetpackTag] + ippPluginStatuses
         return decorateTags(tags: tags, supportSourceTag: supportSourceTag)
     }
 

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -149,7 +149,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     /// Controller for fetching site plugins from Storage
     ///
     private lazy var pluginResultsController: ResultsController<StorageSitePlugin> = createPluginResultsController()
-    
+
     /// Returns a `pluginResultsController` using the latest selected site ID for predicate
     ///
     private func createPluginResultsController() -> ResultsController<StorageSitePlugin> {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -94,14 +94,6 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     ///
     private let sitesResultsController: ResultsController<StorageSite>
 
-    /// Loads Plugins from the Storage Layer.
-    ///
-    private let pluginResultsController: ResultsController<StorageSitePlugin>
-
-    /// IPP plugin statuses
-    ///
-    private(set) var ippPluginstatuses: [String]?
-
     /// Payment Gateway Accounts Results Controller: Loads Payment Gateway Accounts from the Storage Layer
     /// e.g. WooCommerce Payments, but eventually other in-person payment accounts too
     ///
@@ -133,12 +125,6 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
                                                    matching: NSPredicate(format: "isWooCommerceActive == YES"),
                                                    sortedBy: [NSSortDescriptor(key: "name", ascending: true)])
 
-        /// Initialize Plugins Results Controller
-        ///
-        let pluginStatusDescriptor = [NSSortDescriptor(keyPath: \StorageSitePlugin.status, ascending: true)]
-        pluginResultsController = ResultsController(storageManager: storageManager,
-                                                 sortedBy: pluginStatusDescriptor)
-
         /// Initialize Payment Gateway Accounts Results Controller
         ///
         if let siteID = stores.sessionManager.defaultSite?.siteID {
@@ -155,34 +141,6 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
             let action = SystemStatusAction.synchronizeSystemPlugins(siteID: siteID, onCompletion: { _ in })
             stores.dispatch(action)
         }
-
-        ///
-        ///
-        ippPluginstatuses = {
-            var ippTags = [String]()
-            // Check Stripe plugin status
-            if let stripe = pluginResultsController.fetchedObjects.first(where: { $0.plugin == IPPPluginStatus.stripe_plugin_slug }) {
-                if stripe.status == .active {
-                    ippTags.append(IPPPluginStatus.woo_mobile_stripe_installed_and_activated)
-                } else if stripe.status == .inactive {
-                    ippTags.append(IPPPluginStatus.woo_mobile_stripe_installed_and_not_activated)
-                }
-            } else {
-                ippTags.append(IPPPluginStatus.woo_mobile_stripe_not_installed)
-            }
-            // Check WCPay plugin status
-            if let wcpay = pluginResultsController.fetchedObjects.first(where: { $0.plugin == IPPPluginStatus.wcpay_plugin_slug }) {
-                if wcpay.status == .active {
-                    ippTags.append(IPPPluginStatus.woo_mobile_wcpay_installed_and_activated)
-                } else if wcpay.status == .inactive {
-                    ippTags.append(IPPPluginStatus.woo_mobile_wcpay_installed_and_not_activated)
-                }
-            }
-            else {
-                ippTags.append(IPPPluginStatus.woo_mobile_wcpay_not_installed)
-            }
-            return ippTags
-        }()
     }
 
     /// Sets up the view model and loads the settings.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -94,13 +94,13 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     ///
     private let sitesResultsController: ResultsController<StorageSite>
 
+    /// Loads Plugins from the Storage Layer.
     ///
-    ///
-    private let ippResultsController: ResultsController<StorageSitePlugin>
+    private let pluginResultsController: ResultsController<StorageSitePlugin>
 
+    /// IPP plugin statuses
     ///
-    ///
-    private(set) var ippPluginTags: [String]?
+    private(set) var ippPluginstatuses: [String]?
 
     /// Payment Gateway Accounts Results Controller: Loads Payment Gateway Accounts from the Storage Layer
     /// e.g. WooCommerce Payments, but eventually other in-person payment accounts too
@@ -133,11 +133,11 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
                                                    matching: NSPredicate(format: "isWooCommerceActive == YES"),
                                                    sortedBy: [NSSortDescriptor(key: "name", ascending: true)])
 
+        /// Initialize Plugins Results Controller
         ///
-        ///
-        let ippStatusDescriptor = [NSSortDescriptor(keyPath: \StorageSitePlugin.status, ascending: true)]
-        ippResultsController = ResultsController(storageManager: storageManager,
-                                                 sortedBy: ippStatusDescriptor)
+        let pluginStatusDescriptor = [NSSortDescriptor(keyPath: \StorageSitePlugin.status, ascending: true)]
+        pluginResultsController = ResultsController(storageManager: storageManager,
+                                                 sortedBy: pluginStatusDescriptor)
 
         /// Initialize Payment Gateway Accounts Results Controller
         ///
@@ -158,30 +158,30 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
 
         ///
         ///
-        ippPluginTags = {
-            var out = [String]()
-
-            if let stripe = ippResultsController.fetchedObjects.first(where: { $0.plugin == IPPPluginStatus.stripe_plugin_slug }) {
-                if stripe.status == .inactive {
-                    out.append("stripe .inactive")
-                } else if stripe.status == .active {
-                    out.append("stripe .active")
+        ippPluginstatuses = {
+            var ippTags = [String]()
+            // Check Stripe plugin status
+            if let stripe = pluginResultsController.fetchedObjects.first(where: { $0.plugin == IPPPluginStatus.stripe_plugin_slug }) {
+                if stripe.status == .active {
+                    ippTags.append(IPPPluginStatus.woo_mobile_stripe_installed_and_activated)
+                } else if stripe.status == .inactive {
+                    ippTags.append(IPPPluginStatus.woo_mobile_stripe_installed_and_not_activated)
                 }
             } else {
-                out.append("stripe .not installed")
+                ippTags.append(IPPPluginStatus.woo_mobile_stripe_not_installed)
             }
-
-            if let wcpay = ippResultsController.fetchedObjects.first(where: { $0.plugin == IPPPluginStatus.wcpay_plugin_slug }) {
-                if wcpay.status == .inactive {
-                    out.append("wcpay .inactive")
-                } else if wcpay.status == .active {
-                    out.append("wcpay .active")
+            // Check WCPay plugin status
+            if let wcpay = pluginResultsController.fetchedObjects.first(where: { $0.plugin == IPPPluginStatus.wcpay_plugin_slug }) {
+                if wcpay.status == .active {
+                    ippTags.append(IPPPluginStatus.woo_mobile_wcpay_installed_and_activated)
+                } else if wcpay.status == .inactive {
+                    ippTags.append(IPPPluginStatus.woo_mobile_wcpay_installed_and_not_activated)
                 }
             }
             else {
-                out.append("wcpay .not installed")
+                ippTags.append(IPPPluginStatus.woo_mobile_wcpay_not_installed)
             }
-            return out
+            return ippTags
         }()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -361,17 +361,6 @@ private extension SettingsViewModel {
 // MARK: - Localizations
 //
 private extension SettingsViewModel {
-    enum IPPPluginStatus {
-        static let stripe_plugin_slug = "woocommerce-gateway-stripe/woocommerce-gateway-stripe"
-        static let wcpay_plugin_slug = "woocommerce-payments/woocommerce-payments"
-        static let woo_mobile_stripe_not_installed = "woo_mobile_stripe_not_installed"
-        static let woo_mobile_stripe_installed_and_not_activated = "woo_mobile_stripe_installed_and_not_activated"
-        static let woo_mobile_stripe_installed_and_activated = "woo_mobile_stripe_installed_and_activated"
-        static let woo_mobile_wcpay_not_installed = "woo_mobile_wcpay_not_installed"
-        static let woo_mobile_wcpay_installed_and_not_activated = "woo_mobile_wcpay_installed_and_not_activated"
-        static let woo_mobile_wcpay_installed_and_activated = "woo_mobile_wcpay_installed_and_activated"
-        static let woo_mobile_site_plugins_fetching_error = "woo_mobile_site_plugins_fetching_error"
-    }
     enum Localization {
         static let pluginsTitle = NSLocalizedString(
             "Plugins",

--- a/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
+++ b/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
@@ -67,6 +67,10 @@ final class MockZendeskManager: ZendeskManagerProtocol {
     func reset() {
         // no-op
     }
+
+    func observeStoreSwitch() {
+        // no-op
+    }
 }
 
 extension MockZendeskManager: SupportManagerAdapter {


### PR DESCRIPTION
Closes: #7994 

### Description
With this PR, we'll be sending extra tags to ZenDesk that reflect the plugin status of `woocommerce-gateway-stripe` and `woocommerce-payments` plugins. There are 3 tags for each plugin:

- `_installed_and_activated`
- `_installed_and_not_activated`
- `_not_installed`

### Changes

In order to add these IPP statuses to ZenDesk tickets, we need to pass [these tags](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift#L625) through the SupportSDK's `RequestUiConfiguration` class when we create a new request. As we need to do this before ZenDesk tabs loads, we'll be using a `StorageSitePlugin` results controller directly through the `ZendeskManager` class, in order to fetch plugin statuses and pass these as tags.


### Testing instructions
The easiest way is through the debugger:
1. Confirm that you have [WooCommerce Payments](https://wordpress.org/plugins/woocommerce-payments/), and/or [WooCommerce Stripe Gateway](https://wordpress.org/plugins/woocommerce-gateway-stripe/) installed and/or activated
2. Add a breakpoint to [requestConfig.tags](https://github.com/woocommerce/woocommerce-ios/blob/b59a59d2efafc94dd861d15561cd1cac593da4b2/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift#L631) to confirm which tags are we sending to ZenDesk.
3. Go to Menu > Settings > Help and Support > Tap on "Contact Support"
4. In Xcode's debugger, see the tags: 
```
tags	[String]	7 values	
[0]	String	"iOS"	
[1]	String	"woo-mobile-sdk"	
[2]	String	"jetpack"	
[3]	String	"woo_mobile_stripe_not_installed"	
[4]	String	"woo_mobile_wcpay_not_installed"	
[5]	String	"wpcom"	
[6]	String	"eCommerce"	
```
It can also be tested directly in ZenDesk, which requires extra steps:
1. Confirm that you have [WooCommerce Payments](https://wordpress.org/plugins/woocommerce-payments/), and/or [WooCommerce Stripe Gateway](https://wordpress.org/plugins/woocommerce-gateway-stripe/) installed and/or activated
2. Go to Menu > Settings > Help and Support > Confirm that you're logged into the app with a non-a8c account > Tap on "Contact Support" and send a request (You may need to test this on a physical device, not the simulator)
3. Log into ZenDesk, find your ticket, and confirm that the tags have been added and reflect the plugin status. If you have no ZD account, feel free to ping me on Slack with the non-a8c-email used (or any HE :D), in order to find the ticket.

<img width="355" alt="Screenshot 2022-11-07 at 12 30 43" src="https://user-images.githubusercontent.com/3812076/200220826-63d6f806-2ab5-4cc4-8cf5-0a11e5b4b841.png">

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
