### PR TITLE
Configure the SwiftLint build phase to explicitly run on every build

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -9482,6 +9482,7 @@
 		};
 		57CCFFD4249D2A5700825FCF /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION

### Description

Addresses this warning:

![swiftlint-woo](https://user-images.githubusercontent.com/1218433/201365695-ed84fc45-fda1-4c11-a269-2bbcf76dd5ad.jpg)

We should be running SwiftLint on every build.

### Testing instructions
Checkout this branch, build, and verify the warning is gone.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
