### PR TITLE
Remove unused `wpcomSignup` feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -33,8 +33,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .searchProductsBySKU:
             return true
-        case .wpcomSignup:
-            return false
         case .inAppPurchases:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .storeCreationMVP:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -70,10 +70,6 @@ public enum FeatureFlag: Int {
     ///
     case searchProductsBySKU
 
-    /// Enables signing up for a WP.com account.
-    ///
-    case wpcomSignup
-
     /// Enables In-app purchases for buying Hosted WooCommerce plans
     ///
     case inAppPurchases

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -41,13 +41,9 @@ class AuthenticationManager: Authentication {
     ///
     private let storageManager: StorageManagerType
 
-    /// Whether WP.com signup is enabled in the authentication flow based on the feature flag.
-    private let isWPComSignupEnabled: Bool
-
     init(storageManager: StorageManagerType = ServiceLocator.storageManager,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.storageManager = storageManager
-        self.isWPComSignupEnabled = featureFlagService.isFeatureFlagEnabled(.wpcomSignup)
     }
 
     /// Initializes the WordPress Authenticator.
@@ -68,7 +64,7 @@ class AuthenticationManager: Authentication {
                                                                 googleLoginScheme: ApiCredentials.googleAuthScheme,
                                                                 userAgent: UserAgent.defaultUserAgent,
                                                                 showLoginOptions: true,
-                                                                enableSignUp: isWPComSignupEnabled,
+                                                                enableSignUp: false,
                                                                 enableSignInWithApple: true,
                                                                 enableSignupWithGoogle: false,
                                                                 enableUnifiedAuth: true,
@@ -402,27 +398,19 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
     /// Presents the Signup Epilogue, in the specified NavigationController.
     ///
     func presentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?) {
-        if isWPComSignupEnabled {
-            // A proper signup epilogue flow will be added incrementally later as part of the WP.com signup experiment:
-            // Ref: pe5sF9-xP-p2
-            sync(credentials: credentials) { [weak self] in
-                self?.startStorePicker(in: navigationController)
-            }
-        } else {
-            // NO-OP: The current WC version does not support Signup. Let SIWA through.
-            guard case .apple = service else {
-                return
-            }
+        // NO-OP: The current WC version does not support Signup. Let SIWA through.
+        guard case .apple = service else {
+            return
+        }
 
-            // For SIWA, signups are treating like signing in for now.
-            // Signup code in Authenticator normally synchronizes the auth credentials but
-            // since we're hacking in SIWA, that's never called in the pod. Call here so the
-            // person's name and user ID show up on the picker screen.
-            //
-            // This is effectively a useless screen for them other than telling them to install Jetpack.
-            sync(credentials: credentials) { [weak self] in
-                self?.startStorePicker(in: navigationController)
-            }
+        // For SIWA, signups are treating like signing in for now.
+        // Signup code in Authenticator normally synchronizes the auth credentials but
+        // since we're hacking in SIWA, that's never called in the pod. Call here so the
+        // person's name and user ID show up on the picker screen.
+        //
+        // This is effectively a useless screen for them other than telling them to install Jetpack.
+        sync(credentials: credentials) { [weak self] in
+            self?.startStorePicker(in: navigationController)
         }
     }
 
@@ -480,7 +468,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
     /// Note: As of now, this is a NO-OP, we're not supporting any signup flows.
     ///
     func shouldPresentSignupEpilogue() -> Bool {
-        isWPComSignupEnabled
+        false
     }
 
     /// Synchronizes the specified WordPress Account.


### PR DESCRIPTION


<!-- Remember about a good descriptive title. -->

Closes: #7793
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Since the design has changed in favor of native account creation (signup) in https://github.com/woocommerce/woocommerce-ios/issues/7891, I deleted the unused `wpcomSignup` feature flag and reverted the changes in https://github.com/woocommerce/woocommerce-ios/pull/7794. Everything should work as before because the feature is disabled.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You can do a confidence check by:

- Launch the app
- Log out and skip onboarding if needed
- Tap either login button
- When entering the WPCOM email, enter an email that isn't associated with a WPCOM account --> the login email error screen should be shown instead of continuing with the account creation flow in the WPAuthenticator library

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
