### PR TITLE
Products Onboarding: Add Template Experiment

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -20,6 +20,10 @@ public enum ABTest: String, CaseIterable {
     /// Experiment ref: pbxNRc-26F-p2
     case productsOnboardingBanner = "woocommerceios_products_onboarding_first_product_banner"
 
+    /// A/B test for the Products Onboarding product creation type bottom sheet after tapping the "Add Product" CTA.
+    /// Experiment ref: TODO Fill exp
+    case productsOnboardingTemplateProducts = "woocommerceios_products_onboarding_template_products"
+
     /// Returns a variation for the given experiment
     public var variation: Variation {
         ExPlat.shared?.experiment(rawValue) ?? .control
@@ -30,7 +34,7 @@ public enum ABTest: String, CaseIterable {
     /// When adding a new experiment, add it to the appropriate case depending on its context (logged-in or logged-out experience).
     public var context: ExperimentContext {
         switch self {
-        case .aaTestLoggedIn202210, .productsOnboardingBanner:
+        case .aaTestLoggedIn202210, .productsOnboardingBanner, .productsOnboardingTemplateProducts:
             return .loggedIn
         case .aaTestLoggedOut:
             return .loggedOut

--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -21,7 +21,7 @@ public enum ABTest: String, CaseIterable {
     case productsOnboardingBanner = "woocommerceios_products_onboarding_first_product_banner"
 
     /// A/B test for the Products Onboarding product creation type bottom sheet after tapping the "Add Product" CTA.
-    /// Experiment ref: TODO: Fill exp URL
+    /// Experiment ref: pbxNRc-28r-p2
     case productsOnboardingTemplateProducts = "woocommerceios_products_onboarding_template_products"
 
     /// Returns a variation for the given experiment

--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -21,7 +21,7 @@ public enum ABTest: String, CaseIterable {
     case productsOnboardingBanner = "woocommerceios_products_onboarding_first_product_banner"
 
     /// A/B test for the Products Onboarding product creation type bottom sheet after tapping the "Add Product" CTA.
-    /// Experiment ref: TODO Fill exp
+    /// Experiment ref: TODO: Fill exp URL
     case productsOnboardingTemplateProducts = "woocommerceios_products_onboarding_template_products"
 
     /// Returns a variation for the given experiment

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -3,6 +3,7 @@ import Yosemite
 import WooFoundation
 import protocol Storage.StorageManagerType
 import class Networking.ProductsRemote
+import enum Experiments.ABTest
 
 /// Controls navigation for the flow to add a product given a navigation controller.
 /// This class is not meant to be retained so that its life cycle is throughout the navigation. Example usage:
@@ -32,7 +33,7 @@ final class AddProductCoordinator: Coordinator {
     init(siteID: Int64,
          sourceBarButtonItem: UIBarButtonItem,
          sourceNavigationController: UINavigationController,
-         isProductCreationTypeEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productsOnboarding),
+         isProductCreationTypeEnabled: Bool = ABTest.productsOnboardingTemplateProducts.variation == .treatment(nil),
          storage: StorageManagerType = ServiceLocator.storageManager,
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader) {
         self.siteID = siteID
@@ -47,7 +48,7 @@ final class AddProductCoordinator: Coordinator {
     init(siteID: Int64,
          sourceView: UIView,
          sourceNavigationController: UINavigationController,
-         isProductCreationTypeEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productsOnboarding),
+         isProductCreationTypeEnabled: Bool = ABTest.productsOnboardingTemplateProducts.variation == .treatment(nil),
          storage: StorageManagerType = ServiceLocator.storageManager,
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader) {
         self.siteID = siteID


### PR DESCRIPTION
closes #8036

# Why

To ship this experiment to users earlier, I'm getting ahead of the curve and adding the code that will enable the template experiment into the app.

The downside is that we can't test the treatment group right now, because the experiment is not yet modeled in Abacus, but I'm [creating an issue](https://github.com/woocommerce/woocommerce-ios/issues/8037) to make sure the experiment is tested before it is launched.

For now, we can make sure that the control group works as expected, which is that by tapping the Product CTA, we get the product type bottom sheet as normal. 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
