### PR TITLE
Add System Status Report to ZenDesk support requests

### DIFF
--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -669,6 +669,8 @@ private extension ZendeskManager {
         var logsFieldID: Int64 = TicketFieldIDs.legacyLogs
         var systemStatusReportFieldID: Int64 = 0
         if isSSREnabled {
+            // If the SSR feature flag is enabled, we'll use the newly added TicketFieldID
+            // for the Application logs, and the old one for the SSR.
             logsFieldID = 10901699622036
             systemStatusReportFieldID = TicketFieldIDs.legacyLogs
         }
@@ -685,10 +687,6 @@ private extension ZendeskManager {
             CustomField(fieldId: TicketFieldIDs.subcategory, value: Constants.subcategory)
         ].compactMap { $0 }
 
-        for i in 0..<ticketFields.count {
-            print("🍍\(ticketFields[i].fieldId) - \(String(describing: ticketFields[i].value))")
-        }
-
         return createRequest(supportSourceTag: supportSourceTag,
                              formID: TicketFieldIDs.form,
                              ticketFields: ticketFields,
@@ -697,12 +695,22 @@ private extension ZendeskManager {
 
     func createWCPayRequest(supportSourceTag: String?) -> RequestUiConfiguration {
 
+        var logsFieldID: Int64 = TicketFieldIDs.legacyLogs
+        var systemStatusReportFieldID: Int64 = 0
+        if isSSREnabled {
+            // If the SSR feature flag is enabled, we'll use the newly added TicketFieldID
+            // for the Application logs, and the old one for the SSR.
+            logsFieldID = 10901699622036
+            systemStatusReportFieldID = TicketFieldIDs.legacyLogs
+        }
+
         // Set form field values
         let ticketFields = [
             CustomField(fieldId: TicketFieldIDs.appVersion, value: Bundle.main.version),
             CustomField(fieldId: TicketFieldIDs.deviceFreeSpace, value: getDeviceFreeSpace()),
             CustomField(fieldId: TicketFieldIDs.networkInformation, value: getNetworkInformation()),
-            CustomField(fieldId: TicketFieldIDs.legacyLogs, value: getLogFile()),
+            CustomField(fieldId: logsFieldID, value: getLogFile()),
+            CustomField(fieldId: systemStatusReportFieldID, value: getSystemStatusReport()),
             CustomField(fieldId: TicketFieldIDs.currentSite, value: getCurrentSiteDescription()),
             CustomField(fieldId: TicketFieldIDs.sourcePlatform, value: Constants.sourcePlatform),
             CustomField(fieldId: TicketFieldIDs.appLanguage, value: Locale.preferredLanguage),
@@ -1133,13 +1141,7 @@ private extension ZendeskManager {
         static let allBlogs: Int64 = 360000087183
         static let deviceFreeSpace: Int64 = 360000089123
         static let networkInformation: Int64 = 360000086966
-        // ----------------------------------------------------
-        // 1 - We're re-using the "logs" field in order to pass the new SSR
-        // 2 - We add "logs" to a new field
         static let legacyLogs: Int64 = 22871957
-        //static let systemStatusReport: Int64 = 22871957
-        //static let logs: Int64 = 10901699622036
-        // ----------------------------------------------------
         static let currentSite: Int64 = 360000103103
         static let sourcePlatform: Int64 = 360009311651
         static let appLanguage: Int64 = 360008583691

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -220,7 +220,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     /// Formatted system status report to be displayed on-screen
     ///
     private var systemStatusReport: String {
-        return systemStatusReportViewModel.statusReport
+        systemStatusReportViewModel.statusReport
     }
 
     /// Handles fetching the site's System Status Report

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -680,7 +680,7 @@ private extension ZendeskManager {
             CustomField(fieldId: TicketFieldIDs.deviceFreeSpace, value: getDeviceFreeSpace()),
             CustomField(fieldId: TicketFieldIDs.networkInformation, value: getNetworkInformation()),
             CustomField(fieldId: logsFieldID, value: getLogFile()),
-            CustomField(fieldId: systemStatusReportFieldID, value: getSystemStatusReport()),
+            CustomField(fieldId: systemStatusReportFieldID, value: systemStatusReport),
             CustomField(fieldId: TicketFieldIDs.currentSite, value: getCurrentSiteDescription()),
             CustomField(fieldId: TicketFieldIDs.sourcePlatform, value: Constants.sourcePlatform),
             CustomField(fieldId: TicketFieldIDs.appLanguage, value: Locale.preferredLanguage),
@@ -710,7 +710,7 @@ private extension ZendeskManager {
             CustomField(fieldId: TicketFieldIDs.deviceFreeSpace, value: getDeviceFreeSpace()),
             CustomField(fieldId: TicketFieldIDs.networkInformation, value: getNetworkInformation()),
             CustomField(fieldId: logsFieldID, value: getLogFile()),
-            CustomField(fieldId: systemStatusReportFieldID, value: getSystemStatusReport()),
+            CustomField(fieldId: systemStatusReportFieldID, value: systemStatusReport),
             CustomField(fieldId: TicketFieldIDs.currentSite, value: getCurrentSiteDescription()),
             CustomField(fieldId: TicketFieldIDs.sourcePlatform, value: Constants.sourcePlatform),
             CustomField(fieldId: TicketFieldIDs.appLanguage, value: Locale.preferredLanguage),
@@ -856,12 +856,6 @@ private extension ZendeskManager {
         }
 
         return logText
-    }
-
-    /// Get the System Status Report as a formatted String that we can use in the support request
-    ///
-    func getSystemStatusReport() -> String {
-        return systemStatusReport
     }
 
     func getCurrentSiteDescription() -> String {

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -42,6 +42,7 @@ protocol ZendeskManagerProtocol: SupportManagerAdapter {
     func showTicketListIfPossible(from controller: UIViewController)
     func showSupportEmailPrompt(from controller: UIViewController, completion: @escaping onUserInformationCompletion)
     func getTags(supportSourceTag: String?) -> [String]
+    func fetchSystemStatusReport()
     func initialize()
     func reset()
 }
@@ -91,6 +92,10 @@ struct NoZendeskManager: ZendeskManagerProtocol {
 
     func getTags(supportSourceTag: String?) -> [String] {
         []
+    }
+
+    func fetchSystemStatusReport() {
+        // no-op
     }
 
     func initialize() {
@@ -203,6 +208,25 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
             ippTags.append(.wcpayNotInstalled)
         }
         return ippTags.map { $0.rawValue }
+    }
+
+    /// Instantiates the SystemStatusReportViewModel as soon as the Zendesk instance needs it
+    /// This generally happens in the SettingsViewModel if we need to fetch the site's System Status Report
+    ///
+    private lazy var systemStatusReportViewModel: SystemStatusReportViewModel = SystemStatusReportViewModel(
+        siteID: ServiceLocator.stores.sessionManager.defaultSite?.siteID ?? 0
+    )
+    
+    /// Formatted system status report to be displayed on-screen
+    ///
+    private var systemStatusReport: String {
+        return systemStatusReportViewModel.statusReport
+    }
+
+    /// Handles fetching the site's System Status Report
+    ///
+    func fetchSystemStatusReport() {
+        systemStatusReportViewModel.fetchReport()
     }
 
     func showNewRequestIfPossible(from controller: UIViewController) {
@@ -826,8 +850,10 @@ private extension ZendeskManager {
         return logText
     }
 
+    /// Get the System Status Report as a formatted String that we can use in the support request
+    ///
     func getSystemStatusReport() -> String {
-        return "SSR goes here"
+        return self.systemStatusReport
     }
 
     func getCurrentSiteDescription() -> String {

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -152,7 +152,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     private let stores = ServiceLocator.stores
     private let storageManager = ServiceLocator.storageManager
 
-    private let isSSREnabled = DefaultFeatureFlagService().isFeatureFlagEnabled(.systemStatusReportInSupportRequest)
+    private let isSSRFeatureFlagEnabled = DefaultFeatureFlagService().isFeatureFlagEnabled(.systemStatusReportInSupportRequest)
 
     /// Controller for fetching site plugins from Storage
     ///
@@ -668,7 +668,7 @@ private extension ZendeskManager {
 
         var logsFieldID: Int64 = TicketFieldIDs.legacyLogs
         var systemStatusReportFieldID: Int64 = 0
-        if isSSREnabled {
+        if isSSRFeatureFlagEnabled {
             // If the SSR feature flag is enabled, we'll use the newly added TicketFieldID
             // for the Application logs, and the old one for the SSR.
             logsFieldID = 10901699622036
@@ -697,7 +697,7 @@ private extension ZendeskManager {
 
         var logsFieldID: Int64 = TicketFieldIDs.legacyLogs
         var systemStatusReportFieldID: Int64 = 0
-        if isSSREnabled {
+        if isSSRFeatureFlagEnabled {
             // If the SSR feature flag is enabled, we'll use the newly added TicketFieldID
             // for the Application logs, and the old one for the SSR.
             logsFieldID = 10901699622036

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -669,9 +669,10 @@ private extension ZendeskManager {
         var logsFieldID: Int64 = TicketFieldIDs.legacyLogs
         var systemStatusReportFieldID: Int64 = 0
         if isSSRFeatureFlagEnabled {
-            // If the SSR feature flag is enabled, we'll use the newly added TicketFieldID
-            // for the Application logs, and the old one for the SSR.
-            logsFieldID = 10901699622036
+            /// If the feature flag is enabled, `legacyLogs` Field ID is used to send the SSR logs,
+            /// and `logs` Field ID is used to send the logs.
+            ///
+            logsFieldID = TicketFieldIDs.logs
             systemStatusReportFieldID = TicketFieldIDs.legacyLogs
         }
 
@@ -698,9 +699,10 @@ private extension ZendeskManager {
         var logsFieldID: Int64 = TicketFieldIDs.legacyLogs
         var systemStatusReportFieldID: Int64 = 0
         if isSSRFeatureFlagEnabled {
-            // If the SSR feature flag is enabled, we'll use the newly added TicketFieldID
-            // for the Application logs, and the old one for the SSR.
-            logsFieldID = 10901699622036
+            /// If the feature flag is enabled, `legacyLogs` Field ID is used to send the SSR logs,
+            /// and `logs` Field ID is used to send the logs.
+            ///
+            logsFieldID = TicketFieldIDs.logs
             systemStatusReportFieldID = TicketFieldIDs.legacyLogs
         }
 
@@ -1136,6 +1138,7 @@ private extension ZendeskManager {
         static let deviceFreeSpace: Int64 = 360000089123
         static let networkInformation: Int64 = 360000086966
         static let legacyLogs: Int64 = 22871957
+        static let logs: Int64 = 10901699622036
         static let currentSite: Int64 = 360000103103
         static let sourcePlatform: Int64 = 360009311651
         static let appLanguage: Int64 = 360008583691

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -861,7 +861,7 @@ private extension ZendeskManager {
     /// Get the System Status Report as a formatted String that we can use in the support request
     ///
     func getSystemStatusReport() -> String {
-        return self.systemStatusReport
+        return systemStatusReport
     }
 
     func getCurrentSiteDescription() -> String {

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -216,7 +216,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     private lazy var systemStatusReportViewModel: SystemStatusReportViewModel = SystemStatusReportViewModel(
         siteID: ServiceLocator.stores.sessionManager.defaultSite?.siteID ?? 0
     )
-    
+
     /// Formatted system status report to be displayed on-screen
     ///
     private var systemStatusReport: String {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -149,7 +149,7 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
         /// Fetch System Status Report from Zendesk
         /// so it will be ready to be attached to a a support request when needed
         ///
-        self.zendeskShared.fetchSystemStatusReport()
+        zendeskShared.fetchSystemStatusReport()
     }
 
     /// Sets up the view model and loads the settings.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -110,6 +110,10 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
               configuration: upsellCardReadersCampaign.configuration)
     }
 
+    /// Reference to the Zendesk shared instance
+    ///
+    private let zendeskShared: ZendeskManagerProtocol = ZendeskProvider.shared
+
     init(stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
@@ -141,6 +145,11 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
             let action = SystemStatusAction.synchronizeSystemPlugins(siteID: siteID, onCompletion: { _ in })
             stores.dispatch(action)
         }
+
+        /// Fetch System Status Report from Zendesk
+        /// so it will be ready to be attached to a a support request when needed
+        ///
+        self.zendeskShared.fetchSystemStatusReport()
     }
 
     /// Sets up the view model and loads the settings.

--- a/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
+++ b/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
@@ -71,6 +71,10 @@ final class MockZendeskManager: ZendeskManagerProtocol {
     func observeStoreSwitch() {
         // no-op
     }
+
+    func fetchSystemStatusReport() {
+        // no-op
+    }
 }
 
 extension MockZendeskManager: SupportManagerAdapter {


### PR DESCRIPTION
Ref: p8wKgj-3cY-p2

### Description
In order to add the site's System Status Report to ZenDesk support requests, a new `Ticket Field ID` has been created in the backend. As per the requirements above: 
- We'll use this new ID to attach existing Application Logs to support requests.
- We'll re-use the previous ID that was used for Application Logs to send the System Status Report instead.

### Changes
- Added the Ticked Field ID switch behind the `.systemStatusReportInSupportRequest` feature flag, if the feature flag is enabled we'll send both Application Logs and System Status Report in their respective fields. If the feature flag is off, we'll be only sending the Application Logs.
- Added `fetchSystemStatusReport()` method to the `ZendeskManager` protocol. This will lazily access the `SystemStatusReportViewModel` when is required, and perform the necessary work to fetch, format, and return back the SSR as a String.
- We'll call `fetchSystemStatusReport()` in the `SettingsViewModel`, as this is an async call we'll need to have the data ready before the user reaches the "Help & Support" view.

There's a bit of duplication in `createRequest` and `createWCPayRequest` methods, I left these there on purpose for the moment, as once we test this and remove the feature flag, all the logic there to switch Ticket Field IDs can be removed.

### Testing instructions (With ZenDesk access)
1 . Go to Menu > Settings > Help & Support > Contact Support
2. Send a ticket 
3. Log in in ZenDesk and search for your ticket
4. See how both SSR and Application Logs are present

### Testing instructions (Without ZenDesk access)

1. Add a breakpoint to the Request Controller Configuration, when we `createRequest()` here:
https://github.com/woocommerce/woocommerce-ios/blob/9713e44fc92e5254e95488dad3bd3cedb077f945/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift#L692

2. Go to Menu > Settings > Help & Support > Contact Support
3. The breakpoint will be triggered at this point, confirm that the `ticketFields` property contains the SSR:
```
po ticketFields[4].value
```
```
(lldb) po ticketFields[4].value
▿ Optional<Any>
  - some : "### System Status Report generated via the WooCommerce iOS app ###\n\n### WordPress Environment ###\n\nWordPress addresss (URL): https://mywootestingstore.mystagingwebsite.com\nSite address (URL): https://mywootestingstore.mystagingwebsite.com\nWC Version: 7.1.0\nLog Directory Writable: ✔\nWP Version: 6.1.1\nWP Multisite: –\nWP Memory Limit: 512 MB\nWP Debug Mode: –\nWP Cron: ✔\nLanguage: en_US\nExternal object cache: ✔\n\n### Server Environment ###\n\nServer Info: nginx\nPHP Version:

etc...
```