### PR TITLE
Products Onboarding: Remove feature flag and release product preview feature

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -39,8 +39,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .justInTimeMessagesOnDashboard:
             return true
-        case .productsOnboarding:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .performanceMonitoring,
                 .performanceMonitoringCoreData,
                 .performanceMonitoringFileIO,

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -82,10 +82,6 @@ public enum FeatureFlag: Int {
     ///
     case justInTimeMessagesOnDashboard
 
-    /// Hides products onboarding development.
-    ///
-    case productsOnboarding
-
     // MARK: - Performance Monitoring
     //
     // These flags are not transient. That is, they are not here to help us rollout a feature,

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 11.2
 -----
+- [***] You can now preview draft products before publishing. [https://github.com/woocommerce/woocommerce-ios/pull/8102]
 - [*] The survey at the end of the login onboarding flow is no longer available. [https://github.com/woocommerce/woocommerce-ios/pull/8062]
 - [*] Fixed layout issues on the Account Mismatch error screen. [https://github.com/woocommerce/woocommerce-ios/pull/8074]
 - [*] The Accept Payments Easily banner has been removed from the order list [https://github.com/woocommerce/woocommerce-ios/pull/8078]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -152,11 +152,10 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
             }
         }()
 
-        if featureFlagService.isFeatureFlagEnabled(.productsOnboarding),
-           // The `frame_nonce` value must be stored for the preview to be displayed
-           let site = stores.sessionManager.defaultSite,
+        // The `frame_nonce` value must be stored for the preview to be displayed
+        if let site = stores.sessionManager.defaultSite,
            site.frameNonce.isNotEmpty,
-            // Preview existing drafts or new products, that can be saved as a draft
+            // Preview existing drafts or new products that can be saved as a draft
            (canSaveAsDraft() || originalProductModel.status == .draft) {
             buttons.insert(.preview, at: 0)
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -9,7 +9,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isLoginPrologueOnboardingEnabled: Bool
     private let isStoreCreationMVPEnabled: Bool
     private let isStoreCreationM2Enabled: Bool
-    private let isProductsOnboardingEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -17,8 +16,7 @@ struct MockFeatureFlagService: FeatureFlagService {
          shippingLabelsOnboardingM1: Bool = false,
          isLoginPrologueOnboardingEnabled: Bool = false,
          isStoreCreationMVPEnabled: Bool = true,
-         isStoreCreationM2Enabled: Bool = false,
-         isProductsOnboardingEnabled: Bool = false) {
+         isStoreCreationM2Enabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -26,7 +24,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isLoginPrologueOnboardingEnabled = isLoginPrologueOnboardingEnabled
         self.isStoreCreationMVPEnabled = isStoreCreationMVPEnabled
         self.isStoreCreationM2Enabled = isStoreCreationM2Enabled
-        self.isProductsOnboardingEnabled = isProductsOnboardingEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -45,8 +42,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isStoreCreationMVPEnabled
         case .storeCreationM2:
             return isStoreCreationM2Enabled
-        case .productsOnboarding:
-            return isProductsOnboardingEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -276,8 +276,9 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_action_buttons_for_new_product_and_pending_changes() throws {
         // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
         let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: 123))
-        let viewModel = createViewModel(product: product, formType: .add)
+        let viewModel = createViewModel(product: product, formType: .add, stores: stores)
         viewModel.updateName("new name")
 
         // When
@@ -289,8 +290,9 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_action_buttons_for_new_product_and_no_pending_changes() throws {
         // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
         let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: 123))
-        let viewModel = createViewModel(product: product, formType: .add)
+        let viewModel = createViewModel(product: product, formType: .add, stores: stores)
 
         // When
         let actionButtons = viewModel.actionButtons
@@ -305,9 +307,7 @@ final class ProductFormViewModelTests: XCTestCase {
 
         // Adding some value to simulate a template product
         let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: 123)?.copy(price: "10.00"))
-        let viewModel = createViewModel(product: product,
-                                        formType: .add,
-                                        stores: stores)
+        let viewModel = createViewModel(product: product, formType: .add, stores: stores)
 
         // When
         let actionButtons = viewModel.actionButtons
@@ -319,8 +319,9 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_action_buttons_for_new_product_with_different_status() {
         // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
         let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
-        let viewModel = createViewModel(product: product, formType: .add)
+        let viewModel = createViewModel(product: product, formType: .add, stores: stores)
 
         let updatedProduct = product.copy(statusKey: ProductStatus.draft.rawValue)
         let settings = ProductSettings(from: updatedProduct, password: nil)
@@ -335,8 +336,9 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_action_buttons_for_existing_published_product_and_pending_changes() {
         // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
         let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.published.rawValue)
-        let viewModel = createViewModel(product: product, formType: .edit)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
         viewModel.updateName("new name")
 
         // When
@@ -348,8 +350,9 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_action_buttons_for_existing_published_product_and_no_pending_changes() {
         // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
         let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.published.rawValue)
-        let viewModel = createViewModel(product: product, formType: .edit)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
 
         // When
         let actionButtons = viewModel.actionButtons
@@ -360,8 +363,9 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_action_buttons_for_existing_draft_product_and_pending_changes() {
         // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
         let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
-        let viewModel = createViewModel(product: product, formType: .edit)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
         viewModel.updateName("new name")
 
         // When
@@ -373,8 +377,9 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_action_buttons_for_existing_draft_product_and_no_pending_changes() {
         // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
         let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
-        let viewModel = createViewModel(product: product, formType: .edit)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
 
         // When
         let actionButtons = viewModel.actionButtons
@@ -385,8 +390,9 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_action_buttons_for_existing_product_with_other_status_and_peding_changes() {
         // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
         let product = Product.fake().copy(productID: 123, statusKey: "other")
-        let viewModel = createViewModel(product: product, formType: .edit)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
         viewModel.updateName("new name")
 
         // When
@@ -398,8 +404,9 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_action_buttons_for_existing_product_with_other_status_and_no_peding_changes() {
         // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
         let product = Product.fake().copy(productID: 123, statusKey: "other")
-        let viewModel = createViewModel(product: product, formType: .edit)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
 
         // When
         let actionButtons = viewModel.actionButtons
@@ -410,8 +417,9 @@ final class ProductFormViewModelTests: XCTestCase {
 
     func test_action_buttons_for_any_product_in_read_only_mode() {
         // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
         let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.published.rawValue)
-        let viewModel = createViewModel(product: product, formType: .readonly)
+        let viewModel = createViewModel(product: product, formType: .readonly, stores: stores)
         viewModel.updateName("new name")
 
         // When
@@ -426,9 +434,7 @@ final class ProductFormViewModelTests: XCTestCase {
         sessionManager.defaultSite = Site.fake().copy(frameNonce: "")
 
         let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
-        let viewModel = createViewModel(product: product,
-                                        formType: .edit,
-                                        stores: stores)
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores)
 
         // When
         let actionButtons = viewModel.actionButtons

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -274,9 +274,9 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.formType, .edit)
     }
 
-    func test_action_buttons_for_new_product_with_published_status_and_pending_changes() {
+    func test_action_buttons_for_new_product_and_pending_changes() throws {
         // Given
-        let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
+        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: 123))
         let viewModel = createViewModel(product: product, formType: .add)
         viewModel.updateName("new name")
 
@@ -284,19 +284,37 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.publish, .more])
+        XCTAssertEqual(actionButtons, [.preview, .publish, .more])
     }
 
-    func test_action_buttons_for_new_product_with_published_status_and_no_pending_changes() {
+    func test_action_buttons_for_new_product_and_no_pending_changes() throws {
         // Given
-        let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
+        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: 123))
         let viewModel = createViewModel(product: product, formType: .add)
 
         // When
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.publish, .more])
+        XCTAssertEqual(actionButtons, [.preview, .publish, .more])
+    }
+
+    func test_action_buttons_for_new_template_product() throws {
+        // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
+
+        // Adding some value to simulate a template product
+        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: 123)?.copy(price: "10.00"))
+        let viewModel = createViewModel(product: product,
+                                        formType: .add,
+                                        stores: stores)
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [.preview, .publish, .more])
+        XCTAssertTrue(viewModel.shouldEnablePreviewButton())
     }
 
     func test_action_buttons_for_new_product_with_different_status() {
@@ -350,7 +368,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.save, .more])
+        XCTAssertEqual(actionButtons, [.preview, .save, .more])
     }
 
     func test_action_buttons_for_existing_draft_product_and_no_pending_changes() {
@@ -362,7 +380,7 @@ final class ProductFormViewModelTests: XCTestCase {
         let actionButtons = viewModel.actionButtons
 
         // Then
-        XCTAssertEqual(actionButtons, [.publish, .more])
+        XCTAssertEqual(actionButtons, [.preview, .publish, .more])
     }
 
     func test_action_buttons_for_existing_product_with_other_status_and_peding_changes() {
@@ -401,6 +419,22 @@ final class ProductFormViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(actionButtons, [.more])
+    }
+
+    func test_no_preview_button_for_existing_draft_product_on_site_with_no_frame_nonce() {
+        // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "")
+
+        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
+        let viewModel = createViewModel(product: product,
+                                        formType: .edit,
+                                        stores: stores)
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [.publish, .more])
     }
 
     func test_canPublishOption_is_true_when_creating_new_product_with_different_status() {
@@ -538,204 +572,6 @@ final class ProductFormViewModelTests: XCTestCase {
 
         let hasLinkedProducts = try XCTUnwrap(analyticsProvider.receivedProperties.first?["has_linked_products"] as? Bool)
         XCTAssertTrue(hasLinkedProducts)
-    }
-
-    // MARK: Preview button tests (with enabled Product Onboarding feature flag)
-
-    func test_disabled_preview_button_for_new_blank_product_without_any_changes() throws {
-        // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
-
-        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: 123))
-        let viewModel = createViewModel(product: product,
-                                        formType: .add,
-                                        stores: stores,
-                                        featureFlagService: MockFeatureFlagService(isProductsOnboardingEnabled: true))
-
-        // When
-        let actionButtons = viewModel.actionButtons
-
-        // Then
-        XCTAssertEqual(actionButtons, [.preview, .publish, .more])
-        XCTAssertFalse(viewModel.shouldEnablePreviewButton())
-    }
-
-    func test_enabled_preview_button_for_new_template_product() throws {
-        // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
-
-        // Adding some value to simulate a template product
-        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: 123)?.copy(price: "10.00"))
-        let viewModel = createViewModel(product: product,
-                                        formType: .add,
-                                        stores: stores,
-                                        featureFlagService: MockFeatureFlagService(isProductsOnboardingEnabled: true))
-
-        // When
-        let actionButtons = viewModel.actionButtons
-
-        // Then
-        XCTAssertEqual(actionButtons, [.preview, .publish, .more])
-        XCTAssertTrue(viewModel.shouldEnablePreviewButton())
-    }
-
-    func test_enabled_preview_button_for_new_product_with_pending_changes() {
-        // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
-
-        let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
-        let viewModel = createViewModel(product: product,
-                                        formType: .add,
-                                        stores: stores,
-                                        featureFlagService: MockFeatureFlagService(isProductsOnboardingEnabled: true))
-        viewModel.updateName("new name")
-
-        // When
-        let actionButtons = viewModel.actionButtons
-
-        // Then
-        XCTAssertEqual(actionButtons, [.preview, .publish, .more])
-        XCTAssertTrue(viewModel.shouldEnablePreviewButton())
-    }
-
-    func test_no_preview_button_for_existing_published_product_without_any_changes() {
-        // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
-
-        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.published.rawValue)
-        let viewModel = createViewModel(product: product,
-                                        formType: .edit,
-                                        stores: stores,
-                                        featureFlagService: MockFeatureFlagService(isProductsOnboardingEnabled: true))
-        viewModel.updateName("new name")
-
-        // When
-        let actionButtons = viewModel.actionButtons
-
-        // Then
-        XCTAssertEqual(actionButtons, [.save, .more])
-    }
-
-    func test_no_preview_button_for_existing_published_product_with_pending_changes() {
-        // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
-
-        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.published.rawValue)
-        let viewModel = createViewModel(product: product,
-                                        formType: .edit,
-                                        stores: stores,
-                                        featureFlagService: MockFeatureFlagService(isProductsOnboardingEnabled: true))
-
-        // When
-        let actionButtons = viewModel.actionButtons
-
-        // Then
-        XCTAssertEqual(actionButtons, [.more])
-    }
-
-    func test_preview_button_for_existing_draft_product_without_any_changes() {
-        // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
-
-        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
-        let viewModel = createViewModel(product: product,
-                                        formType: .edit,
-                                        stores: stores,
-                                        featureFlagService: MockFeatureFlagService(isProductsOnboardingEnabled: true))
-
-        // When
-        let actionButtons = viewModel.actionButtons
-
-        // Then
-        XCTAssertEqual(actionButtons, [.preview, .publish, .more])
-    }
-
-    func test_preview_button_for_existing_draft_product_with_pending_changes() {
-        // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
-
-        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
-        let viewModel = createViewModel(product: product,
-                                        formType: .edit,
-                                        stores: stores,
-                                        featureFlagService: MockFeatureFlagService(isProductsOnboardingEnabled: true))
-        viewModel.updateName("new name")
-
-        // When
-        let actionButtons = viewModel.actionButtons
-
-        // Then
-        XCTAssertEqual(actionButtons, [.preview, .save, .more])
-    }
-
-    func test_no_preview_button_for_existing_product_with_other_status_and_without_any_changes() {
-        // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
-
-        let product = Product.fake().copy(productID: 123, statusKey: "other")
-        let viewModel = createViewModel(product: product,
-                                        formType: .edit,
-                                        stores: stores,
-                                        featureFlagService: MockFeatureFlagService(isProductsOnboardingEnabled: true))
-
-        // When
-        let actionButtons = viewModel.actionButtons
-
-        // Then
-        XCTAssertEqual(actionButtons, [.publish, .more])
-    }
-
-    func test_no_preview_button_for_existing_product_with_other_status_and_pending_changes() {
-        // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
-
-        let product = Product.fake().copy(productID: 123, statusKey: "other")
-        let viewModel = createViewModel(product: product,
-                                        formType: .edit,
-                                        stores: stores,
-                                        featureFlagService: MockFeatureFlagService(isProductsOnboardingEnabled: true))
-        viewModel.updateName("new name")
-
-        // When
-        let actionButtons = viewModel.actionButtons
-
-        // Then
-        XCTAssertEqual(actionButtons, [.save, .more])
-    }
-
-    func test_no_preview_button_for_any_product_in_read_only_mode() {
-        // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
-
-        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.published.rawValue)
-        let viewModel = createViewModel(product: product,
-                                        formType: .readonly,
-                                        stores: stores,
-                                        featureFlagService: MockFeatureFlagService(isProductsOnboardingEnabled: true))
-        viewModel.updateName("new name")
-
-        // When
-        let actionButtons = viewModel.actionButtons
-
-        // Then
-        XCTAssertEqual(actionButtons, [.more])
-    }
-
-    func test_no_preview_button_for_existing_draft_product_on_site_with_no_frame_nonce() {
-        // Given
-        sessionManager.defaultSite = Site.fake().copy(frameNonce: "")
-
-        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
-        let viewModel = createViewModel(product: product,
-                                        formType: .edit,
-                                        stores: stores,
-                                        featureFlagService: MockFeatureFlagService(isProductsOnboardingEnabled: true))
-
-        // When
-        let actionButtons = viewModel.actionButtons
-
-        // Then
-        XCTAssertEqual(actionButtons, [.publish, .more])
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/8096

## Description

This PR removes the `productsOnboarding` feature flag and enables product preview feature for all users.

Many unit tests are removed because they were duplicated for feature flag disabled/enabled state.

## Testing

1. Go to the Products tab and add a new product.
2. Confirm the Preview button is visible but disabled, and it is enabled once you start making changes.
3. Tap the Preview button. Confirm the new product is saved and you can see a preview on your store.
4. Go to the Products tab and open existing product draft (can be from previous step).
5. Confirm the Preview button is visible and enabled.
6. Tap the Preview button. Confirm that you can see a preview on your store.

## Video

https://user-images.githubusercontent.com/3132438/201381814-9fe780aa-2e50-43ee-9d65-2cc5ec5f8a5a.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
