### PR TITLE
[Analytics Hub] Add a "see more" button on the dashboard

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -49,6 +49,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .alpha
         case .nativeJetpackSetupFlow:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .analyticsHub:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -121,4 +121,8 @@ public enum FeatureFlag: Int {
     /// TODO-8075: replace this with A/B test.
     ///
     case nativeJetpackSetupFlow
+
+    /// Temporary feature flag for the native Jetpack setup flow.
+    ///
+    case analyticsHub
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/AnalyticsHub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/AnalyticsHub/AnalyticsHubView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+import Yosemite
+
+final class AnalyticsHubHostingViewController: UIHostingController<AnalyticsHubView> {
+    init(timeRange: StatsTimeRangeV4) {
+        super.init(rootView: AnalyticsHubView(timeRange: timeRange))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+struct AnalyticsHubView: View {
+    let timeRange: StatsTimeRangeV4
+
+    var body: some View {
+        Text("Selected time range: \(timeRange.rawValue)")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -83,6 +83,8 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
 
     private lazy var inAppFeedbackCardViewController = InAppFeedbackCardViewController()
 
+    private lazy var analyticsHubButtonView = createAnalyticsHubButtonView()
+
     /// An array of UIViews for the In-app Feedback Card. This will be dynamically shown
     /// or hidden depending on the configuration.
     private lazy var inAppFeedbackCardViewsForStackView: [UIView] = createInAppFeedbackCardViewsForStackView()
@@ -182,6 +184,7 @@ extension StoreStatsAndTopPerformersPeriodViewController {
 
     func displayGhostContent() {
         storeStatsPeriodViewController.displayGhostContent()
+        analyticsHubButtonView.startGhostAnimation(style: Constants.ghostStyle)
         topPerformersHeaderView.startGhostAnimation(style: Constants.ghostStyle)
         topPerformersPeriodViewController.displayGhostContent()
     }
@@ -190,6 +193,7 @@ extension StoreStatsAndTopPerformersPeriodViewController {
     ///
     func removeStoreStatsGhostContent() {
         storeStatsPeriodViewController.removeGhostContent()
+        analyticsHubButtonView.stopGhostAnimation()
         topPerformersHeaderView.stopGhostAnimation()
     }
 
@@ -288,7 +292,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
             ])
 
         // Analytics Hub ("See more") button
-        stackView.addArrangedSubview(createAnalyticsHubButtonView())
+        stackView.addArrangedSubview(analyticsHubButtonView)
 
         // In-app Feedback Card
         stackView.addArrangedSubviews(inAppFeedbackCardViewsForStackView)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -357,7 +357,8 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
     }
 
     @objc func seeMoreButtonTapped() {
-        // TODO: navigate to analytics hub view
+        let analyticsHubVC = AnalyticsHubHostingViewController(timeRange: timeRange)
+        show(analyticsHubVC, sender: self)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -292,7 +292,9 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
             ])
 
         // Analytics Hub ("See more") button
-        stackView.addArrangedSubview(analyticsHubButtonView)
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.analyticsHub) {
+            stackView.addArrangedSubview(analyticsHubButtonView)
+        }
 
         // In-app Feedback Card
         stackView.addArrangedSubviews(inAppFeedbackCardViewsForStackView)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -287,6 +287,9 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
             storeStatsPeriodView.heightAnchor.constraint(equalToConstant: Constants.storeStatsPeriodViewHeight),
             ])
 
+        // Analytics Hub ("See more") button
+        stackView.addArrangedSubview(createAnalyticsHubButtonView())
+
         // In-app Feedback Card
         stackView.addArrangedSubviews(inAppFeedbackCardViewsForStackView)
 
@@ -327,10 +330,28 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
         return [emptySpaceView, cardView]
     }
 
+    func createAnalyticsHubButtonView() -> UIView {
+        let button = UIButton(frame: .zero)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.applySecondaryButtonStyle()
+        button.setTitle(Localization.seeMoreButton, for: .normal)
+        button.addTarget(self, action: #selector(seeMoreButtonTapped), for: .touchUpInside)
+
+        let view = UIView(frame: .zero)
+        view.addSubview(button)
+        view.pinSubviewToSafeArea(button, insets: Constants.buttonInsets)
+
+        return view
+    }
+
     func configureInAppFeedbackViewControllerAction() {
         inAppFeedbackCardViewController.onFeedbackGiven = { [weak self] in
             self?.viewModel.onInAppFeedbackCardAction()
         }
+    }
+
+    @objc func seeMoreButtonTapped() {
+        // TODO: navigate to analytics hub view
     }
 }
 
@@ -349,5 +370,10 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
         static let storeStatsPeriodViewHeight: CGFloat = 444
         static let ghostStyle: GhostStyle = .wooDefaultGhostStyle
         static let backgroundColor: UIColor = .systemBackground
