### PR TITLE
[Analytics Hub] Add Networking support for Average Order Value analytics

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -604,7 +604,8 @@ extension Networking.OrderStatsV4Totals {
             taxes: .fake(),
             shipping: .fake(),
             netRevenue: .fake(),
-            totalProducts: .fake()
+            totalProducts: .fake(),
+            averageOrderValue: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -730,7 +730,7 @@ extension Networking.OrderStatsV4Totals {
         shipping: CopiableProp<Decimal> = .copy,
         netRevenue: CopiableProp<Decimal> = .copy,
         totalProducts: NullableCopiableProp<Int> = .copy,
-        averageOrderValue: CopiableProp<Double> = .copy
+        averageOrderValue: CopiableProp<Decimal> = .copy
     ) -> Networking.OrderStatsV4Totals {
         let totalOrders = totalOrders ?? self.totalOrders
         let totalItemsSold = totalItemsSold ?? self.totalItemsSold

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -729,7 +729,8 @@ extension Networking.OrderStatsV4Totals {
         taxes: CopiableProp<Decimal> = .copy,
         shipping: CopiableProp<Decimal> = .copy,
         netRevenue: CopiableProp<Decimal> = .copy,
-        totalProducts: NullableCopiableProp<Int> = .copy
+        totalProducts: NullableCopiableProp<Int> = .copy,
+        averageOrderValue: CopiableProp<Double> = .copy
     ) -> Networking.OrderStatsV4Totals {
         let totalOrders = totalOrders ?? self.totalOrders
         let totalItemsSold = totalItemsSold ?? self.totalItemsSold
@@ -741,6 +742,7 @@ extension Networking.OrderStatsV4Totals {
         let shipping = shipping ?? self.shipping
         let netRevenue = netRevenue ?? self.netRevenue
         let totalProducts = totalProducts ?? self.totalProducts
+        let averageOrderValue = averageOrderValue ?? self.averageOrderValue
 
         return Networking.OrderStatsV4Totals(
             totalOrders: totalOrders,
@@ -752,7 +754,8 @@ extension Networking.OrderStatsV4Totals {
             taxes: taxes,
             shipping: shipping,
             netRevenue: netRevenue,
-            totalProducts: totalProducts
+            totalProducts: totalProducts,
+            averageOrderValue: averageOrderValue
         )
     }
 }

--- a/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
+++ b/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
@@ -13,7 +13,7 @@ public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, Gener
     public let shipping: Decimal
     public let netRevenue: Decimal
     public let totalProducts: Int?
-    public let averageOrderValue: Double
+    public let averageOrderValue: Decimal
 
     public init(totalOrders: Int,
                 totalItemsSold: Int,
@@ -25,7 +25,7 @@ public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, Gener
                 shipping: Decimal,
                 netRevenue: Decimal,
                 totalProducts: Int?,
-                averageOrderValue: Double) {
+                averageOrderValue: Decimal) {
         self.totalOrders = totalOrders
         self.totalItemsSold = totalItemsSold
         self.grossRevenue = grossRevenue
@@ -51,7 +51,7 @@ public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, Gener
         let shipping = try container.decode(Decimal.self, forKey: .shipping)
         let netRevenue = try container.decode(Decimal.self, forKey: .netRevenue)
         let totalProducts = try container.decodeIfPresent(Int.self, forKey: .products)
-        let averageOrderValue = try container.decode(Double.self, forKey: .averageOrderValue)
+        let averageOrderValue = try container.decode(Decimal.self, forKey: .averageOrderValue)
 
         self.init(totalOrders: totalOrders,
                   totalItemsSold: totalItemsSold,

--- a/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
+++ b/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
@@ -13,6 +13,7 @@ public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, Gener
     public let shipping: Decimal
     public let netRevenue: Decimal
     public let totalProducts: Int?
+    public let averageOrderValue: Double
 
     public init(totalOrders: Int,
                 totalItemsSold: Int,
@@ -23,7 +24,8 @@ public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, Gener
                 taxes: Decimal,
                 shipping: Decimal,
                 netRevenue: Decimal,
-                totalProducts: Int?) {
+                totalProducts: Int?,
+                averageOrderValue: Double) {
         self.totalOrders = totalOrders
         self.totalItemsSold = totalItemsSold
         self.grossRevenue = grossRevenue
@@ -34,6 +36,7 @@ public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, Gener
         self.shipping = shipping
         self.netRevenue = netRevenue
         self.totalProducts = totalProducts
+        self.averageOrderValue = averageOrderValue
     }
 
     public init(from decoder: Decoder) throws {
@@ -48,6 +51,7 @@ public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, Gener
         let shipping = try container.decode(Decimal.self, forKey: .shipping)
         let netRevenue = try container.decode(Decimal.self, forKey: .netRevenue)
         let totalProducts = try container.decodeIfPresent(Int.self, forKey: .products)
+        let averageOrderValue = try container.decode(Double.self, forKey: .averageOrderValue)
 
         self.init(totalOrders: totalOrders,
                   totalItemsSold: totalItemsSold,
@@ -58,7 +62,8 @@ public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, Gener
                   taxes: taxes,
                   shipping: shipping,
                   netRevenue: netRevenue,
-                  totalProducts: totalProducts)
+                  totalProducts: totalProducts,
+                  averageOrderValue: averageOrderValue)
     }
 }
 
@@ -77,5 +82,6 @@ private extension OrderStatsV4Totals {
         case shipping
         case netRevenue = "net_revenue"
         case products
+        case averageOrderValue = "avg_order_value"
     }
 }

--- a/Networking/NetworkingTests/Mapper/OrderStatsMapperV4Tests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderStatsMapperV4Tests.swift
@@ -30,6 +30,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(hourlyStats.totals.shipping, 0)
         XCTAssertEqual(hourlyStats.totals.netRevenue, 800)
         XCTAssertEqual(hourlyStats.totals.totalProducts, 2)
+        XCTAssertEqual(hourlyStats.totals.averageOrderValue, 266.66666666666667)
 
         XCTAssertEqual(hourlyStats.intervals.count, 24)
 
@@ -47,6 +48,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(nonZeroHourTotals.shipping, 0)
         XCTAssertEqual(nonZeroHourTotals.netRevenue, 350)
         XCTAssertNil(nonZeroHourTotals.totalProducts)
+        XCTAssertEqual(nonZeroHourTotals.averageOrderValue, 175)
     }
 
     /// Verifies that all of the daily unit OrderStatsV4 fields are parsed correctly.
@@ -70,6 +72,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(dailyStats.totals.shipping, 0)
         XCTAssertEqual(dailyStats.totals.netRevenue, 800)
         XCTAssertEqual(dailyStats.totals.totalProducts, 2)
+        XCTAssertEqual(dailyStats.totals.averageOrderValue, 266.66666666666667)
 
         XCTAssertEqual(dailyStats.intervals.count, 1)
 
@@ -87,6 +90,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(nonZeroDayTotals.shipping, 0)
         XCTAssertEqual(nonZeroDayTotals.netRevenue, 800)
         XCTAssertNil(nonZeroDayTotals.totalProducts)
+        XCTAssertEqual(nonZeroDayTotals.averageOrderValue, 266.66666666666667)
     }
 
     /// Verifies that all of the weekly unit OrderStatsV4 fields are parsed correctly.
