### PR TITLE
Store creation M2: store name form

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Store name/StoreNameForm.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Store name/StoreNameForm.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+
+/// Hosting controller that wraps the `StoreNameForm`.
+final class StoreNameFormHostingController: UIHostingController<StoreNameForm> {
+    private let onContinue: (String) -> Void
+    private let onClose: () -> Void
+
+    init(onContinue: @escaping (String) -> Void,
+         onClose: @escaping () -> Void) {
+        self.onContinue = onContinue
+        self.onClose = onClose
+        super.init(rootView: StoreNameForm())
+
+        rootView.onContinue = { [weak self] storeName in
+            self?.onContinue(storeName)
+        }
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureNavigationBarAppearance()
+    }
+
+    /// Shows a transparent navigation bar without a bottom border and with a close button to dismiss.
+    func configureNavigationBarAppearance() {
+        addCloseNavigationBarButton(title: Localization.cancelButtonTitle,
+                                    target: self,
+                                    action: #selector(closeButtonTapped))
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithTransparentBackground()
+        appearance.backgroundColor = .systemBackground
+
+        navigationItem.standardAppearance = appearance
+        navigationItem.scrollEdgeAppearance = appearance
+        navigationItem.compactAppearance = appearance
+    }
+
+    @objc private func closeButtonTapped() {
+        onClose()
+    }
+}
+
+private extension StoreNameFormHostingController {
+    enum Localization {
+        static let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Navigation bar button on the store name form to leave the store creation flow.")
+    }
+}
+
+/// Allows the user to enter a store name during the store creation flow.
+struct StoreNameForm: View {
+    /// Set in the hosting controller.
+    var onContinue: (String) -> Void = { _ in }
+
+    @State private var name: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 40) {
+                    VStack(alignment: .leading, spacing: 16) {
+                        // Top header label.
+                        Text(Localization.topHeader)
+                            .foregroundColor(Color(.secondaryLabel))
+                            .footnoteStyle()
+
+                        // Title label.
+                        Text(Localization.title)
+                            .fontWeight(.bold)
+                            .titleStyle()
+
+                        // Subtitle label.
+                        Text(Localization.subtitle)
+                            .foregroundColor(Color(.secondaryLabel))
+                            .bodyStyle()
+                    }
+
+                    VStack(alignment: .leading, spacing: 16) {
+                        // Text field prompt label.
+                        Text(Localization.textFieldPrompt)
+                            .foregroundColor(Color(.label))
+                            .bodyStyle()
+
+                        // Store name text field.
+                        TextField("", text: $name)
+                            .font(.body)
+                            .textFieldStyle(RoundedBorderTextFieldStyle(focused: false))
+                            .focused()
+                    }
+                }
+                .padding(Layout.contentPadding)
+            }
+
+            // Continue button.
+            Button(Localization.continueButtonTitle) {
+                onContinue(name)
+            }
+            .padding(Layout.defaultButtonPadding)
+            .buttonStyle(PrimaryButtonStyle())
+            .disabled(name.isEmpty)
+        }
+    }
+}
+
+private extension StoreNameForm {
+    enum Layout {
+        static let spacingBetweenSubtitleAndStoreInfo: CGFloat = 40
+        static let spacingBetweenStoreNameAndDomain: CGFloat = 4
+        static let defaultHorizontalPadding: CGFloat = 16
+        static let dividerHeight: CGFloat = 1
+        static let contentPadding: EdgeInsets = .init(top: 38, leading: 16, bottom: 16, trailing: 16)
+        static let defaultButtonPadding: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+        static let storeInfoPadding: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+        static let storeInfoCornerRadius: CGFloat = 8
+    }
+
+    enum Localization {
+        static let topHeader = NSLocalizedString(
+            "ABOUT YOUR STORE",
+            comment: "Header label on the top of the store name form in the store creation flow."
+        )
+        static let title = NSLocalizedString(
+            "What’s your store name?",
+            comment: "Title label on the store name form in the store creation flow."
+        )
+        static let subtitle = NSLocalizedString(
+            "Don’t worry you can always change it later.",
+            comment: "Subtitle label on the store name form in the store creation flow."
+        )
+        static let textFieldPrompt = NSLocalizedString(
+            "Store name",
+            comment: "Text field prompt on the store name form in the store creation flow."
+        )
+        static let continueButtonTitle = NSLocalizedString(
+            "Continue",
+            comment: "Title of the button on the store creation store name form to continue."
+        )
+    }
+}
+
+struct StoreNameForm_Previews: PreviewProvider {
+    static var previews: some View {
+        StoreNameForm()
+    }
+}

