### PR TITLE
Add feature flag: System Status Report to support requests

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -39,6 +39,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .justInTimeMessagesOnDashboard:
             return true
+        case .systemStatusReportInSupportRequest:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .performanceMonitoring,
                 .performanceMonitoringCoreData,
                 .performanceMonitoringFileIO,

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -82,6 +82,10 @@ public enum FeatureFlag: Int {
     ///
     case justInTimeMessagesOnDashboard
 
+    /// Adds the System Status Report to a support requests
+    ///
+    case systemStatusReportInSupportRequest
+
     // MARK: - Performance Monitoring
     //
     // These flags are not transient. That is, they are not here to help us rollout a feature,

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -82,7 +82,7 @@ public enum FeatureFlag: Int {
     ///
     case justInTimeMessagesOnDashboard
 
-    /// Adds the System Status Report to a support requests
+    /// Adds the System Status Report to support requests
     ///
     case systemStatusReportInSupportRequest
 


### PR DESCRIPTION
### Description
As part of the work needed for adding the store's System Status Report to support requests ( p8wKgj-3cY-p2 ), we're adding a feature flag to hide any changes behind it.

### Changes
- Adds the `.systemStatusReportInSupportRequest` feature flag