@@ -110,6 +114,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(weeklyStats.totals.shipping, 0)
         XCTAssertEqual(weeklyStats.totals.netRevenue, 800)
         XCTAssertEqual(weeklyStats.totals.totalProducts, 2)
+        XCTAssertEqual(weeklyStats.totals.averageOrderValue, 266.66666666666667)
 
         XCTAssertEqual(weeklyStats.intervals.count, 2)
 
@@ -127,6 +132,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(nonZeroWeekTotals.shipping, 0)
         XCTAssertEqual(nonZeroWeekTotals.netRevenue, 800)
         XCTAssertNil(nonZeroWeekTotals.totalProducts)
+        XCTAssertEqual(nonZeroWeekTotals.averageOrderValue, 266.66666666666667)
     }
 
     /// Verifies that all of the monthly unit OrderStatsV4 fields are parsed correctly.
@@ -150,6 +156,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(monthlyStats.totals.shipping, 0)
         XCTAssertEqual(monthlyStats.totals.netRevenue, 800)
         XCTAssertEqual(monthlyStats.totals.totalProducts, 2)
+        XCTAssertEqual(monthlyStats.totals.averageOrderValue, 266.66666666666667)
 
         XCTAssertEqual(monthlyStats.intervals.count, 1)
 
@@ -167,6 +174,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(nonZeroMonthTotals.shipping, 0)
         XCTAssertEqual(nonZeroMonthTotals.netRevenue, 800)
         XCTAssertNil(nonZeroMonthTotals.totalProducts)
