### PR TITLE
Account creation: add `UnauthenticatedRequest` instead of passing empty credentials to `AuthenticatedRequest`

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		020D07BE23D8570800FD9580 /* MediaListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020D07BD23D8570800FD9580 /* MediaListMapper.swift */; };
 		020D07C023D8587700FD9580 /* MediaRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020D07BF23D8587700FD9580 /* MediaRemoteTests.swift */; };
 		020D07C223D858BB00FD9580 /* media-upload.json in Resources */ = {isa = PBXBuildFile; fileRef = 020D07C123D858BB00FD9580 /* media-upload.json */; };
+		020D0C03291504DE00BB3DCE /* UnauthenticatedRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020D0C02291504DE00BB3DCE /* UnauthenticatedRequestTests.swift */; };
 		0212683524C046CB00F8A892 /* MockNetwork+Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212683424C046CB00F8A892 /* MockNetwork+Path.swift */; };
 		0219B03923964BB3007DCD5E /* ProductShippingClassMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0219B03823964BB3007DCD5E /* ProductShippingClassMapper.swift */; };
 		021A84DA257DF92800BC71D1 /* ShippingLabelRefundMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021A84D9257DF92800BC71D1 /* ShippingLabelRefundMapper.swift */; };
@@ -55,6 +56,7 @@
 		029BA4F0255D7282006171FD /* ShippingLabelRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */; };
 		029BA4F4255D72EC006171FD /* ShippingLabelPrintData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA4F3255D72EC006171FD /* ShippingLabelPrintData.swift */; };
 		029BA53B255DFABD006171FD /* ShippingLabelPrintDataMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA53A255DFABD006171FD /* ShippingLabelPrintDataMapper.swift */; };
+		029C9E5C291507A40013E5EE /* UnauthenticatedRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029C9E5B291507A40013E5EE /* UnauthenticatedRequest.swift */; };
 		02A26F1B2744F5FC008E4EDB /* wc-site-settings-partial.json in Resources */ = {isa = PBXBuildFile; fileRef = 02A26F192744F5FC008E4EDB /* wc-site-settings-partial.json */; };
 		02A26F1C2744F5FC008E4EDB /* wp-site-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = 02A26F1A2744F5FC008E4EDB /* wp-site-settings.json */; };
 		02AAD53F250092A400BA1E26 /* product-add-or-delete.json in Resources */ = {isa = PBXBuildFile; fileRef = 02AAD53E250092A300BA1E26 /* product-add-or-delete.json */; };
@@ -751,6 +753,7 @@
 		020D07BD23D8570800FD9580 /* MediaListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaListMapper.swift; sourceTree = "<group>"; };
 		020D07BF23D8587700FD9580 /* MediaRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaRemoteTests.swift; sourceTree = "<group>"; };
 		020D07C123D858BB00FD9580 /* media-upload.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-upload.json"; sourceTree = "<group>"; };
+		020D0C02291504DE00BB3DCE /* UnauthenticatedRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnauthenticatedRequestTests.swift; sourceTree = "<group>"; };
 		0212683424C046CB00F8A892 /* MockNetwork+Path.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockNetwork+Path.swift"; sourceTree = "<group>"; };
 		0219B03823964BB3007DCD5E /* ProductShippingClassMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductShippingClassMapper.swift; sourceTree = "<group>"; };
 		021A84D9257DF92800BC71D1 /* ShippingLabelRefundMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRefundMapper.swift; sourceTree = "<group>"; };
@@ -789,6 +792,7 @@
 		029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRemote.swift; sourceTree = "<group>"; };
 		029BA4F3255D72EC006171FD /* ShippingLabelPrintData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintData.swift; sourceTree = "<group>"; };
 		029BA53A255DFABD006171FD /* ShippingLabelPrintDataMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintDataMapper.swift; sourceTree = "<group>"; };
+		029C9E5B291507A40013E5EE /* UnauthenticatedRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnauthenticatedRequest.swift; sourceTree = "<group>"; };
 		02A26F192744F5FC008E4EDB /* wc-site-settings-partial.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wc-site-settings-partial.json"; sourceTree = "<group>"; };
 		02A26F1A2744F5FC008E4EDB /* wp-site-settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wp-site-settings.json"; sourceTree = "<group>"; };
 		02AAD53E250092A300BA1E26 /* product-add-or-delete.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-add-or-delete.json"; sourceTree = "<group>"; };
@@ -1726,6 +1730,7 @@
 				DE34052028BDFE3500CF0D97 /* WordPressOrgRequestTests.swift */,
 				B567AF2D20A0FB8F00AB6C62 /* DotcomRequestTests.swift */,
 				B567AF2E20A0FB8F00AB6C62 /* JetpackRequestTests.swift */,
+				020D0C02291504DE00BB3DCE /* UnauthenticatedRequestTests.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -1853,6 +1858,7 @@
 				B557DA0E20975E07005962F4 /* DotcomRequest.swift */,
 				B557D9FF209754FF005962F4 /* JetpackRequest.swift */,
 				DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */,
