### PR TITLE
Products Onboarding: Improve bottom sheet template copy

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductCreationTypeCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductCreationTypeCommand.swift
@@ -23,7 +23,7 @@ public enum ProductCreationType: Equatable {
     var actionSheetDescription: String {
         switch self {
         case .template:
-            return NSLocalizedString("Use a template to create physical, virtual, and variable products.",
+            return NSLocalizedString("Use a template to create physical, virtual, and variable products. You can edit it as you go.",
                                      comment: "Description for the option to create a template product")
         case .manual:
             return NSLocalizedString("Add a product manually.",


### PR DESCRIPTION
Part of #8039 

# Why 

This PR updates the description of the "template" bottom sheet option to better convey that the merchants can edit the template products.

# Testing Step

- Login into a store with less than 3 products
- Tap on the Add product CTA in the product list screen
- See that the "Template" option of the presented bottom sheet reads 
> Use a template to create physical, virtual, and variable products. You can edit it as you go.

# Screenshots

![template](https://user-images.githubusercontent.com/562080/200019610-3be233d0-9ada-4232-98a7-eb18be1a3652.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
