### PR TITLE
Convert async -> Result signature functions to async throws

### DIFF
--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -13,7 +13,7 @@ public protocol AccountRemoteProtocol {
     func checkIfWooCommerceIsActive(for siteID: Int64) -> AnyPublisher<Result<Bool, Error>, Never>
     func fetchWordPressSiteSettings(for siteID: Int64) -> AnyPublisher<Result<WordPressSiteSettings, Error>, Never>
     func loadSitePlan(for siteID: Int64, completion: @escaping (Result<SitePlan, Error>) -> Void)
-    func loadUsernameSuggestions(from text: String) async -> Result<[String], Error>
+    func loadUsernameSuggestions(from text: String) async throws -> [String]
 
     /// Creates a WPCOM account with the given email and password.
     /// - Parameters:
@@ -131,17 +131,15 @@ public class AccountRemote: Remote, AccountRemoteProtocol {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    public func loadUsernameSuggestions(from text: String) async -> Result<[String], Error> {
+    public func loadUsernameSuggestions(from text: String) async throws -> [String] {
         let path = Path.usernameSuggestions
         let parameters = [ParameterKey.name: text]
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .get, path: path, parameters: parameters)
-        do {
-            let result: [String: [String]] = try await enqueue(request)
-            let suggestions = result["suggestions"] ?? []
-            return .success(suggestions)
-        } catch {
-            return .failure(error)
-        }
+
+        let result: [String: [String]] = try await enqueue(request)
+        let suggestions = result["suggestions"] ?? []
+
+        return suggestions
     }
 
     public func createAccount(email: String,

--- a/Networking/Networking/Remote/DomainRemote.swift
+++ b/Networking/Networking/Remote/DomainRemote.swift
@@ -5,13 +5,13 @@ public protocol DomainRemoteProtocol {
     /// Loads domain suggestions that are free (`*.wordpress.com` only) based on the query.
     /// - Parameter query: What the domain suggestions are based on.
     /// - Returns: The result of free domain suggestions.
-    func loadFreeDomainSuggestions(query: String) async -> Result<[FreeDomainSuggestion], Error>
+    func loadFreeDomainSuggestions(query: String) async throws -> [FreeDomainSuggestion]
 }
 
 /// Domain: Remote Endpoints
 ///
 public class DomainRemote: Remote, DomainRemoteProtocol {
-    public func loadFreeDomainSuggestions(query: String) async -> Result<[FreeDomainSuggestion], Error> {
+    public func loadFreeDomainSuggestions(query: String) async throws -> [FreeDomainSuggestion] {
         let path = Path.domainSuggestions
         let parameters: [String: Any] = [
             ParameterKey.query: query,
@@ -19,12 +19,7 @@ public class DomainRemote: Remote, DomainRemoteProtocol {
             ParameterKey.wordPressDotComSubdomainsOnly: true
         ]
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path, parameters: parameters)
-        do {
-            let suggestions: [FreeDomainSuggestion] = try await enqueue(request)
-            return .success(suggestions)
-        } catch {
-            return .failure(error)
-        }
+            return try await enqueue(request)
     }
 }
 

--- a/Networking/Networking/Remote/DomainRemote.swift
+++ b/Networking/Networking/Remote/DomainRemote.swift
@@ -19,7 +19,7 @@ public class DomainRemote: Remote, DomainRemoteProtocol {
             ParameterKey.wordPressDotComSubdomainsOnly: true
         ]
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path, parameters: parameters)
-            return try await enqueue(request)
+        return try await enqueue(request)
     }
 }
 

--- a/Networking/Networking/Remote/JustInTimeMessagesRemote.swift
+++ b/Networking/Networking/Remote/JustInTimeMessagesRemote.swift
@@ -4,10 +4,10 @@ public protocol JustInTimeMessagesRemoteProtocol {
     func loadAllJustInTimeMessages(for siteID: Int64,
                                    messagePath: JustInTimeMessagesRemote.MessagePath,
                                    query: [String: String?]?,
-                                   locale: String?) async -> Result<[JustInTimeMessage], Error>
+                                   locale: String?) async throws -> [JustInTimeMessage]
     func dismissJustInTimeMessage(for siteID: Int64,
                                   messageID: String,
-                                  featureClass: String) async -> Result<Bool, Error>
+                                  featureClass: String) async throws -> Bool
 }
 
 /// Just In Time Messages: Remote endpoints
@@ -28,7 +28,7 @@ public final class JustInTimeMessagesRemote: Remote, JustInTimeMessagesRemotePro
     public func loadAllJustInTimeMessages(for siteID: Int64,
                                           messagePath: JustInTimeMessagesRemote.MessagePath,
                                           query: [String: String?]?,
-                                          locale: String?) async -> Result<[JustInTimeMessage], Error> {
+                                          locale: String?) async throws -> [JustInTimeMessage] {
         let request = JetpackRequest(wooApiVersion: .none,
                                      method: .get,
                                      siteID: siteID,
@@ -39,7 +39,7 @@ public final class JustInTimeMessagesRemote: Remote, JustInTimeMessagesRemotePro
 
         let mapper = JustInTimeMessageListMapper(siteID: siteID)
 
-        return await enqueue(request, mapper: mapper)
+        return try await enqueue(request, mapper: mapper)
     }
 
     private func getParameters(messagePath: JustInTimeMessagesRemote.MessagePath,
@@ -88,7 +88,7 @@ public final class JustInTimeMessagesRemote: Remote, JustInTimeMessagesRemotePro
     ///
     public func dismissJustInTimeMessage(for siteID: Int64,
                                          messageID: String,
-                                         featureClass: String) async -> Result<Bool, Error> {
+                                         featureClass: String) async throws -> Bool {
 
         let parameters = [ParameterKey.featureClass: featureClass,
                           ParameterKey.messageID: messageID]
@@ -99,7 +99,7 @@ public final class JustInTimeMessagesRemote: Remote, JustInTimeMessagesRemotePro
                                      path: Path.jitm,
                                      parameters: parameters)
 
-        return await enqueue(request, mapper: DataBoolMapper())
+        return try await enqueue(request, mapper: DataBoolMapper())
     }
 }
 

--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -6,9 +6,8 @@ public protocol SiteRemoteProtocol {
     /// - Parameters:
     ///   - name: The name of the site.
     ///   - domain: The domain selected for the site.
-    /// - Returns: The result of site creation.
-    func createSite(name: String,
-                    domain: String) async -> Result<SiteCreationResponse, Error>
+    /// - Returns: The response with the site creation.
+    func createSite(name: String, domain: String) async throws -> SiteCreationResponse
 }
 
 /// Site: Remote Endpoints
@@ -24,12 +23,12 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
     }
 
     public func createSite(name: String,
-                           domain: String) async -> Result<SiteCreationResponse, Error> {
+                           domain: String) async throws -> SiteCreationResponse {
         let path = Path.siteCreation
 
         // Domain input should be a `wordpress.com` subdomain.
         guard let subdomainName = domain.split(separator: ".").first else {
-            return .failure(SiteCreationError.invalidDomain)
+            throw SiteCreationError.invalidDomain
         }
         let parameters: [String: Any] = [
             "blog_name": subdomainName,
@@ -52,12 +51,7 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
         ]
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters)
 
-        do {
-            let response: SiteCreationResponse = try await enqueue(request)
-            return .success(response)
-        } catch {
-            return .failure(error)
-        }
+        return try await enqueue(request)
     }
 }
 

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -151,10 +151,9 @@ final class AccountRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "username/suggestions", filename: "account-username-suggestions")
 
         // When
-        let result = await remote.loadUsernameSuggestions(from: "woo")
+        let suggestions = try await remote.loadUsernameSuggestions(from: "woo")
 
         // Then
-        let suggestions = try XCTUnwrap(result.get())
         XCTAssertEqual(suggestions, ["woowriter", "woowoowoo", "woodaily"])
     }
 
