### PR TITLE
[Mobile Payments] Remove upsellCardReader banner from OrderList

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 11.2
 -----
 - [*] The survey at the end of the login onboarding flow is no longer available. [https://github.com/woocommerce/woocommerce-ios/pull/8062]
+- [*] The Accept Payments Easily banner has been removed from the order list [https://github.com/woocommerce/woocommerce-ios/pull/8078]
 
 11.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -185,8 +185,6 @@ final class OrderListViewController: UIViewController, GhostableViewController {
             // Reload table view to update selected state on the list when changing rotation
             tableView.reloadData()
         }
-
-        updateUpsellCardReaderTopBannerVisibility(with: newCollection)
     }
 
     /// Returns a function that creates cells for `dataSource`.
@@ -248,11 +246,6 @@ private extension OrderListViewController {
                 switch topBannerType {
                 case .none:
                     self.hideTopBannerView()
-                case .upsellCardReaders:
-                    // The banner is too large to be shown when the vertical size class is compact
-                    if self.traitCollection.verticalSizeClass == .regular {
-                        self.showUpsellCardReadersBanner()
-                    }
                 case .error:
                     self.setErrorTopBanner()
                 case .orderCreation:
@@ -410,48 +403,6 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
         }
 
         tableView.updateHeaderHeight()
-    }
-
-    private func showUpsellCardReadersBanner() {
-        let view = FeatureAnnouncementCardView(viewModel: viewModel.upsellCardReadersAnnouncementViewModel,
-                                               dismiss: { [weak self] in
-            self?.viewModel.dismissUpsellCardReadersBanner()
-        }, callToAction: { [weak self] in
-            self?.openCardReaderProductPageInWebView()
-        })
-            .background(Color(.listForeground))
-
-        guard let hostingView = UIHostingController(rootView: view).view else {
-            return
-        }
-
-        hostingView.translatesAutoresizingMaskIntoConstraints = false
-        topBannerView = hostingView
-
-        showTopBannerView()
-    }
-
-    private func openCardReaderProductPageInWebView() {
-        let configuration = CardPresentConfigurationLoader().configuration
-        let url = configuration.purchaseCardReaderUrl(utmProvider: viewModel.upsellCardReadersCampaign.utmProvider)
-        let cardReaderWebview = WebViewSheet(
-            viewModel: WebViewSheetViewModel(
-                url: url,
-                navigationTitle: UpsellCardReadersCampaign.Localization.cardReaderWebViewTitle,
-                wpComAuthenticated: true),
-            done: { [weak self] in
-                self?.dismiss(animated: true)
-            })
-        let hostingController = UIHostingController(rootView: cardReaderWebview)
-        present(hostingController, animated: true, completion: nil)
-    }
-
-    func updateUpsellCardReaderTopBannerVisibility(with newCollection: UITraitCollection) {
-        guard viewModel.topBanner == .upsellCardReaders else {
-            return
-        }
-
-        newCollection.verticalSizeClass == .regular ? showUpsellCardReadersBanner() : hideTopBannerView()
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -239,58 +239,12 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertFalse(resynchronizeRequested)
     }
 
-    func test_when_having_no_error_and_upsellCardReaders_banner_should_be_shown_shows_upsellCardReaders_banner_if_country_supported() {
-        // Given
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .getFeatureAnnouncementVisibility(FeatureAnnouncementCampaign.upsellCardReaders, onCompletion):
-                onCompletion(.success(true))
-            default:
-                break
-            }
-        }
-        setupCountry(country: .us)
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
-
-        // When
-        viewModel.activate()
-
-        // Then
-        waitUntil {
-            viewModel.topBanner == .upsellCardReaders
-        }
-    }
-
-    func test_when_having_no_error_and_upsellCardReaders_banner_should_be_shown_shows_nothing_if_country_unsupported() {
-        // Given
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .getFeatureAnnouncementVisibility(FeatureAnnouncementCampaign.upsellCardReaders, onCompletion):
-                onCompletion(.success(true))
-            default:
-                break
-            }
-        }
-        setupCountry(country: .es)
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
-
-        // When
-        viewModel.activate()
-
-        // Then
-        waitUntil {
-            viewModel.topBanner == .none
-        }
-    }
-
-    func test_when_having_no_error_and_upsellCardReaders_banner_should_not_be_shown_and_orders_banner_should_not_be_shown_shows_nothing() {
+    func test_when_having_no_error__and_orders_banner_should_not_be_shown_shows_nothing() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case let .loadFeedbackVisibility(_, onCompletion):
-                onCompletion(.success(false))
-            case let .getFeatureAnnouncementVisibility(FeatureAnnouncementCampaign.upsellCardReaders, onCompletion):
                 onCompletion(.success(false))
             default:
                 break
@@ -306,15 +260,13 @@ final class OrderListViewModelTests: XCTestCase {
         }
     }
 
-    func test_when_having_no_error_and_upsellCardReaders_banner_should_not_be_shown_and_orders_banner_should_be_shown_shows_orders_banner() {
+    func test_when_having_no_error_and_orders_banner_should_be_shown_shows_orders_banner() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case let .loadFeedbackVisibility(_, onCompletion):
                 onCompletion(.success(true))
-            case let .getFeatureAnnouncementVisibility(FeatureAnnouncementCampaign.upsellCardReaders, onCompletion):
-                onCompletion(.success(false))
             default:
                 break
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8069 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Since we have added Just In Time Messages in Project Salas, we are showing a very similar message to the Upsell Card Reader banner in a similarly prominent location. It will be frustrating for the (small number of) users who see both, especially since they are dismissed independently of one another.

In this PR we remove the Upsell Card Reader banner from the order list, but retain it on the Payment Method screen.

It's also shown on the Payment Method screen: this is much lower traffic, and the card is more relevant there. It's also using otherwise-empty space and adds interest to that screen.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a US or CA store

1. Delete and reinstall the app on your phone (to reset any saved dismissals of the banner)
2. Open the Orders tab
3. Observe that the Upsell Card Reader banner is not shown at the top
4. Navigate to `Menu > Payments > Collect Payment` and enter an amount
5. Tap `Next`, then `Take Payment`
6. Observe that the Upsell Card Readers banner is shown on the Payment Methods screen

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/201078026-dd3a1501-bfff-44f8-93f5-c7eaf0c24642.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
