### PR TITLE
[Just In Time Messages] GET request and view analytic events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -625,8 +625,28 @@ extension WooAnalyticsEvent {
     enum JustInTimeMessage {
         private enum Keys {
             static let source = "source"
+            static let justInTimeMessage = "jitm"
             static let justInTimeMessageID = "jitm_id"
             static let justInTimeMessageGroup = "jitm_group"
+            static let count = "count"
+        }
+
+        static func fetchSuccess(source: String,
+                                 messageID: String,
+                                 count: Int64) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .justInTimeMessageFetchSuccess,
+                              properties: [
+                                Keys.source: source,
+                                Keys.justInTimeMessage: messageID,
+                                Keys.count: count
+                              ])
+        }
+
+        static func fetchFailure(source: String,
+                                 error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .justInTimeMessageFetchFailure,
+                              properties: [Keys.source: source],
+                              error: error)
         }
 
         static func callToActionTapped(source: String,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -649,6 +649,17 @@ extension WooAnalyticsEvent {
                               error: error)
         }
 
+        static func messageDisplayed(source: String,
+                                     messageID: String,
+                                     featureClass: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .justInTimeMessageDisplayed,
+                              properties: [
+                                Keys.source: source,
+                                Keys.justInTimeMessageID: messageID,
+                                Keys.justInTimeMessageGroup: featureClass
+                              ])
+        }
+
         static func callToActionTapped(source: String,
                                        messageID: String,
                                        featureClass: String) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -632,6 +632,8 @@ public enum WooAnalyticsStat: String {
     case justInTimeMessageDismissTapped = "jitm_dismissed"
     case justInTimeMessageDismissSuccess = "jitm_dismiss_success"
     case justInTimeMessageDismissFailure = "jitm_dismiss_failure"
+    case justInTimeMessageFetchSuccess = "jitm_fetch_success"
+    case justInTimeMessageFetchFailure = "jitm_fetch_failure"
 
     // MARK: Simple Payments events
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -634,6 +634,7 @@ public enum WooAnalyticsStat: String {
     case justInTimeMessageDismissFailure = "jitm_dismiss_failure"
     case justInTimeMessageFetchSuccess = "jitm_fetch_success"
     case justInTimeMessageFetchFailure = "jitm_fetch_failure"
+    case justInTimeMessageDisplayed = "jitm_displayed"
 
     // MARK: Simple Payments events
     //

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModel.swift
@@ -71,7 +71,9 @@ final class JustInTimeMessageAnnouncementCardViewModel: AnnouncementCardViewMode
 
     // MARK: - AnnouncementCardViewModelProtocol methods
     func onAppear() {
-        // No-op
+        analytics.track(event: .JustInTimeMessage.messageDisplayed(source: screenName,
+                                                                   messageID: messageID,
+                                                                   featureClass: featureClass))
     }
 
     func ctaTapped() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -157,11 +157,14 @@ final class DashboardViewModel {
             hook: .adminNotices) { [weak self] result in
                 guard let self = self else { return }
                 switch result {
-                case let .success(.some(message)):
+                case let .success(messages):
+                    guard let message = messages.first else {
+                        return
+                    }
                     self.analytics.track(event:
                             .JustInTimeMessage.fetchSuccess(source: Constants.dashboardScreenName,
                                                             messageID: message.messageID,
-                                                            count: 1))
+                                                            count: Int64(messages.count)))
                     let viewModel = JustInTimeMessageAnnouncementCardViewModel(
                         justInTimeMessage: message,
                         screenName: Constants.dashboardScreenName,
@@ -172,8 +175,6 @@ final class DashboardViewModel {
                     self.analytics.track(event:
                             .JustInTimeMessage.fetchFailure(source: Constants.dashboardScreenName,
                                                             error: error))
-                case .success(.none):
-                    break
                 }
             }
         stores.dispatch(action)

--- a/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModelTests.swift
@@ -159,6 +159,17 @@ final class JustInTimeMessageAnnouncementCardViewModelTests: XCTestCase {
         assertAnalyticEventLogged(name: "jitm_dismiss_failure", message: message, error: expectedError)
     }
 
+    func test_onAppear_tracks_just_in_time_message_displayed_analytic_event() {
+        let message = Yosemite.JustInTimeMessage.fake().copy(messageID: "test-message-id", featureClass: "test-feature-class")
+        setUp(with: message)
+
+        // When
+        sut.onAppear()
+
+        // Then
+        assertAnalyticEventLogged(name: "jitm_displayed", message: message)
+    }
+
     private func assertAnalyticEventLogged(name: String, message: Yosemite.JustInTimeMessage) {
         let expectedProperties = ["jitm_id": message.messageID,
                                   "jitm_group": message.featureClass,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -9,6 +9,16 @@ import struct Yosemite.JustInTimeMessage
 final class DashboardViewModelTests: XCTestCase {
     private let sampleSiteID: Int64 = 122
 
+    private var analytics: Analytics!
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var stores: MockStoresManager!
+
+    override func setUp() {
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        stores = MockStoresManager(sessionManager: .makeForTesting())
+    }
+
     func test_default_statsVersion_is_v4() {
         // Given
         let viewModel = DashboardViewModel()
@@ -19,7 +29,6 @@ final class DashboardViewModelTests: XCTestCase {
 
     func test_statsVersion_changes_from_v4_to_v3_when_store_stats_sync_returns_noRestRoute_error() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
             if case let .retrieveStats(_, _, _, _, _, _, completion) = action {
                 completion(.failure(DotcomError.noRestRoute))
@@ -37,7 +46,6 @@ final class DashboardViewModelTests: XCTestCase {
 
     func test_statsVersion_remains_v4_when_non_store_stats_sync_returns_noRestRoute_error() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
             if case let .retrieveStats(_, _, _, _, _, _, completion) = action {
                 completion(.failure(DotcomError.empty))
@@ -61,7 +69,6 @@ final class DashboardViewModelTests: XCTestCase {
 
     func test_statsVersion_changes_from_v3_to_v4_when_store_stats_sync_returns_success() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
         // `DotcomError.noRestRoute` error indicates the stats are unavailable.
         var storeStatsResult: Result<Void, Error> = .failure(DotcomError.noRestRoute)
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
@@ -83,7 +90,6 @@ final class DashboardViewModelTests: XCTestCase {
 
     func test_products_onboarding_announcements_take_precedence() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .checkProductsOnboardingEligibility(_, completion):
@@ -111,7 +117,18 @@ final class DashboardViewModelTests: XCTestCase {
 
     func test_view_model_syncs_just_in_time_messages_when_ineligible_for_products_onboarding() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let message = Yosemite.JustInTimeMessage.fake().copy(title: "JITM Message")
+        prepareStoresToShowJustInTimeMessage(.success(message))
+        let viewModel = DashboardViewModel(stores: stores)
+
+        // When
+        viewModel.syncAnnouncements(for: sampleSiteID)
+
+        // Then
+        XCTAssertEqual(viewModel.announcementViewModel?.title, "JITM Message")
+    }
+
+    func prepareStoresToShowJustInTimeMessage(_ response: Result<Yosemite.JustInTimeMessage?, Error>) {
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .checkProductsOnboardingEligibility(_, completion):
@@ -123,23 +140,15 @@ final class DashboardViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: JustInTimeMessageAction.self) { action in
             switch action {
             case let .loadMessage(_, _, _, completion):
-                completion(.success(Yosemite.JustInTimeMessage.fake().copy(title: "JITM Message")))
+                completion(response)
             default:
                 XCTFail("Received unsupported action: \(action)")
             }
         }
-        let viewModel = DashboardViewModel(stores: stores)
-
-        // When
-        viewModel.syncAnnouncements(for: sampleSiteID)
-
-        // Then
-        XCTAssertEqual(viewModel.announcementViewModel?.title, "JITM Message")
     }
 
     func test_no_announcement_to_display_when_no_announcements_are_synced() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .checkProductsOnboardingEligibility(_, completion):
@@ -191,5 +200,48 @@ final class DashboardViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNil(viewModel.announcementViewModel)
+    }
+
+    func test_fetch_success_analytics_logged_when_just_in_time_message_retrieved() {
+        // Given
+        let message = Yosemite.JustInTimeMessage.fake().copy(messageID: "test-message-id",
+                                                             featureClass: "test-feature-class")
+        prepareStoresToShowJustInTimeMessage(.success(message))
+        let viewModel = DashboardViewModel(stores: stores, analytics: analytics)
+
+        // When
+        viewModel.syncAnnouncements(for: sampleSiteID)
+
+        // Then
+        guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: "jitm_fetch_success"),
+              let properties = analyticsProvider.receivedProperties[eventIndex] as? [String: AnyHashable]
+        else {
+            return XCTFail("Expected event was not logged")
+        }
+
+        assertEqual("my_store", properties["source"] as? String)
+        assertEqual("test-message-id", properties["jitm"] as? String)
+        assertEqual(1, properties["count"] as? Int64)
+    }
+
+    func test_fetch_failure_analytics_logged_when_just_in_time_message_errors() {
+        // Given
+        let error = DotcomError.noRestRoute
+        prepareStoresToShowJustInTimeMessage(.failure(error))
+        let viewModel = DashboardViewModel(stores: stores, analytics: analytics)
+
+        // When
+        viewModel.syncAnnouncements(for: sampleSiteID)
+
+        // Then
+        guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: "jitm_fetch_failure"),
+              let properties = analyticsProvider.receivedProperties[eventIndex] as? [String: AnyHashable]
+        else {
+            return XCTFail("Expected event was not logged")
+        }
+
+        assertEqual("my_store", properties["source"] as? String)
+        assertEqual("Networking.DotcomError", properties["error_domain"] as? String)
+        assertEqual("Dotcom Invalid REST Route", properties["error_description"] as? String)
     }
 }

--- a/Yosemite/Yosemite/Actions/JustInTimeMessageAction.swift
+++ b/Yosemite/Yosemite/Actions/JustInTimeMessageAction.swift
@@ -8,7 +8,7 @@ public enum JustInTimeMessageAction: Action {
     case loadMessage(siteID: Int64,
                      screen: String,
                      hook: JustInTimeMessageHook,
-                     completion: (Result<JustInTimeMessage?, Error>) -> ())
+                     completion: (Result<[JustInTimeMessage], Error>) -> ())
 
     /// Dismisses a `JustInTimeMessage` and others for the same `featureClass`
     ///

--- a/Yosemite/Yosemite/Stores/JustInTimeMessageStore.swift
+++ b/Yosemite/Yosemite/Stores/JustInTimeMessageStore.swift
@@ -44,25 +44,22 @@ private extension JustInTimeMessageStore {
     func loadMessage(for siteID: Int64,
                      screen: String,
                      hook: JustInTimeMessageHook,
-                     completion: @escaping (Result<JustInTimeMessage?, Error>) -> ()) {
+                     completion: @escaping (Result<[JustInTimeMessage], Error>) -> ()) {
         Task {
             let result = await remote.loadAllJustInTimeMessages(
                     for: siteID,
                     messagePath: .init(app: .wooMobile,
                                        screen: screen,
                                        hook: hook))
-            let displayResult = result.map(topDisplayMessage(_:))
+            let displayResult = result.map(displayMessages(_:))
             await MainActor.run {
                 completion(displayResult)
             }
         }
     }
 
-    func topDisplayMessage(_ messages: [Networking.JustInTimeMessage]) -> JustInTimeMessage? {
-        guard let topMessage = messages.first else {
-            return nil
-        }
-        return JustInTimeMessage(message: topMessage)
+    func displayMessages(_ messages: [Networking.JustInTimeMessage]) -> [JustInTimeMessage] {
+        return messages.map { JustInTimeMessage(message: $0) }
     }
 
     func dismissMessage(_ message: JustInTimeMessage,

--- a/Yosemite/YosemiteTests/Stores/JustInTimeMessageStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/JustInTimeMessageStoreTests.swift
@@ -26,7 +26,7 @@ final class JustInTimeMessageStoreTests: XCTestCase {
         sut = JustInTimeMessageStore(dispatcher: Dispatcher(), storageManager: storageManager, network: network)
     }
 
-    func test_loadMessage_then_it_returns_nil_upon_successful_empty_response() throws {
+    func test_loadMessage_then_it_returns_empty_array_upon_successful_empty_response() throws {
         // Given
         network.simulateResponse(requestUrlSuffix: "jetpack/v4/jitm", filename: "empty-data-array")
 
@@ -43,7 +43,7 @@ final class JustInTimeMessageStoreTests: XCTestCase {
 
         // Then
         XCTAssert(result.isSuccess)
-        XCTAssertNil(try result.get())
+        XCTAssert(try result.get().isEmpty)
     }
 
     func test_loadMessage_then_it_returns_the_Just_In_Time_Message_upon_successful_response() throws {
@@ -72,37 +72,7 @@ final class JustInTimeMessageStoreTests: XCTestCase {
 
         // Then
         XCTAssert(result.isSuccess)
-        let recievedMessage = try XCTUnwrap(result.get())
-        assertEqual(expectedJustInTimeMessage, recievedMessage)
-    }
-
-    func test_loadMessage_then_it_returns_the_first_Just_In_Time_Message_upon_successful_response_with_multiple_jitms() throws {
-        // Given
-        network.simulateResponse(requestUrlSuffix: "jetpack/v4/jitm", filename: "just-in-time-message-list-multiple")
-
-        // When
-        let result = waitFor { promise in
-            let action = JustInTimeMessageAction.loadMessage(
-                siteID: self.sampleSiteID,
-                screen: "my_store",
-                hook: .adminNotices) { result in
-                    promise(result)
-                }
-            self.sut.onAction(action)
-        }
-
-        let expectedJustInTimeMessage = JustInTimeMessage(
-            siteID: sampleSiteID,
-            messageID: "woomobile_onboarding_add_product",
-            featureClass: "woomobile_onboarding_products",
-            title: "Add some products",
-            detail: "Get started selling your products: add them easily using the Products tab",
-            buttonTitle: "Add product",
-            url: "woocommerce://products/add")
-
-        // Then
-        XCTAssert(result.isSuccess)
-        let recievedMessage = try XCTUnwrap(result.get())
+        let recievedMessage = try XCTUnwrap(result.get().first)
         assertEqual(expectedJustInTimeMessage, recievedMessage)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7853 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We added the ability to show Just In Time Messages in #7948 and previous PRs, however that did not include the analytics for fetching and displaying the messages.

This PR adds those events.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

N.B. see pdfdoF-1uc-p2#comment-2581 for details of setting up your store to be eligible for the test JITM

With a US store that is eligible for the test JITM, on a debug/alpha build of the app

### Fetch success and displayed are tracked:

1. Open the app
2. Observe that the message is shown
3. Observe in the debug output that the `woocommerceios_jitm_fetch_success` and `woocommerceios_jitm_displayed` events are tracked with the following properties: 

- [ ] Track `*_jitm_displayed` event with props `jitm_group: {FEATURE_CLASS}`, `jitm_id: {JITM_ID}`, `source: my_store`
- [ ] Track `*_jitm_fetch_success` event with props `source: my_store`, `jitm: {FIRST_RECEIVED_JITM_ID}`, `count: {NUMBER_OF_JITMs_IN_RESPONSE}`

### Fetch failure is tracked

1. Set up Proxyman or Charles with a breakpoint on `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{siteid}/rest-api/`, for POST requests only.
2. Repeat the steps to view the JITM
3. When you reach your Proxyman/Charles breakpoint, abort the request
4. Observe that the failure event below is tracked correctly.

- [ ] Track `*_jitm_fetch_failure` event with props `source: my_store` and standard `error` props

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="853" alt="CleanShot 2022-11-02 at 12 20 47@2x" src="https://user-images.githubusercontent.com/2472348/199493982-01140749-cbdc-43e1-afd2-10d87045a0d7.png">

<img width="547" alt="Tracks live view JITM displayed" src="https://user-images.githubusercontent.com/2472348/199502979-710d94d9-295c-475a-a6ef-d94fc0361e67.png">
<img width="708" alt="Tracks live view fetch success" src="https://user-images.githubusercontent.com/2472348/199502738-c9262a0e-a6b3-439e-aec8-da7168abab14.png">
<img width="1369" alt="Tracks live view fetch failure" src="https://user-images.githubusercontent.com/2472348/199502753-b3288491-b222-4b56-b980-d6971e180e3e.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
