### PR TITLE
Merge 11.3 release notes to trunk

### DIFF
--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -57,9 +57,9 @@ msgctxt "app_store_promo_text"
 msgid "Run your store from anywhere"
 msgstr ""
 
-msgctxt "v11.2-whats-new"
+msgctxt "v11.3-whats-new"
 msgid ""
-"For this release, we focused on polishing a few things and taking care of minor bugs that our team found, including the option to preview your products before publishing them. Don’t be fooled – we are working on some pretty cool stuff for you all! Keep sharing feedback 💜\n"
+"Merchants using the app for taking payments in person will be happy to hear of improvements we’ve made. This and many other tiny improvements were made to make your experience smoother. We hope you notice the love we put into our software.\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,4 +1,1 @@
-- [*] In-Person Payments: Show spinner while preparing reader for payment, instead of saying it's ready before it is. [https://github.com/woocommerce/woocommerce-ios/pull/8115]
-- [internal] In-Person Payments: update StripeTerminal from 2.7 to 2.14 [https://github.com/woocommerce/woocommerce-ios/pull/8132]
-- [*] In-Person Payments: Fixed payment method prompt for WisePad 3 to show only Tap and Insert options [https://github.com/woocommerce/woocommerce-ios/pull/8136]
-
+Merchants using the app for taking payments in person will be happy to hear of improvements we’ve made. This and many other tiny improvements were made to make your experience smoother. We hope you notice the love we put into our software.


### PR DESCRIPTION
Adds editorialized release notes from https://github.com/woocommerce/woocommerce-ios/pull/8167.