### PR TITLE
Products Onboarding: Template Analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1632,6 +1632,15 @@ extension WooAnalyticsEvent {
 //
 extension WooAnalyticsEvent {
     enum ProductsOnboarding {
+        enum Keys: String {
+            case type
+        }
+
+        enum CreationType: String {
+            case manual
+            case template
+        }
+
         /// Tracks when a store is eligible for products onboarding
         ///
         static func storeIsEligible() -> WooAnalyticsEvent {
@@ -1642,6 +1651,12 @@ extension WooAnalyticsEvent {
         ///
         static func bannerCTATapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productsOnboardingCTATapped, properties: [:])
+        }
+
+        /// Trackas when the merchants selects a product creation type.
+        ///
+        static func productCreationTypeSelected(type: CreationType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .addProductCreationTypeSelected, properties: [Keys.type.rawValue: type.rawValue])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -424,6 +424,7 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Add Product Events
     //
+    case addProductCreationTypeSelected = "add_product_creation_type_selected"
     case addProductTypeSelected = "add_product_product_type_selected"
     case addProductPublishTapped = "add_product_publish_tapped"
     case addProductSaveAsDraftTapped = "add_product_save_as_draft_tapped"

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -89,7 +89,7 @@ private extension AddProductCoordinator {
                                       comment: "Message title of bottom sheet for selecting a template or manual product")
         let viewProperties = BottomSheetListSelectorViewProperties(title: title)
         let command = ProductCreationTypeSelectorCommand { selectedCreationType in
-            // TODO: Add analytics
+            self.trackProductCreationType(selectedCreationType)
             self.presentProductTypeBottomSheet(creationType: selectedCreationType)
         }
         let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
@@ -224,9 +224,23 @@ private extension AddProductCoordinator {
 
     /// Presents an general error notice using the system notice presenter.
     ///
-    private func presentErrorNotice() {
+    func presentErrorNotice() {
         let notice = Notice(title: NSLocalizedString("There was a problem creating the template product.",
                                                      comment: "Title for the error notice when creating a template product"))
         ServiceLocator.noticePresenter.enqueue(notice: notice)
+    }
+
+    /// Tracks the selected product creation type.
+    ///
+    func trackProductCreationType(_ type: ProductCreationType) {
+        let analyticsType: WooAnalyticsEvent.ProductsOnboarding.CreationType = {
+            switch type {
+            case .template:
+                return .template
+            case .manual:
+                return .manual
+            }
+        }()
+        ServiceLocator.analytics.track(event: .ProductsOnboarding.productCreationTypeSelected(type: analyticsType))
     }
 }


### PR DESCRIPTION
Closes: #7923 

# Why

This PR makes sure that the `*_add_product_creation_type_selected` is fired with the `template | manual`  custom property when the merchants selects a product creation type as a part of the product onboarding experience when creating a new product.

Event registration: https://github.com/Automattic/tracks-events-registration/pull/1162

# Screenshots

<img width="1480" alt="screenshot" src="https://user-images.githubusercontent.com/562080/199496629-afcfed7f-f7ef-461d-923a-f72c7520f75f.png">

# Testing Steps

- On a store with less than 3 products, tap the add product button
- Select the "Template" option and a product type.
- See the event being fired.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
