### PR TITLE
[In-app Purchases] Improve transaction handling logic

### DIFF
--- a/Networking/Networking/Model/WordPressApiError.swift
+++ b/Networking/Networking/Model/WordPressApiError.swift
@@ -8,6 +8,10 @@ public enum WordPressApiError: Error, Decodable, Equatable {
     ///
     case unknown(code: String, message: String)
 
+    /// An order already exists for this IAP receipt
+    ///
+    case productPurchased
+
     /// Decodable Initializer.
     ///
     public init(from decoder: Decoder) throws {
@@ -16,6 +20,8 @@ public enum WordPressApiError: Error, Decodable, Equatable {
         let message = try container.decode(String.self, forKey: .message)
 
         switch code {
+        case Constants.productPurchased:
+            self = .productPurchased
         default:
             self = .unknown(code: code, message: message)
         }
@@ -25,6 +31,7 @@ public enum WordPressApiError: Error, Decodable, Equatable {
     /// Constants for Possible Error Identifiers
     ///
     private enum Constants {
+        static let productPurchased = "product_purchased"
     }
 
     /// Coding Keys
@@ -50,6 +57,10 @@ extension WordPressApiError: CustomStringConvertible {
 
     public var description: String {
         switch self {
+        case .productPurchased:
+            return NSLocalizedString(
+                "An order aready exists for this receipt",
+                comment: "Error message when an order already exists in the backend for a given receipt")
         case .unknown(let code, let message):
             let messageFormat = NSLocalizedString(
                 "WordPress API Error: [%1$@] %2$@",

--- a/Networking/Networking/Model/WordPressApiError.swift
+++ b/Networking/Networking/Model/WordPressApiError.swift
@@ -70,3 +70,11 @@ extension WordPressApiError: CustomStringConvertible {
         }
     }
 }
+
+// MARK: - LocalizedError Conformance
+//
+extension WordPressApiError: LocalizedError {
+    public var errorDescription: String? {
+        description
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8121 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR intends to improve some of the transaction handling logic:

- First, by pausing the transaction listener while making a purchase, so the purchase logic gets to create the order first. I've observed that sometimes there were race conditions where the transaction update got there first and the purchase failed because it was trying to create a duplicate order. This is a bit random and hard to reproduce though.
- Then, even if we re-send a transaction, if the backend returns a `product_purchased` error, it means that we have already sent that transaction before and there's an order for it. So now we treat this case as a success instead of a failure

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Hub menu > IAP Debug
2. Purchase a new subscription
3. Notice the `Pausing transaction listener` and `Resuming transaction listener` messages in the console while the purchase is happening
4. Try to purchase the same product again. iOS will tell you that you already own that, but after dismissing the dialog, it returns a transaction and the app tries to submit that
5. Notice the `Sending transaction to API` message in the console followed by `Existing order found for transaction ##### on site #####, ignoring`. The app should show no alert with an error (unless the API call failed for another reason)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