@@ -163,11 +162,14 @@ final class AccountRemoteTests: XCTestCase {
         let remote = AccountRemote(network: network)
 
         // When
-        let result = await remote.loadUsernameSuggestions(from: "woo")
+        do {
+            _ = try await remote.loadUsernameSuggestions(from: "woo")
 
-        // Then
-        let error = try XCTUnwrap(result.failure as? NetworkError)
-        XCTAssertEqual(error, .notFound)
+            XCTFail("It should throw an error")
+        } catch {
+            let networkError = try XCTUnwrap(error as? NetworkError)
+            XCTAssertEqual(networkError, .notFound)
+        }
     }
 
     // MARK: - `createAccount`

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -1,5 +1,6 @@
 import Combine
 import XCTest
+import TestKit
 @testable import Networking
 
 
@@ -161,15 +162,13 @@ final class AccountRemoteTests: XCTestCase {
         // Given
         let remote = AccountRemote(network: network)
 
-        // When
-        do {
+        await assertThrowsError({
+            // When
             _ = try await remote.loadUsernameSuggestions(from: "woo")
-
-            XCTFail("It should throw an error")
-        } catch {
-            let networkError = try XCTUnwrap(error as? NetworkError)
-            XCTAssertEqual(networkError, .notFound)
-        }
+        }, errorAssert: { error in
+            // Then
+            (error as? NetworkError) == .notFound
+        })
     }
 
     // MARK: - `createAccount`

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -162,13 +162,7 @@ final class AccountRemoteTests: XCTestCase {
         // Given
         let remote = AccountRemote(network: network)
 
-        await assertThrowsError({
-            // When
-            _ = try await remote.loadUsernameSuggestions(from: "woo")
-        }, errorAssert: { error in
-            // Then
-            (error as? NetworkError) == .notFound
-        })
+        await assertThrowsError({  _ = try await remote.loadUsernameSuggestions(from: "woo")}, errorAssert: { ($0 as? NetworkError) == .notFound })
     }
 
     // MARK: - `createAccount`

--- a/Networking/NetworkingTests/Remote/DomainRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/DomainRemoteTests.swift
@@ -35,12 +35,6 @@ final class DomainRemoteTests: XCTestCase {
         // Given
         let remote = DomainRemote(network: network)
 
-        await assertThrowsError({
-            // When
-            _ = try await remote.loadFreeDomainSuggestions(query: "domain")
-        }, errorAssert: { error in
-            // Then
-            (error as? NetworkError) == .notFound
-        })
+        await assertThrowsError({_ = try await remote.loadFreeDomainSuggestions(query: "domain")}, errorAssert: { ($0 as? NetworkError) == .notFound })
     }
 }

--- a/Networking/NetworkingTests/Remote/DomainRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/DomainRemoteTests.swift
@@ -21,11 +21,9 @@ final class DomainRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "domains/suggestions", filename: "domain-suggestions")
 
         // When
-        let result = await remote.loadFreeDomainSuggestions(query: "domain")
+        let suggestions = try await remote.loadFreeDomainSuggestions(query: "domain")
 
         // Then
-        XCTAssertTrue(result.isSuccess)
-        let suggestions = try XCTUnwrap(result.get())
         XCTAssertEqual(suggestions, [
             .init(name: "domaintestingtips.wordpress.com", isFree: true),
             .init(name: "domaintestingtoday.wordpress.com", isFree: true),
@@ -37,11 +35,12 @@ final class DomainRemoteTests: XCTestCase {
         let remote = DomainRemote(network: network)
 
         // When
-        let result = await remote.loadFreeDomainSuggestions(query: "domain")
-
-        // Then
-        XCTAssertTrue(result.isFailure)
-        let error = try XCTUnwrap(result.failure as? NetworkError)
-        XCTAssertEqual(error, .notFound)
+        do {
+            _ = try await remote.loadFreeDomainSuggestions(query: "domain")
+            XCTFail("it should throw an error")
+        } catch {
+            let error = try XCTUnwrap(error as? NetworkError)
+            XCTAssertEqual(error, .notFound)
+        }
     }
 }

--- a/Networking/NetworkingTests/Remote/DomainRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/DomainRemoteTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import TestKit
 @testable import Networking
 
 final class DomainRemoteTests: XCTestCase {
@@ -34,13 +35,12 @@ final class DomainRemoteTests: XCTestCase {
         // Given
         let remote = DomainRemote(network: network)
 
-        // When
-        do {
+        await assertThrowsError({
+            // When
             _ = try await remote.loadFreeDomainSuggestions(query: "domain")
-            XCTFail("it should throw an error")
-        } catch {
-            let error = try XCTUnwrap(error as? NetworkError)
-            XCTAssertEqual(error, .notFound)
-        }
+        }, errorAssert: { error in
+            // Then
+            (error as? NetworkError) == .notFound
+        })
     }
 }

--- a/Networking/NetworkingTests/Remote/JustInTimeMessagesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/JustInTimeMessagesRemoteTests.swift
@@ -117,7 +117,7 @@ final class JustInTimeMessagesRemoteTests: XCTestCase {
         network.simulateError(requestUrlSuffix: "jetpack/v4/jitm", error: expectedError)
 
         // When
-        do {
+        await assertThrowsError({
             _ = try await remote.loadAllJustInTimeMessages(
                     for: self.sampleSiteID,
                     messagePath: JustInTimeMessagesRemote.MessagePath(
@@ -126,12 +126,10 @@ final class JustInTimeMessagesRemoteTests: XCTestCase {
                         hook: .adminNotices),
                     query: nil,
                     locale: "en_US")
-            XCTFail("It should throw an error")
-        } catch {
+        }, errorAssert: { error in
             // Then
-            let resultError = try XCTUnwrap(error as? NetworkError)
-            assertEqual(expectedError, resultError)
-        }
+            (error as? NetworkError) == expectedError
+        })
     }
 
     func test_test_loadAllJustInTimeMessages_uses_passed_locale_for_request() async throws {

--- a/Networking/NetworkingTests/Remote/JustInTimeMessagesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/JustInTimeMessagesRemoteTests.swift
@@ -126,10 +126,7 @@ final class JustInTimeMessagesRemoteTests: XCTestCase {
                         hook: .adminNotices),
                     query: nil,
                     locale: "en_US")
-        }, errorAssert: { error in
-            // Then
-            (error as? NetworkError) == expectedError
-        })
+        }, errorAssert: { ($0 as? NetworkError) == expectedError })
     }
 
     func test_test_loadAllJustInTimeMessages_uses_passed_locale_for_request() async throws {

--- a/Networking/NetworkingTests/Remote/JustInTimeMessagesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/JustInTimeMessagesRemoteTests.swift
@@ -27,7 +27,7 @@ final class JustInTimeMessagesRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "jetpack/v4/jitm", filename: "just-in-time-message-list")
 
         // When
