### PR TITLE
Product Preview: Track preview failed event

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -349,6 +349,12 @@ extension WooAnalyticsEvent {
         static func previewTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productDetailPreviewTapped, properties: [:])
         }
+
+        /// Tracks when the product preview fails due to a HTTP error.
+        ///
+        static func previewFailed(statusCode: Int) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDetailPreviewFailed, properties: ["status_code": String(statusCode)])
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -353,7 +353,7 @@ extension WooAnalyticsEvent {
         /// Tracks when the product preview fails due to a HTTP error.
         ///
         static func previewFailed(statusCode: Int) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productDetailPreviewFailed, properties: ["status_code": String(statusCode)])
+            WooAnalyticsEvent(statName: .productDetailPreviewFailed, properties: ["status_code": Int64(statusCode)])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -465,6 +465,7 @@ public enum WooAnalyticsStat: String {
     case productInventorySettingsSKUScannerButtonTapped = "product_inventory_settings_sku_scanner_button_tapped"
     case productInventorySettingsSKUScanned = "product_inventory_settings_sku_scanned"
     case productDetailPreviewTapped = "product_detail_preview_tapped"
+    case productDetailPreviewFailed = "product_detail_preview_failed"
 
     // MARK: Edit Product Variation Events
     //

--- a/WooCommerce/Classes/Authentication/WebAuth/WebKitViewController.swift
+++ b/WooCommerce/Classes/Authentication/WebAuth/WebKitViewController.swift
@@ -452,6 +452,11 @@ extension WebKitViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView,
                  decidePolicyFor navigationResponse: WKNavigationResponse,
                  decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+        // Log HTTP error when the status code is outside of the predefined range (200-400)
+        if let response = navigationResponse.response as? HTTPURLResponse, !(200..<400).contains(response.statusCode) {
+            ServiceLocator.analytics.track(event: .ProductDetail.previewFailed(statusCode: response.statusCode))
+        }
+
         guard navigationResponse.isForMainFrame, let authenticator = authenticator, !hasAttemptedAuthRecovery else {
             decisionHandler(.allow)
             return


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8066

## Description

PR adds new `product_detail_preview_tapped` event which is triggered when WKWebView inside WebKitViewController receives response with status code outside of `200..<400` range.
WebKitViewController is only used for previews now, so the event name is feature-specific. Refactoring is coming in later PRs to unify it with other WebKit view controllers in the codebase.

Event registration: 1174-gh-tracks-events-registration
Mobile Tracks spreadsheet updated.

## Testing

1. Build and run the app in debug/alpha mode (to enable preview feature).
2. Start creating a new product ("+" in the navbar).
3. Enter the title to enable preview/save.
4. Tap the "Preview" button in the navbar.
5. Confirm the preview loads and the `product_detail_preview_failed` event is **NOT** triggered.
6. In `ProductFormViewController > displayProductPreview()` on line 221 update nonce to be any random string.
7. Build and run the app.
8. Repeat steps 2-4 with a new product or any existing draft.
9. Confirm the `product_detail_preview_failed` event is triggered with a correct parameter:
```
🔵 Tracked product_detail_preview_failed, properties: [AnyHashable("status_code"): 404, ...]
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
