### PR TITLE
Fix order notification deeplink

### DIFF
--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -477,6 +477,7 @@ private extension PushNotificationsManager {
     /// Handles a remote notification while the app is inactive.
     ///
     /// - Parameter notification: Push notification content from a remote notification.
+    @MainActor
     func handleInactiveRemoteNotification(notification: PushNotification) async {
         guard applicationState == .inactive else {
             return

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -337,10 +337,8 @@ extension MainTabBarController {
             }
             let siteID = Int64(note.meta.identifier(forKey: .site) ?? Int.min)
 
-            switchToStore(with: siteID, onCompletion: { siteChanged in
-                if siteChanged {
-                    presentNotificationDetails(for: note)
-                }
+            switchToStore(with: siteID, onCompletion: { _ in
+                presentNotificationDetails(for: note)
             })
         }
         ServiceLocator.stores.dispatch(action)


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/8020

## Description
This PR updates updates push notification deeplink condition. Previously it only continued after the store switch (for multi-store notifications).

## How
- Added `@MainActor` to prevent hitting [thread assertion](https://github.com/woocommerce/woocommerce-ios/blob/50cb84af7ed0adb572c6f3a48b8333986de2b847/Yosemite/Yosemite/Internal/Assert.swift#L6-L8). It doesn't impact release build, but is a blocker for debug.
- Removed unnecessary condition from `presentNotificationDetails` func.

## Testing

1. Test on the device.
2. Agree to push notifications on the first app run or update it in the iOS settings for the Woo app.
3. Test foreground notification
    1. Run the app and keep it in foreground.
    2. Make a new order from the desktop to trigger a notification.
    4. Tap "view" on in-app banner.
    5. Confirm it switches to the orders tab and opens order details.
    6. Navigate back to dashboard.
3. Test background notification
    1. Run the app and dismiss it, navigating to the home screen (don't force close it).
    2. Make a new order from the desktop to trigger a notification.
    3. Tap iOS notification for the order.
    4. Confirm app launches, switches to the orders tab and opens order details.
    5. Navigate back to dashboard.
4. Test notification for the closed app
    1. Force close the Woo app (swipe up from app switcher).
    2. Make a new order from the desktop to trigger a notification.
    3. Tap iOS notification for the order.
    4. Confirm app launches, switches to the orders tab and opens order details.
    5. Navigate back to dashboard.

*Note:* sometimes in "closed app" state the flow doesn't navigate fully to the order details, stopping on top of refreshed orders list. I wasn't able to find the issue or reliably reproduce it.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
