### PR TITLE
Login: Update Yosemite layer to handle Jetpack plugin management with cookie authentication

### DIFF
--- a/Yosemite/Yosemite/Actions/JetpackConnectionAction.swift
+++ b/Yosemite/Yosemite/Actions/JetpackConnectionAction.swift
@@ -6,6 +6,12 @@ public enum JetpackConnectionAction: Action {
     /// Updates the store remote with the input siteURL and network to handle cookie authentication.
     /// Call this before triggering any other case in this action.
     case authenticate(siteURL: String, network: Network)
+    /// Retrieves details about Jetpack plugin for the current site.
+    case retrieveJetpackPluginDetails(completion: (Result<SitePlugin, Error>) -> Void)
+    /// Installs Jetpack the plugin for the current site.
+    case installJetpackPlugin(completion: (Result<Void, Error>) -> Void)
+    /// Updates Jetpack the plugin for the current site.
+    case activateJetpackPlugin(completion: (Result<Void, Error>) -> Void)
     /// Fetches the URL used for setting up Jetpack connection.
     case fetchJetpackConnectionURL(completion: (Result<URL, Error>) -> Void)
     /// Fetches the user connection state with the given site's Jetpack.

--- a/Yosemite/Yosemite/Stores/JetpackConnectionStore.swift
+++ b/Yosemite/Yosemite/Stores/JetpackConnectionStore.swift
@@ -26,6 +26,12 @@ public final class JetpackConnectionStore: DeauthenticatedStore {
         switch action {
         case .authenticate(let siteURL, let network):
             updateRemote(with: siteURL, network: network)
+        case .retrieveJetpackPluginDetails(let completion):
+            retrieveJetpackPluginDetails(completion: completion)
+        case .installJetpackPlugin(let completion):
+            installJetpackPlugin(completion: completion)
+        case .activateJetpackPlugin(let completion):
+            activateJetpackPlugin(completion: completion)
         case .fetchJetpackConnectionURL(let completion):
             fetchJetpackConnectionURL(completion: completion)
         case .fetchJetpackUser(let completion):
@@ -37,6 +43,32 @@ public final class JetpackConnectionStore: DeauthenticatedStore {
 private extension JetpackConnectionStore {
     func updateRemote(with siteURL: String, network: Network) {
         self.remote = JetpackConnectionRemote(siteURL: siteURL, network: network)
+    }
+
+    func retrieveJetpackPluginDetails(completion: @escaping (Result<SitePlugin, Error>) -> Void) {
+        remote?.retrieveJetpackPluginDetails(completion: completion)
+    }
+
+    func installJetpackPlugin(completion: @escaping (Result<Void, Error>) -> Void) {
+        remote?.installJetpackPlugin(completion: { result in
+            switch result {
+            case .success:
+                completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        })
+    }
+
+    func activateJetpackPlugin(completion: @escaping (Result<Void, Error>) -> Void) {
+        remote?.activateJetpackPlugin(completion: { result in
+            switch result {
+            case .success:
+                completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        })
     }
 
     func fetchJetpackConnectionURL(completion: @escaping (Result<URL, Error>) -> Void) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Part of #8075
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates `JetpackConnectionStore` and `JetpackConnectionAction` with endpoints to install, activate, and retrieve Jetpack-the-plugin details in the unauthenticated state with cookie authentication.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
These actions haven't been integrated yet so just CI passing is sufficient.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
