### PR TITLE
Read `version` for `update_appstore_strings` from codebase

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -217,10 +217,10 @@ platform :ios do
   # the release_notes.txt file and the other text sources
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane update_appstore_strings version:<release note version>
+  # bundle exec fastlane update_appstore_strings
   #
   # Example:
-  # bundle exec fastlane update_appstore_strings version:1.1
+  # bundle exec fastlane update_appstore_strings
   #####################################################################################
   desc 'Updates the AppStoreStrings.pot file with the latest data'
   lane :update_appstore_strings do |options|
@@ -242,7 +242,7 @@ platform :ios do
     ios_update_metadata_source(
       po_file_path: File.join(RESOURCES_FOLDER, 'AppStoreStrings.pot'),
       source_files: files,
-      release_version: options[:version]
+      release_version: options.fetch(:version, ios_get_app_version)
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -210,18 +210,10 @@ platform :ios do
     end
   end
 
-  #####################################################################################
-  # update_appstore_strings
-  # -----------------------------------------------------------------------------------
-  # This lane updates the AppStoreStrings.pot files with the latest content from
-  # the release_notes.txt file and the other text sources
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  # bundle exec fastlane update_appstore_strings
+  # Updates the `AppStoreStrings.pot` file with the latest content from the `release_notes.txt` files and the other text sources.
   #
-  # Example:
-  # bundle exec fastlane update_appstore_strings
-  #####################################################################################
+  # @option [String] version The current `x.y[.z]` version of the app. Optional. Used to derive the `vx.y[.z]-whats-new` key to use in the `.pot` file.
+  #
   desc 'Updates the AppStoreStrings.pot file with the latest data'
   lane :update_appstore_strings do |options|
     source_metadata_folder = File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'appstoreres', 'metadata', 'source')


### PR DESCRIPTION
### Description
The `update_appstore_strings` required a `version` parameter at call site, but the information we passed to it – the current app version – could be read from the codebase itself.

Not having to pass the parameter makes the process simpler, _and more shell history friendly_.

### Testing instructions

Here's a screenshot of the lane running with no parameter and correctly picking up [11.2](https://github.com/woocommerce/woocommerce-ios/blob/c0439faccead6ef296176c6410d94f161558faec/config/Version.Public.xcconfig) as the version

![image](https://user-images.githubusercontent.com/1218433/202834031-55448823-02b3-4a80-9c3f-98f96169eb89.png)

Here's a screenshot of the lane running with `version: 1.2.3` to override the one in the code. You can see the lane uses it and updates the `.po` file. The push then failed because I hadn't `git push -u` my branch yet.

![image](https://user-images.githubusercontent.com/1218433/202834058-073d6380-3d13-4531-8468-869c3b087568.png)


---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