+        XCTAssertEqual(nonZeroMonthTotals.averageOrderValue, 266.66666666666667)
     }
 
     /// Verifies that all of the yearly unit OrderStatsV4 fields are parsed correctly.
@@ -190,6 +198,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(yearlyStats.totals.shipping, 0)
         XCTAssertEqual(yearlyStats.totals.netRevenue, 800)
         XCTAssertEqual(yearlyStats.totals.totalProducts, 2)
+        XCTAssertEqual(yearlyStats.totals.averageOrderValue, 266.66666666666667)
 
         XCTAssertEqual(yearlyStats.intervals.count, 1)
 
@@ -207,6 +216,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(nonZeroYearTotals.shipping, 0)
         XCTAssertEqual(nonZeroYearTotals.netRevenue, 800)
         XCTAssertNil(nonZeroYearTotals.totalProducts)
+        XCTAssertEqual(nonZeroYearTotals.averageOrderValue, 266.66666666666667)
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/OrderStatsMapperV4Tests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderStatsMapperV4Tests.swift
@@ -30,7 +30,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(hourlyStats.totals.shipping, 0)
         XCTAssertEqual(hourlyStats.totals.netRevenue, 800)
         XCTAssertEqual(hourlyStats.totals.totalProducts, 2)
-        XCTAssertEqual(hourlyStats.totals.averageOrderValue, 266.66666666666667)
+        XCTAssertEqual(hourlyStats.totals.averageOrderValue, 266)
 
         XCTAssertEqual(hourlyStats.intervals.count, 24)
 
@@ -72,7 +72,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(dailyStats.totals.shipping, 0)
         XCTAssertEqual(dailyStats.totals.netRevenue, 800)
         XCTAssertEqual(dailyStats.totals.totalProducts, 2)
-        XCTAssertEqual(dailyStats.totals.averageOrderValue, 266.66666666666667)
+        XCTAssertEqual(dailyStats.totals.averageOrderValue, 266)
 
         XCTAssertEqual(dailyStats.intervals.count, 1)
 
@@ -90,7 +90,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(nonZeroDayTotals.shipping, 0)
         XCTAssertEqual(nonZeroDayTotals.netRevenue, 800)
         XCTAssertNil(nonZeroDayTotals.totalProducts)
-        XCTAssertEqual(nonZeroDayTotals.averageOrderValue, 266.66666666666667)
+        XCTAssertEqual(nonZeroDayTotals.averageOrderValue, 266)
     }
 
     /// Verifies that all of the weekly unit OrderStatsV4 fields are parsed correctly.
@@ -114,7 +114,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(weeklyStats.totals.shipping, 0)
         XCTAssertEqual(weeklyStats.totals.netRevenue, 800)
         XCTAssertEqual(weeklyStats.totals.totalProducts, 2)
-        XCTAssertEqual(weeklyStats.totals.averageOrderValue, 266.66666666666667)
+        XCTAssertEqual(weeklyStats.totals.averageOrderValue, 266)
 
         XCTAssertEqual(weeklyStats.intervals.count, 2)
 
@@ -132,7 +132,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(nonZeroWeekTotals.shipping, 0)
         XCTAssertEqual(nonZeroWeekTotals.netRevenue, 800)
         XCTAssertNil(nonZeroWeekTotals.totalProducts)
