### PR TITLE
windows was deprecated in iOS 15: Use UIWindowScene.windows instead

### DIFF
--- a/WooCommerce/Classes/Environment Keys/SafeAreaInsetsKey.swift
+++ b/WooCommerce/Classes/Environment Keys/SafeAreaInsetsKey.swift
@@ -8,7 +8,10 @@ struct SafeAreaInsetsKey: EnvironmentKey {
     /// Returns the safe areas of the main window.
     ///
     static var defaultValue: EdgeInsets {
-        guard let window = UIApplication.shared.windows.first else {
+
+        // Get the first window from all connected scenes
+        let scenes = UIApplication.shared.connectedScenes
+        guard let window = scenes.compactMap({ $0 as? UIWindowScene }).flatMap({ $0.windows }).first else {
             return .zero
         }
 


### PR DESCRIPTION
### Description
By updating the minimum release version to iOS 15 recently, we've seen some deprecation warnings. This PR fixes the case for `'windows' was deprecated in iOS 15.0: Use UIWindowScene.windows on a relevant window scene instead`.

### Changes

Rather than getting the first window through the `UIApplication.windows` shared instance, we get the window through its connected scenes, by filtering down the first one that is of type `UIWindowScene`. With this we still get the same behavior, and we remove the deprecation warning.

### Testing instructions
I based my own testing on the cases of the [original PR](https://github.com/woocommerce/woocommerce-ios/pull/5782), in this case, as this pattern allows us to set custom safe areas for the focus window, we can test the Simple Payments flow with big fonts and on landscape and see that everything still looks correct.

### Screenshots
| Before | After |
|--|--|
|<img width=400 src="https://user-images.githubusercontent.com/3812076/201074836-9ef27781-9400-497a-b47c-a248d5edad26.png"> |<img width=400 src="https://user-images.githubusercontent.com/3812076/201074836-9ef27781-9400-497a-b47c-a248d5edad26.png"> |

| Before | After |
|--|--|
| <img width=400 src="https://user-images.githubusercontent.com/3812076/201075095-791d2163-0655-46b7-81aa-c9705e070e2c.png"> | <img width=400 src="https://user-images.githubusercontent.com/3812076/201075095-791d2163-0655-46b7-81aa-c9705e070e2c.png">|

