### PR TITLE
Product Onboarding: Allow Template Products to be previewed

### DIFF
--- a/Fakes/Fakes/Products/ProductFactory.swift
+++ b/Fakes/Fakes/Products/ProductFactory.swift
@@ -24,7 +24,8 @@ public enum ProductFactory {
     /// Returns a fake product filled with data can be edited by the merchants
     ///
     public static func productWithEditableDataFilled() -> Product {
-        Product.fake().copy(name: "name",
+        Product.fake().copy(productID: 123,
+                            name: "name",
                             dateOnSaleStart: Date(),
                             dateOnSaleEnd: Date(),
                             fullDescription: "description",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -184,12 +184,16 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
 
     /// Helper to determine if a product model is empty.
     /// We consider it as empty if its underlying product matches the `ProductFactory.createNewProduct` output.
+    /// Additionally we don't take dates into consideration as we don't control their value when creating a product.
     ///
     func isEmpty() -> Bool {
         guard let emptyProduct = ProductFactory().createNewProduct(type: productType, isVirtual: virtual, siteID: siteID) else {
             return false
         }
-        return emptyProduct == product
+
+        let commonDate = Date()
+        return emptyProduct.copy(date: commonDate, dateCreated: commonDate, dateModified: commonDate, dateOnSaleStart: commonDate, dateOnSaleEnd: commonDate) ==
+               product.copy(date: commonDate, dateCreated: commonDate, dateModified: commonDate, dateOnSaleStart: commonDate, dateOnSaleEnd: commonDate)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -181,6 +181,16 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
     var existsRemotely: Bool {
         product.existsRemotely
     }
+
+    /// Helper to determine if a product model is empty.
+    /// We consider it as empty if its underlying product matches the `ProductFactory.createNewProduct` output.
+    ///
+    func isEmpty() -> Bool {
+        guard let emptyProduct = ProductFactory().createNewProduct(type: productType, isVirtual: virtual, siteID: siteID) else {
+            return false
+        }
+        return emptyProduct == product
+    }
 }
 
 extension EditableProductModel: Equatable {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -221,7 +221,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
                                                   productOrVariationID: .product(id: product.productID),
                                                   isLocalID: !product.existsRemotely),
                                        originalImages: originalProduct.images)
-        return hasProductChangesExcludingImages || hasImageChanges || password != originalPassword
+        return hasProductChangesExcludingImages || hasImageChanges || password != originalPassword || isNewTemplateProduct()
     }
 }
 
@@ -619,6 +619,15 @@ private extension ProductFormViewModel {
         }
 
         return controller
+    }
+
+    /// Helper to determine if the added/editted product comes as a new template product.
+    /// We assume that a new template product is a product that:
+    ///  - Doesn't have an `id` - has not been saved remotely
+    ///  - Is not empty.
+    ///
+    private func isNewTemplateProduct() -> Bool {
+        originalProduct.productID == .zero && !originalProduct.isEmpty()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -185,6 +185,11 @@ extension ProductFormViewModelProtocol {
     /// Returns `false` when it's a new blank product without any changes.
     ///
     func shouldEnablePreviewButton() -> Bool {
-        !(formType == .add && !hasUnsavedChanges())
+        switch formType {
+        case .add:
+            return hasUnsavedChanges()
+        case .edit, .readonly:
+            return true
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -159,7 +159,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
 
     func testObservablesFromUpdatingProductPasswordRemotely() {
         // Arrange
-        let product = Product.fake()
+        let product = Product.fake().copy(productID: 123)
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -542,11 +542,11 @@ final class ProductFormViewModelTests: XCTestCase {
 
     // MARK: Preview button tests (with enabled Product Onboarding feature flag)
 
-    func test_disabled_preview_button_for_new_blank_product_without_any_changes() {
+    func test_disabled_preview_button_for_new_blank_product_without_any_changes() throws {
         // Given
         sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
 
-        let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
+        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: 123))
         let viewModel = createViewModel(product: product,
                                         formType: .add,
                                         stores: stores,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -560,6 +560,25 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldEnablePreviewButton())
     }
 
+    func test_enabled_preview_button_for_new_template_product() throws {
+        // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
+
+        // Adding some value to simulate a template product
+        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: 123)?.copy(price: "10.00"))
+        let viewModel = createViewModel(product: product,
+                                        formType: .add,
+                                        stores: stores,
+                                        featureFlagService: MockFeatureFlagService(isProductsOnboardingEnabled: true))
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [.preview, .publish, .more])
+        XCTAssertTrue(viewModel.shouldEnablePreviewButton())
+    }
+
     func test_enabled_preview_button_for_new_product_with_pending_changes() {
         // Given
         sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")


### PR DESCRIPTION
Closes: #8071 

# Why

Prior to this PR, template products where considered unsaved new products, so the preview button was disabled for them.
Here, I'm making sure that a template product is able to be previewed as soon as it is created.

# How

- Added an `isEmpty` property on `EditableProductModel` to be able to differentiate a product with content from an empty prroduct.

- Added a new `isNewTemplateProduct` on `ProductFormViewModel` to identify a template product, which is when the original product has id zero and is not not empty.

- Refactored a bit the `shouldEnablePreviewButton()` because I found it hard to read 😇 

# Demo

## Preview Template

https://user-images.githubusercontent.com/562080/201233523-9bbf786b-9251-43a7-9bb0-253243b57830.mov

## Disable preview on empty products

https://user-images.githubusercontent.com/562080/201233520-5e16fd59-814e-479f-a2f9-c57568876bfd.mov

# Testing
## Note
The feature is currently only visible to users in the experiment treatment group. In the Audience section of the [template experiment model](https://experiments.a8c.com/experiments/20890-woocommerceios-products-onboarding-template-products/overview), go to Variations > Manual Assignment and use the bookmarklet to assign yourself (your a8c account) to the treatment group.

You will need to log in to the app with your a8c account to see the experiment while it is in staging (not launched to users yet).

## Steps
- Launch the app in a store with less than 3 products and tap the Add Product CTA
- Create a template product
- See that the preview button is enabled

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
