### PR TITLE
WIP - Use `xcodes` in CI with Fastlane

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Job lifecycle hooks are sourced by the Buildkite bootstrap in the different
+# job phases, so we need to explicitly call `set -e` etc. instead of passing
+# the options to the shebang.
+set -e
+
+# This is a temporary check while we provision the tool as part of our VMs in
+# CI.
+if [[ $IMAGE_ID =~ ^xcode ]]; then
+  echo '--- :xcode: Ensure xcodes tool is installed'
+  brew install xcodes
+else
+  # Leave a note in the logs for why the hook returned without doing anything.
+  echo 'Running on an agent that does not use Xcode. Skipping xcodes tool installation.'
+fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -7,7 +7,17 @@ set -e
 
 # This is a temporary check while we provision the tool as part of our VMs in
 # CI.
-if [[ $IMAGE_ID =~ ^xcode ]]; then
+#
+# A more precise check would be:
+#
+# if [[ $IMAGE_ID =~ ^xcode ]]; then
+#
+# but our tooling doesn't currently forward that environment variable.
+# See
+#
+# - https://github.com/Automattic/hostmgr/pull/47
+# - https://github.com/Automattic/hostmgr/issues/48
+if [[ $BUILDKITE_AGENT_META_DATA_QUEUE = 'mac' ]]; then
   echo '--- :xcode: Ensure xcodes tool is installed'
   brew install xcodes
 else


### PR DESCRIPTION
Things that need to happen before working on this PR again:

- [ ] [See how Fastlane will react in terms of using `xcodes` now that Apple requires authentication for downloads](https://github.com/woocommerce/woocommerce-ios/pull/8131#issuecomment-1319952750)
- [ ] Upgrade CI to Xcode 14.1 stable, [which will include `xcodes`](https://github.com/woocommerce/woocommerce-ios/pull/8131#issuecomment-1319392414)