-        XCTAssertEqual(nonZeroWeekTotals.averageOrderValue, 266.66666666666667)
+        XCTAssertEqual(nonZeroWeekTotals.averageOrderValue, 266)
     }
 
     /// Verifies that all of the monthly unit OrderStatsV4 fields are parsed correctly.
@@ -156,7 +156,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(monthlyStats.totals.shipping, 0)
         XCTAssertEqual(monthlyStats.totals.netRevenue, 800)
         XCTAssertEqual(monthlyStats.totals.totalProducts, 2)
-        XCTAssertEqual(monthlyStats.totals.averageOrderValue, 266.66666666666667)
+        XCTAssertEqual(monthlyStats.totals.averageOrderValue, 266)
 
         XCTAssertEqual(monthlyStats.intervals.count, 1)
 
@@ -174,7 +174,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(nonZeroMonthTotals.shipping, 0)
         XCTAssertEqual(nonZeroMonthTotals.netRevenue, 800)
         XCTAssertNil(nonZeroMonthTotals.totalProducts)
-        XCTAssertEqual(nonZeroMonthTotals.averageOrderValue, 266.66666666666667)
+        XCTAssertEqual(nonZeroMonthTotals.averageOrderValue, 266)
     }
 
     /// Verifies that all of the yearly unit OrderStatsV4 fields are parsed correctly.
@@ -198,7 +198,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(yearlyStats.totals.shipping, 0)
         XCTAssertEqual(yearlyStats.totals.netRevenue, 800)
         XCTAssertEqual(yearlyStats.totals.totalProducts, 2)
-        XCTAssertEqual(yearlyStats.totals.averageOrderValue, 266.66666666666667)
+        XCTAssertEqual(yearlyStats.totals.averageOrderValue, 266)
 
         XCTAssertEqual(yearlyStats.intervals.count, 1)
 
@@ -216,7 +216,7 @@ final class OrderStatsV4MapperTests: XCTestCase {
         XCTAssertEqual(nonZeroYearTotals.shipping, 0)
         XCTAssertEqual(nonZeroYearTotals.netRevenue, 800)
         XCTAssertNil(nonZeroYearTotals.totalProducts)
-        XCTAssertEqual(nonZeroYearTotals.averageOrderValue, 266.66666666666667)
+        XCTAssertEqual(nonZeroYearTotals.averageOrderValue, 266)
     }
 }
 

--- a/Networking/NetworkingTests/Responses/order-stats-v4-daily.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-daily.json
@@ -11,7 +11,7 @@
             "shipping": 0,
             "net_revenue": 800,
             "products": 2,
-            "avg_order_value": 266.66666666666667,
+            "avg_order_value": 266,
             "segments": []
         },
         "intervals": [
@@ -31,7 +31,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 800,
-                    "avg_order_value": 266.66666666666667,
+                    "avg_order_value": 266,
                     "segments": []
                 }
             }

--- a/Networking/NetworkingTests/Responses/order-stats-v4-daily.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-daily.json
@@ -11,6 +11,7 @@
             "shipping": 0,
             "net_revenue": 800,
             "products": 2,
+            "avg_order_value": 266.66666666666667,
             "segments": []
         },
         "intervals": [
@@ -30,6 +31,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 800,
+                    "avg_order_value": 266.66666666666667,
                     "segments": []
                 }
             }

--- a/Networking/NetworkingTests/Responses/order-stats-v4-defaults.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-defaults.json
@@ -10,7 +10,7 @@
             "taxes": 0,
             "shipping": 0,
             "net_revenue": 800,
-            "avg_order_value": 266.66666666666667,
+            "avg_order_value": 266,
             "products": 2,
             "segments": []
         },
@@ -31,7 +31,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 800,
-                    "avg_order_value": 266.66666666666667,
+                    "avg_order_value": 266,
                     "segments": []
                 }
             },

--- a/Networking/NetworkingTests/Responses/order-stats-v4-defaults.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-defaults.json
@@ -10,6 +10,7 @@
             "taxes": 0,
             "shipping": 0,
             "net_revenue": 800,
