### PR TITLE
Track XMLRPC failure

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -72,7 +72,7 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   # pod 'WordPressAuthenticator', '~> 4.1.1'
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'c169358f383aa0bcbfb383dfa03ae983d543b266'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'f2ad89e43f769ac144dcb19df89bb5c78efa7c2a'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -71,8 +71,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  # pod 'WordPressAuthenticator', '~> 4.1.1'
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'f2ad89e43f769ac144dcb19df89bb5c78efa7c2a'
+  pod 'WordPressAuthenticator', '~> 4.2.0-beta.1'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -71,8 +71,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 4.1.1'
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'f24fd9c6dbc73cfee583a7eba16fa81e2948fa43'
+  # pod 'WordPressAuthenticator', '~> 4.1.1'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'c169358f383aa0bcbfb383dfa03ae983d543b266'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -91,7 +91,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `c169358f383aa0bcbfb383dfa03ae983d543b266`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `f2ad89e43f769ac144dcb19df89bb5c78efa7c2a`)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -140,12 +140,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: c169358f383aa0bcbfb383dfa03ae983d543b266
+    :commit: f2ad89e43f769ac144dcb19df89bb5c78efa7c2a
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: c169358f383aa0bcbfb383dfa03ae983d543b266
+    :commit: f2ad89e43f769ac144dcb19df89bb5c78efa7c2a
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -186,6 +186,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: b0739044fc0ab9b7fc5978c67acd90536c58f49a
+PODFILE CHECKSUM: 127e272a219e58543a375387ad6ea967d11bee6a
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -91,7 +91,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `f2ad89e43f769ac144dcb19df89bb5c78efa7c2a`)
+  - WordPressAuthenticator (~> 4.2.0-beta.1)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -101,6 +101,8 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
+  https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -138,16 +140,6 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :commit: f2ad89e43f769ac144dcb19df89bb5c78efa7c2a
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: f2ad89e43f769ac144dcb19df89bb5c78efa7c2a
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 8fca6b5563a5baef2c04bee27538025e4ceb2add
@@ -170,7 +162,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 7ee99598a2d4acb5a837aa1ff2d766c0ff497f34
+  WordPressAuthenticator: 41527f0d502d006df9604aa5d968021c195a1917
   WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -186,6 +178,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 127e272a219e58543a375387ad6ea967d11bee6a
+PODFILE CHECKSUM: e0c278d30dacb5909924805c869452fc3aaffbf6
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -42,7 +42,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (4.1.1):
+  - WordPressAuthenticator (4.2.0-beta.1):
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
@@ -91,7 +91,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 4.1.1)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `c169358f383aa0bcbfb383dfa03ae983d543b266`)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -101,8 +101,6 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -140,6 +138,16 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :commit: c169358f383aa0bcbfb383dfa03ae983d543b266
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: c169358f383aa0bcbfb383dfa03ae983d543b266
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 8fca6b5563a5baef2c04bee27538025e4ceb2add
@@ -162,7 +170,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 6b15ea70d238d90d5ba3c78dae002a707e8c23c4
+  WordPressAuthenticator: 7ee99598a2d4acb5a837aa1ff2d766c0ff497f34
   WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -178,6 +186,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 55531c64b396f477ea6e3814ab400e9b14d0bf48
+PODFILE CHECKSUM: b0739044fc0ab9b7fc5978c67acd90536c58f49a
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8063
<!-- Id number of the GitHub issue this PR addresses. -->

- [ ] Please review - https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/701

### Description

Currently, we don't have a specific tracking event to track the XMLRPC-related errors. This PR adds a new tracking event to track these failures.

This PR is for testing the changes made to the Authenticator library. 

### Testing instructions

**Prerequisites**
- Disable simplified login
As we are running AB tests to be able to sign in using a store address you may have to hardcode and disable simplified login by changing line no 58 in `AuthenticationManager` file.

```swift
let isSimplifiedLoginI1Enabled = false//ABTest.abTestLoginWithWPComOnly.variation != .control
```

- Create a JN site and [disable XMLRPC in it](https://mediatemple.net/community/products/dv/360048950192/how-to-disable-xmlrpc.php-for-wordpress).

**Steps to test**
1. Install and launch the app.
1. Skip the prologue and tap on the "Enter Your Store Address" button.
1. Enter the JN site address and tap `Continue`.
1. After the request finishes, you will see an error screen. (It shows not a WP site error which will be fixed when we remove XMLRPC checks)
1.  Check logs and ensure that the following event is tracked.
```
Tracked unified_login_failure, properties: [AnyHashable("failure"): "login_failed_to_guess_xmlrpc_url", AnyHashable("source"): "default", AnyHashable("flow"): "login_site_address", AnyHashable("step"): "start"]
```
1.  There should also be another `unified_login_failure` event with the actual error message. Please note that the error message will be different for various type of errors.
```
Tracked unified_login_failure, properties: [AnyHashable("failure"): "Couldn\'t connect to the WordPress site. There is no valid WordPress site at this address. Check the site address (URL) you entered.", AnyHashable("source"): "default", AnyHashable("flow"): "login_site_address", AnyHashable("step"): "start"]
```

### Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
