### PR TITLE
[In-App Purchases] Route to wp.com sandbox when submitting orders

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -531,6 +531,7 @@
 		B5C6FCD620A3768900A4F8E4 /* order.json in Resources */ = {isa = PBXBuildFile; fileRef = B5C6FCD520A3768900A4F8E4 /* order.json */; };
 		B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */; };
 		B963A5CC2853870000EFADA0 /* OrderItemRefundMetaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B963A5CB2853870000EFADA0 /* OrderItemRefundMetaData.swift */; };
+		B99CFA6B291409F100B85A3F /* SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99CFA6A291409F100B85A3F /* SettingsTests.swift */; };
 		BAB373722795A1FB00837B4A /* OrderTaxLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB373712795A1FB00837B4A /* OrderTaxLine.swift */; };
 		CC07865F267799EE00BA9AC1 /* ShippingLabelPurchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */; };
 		CC0786612677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */; };
@@ -1267,6 +1268,7 @@
 		B5C6FCD520A3768900A4F8E4 /* order.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = order.json; sourceTree = "<group>"; };
 		B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationsRemote.swift; sourceTree = "<group>"; };
 		B963A5CB2853870000EFADA0 /* OrderItemRefundMetaData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderItemRefundMetaData.swift; sourceTree = "<group>"; };
+		B99CFA6A291409F100B85A3F /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
 		BAB373712795A1FB00837B4A /* OrderTaxLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTaxLine.swift; sourceTree = "<group>"; };
 		BD9439D9B8F2C1ED2EADAA51 /* Pods-NetworkingTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C8F9A8CC6F90A8C9B5EF2EE2 /* Pods-Networking.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release.xcconfig"; sourceTree = "<group>"; };
@@ -1715,6 +1717,7 @@
 			children = (
 				45551F132523E7FF007EF104 /* UserAgentTests.swift */,
 				B518663320A0A2E800037A38 /* Constants.swift */,
+				B99CFA6A291409F100B85A3F /* SettingsTests.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -3363,6 +3366,7 @@
 				2685C102263B6A1000D9EE97 /* AddOnGroupRemoteTests.swift in Sources */,
 				B57B1E6721C916850046E764 /* NetworkErrorTests.swift in Sources */,
 				D8FBFF0F22D3B25E006E3336 /* WooAPIVersionTests.swift in Sources */,
+				B99CFA6B291409F100B85A3F /* SettingsTests.swift in Sources */,
 				45152831257A8E1A0076B03C /* ProductAttributeMapperTests.swift in Sources */,
 				26B2F74924C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift in Sources */,
 				45CCFCE827A2E5020012E8CB /* InboxNoteListMapperTests.swift in Sources */,

--- a/Networking/Networking/Remote/InAppPurchasesRemote.swift
+++ b/Networking/Networking/Remote/InAppPurchasesRemote.swift
@@ -31,6 +31,7 @@ public class InAppPurchasesRemote: Remote {
         productIdentifier: String,
         appStoreCountryCode: String,
         receiptData: Data,
+        wpComSandboxUsername: String? = nil,
         completion: @escaping (Swift.Result<Int, Error>) -> Void) {
             let parameters: [String: Any] = [
                 Constants.siteIDKey: siteID,
@@ -39,8 +40,13 @@ public class InAppPurchasesRemote: Remote {
                 Constants.appStoreCountryCodeKey: appStoreCountryCode,
                 Constants.receiptDataKey: receiptData.base64EncodedString()
             ]
-            let dotComRequest = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: Constants.ordersPath, parameters: parameters)
+            let dotComRequest = DotcomRequest(wordpressApiVersion: .wpcomMark2,
+                                              method: .post,
+                                              path: Constants.ordersPath,
+                                              parameters: parameters,
+                                              wpComSandboxUsername: wpComSandboxUsername)
             let request = augmentedRequestWithAppId(dotComRequest)
+            debugPrint("request", try? request.asURLRequest().url)
             let mapper = InAppPurchaseOrderResultMapper()
             enqueue(request, mapper: mapper, completion: completion)
         }
