### PR TITLE
[In-App Purchases] Add environment variable for the WordPress.com API base url

### DIFF
--- a/Networking/Networking/Settings/Settings.swift
+++ b/Networking/Networking/Settings/Settings.swift
@@ -10,6 +10,8 @@ public struct Settings {
     public static var wordpressApiBaseURL: String = {
         if ProcessInfo.processInfo.arguments.contains("mocked-wpcom-api") {
             return "http://localhost:8282/"
+        } else if let wpComApiBaseURL = ProcessInfo.processInfo.environment["wpcom-api-base-url"] {
+            return wpComApiBaseURL
         }
 
         return "https://public-api.wordpress.com/"

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -136,6 +136,13 @@
             isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "wpcom-api-base-url"
+            value = ""
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8016
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we provide the option to route the WordPress.com API requests to your wp.com sandbox e.g to use the sandbox billing mode instead of production when creation orders after an In-App purchase. That way, we avoid having to set up Charles to map the request, and ensure that all calls to create an order goes to the wp.com sandbox.
Firstly I intended to add a debug setting to switch on or off routing to the wp.com sandbox, but I ended up discarding that given the complexity of configuring all remotes to use the wp.com username. After that, I hardcoded the sandbox URL with the logged in WordPress.com username, but also rejected it because of security reasons.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Prerequisites
- Have a wp.com sandbox linked to the same wp.com account you use to authenticate in the app
- Login in the terminal to that sandbox via ssh so the server can start
- Enable the `wpcom-api-base-url` environment variable and add your WordPress.com API base URL.

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
