### PR TITLE
Products Onboarding: Update banner design based on review feedback

### DIFF
--- a/Storage/Storage/Model/Feature Announcements/FeatureAnnouncementCampaign.swift
+++ b/Storage/Storage/Model/Feature Announcements/FeatureAnnouncementCampaign.swift
@@ -5,6 +5,7 @@ public enum FeatureAnnouncementCampaign: String, Codable, Equatable {
     case linkedProductsPromo = "linked_products_promo"
     case paymentsInMenuTabBarButton = "payments_menu_tabbar_button"
     case paymentsInHubMenuButton = "payments_hub_menu_button"
+    case productsOnboarding = "products_onboarding_first_product"
 
     /// Added for use in `test_setFeatureAnnouncementDismissed_with_another_campaign_previously_dismissed_keeps_values_for_both`
     /// This can be removed when we have a second campaign, which can be used in the above test instead.

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/FeatureAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/FeatureAnnouncementCardViewModel.swift
@@ -17,7 +17,6 @@ protocol AnnouncementCardViewModelProtocol {
     func onAppear()
     func ctaTapped()
 
-    var showDismissButton: Bool { get }
     var showDismissConfirmation: Bool { get }
     var dismissAlertTitle: String { get }
     var dismissAlertMessage: String { get }
@@ -45,8 +44,6 @@ class FeatureAnnouncementCardViewModel: AnnouncementCardViewModelProtocol {
     var image: UIImage {
         config.image
     }
-
-    var showDismissButton: Bool = true
 
     var showDismissConfirmation: Bool {
         config.showDismissConfirmation

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModel.swift
@@ -61,9 +61,7 @@ final class JustInTimeMessageAnnouncementCardViewModel: AnnouncementCardViewMode
 
     let image: UIImage = .paymentsFeatureBannerImage
 
-    var showDismissButton: Bool = true
-
-    let showDismissConfirmation: Bool = false
+    var showDismissConfirmation: Bool = false
 
     let dismissAlertTitle: String = ""
 

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
@@ -27,14 +27,6 @@ struct ProductsOnboardingAnnouncementCardViewModel: AnnouncementCardViewModelPro
         onCTATapped?()
     }
 
-    // MARK: Dismiss button (disabled)
-
-    var showDismissButton: Bool = false
-
-    func dontShowAgainTapped() {
-        // No-op
-    }
-
     // MARK: Dismiss confirmation alert (disabled)
 
     var showDismissConfirmation: Bool = false
@@ -42,6 +34,10 @@ struct ProductsOnboardingAnnouncementCardViewModel: AnnouncementCardViewModelPro
     var dismissAlertTitle: String = ""
 
     var dismissAlertMessage: String = ""
+
+    func dontShowAgainTapped() {
+        // No-op
+    }
 
     func remindLaterTapped() {
         // No-op

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 struct ProductsOnboardingAnnouncementCardViewModel: AnnouncementCardViewModelProtocol {
-    var showDividers: Bool = false
+    var showDividers: Bool = true
 
     var badgeType: BadgeView.BadgeType = .tip
 

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import enum Yosemite.AppSettingsAction
 
 struct ProductsOnboardingAnnouncementCardViewModel: AnnouncementCardViewModelProtocol {
     var showDividers: Bool = true
@@ -27,6 +28,17 @@ struct ProductsOnboardingAnnouncementCardViewModel: AnnouncementCardViewModelPro
         onCTATapped?()
     }
 
+    // MARK: Dismiss button
+
+    /// Ensures the banner isn't shown again after the user manually dismisses it.
+    ///
+    func dontShowAgainTapped() {
+        let action = AppSettingsAction.setFeatureAnnouncementDismissed(campaign: .productsOnboarding,
+                                                                       remindLater: false,
+                                                                       onCompletion: nil)
+        ServiceLocator.stores.dispatch(action)
+    }
+
     // MARK: Dismiss confirmation alert (disabled)
 
     var showDismissConfirmation: Bool = false
@@ -34,10 +46,6 @@ struct ProductsOnboardingAnnouncementCardViewModel: AnnouncementCardViewModelPro
     var dismissAlertTitle: String = ""
 
     var dismissAlertMessage: String = ""
-
-    func dontShowAgainTapped() {
-        // No-op
-    }
 
     func remindLaterTapped() {
         // No-op

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
@@ -30,7 +30,7 @@ struct FeatureAnnouncementCardView: View {
                 BadgeView(type: viewModel.badgeType)
                     .padding(.leading, Layout.padding)
                 Spacer()
-                if viewModel.showDismissButton, let dismiss = dismiss {
+                if let dismiss = dismiss {
                     Button(action: {
                         if viewModel.showDismissConfirmation {
                             showingDismissActionSheet = true


### PR DESCRIPTION
Closes: #8032

## Description

This PR makes the following design changes based on our design review:

* Adds top and bottom borders to the banner
* Makes the banner dismissible (the user can dismiss the banner and it will not appear again)

This reverts the previous changes that removed the dismiss button from the onboarding banner. Now, we use a `FeatureAnnouncementCampaign` and the corresponding `AppSettingsActions` to set when the banner has been dismissed by the user and check that it wasn't dismissed before displaying it.

Using a `FeatureAnnouncementCampaign` for this is a bit of a shortcut but seems worth it to quickly add the dismiss button for this banner.

## Testing

**Prerequisite (before launching the app)**

1. Open the experiment details in Abacus (linked at the top of pbxNRc-26F-p2 or ping me for the direct link).
2. In the Audience section of the experiment setup, go to Variations > Manual Assignment and use the bookmarklet to assign yourself to the treatment group.

**Test steps**

1. Build and run the app. Note: You must be logged in to the app with an a8c account to test the experiment assignment/behavior while the experiment is in staging. If you are logged in to a different account, log out and log in again with your a8c account.
2. Select a store with no products.
3. Confirm you see the products onboarding banner on the My Store dashboard, with the expected design (top/bottom borders and a dismiss button).
4. Tap the "Add a Product" call to action, but don't add a product.
5. Go back to My Store, pull to refresh, and confirm the banner appears again.
6. Tap the "X" to dismiss the banner permanently.
7. Pull to refresh and confirm the banner does not appear again.

## Screenshots

Before|After
-|-
![ProductsOnboarding-Banner](https://user-images.githubusercontent.com/8658164/200015587-b8d53c44-92b1-4a9f-a573-2914de04a4ef.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-04 at 13 26 28](https://user-images.githubusercontent.com/8658164/200001307-08340df1-1709-4244-8f1c-7e45abc0bc83.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.