+				029C9E5B291507A40013E5EE /* UnauthenticatedRequest.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -3039,6 +3045,7 @@
 				B5A2417D217F9ECC00595DEF /* MetaContainer.swift in Sources */,
 				025CA2C4238EBC4300B05C81 /* ProductShippingClassRemote.swift in Sources */,
 				D88D5A4B230BCF0A007B6E01 /* ProductReviewListMapper.swift in Sources */,
+				029C9E5C291507A40013E5EE /* UnauthenticatedRequest.swift in Sources */,
 				93D8BBFB226BBC5100AD2EB3 /* AccountSettings.swift in Sources */,
 				B53EF53821813806003E146F /* DotcomError.swift in Sources */,
 				CC07865F267799EE00BA9AC1 /* ShippingLabelPurchase.swift in Sources */,
@@ -3287,6 +3294,7 @@
 				4513382227A8409000AE5E78 /* InboxNotesRemoteTests.swift in Sources */,
 				45E461BE26837DB900011BF2 /* DataRemoteTests.swift in Sources */,
 				CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */,
+				020D0C03291504DE00BB3DCE /* UnauthenticatedRequestTests.swift in Sources */,
 				24F98C5E2502EDCF00F49B68 /* BundleWooTests.swift in Sources */,
 				036563DF29069C8F00D84BFD /* JustInTimeMessageListMapperTests.swift in Sources */,
 				74AB0ACA21948CE4008220CD /* CommentResultMapperTests.swift in Sources */,