-        let result = await remote.loadAllJustInTimeMessages(
+        let justInTimeMessages = try await remote.loadAllJustInTimeMessages(
                 for: self.sampleSiteID,
                 messagePath: JustInTimeMessagesRemote.MessagePath(
                     app: .wooMobile,
@@ -37,8 +37,6 @@ final class JustInTimeMessagesRemoteTests: XCTestCase {
                 locale: "en_US")
 
         // Then
-        XCTAssert(result.isSuccess)
-        let justInTimeMessages = try XCTUnwrap(result.get())
         assertEqual(1, justInTimeMessages.count)
     }
 
@@ -49,7 +47,7 @@ final class JustInTimeMessagesRemoteTests: XCTestCase {
         let remote = JustInTimeMessagesRemote(network: network)
 
         // When
-        _ = await remote.loadAllJustInTimeMessages(
+        _ = try? await remote.loadAllJustInTimeMessages(
             for: self.sampleSiteID,
             messagePath: JustInTimeMessagesRemote.MessagePath(
                 app: .wooMobile,
@@ -72,7 +70,7 @@ final class JustInTimeMessagesRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "jetpack/v4/jitm", filename: "just-in-time-message-list")
 
         // When
-        let result = await remote.loadAllJustInTimeMessages(
+        let justInTimeMessages = try await remote.loadAllJustInTimeMessages(
                 for: self.sampleSiteID,
                 messagePath: JustInTimeMessagesRemote.MessagePath(
                     app: .wooMobile,
@@ -82,7 +80,6 @@ final class JustInTimeMessagesRemoteTests: XCTestCase {
                 locale: "en_US")
 
         // Then
-        let justInTimeMessages = try result.get()
         assertEqual(sampleSiteID, justInTimeMessages.first?.siteID)
     }
 
@@ -93,7 +90,7 @@ final class JustInTimeMessagesRemoteTests: XCTestCase {
         let remote = JustInTimeMessagesRemote(network: network)
 
         // When
-        _ = await remote.loadAllJustInTimeMessages(
+        _ = try? await remote.loadAllJustInTimeMessages(
             for: self.sampleSiteID,
             messagePath: JustInTimeMessagesRemote.MessagePath(
                 app: .wooMobile,
@@ -116,23 +113,25 @@ final class JustInTimeMessagesRemoteTests: XCTestCase {
         // Given
         let remote = JustInTimeMessagesRemote(network: network)
 
-        let error = NetworkError.unacceptableStatusCode(statusCode: 403)
-        network.simulateError(requestUrlSuffix: "jetpack/v4/jitm", error: error)
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 403)
+        network.simulateError(requestUrlSuffix: "jetpack/v4/jitm", error: expectedError)
 
         // When
-        let result = await remote.loadAllJustInTimeMessages(
-                for: self.sampleSiteID,
-                messagePath: JustInTimeMessagesRemote.MessagePath(
-                    app: .wooMobile,
-                    screen: "my_store",
-                    hook: .adminNotices),
-                query: nil,
-                locale: "en_US")
-
-        // Then
-        XCTAssertTrue(result.isFailure)
-        let resultError = try XCTUnwrap(result.failure as? NetworkError)
-        assertEqual(error, resultError)
+        do {
+            _ = try await remote.loadAllJustInTimeMessages(
+                    for: self.sampleSiteID,
+                    messagePath: JustInTimeMessagesRemote.MessagePath(
+                        app: .wooMobile,
+                        screen: "my_store",
+                        hook: .adminNotices),
+                    query: nil,
+                    locale: "en_US")
+            XCTFail("It should throw an error")
+        } catch {
+            // Then
+            let resultError = try XCTUnwrap(error as? NetworkError)
+            assertEqual(expectedError, resultError)
+        }
     }
 
     func test_test_loadAllJustInTimeMessages_uses_passed_locale_for_request() async throws {
@@ -140,7 +139,7 @@ final class JustInTimeMessagesRemoteTests: XCTestCase {
         let remote = JustInTimeMessagesRemote(network: network)
 
         // When
-        _ = await remote.loadAllJustInTimeMessages(
+        _ = try? await remote.loadAllJustInTimeMessages(
             for: self.sampleSiteID,
             messagePath: JustInTimeMessagesRemote.MessagePath(
                 app: .wooMobile,
@@ -162,7 +161,7 @@ final class JustInTimeMessagesRemoteTests: XCTestCase {
         let remote = JustInTimeMessagesRemote(network: network)
 
         // When
-        _ = await remote.loadAllJustInTimeMessages(
+        _ = try? await remote.loadAllJustInTimeMessages(
             for: self.sampleSiteID,
             messagePath: JustInTimeMessagesRemote.MessagePath(
                 app: .wooMobile,
@@ -180,7 +179,6 @@ final class JustInTimeMessagesRemoteTests: XCTestCase {
         let queryItems = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
         let queryJson = try XCTUnwrap(queryItems.first { $0.name == "query" }?.value)
         assertThat(queryJson, contains: "\"query\":")
-        let parameters = request.parameters
         let jitmQuery = try XCTUnwrap(request.parameters["query"] as? String)
         // Individually check query items because dictionaries aren't ordered
         assertThat(jitmQuery, contains: "platform=ios") // platform=ios

--- a/Networking/NetworkingTests/Remote/RemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/RemoteTests.swift
@@ -276,11 +276,7 @@ final class RemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "mock", filename: "timeout_error")
 
-        await assertThrowsError({
-            _ = try await remote.enqueue(request, mapper: mapper)
-        }, errorAssert: { error in
-            error is DotcomError
-        })
+        await assertThrowsError({ _ = try await remote.enqueue(request, mapper: mapper)}, errorAssert: { $0 is DotcomError })
     }
 
     /// Verifies that dotcom v1.1 request doesn't parse WordPressApiError
@@ -310,13 +306,7 @@ final class RemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "mock", filename: "timeout_error")
 
-        // When
-        await assertThrowsError({
-            _ = try await remote.enqueue(request, mapper: mapper)
-        }, errorAssert: { error in
-            // Then
-            error is DotcomError
-        })
+        await assertThrowsError({ _ = try await remote.enqueue(request, mapper: mapper)}, errorAssert: { $0 is DotcomError })
     }
 
     /// Verifies that dotcom v1.2 request doesn't parse WordPressApiError
@@ -348,13 +338,7 @@ final class RemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "mock", filename: "error-wp-rest-forbidden")
 
-        // When
-        await assertThrowsError({
-            _ = try await remote.enqueue(request, mapper: mapper)
-        }, errorAssert: { error in
-            // Then
-            error is WordPressApiError
-        })
+        await assertThrowsError({ _ = try await remote.enqueue(request, mapper: mapper)}, errorAssert: { $0 is WordPressApiError })
     }
 
     /// Verifies that dotcom wpcom v2 request doesn't parse DotcomError
@@ -386,13 +370,7 @@ final class RemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "mock", filename: "error-wp-rest-forbidden")
 
-        // When
-        await assertThrowsError({
-            _ = try await remote.enqueue(request, mapper: mapper)
-        }, errorAssert: { error in
-            // Then
-            error is WordPressApiError
-        })
+        await assertThrowsError({ _ = try await remote.enqueue(request, mapper: mapper)}, errorAssert: { $0 is WordPressApiError })
     }
 
     /// Verifies that dotcom wp v2 request doesn't parse DotcomError
@@ -424,13 +402,7 @@ final class RemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "mock", filename: "timeout_error")
 
-        await assertThrowsError({
-            // When
-            _ = try await remote.enqueue(request, mapper: mapper)
-        }, errorAssert: { error in
-            // Then
-            error is DotcomError
-        })
+        await assertThrowsError({ _ = try await remote.enqueue(request, mapper: mapper)}, errorAssert: { $0 is DotcomError })
     }
 
     /// Verifies that Jetpack request doesn't parse WordPressApiError
@@ -462,13 +434,7 @@ final class RemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "mock", filename: "error-wp-rest-forbidden")
 
-        // When
-        await assertThrowsError({
-            _ = try await remote.enqueue(request, mapper: mapper)
-        }, errorAssert: { error in
-            // Then
-            error is WordPressApiError
-        })
+        await assertThrowsError({ _ = try await remote.enqueue(request, mapper: mapper)}, errorAssert: { $0 is WordPressApiError })
     }
 
     /// Verifies that WordPressOrg request doesn't parse DotcomError

--- a/Networking/NetworkingTests/Remote/RemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/RemoteTests.swift
@@ -1,6 +1,7 @@
 import Combine
 import XCTest
 import Fakes
+import TestKit
 
 @testable import Networking
 
@@ -275,13 +276,11 @@ final class RemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "mock", filename: "timeout_error")
 
-        // When
-        do {
+        await assertThrowsError({
             _ = try await remote.enqueue(request, mapper: mapper)
-            XCTFail("It should throw an error")
-        } catch {
-            XCTAssert(error is DotcomError)
-        }
+        }, errorAssert: { error in
+            error is DotcomError
+        })
     }
 
     /// Verifies that dotcom v1.1 request doesn't parse WordPressApiError
@@ -312,13 +311,12 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "timeout_error")
 
         // When
-        do {
+        await assertThrowsError({
             _ = try await remote.enqueue(request, mapper: mapper)
-            XCTFail("It should throw an error")
-        } catch {
+        }, errorAssert: { error in
             // Then
-            XCTAssert(error is DotcomError)
-        }
+            error is DotcomError
+        })
     }
 
     /// Verifies that dotcom v1.2 request doesn't parse WordPressApiError
@@ -351,14 +349,12 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "error-wp-rest-forbidden")
 
         // When
-        do {
+        await assertThrowsError({
             _ = try await remote.enqueue(request, mapper: mapper)
-
-            XCTFail("It should throw an error")
-        } catch {
+        }, errorAssert: { error in
             // Then
-            XCTAssert(error is WordPressApiError)
-        }
+            error is WordPressApiError
+        })
     }
 
     /// Verifies that dotcom wpcom v2 request doesn't parse DotcomError
@@ -391,14 +387,12 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "error-wp-rest-forbidden")
 
         // When
-        do {
-            let result = try await remote.enqueue(request, mapper: mapper)
-
-            XCTFail("It should throw an error")
-        } catch {
+        await assertThrowsError({
+            _ = try await remote.enqueue(request, mapper: mapper)
+        }, errorAssert: { error in
             // Then
-            XCTAssert(error is WordPressApiError)
-        }
+            error is WordPressApiError
+        })
     }
 
     /// Verifies that dotcom wp v2 request doesn't parse DotcomError
