### PR TITLE
Distribute WCiOS Prototype Builds to Collaborators

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -532,7 +532,7 @@ platform :ios do
       owner_name: 'automattic',
       owner_type: 'organization',
       app_name: 'WooCommerce-Installable-Builds',
-      destinations: 'All-users-of-WooCommerce-Installable-Builds',
+      destinations: 'Collaborators',
       notify_testers: false
     )
 


### PR DESCRIPTION
### Description
This PR should resolve access issues by distributing prototype builds to the `Collaborators` group on App Center, which is the group associated with our internal automation.

### Testing instructions
Note that the build associated with this PR is distributed to the `Collaborators` group.