### PR TITLE
Update the git cache path from `woocommerce` to `automattic`

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -10,6 +10,9 @@ common_params:
     - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
+        # This is not necessarily the actual name of the repo or the GitHub organization
+        # it belongs to. It is the key used in the bucket, which is set based on
+        # the Buildkite pipeline slug
         repo: "automattic/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env

--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -10,7 +10,7 @@ common_params:
     - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
-        repo: "woocommerce/woocommerce-ios/"
+        repo: "automattic/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
     IMAGE_ID: xcode-14

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ common_params:
     - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
-        repo: "woocommerce/woocommerce-ios/"
+        repo: "automattic/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
     IMAGE_ID: xcode-14

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,9 @@ common_params:
     - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
+        # This is not necessarily the actual name of the repo or the GitHub organization
+        # it belongs to. It is the key used in the bucket, which is set based on
+        # the Buildkite pipeline slug
         repo: "automattic/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -7,7 +7,7 @@ common_params:
     - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
-        repo: "woocommerce/woocommerce-ios/"
+        repo: "automattic/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
     IMAGE_ID: xcode-14

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -7,6 +7,9 @@ common_params:
     - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
+        # This is not necessarily the actual name of the repo or the GitHub organization
+        # it belongs to. It is the key used in the bucket, which is set based on
+        # the Buildkite pipeline slug
         repo: "automattic/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env


### PR DESCRIPTION
WooCommerce iOS has had a `cache-builder.yml` configuration file for a while, but the git cache uses the Buildkite organization when uploading the cache instead of the GitHub repo (I discovered that after a lot of troubleshooting when adding caching to Day One 😄). This PR updates the `repo` path to `automattic` instead of `woocommerce` so that the caches can save correctly. 

There has been a single git cache file saved from 2022-03-22 saved in the `a8c-repo-mirrors/woocommerce/woocommerce-ios` folder that has been used to update the cache from. These changes make it so the cache can be updated daily and not have to update from the older cache. That `woocommerce` folder can be removed after this PR is merged. 

I also created a schedule in Buildkite (WooCommerce iOS > Pipeline Settings > Schedules) to rebuild the cache daily. 

### How to Test
1. Open WooCommerce iOS in Buildkite
2. Click the green "New Build" button in the upper right
3. Use `update/Git-cache-path` for the branch to build
4. Add `PIPELINE=cache-builder.yml` in the Environment Variables field (click the Options button to show the field)
5. Click "Create Build"
6. A cache rebuild will be kicked off. 
7. It should complete successfully. You can also verify by checking in the `a8c-repo-mirrors/automattic/woocommerce-ios` for the Git cache file (labeled with today's date) and in the `a8c-ci-cache` bucket for the pods cache (labeled `woocommerce-ios-specs-repos` and `woocommerce-ios-global-pod-cache`)
