### PR TITLE
Products Onboarding: Stay on My Store screen after tapping on banner CTA

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -123,6 +123,7 @@ final class DashboardViewController: UIViewController {
         observeStatsVersionForDashboardUIUpdates()
         observeAnnouncements()
         observeShowWebViewSheet()
+        observeAddProductTrigger()
         viewModel.syncAnnouncements(for: siteID)
         Task { @MainActor in
             await reloadDashboardUIStatsVersion(forced: true)
@@ -301,6 +302,23 @@ private extension DashboardViewController {
         let hostingController = UIHostingController(rootView: webViewSheet)
         hostingController.presentationController?.delegate = self
         present(hostingController, animated: true, completion: nil)
+    }
+
+    /// Subscribes to the trigger to start the Add Product flow for products onboarding
+    ///
+    private func observeAddProductTrigger() {
+        viewModel.addProductTrigger.sink { [weak self] _ in
+            self?.startAddProductFlow()
+        }
+        .store(in: &subscriptions)
+    }
+
+    /// Starts the Add Product flow (without switching tabs)
+    ///
+    private func startAddProductFlow() {
+        guard let announcementView, let navigationController else { return }
+        let coordinator = AddProductCoordinator(siteID: siteID, sourceView: announcementView, sourceNavigationController: navigationController)
+        coordinator.start()
     }
 
     // This is used so we have a specific type for the view while applying modifiers.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -318,6 +318,11 @@ private extension DashboardViewController {
     private func startAddProductFlow() {
         guard let announcementView, let navigationController else { return }
         let coordinator = AddProductCoordinator(siteID: siteID, sourceView: announcementView, sourceNavigationController: navigationController)
+        coordinator.onProductCreated = { [weak self] in
+            guard let self else { return }
+            self.viewModel.announcementViewModel = nil // Remove the products onboarding banner
+            self.viewModel.syncAnnouncements(for: self.siteID)
+        }
         coordinator.start()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -1,4 +1,5 @@
 import Yosemite
+import Combine
 import enum Networking.DotcomError
 import enum Storage.StatsVersion
 import protocol Experiments.FeatureFlagService
@@ -12,6 +13,10 @@ final class DashboardViewModel {
     @Published var announcementViewModel: AnnouncementCardViewModelProtocol? = nil
 
     @Published private(set) var showWebViewSheet: WebViewSheetViewModel? = nil
+
+    /// Trigger to start the Add Product flow
+    ///
+    let addProductTrigger = PassthroughSubject<Void, Never>()
 
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
@@ -154,8 +159,7 @@ final class DashboardViewModel {
             guard let self else { return }
             if case let .success(isVisible) = result, isVisible {
                 let viewModel = ProductsOnboardingAnnouncementCardViewModel(onCTATapped: { [weak self] in
-                    self?.announcementViewModel = nil // Dismiss announcement
-                    MainTabBarController.presentAddProductFlow()
+                    self?.addProductTrigger.send()
                 })
                 self.announcementViewModel = viewModel
             }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -414,19 +414,6 @@ extension MainTabBarController {
         }
     }
 
-    static func presentAddProductFlow() {
-        navigateTo(.products)
-
-        guard let productsViewController: ProductsViewController = childViewController() else {
-            return
-        }
-
-        // We give some time for the products tab transition to finish, so the add product button is present to start the flow
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            productsViewController.addProduct()
-        }
-    }
-
     static func presentPayments() {
         switchToHubMenuTab()
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -30,6 +30,10 @@ final class AddProductCoordinator: Coordinator {
         return controller
     }()
 
+    /// Assign this closure to be notified when a new product is saved remotely
+    ///
+    var onProductCreated: () -> Void = {}
+
     init(siteID: Int64,
          sourceBarButtonItem: UIBarButtonItem,
          sourceNavigationController: UINavigationController,
@@ -211,6 +215,7 @@ private extension AddProductCoordinator {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .add,
                                              productImageActionHandler: productImageActionHandler)
+        viewModel.onProductCreated = onProductCreated
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        eventLogger: ProductFormEventLogger(),
                                                        productImageActionHandler: productImageActionHandler,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -181,6 +181,10 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     private let featureFlagService: FeatureFlagService
 
+    /// Assign this closure to be notified when a new product is saved remotely
+    ///
+    var onProductCreated: () -> Void = {}
+
     init(product: EditableProductModel,
          formType: ProductFormType,
          productImageActionHandler: ProductImageActionHandler,
@@ -432,7 +436,7 @@ extension ProductFormViewModel {
             let productWithStatusUpdated = product.product.copy(statusKey: status.rawValue)
             return EditableProductModel(product: productWithStatusUpdated)
         }()
-        let remoteActionUseCase = ProductFormRemoteActionUseCase()
+        let remoteActionUseCase = ProductFormRemoteActionUseCase(stores: stores)
         switch formType {
         case .add:
             let productIDBeforeSave = productModel.productID
@@ -449,6 +453,7 @@ extension ProductFormViewModel {
                     onCompletion(.success(data.product))
                     self.replaceProductID(productIDBeforeSave: productIDBeforeSave)
                     self.saveProductImagesWhenNoneIsPendingUploadAnymore()
+                    self.onProductCreated()
                 }
             }
         case .edit:

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -220,16 +220,6 @@ final class ProductsViewController: UIViewController, GhostableViewController {
     }
 }
 
-// MARK: - Public API
-//
-extension ProductsViewController {
-    /// Adds a new product using the "Add Product" navigation bar button as the source
-    ///
-    func addProduct() {
-        addProduct(addProductButton)
-    }
-}
-
 // MARK: - Navigation Bar Actions
 //
 private extension ProductsViewController {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -579,6 +579,30 @@ final class ProductFormViewModelTests: XCTestCase {
         let hasLinkedProducts = try XCTUnwrap(analyticsProvider.receivedProperties.first?["has_linked_products"] as? Bool)
         XCTAssertTrue(hasLinkedProducts)
     }
+
+    func test_onProductCreated_called_when_new_product_saved_remotely() {
+        // Given
+        var isCallbackCalled = false
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let viewModel = createViewModel(product: Product.fake(), formType: .add, stores: stores)
+        viewModel.onProductCreated = {
+            isCallbackCalled = true
+        }
+
+        // When
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .addProduct(product, onCompletion):
+                onCompletion(.success(product))
+            default:
+                XCTFail("Received unsupported action: \(action)")
+            }
+        }
+        viewModel.saveProductRemotely(status: .draft) { _ in }
+
+        // Then
+        XCTAssertTrue(isCallbackCalled)
+    }
 }
 
 private extension ProductFormViewModelTests {


### PR DESCRIPTION
Closes: #8137

## Description

This PR updates the navigation after tapping the products onboarding banner CTA. Now we start the product creation flow immediately, without navigating to the Products tab first.

## Changes

* Adds a `PassthroughSubject` to the dashboard view model (`addProductTrigger`), used to trigger the add product flow when the CTA is tapped.
* Adds the `onProductCreated()` callback to the product form view model, which is called when a new product is added so we can clear and resync the dashboard banner.
* Removes the code for `MainTabBarController.presentAddProductFlow()` that's no longer needed.

## Testing

Because the banner is currently in an experiment, the easiest way to test it is to first comment out the experiment check:

https://github.com/woocommerce/woocommerce-ios/blob/5ffc0a3f94b0da7b6b1bbcfc4f34f9631b12c4a8/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift#L154-L156

Then proceed with testing:

1. Build and run the app.
2. Select a store with no products.
3. On the My Store screen, tap the "Add a Product" button on the onboarding banner. Confirm a bottom sheet appears to start the add product flow without changing screens.
4. Check the console and confirm the analytics event `product_list_add_product_button_tapped` was tracked.
5. Finish adding a product, and save it as a draft or publish it.
6. Go back and confirm you are returned to the My Store screen and the banner is gone.

Note: If you go back without saving or publishing the product, you can see you are returned to the My Store screen and the banner is still visible.

## Screenshots

Tapping the banner CTA without product templates enabled:

https://user-images.githubusercontent.com/8658164/202298411-c2886c39-2b85-4d84-8702-98d993917876.mp4

Tapping the banner CTA with product templates enabled:

https://user-images.githubusercontent.com/8658164/202298425-a3fe60dd-e80a-48fb-b4ae-1546bf371cbb.mp4



## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