@@ -76,7 +82,8 @@ public extension InAppPurchasesRemote {
         price: Int,
         productIdentifier: String,
         appStoreCountryCode: String,
-        receiptData: Data
+        receiptData: Data,
+        wpComSandboxUsername: String? = nil
     ) async throws -> Int {
         try await withCheckedThrowingContinuation { continuation in
             createOrder(
@@ -84,7 +91,8 @@ public extension InAppPurchasesRemote {
                 price: price,
                 productIdentifier: productIdentifier,
                 appStoreCountryCode: appStoreCountryCode,
-                receiptData: receiptData
+                receiptData: receiptData,
+                wpComSandboxUsername: wpComSandboxUsername
             ) { result in
                 continuation.resume(with: result)
             }

--- a/Networking/Networking/Remote/InAppPurchasesRemote.swift
+++ b/Networking/Networking/Remote/InAppPurchasesRemote.swift
@@ -46,7 +46,6 @@ public class InAppPurchasesRemote: Remote {
                                               parameters: parameters,
                                               wpComSandboxUsername: wpComSandboxUsername)
             let request = augmentedRequestWithAppId(dotComRequest)
-            debugPrint("request", try? request.asURLRequest().url)
             let mapper = InAppPurchaseOrderResultMapper()
             enqueue(request, mapper: mapper, completion: completion)
         }

--- a/Networking/Networking/Requests/DotcomRequest.swift
+++ b/Networking/Networking/Requests/DotcomRequest.swift
@@ -22,6 +22,10 @@ struct DotcomRequest: URLRequestConvertible {
     ///
     let parameters: [String: Any]?
 
+    /// WPCom Sandbox username, so the public WordPress.com API can be routed. If nil it will be ignored
+    ///
+    let wpComSandboxUsername: String?
+
 
     /// Designated Initializer.
     ///
@@ -31,17 +35,18 @@ struct DotcomRequest: URLRequestConvertible {
     ///     - path: RPC that should be executed.
     ///     - parameters: Collection of String parameters to be passed over to our target RPC.
     ///
-    init(wordpressApiVersion: WordPressAPIVersion, method: HTTPMethod, path: String, parameters: [String: Any]? = nil) {
+    init(wordpressApiVersion: WordPressAPIVersion, method: HTTPMethod, path: String, parameters: [String: Any]? = nil, wpComSandboxUsername: String? = nil) {
         self.wordpressApiVersion = wordpressApiVersion
         self.method = method
         self.path = path
+        self.wpComSandboxUsername = wpComSandboxUsername
         self.parameters = parameters ?? [:]
     }
 
     /// Returns a URLRequest instance representing the current WordPress.com Request.
     ///
     func asURLRequest() throws -> URLRequest {
-        let dotcomURL = URL(string: Settings.wordpressApiBaseURL + wordpressApiVersion.path + path)!
+        let dotcomURL = URL(string: Settings.wordpressApiBaseURL(wpComSandboxUsername: wpComSandboxUsername) + wordpressApiVersion.path + path)!
         let dotcomRequest = try URLRequest(url: dotcomURL, method: method, headers: nil)
 
         return try URLEncoding.default.encode(dotcomRequest, with: parameters)

--- a/Networking/Networking/Settings/Settings.swift
+++ b/Networking/Networking/Settings/Settings.swift
@@ -7,11 +7,13 @@ public struct Settings {
 
     /// WordPress.com API Base URL
     ///
-    public static var wordpressApiBaseURL: String = {
+    public static func wordpressApiBaseURL(wpComSandboxUsername: String? = nil) -> String {
         if ProcessInfo.processInfo.arguments.contains("mocked-wpcom-api") {
             return "http://localhost:8282/"
+        } else if let wpComSandboxUsername = wpComSandboxUsername {
+            return "https://\(wpComSandboxUsername).dev.dfw.wordpress.com/sandboxed-api/"
         }
 
         return "https://public-api.wordpress.com/"
-    }()
+    }
 }

--- a/Networking/NetworkingTests/Requests/DotcomRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/DotcomRequestTests.swift
@@ -34,7 +34,7 @@ class DotcomRequestTests: XCTestCase {
     func test_request_url_contains_expected_components() {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: sampleRPC)
 
-        let expectedURL = URL(string: Settings.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC)!
+        let expectedURL = URL(string: Settings.wordpressApiBaseURL() + request.wordpressApiVersion.path + sampleRPC)!
         let generatedURL = try! request.asURLRequest().url!
         XCTAssertEqual(expectedURL, generatedURL)
     }
@@ -44,7 +44,7 @@ class DotcomRequestTests: XCTestCase {
     func test_parameters_are_serialized_as_part_of_the_url_query_when_method_is_set_to_get() {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: sampleRPC, parameters: sampleParameters)
 
-        let expectedURL = URL(string: Settings.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC + sampleParametersForQuery)!
+        let expectedURL = URL(string: Settings.wordpressApiBaseURL() + request.wordpressApiVersion.path + sampleRPC + sampleParametersForQuery)!
         let generatedURL = try! request.asURLRequest().url!
 
         /// Note: Why not compare URL's directly?. As of iOS 12, URLQueryItem's serialization to string can result in swizzled entries.
@@ -68,7 +68,7 @@ class DotcomRequestTests: XCTestCase {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: sampleRPC, parameters: sampleParameters)
 
         let generatedURL = try! request.asURLRequest().url!
-        let expectedURL = URL(string: Settings.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC)!
+        let expectedURL = URL(string: Settings.wordpressApiBaseURL() + request.wordpressApiVersion.path + sampleRPC)!
         XCTAssertEqual(expectedURL, generatedURL)
     }
 

--- a/Networking/NetworkingTests/Requests/JetpackRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/JetpackRequestTests.swift
@@ -25,7 +25,7 @@ final class JetpackRequestTests: XCTestCase {
     /// Base URL: Mapping the Sample Site + Jetpack Tunneling API
     ///
     private var jetpackEndpointBaseURL: String {
-        return Settings.wordpressApiBaseURL + JetpackRequest.wordpressApiVersion.path + "jetpack-blogs/" + String(sampleSiteID) + "/rest-api/"
+        return Settings.wordpressApiBaseURL() + JetpackRequest.wordpressApiVersion.path + "jetpack-blogs/" + String(sampleSiteID) + "/rest-api/"
     }
 
 

--- a/Networking/NetworkingTests/Settings/SettingsTests.swift
+++ b/Networking/NetworkingTests/Settings/SettingsTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import Networking
+
+final class SettingsTests: XCTestCase {
+    func test_wordpressApiBaseURL_when_wpComSandboxUsername_is_passed_then_it_returns_sandboxed_url() {
+        let wpComSandboxUsername = "wpcomtester"
+        let expectedResult = "https://\(wpComSandboxUsername).dev.dfw.wordpress.com/sandboxed-api/"
+
+        XCTAssertEqual(Settings.wordpressApiBaseURL(wpComSandboxUsername: wpComSandboxUsername), expectedResult)
+    }
+}

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -61,7 +61,7 @@ class AuthenticationManager: Authentication {
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
                                                                 wpcomScheme: ApiCredentials.dotcomAuthScheme,
                                                                 wpcomTermsOfServiceURL: WooConstants.URLs.termsOfService.rawValue,
-                                                                wpcomAPIBaseURL: Settings.wordpressApiBaseURL,
+                                                                wpcomAPIBaseURL: Settings.wordpressApiBaseURL(),
                                                                 whatIsWPComURL: isSimplifiedLoginI1Enabled ? nil : WooConstants.URLs.whatIsWPCom.rawValue,
                                                                 googleLoginClientId: ApiCredentials.googleClientId,
                                                                 googleLoginServerClientId: ApiCredentials.googleServerId,

--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -19,7 +19,8 @@ struct InAppPurchasesDebugView: View {
                     }
                 }
             }
-            Section("Products") {
+            Section(header: Text("Products"), footer: Text("Be sure that you have an updated WPCOM sandbox linked to the" +
+                                                           " WPCOM username you used to authenticate in the app and a session started via ssh")) {
                 if products.isEmpty {
                     Text("No products")
                 } else {

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -37,7 +37,7 @@ class AuthenticatedState: StoresManagerState {
             CouponStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             CustomerStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             DataStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
-            InAppPurchaseStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
+            InAppPurchaseStore(dispatcher: dispatcher, storageManager: storageManager, network: network, wpComUsername: credentials.username),
             InboxNotesStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             JustInTimeMessageStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             MediaStore(dispatcher: dispatcher, storageManager: storageManager, network: network),

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -28,7 +28,7 @@ public class AccountStore: Store {
         let remote = AccountRemote(network: network)
         let dotcomAPI = WordPressComRestApi(oAuthToken: dotcomAuthToken,
                                             userAgent: UserAgent.defaultUserAgent,
-                                            baseUrlString: Settings.wordpressApiBaseURL)
+                                            baseUrlString: Settings.wordpressApiBaseURL())
         let dotcomRemote = AccountSettingsRemote(wordPressComRestApi: dotcomAPI)
         self.init(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote, dotcomRemote: dotcomRemote)
     }

--- a/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
+++ b/Yosemite/Yosemite/Stores/AnnouncementsStore.swift
@@ -13,7 +13,7 @@ public protocol AnnouncementsRemoteProtocol {
 
 extension AnnouncementServiceRemote: AnnouncementsRemoteProtocol {
     public override convenience init() {
-        self.init(wordPressComRestApi: WordPressComRestApi(baseUrlString: Settings.wordpressApiBaseURL))
+        self.init(wordPressComRestApi: WordPressComRestApi(baseUrlString: Settings.wordpressApiBaseURL()))
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8016
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we route the MobilePay "create orders" API request to the developer wp.com sandbox in debug mode. That way we avoid having to set up Charles to map the request, and ensure that all calls to create an order goes to the wp.com sandbox. It actually uses the user credentials to get the wp.com username, so it can compose the sandbox URL that replaces wp.com public API base URL.
Firstly I intended to add a debug setting to switch on or off routing to the wp.com sandbox, but I ended up discarding that given the complexity of configuring all remotes to use the wp.com username. If we need to be pointing to the wp.com sandbox to test other functionalities in the future we can extend it anyways.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Prerequisites
- Have a wp.com sandbox linked to the same wp.com account you use to authenticate in the app
- Login in the terminal to that sandbox via ssh so the server can start
- With a debug build, purchase an In-App purchase product and be sure that when submitting the request to our IAP backend it is pointing to your wp.com sandbox ("https://your wp.com user name.dev.dfw.wordpress.com/sandboxed-api/")

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