--- a/WooCommerce/Classes/Authentication/Store Creation/Store name/StoreNameForm.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Store name/StoreNameForm.swift
@@ -87,7 +87,7 @@ struct StoreNameForm: View {
                             .bodyStyle()
 
                         // Store name text field.
-                        TextField("", text: $name)
+                        TextField(Localization.textFieldPlaceholder, text: $name)
                             .font(.body)
                             .textFieldStyle(RoundedBorderTextFieldStyle(focused: false))
                             .focused()
@@ -135,6 +135,10 @@ private extension StoreNameForm {
         static let textFieldPrompt = NSLocalizedString(
             "Store name",
             comment: "Text field prompt on the store name form in the store creation flow."
+        )
+        static let textFieldPlaceholder = NSLocalizedString(
+            "Type a name for your store",
+            comment: "Text field placeholder on the store name form in the store creation flow."
         )
         static let continueButtonTitle = NSLocalizedString(
             "Continue",

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -72,15 +72,14 @@ private extension StoreCreationCoordinator {
         let storeCreationNavigationController = UINavigationController()
         storeCreationNavigationController.navigationBar.prefersLargeTitles = true
 
-        let domainSelector = DomainSelectorHostingController(viewModel: .init(),
-                                                             onDomainSelection: { [weak self] domain in
-            guard let self else { return }
-            // TODO: add a store name screen before the domain selector screen.
-            await self.createStoreAndContinueToStoreSummary(from: storeCreationNavigationController, name: "Test store", domain: domain)
-        }, onSkip: {
-            // TODO-8045: skip to the next step of store creation with an auto-generated domain.
-        })
-        storeCreationNavigationController.pushViewController(domainSelector, animated: false)
+        let storeNameForm = StoreNameFormHostingController { [weak self] storeName in
+            self?.showDomainSelector(from: storeCreationNavigationController,
+                                     storeName: storeName)
+        } onClose: { [weak self] in
+            self?.showDiscardChangesAlert()
+        }
+        storeCreationNavigationController.pushViewController(storeNameForm, animated: false)
+
         presentStoreCreation(viewController: storeCreationNavigationController)
     }
 
@@ -192,6 +191,20 @@ private extension StoreCreationCoordinator {
 // MARK: - Store creation M2
 
 private extension StoreCreationCoordinator {
+    func showDomainSelector(from navigationController: UINavigationController,
+                            storeName: String) {
+        let domainSelector = DomainSelectorHostingController(viewModel: .init(initialSearchTerm: storeName),
+                                                             onDomainSelection: { [weak self] domain in
+            guard let self else { return }
+            await self.createStoreAndContinueToStoreSummary(from: navigationController,
+                                                            name: storeName,
+                                                            domain: domain)
+        }, onSkip: {
+            // TODO-8045: skip to the next step of store creation with an auto-generated domain.
+        })
+        navigationController.pushViewController(domainSelector, animated: false)
+    }
+
     @MainActor
     func createStoreAndContinueToStoreSummary(from navigationController: UINavigationController, name: String, domain: String) async {
         let result = await createStore(name: name, domain: domain)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		020886572499E643001D784E /* ProductExternalLinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020886562499E642001D784E /* ProductExternalLinkViewController.swift */; };
 		020A55F127F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020A55F027F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift */; };
 		020AF66329235860007760E5 /* StoreCreationPlanViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020AF66229235860007760E5 /* StoreCreationPlanViewModel.swift */; };
+		020AF6662923C7ED007760E5 /* StoreNameForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020AF6652923C7ED007760E5 /* StoreNameForm.swift */; };
 		020B2F8F23BD9F1F00BD79AD /* IntegerInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */; };
 		020B2F9123BDD71500BD79AD /* IntegerInputFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F9023BDD71500BD79AD /* IntegerInputFormatterTests.swift */; };
 		020B2F9423BDDBDC00BD79AD /* ProductUpdateError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F9323BDDBDC00BD79AD /* ProductUpdateError+UI.swift */; };
