### PR TITLE
[Just In Time Messages] Refresh JITMs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -293,10 +293,12 @@ private extension DashboardViewController {
     }
 
     private func openWebView(viewModel: WebViewSheetViewModel) {
-        let cardReaderWebview = WebViewSheet(viewModel: viewModel) { [weak self] in
-            self?.dismiss(animated: true)
+        let webViewSheet = WebViewSheet(viewModel: viewModel) { [weak self] in
+            guard let self = self else { return }
+            self.dismiss(animated: true)
+            self.viewModel.syncAnnouncements(for: self.siteID)
         }
-        let hostingController = UIHostingController(rootView: cardReaderWebview)
+        let hostingController = UIHostingController(rootView: webViewSheet)
         present(hostingController, animated: true, completion: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -499,6 +499,7 @@ private extension DashboardViewController {
 
     func pullToRefresh() async {
         ServiceLocator.analytics.track(.dashboardPulledToRefresh)
+        viewModel.syncAnnouncements(for: siteID)
         await reloadDashboardUIStatsVersion(forced: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -299,6 +299,7 @@ private extension DashboardViewController {
             self.viewModel.syncAnnouncements(for: self.siteID)
         }
         let hostingController = UIHostingController(rootView: webViewSheet)
+        hostingController.presentationController?.delegate = self
         present(hostingController, animated: true, completion: nil)
     }
 
@@ -385,9 +386,18 @@ private extension DashboardViewController {
     }
 }
 
+// MARK: - Delegate conformance
 extension DashboardViewController: DashboardUIScrollDelegate {
     func dashboardUIScrollViewDidScroll(_ scrollView: UIScrollView) {
         hiddenScrollView.updateFromScrollViewDidScrollEventForLargeTitleWorkaround(scrollView)
+    }
+}
+
+extension DashboardViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        if presentationController.presentedViewController is UIHostingController<WebViewSheet> {
+            viewModel.syncAnnouncements(for: siteID)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -110,11 +110,7 @@ final class DashboardViewModel {
     ///
     func syncAnnouncements(for siteID: Int64) {
         syncProductsOnboarding(for: siteID) { [weak self] in
-            // For now, products onboarding takes precedence over Just In Time Messages, so we can stop if there is an onboarding announcement to display.
-            // This should be revisited when either onboarding or JITMs are expanded. See: pe5pgL-11B-p2
-            guard let self, self.announcementViewModel == nil else { return }
-
-            self.syncJustInTimeMessages(for: siteID)
+            self?.syncJustInTimeMessages(for: siteID)
         }
     }
 
@@ -133,6 +129,9 @@ final class DashboardViewModel {
                             MainTabBarController.presentAddProductFlow()
                         })
                         self?.announcementViewModel = viewModel
+                        // For now, products onboarding takes precedence over Just In Time Messages, so we can stop if there is an onboarding announcement to display.
+                        // This should be revisited when either onboarding or JITMs are expanded. See: pe5pgL-11B-p2
+                        return
                     }
                 }
                 onCompletion()
@@ -159,6 +158,7 @@ final class DashboardViewModel {
                 switch result {
                 case let .success(messages):
                     guard let message = messages.first else {
+                        self.announcementViewModel = nil
                         return
                     }
                     self.analytics.track(event:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -129,8 +129,10 @@ final class DashboardViewModel {
                             MainTabBarController.presentAddProductFlow()
                         })
                         self?.announcementViewModel = viewModel
-                        // For now, products onboarding takes precedence over Just In Time Messages, so we can stop if there is an onboarding announcement to display.
-                        // This should be revisited when either onboarding or JITMs are expanded. See: pe5pgL-11B-p2
+                        // For now, products onboarding takes precedence over Just In Time Messages,
+                        // so we can stop if there is an onboarding announcement to display.
+                        // This should be revisited when either onboarding or JITMs are expanded. See:
+                        // pe5pgL-11B-p2
                         return
                     }
                 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -262,4 +262,21 @@ final class DashboardViewModelTests: XCTestCase {
         assertEqual("Networking.DotcomError", properties["error_domain"] as? String)
         assertEqual("Dotcom Invalid REST Route", properties["error_description"] as? String)
     }
+
+    func test_when_no_messages_are_received_existing_messages_are_removed() {
+        // Given
+        prepareStoresToShowJustInTimeMessage(.success([]))
+
+        let viewModel = DashboardViewModel(stores: stores, analytics: analytics)
+        viewModel.announcementViewModel = JustInTimeMessageAnnouncementCardViewModel(
+            justInTimeMessage: .fake(),
+            screenName: "my_store",
+            siteID: sampleSiteID)
+
+        // When
+        viewModel.syncAnnouncements(for: sampleSiteID)
+
+        // Then
+        XCTAssertNil(viewModel.announcementViewModel)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #7916 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

JITMs were previously only loaded when the Dashboard was first loaded. This could mean that the latest message is not shown, especially if the app has stayed in memory for some time.

The dashboard has data which benefits from regular refreshing, so in this PR we refresh the JITMs whenever that data is refreshed.

Additionally, when the user takes action in a webview, they may make themselves ineligible for a JITM, by completing the action it's informing them of. This PR resyncs the announcements when the webview is closed, so that JITMs will be automatically dismissed in that case

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

N.B. see pdfdoF-1uc-p2#comment-2581 for details of setting up your store to be eligible for the test JITM

With a US store that is eligible for the test JITM, on a debug/alpha build of the app

### Pull to refresh:

1. Set up Proxyman or Charles to observe network requests
2. Open the app
3. Observe that the message is shown, after a network request to `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{SITEID}/rest-api/?json=true&path=/jetpack/v4/jitm%26_method%3Dget&query=%7B%22message_path%22%3A%22woomobile%3Amy_store%3Aadmin_notices%22%7D`
4. Dismiss the JITM
5. Pull to Refresh
6. Observe that the JITM doesn't show, but that there's been another network request (with `{data: []}` as the response)
7. Wait 30 seconds, then Pull to Refresh again
8. Observe that the JITM shows again

### Refresh after webview dismissal

1. Set up Proxyman or Charles to observe network requests, setting a breakpoint on the response to `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/*/rest-api/?json=true&path=/jetpack/v4/jitm*`
2. Open the app
3. Observe that the message is shown
4. Tap the CTA
5. Tap `Done` or swipe the webview away 
6. At the breakpoint, edit the response body to `{"data": []}`
7. Observe that the JITMs are dismissed. (Since this is simulated, they will return when pulling to refresh unless you edit the response again!)


N.B. there's nothing you can do in this webview to become ineligible for the JITM, which is the expected use case. With potential future backend changes, e.g. to target only people who've not bought a card reader, this refresh behaviour could automatically remove a JITM without need for them to dismiss it.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/199524362-b8590819-dd7c-48dd-ac1d-f5cdf92ab54a.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
