### PR TITLE
[In-app Purchases] Improve error reporting

### DIFF
--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -119,7 +119,11 @@ private struct PurchaseError: LocalizedError {
     let error: Error
 
     var errorDescription: String? {
-        error.localizedDescription
+        if let error = error as? LocalizedError {
+            return error.errorDescription
+        } else {
+            return error.localizedDescription
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -10,6 +10,12 @@ struct InAppPurchasesDebugView: View {
     @State var entitledProductIDs: Set<String> = []
     @State var inAppPurchasesAreSupported = true
     @State var isPurchasing = false
+    @State private var purchaseError: PurchaseError? {
+        didSet {
+            presentAlert = purchaseError != nil
+        }
+    }
+    @State var presentAlert = false
 
     var body: some View {
         List {
@@ -30,11 +36,16 @@ struct InAppPurchasesDebugView: View {
                         Button(entitledProductIDs.contains(product.id) ? "Entitled: \(product.description)" : product.description) {
                             Task {
                                 isPurchasing = true
-                                try? await inAppPurchasesForWPComPlansManager.purchaseProduct(with: product.id, for: siteID)
+                                do {
+                                    try await inAppPurchasesForWPComPlansManager.purchaseProduct(with: product.id, for: siteID)
+                                } catch {
+                                    purchaseError = PurchaseError(error: error)
+                                }
                                 await loadUserEntitlements()
                                 isPurchasing = false
                             }
                         }
+                        .alert(isPresented: $presentAlert, error: purchaseError, actions: {})
                     }
                 }
             }
@@ -99,6 +110,16 @@ struct InAppPurchasesDebugView: View {
                 try await inAppPurchasesForWPComPlansManager.retryWPComSyncForPurchasedProduct(with: id)
             }
         }
+    }
+}
+
+/// Just a silly little wrapper because SwiftUI's `alert(isPresented:error:actions:)` wants a `LocalizedError`
+/// but we only have an `Error` coming from `purchaseProduct`.
+private struct PurchaseError: LocalizedError {
+    let error: Error
+
+    var errorDescription: String? {
+        error.localizedDescription
     }
 }
 

--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -107,13 +107,10 @@ private extension InAppPurchaseStore {
                     await transaction.finish()
                 case .userCancelled:
                     logInfo("User cancelled the purchase flow")
-                    throw Errors.userCancelled
                 case .pending:
                     logError("Purchase returned in a pending state, it might succeed in the future")
-                    throw Errors.pending
                 @unknown default:
                     logError("Unknown result for purchase: \(purchaseResult)")
-                    throw Errors.unknownResult
                 }
                 completion(.success(purchaseResult))
             } catch {
@@ -281,18 +278,6 @@ private extension InAppPurchaseStore {
 
 public extension InAppPurchaseStore {
     enum Errors: Error, LocalizedError {
-        /// The user canceled the IAP flow
-        case userCancelled
-
-        /// The purchase is pending some user action.
-        ///
-        /// These purchases may succeed in the future, and the resulting `Transaction` will be
-        /// delivered via `Transaction.updates`
-        case pending
-
-        /// The purchase returned a PurchaseResult value that didn't exist when this was developed
-        case unknownResult
-
         /// The purchase was successful but the transaction was unverified
         ///
         case unverifiedTransaction
@@ -323,18 +308,6 @@ public extension InAppPurchaseStore {
 
         public var errorDescription: String? {
             switch self {
-            case .userCancelled:
-                return NSLocalizedString(
-                    "Purchase cancelled by user",
-                    comment: "Error message used when the user cancelled an In-app purchase flow")
-            case .pending:
-                return NSLocalizedString(
-                    "Purchase pending",
-                    comment: "Error message used when the purchase is pending some user action")
-            case .unknownResult:
-                return NSLocalizedString(
-                    "Unexpected purchase result",
-                    comment: "Error message used when a purchase returned something unexpected that we don't know how to handle")
             case .unverifiedTransaction:
                 return NSLocalizedString(
                     "The purchase transaction couldn't be verified",

--- a/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
+++ b/Yosemite/Yosemite/Stores/InAppPurchaseStore.swift
@@ -280,7 +280,7 @@ private extension InAppPurchaseStore {
 }
 
 public extension InAppPurchaseStore {
-    enum Errors: String, Error {
+    enum Errors: Error, LocalizedError {
         /// The user canceled the IAP flow
         case userCancelled
 
@@ -320,6 +320,51 @@ public extension InAppPurchaseStore {
         /// In-app purchases are not supported for this user
         ///
         case inAppPurchasesNotSupported
+
+        public var errorDescription: String? {
+            switch self {
+            case .userCancelled:
+                return NSLocalizedString(
+                    "Purchase cancelled by user",
+                    comment: "Error message used when the user cancelled an In-app purchase flow")
+            case .pending:
+                return NSLocalizedString(
+                    "Purchase pending",
+                    comment: "Error message used when the purchase is pending some user action")
+            case .unknownResult:
+                return NSLocalizedString(
+                    "Unexpected purchase result",
+                    comment: "Error message used when a purchase returned something unexpected that we don't know how to handle")
+            case .unverifiedTransaction:
+                return NSLocalizedString(
+                    "The purchase transaction couldn't be verified",
+                    comment: "Error message used when a purchase was successful but its transaction was unverified")
+            case .transactionMissingAppAccountToken:
+                return NSLocalizedString(
+                    "Purchase transaction missing account information",
+                    comment: "Error message used when the purchase transaction doesn't have the right metadata to associate to a specific site")
+            case .appAccountTokenMissingSiteIdentifier:
+                return NSLocalizedString(
+                    "Purchase transaction can't be associated to a site",
+                    comment: "Error message used when the purchase transaction doesn't have the right metadata to associate to a specific site")
+            case .transactionProductUnknown:
+                return NSLocalizedString(
+                    "Purchase transaction received for an unknown product",
+                    comment: "Error message used when we received a transaction for an unknown product")
+            case .storefrontUnknown:
+                return NSLocalizedString(
+                    "Couldn't determine App Stoure country",
+                    comment: "Error message used when we can't determine the user's App Store country")
+            case .missingAppReceipt:
+                return NSLocalizedString(
+                    "Couldn't retrieve app receipt",
+                    comment: "Error message used when we can't read the app receipt")
+            case .inAppPurchasesNotSupported:
+                return NSLocalizedString(
+                    "In-app purchases are not supported for this user yet",
+                    comment: "Error message used when In-app purchases are not supported for this user/site")
+            }
+        }
     }
 
     enum Constants {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8112 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR tries to make the IAP logging clearer and shows any error purchasing as an alert in the debug view. This includes:

- After a purchase, we call `submitTransaction` directly if the purchase was successful and verified. We don't reuse `handleCompletedTransaction` anymore and that method is reserved for the transaction listener. This means different logging for the interactive purchase and transaction listener so that hopefully we'll differentiate those better in the logs.
- More explicit handling of pending and user canceled purchases as a specific error
- Added descriptions for all store errors

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

There are many different ways to test all the errors, but the simplest way to verify this:

1. Go to Hub menu > IAP debug
2. Tap on a product to purchase
3. When the IAP flow is presented, tap outside to dismiss it
4. See an alert saying the purchase was cancelled

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![Screen Shot 2022-11-14 at 16 23 49](https://user-images.githubusercontent.com/8739/201700830-e6d85908-a7ba-42fc-9d27-d83d10e979f5.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