@@ -1997,6 +1998,7 @@
 		020886562499E642001D784E /* ProductExternalLinkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductExternalLinkViewController.swift; sourceTree = "<group>"; };
 		020A55F027F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionAnalyticsTracker.swift; sourceTree = "<group>"; };
 		020AF66229235860007760E5 /* StoreCreationPlanViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationPlanViewModel.swift; sourceTree = "<group>"; };
+		020AF6652923C7ED007760E5 /* StoreNameForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreNameForm.swift; sourceTree = "<group>"; };
 		020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerInputFormatter.swift; sourceTree = "<group>"; };
 		020B2F9023BDD71500BD79AD /* IntegerInputFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerInputFormatterTests.swift; sourceTree = "<group>"; };
 		020B2F9323BDDBDC00BD79AD /* ProductUpdateError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductUpdateError+UI.swift"; sourceTree = "<group>"; };
@@ -3999,6 +4001,14 @@
 			path = "Edit External Link";
 			sourceTree = "<group>";
 		};
+		020AF6642923C745007760E5 /* Store name */ = {
+			isa = PBXGroup;
+			children = (
+				020AF6652923C7ED007760E5 /* StoreNameForm.swift */,
+			);
+			path = "Store name";
+			sourceTree = "<group>";
+		};
 		020B2F9223BDDBC300BD79AD /* Error Handling */ = {
 			isa = PBXGroup;
 			children = (
@@ -4537,6 +4547,7 @@
 		02759B8F28FFA06F00918176 /* Store Creation */ = {
 			isa = PBXGroup;
 			children = (
+				020AF6642923C745007760E5 /* Store name */,
 				02EEA92929233F0F00D05F47 /* Plan */,
 				02759B9028FFA09600918176 /* StoreCreationWebViewModel.swift */,
 				02E3B63029066858007E0F13 /* StoreCreationCoordinator.swift */,
@@ -10317,6 +10328,7 @@
 				D831E2E0230E0BA7000037D0 /* Logs.swift in Sources */,
 				02CEBB8224C98861002EDF35 /* ProductFormDataModel.swift in Sources */,
 				3120491B26DD80E000A4EC4F /* ActivitySpinnerAndLabelTableViewCell.swift in Sources */,
+				020AF6662923C7ED007760E5 /* StoreNameForm.swift in Sources */,
 				DEC51AFD276AEAE3009F3DF4 /* SystemStatusReportView.swift in Sources */,
 				CECC759C23D61C1400486676 /* AggregateDataHelper.swift in Sources */,
 				02645D7D27BA027B0065DC68 /* Inbox.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/StoreCreationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/StoreCreationCoordinatorTests.swift
@@ -71,7 +71,7 @@ final class StoreCreationCoordinatorTests: XCTestCase {
 
     // MARK: - Presentation in different states for store creation M2
 
-    func test_DomainSelectorHostingController_is_presented_when_navigationController_is_presenting_another_view() throws {
+    func test_StoreNameFormHostingController_is_presented_when_navigationController_is_presenting_another_view() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true)
         let coordinator = StoreCreationCoordinator(source: .storePicker,
@@ -92,10 +92,10 @@ final class StoreCreationCoordinatorTests: XCTestCase {
             self.navigationController.presentedViewController is UINavigationController
         }
         let storeCreationNavigationController = try XCTUnwrap(navigationController.presentedViewController as? UINavigationController)
-        assertThat(storeCreationNavigationController.topViewController, isAnInstanceOf: DomainSelectorHostingController.self)
+        assertThat(storeCreationNavigationController.topViewController, isAnInstanceOf: StoreNameFormHostingController.self)
     }
 
-    func test_AuthenticatedWebViewController_is_presented_when_navigationController_is_showing_another_view() throws {
+    func test_StoreNameFormHostingController_is_presented_when_navigationController_is_showing_another_view() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true)
         navigationController.show(.init(), sender: nil)
@@ -113,6 +113,6 @@ final class StoreCreationCoordinatorTests: XCTestCase {
             self.navigationController.presentedViewController is UINavigationController
         }
         let storeCreationNavigationController = try XCTUnwrap(navigationController.presentedViewController as? UINavigationController)
-        assertThat(storeCreationNavigationController.topViewController, isAnInstanceOf: DomainSelectorHostingController.self)
+        assertThat(storeCreationNavigationController.topViewController, isAnInstanceOf: StoreNameFormHostingController.self)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8117 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Originally, this is the first profiler question followed by a few other questions. However, due to the profiler questions API timeline, we plan to just implement the first question on the store name natively since this is important information about their site. When tapping to continue with the store name, the name is then used as the initial query in the next domain selector.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in if needed
- Go to the Menu tab, and tap `Switch store`
- On the store picker, tap `+ Add a store`
- Tap `Create a new store` --> the store name form should be shown with the Continue button disabled
- Enter some text into the text field --> the Continue button should be enabled when the store name is non-empty
- Tap `Continue` to continue with the store name --> the name should be used as the initial query in the next domain selector screen

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

light | dark | cancel action | empty field
-- | -- | -- | --
![Simulator Screen Shot - iPhone 14 - 2022-11-16 at 09 52 39](https://user-images.githubusercontent.com/1945542/202063930-6cdae95c-49ae-453d-8e6d-55cf11ae4201.png) | ![Simulator Screen Shot - iPhone 14 - 2022-11-16 at 09 50 56](https://user-images.githubusercontent.com/1945542/202063779-fe6bfb86-4999-4235-bc81-f3b01b752ed7.png) | ![Simulator Screen Shot - iPhone 14 - 2022-11-16 at 09 51 01](https://user-images.githubusercontent.com/1945542/202063784-6b0f3668-f90f-4c4a-a5ea-e2c58a05fff9.png) | ![Simulator Screen Shot - iPhone 14 - 2022-11-16 at 10 31 16](https://user-images.githubusercontent.com/1945542/202069247-978ee04a-2057-4388-89cf-dc24308c0dc1.png)

Example screencast:

https://user-images.githubusercontent.com/1945542/202063695-14fb2d8c-9803-4125-b837-d410798c34c1.mov




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
