### PR TITLE
[Mobile Payments] Update StripeTerminal to 2.14

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -53,7 +53,7 @@ def cocoa_lumberjack
 end
 
 def stripe_terminal
-  pod 'StripeTerminal', '~> 2.7'
+  pod 'StripeTerminal', '~> 2.14'
 end
 
 # Main Target!

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -36,7 +36,7 @@ PODS:
   - Sentry/Core (7.25.1)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
-  - StripeTerminal (2.7.0)
+  - StripeTerminal (2.14.0)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (2.0.0)
   - WordPress-Aztec-iOS (1.11.0)
@@ -89,7 +89,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 4.2.2)
   - Kingfisher (~> 7.2.2)
   - Sourcery (~> 1.0.3)
-  - StripeTerminal (~> 2.7)
+  - StripeTerminal (~> 2.14)
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (~> 4.2.0)
   - WordPressKit (~> 4.49.0)
@@ -157,7 +157,7 @@ SPEC CHECKSUMS:
   Sentry: dd29c18c32b0af9269949f079cf631d581ca76ca
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
-  StripeTerminal: 237b759168a00c7f55b97c743cd8a4921866c46b
+  StripeTerminal: 9bb367c9efa7bcddf2602cc29f8962390d87b6a6
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
@@ -178,6 +178,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 3eb40bbfcf83cb0e4f4b28bc5b6229c27ae4cbf7
+PODFILE CHECKSUM: 8b243f1ea76d4db3aa638b50ef0d516185d01c2c
 
 COCOAPODS: 1.11.3

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 11.3
 -----
 - [*] In-Person Payments: Show spinner while preparing reader for payment, instead of saying it's ready before it is. [https://github.com/woocommerce/woocommerce-ios/pull/8115]
+- [internal] In-Person Payments: update StripeTerminal from 2.7 to 2.14 [https://github.com/woocommerce/woocommerce-ios/pull/8132]
 
 11.2
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Closes: #8086 

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

StripeTerminal 2.14 is required for [Tap on Mobile work in sTAP Away](https://github.com/woocommerce/woocommerce-ios/projects/52). Updating to this version in the production version of the app will make the development process much easier, as we can't change dependencies based on feature flags.

## Testing instructions
Run unit tests

Test card reader payment flows. I've checked the following:

### Connection

- [x] Connection during payment flow (take a payment with no connected reader)
- [x] Connection from Payments menu
- [x] Connection of a reader with a mandatory update: starts update process
- [x] Connection of M2 reader
- [x] Connection of WisePad 3 reader
- [x] Connection of Chipper reader

### Payment

- [x] Take payment after in-line connection process
- [x] Take payment with a previously-connected reader
- [x] Take Interac payment
- [x] Refund Interac payment
- [x] Take contactless payment
- [x] Take card-inserted payment

### Update reader

- [x] Reader update: error message when attempted with low battery
- [x] Reader update: successfully updates software and starts payment (in that flow) when complete


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
