### PR TITLE
Store creation: show a confirmation alert when dismissing the view, store picker popover fix

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -317,7 +317,7 @@ private extension StorePickerViewController {
 
     func presentAddStoreActionSheet() {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        actionSheet.view.tintColor = .black
+        actionSheet.view.tintColor = .text
         let createStoreAction = UIAlertAction(title: Localization.createStore, style: .default) { [weak self] _ in
             // TODO: add tracks for site creation
             self?.createStoreButtonPressed()

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -127,7 +127,7 @@ final class StorePickerViewController: UIViewController {
        AddStoreFooterView(addStoreHandler: { [weak self] in
            guard let self else { return }
            ServiceLocator.analytics.track(.sitePickerAddStoreTapped)
-           self.presentAddStoreActionSheet()
+           self.presentAddStoreActionSheet(from: self.addStoreFooterView)
        })
     }()
 
@@ -315,7 +315,7 @@ private extension StorePickerViewController {
         ServiceLocator.authenticationManager.presentSupport(from: self, screen: .storePicker)
     }
 
-    func presentAddStoreActionSheet() {
+    func presentAddStoreActionSheet(from view: UIView) {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
         let createStoreAction = UIAlertAction(title: Localization.createStore, style: .default) { [weak self] _ in
@@ -331,6 +331,12 @@ private extension StorePickerViewController {
         actionSheet.addAction(createStoreAction)
         actionSheet.addAction(addExistingStoreAction)
         actionSheet.addAction(cancelAction)
+
+        if let popoverController = actionSheet.popoverPresentationController {
+            popoverController.sourceView = view
+            popoverController.sourceRect = view.bounds
+        }
+
         present(actionSheet, animated: true)
     }
 
@@ -615,7 +621,7 @@ private extension StorePickerViewController {
     @IBAction private func addStoreWasPressed() {
         if featureFlagService.isFeatureFlagEnabled(.storeCreationMVP) {
             ServiceLocator.analytics.track(.sitePickerAddStoreTapped)
-            presentAddStoreActionSheet()
+            presentAddStoreActionSheet(from: addStoreButton)
         } else {
             ServiceLocator.analytics.track(.sitePickerConnectExistingStoreTapped)
             presentSiteDiscovery()

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -149,12 +149,6 @@ private extension StoreCreationCoordinator {
 
         alert.addCancelActionWithTitle(Localization.DiscardChangesAlert.cancelActionTitle) { _ in }
 
-        if let popoverController = alert.popoverPresentationController {
-            popoverController.sourceView = navigationController.view
-            popoverController.sourceRect = navigationController.view.bounds
-            popoverController.permittedArrowDirections = []
-        }
-
         // Presents the alert with the presented webview.
         navigationController.presentedViewController?.present(alert, animated: true)
     }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -88,9 +88,8 @@ private extension StoreCreationCoordinator {
     }
 
     @objc func handleStoreCreationCloseAction() {
-        // TODO-7879: show a confirmation alert before closing the store creation view
         analytics.track(event: .StoreCreation.siteCreationDismissed(source: source.analyticsValue))
-        navigationController.dismiss(animated: true)
+        showDiscardChangesAlert()
     }
 
     func handleStoreCreationResult(_ result: Result<String, Error>) {
@@ -137,11 +136,46 @@ private extension StoreCreationCoordinator {
             self.navigationController.dismiss(animated: true)
         }
     }
+
+    func showDiscardChangesAlert() {
+        let alert = UIAlertController(title: Localization.DiscardChangesAlert.title,
+                                      message: Localization.DiscardChangesAlert.message,
+                                      preferredStyle: .alert)
+        alert.view.tintColor = .text
+
+        alert.addDestructiveActionWithTitle(Localization.DiscardChangesAlert.confirmActionTitle) { [weak self] _ in
+            self?.navigationController.dismiss(animated: true)
+        }
+
+        alert.addCancelActionWithTitle(Localization.DiscardChangesAlert.cancelActionTitle) { _ in }
+
+        if let popoverController = alert.popoverPresentationController {
+            popoverController.sourceView = navigationController.view
+            popoverController.sourceRect = navigationController.view.bounds
+            popoverController.permittedArrowDirections = []
+        }
+
+        // Presents the alert with the presented webview.
+        navigationController.presentedViewController?.present(alert, animated: true)
+    }
 }
 
 private extension StoreCreationCoordinator {
     enum StoreCreationCoordinatorError: Error {
         case selfDeallocated
+    }
+
+    enum Localization {
+        enum DiscardChangesAlert {
+            static let title = NSLocalizedString("Do you want to leave?",
+                                                 comment: "Title of the alert when the user dismisses the store creation flow.")
+            static let message = NSLocalizedString("You will lose all your store information.",
+                                                   comment: "Message of the alert when the user dismisses the store creation flow.")
+            static let confirmActionTitle = NSLocalizedString("Confirm and leave",
+                                                              comment: "Button title Discard Changes in Discard Changes Action Sheet")
+            static let cancelActionTitle = NSLocalizedString("Cancel",
+                                                             comment: "Button title Cancel in Discard Changes Action Sheet")
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7879 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In the store creation view, the merchant might dismiss the view accidentally. Since it's not possible to restore the progress, we decided to show a confirmation alert p1667295008185859-slack-C045CUK1Y3U. For the copy, I followed Android except for the confirmation action from `OK` to `Confirm and leave` since `OK` and `Cancel` sound quite similar.

While testing the entry point from the store picker, I noticed a crash when testing on a tablet and a minor issue in dark mode. I included these fixes in this PR.
- Because the popover isn't handled for tablet layout, the app crashes when presenting the action sheet --> this PR passes the source view to the popover controller
- The action sheet's text color is set to `.black` which is harder to read in dark mode --> this PR updates the color to `.text` similar to other `UIAlertController` use cases

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Logged-out entry point

- Launch the app
- Log out and skip onboarding if needed
- Tap `Create a Store`
- Tap `Log in` and continue logging in --> at the end, the store creation view should be shown
- Tap `X` in the navigation bar to dismiss the view --> a confirmation alert should appear
- Tap `Cancel` to cancel the dismiss action --> it should go back to the store creation view
- Tap `X` in the navigation bar to dismiss the view again --> a confirmation alert should appear
- Tap `Confirm and leave` to confirm the dismiss action --> the store creation view should be dismissed and the store picker should be shown

#### Logged-in entry point

- Launch the app in an iPad device/simulator to test the popover crash
- Log in
- Go to the Menu tab, and tap `Switch store`
- At the bottom of the site list, tap `+ Add a Store` --> an action sheet should be shown, and is easily readable in dark mode
- Tap `Create a new store` --> the store creation view should be shown
- Tap `X` in the navigation bar to dismiss the view --> a confirmation alert should appear
- Tap `Cancel` to cancel the dismiss action --> it should go back to the store creation view
- Tap `X` in the navigation bar to dismiss the view again --> a confirmation alert should appear
- Tap `Confirm and leave` to confirm the dismiss action --> the store creation view should be dismissed and the app should go back to the Menu tab
---
- [x] @jaclync test the store picker entry point when the sites are empty and the store creation CTA is at the bottom

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light | tablet
-- | -- | --
![Simulator Screen Shot - iPhone 13 Pro - 2022-11-02 at 15 03 46](https://user-images.githubusercontent.com/1945542/199426702-6f84503a-6a28-44af-991a-099a5ab00058.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-11-02 at 15 03 59](https://user-images.githubusercontent.com/1945542/199426708-1492f6ae-3966-461a-b6f0-7670fdba3e44.png) | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2022-11-02 at 15 19 41](https://user-images.githubusercontent.com/1945542/199426790-c0afdf50-1c09-4592-82a8-7e9b8bbb6b3b.png)

Crash on store picker popover in a tablet:

non-empty sites | empty sites
-- | --
![Simulator Screen Shot - iPad Pro (9 7-inch) - 2022-11-02 at 15 19 23](https://user-images.githubusercontent.com/1945542/199426777-7e546845-b954-4a92-8d8e-69674701908e.png) | ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-11-02 at 15 29 08](https://user-images.githubusercontent.com/1945542/199426795-b9705dbe-a90a-4835-8ba1-eb3f9671f91e.png)

Action sheet text color change:

before | after
-- | --
![Simulator Screen Shot - iPhone 13 Pro - 2022-11-02 at 14 42 45](https://user-images.githubusercontent.com/1945542/199426615-f626506b-6e53-4b2f-ae91-26894c65548d.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-11-02 at 14 50 16](https://user-images.githubusercontent.com/1945542/199426631-d2e36c52-f88f-41b8-8f1f-c7a35180b654.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->