### PR TITLE
Products Onboarding: Enable product previews for all stores

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -971,7 +971,9 @@ private extension ProductFormViewController {
     }
 
     func createPreviewBarButtonItem() -> UIBarButtonItem {
-        return UIBarButtonItem(title: Localization.previewTitle, style: .done, target: self, action: #selector(saveDraftAndDisplayProductPreview))
+        let previewButton = UIBarButtonItem(title: Localization.previewTitle, style: .done, target: self, action: #selector(saveDraftAndDisplayProductPreview))
+        previewButton.isEnabled = viewModel.shouldEnablePreviewButton()
+        return previewButton
     }
 
     func createMoreOptionsBarButtonItem() -> UIBarButtonItem {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -226,6 +226,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         permalink.queryItems = updatedQueryItems
 
         let configuration = WebViewControllerConfiguration(url: permalink.url)
+        configuration.secureInteraction = true
         let webKitVC = WebKitViewController(configuration: configuration)
         let nc = WooNavigationController(rootViewController: webKitVC)
         present(nc, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -153,11 +153,9 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         }()
 
         if featureFlagService.isFeatureFlagEnabled(.productsOnboarding),
-           // The store is hosted on WP.com
+           // The `frame_nonce` value must be stored for the preview to be displayed
            let site = stores.sessionManager.defaultSite,
-           site.isWordPressComStore,
-           // In some edge cases loginURL can be empty preventing successful login flow
-           site.loginURL.isNotEmpty,
+           site.frameNonce.isNotEmpty,
             // Preview existing drafts or new products, that can be saved as a draft
            (canSaveAsDraft() || originalProductModel.status == .draft),
            // Do not preview new blank products without any changes

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -157,9 +157,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
            let site = stores.sessionManager.defaultSite,
            site.frameNonce.isNotEmpty,
             // Preview existing drafts or new products, that can be saved as a draft
-           (canSaveAsDraft() || originalProductModel.status == .draft),
-           // Do not preview new blank products without any changes
-           !(formType == .add && !hasUnsavedChanges()) {
+           (canSaveAsDraft() || originalProductModel.status == .draft) {
             buttons.insert(.preview, at: 0)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -180,4 +180,11 @@ extension ProductFormViewModelProtocol {
             }
         }
     }
+
+    /// Whether the Preview button should be enabled, when it's available in the navigation bar.
+    /// Returns `false` when it's a new blank product without any changes.
+    ///
+    func shouldEnablePreviewButton() -> Bool {
+        !(formType == .add && !hasUnsavedChanges())
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -542,7 +542,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     // MARK: Preview button tests (with enabled Product Onboarding feature flag)
 
-    func test_no_preview_button_for_new_blank_product_without_any_changes() {
+    func test_disabled_preview_button_for_new_blank_product_without_any_changes() {
         // Given
         sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
 
@@ -556,10 +556,11 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.publish, .more])
+        XCTAssertEqual(actionButtons, [.preview, .publish, .more])
+        XCTAssertFalse(viewModel.shouldEnablePreviewButton())
     }
 
-    func test_preview_button_for_new_product_with_pending_changes() {
+    func test_enabled_preview_button_for_new_product_with_pending_changes() {
         // Given
         sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
 
@@ -575,6 +576,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(actionButtons, [.preview, .publish, .more])
+        XCTAssertTrue(viewModel.shouldEnablePreviewButton())
     }
 
     func test_no_preview_button_for_existing_published_product_without_any_changes() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -544,7 +544,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_no_preview_button_for_new_blank_product_without_any_changes() {
         // Given
-        sessionManager.defaultSite = Site.fake().copy(loginURL: "http://test.com/wp-login.php", isWordPressComStore: true)
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
 
         let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
         let viewModel = createViewModel(product: product,
@@ -561,7 +561,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_preview_button_for_new_product_with_pending_changes() {
         // Given
-        sessionManager.defaultSite = Site.fake().copy(loginURL: "http://test.com/wp-login.php", isWordPressComStore: true)
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
 
         let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
         let viewModel = createViewModel(product: product,
@@ -579,7 +579,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_no_preview_button_for_existing_published_product_without_any_changes() {
         // Given
-        sessionManager.defaultSite = Site.fake().copy(loginURL: "http://test.com/wp-login.php", isWordPressComStore: true)
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
 
         let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.published.rawValue)
         let viewModel = createViewModel(product: product,
@@ -597,7 +597,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_no_preview_button_for_existing_published_product_with_pending_changes() {
         // Given
-        sessionManager.defaultSite = Site.fake().copy(loginURL: "http://test.com/wp-login.php", isWordPressComStore: true)
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
 
         let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.published.rawValue)
         let viewModel = createViewModel(product: product,
@@ -614,7 +614,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_preview_button_for_existing_draft_product_without_any_changes() {
         // Given
-        sessionManager.defaultSite = Site.fake().copy(loginURL: "http://test.com/wp-login.php", isWordPressComStore: true)
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
 
         let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
         let viewModel = createViewModel(product: product,
@@ -631,7 +631,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_preview_button_for_existing_draft_product_with_pending_changes() {
         // Given
-        sessionManager.defaultSite = Site.fake().copy(loginURL: "http://test.com/wp-login.php", isWordPressComStore: true)
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
 
         let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
         let viewModel = createViewModel(product: product,
@@ -649,7 +649,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_no_preview_button_for_existing_product_with_other_status_and_without_any_changes() {
         // Given
-        sessionManager.defaultSite = Site.fake().copy(loginURL: "http://test.com/wp-login.php", isWordPressComStore: true)
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
 
         let product = Product.fake().copy(productID: 123, statusKey: "other")
         let viewModel = createViewModel(product: product,
@@ -666,7 +666,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_no_preview_button_for_existing_product_with_other_status_and_pending_changes() {
         // Given
-        sessionManager.defaultSite = Site.fake().copy(loginURL: "http://test.com/wp-login.php", isWordPressComStore: true)
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
 
         let product = Product.fake().copy(productID: 123, statusKey: "other")
         let viewModel = createViewModel(product: product,
@@ -684,7 +684,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_no_preview_button_for_any_product_in_read_only_mode() {
         // Given
-        sessionManager.defaultSite = Site.fake().copy(loginURL: "http://test.com/wp-login.php", isWordPressComStore: true)
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
 
         let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.published.rawValue)
         let viewModel = createViewModel(product: product,
@@ -700,26 +700,9 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertEqual(actionButtons, [.more])
     }
 
-    func test_no_preview_button_for_existing_draft_product_on_self_hosted_store() {
+    func test_no_preview_button_for_existing_draft_product_on_site_with_no_frame_nonce() {
         // Given
-        sessionManager.defaultSite = Site.fake().copy(loginURL: "http://test.com/wp-login.php", isWordPressComStore: false)
-
-        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
-        let viewModel = createViewModel(product: product,
-                                        formType: .edit,
-                                        stores: stores,
-                                        featureFlagService: MockFeatureFlagService(isProductsOnboardingEnabled: true))
-
-        // When
-        let actionButtons = viewModel.actionButtons
-
-        // Then
-        XCTAssertEqual(actionButtons, [.publish, .more])
-    }
-
-    func test_no_preview_button_for_existing_draft_product_on_site_with_no_preview_url() {
-        // Given
-        sessionManager.defaultSite = Site.fake().copy(loginURL: "", isWordPressComStore: true)
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "")
 
         let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
         let viewModel = createViewModel(product: product,


### PR DESCRIPTION
Closes: #8046

## Description

This PR enables product preview for all stores (instead of only WordPress.com-hosted stores) by using a `frame-nonce` parameter in the preview URL. The same preview approach is used for all stores, to reduce complexity.

It also updates the Preview button so it's always visible on products that can be previewed (new and draft products), and just disabled when the product is a new blank product. This is better for accessibility, so the button doesn't appear/disappear from the navigation bar.

Caveat: I can't come up with a good way to distinguish template products from new blank products, so the preview button is only enabled once you make changes to the template product details. (This is the same behavior as before.)

## Changes

* Removes the authentication step from `displayProductPreview()` and just adds the required query parameters (`preview` and `frame-nonce`) to the preview URL.
* Removes the check for new blank products when action buttons are added to the navigation bar, and moves that to a separate check `shouldEnablePreviewButton()` to determine if the Preview button should be enabled.

## Testing

1. Build and run the app in debug or alpha mode.
2. Select a store not hosted on WordPress.com.
3. Go to the Products tab and add a new product. Confirm the Preview button is visible but disabled, and it is enabled once you start making changes.
5. Tap the Preview button. Confirm the new product is saved and you can see a preview on your store.

## Screenshots



https://user-images.githubusercontent.com/8658164/200646711-5f4a7760-7db7-4317-97ea-eaa74ff50ba3.mp4


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
