### PR TITLE
[In-app Purchases] Include purchase result in purchaseProduct API

### DIFF
--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -37,7 +37,8 @@ struct InAppPurchasesDebugView: View {
                             Task {
                                 isPurchasing = true
                                 do {
-                                    try await inAppPurchasesForWPComPlansManager.purchaseProduct(with: product.id, for: siteID)
+                                    let result = try await inAppPurchasesForWPComPlansManager.purchaseProduct(with: product.id, for: siteID)
+                                    print("[IAP Debug] Purchase result: \(result)")
                                 } catch {
                                     purchaseError = PurchaseError(error: error)
                                 }

--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import StoreKit
 import Yosemite
 
 @MainActor

--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesForWPComPlansManager.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesForWPComPlansManager.swift
@@ -15,6 +15,8 @@ protocol WPComPlanProduct {
 
 extension StoreKit.Product: WPComPlanProduct {}
 
+typealias InAppPurchaseResult = StoreKit.Product.PurchaseResult
+
 protocol InAppPurchasesForWPComPlansProtocol {
     /// Retrieves asynchronously all WPCom plans In-App Purchases products.
     ///
@@ -33,7 +35,7 @@ protocol InAppPurchasesForWPComPlansProtocol {
     ///     id: the id of the product to be purchased
     ///     remoteSiteId: the id of the site linked to the purchasing plan
     ///
-    func purchaseProduct(with id: String, for remoteSiteId: Int64) async throws -> StoreKit.Product.PurchaseResult
+    func purchaseProduct(with id: String, for remoteSiteId: Int64) async throws -> InAppPurchaseResult
 
     /// Retries forwarding the product purchase to our backend, so the plan can be unlocked.
     /// This can happen when the purchase was previously successful but unlocking the WPCom plan request
@@ -73,7 +75,7 @@ final class InAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProto
         }
     }
 
-    func purchaseProduct(with id: String, for remoteSiteId: Int64) async throws -> StoreKit.Product.PurchaseResult {
+    func purchaseProduct(with id: String, for remoteSiteId: Int64) async throws -> InAppPurchaseResult {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(InAppPurchaseAction.purchaseProduct(siteID: remoteSiteId, productID: id, completion: { result in
                 continuation.resume(with: result)

--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesForWPComPlansManager.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesForWPComPlansManager.swift
@@ -33,7 +33,7 @@ protocol InAppPurchasesForWPComPlansProtocol {
     ///     id: the id of the product to be purchased
     ///     remoteSiteId: the id of the site linked to the purchasing plan
     ///
-    func purchaseProduct(with id: String, for remoteSiteId: Int64) async throws
+    func purchaseProduct(with id: String, for remoteSiteId: Int64) async throws -> StoreKit.Product.PurchaseResult
 
     /// Retries forwarding the product purchase to our backend, so the plan can be unlocked.
     /// This can happen when the purchase was previously successful but unlocking the WPCom plan request
@@ -73,8 +73,8 @@ final class InAppPurchasesForWPComPlansManager: InAppPurchasesForWPComPlansProto
         }
     }
 
-    func purchaseProduct(with id: String, for remoteSiteId: Int64) async throws {
-        _ = try await withCheckedThrowingContinuation { continuation in
+    func purchaseProduct(with id: String, for remoteSiteId: Int64) async throws -> StoreKit.Product.PurchaseResult {
+        try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(InAppPurchaseAction.purchaseProduct(siteID: remoteSiteId, productID: id, completion: { result in
                 continuation.resume(with: result)
             }))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8130 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This updates the `InAppPurchasesForWPComPlansProtocol.purchaseProduct` so it returns the actual `PurchaseResult` and the site creation flow is able to differentiate a successful purchase from a pending one or a user cancellation.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Hub menu > IAP Debug
2. Tap on a product to purchase
3. Dismiss the IAP modal and notice a `Purchase result: userCancelled` message in the console
4. Tap on a product to purchase
5. Complete the purchase and notice a `Purchase result: success(...` message in the console

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