+            "avg_order_value": 266.66666666666667,
             "products": 2,
             "segments": []
         },
@@ -30,6 +31,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 800,
+                    "avg_order_value": 266.66666666666667,
                     "segments": []
                 }
             },
@@ -49,6 +51,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             }

--- a/Networking/NetworkingTests/Responses/order-stats-v4-hour.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-hour.json
@@ -10,6 +10,7 @@
             "taxes": 0,
             "shipping": 0,
             "net_revenue": 800,
+            "avg_order_value": 266.66666666666667,
             "products": 2,
             "segments": []
         },
@@ -30,6 +31,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -49,6 +51,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -68,6 +71,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -87,6 +91,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -106,6 +111,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -125,6 +131,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -144,6 +151,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -163,6 +171,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -182,6 +191,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -201,6 +211,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -220,6 +231,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -239,6 +251,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -258,6 +271,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -277,6 +291,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 350,
+                    "avg_order_value": 175,
                     "segments": []
                 }
             },
@@ -296,6 +311,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 450,
+                    "avg_order_value": 450,
                     "segments": []
                 }
             },
@@ -315,6 +331,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -334,6 +351,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -353,6 +371,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -372,6 +391,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -391,6 +411,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -410,6 +431,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -429,6 +451,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -448,6 +471,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             },
@@ -467,6 +491,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 0,
+                    "avg_order_value": 0,
                     "segments": []
                 }
             }

--- a/Networking/NetworkingTests/Responses/order-stats-v4-hour.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-hour.json
@@ -10,7 +10,7 @@
             "taxes": 0,
             "shipping": 0,
             "net_revenue": 800,
-            "avg_order_value": 266.66666666666667,
+            "avg_order_value": 266,
             "products": 2,
             "segments": []
         },

--- a/Networking/NetworkingTests/Responses/order-stats-v4-month.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-month.json
@@ -10,7 +10,7 @@
             "taxes": 0,
             "shipping": 0,
             "net_revenue": 800,
-            "avg_order_value": 266.66666666666667,
+            "avg_order_value": 266,
             "products": 2,
             "segments": []
         },
@@ -31,7 +31,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 800,
-                    "avg_order_value": 266.66666666666667,
+                    "avg_order_value": 266,
                     "segments": []
                 }
             }

--- a/Networking/NetworkingTests/Responses/order-stats-v4-month.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-month.json
@@ -10,6 +10,7 @@
             "taxes": 0,
             "shipping": 0,
             "net_revenue": 800,
+            "avg_order_value": 266.66666666666667,
             "products": 2,
             "segments": []
         },
@@ -30,6 +31,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 800,
+                    "avg_order_value": 266.66666666666667,
                     "segments": []
                 }
             }

--- a/Networking/NetworkingTests/Responses/order-stats-v4-year.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-year.json
@@ -11,7 +11,7 @@
             "shipping": 0,
             "net_revenue": 800,
             "products": 2,
-            "avg_order_value": 266.66666666666667,
+            "avg_order_value": 266,
             "segments": []
         },
         "intervals": [
@@ -31,7 +31,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 800,
-                    "avg_order_value": 266.66666666666667,
+                    "avg_order_value": 266,
                     "segments": []
                 }
             }

--- a/Networking/NetworkingTests/Responses/order-stats-v4-year.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-year.json
@@ -11,6 +11,7 @@
             "shipping": 0,
             "net_revenue": 800,
             "products": 2,
+            "avg_order_value": 266.66666666666667,
             "segments": []
         },
         "intervals": [
@@ -30,6 +31,7 @@
                     "taxes": 0,
                     "shipping": 0,
                     "net_revenue": 800,
+                    "avg_order_value": 266.66666666666667,
                     "segments": []
                 }
             }

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -426,7 +426,8 @@ extension MockObjectGraph {
             taxes: 0,
             shipping: 0,
             netRevenue: 0,
-            totalProducts: 0
+            totalProducts: 0,
+            averageOrderValue: 0
         )
     }
 