--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -13,13 +13,13 @@ public class AlamofireNetwork: Network {
 
     /// WordPress.com Credentials.
     ///
-    private let credentials: Credentials
+    private let credentials: Credentials?
 
     public var session: URLSession { SessionManager.default.session }
 
     /// Public Initializer
     ///
-    public required init(credentials: Credentials) {
+    public required init(credentials: Credentials?) {
         self.credentials = credentials
 
         // A unique ID is included in the background session identifier so that the session does not get invalidated when the initializer is called multiple
@@ -45,9 +45,9 @@ public class AlamofireNetwork: Network {
     ///     - Yes. We do the above because the Jetpack Tunnel endpoint doesn't properly relay the correct statusCode.
     ///
     public func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) {
-        let authenticated = AuthenticatedRequest(credentials: credentials, request: request)
+        let request = createRequest(wrapping: request)
 
-        Alamofire.request(authenticated)
+        Alamofire.request(request)
             .responseData { response in
                 completion(response.value, response.networkingError)
             }
@@ -63,9 +63,9 @@ public class AlamofireNetwork: Network {
     ///     - completion: Closure to be executed upon completion.
     ///
     public func responseData(for request: URLRequestConvertible, completion: @escaping (Swift.Result<Data, Error>) -> Void) {
-        let authenticated = AuthenticatedRequest(credentials: credentials, request: request)
+        let request = createRequest(wrapping: request)
 
-        Alamofire.request(authenticated).responseData { response in
+        Alamofire.request(request).responseData { response in
             completion(response.result.toSwiftResult())
         }
     }
@@ -79,10 +79,10 @@ public class AlamofireNetwork: Network {
     /// - Parameter request: Request that should be performed.
     /// - Returns: A publisher that emits the result of the given request.
     public func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Swift.Result<Data, Error>, Never> {
-        let authenticated = AuthenticatedRequest(credentials: credentials, request: request)
+        let request = createRequest(wrapping: request)
 
         return Future() { promise in
-            Alamofire.request(authenticated).responseData { response in
+            Alamofire.request(request).responseData { response in
                 let result = response.result.toSwiftResult()
                 promise(Swift.Result.success(result))
             }
@@ -92,9 +92,9 @@ public class AlamofireNetwork: Network {
     public func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void,
                                         to request: URLRequestConvertible,
                                         completion: @escaping (Data?, Error?) -> Void) {
-        let authenticated = AuthenticatedRequest(credentials: credentials, request: request)
+        let request = createRequest(wrapping: request)
 
-        backgroundSessionManager.upload(multipartFormData: multipartFormData, with: authenticated) { (encodingResult) in
+        backgroundSessionManager.upload(multipartFormData: multipartFormData, with: request) { (encodingResult) in
             switch encodingResult {
             case .success(let upload, _, _):
                 upload.responseData { response in
@@ -104,6 +104,13 @@ public class AlamofireNetwork: Network {
                 completion(nil, error)
             }
         }
+    }
+}
+
+private extension AlamofireNetwork {
+    func createRequest(wrapping request: URLRequestConvertible) -> URLRequestConvertible {
+        credentials.map { AuthenticatedRequest(credentials: $0, request: request) } ??
+        UnauthenticatedRequest(request: request)
     }
 }
 

--- a/Networking/Networking/Network/MockNetwork.swift
+++ b/Networking/Networking/Network/MockNetwork.swift
@@ -185,6 +185,8 @@ private extension MockNetwork {
         switch request {
         case let request as AuthenticatedRequest:
             return path(for: request.request)
+        case let request as UnauthenticatedRequest:
+            return path(for: request.request)
         case let request as JetpackRequest:
             return request.path
         case let request as DotcomRequest:

--- a/Networking/Networking/Requests/UnauthenticatedRequest.swift
+++ b/Networking/Networking/Requests/UnauthenticatedRequest.swift
@@ -1,0 +1,23 @@
+import Foundation
+import protocol Alamofire.URLRequestConvertible
+
+
+/// Wraps up a `URLRequestConvertible` instance, and injects the `UserAgent.defaultUserAgent`.
+///
+struct UnauthenticatedRequest: URLRequestConvertible {
+
+    /// Request that does not require WPCOM authentication.
+    ///
+    let request: URLRequestConvertible
+
+    /// Returns the wrapped request, with a custom user-agent header.
+    ///
+    func asURLRequest() throws -> URLRequest {
+        var authenticated = try request.asURLRequest()
+
+        authenticated.setValue("application/json", forHTTPHeaderField: "Accept")
+        authenticated.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
+
+        return authenticated
+    }
+}

--- a/Networking/NetworkingTests/Requests/UnauthenticatedRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/UnauthenticatedRequestTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import XCTest
+@testable import Networking
+
+/// `UnauthenticatedRequest` Unit Tests
+final class UnauthenticatedRequestTests: XCTestCase {
+    /// Sample Unauthenticated Request
+    private let unauthenticatedRequest = try! URLRequest(url: "www.automattic.com", method: .get)
+
+    /// Verifies that the user-agent is injected as part of the HTTP Headers.
+    func test_user_agent_is_injected_as_request_header() throws {
+        // Given
+        let request = UnauthenticatedRequest(request: unauthenticatedRequest)
+
+        // When
+        let urlRequest = try request.asURLRequest()
+
+        // Then
+        let userAgentHeader = urlRequest.allHTTPHeaderFields?["User-Agent"]
+        XCTAssertEqual(userAgentHeader, UserAgent.defaultUserAgent)
+    }
+}

--- a/WooCommerce/Classes/Yosemite/DeauthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/DeauthenticatedState.swift
@@ -15,7 +15,7 @@ class DeauthenticatedState: StoresManagerState {
 
     init() {
         // Used for logged-out state without a WPCOM auth token.
-        let network = AlamofireNetwork(credentials: .init(authToken: ""))
+        let network = AlamofireNetwork(credentials: nil)
         services = [
             JetpackConnectionStore(dispatcher: dispatcher),
             AccountCreationStore(dotcomClientID: ApiCredentials.dotcomAppId,

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -45,6 +45,7 @@ At the moment, we provide four implementations of `URLRequestConvertible`:
 * [`JetpackRequest`](../Networking/Networking/Requests/JetpackRequest.swift) represents a Jetpack-Tunneled WordPress.com 
 * [`AuthenticatedRequest`](../Networking/Networking/Requests/AuthenticatedRequest.swift) Wraps up a `URLRequestConvertible` instance, and injects credentials (username and token) when required
 * [`WordPressOrgRequest`](../Networking/Networking/Requests/WordPressOrgRequest.swift) model requests to the WordPress.org REST API.
+* [`UnauthenticatedRequest`](../Networking/Networking/Requests/UnauthenticatedRequest.swift) Wraps up a `URLRequestConvertible` instance, and injects a custom user-agent header
 
 ## [`Mapper`](../Networking/Networking/Mapper/Mapper.swift)
 A protocol that abstracts the different parsers.

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -171,10 +171,12 @@ of performing this task for us:
 
 3.  **AuthenticatedRequest**
 
-        Injects a set of Credentials into anything that conforms to the URLConvertible protocol. Usually wraps up
+        Injects a set of Credentials and a custom user-agent header into anything that conforms to the URLConvertible protocol. Usually wraps up
         a DotcomRequest (OR) JetpackRequest.
 
+4. **UnauthenticatedRequest**
 
+        Wraps up a `URLConvertible` with a custom user-agent header. Used when the request does not require WordPress.com authentication.
 
 ### Remote Endpoints
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #7891 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In `AlamofireNetwork`, we currently assume all requests are authenticated because our app most often handles requests after logging in. With the addition of account creation for store creation M1, we're making API requests without a WPCOM account. Before this PR, we were passing an empty auth token to the `AlamofireNetwork` in `DeauthenticatedState`. This PR added `UnauthenticatedRequest` which is similar to `AuthenticatedRequest` but without the WPCOM credentials for unauthenticated use cases. Then in `AlamofireNetwork`, the WPCOM credentials parameter is now optional and it creates a `UnauthenticatedRequest` request if the credentials are nil.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please do a confidence check on:
- Account creation flow
  - Log out and skip onboarding if needed
  - Tap `Get Started` then continue to create an account and store --> the WPCOM account should be created successfully as before using `UnauthenticatedRequest`
- Logged-in state
  - Log in to the app
  - Continue with a connected store --> all the data like stats, orders, products, reviews should be loaded as before

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
