### PR TITLE
[In-app Purchases]Use environment variable to get test site id for IAP

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -113,7 +113,7 @@ struct HubMenu: View {
             NavigationLink(destination: CouponListView(siteID: viewModel.siteID), isActive: $showingCoupons) {
                 EmptyView()
             }.hidden()
-            NavigationLink(destination: InAppPurchasesDebugView(siteID: viewModel.siteID), isActive: $showingIAPDebug) {
+            NavigationLink(destination: InAppPurchasesDebugView(), isActive: $showingIAPDebug) {
                 EmptyView()
             }.hidden()
             LazyNavigationLink(destination: viewModel.getReviewDetailDestination(), isActive: $viewModel.showingReviewDetail) {

--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -37,7 +37,7 @@ struct InAppPurchasesDebugView: View {
                         }
                     }
                 } else {
-                    Text("Couldn't retrieve site id to purchase product. " +
+                    Text("No valid site id could be retrieved to purchase product. " +
                          "Please set your Int64 test site id to the Xcode environment variable with name \(Constants.siteIdEnvironmentVariableName).")
                         .foregroundColor(.red)
                 }

--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -4,7 +4,6 @@ import Yosemite
 
 @MainActor
 struct InAppPurchasesDebugView: View {
-    let siteID: Int64
     private let inAppPurchasesForWPComPlansManager = InAppPurchasesForWPComPlansManager()
     @State var products: [WPComPlanProduct] = []
     @State var entitledProductIDs: Set<String> = []
@@ -25,7 +24,8 @@ struct InAppPurchasesDebugView: View {
                     Text("No products")
                 } else if isPurchasing {
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
-                } else {
+                } else if let stringSiteID = ProcessInfo.processInfo.environment[Constants.siteIdEnvironmentVariableName],
+                          let siteID = Int64(stringSiteID) {
                     ForEach(products, id: \.id) { product in
                         Button(entitledProductIDs.contains(product.id) ? "Entitled: \(product.description)" : product.description) {
                             Task {
@@ -36,6 +36,10 @@ struct InAppPurchasesDebugView: View {
                             }
                         }
                     }
+                } else {
+                    Text("Couldn't retrieve site id to purchase product. " +
+                         "Please set your Int64 test site id to the Xcode environment variable with name \(Constants.siteIdEnvironmentVariableName).")
+                        .foregroundColor(.red)
                 }
             }
 
@@ -104,6 +108,10 @@ struct InAppPurchasesDebugView: View {
 
 struct InAppPurchasesDebugView_Previews: PreviewProvider {
     static var previews: some View {
-        InAppPurchasesDebugView(siteID: 0)
+        InAppPurchasesDebugView()
     }
+}
+
+private enum Constants {
+    static let siteIdEnvironmentVariableName = "iap-debug-site-id-purchase-param"
 }

--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -113,5 +113,5 @@ struct InAppPurchasesDebugView_Previews: PreviewProvider {
 }
 
 private enum Constants {
-    static let siteIdEnvironmentVariableName = "iap-debug-site-id-purchase-param"
+    static let siteIdEnvironmentVariableName = "iap-debug-site-id"
 }

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -143,7 +143,7 @@
             isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "iap-debug-site-id-purchase-param"
+            key = "iap-debug-site-id"
             value = ""
             isEnabled = "NO">
          </EnvironmentVariable>

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -142,6 +142,11 @@
             value = ""
             isEnabled = "NO">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "iap-debug-site-id-purchase-param"
+            value = ""
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8110
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, we used the default app site id when debugging In-App purchases and plans, which didn't make much sense because that site was either a wp.com with an e-commerce plan active or a self-hosted site, and thus not eligible for new plans. 
When testing IAP plans, we want a wp.com site without a plan, so, to test that, we have added a Xcode environment variable in this PR. This way we can easily set the site id we want to use to that environment variable and test the whole process.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### No test id set

Run the app without setting a site id in the environment variable, or entering it with the wrong format e.g string. Go to the IAP Debug menu. After the products are loaded, you should see the warning explaining that the site couldn't be retrieved, and you shouldn't be able to purchase any product:

<img src="https://user-images.githubusercontent.com/1864060/201651734-62f91d3b-a54a-4d8e-ab81-6da6b7d8764f.jpeg" width="375">

#### Test id set

If you set a valid site id, the IAP Debug screen should show the products and you should be able to trigger a product purchase with the site id set in the environment variable. To verify that that, you can set a breakpoint in InAppPurchasesForWPComPlansManager.swift, ` func purchaseProduct(with id: String, for remoteSiteId: Int64) async throws `, and inspect the `remoteSiteId` variable.
### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
See above
---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
