### PR TITLE
Products Onboarding: Update save and publish events

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -202,6 +202,10 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     // MARK: Product preview action handling
 
     @objc private func saveDraftAndDisplayProductPreview() {
+        if viewModel.formType == .add {
+            ServiceLocator.analytics.track(.addProductSaveAsDraftTapped, withProperties: ["product_type": product.productType.rawValue])
+        }
+
         guard viewModel.canSaveAsDraft() || viewModel.hasUnsavedChanges() else {
             displayProductPreview()
             return


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/8066

## Description

Currently `add_product_publish_tapped` and `add_product_save_as_draft_tapped` events are used in product onboarding experiments. They are setup to be sent only for new product flow. But when the "preview" action is triggered for a new product - it's saved without sending these events (only sending `product_detail_update_success`). Even more, it changes the form state from `add` to `edit`, so even after user's action to manually save/publish they won't be triggered, so we are losing last step from a successful funnel.

This PR changes:
- `add_product_publish_tapped` is now triggered in edit mode. While it's possible to be triggered multiple times for the same product - it's a valid workflow and shouldn't result in duplicated events.
- `add_product_save_as_draft_tapped` is now triggered when the preview action performed on a new product.

## Testing instructions

1. Build and run the app in debug/alpha mode (to enable preview feature).
2. Start creating a new product ("+" in the navbar).
3. Enter the title to enable preview/save.
4. Tap the "Preview" button in the navbar.
5. Confirm the `add_product_save_as_draft_tapped` event is triggered.
6. Dismiss the preview modal, tap "Publish".
7. Confirm the `add_product_publish_tapped` event is triggered.
8. Open details for an existing draft product.
9. Tap the "Preview" button in the navbar.
10. Confirm the `add_product_save_as_draft_tapped` event is **not** triggered.
11. Tap the "Publish" button in the navbar.
12. Confirm the `add_product_publish_tapped` event is triggered.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