@@ -430,13 +424,13 @@ final class RemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "mock", filename: "timeout_error")
 
-        // When
-        do {
+        await assertThrowsError({
+            // When
             _ = try await remote.enqueue(request, mapper: mapper)
-            XCTFail("It should thrown an error")
-        } catch {
-            XCTAssert(error is DotcomError)
-        }
+        }, errorAssert: { error in
+            // Then
+            error is DotcomError
+        })
     }
 
     /// Verifies that Jetpack request doesn't parse WordPressApiError
@@ -469,13 +463,12 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "error-wp-rest-forbidden")
 
         // When
-        do {
+        await assertThrowsError({
             _ = try await remote.enqueue(request, mapper: mapper)
-            XCTFail("It should throw an error")
-        } catch {
+        }, errorAssert: { error in
             // Then
-            XCTAssert(error is WordPressApiError)
-        }
+            error is WordPressApiError
+        })
     }
 
     /// Verifies that WordPressOrg request doesn't parse DotcomError

--- a/Networking/NetworkingTests/Remote/RemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/RemoteTests.swift
@@ -276,11 +276,12 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "timeout_error")
 
         // When
-        let result = await remote.enqueue(request, mapper: mapper)
-
-        // Then
-        let error = try XCTUnwrap(result.failure)
-        XCTAssert(error is DotcomError)
+        do {
+            _ = try await remote.enqueue(request, mapper: mapper)
+            XCTFail("It should throw an error")
+        } catch {
+            XCTAssert(error is DotcomError)
+        }
     }
 
     /// Verifies that dotcom v1.1 request doesn't parse WordPressApiError
@@ -295,10 +296,8 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "error-wp-rest-forbidden")
 
         // When
-        let result = await remote.enqueue(request, mapper: mapper)
-
-        // Then
-        XCTAssert(result.isSuccess)
+        let result = try await remote.enqueue(request, mapper: mapper)
+        XCTAssertNotNil(result)
     }
 
     /// Verifies that dotcom v1.2 request parses DotcomError
@@ -313,11 +312,13 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "timeout_error")
 
         // When
-        let result = await remote.enqueue(request, mapper: mapper)
-
-        // Then
-        let error = try XCTUnwrap(result.failure)
-        XCTAssert(error is DotcomError)
+        do {
+            _ = try await remote.enqueue(request, mapper: mapper)
+            XCTFail("It should throw an error")
+        } catch {
+            // Then
+            XCTAssert(error is DotcomError)
+        }
     }
 
     /// Verifies that dotcom v1.2 request doesn't parse WordPressApiError
@@ -332,10 +333,10 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "error-wp-rest-forbidden")
 
         // When
-        let result = await remote.enqueue(request, mapper: mapper)
+        let result = try await remote.enqueue(request, mapper: mapper)
 
         // Then
-        XCTAssert(result.isSuccess)
+        XCTAssertNotNil(result)
     }
 
     /// Verifies that dotcom wpcom v2 request parses WordPressApiError
@@ -350,11 +351,14 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "error-wp-rest-forbidden")
 
         // When
-        let result = await remote.enqueue(request, mapper: mapper)
+        do {
+            _ = try await remote.enqueue(request, mapper: mapper)
 
-        // Then
-        let error = try XCTUnwrap(result.failure)
-        XCTAssert(error is WordPressApiError)
+            XCTFail("It should throw an error")
+        } catch {
+            // Then
+            XCTAssert(error is WordPressApiError)
+        }
     }
 
     /// Verifies that dotcom wpcom v2 request doesn't parse DotcomError
@@ -369,10 +373,10 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "timeout_error")
 
         // When
-        let result = await remote.enqueue(request, mapper: mapper)
+        let result = try await remote.enqueue(request, mapper: mapper)
 
         // Then
-        XCTAssert(result.isSuccess)
+        XCTAssertNotNil(result)
     }
 
     /// Verifies that dotcom wp v2 request parses WordPressApiError
@@ -387,11 +391,14 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "error-wp-rest-forbidden")
 
         // When
-        let result = await remote.enqueue(request, mapper: mapper)
+        do {
+            let result = try await remote.enqueue(request, mapper: mapper)
 
-        // Then
-        let error = try XCTUnwrap(result.failure)
-        XCTAssert(error is WordPressApiError)
+            XCTFail("It should throw an error")
+        } catch {
+            // Then
+            XCTAssert(error is WordPressApiError)
+        }
     }
 
     /// Verifies that dotcom wp v2 request doesn't parse DotcomError
@@ -406,10 +413,10 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "timeout_error")
 
         // When
-        let result = await remote.enqueue(request, mapper: mapper)
+        let result = try await remote.enqueue(request, mapper: mapper)
 
         // Then
-        XCTAssert(result.isSuccess)
+        XCTAssertNotNil(result)
     }
 
     /// Verifies that Jetpack request parses DotcomError
@@ -424,11 +431,12 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "timeout_error")
 
         // When
-        let result = await remote.enqueue(request, mapper: mapper)
-
-        // Then
-        let error = try XCTUnwrap(result.failure)
-        XCTAssert(error is DotcomError)
+        do {
+            _ = try await remote.enqueue(request, mapper: mapper)
+            XCTFail("It should thrown an error")
+        } catch {
+            XCTAssert(error is DotcomError)
+        }
     }
 
     /// Verifies that Jetpack request doesn't parse WordPressApiError
@@ -443,10 +451,10 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "error-wp-rest-forbidden")
 
         // When
-        let result = await remote.enqueue(request, mapper: mapper)
+        let result = try await remote.enqueue(request, mapper: mapper)
 
         // Then
-        XCTAssert(result.isSuccess)
+        XCTAssertNotNil(result)
     }
 
     /// Verifies that WordPressOrg request parses WordPressApiError
@@ -461,11 +469,13 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "error-wp-rest-forbidden")
 
         // When
-        let result = await remote.enqueue(request, mapper: mapper)
-
-        // Then
-        let error = try XCTUnwrap(result.failure)
-        XCTAssert(error is WordPressApiError)
+        do {
+            _ = try await remote.enqueue(request, mapper: mapper)
+            XCTFail("It should throw an error")
+        } catch {
+            // Then
+            XCTAssert(error is WordPressApiError)
+        }
     }
 
     /// Verifies that WordPressOrg request doesn't parse DotcomError
@@ -480,10 +490,10 @@ final class RemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "mock", filename: "timeout_error")
 
         // When
-        let result = await remote.enqueue(request, mapper: mapper)
+        let result = try await remote.enqueue(request, mapper: mapper)
 
         // Then
-        XCTAssert(result.isSuccess)
+        XCTAssertNotNil(result)
     }
 }
 