+        static let buttonInsets: UIEdgeInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    }
+
+    enum Localization {
+        static let seeMoreButton = NSLocalizedString("See more", comment: "Button on the stats dashboard that navigates user to the analytics hub")
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1159,6 +1159,7 @@
 		ABC35528D2D6BE6F516E5CEF /* InPersonPaymentsOnboardingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC35A4B736A0B2D8348DD08 /* InPersonPaymentsOnboardingError.swift */; };
 		ABC35F18E744C5576B986CB3 /* InPersonPaymentsUnavailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC35055F8AC8C8EB649F421 /* InPersonPaymentsUnavailableView.swift */; };
 		AE1CC33829129A010021C8EF /* LinkBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1CC33729129A010021C8EF /* LinkBehavior.swift */; };
+		AE2EA1142927F87B000392B6 /* AnalyticsHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2EA1132927F87B000392B6 /* AnalyticsHubView.swift */; };
 		AE3AA889290C303B00BE422D /* WebKitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3AA888290C303B00BE422D /* WebKitViewController.swift */; };
 		AE3AA88B290C30B900BE422D /* WebViewControllerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3AA88A290C30B900BE422D /* WebViewControllerConfiguration.swift */; };
 		AE3AA88D290C30E800BE422D /* WebProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3AA88C290C30E800BE422D /* WebProgressView.swift */; };
@@ -3110,6 +3111,7 @@
 		ABC353433EABC5F0EC796222 /* CardReaderSettingsSearchingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsSearchingViewController.swift; sourceTree = "<group>"; };
 		ABC35A4B736A0B2D8348DD08 /* InPersonPaymentsOnboardingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsOnboardingError.swift; sourceTree = "<group>"; };
 		AE1CC33729129A010021C8EF /* LinkBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkBehavior.swift; sourceTree = "<group>"; };
+		AE2EA1132927F87B000392B6 /* AnalyticsHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubView.swift; sourceTree = "<group>"; };
 		AE3AA888290C303B00BE422D /* WebKitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebKitViewController.swift; sourceTree = "<group>"; };
 		AE3AA88A290C30B900BE422D /* WebViewControllerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewControllerConfiguration.swift; sourceTree = "<group>"; };
 		AE3AA88C290C30E800BE422D /* WebProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebProgressView.swift; sourceTree = "<group>"; };
@@ -6680,6 +6682,14 @@
 			path = FlowCoordinator;
 			sourceTree = "<group>";
 		};
+		AE2EA1122927F86C000392B6 /* AnalyticsHub */ = {
+			isa = PBXGroup;
+			children = (
+				AE2EA1132927F87B000392B6 /* AnalyticsHubView.swift */,
+			);
+			path = AnalyticsHub;
+			sourceTree = "<group>";
+		};
 		AE9E04732776034B003FA09E /* CustomerSection */ = {
 			isa = PBXGroup;
 			children = (
@@ -8047,6 +8057,7 @@
 		CE85FD5120F677460080B73E /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				AE2EA1122927F86C000392B6 /* AnalyticsHub */,
 				DE23CFF827462CD2003BE54E /* JetpackInstall */,
 				02F843D8273646190017FE12 /* JetpackConnectionPackageSites */,
 				028BAC4322F3AE3B008BB4AF /* Stats v4 */,
@@ -10193,6 +10204,7 @@
 				CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */,
 				DEF36DE92898D3CF00178AC2 /* AuthenticatedWebViewController.swift in Sources */,
 				74334F36214AB130006D6AC5 /* ProductTableViewCell.swift in Sources */,
+				AE2EA1142927F87B000392B6 /* AnalyticsHubView.swift in Sources */,
 				D8610D762570AE1F00A5DF27 /* NotWPErrorViewModel.swift in Sources */,
 				0245465B24EE7637004F531C /* ProductFormEventLoggerProtocol.swift in Sources */,
 				02C1853D27FF153A00ABD764 /* CardPresentRefundOrchestrator.swift in Sources */,


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8145

## Description

This PR adds a new feature flag for the analytics hub feature and a button serving as entry point.

## Testing

1. Build and run the app in debug/alpha mode.
2. During the dashboard screen loading verify button ghost state.
3. After loading finished verify button appears on all tabs (today/week/month/year) and looks correctly.
4. Tap the button to open placeholder analytics hub view.

## Screenshots

loading|normal
--|--
![1](https://user-images.githubusercontent.com/3132438/202770074-e7031861-9d13-4b50-a041-3c42b67654c6.png)|![2](https://user-images.githubusercontent.com/3132438/202770088-8ee24725-c884-4898-a2fb-6eaef95772ff.png)

|landscape|
|--|
|![3](https://user-images.githubusercontent.com/3132438/202770135-1c6f6945-2bc7-414e-95a1-50791882a16b.png)|

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
