### PR TITLE
Products Onboarding: Adds a templateEligible property to productListAddProductTapped event

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1722,6 +1722,7 @@ extension WooAnalyticsEvent {
     enum ProductsOnboarding {
         enum Keys: String {
             case type
+            case templateEligible = "template_eligible"
         }
 
         enum CreationType: String {
@@ -1745,6 +1746,10 @@ extension WooAnalyticsEvent {
         ///
         static func productCreationTypeSelected(type: CreationType) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .addProductCreationTypeSelected, properties: [Keys.type.rawValue: type.rawValue])
+        }
+
+        static func productListAddProductButtonTapped(templateEligible: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productListAddProductTapped, properties: [Keys.templateEligible.rawValue: templateEligible])
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -65,6 +65,9 @@ final class AddProductCoordinator: Coordinator {
     }
 
     func start() {
+
+        ServiceLocator.analytics.track(event: .ProductsOnboarding.productListAddProductButtonTapped(templateEligible: isTemplateOptionsEligible()))
+
         if shouldPresentProductCreationBottomSheet() {
             presentProductCreationTypeBottomSheet()
         } else {
@@ -77,10 +80,16 @@ final class AddProductCoordinator: Coordinator {
 private extension AddProductCoordinator {
 
     /// Defines if the product creation bottom sheet should be presented.
-    /// Currently returns `true` when the feature is enabled and the number of products is fewer than 3.
+    /// Currently returns `true` when the feature is enabled and the store is eligible for displaying template options.
     ///
     func shouldPresentProductCreationBottomSheet() -> Bool {
-        isProductCreationTypeEnabled && productsResultsController.numberOfObjects < 3
+        isProductCreationTypeEnabled && isTemplateOptionsEligible()
+    }
+
+    /// Returns `true` when the number of products is fewer than 3.
+    ///
+    func isTemplateOptionsEligible() -> Bool {
+        productsResultsController.numberOfObjects < 3
     }
 
     /// Presents a bottom sheet for users to choose if they want a create a product manually or via a template.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -258,8 +258,6 @@ private extension ProductsViewController {
             return
         }
 
-        ServiceLocator.analytics.track(.productListAddProductTapped)
-
         let coordinatingController: AddProductCoordinator
         if let sourceBarButtonItem = sourceBarButtonItem {
             coordinatingController = AddProductCoordinator(siteID: siteID,


### PR DESCRIPTION
# Why

In order to properly identify which users should count toward the template experiment, this PR updates the `productListAddProductTapped` event to add a `template-eligible` property to be used as an exposure event on the Abacus experiment.

# Screenshots

<img width="1322" alt="Screen Shot 2022-11-09 at 11 28 39 AM" src="https://user-images.githubusercontent.com/562080/200887251-0b66785c-94bd-492d-b28f-5557a1b4ceaa.png">

# Testing

- Launch the app in a store with less than 3 products and tap the Add Product CTA
- See that the event tracked has a `template-eligible` property with a `true` value

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
