### PR TITLE
Login: Update Networking for plugin management endpoints with cookie authentication

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -684,6 +684,7 @@
 		DE74F2A027E3137F0002FE59 /* setting-analytics.json in Resources */ = {isa = PBXBuildFile; fileRef = DE74F29F27E3137F0002FE59 /* setting-analytics.json */; };
 		DE97C3922861B8E20042E973 /* CouponEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE97C3912861B8E20042E973 /* CouponEncoderTests.swift */; };
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
+		DE9DEEF5291CF1B40070AD7C /* site-plugin-without-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9DEEF4291CF1B40070AD7C /* site-plugin-without-envelope.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
 		DEC51A97274DD962009F3DF4 /* plugin.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51A96274DD962009F3DF4 /* plugin.json */; };
@@ -1432,6 +1433,7 @@
 		DE74F29F27E3137F0002FE59 /* setting-analytics.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-analytics.json"; sourceTree = "<group>"; };
 		DE97C3912861B8E20042E973 /* CouponEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponEncoderTests.swift; sourceTree = "<group>"; };
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
+		DE9DEEF4291CF1B40070AD7C /* site-plugin-without-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-plugin-without-envelope.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
 		DEC51A96274DD962009F3DF4 /* plugin.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = plugin.json; sourceTree = "<group>"; };
@@ -1987,6 +1989,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DE9DEEF4291CF1B40070AD7C /* site-plugin-without-envelope.json */,
 				028CB714290223CB00331C09 /* account-username-suggestions.json */,
 				028CB71C2902589E00331C09 /* create-account-error-email-exists.json */,
 				028CB71D2902589E00331C09 /* create-account-error-invalid-email.json */,
@@ -2660,6 +2663,7 @@
 				D865CE5F278CA183002C8520 /* stripe-payment-intent-requires-action.json in Resources */,
 				CCF48B2C2628AE160034EA83 /* shipping-label-account-settings.json in Resources */,
 				31A451D927863A2E00FE81AA /* stripe-account-live-test.json in Resources */,
+				DE9DEEF5291CF1B40070AD7C /* site-plugin-without-envelope.json in Resources */,
 				0261F5A928D4641500B7AC72 /* products-sku-search.json in Resources */,
 				09885C8027C3FFD200910A62 /* product-variations-bulk-update.json in Resources */,
 				31054734262E36AB00C5C02B /* wcpay-payment-intent-error.json in Resources */,

--- a/Networking/Networking/Mapper/SitePluginMapper.swift
+++ b/Networking/Networking/Mapper/SitePluginMapper.swift
@@ -7,7 +7,14 @@ struct SitePluginMapper: Mapper {
     /// Site Identifier associated to the plugin that will be parsed.
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the SiteID in the plugin endpoint.
     ///
-    let siteID: Int64
+    private let siteID: Int64
+
+    private let withDataEnvelope: Bool
+
+    init(siteID: Int64 = -1, withDataEnvelope: Bool = true) {
+        self.siteID = siteID
+        self.withDataEnvelope = withDataEnvelope
+    }
 
     /// (Attempts) to convert a dictionary into SitePlugin.
     ///
@@ -17,7 +24,11 @@ struct SitePluginMapper: Mapper {
             .siteID: siteID
         ]
 
-        return try decoder.decode(SitePluginEnvelope.self, from: response).plugin
+        if withDataEnvelope {
+            return try decoder.decode(SitePluginEnvelope.self, from: response).plugin
+        }
+
+        return try decoder.decode(SitePlugin.self, from: response)
     }
 }
 