--- a/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import TestKit
 @testable import Networking
 
 final class SiteRemoteTests: XCTestCase {
@@ -35,43 +36,36 @@ final class SiteRemoteTests: XCTestCase {
     }
 
     func test_createSite_returns_invalidDomain_error_when_domain_is_empty() async throws {
-        // When
-        do {
+        await assertThrowsError({
+            // When
             _ = try await remote.createSite(name: "Wapuu swags", domain: "")
-            XCTFail("It should throw an error")
-        } catch {
+        }, errorAssert: { error in
             // Then
-            let error = try XCTUnwrap(error as? SiteCreationError)
-            XCTAssertEqual(error, .invalidDomain)
-        }
+            (error as? SiteCreationError) == .invalidDomain
+        })
     }
 
     func test_createSite_returns_DotcomError_failure_on_domain_error() async throws {
         // Given
         network.simulateResponse(requestUrlSuffix: "sites/new", filename: "site-creation-domain-error")
 
-        // When
-        do {
+        await assertThrowsError({
+            // When
             _ = try await remote.createSite(name: "Wapuu swags", domain: "wapuu.store")
-            XCTFail("It should throw an error")
-        } catch {
+        }, errorAssert: { error in
             // Then
-            let error = try XCTUnwrap(error as? DotcomError)
-            XCTAssertEqual(error,
-                           .unknown(code: "blog_name_only_lowercase_letters_and_numbers",
-                                    message: "Site names can only contain lowercase letters (a-z) and numbers."))
-        }
+            (error as? DotcomError) == .unknown(code: "blog_name_only_lowercase_letters_and_numbers",
+                                                message: "Site names can only contain lowercase letters (a-z) and numbers.")
+        })
     }
 
     func test_createSite_returns_failure_on_empty_response() async throws {
-        // When
-        do {
+        await assertThrowsError({
+            // When
             _ = try await remote.createSite(name: "Wapuu swags", domain: "wapuu.store")
-            XCTFail("It should throw an error")
-        } catch {
+        }, errorAssert: { error in
             // Then
-            let error = try XCTUnwrap(error as? NetworkError)
-            XCTAssertEqual(error, .notFound)
-        }
+            (error as? NetworkError) == .notFound
+        })
     }
 }

--- a/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
@@ -36,13 +36,8 @@ final class SiteRemoteTests: XCTestCase {
     }
 
     func test_createSite_returns_invalidDomain_error_when_domain_is_empty() async throws {
-        await assertThrowsError({
-            // When
-            _ = try await remote.createSite(name: "Wapuu swags", domain: "")
-        }, errorAssert: { error in
-            // Then
-            (error as? SiteCreationError) == .invalidDomain
-        })
+        await assertThrowsError({ _ = try await remote.createSite(name: "Wapuu swags", domain: "") },
+                                errorAssert: { ($0 as? SiteCreationError) == .invalidDomain} )
     }
 
     func test_createSite_returns_DotcomError_failure_on_domain_error() async throws {
@@ -52,9 +47,7 @@ final class SiteRemoteTests: XCTestCase {
         await assertThrowsError({
             // When
             _ = try await remote.createSite(name: "Wapuu swags", domain: "wapuu.store")
-        }, errorAssert: { error in
-            // Then
-            (error as? DotcomError) == .unknown(code: "blog_name_only_lowercase_letters_and_numbers",
+        }, errorAssert: { ($0 as? DotcomError) == .unknown(code: "blog_name_only_lowercase_letters_and_numbers",
                                                 message: "Site names can only contain lowercase letters (a-z) and numbers.")
         })
     }
@@ -63,9 +56,6 @@ final class SiteRemoteTests: XCTestCase {
         await assertThrowsError({
             // When
             _ = try await remote.createSite(name: "Wapuu swags", domain: "wapuu.store")
-        }, errorAssert: { error in
-            // Then
-            (error as? NetworkError) == .notFound
-        })
+        }, errorAssert: { ($0 as? NetworkError) == .notFound })
     }
 }

--- a/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
@@ -24,11 +24,9 @@ final class SiteRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "sites/new", filename: "site-creation-success")
 
         // When
-        let result = await remote.createSite(name: "Wapuu swags", domain: "wapuu.store")
+        let response = try await remote.createSite(name: "Wapuu swags", domain: "wapuu.store")
 
         // Then
-        XCTAssertTrue(result.isSuccess)
-        let response = try XCTUnwrap(result.get())
         XCTAssertTrue(response.success)
         XCTAssertEqual(response.site, .init(siteID: "202211",
                                             name: "Wapuu swags",
@@ -38,11 +36,14 @@ final class SiteRemoteTests: XCTestCase {
 
     func test_createSite_returns_invalidDomain_error_when_domain_is_empty() async throws {
         // When
-        let result = await remote.createSite(name: "Wapuu swags", domain: "")
-
-        // Then
-        let error = try XCTUnwrap(result.failure as? SiteCreationError)
-        XCTAssertEqual(error, .invalidDomain)
+        do {
+            _ = try await remote.createSite(name: "Wapuu swags", domain: "")
+            XCTFail("It should throw an error")
+        } catch {
+            // Then
+            let error = try XCTUnwrap(error as? SiteCreationError)
+            XCTAssertEqual(error, .invalidDomain)
+        }
     }
 
     func test_createSite_returns_DotcomError_failure_on_domain_error() async throws {
@@ -50,21 +51,27 @@ final class SiteRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "sites/new", filename: "site-creation-domain-error")
 
         // When
-        let result = await remote.createSite(name: "Wapuu swags", domain: "wapuu.store")
-
-        // Then
-        let error = try XCTUnwrap(result.failure as? DotcomError)
-        XCTAssertEqual(error,
-                       .unknown(code: "blog_name_only_lowercase_letters_and_numbers",
-                                message: "Site names can only contain lowercase letters (a-z) and numbers."))
+        do {
+            _ = try await remote.createSite(name: "Wapuu swags", domain: "wapuu.store")
+            XCTFail("It should throw an error")
+        } catch {
+            // Then
+            let error = try XCTUnwrap(error as? DotcomError)
+            XCTAssertEqual(error,
+                           .unknown(code: "blog_name_only_lowercase_letters_and_numbers",
+                                    message: "Site names can only contain lowercase letters (a-z) and numbers."))
+        }
     }
 
     func test_createSite_returns_failure_on_empty_response() async throws {
         // When
-        let result = await remote.createSite(name: "Wapuu swags", domain: "wapuu.store")
-
-        // Then
-        let error = try XCTUnwrap(result.failure as? NetworkError)
-        XCTAssertEqual(error, .notFound)
+        do {
+            _ = try await remote.createSite(name: "Wapuu swags", domain: "wapuu.store")
+            XCTFail("It should throw an error")
+        } catch {
+            // Then
+            let error = try XCTUnwrap(error as? NetworkError)
+            XCTAssertEqual(error, .notFound)
+        }
     }
 }

--- a/TestKit/Sources/TestKit/Assertions.swift
+++ b/TestKit/Sources/TestKit/Assertions.swift
@@ -49,6 +49,22 @@ public func assertThat<T>(_ subject: Any?, isAnInstanceOf expectedType: T.Type, 
                   line: line)
 }
 
