### PR TITLE
kUTType was deprecated in iOS15, use UTType instead

### DIFF
--- a/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -112,7 +112,7 @@ private extension MediaAssetExporter {
                 return nil
         }
         guard allowableFileExtensions.contains(fileExtensionForType) else {
-            return kUTTypeJPEG as String
+            return UTType.jpeg.identifier as String
         }
         return uti
     }

--- a/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -50,7 +50,8 @@ final class MediaAssetExporter: MediaExporter {
         if let resource = resources.first {
             resourceAvailableLocally = true
             filename = resource.originalFilename
-            if UTTypeEqual(resource.uniformTypeIdentifier as CFString, kUTTypeGIF) {
+            let gifTypeIdentifier = UTType.gif.identifier as CFString
+            if UTTypeEqual(resource.uniformTypeIdentifier as CFString, gifTypeIdentifier) {
                 // Handles GIF export differently from images.
                 exportGIF(forAsset: asset, resource: resource, onCompletion: onCompletion)
                 return
@@ -123,7 +124,8 @@ private extension MediaAssetExporter {
     /// - parameter onError: Called if an error was encountered during export.
     ///
     private func exportGIF(forAsset asset: PHAsset, resource: PHAssetResource, onCompletion: @escaping MediaExportCompletion) {
-        guard UTTypeEqual(resource.uniformTypeIdentifier as CFString, kUTTypeGIF) else {
+        let gifTypeIdentifier = UTType.gif.identifier as CFString
+        guard UTTypeEqual(resource.uniformTypeIdentifier as CFString, gifTypeIdentifier) else {
             onCompletion(nil, AssetExportError.expectedPHAssetGIFType)
             return
         }

--- a/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -50,8 +50,7 @@ final class MediaAssetExporter: MediaExporter {
         if let resource = resources.first {
             resourceAvailableLocally = true
             filename = resource.originalFilename
-            let gifTypeIdentifier = UTType.gif.identifier as CFString
-            if UTTypeEqual(resource.uniformTypeIdentifier as CFString, gifTypeIdentifier) {
+            if resource.uniformTypeIdentifier == UTType.gif.identifier {
                 // Handles GIF export differently from images.
                 exportGIF(forAsset: asset, resource: resource, onCompletion: onCompletion)
                 return
@@ -124,8 +123,7 @@ private extension MediaAssetExporter {
     /// - parameter onError: Called if an error was encountered during export.
     ///
     private func exportGIF(forAsset asset: PHAsset, resource: PHAssetResource, onCompletion: @escaping MediaExportCompletion) {
-        let gifTypeIdentifier = UTType.gif.identifier as CFString
-        guard UTTypeEqual(resource.uniformTypeIdentifier as CFString, gifTypeIdentifier) else {
+        guard resource.uniformTypeIdentifier == UTType.gif.identifier else {
             onCompletion(nil, AssetExportError.expectedPHAssetGIFType)
             return
         }

--- a/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -113,7 +113,7 @@ private extension MediaAssetExporter {
                 return nil
         }
         guard allowableFileExtensions.contains(fileExtensionForType) else {
-            return UTType.jpeg.identifier as String
+            return UTType.jpeg.identifier
         }
         return uti
     }

--- a/Yosemite/Yosemite/Tools/Media/MediaImageExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaImageExporter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UniformTypeIdentifiers
 import MobileCoreServices
 
 /// Available options for an image export.
@@ -75,7 +76,7 @@ final class MediaImageExporter: MediaExporter {
                              typeHint: String?,
                              onCompletion: @escaping MediaExportCompletion) {
         do {
-            let hint = typeHint ?? kUTTypeJPEG as String
+            let hint = typeHint ?? UTType.jpeg.identifier as String
             let sourceOptions: [String: Any] = [kCGImageSourceTypeIdentifierHint as String: hint as CFString]
             guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions as CFDictionary) else {
                 throw ImageExportError.imageSourceCreationWithDataFailed

--- a/Yosemite/Yosemite/Tools/Media/MediaImageExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaImageExporter.swift
@@ -76,7 +76,7 @@ final class MediaImageExporter: MediaExporter {
                              typeHint: String?,
                              onCompletion: @escaping MediaExportCompletion) {
         do {
-            let hint = typeHint ?? UTType.jpeg.identifier as String
+            let hint = typeHint ?? UTType.jpeg.identifier
             let sourceOptions: [String: Any] = [kCGImageSourceTypeIdentifierHint as String: hint as CFString]
             guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions as CFDictionary) else {
                 throw ImageExportError.imageSourceCreationWithDataFailed

--- a/Yosemite/YosemiteTests/Tools/Media/MediaImageExporterTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Media/MediaImageExporterTests.swift
@@ -8,7 +8,7 @@ final class MediaImageExporterTests: XCTestCase {
         // Loads the test image into png data.
         let mockData = UIImage(named: "image", in: Bundle(for: type(of: self)), compatibleWith: nil)!.pngData()
         let filename = "test"
-        let typeHint = UTType.jpeg.identifier as String
+        let typeHint = UTType.jpeg.identifier
         let mockImageSourceWriter = MockImageSourceWriter()
         let exporter = MediaImageExporter(data: mockData!,
                                           filename: filename,
@@ -66,7 +66,7 @@ final class MediaImageExporterTests: XCTestCase {
     func testExportingNonImageData() {
         let mockData = Data()
         let filename = "test"
-        let typeHint = UTType.jpeg.identifier as String
+        let typeHint = UTType.jpeg.identifier
         let mockImageSourceWriter = MockImageSourceWriter()
         let exporter = MediaImageExporter(data: mockData,
                                           filename: filename,

--- a/Yosemite/YosemiteTests/Tools/Media/MediaImageExporterTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Media/MediaImageExporterTests.swift
@@ -1,5 +1,6 @@
 import MobileCoreServices
 import XCTest
+import UniformTypeIdentifiers
 @testable import Yosemite
 
 final class MediaImageExporterTests: XCTestCase {
@@ -7,7 +8,7 @@ final class MediaImageExporterTests: XCTestCase {
         // Loads the test image into png data.
         let mockData = UIImage(named: "image", in: Bundle(for: type(of: self)), compatibleWith: nil)!.pngData()
         let filename = "test"
-        let typeHint = kUTTypeJPEG as String
+        let typeHint = UTType.jpeg.identifier as String
         let mockImageSourceWriter = MockImageSourceWriter()
         let exporter = MediaImageExporter(data: mockData!,
                                           filename: filename,
@@ -65,7 +66,7 @@ final class MediaImageExporterTests: XCTestCase {
     func testExportingNonImageData() {
         let mockData = Data()
         let filename = "test"
-        let typeHint = kUTTypeJPEG as String
+        let typeHint = UTType.jpeg.identifier as String
         let mockImageSourceWriter = MockImageSourceWriter()
         let exporter = MediaImageExporter(data: mockData,
                                           filename: filename,

--- a/Yosemite/YosemiteTests/Tools/Media/URL+MediaTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Media/URL+MediaTests.swift
@@ -39,16 +39,16 @@ final class URL_MediaTests: XCTestCase {
 
     func testFileExtensionForJPEGType() {
         let expectedFileExtension = "jpeg"
-        XCTAssertEqual(URL.fileExtensionForUTType(UTType.jpeg.identifier as String), expectedFileExtension)
+        XCTAssertEqual(URL.fileExtensionForUTType(UTType.jpeg.identifier), expectedFileExtension)
     }
 
     func testFileExtensionForGIFType() {
         let expectedFileExtension = "gif"
-        XCTAssertEqual(URL.fileExtensionForUTType(UTType.gif.identifier as String), expectedFileExtension)
+        XCTAssertEqual(URL.fileExtensionForUTType(UTType.gif.identifier), expectedFileExtension)
     }
 
     func testFileExtensionForPNGType() {
         let expectedFileExtension = "png"
-        XCTAssertEqual(URL.fileExtensionForUTType(UTType.png.identifier as String), expectedFileExtension)
+        XCTAssertEqual(URL.fileExtensionForUTType(UTType.png.identifier), expectedFileExtension)
     }
 }

--- a/Yosemite/YosemiteTests/Tools/Media/URL+MediaTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Media/URL+MediaTests.swift
@@ -1,5 +1,6 @@
 import MobileCoreServices
 import XCTest
+import UniformTypeIdentifiers
 @testable import Yosemite
 
 final class URL_MediaTests: XCTestCase {
@@ -38,16 +39,16 @@ final class URL_MediaTests: XCTestCase {
 
     func testFileExtensionForJPEGType() {
         let expectedFileExtension = "jpeg"
-        XCTAssertEqual(URL.fileExtensionForUTType(kUTTypeJPEG as String), expectedFileExtension)
+        XCTAssertEqual(URL.fileExtensionForUTType(UTType.jpeg.identifier as String), expectedFileExtension)
     }
 
     func testFileExtensionForGIFType() {
         let expectedFileExtension = "gif"
-        XCTAssertEqual(URL.fileExtensionForUTType(kUTTypeGIF as String), expectedFileExtension)
+        XCTAssertEqual(URL.fileExtensionForUTType(UTType.gif.identifier as String), expectedFileExtension)
     }
 
     func testFileExtensionForPNGType() {
         let expectedFileExtension = "png"
-        XCTAssertEqual(URL.fileExtensionForUTType(kUTTypePNG as String), expectedFileExtension)
+        XCTAssertEqual(URL.fileExtensionForUTType(UTType.png.identifier as String), expectedFileExtension)
     }
 }


### PR DESCRIPTION
### Context
From https://github.com/woocommerce/woocommerce-ios/pull/1767 : 

> When the user picks an image from the device media library or took a picture from the device camera, we have to first save it in the app file system and then upload the image given the file URL. The image from the device media library or camera is of type PHAsset, and before we save it for future upload, we'd first export the raw PHAsset to an image with some optimization options.

### Description

By updating the minimum release version to iOS 15 recently, we've seen some deprecation warnings. This PR fixes the case for uses of `kUTTypeJPEG`,  `kUTTypePNG`, and `kUTTypeGIF`.

This PR does not deal with cases for `UTTypeEqual`, as it would seems the deprecation message is meant for Objective-C code?
```
'UTTypeEqual' was deprecated in iOS 15.0: Use -[UTType isEqual:] instead.
```

### Changes

When returning or comparing different file extensions or file types, we change from using `kUUType*`, to `UTType.*` instead. 

### Testing instructions
I'm not 100% sure if I'm handling all test scenarios here, happy to get further feedback about it, but it should be good with the following:

- Confirm that there's no issues uploading JPEG or GIF media types to a product
- Tests should pass