### PR TITLE
[In-app Purchases] Improve debug view UX

### DIFF
--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -9,6 +9,7 @@ struct InAppPurchasesDebugView: View {
     @State var products: [WPComPlanProduct] = []
     @State var entitledProductIDs: [String] = []
     @State var inAppPurchasesAreSupported = true
+    @State var isPurchasing = false
 
     var body: some View {
         List {
@@ -22,11 +23,15 @@ struct InAppPurchasesDebugView: View {
             Section("Products") {
                 if products.isEmpty {
                     Text("No products")
+                } else if isPurchasing {
+                    ActivityIndicator(isAnimating: .constant(true), style: .medium)
                 } else {
                     ForEach(products, id: \.id) { product in
                         Button(entitledProductIDs.contains(product.id) ? "Entitled: \(product.description)" : product.description) {
                             Task {
+                                isPurchasing = true
                                 try? await inAppPurchasesForWPComPlansManager.purchaseProduct(with: product.id, for: siteID)
+                                isPurchasing = false
                             }
                         }
                     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After some In-app Purchases testing, I noticed some confusion with the information shown by the IAP debug screen. This PR adds a couple of improvements:

- Disable the purchase button while a purchase is in progress. Since iOS takes a few seconds to show any UI, and there was nothing else shown while communicating with WordPress.com servers, it wasn't clear when the process ended. Now it shows an activity indicator instead of the button while making a purchase.
- Update entitlements more consistently. Previously, the screen loaded the current entitlements when loading products, but didn't update correctly when a purchase was made or a subscription expired unless you reloaded products manually. Now it updates in those cases.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Hub Menu > IAP Debug
2. Purchase a monthly subscription. Notice the button is replaced by an activity indicator until the process finishes.
3. Once the subscription purchase is complete, the button should be back and show "Entitled"
4. Go to iOS Settings > App Store > Manage sandbox account and cancel the subscription
5. Wait a few minutes until the subscription expires and go back to the app
6. The button shouldn't show Entitled anymore. If the subscription hasn't expired yet, sending the app to the background and open again should reload the entitlements.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