+/// Asserts that the async throws `expression` throws an error, and asserts the given Bool expression
+/// with the generated error.
+///
+public func assertThrowsError(_ expression: () async throws -> (), errorAssert: (Error) -> Bool, file: StaticString = #file, line: UInt = #line) async {
+    do {
+        _ = try await expression()
+        XCTFail("It should throw an error",
+                file: file,
+                line: line)
+    } catch {
+        XCTAssert(errorAssert(error),
+                  file: file,
+                  line: line)
+    }
+}
+
 extension XCTestCase {
     /// Alternative to the regular `XCTAssertEqual` that outputs a `diff` between the `expect` and `received` objects.
     ///

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -157,8 +157,8 @@ final class StorePickerViewController: UIViewController {
 
     private lazy var removeAppleIDAccessCoordinator: RemoveAppleIDAccessCoordinator =
     RemoveAppleIDAccessCoordinator(sourceViewController: self) { [weak self] in
-        guard let self = self else { return .failure(RemoveAppleIDAccessError.presenterDeallocated) }
-        return await self.removeAppleIDAccess()
+        guard let self = self else { throw RemoveAppleIDAccessError.presenterDeallocated }
+        return try await self.removeAppleIDAccess()
     } onRemoveSuccess: { [weak self] in
         self?.restartAuthentication()
     }
@@ -758,11 +758,11 @@ extension StorePickerViewController: UITableViewDelegate {
 }
 
 private extension StorePickerViewController {
-    func removeAppleIDAccess() async -> Result<Void, Error> {
-        await withCheckedContinuation { [weak self] continuation in
+    func removeAppleIDAccess() async throws {
+        try await withCheckedThrowingContinuation { [weak self] continuation in
             guard let self = self else { return }
             let action = AccountAction.closeAccount { result in
-                continuation.resume(returning: result)
+                continuation.resume(with: result)
             }
             self.stores.dispatch(action)
         }

--- a/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
@@ -69,7 +69,7 @@ final class AccountCreationFormViewModel: ObservableObject {
         } catch let error as CreateAccountError {
             analytics.track(event: .StoreCreation.signupFailed(error: error))
             handleFailure(error: error)
-        } catch {
+
             throw error
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -122,14 +122,11 @@ struct AccountCreationForm: View {
                 // CTA to submit the form.
                 Button(Localization.submitButtonTitle) {
                     Task { @MainActor in
-                        isPerformingTask = true
+                        let createAccountCompleted = (try? await viewModel.createAccount()) != nil
+                        isPerformingTask = false
 
-                        do {
-                            try await viewModel.createAccount()
-                            isPerformingTask = false
+                        if createAccountCompleted {
                             completion()
-                        } catch {
-                            isPerformingTask = false
                         }
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -123,13 +123,13 @@ struct AccountCreationForm: View {
                 Button(Localization.submitButtonTitle) {
                     Task { @MainActor in
                         isPerformingTask = true
-                        let result = await viewModel.createAccount()
-                        isPerformingTask = false
-                        switch result {
-                        case .success:
+
+                        do {
+                            try await viewModel.createAccount()
+                            isPerformingTask = false
                             completion()
-                        case .failure:
-                            break
+                        } catch {
+                            isPerformingTask = false
                         }
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -31,8 +31,8 @@ final class SettingsViewController: UIViewController {
 
     private lazy var removeAppleIDAccessCoordinator: RemoveAppleIDAccessCoordinator =
     RemoveAppleIDAccessCoordinator(sourceViewController: self) { [weak self] in
-        guard let self = self else { return .failure(RemoveAppleIDAccessError.presenterDeallocated) }
-        return await self.removeAppleIDAccess()
+        guard let self = self else { throw RemoveAppleIDAccessError.presenterDeallocated }
+        try await self.removeAppleIDAccess()
     } onRemoveSuccess: { [weak self] in
         self?.logOutUser()
     }
@@ -284,11 +284,11 @@ private extension SettingsViewController {
         removeAppleIDAccessCoordinator.start()
     }
 
-    func removeAppleIDAccess() async -> Result<Void, Error> {
-        await withCheckedContinuation { [weak self] continuation in
+    func removeAppleIDAccess() async throws {
+        try await withCheckedThrowingContinuation { [weak self] continuation in
             guard let self = self else { return }
             let action = AccountAction.closeAccount { result in
-                continuation.resume(returning: result)
+                continuation.resume(with: result)
             }
             self.stores.dispatch(action)
         }

--- a/WooCommerce/WooCommerceTests/ViewModels/Authentication/AccountCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Authentication/AccountCreationFormViewModelTests.swift
@@ -75,12 +75,16 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         mockAccountCreationSuccess(result: .init(authToken: "token", username: "username"))
         XCTAssertFalse(stores.isAuthenticated)
 
-        // When
-        let result = await viewModel.createAccount()
+        do {
+            // When
+            try await viewModel.createAccount()
 
-        // Then
-        XCTAssertTrue(result.isSuccess)
-        XCTAssertTrue(stores.isAuthenticated)
+            // Then
+            XCTAssertTrue(stores.isAuthenticated)
+
+        } catch {
+            XCTFail("Function should not throw an error")
+        }
     }
 
     func test_createAccount_password_failure_sets_passwordErrorMessage() async {
@@ -89,13 +93,14 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         XCTAssertFalse(stores.isAuthenticated)
         XCTAssertNil(viewModel.passwordErrorMessage)
 
-        // When
-        let result = await viewModel.createAccount()
+        do {
+            try await viewModel.createAccount()
 
-        // Then
-        XCTAssertTrue(result.isFailure)
-        XCTAssertFalse(stores.isAuthenticated)
-        XCTAssertEqual(viewModel.passwordErrorMessage, "too complex to guess")
+            XCTFail("Function should have thrown an error")
+        } catch {
+            XCTAssertFalse(stores.isAuthenticated)
+            XCTAssertEqual(viewModel.passwordErrorMessage, "too complex to guess")
+        }
     }
 
     func test_createAccount_invalidEmail_failure_sets_emailErrorMessage() async {
@@ -103,12 +108,14 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         mockAccountCreationFailure(error: .invalidEmail)
         XCTAssertNil(viewModel.emailErrorMessage)
 
-        // When
-        let result = await viewModel.createAccount()
+        do {
+            try await viewModel.createAccount()
 
-        // Then
-        XCTAssertTrue(result.isFailure)
-        XCTAssertNotNil(viewModel.emailErrorMessage)
+            XCTFail("Function should have thrown an error")
+        } catch {
+            // Then
+            XCTAssertNotNil(viewModel.emailErrorMessage)
+        }
     }
 
     func test_passwordErrorMessage_is_cleared_after_changing_password_input() async {
@@ -116,7 +123,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         mockAccountCreationFailure(error: .invalidPassword(message: "too complex to guess"))
 
         // When
-        let _ = await viewModel.createAccount()
+        try? await viewModel.createAccount()
         viewModel.password = "simple password"
 
         // Then
@@ -130,7 +137,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         mockAccountCreationFailure(error: .emailExists)
 
         // When
-        let _ = await viewModel.createAccount()
+        try? await viewModel.createAccount()
         viewModel.email = "real@woo.com"
 
         // Then
@@ -146,7 +153,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         mockAccountCreationSuccess(result: .init(authToken: "", username: ""))
 
         // When
-        let _ = await viewModel.createAccount()
+        try? await viewModel.createAccount()
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents, ["signup_submitted", "signup_success"])
@@ -157,7 +164,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         mockAccountCreationFailure(error: .emailExists)
 
         // When
-        let _ = await viewModel.createAccount()
+        try? await viewModel.createAccount()
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents, ["signup_submitted", "signup_failed"])

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/RemoveAppleIDAccessCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/RemoveAppleIDAccessCoordinatorTests.swift
@@ -30,9 +30,7 @@ final class RemoveAppleIDAccessCoordinatorTests: XCTestCase {
 
     @MainActor func test_alert_is_presented_when_starting_coordinator() throws {
         // Given
-        let coordinator = RemoveAppleIDAccessCoordinator(sourceViewController: sourceViewController) {
-            return .success(())
-        } onRemoveSuccess: {}
+        let coordinator = RemoveAppleIDAccessCoordinator(sourceViewController: sourceViewController) {} onRemoveSuccess: {}
 
         // When
         coordinator.start()

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		9FA5113235035AC9A6079B0D /* Pods_WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1733C61561AE3A1AD3C16B7 /* Pods_WooFoundation.framework */; };
 		AE948D0A28CF67CF009F3246 /* Date+StartAndEnd.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE948D0928CF67CE009F3246 /* Date+StartAndEnd.swift */; };
 		AE948D0D28CF6D50009F3246 /* DateStartAndEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE948D0C28CF6D50009F3246 /* DateStartAndEndTests.swift */; };
+		B97190D1292CF3BC0065E413 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97190D0292CF3BC0065E413 /* Result+Extensions.swift */; };
 		B987B06F284540D300C53CF6 /* CurrencyCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B987B06E284540D300C53CF6 /* CurrencyCode.swift */; };
 		B9C9C63F283E703C001B879F /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9C9C635283E703C001B879F /* WooFoundation.framework */; };
 		B9C9C659283E7195001B879F /* NSDecimalNumber+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C9C658283E7195001B879F /* NSDecimalNumber+Helpers.swift */; };
@@ -79,6 +80,7 @@
 		A21D73D352B4162AB096E276 /* Pods-WooFoundationTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooFoundationTests.release-alpha.xcconfig"; path = "Target Support Files/Pods-WooFoundationTests/Pods-WooFoundationTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		AE948D0928CF67CE009F3246 /* Date+StartAndEnd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+StartAndEnd.swift"; sourceTree = "<group>"; };
 		AE948D0C28CF6D50009F3246 /* DateStartAndEndTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateStartAndEndTests.swift; sourceTree = "<group>"; };
+		B97190D0292CF3BC0065E413 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		B987B06E284540D300C53CF6 /* CurrencyCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrencyCode.swift; sourceTree = "<group>"; };
 		B9AED558283E7553002A2668 /* Yosemite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Yosemite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9AED55B283E755A002A2668 /* Hardware.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Hardware.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -246,6 +248,7 @@
 				B9C9C658283E7195001B879F /* NSDecimalNumber+Helpers.swift */,
 				68FBC5B228926B2C00A05461 /* Collection+Extensions.swift */,
 				03B8C3882914083F002235B1 /* Bundle+Woo.swift */,
+				B97190D0292CF3BC0065E413 /* Result+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -480,6 +483,7 @@
 				03597A9B28F87BFC005E4A98 /* WooCommerceComUTMProvider.swift in Sources */,
 				B9C9C663283E7296001B879F /* Logging.swift in Sources */,
 				6874E81428998AD300074A97 /* LogErrorAndExit.swift in Sources */,
+				B97190D1292CF3BC0065E413 /* Result+Extensions.swift in Sources */,
 				B9C9C65D283E71C8001B879F /* CurrencyFormatter.swift in Sources */,
 				AE948D0A28CF67CF009F3246 /* Date+StartAndEnd.swift in Sources */,
 				03597A9428F85686005E4A98 /* UTMParameters.swift in Sources */,

--- a/WooFoundation/WooFoundation/Extensions/Result+Extensions.swift
+++ b/WooFoundation/WooFoundation/Extensions/Result+Extensions.swift
@@ -1,0 +1,12 @@
+extension Result where Failure == Error {
+    /// Initializes asyncrhonously a `Result` with a `async throws` closure returning a object of the specified type
+    ///
+    public init(catching body: () async throws -> Success) async {
+        do {
+            let value = try await body()
+            self = .success(value)
+        } catch {
+            self = .failure(error)
+        }
+    }
+}

--- a/Yosemite/Yosemite/Stores/AccountCreationStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountCreationStore.swift
@@ -77,12 +77,7 @@ private extension AccountCreationStore {
     }
 
     func generateUsername(base: String) async -> String? {
-        let usernameSuggestionsResult = await remote.loadUsernameSuggestions(from: base)
-        guard case let .success(usernameSuggestions) = usernameSuggestionsResult,
-              let username = usernameSuggestions.first else {
-            return nil
-        }
-        return username
+        try? await remote.loadUsernameSuggestions(from: base).first
     }
 }
 

--- a/Yosemite/Yosemite/Stores/DomainStore.swift
+++ b/Yosemite/Yosemite/Stores/DomainStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Networking
+import WooFoundation
 import protocol Storage.StorageManagerType
 
 /// Handles `DomainAction`.
@@ -39,12 +40,8 @@ public final class DomainStore: Store {
 private extension DomainStore {
     func loadFreeDomainSuggestions(query: String, completion: @escaping (Result<[FreeDomainSuggestion], Error>) -> Void) {
         Task { @MainActor in
-            do {
-                let suggestions = try await remote.loadFreeDomainSuggestions(query: query)
-                completion(.success(suggestions))
-            } catch {
-                completion(.failure(error))
-            }
+            let result = await Result { try await remote.loadFreeDomainSuggestions(query: query) }
+            completion(result)
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/DomainStore.swift
+++ b/Yosemite/Yosemite/Stores/DomainStore.swift
@@ -39,8 +39,12 @@ public final class DomainStore: Store {
 private extension DomainStore {
     func loadFreeDomainSuggestions(query: String, completion: @escaping (Result<[FreeDomainSuggestion], Error>) -> Void) {
         Task { @MainActor in
-            let result = await remote.loadFreeDomainSuggestions(query: query)
-            completion(result)
+            do {
+                let suggestions = try await remote.loadFreeDomainSuggestions(query: query)
+                completion(.success(suggestions))
+            } catch {
+                completion(.failure(error))
+            }
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/JustInTimeMessageStore.swift
+++ b/Yosemite/Yosemite/Stores/JustInTimeMessageStore.swift
@@ -46,16 +46,22 @@ private extension JustInTimeMessageStore {
                      hook: JustInTimeMessageHook,
                      completion: @escaping (Result<[JustInTimeMessage], Error>) -> ()) {
         Task {
-            let result = await remote.loadAllJustInTimeMessages(
-                    for: siteID,
-                    messagePath: .init(app: .wooMobile,
-                                       screen: screen,
-                                       hook: hook),
-                    query: justInTimeMessageQuery(),
-                    locale: localeLanguageRegionIdentifier())
-            let displayResult = result.map(displayMessages(_:))
-            await MainActor.run {
-                completion(displayResult)
+            do {
+                let result = try await remote.loadAllJustInTimeMessages(
+                        for: siteID,
+                        messagePath: .init(app: .wooMobile,
+                                           screen: screen,
+                                           hook: hook),
+                        query: justInTimeMessageQuery(),
+                        locale: localeLanguageRegionIdentifier())
+
+                await MainActor.run {
+                    completion(.success(displayMessages(result)))
+                }
+            } catch {
+                await MainActor.run {
+                    completion(.failure(error))
+                }
             }
         }
     }
@@ -114,11 +120,17 @@ private extension JustInTimeMessageStore {
                         for siteID: Int64,
                         completion: @escaping (Result<Bool, Error>) -> ()) {
         Task {
-            let result = await remote.dismissJustInTimeMessage(for: siteID,
-                                                               messageID: message.messageID,
-                                                               featureClass: message.featureClass)
-            await MainActor.run {
-                completion(result)
+            do {
+                let result = try await remote.dismissJustInTimeMessage(for: siteID,
+                                                                   messageID: message.messageID,
+                                                                   featureClass: message.featureClass)
+                await MainActor.run {
+                    completion(.success(result))
+                }
+            } catch {
+                await MainActor.run {
+                    completion(.failure(error))
+                }
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/SiteStore.swift
+++ b/Yosemite/Yosemite/Stores/SiteStore.swift
@@ -51,10 +51,9 @@ private extension SiteStore {
                     domain: String,
                     completion: @escaping (Result<SiteCreationResult, SiteCreationError>) -> Void) {
         Task { @MainActor in
-            let result = await remote.createSite(name: name,
-                                                 domain: domain)
-            switch result {
-            case .success(let response):
+            do {
+                let response = try await remote.createSite(name: name, domain: domain)
+
                 guard response.success else {
                     return completion(.failure(SiteCreationError.unsuccessful))
                 }
@@ -65,8 +64,8 @@ private extension SiteStore {
                                           name: response.site.name,
                                           url: response.site.url,
                                           siteSlug: response.site.siteSlug)))
-            case .failure(let remoteError):
-                completion(.failure(SiteCreationError(remoteError: remoteError)))
+            } catch {
+                completion(.failure(SiteCreationError(remoteError: error)))
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -155,26 +155,29 @@ private extension StatsStoreV4 {
                                 forceRefresh: Bool,
                                 onCompletion: @escaping (Result<Void, Error>) -> Void) {
         Task { @MainActor in
-            let result = await loadTopEarnerStats(siteID: siteID,
-                                                  timeRange: timeRange,
-                                                  earliestDateToInclude: earliestDateToInclude,
-                                                  latestDateToInclude: latestDateToInclude,
-                                                  quantity: quantity,
-                                                  forceRefresh: forceRefresh)
-            switch result {
-            case .success:
-                onCompletion(result)
-            case .failure(let error):
+            do {
+                try await loadTopEarnerStats(siteID: siteID,
+                                                      timeRange: timeRange,
+                                                      earliestDateToInclude: earliestDateToInclude,
+                                                      latestDateToInclude: latestDateToInclude,
+                                                      quantity: quantity,
+                                                      forceRefresh: forceRefresh)
+                onCompletion(.success(()))
+            } catch {
                 if let error = error as? DotcomError, error == .noRestRoute {
-                    let resultFromDeprecatedAPI = await loadTopEarnerStatsWithDeprecatedAPI(siteID: siteID,
-                                                                                            timeRange: timeRange,
-                                                                                            earliestDateToInclude: earliestDateToInclude,
-                                                                                            latestDateToInclude: latestDateToInclude,
-                                                                                            quantity: quantity,
-                                                                                            forceRefresh: forceRefresh)
-                    onCompletion(resultFromDeprecatedAPI)
+                    do {
+                        try await loadTopEarnerStatsWithDeprecatedAPI(siteID: siteID,
+                                                                      timeRange: timeRange,
+                                                                      earliestDateToInclude: earliestDateToInclude,
+                                                                      latestDateToInclude: latestDateToInclude,
+                                                                      quantity: quantity,
+                                                                      forceRefresh: forceRefresh)
+                        onCompletion(.success(()))
+                    } catch {
+                        onCompletion(.failure(error))
+                    }
                 } else {
-                    onCompletion(result)
+                    onCompletion(.failure(error))
                 }
             }
         }
@@ -186,8 +189,8 @@ private extension StatsStoreV4 {
                             earliestDateToInclude: Date,
                             latestDateToInclude: Date,
                             quantity: Int,
-                            forceRefresh: Bool) async -> Result<Void, Error> {
-        await withCheckedContinuation { continuation in
+                            forceRefresh: Bool) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) -> Void in
             let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
             let earliestDate = dateFormatter.string(from: earliestDateToInclude)
             let latestDate = dateFormatter.string(from: latestDateToInclude)
@@ -208,10 +211,14 @@ private extension StatsStoreV4 {
                                                                    date: latestDateToInclude,
                                                                    leaderboards: leaderboards,
                                                                    quantity: quantity) { result in
-                        continuation.resume(returning: result)
+                        if case let .failure(error) = result {
+                            continuation.resume(throwing: error)
+                        } else {
+                            continuation.resume(returning: (()))
+                        }
                     }
                 case .failure(let error):
-                    continuation.resume(returning: .failure(error))
+                    continuation.resume(throwing: error)
                 }
             }
         }
@@ -223,8 +230,8 @@ private extension StatsStoreV4 {
                                              earliestDateToInclude: Date,
                                              latestDateToInclude: Date,
                                              quantity: Int,
-                                             forceRefresh: Bool) async -> Result<Void, Error> {
-        await withCheckedContinuation { continuation in
+                                             forceRefresh: Bool) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) -> Void in
             let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
             let earliestDate = dateFormatter.string(from: earliestDateToInclude)
             let latestDate = dateFormatter.string(from: latestDateToInclude)
@@ -245,10 +252,14 @@ private extension StatsStoreV4 {
                                                                    date: latestDateToInclude,
                                                                    leaderboards: leaderboards,
                                                                    quantity: quantity) { result in
-                        continuation.resume(returning: result)
+                        if case let .failure(error) = result {
+                            continuation.resume(throwing: error)
+                        } else {
+                            continuation.resume(returning: ())
+                        }
                     }
                 case .failure(let error):
-                    continuation.resume(returning: .failure(error))
+                    continuation.resume(throwing: error)
                 }
             }
         }

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Networking
 import Storage
-
+import WooFoundation
 
 // MARK: - StatsStoreV4
 //
@@ -165,17 +165,16 @@ private extension StatsStoreV4 {
                 onCompletion(.success(()))
             } catch {
                 if let error = error as? DotcomError, error == .noRestRoute {
-                    do {
+                    let result = await Result {
                         try await loadTopEarnerStatsWithDeprecatedAPI(siteID: siteID,
                                                                       timeRange: timeRange,
                                                                       earliestDateToInclude: earliestDateToInclude,
                                                                       latestDateToInclude: latestDateToInclude,
                                                                       quantity: quantity,
                                                                       forceRefresh: forceRefresh)
-                        onCompletion(.success(()))
-                    } catch {
-                        onCompletion(.failure(error))
                     }
+
+                    onCompletion(result)
                 } else {
                     onCompletion(.failure(error))
                 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
@@ -104,12 +104,7 @@ extension MockAccountRemote: AccountRemoteProtocol {
             throw NetworkError.notFound
         }
 
-        switch result {
-        case let .success(suggestions):
-            return suggestions
-        case let .failure(error):
-            throw error
-        }
+        return try result.get()
     }
 
     func createAccount(email: String,

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockAccountRemote.swift
@@ -98,12 +98,18 @@ extension MockAccountRemote: AccountRemoteProtocol {
         // no-op
     }
 
-    func loadUsernameSuggestions(from text: String) async -> Result<[String], Error> {
+    func loadUsernameSuggestions(from text: String) async throws -> [String] {
         guard let result = loadUsernameSuggestionsResult else {
             XCTFail("Could not find result for loading username suggestions.")
-            return .failure(NetworkError.notFound)
+            throw NetworkError.notFound
         }
-        return result
+
+        switch result {
+        case let .success(suggestions):
+            return suggestions
+        case let .failure(error):
+            throw error
+        }
     }
 
     func createAccount(email: String,

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDomainRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDomainRemote.swift
@@ -14,11 +14,16 @@ final class MockDomainRemote {
 }
 
 extension MockDomainRemote: DomainRemoteProtocol {
-    func loadFreeDomainSuggestions(query: String) async -> Result<[FreeDomainSuggestion], Error> {
+    func loadFreeDomainSuggestions(query: String) async throws -> [FreeDomainSuggestion] {
         guard let result = loadDomainSuggestionsResult else {
             XCTFail("Could not find result for loading domain suggestions.")
-            return .failure(NetworkError.notFound)
+            throw NetworkError.notFound
         }
-        return result
+        switch result {
+        case let .success(suggestions):
+            return suggestions
+        case let .failure(error):
+            throw error
+        }
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDomainRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDomainRemote.swift
@@ -19,7 +19,6 @@ extension MockDomainRemote: DomainRemoteProtocol {
             XCTFail("Could not find result for loading domain suggestions.")
             throw NetworkError.notFound
         }
-        
         return try result.get()
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDomainRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDomainRemote.swift
@@ -19,11 +19,7 @@ extension MockDomainRemote: DomainRemoteProtocol {
             XCTFail("Could not find result for loading domain suggestions.")
             throw NetworkError.notFound
         }
-        switch result {
-        case let .success(suggestions):
-            return suggestions
-        case let .failure(error):
-            throw error
-        }
+        
+        return try result.get()
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
@@ -14,11 +14,17 @@ final class MockSiteRemote {
 }
 
 extension MockSiteRemote: SiteRemoteProtocol {
-    func createSite(name: String, domain: String) async -> Result<SiteCreationResponse, Error> {
+    func createSite(name: String, domain: String) async throws -> SiteCreationResponse {
         guard let result = createSiteResult else {
             XCTFail("Could not find result for creating a site.")
-            return .failure(NetworkError.notFound)
+            throw NetworkError.notFound
         }
-        return result
+
+        switch result {
+        case let .success(response):
+            return response
+        case let .failure(error):
+            throw error
+        }
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
@@ -20,11 +20,6 @@ extension MockSiteRemote: SiteRemoteProtocol {
             throw NetworkError.notFound
         }
 
-        switch result {
-        case let .success(response):
-            return response
-        case let .failure(error):
-            throw error
-        }
+        return try result.get()
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8104 (Sorry for the bigger PR)
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR I convert the function signatures with `await -> Result<..., Error>` to the most natural `async throws -> ...`, except in those cases where we have a specific error type e.g [here](https://github.com/woocommerce/woocommerce-ios/blob/636a27307afac5c2cc1ac7cb45dc349172c08c23/WooCommerce/Classes/Authentication/Store%20Creation/StoreCreationCoordinator.swift#L220)

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Unit tests should pass. You can also check that the related features do not present any side effects:
- Remove Apple Id access
- Create account
- Domain suggestions
- Username suggestions
- Free domain suggestions
- Site creation
- Just in Time Messages
- Stats


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