@@ -501,7 +502,8 @@ private extension Array where Element == OrderStatsV4Interval {
             taxes: 0,
             shipping: 0,
             netRevenue: 0,
-            totalProducts: 0
+            totalProducts: 0,
+            averageOrderValue: 0
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/OrderStatsV4+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderStatsV4+ReadOnlyConvertible.swift
@@ -37,6 +37,7 @@ extension Storage.OrderStatsV4: ReadOnlyConvertible {
                                   taxes: 0,
                                   shipping: 0,
                                   netRevenue: 0,
-                                  totalProducts: 0)
+                                  totalProducts: 0,
+                                  averageOrderValue: 0)
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/OrderStatsV4Interval+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderStatsV4Interval+ReadOnlyConvertible.swift
@@ -36,6 +36,7 @@ extension Storage.OrderStatsV4Interval: ReadOnlyConvertible {
                                   taxes: 0,
                                   shipping: 0,
                                   netRevenue: 0,
-                                  totalProducts: 0)
+                                  totalProducts: 0,
+                                  averageOrderValue: 0)
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/OrderStatsV4Totals+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderStatsV4Totals+ReadOnlyConvertible.swift
@@ -33,6 +33,7 @@ extension Storage.OrderStatsV4Totals: ReadOnlyConvertible {
                                   taxes: taxes.decimalValue,
                                   shipping: shipping.decimalValue,
                                   netRevenue: netRevenue.decimalValue,
-                                  totalProducts: Int(totalProducts))
+                                  totalProducts: Int(totalProducts),
+                                  averageOrderValue: 0) // TODO-8156: Update after Storage.OrderStatsV4Totals is updated
     }
 }

--- a/Yosemite/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
+++ b/Yosemite/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class OrderStatsV4Interval_DateTests: XCTestCase {
     private let mockIntervalSubtotals = OrderStatsV4Totals(totalOrders: 0, totalItemsSold: 0, grossRevenue: 0, couponDiscount: 0, totalCoupons: 0,
-                                                           refunds: 0, taxes: 0, shipping: 0, netRevenue: 0, totalProducts: nil)
+                                                           refunds: 0, taxes: 0, shipping: 0, netRevenue: 0, totalProducts: nil, averageOrderValue: 0)
 
     func testDateStartAndDateEnd() {
         let dateStringInSiteTimeZone = "2019-08-08 10:45:00"

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -523,7 +523,8 @@ private extension StatsStoreV4Tests {
                                   taxes: 0,
                                   shipping: 0,
                                   netRevenue: 800,
-                                  totalProducts: 2)
+                                  totalProducts: 2,
+                                  averageOrderValue: 0)
     }
 
     /// Matches the first interval's `subtotals` field in `order-stats-v4-year` response.
@@ -537,7 +538,8 @@ private extension StatsStoreV4Tests {
                                   taxes: 0,
                                   shipping: 0,
                                   netRevenue: 800,
-                                  totalProducts: 0)
+                                  totalProducts: 0,
+                                  averageOrderValue: 0)
     }
 
     func sampleIntervals() -> [Networking.OrderStatsV4Interval] {
@@ -579,7 +581,8 @@ private extension StatsStoreV4Tests {
                                   taxes: 0,
                                   shipping: 0,
                                   netRevenue: 0,
-                                  totalProducts: 0)
+                                  totalProducts: 0,
+                                  averageOrderValue: 0)
     }
 
     // MARK: - Site Visit Stats Sample


### PR DESCRIPTION
Part of: #8156

## Description

This PR adds Networking support for retrieving the `Average Order Value` data from requests to `GET /wc-analytics/reports/revenue/stats`, to use on the Order Analytics card in Analytics Hub.

(We already make requests to this endpoint when dashboard stats load on the My Store screen but we aren't yet using `Average Order Value` in the app.)

## Changes

* Adds the `averageOrderValue` property to the `OrderStatsV4Totals` model.
* Updates unit tests, mocks, etc to include this property.

## Testing

1. Build and run the app.
2. When your dashboard stats load, confirm there are no decoding errors.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