--- a/Networking/Networking/Mapper/SitePluginMapper.swift
+++ b/Networking/Networking/Mapper/SitePluginMapper.swift
@@ -11,6 +11,11 @@ struct SitePluginMapper: Mapper {
 
     private let withDataEnvelope: Bool
 
+    /// Initialized a mapper to serialize site plugins.
+    /// - Parameters:
+    ///   - siteID: Identifier for the site. Only required in authenticated state.
+    ///   - withDataEnvelope: Whether site plugin details are wrapped inside a `data` field.
+    ///
     init(siteID: Int64 = -1, withDataEnvelope: Bool = true) {
         self.siteID = siteID
         self.withDataEnvelope = withDataEnvelope

--- a/Networking/Networking/Remote/JetpackConnectionRemote.swift
+++ b/Networking/Networking/Remote/JetpackConnectionRemote.swift
@@ -16,7 +16,7 @@ public final class JetpackConnectionRemote: Remote {
     /// Retrieves the information about Jetpack the plugin for the current site.
     ///
     public func retrieveJetpackPluginDetails(completion: @escaping (Result<SitePlugin, Error>) -> Void) {
-        let path = String(format: "%@/%@", Path.plugins, Constants.jetpackPluginName)
+        let path = "\(Path.plugins)/\(Constants.jetpackPluginName)"
         let request = WordPressOrgRequest(baseURL: siteURL, method: .get, path: path)
         let mapper = SitePluginMapper(withDataEnvelope: false)
         enqueue(request, mapper: mapper, completion: completion)
@@ -34,7 +34,7 @@ public final class JetpackConnectionRemote: Remote {
     /// Activates Jetpack the plugin to the current site
     ///
     public func activateJetpackPlugin(completion: @escaping (Result<SitePlugin, Error>) -> Void) {
-        let path = String(format: "%@/%@", Path.plugins, Constants.jetpackPluginName)
+        let path = "\(Path.plugins)/\(Constants.jetpackPluginName)"
         let parameters: [String: Any] = [Field.status.rawValue: Constants.activeStatus]
         let request = WordPressOrgRequest(baseURL: siteURL, method: .put, path: path, parameters: parameters)
         let mapper = SitePluginMapper(withDataEnvelope: false)

--- a/Networking/Networking/Remote/JetpackConnectionRemote.swift
+++ b/Networking/Networking/Remote/JetpackConnectionRemote.swift
@@ -13,6 +13,15 @@ public final class JetpackConnectionRemote: Remote {
         super.init(network: network)
     }
 
+    /// Retrieves the information about Jetpack the plugin for the current site.
+    ///
+    public func retrieveJetpackPluginDetails(completion: @escaping (Result<SitePlugin, Error>) -> Void) {
+        let path = String(format: "%@/%@", Path.plugins, Constants.jetpackPluginName)
+        let request = WordPressOrgRequest(baseURL: siteURL, method: .get, path: path)
+        let mapper = SitePluginMapper(withDataEnvelope: false)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
     /// Fetches the URL for setting up Jetpack connection.
     ///
     public func fetchJetpackConnectionURL(completion: @escaping (Result<URL, Error>) -> Void) {
@@ -95,9 +104,11 @@ private extension JetpackConnectionRemote {
     enum Path {
         static let jetpackConnectionURL = "/jetpack/v4/connection/url"
         static let jetpackConnectionUser = "/jetpack/v4/connection/data"
+        static let plugins = "/wp/v2/plugins"
     }
 
     enum Constants {
         static let jetpackAccountConnectionURL = "https://jetpack.wordpress.com/jetpack.authorize"
+        static let jetpackPluginName = "jetpack/jetpack"
     }
 }

--- a/Networking/Networking/Remote/JetpackConnectionRemote.swift
+++ b/Networking/Networking/Remote/JetpackConnectionRemote.swift
@@ -22,6 +22,25 @@ public final class JetpackConnectionRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    /// Installs Jetpack the plugin to the current site.
+    ///
+    public func installJetpackPlugin(completion: @escaping (Result<SitePlugin, Error>) -> Void) {
+        let parameters: [String: Any] = [Field.slug.rawValue: Constants.jetpackPluginSlug]
+        let request = WordPressOrgRequest(baseURL: siteURL, method: .post, path: Path.plugins, parameters: parameters)
+        let mapper = SitePluginMapper(withDataEnvelope: false)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
+    /// Activates Jetpack the plugin to the current site
+    ///
+    public func activateJetpackPlugin(completion: @escaping (Result<SitePlugin, Error>) -> Void) {
+        let path = String(format: "%@/%@", Path.plugins, Constants.jetpackPluginName)
+        let parameters: [String: Any] = [Field.status.rawValue: Constants.activeStatus]
+        let request = WordPressOrgRequest(baseURL: siteURL, method: .put, path: path, parameters: parameters)
+        let mapper = SitePluginMapper(withDataEnvelope: false)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
     /// Fetches the URL for setting up Jetpack connection.
     ///
     public func fetchJetpackConnectionURL(completion: @escaping (Result<URL, Error>) -> Void) {
@@ -107,8 +126,15 @@ private extension JetpackConnectionRemote {
         static let plugins = "/wp/v2/plugins"
     }
 
+    enum Field: String {
+        case slug
+        case status
+    }
+
     enum Constants {
         static let jetpackAccountConnectionURL = "https://jetpack.wordpress.com/jetpack.authorize"
         static let jetpackPluginName = "jetpack/jetpack"
+        static let jetpackPluginSlug = "jetpack"
+        static let activeStatus = "active"
     }
 }

--- a/Networking/NetworkingTests/Mapper/SitePluginMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SitePluginMapperTests.swift
@@ -26,6 +26,26 @@ final class SitePluginMapperTests: XCTestCase {
         XCTAssertEqual(plugin?.version, "9.5")
         XCTAssertEqual(plugin?.textDomain, "jetpack")
     }
+
+    /// Verifies the SitePlugin fields are parsed correctly when there's no data envelope wrapping the response.
+    ///
+    func test_SitePlugin_fields_are_properly_parsed_for_response_without_data_envelope() {
+        let plugin = mapPluginWithoutEnvelope(from: "site-plugin-without-envelope")
+        XCTAssertNotNil(plugin)
+        XCTAssertEqual(plugin?.plugin, "jetpack/jetpack")
+        XCTAssertEqual(plugin?.siteID, -1)
+        XCTAssertEqual(plugin?.status, .active)
+        XCTAssertEqual(plugin?.name, "Jetpack")
+        XCTAssertEqual(plugin?.pluginUri, "https://jetpack.com")
+        XCTAssertEqual(plugin?.author, "Automattic")
+        XCTAssertEqual(plugin?.descriptionRaw, "Security, performance, and marketing tools made by WordPress experts. " +
+                       "Jetpack keeps your site protected so you can focus on more important things.")
+        XCTAssertEqual(plugin?.descriptionRendered, "Security, performance, and marketing tools made by WordPress experts. " +
+                       "Jetpack keeps your site protected so you can focus on more important things. " +
+                       "<cite>By <a href=\"https://jetpack.com\">Automattic</a>.</cite>")
+        XCTAssertEqual(plugin?.version, "11.5.1")
+        XCTAssertEqual(plugin?.textDomain, "jetpack")
+    }
 }
 
 
@@ -41,5 +61,16 @@ private extension SitePluginMapperTests {
         }
 
         return try? SitePluginMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    /// Returns the SitePluginMapper output upon receiving `filename` (Data Encoded)
+    /// The decoder should not include data envelope.
+    ///
+    func mapPluginWithoutEnvelope(from filename: String) -> SitePlugin? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try? SitePluginMapper(withDataEnvelope: false).map(response: response)
     }
 }

--- a/Networking/NetworkingTests/Mapper/SitePluginMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SitePluginMapperTests.swift
@@ -11,40 +11,38 @@ final class SitePluginMapperTests: XCTestCase {
 
     /// Verifies the SitePlugin fields are parsed correctly.
     ///
-    func test_SitePlugin_fields_are_properly_parsed() {
-        let plugin = mapPlugin(from: "plugin")
-        XCTAssertNotNil(plugin)
-        XCTAssertEqual(plugin?.plugin, "jetpack/jetpack")
-        XCTAssertEqual(plugin?.siteID, dummySiteID)
-        XCTAssertEqual(plugin?.status, .active)
-        XCTAssertEqual(plugin?.name, "Jetpack by WordPress.com")
-        XCTAssertEqual(plugin?.pluginUri, "https://jetpack.com")
-        XCTAssertEqual(plugin?.author, "Automattic")
-        XCTAssertEqual(plugin?.descriptionRaw, "Bring the power of the WordPress.com cloud to your self-hosted WordPress.")
-        XCTAssertEqual(plugin?.descriptionRendered, "Bring the power of the WordPress.com cloud to your self-hosted WordPress. " +
+    func test_SitePlugin_fields_are_properly_parsed() throws {
+        let plugin = try XCTUnwrap(mapPlugin(from: "plugin"))
+        XCTAssertEqual(plugin.plugin, "jetpack/jetpack")
+        XCTAssertEqual(plugin.siteID, dummySiteID)
+        XCTAssertEqual(plugin.status, .active)
+        XCTAssertEqual(plugin.name, "Jetpack by WordPress.com")
+        XCTAssertEqual(plugin.pluginUri, "https://jetpack.com")
+        XCTAssertEqual(plugin.author, "Automattic")
+        XCTAssertEqual(plugin.descriptionRaw, "Bring the power of the WordPress.com cloud to your self-hosted WordPress.")
+        XCTAssertEqual(plugin.descriptionRendered, "Bring the power of the WordPress.com cloud to your self-hosted WordPress. " +
                        "<cite>By <a href=\"https://jetpack.com\">Automattic</a>.</cite>")
-        XCTAssertEqual(plugin?.version, "9.5")
-        XCTAssertEqual(plugin?.textDomain, "jetpack")
+        XCTAssertEqual(plugin.version, "9.5")
+        XCTAssertEqual(plugin.textDomain, "jetpack")
     }
 
     /// Verifies the SitePlugin fields are parsed correctly when there's no data envelope wrapping the response.
     ///
-    func test_SitePlugin_fields_are_properly_parsed_for_response_without_data_envelope() {
-        let plugin = mapPluginWithoutEnvelope(from: "site-plugin-without-envelope")
-        XCTAssertNotNil(plugin)
-        XCTAssertEqual(plugin?.plugin, "jetpack/jetpack")
-        XCTAssertEqual(plugin?.siteID, -1)
-        XCTAssertEqual(plugin?.status, .active)
-        XCTAssertEqual(plugin?.name, "Jetpack")
-        XCTAssertEqual(plugin?.pluginUri, "https://jetpack.com")
-        XCTAssertEqual(plugin?.author, "Automattic")
-        XCTAssertEqual(plugin?.descriptionRaw, "Security, performance, and marketing tools made by WordPress experts. " +
+    func test_SitePlugin_fields_are_properly_parsed_for_response_without_data_envelope() throws {
+        let plugin = try XCTUnwrap(mapPluginWithoutEnvelope(from: "site-plugin-without-envelope"))
+        XCTAssertEqual(plugin.plugin, "jetpack/jetpack")
+        XCTAssertEqual(plugin.siteID, -1)
+        XCTAssertEqual(plugin.status, .active)
+        XCTAssertEqual(plugin.name, "Jetpack")
+        XCTAssertEqual(plugin.pluginUri, "https://jetpack.com")
+        XCTAssertEqual(plugin.author, "Automattic")
+        XCTAssertEqual(plugin.descriptionRaw, "Security, performance, and marketing tools made by WordPress experts. " +
                        "Jetpack keeps your site protected so you can focus on more important things.")
-        XCTAssertEqual(plugin?.descriptionRendered, "Security, performance, and marketing tools made by WordPress experts. " +
+        XCTAssertEqual(plugin.descriptionRendered, "Security, performance, and marketing tools made by WordPress experts. " +
                        "Jetpack keeps your site protected so you can focus on more important things. " +
                        "<cite>By <a href=\"https://jetpack.com\">Automattic</a>.</cite>")
-        XCTAssertEqual(plugin?.version, "11.5.1")
-        XCTAssertEqual(plugin?.textDomain, "jetpack")
+        XCTAssertEqual(plugin.version, "11.5.1")
+        XCTAssertEqual(plugin.textDomain, "jetpack")
     }
 }
 

--- a/Networking/NetworkingTests/Remote/JetpackConnectionRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/JetpackConnectionRemoteTests.swift
@@ -3,9 +3,11 @@ import XCTest
 
 final class JetpackConnectionRemoteTests: XCTestCase {
 
+    private let siteURL = "http://test.com"
+
     /// Dummy Network Wrapper
     ///
-    let network = MockNetwork()
+    private let network = MockNetwork()
 
     /// Repeat always!
     ///
@@ -13,9 +15,128 @@ final class JetpackConnectionRemoteTests: XCTestCase {
         network.removeAllSimulatedResponses()
     }
 
+    func test_retrieveJetpackPluginDetails_correctly_returns_parsed_plugin() throws {
+        // Given
+        let remote = JetpackConnectionRemote(siteURL: siteURL, network: network)
+        let urlSuffix = "/wp/v2/plugins/jetpack/jetpack"
+        network.simulateResponse(requestUrlSuffix: urlSuffix, filename: "site-plugin-without-envelope")
+
+        // When
+        let result: Result<SitePlugin, Error> = waitFor { promise in
+            remote.retrieveJetpackPluginDetails { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let plugin = try XCTUnwrap(result.get())
+        assertEqual(plugin.plugin, "jetpack/jetpack")
+        assertEqual(plugin.status, .active)
+        assertEqual(plugin.name, "Jetpack")
+    }
+
+    func test_retrieveJetpackPluginDetails_properly_relays_errors() {
+        // Given
+        let remote = JetpackConnectionRemote(siteURL: siteURL, network: network)
+        let urlSuffix = "/wp/v2/plugins/jetpack/jetpack"
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: urlSuffix, error: error)
+
+        // When
+        let result: Result<SitePlugin, Error> = waitFor { promise in
+            remote.retrieveJetpackPluginDetails { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, error)
+    }
+
+    func test_installJetpackPlugin_correctly_returns_parsed_plugin() throws {
+        // Given
+        let remote = JetpackConnectionRemote(siteURL: siteURL, network: network)
+        let urlSuffix = "/wp/v2/plugins"
+        network.simulateResponse(requestUrlSuffix: urlSuffix, filename: "site-plugin-without-envelope")
+
+        // When
+        let result: Result<SitePlugin, Error> = waitFor { promise in
+            remote.installJetpackPlugin { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let plugin = try XCTUnwrap(result.get())
+        assertEqual(plugin.plugin, "jetpack/jetpack")
+        assertEqual(plugin.status, .active)
+        assertEqual(plugin.name, "Jetpack")
+    }
+
+    func test_installJetpackPlugin_properly_relays_errors() {
+        // Given
+        let remote = JetpackConnectionRemote(siteURL: siteURL, network: network)
+        let urlSuffix = "/wp/v2/plugins"
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: urlSuffix, error: error)
+
+        // When
+        let result: Result<SitePlugin, Error> = waitFor { promise in
+            remote.installJetpackPlugin { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, error)
+    }
+
+    func test_activateJetpackPlugin_correctly_returns_parsed_plugin() throws {
+        // Given
+        let remote = JetpackConnectionRemote(siteURL: siteURL, network: network)
+        let urlSuffix = "/wp/v2/plugins/jetpack/jetpack"
+        network.simulateResponse(requestUrlSuffix: urlSuffix, filename: "site-plugin-without-envelope")
+
+        // When
+        let result: Result<SitePlugin, Error> = waitFor { promise in
+            remote.activateJetpackPlugin { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let plugin = try XCTUnwrap(result.get())
+        assertEqual(plugin.plugin, "jetpack/jetpack")
+        assertEqual(plugin.status, .active)
+        assertEqual(plugin.name, "Jetpack")
+    }
+
+    func test_activateJetpackPlugin_properly_relays_errors() {
+        // Given
+        let remote = JetpackConnectionRemote(siteURL: siteURL, network: network)
+        let urlSuffix = "/wp/v2/plugins/jetpack/jetpack"
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: urlSuffix, error: error)
+
+        // When
+        let result: Result<SitePlugin, Error> = waitFor { promise in
+            remote.activateJetpackPlugin { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, error)
+    }
+
     func test_fetchJetpackConnectionURL_correctly_returns_parsed_url() throws {
         // Given
-        let siteURL = "http://test.com"
         let remote = JetpackConnectionRemote(siteURL: siteURL, network: network)
         let urlSuffix = "/jetpack/v4/connection/url"
         network.simulateResponse(requestUrlSuffix: urlSuffix, filename: "jetpack-connection-url")
@@ -36,7 +157,6 @@ final class JetpackConnectionRemoteTests: XCTestCase {
 
     func test_fetchJetpackConnectionURL_properly_relays_errors() {
         // Given
-        let siteURL = "http://test.com"
         let remote = JetpackConnectionRemote(siteURL: siteURL, network: network)
         let urlSuffix = "/jetpack/v4/connection/url"
         let error = NetworkError.unacceptableStatusCode(statusCode: 500)
@@ -56,7 +176,6 @@ final class JetpackConnectionRemoteTests: XCTestCase {
 
     func test_fetchJetpackUser_correctly_returns_parsed_user() throws {
         // Given
-        let siteURL = "http://test.com"
         let remote = JetpackConnectionRemote(siteURL: siteURL, network: network)
         let urlSuffix = "/jetpack/v4/connection/data"
         network.simulateResponse(requestUrlSuffix: urlSuffix, filename: "jetpack-connected-user")
@@ -77,7 +196,6 @@ final class JetpackConnectionRemoteTests: XCTestCase {
 
     func test_fetchJetpackUser_properly_relays_errors() {
         // Given
-        let siteURL = "http://test.com"
         let remote = JetpackConnectionRemote(siteURL: siteURL, network: network)
         let urlSuffix = "/jetpack/v4/connection/data"
         let error = NetworkError.unacceptableStatusCode(statusCode: 500)

--- a/Networking/NetworkingTests/Responses/site-plugin-without-envelope.json
+++ b/Networking/NetworkingTests/Responses/site-plugin-without-envelope.json
@@ -1,0 +1,24 @@
+{
+    "plugin": "jetpack/jetpack",
+    "status": "active",
+    "name": "Jetpack",
+    "plugin_uri": "https://jetpack.com",
+    "author": "Automattic",
+    "author_uri": "https://jetpack.com",
+    "description": {
+        "raw": "Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.",
+        "rendered": "Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things. <cite>By <a href=\"https://jetpack.com\">Automattic</a>.</cite>"
+    },
+    "version": "11.5.1",
+    "network_only": false,
+    "requires_wp": "6.0",
+    "requires_php": "5.6",
+    "textdomain": "jetpack",
+    "_links": {
+        "self": [
+            {
+                "href": "https://test.com/wp-json/wp/v2/plugins/jetpack/jetpack"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8075 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
To support the native experience for Jetpack installation, this PR updates the Networking layer with plugin management endpoints that use cookie authentication. Changes include:
- Updated `JetpackConnectionRemote` with endpoints for retrieving, installing, and activating Jetpack the plugin.
- Updated `SitePluginMapper` to map site plugins without the data envelope. The default site ID, in this case, is -1 since we are using the mapper in the unauthenticated state.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The APIs have not been integrated so just CI passing should be sufficient.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
