### PR TITLE
Analytics Hub: Adds Report Card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -36,10 +36,15 @@ struct AnalyticsHubView: View {
                 VStack(spacing: 0) {
                     Divider()
 
-                    Text("Placeholder For Revenue Card")
-                        .padding(.leading)
-                        .frame(maxWidth: .infinity, minHeight: 220, alignment: .leading)
-                        .background(Color(uiColor: .listForeground))
+                    AnalyticsReportCard(title: Localization.revenue,
+                                        totalSales: "$3.234",
+                                        totalGrowth: "+23%",
+                                        totalGrowthColor: .withColorStudio(.green, shade: .shade50),
+                                        netSales: "$2.324",
+                                        netGrowth: "-4%",
+                                        netGrowthColor: .withColorStudio(.red, shade: .shade40))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(uiColor: .listForeground))
 
                     Divider()
                 }
@@ -47,10 +52,15 @@ struct AnalyticsHubView: View {
                 VStack(spacing: 0) {
                     Divider()
 
-                    Text("Placeholder For Orders Card")
-                        .padding(.leading)
-                        .frame(maxWidth: .infinity, minHeight: 220, alignment: .leading)
-                        .background(Color(uiColor: .listForeground))
+                    AnalyticsReportCard(title: Localization.orders,
+                                        totalSales: "$2.934",
+                                        totalGrowth: "+15%",
+                                        totalGrowthColor: .withColorStudio(.green, shade: .shade50),
+                                        netSales: "$1.624",
+                                        netGrowth: "-9%",
+                                        netGrowthColor: .withColorStudio(.red, shade: .shade40))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(uiColor: .listForeground))
 
                     Divider()
                 }
@@ -69,6 +79,8 @@ struct AnalyticsHubView: View {
 private extension AnalyticsHubView {
     struct Localization {
         static let title = NSLocalizedString("Analytics", comment: "Title for the Analytics Hub screen.")
+        static let revenue = NSLocalizedString("REVENUE", comment: "Title for the revenue report card on the analytics hub screen. Capitalized")
+        static let orders = NSLocalizedString("ORDERS", comment: "Title for the orders report card on the analytics hub screen. Capitalized")
     }
 
     struct Layout {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -43,7 +43,6 @@ struct AnalyticsHubView: View {
                                         netSales: "$2.324",
                                         netGrowth: "-4%",
                                         netGrowthColor: .withColorStudio(.red, shade: .shade40))
-                    .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color(uiColor: .listForeground))
 
                     Divider()
@@ -59,7 +58,6 @@ struct AnalyticsHubView: View {
                                         netSales: "$1.624",
                                         netGrowth: "-9%",
                                         netGrowthColor: .withColorStudio(.red, shade: .shade40))
-                    .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color(uiColor: .listForeground))
 
                     Divider()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -36,13 +36,15 @@ struct AnalyticsHubView: View {
                 VStack(spacing: 0) {
                     Divider()
 
-                    AnalyticsReportCard(title: Localization.revenue,
-                                        totalSales: "$3.234",
-                                        totalGrowth: "+23%",
-                                        totalGrowthColor: .withColorStudio(.green, shade: .shade50),
-                                        netSales: "$2.324",
-                                        netGrowth: "-4%",
-                                        netGrowthColor: .withColorStudio(.red, shade: .shade40))
+                    AnalyticsReportCard(title: "REVENUE",
+                                        leadingTitle: "Total Sales",
+                                        leadingValue: "$3.234",
+                                        leadingGrowth: "+23%",
+                                        leadingGrowthColor: .withColorStudio(.green, shade: .shade50),
+                                        trailingTitle: "Net Sales",
+                                        trailingValue: "$2.324",
+                                        trailingGrowth: "-4%",
+                                        trailingGrowthColor: .withColorStudio(.red, shade: .shade40))
                     .background(Color(uiColor: .listForeground))
 
                     Divider()
@@ -51,13 +53,15 @@ struct AnalyticsHubView: View {
                 VStack(spacing: 0) {
                     Divider()
 
-                    AnalyticsReportCard(title: Localization.orders,
-                                        totalSales: "$2.934",
-                                        totalGrowth: "+15%",
-                                        totalGrowthColor: .withColorStudio(.green, shade: .shade50),
-                                        netSales: "$1.624",
-                                        netGrowth: "-9%",
-                                        netGrowthColor: .withColorStudio(.red, shade: .shade40))
+                    AnalyticsReportCard(title: "ORDERS",
+                                        leadingTitle: "Total Orders",
+                                        leadingValue: "145",
+                                        leadingGrowth: "+36%",
+                                        leadingGrowthColor: .withColorStudio(.green, shade: .shade50),
+                                        trailingTitle: "Average Order Value",
+                                        trailingValue: "$57,99",
+                                        trailingGrowth: "-16%",
+                                        trailingGrowthColor: .withColorStudio(.red, shade: .shade40))
                     .background(Color(uiColor: .listForeground))
 
                     Divider()
@@ -77,8 +81,6 @@ struct AnalyticsHubView: View {
 private extension AnalyticsHubView {
     struct Localization {
         static let title = NSLocalizedString("Analytics", comment: "Title for the Analytics Hub screen.")
-        static let revenue = NSLocalizedString("REVENUE", comment: "Title for the revenue report card on the analytics hub screen. Capitalized")
-        static let orders = NSLocalizedString("ORDERS", comment: "Title for the orders report card on the analytics hub screen. Capitalized")
     }
 
     struct Layout {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -39,12 +39,12 @@ struct AnalyticsHubView: View {
                     AnalyticsReportCard(title: "REVENUE",
                                         leadingTitle: "Total Sales",
                                         leadingValue: "$3.234",
-                                        leadingGrowth: "+23%",
-                                        leadingGrowthColor: .withColorStudio(.green, shade: .shade50),
+                                        leadingDelta: "+23%",
+                                        leadingDeltaColor: .withColorStudio(.green, shade: .shade50),
                                         trailingTitle: "Net Sales",
                                         trailingValue: "$2.324",
-                                        trailingGrowth: "-4%",
-                                        trailingGrowthColor: .withColorStudio(.red, shade: .shade40))
+                                        trailingDelta: "-4%",
+                                        trailingDeltaColor: .withColorStudio(.red, shade: .shade40))
                     .background(Color(uiColor: .listForeground))
 
                     Divider()
@@ -56,12 +56,12 @@ struct AnalyticsHubView: View {
                     AnalyticsReportCard(title: "ORDERS",
                                         leadingTitle: "Total Orders",
                                         leadingValue: "145",
-                                        leadingGrowth: "+36%",
-                                        leadingGrowthColor: .withColorStudio(.green, shade: .shade50),
+                                        leadingDelta: "+36%",
+                                        leadingDeltaColor: .withColorStudio(.green, shade: .shade50),
                                         trailingTitle: "Average Order Value",
                                         trailingValue: "$57,99",
-                                        trailingGrowth: "-16%",
-                                        trailingGrowthColor: .withColorStudio(.red, shade: .shade40))
+                                        trailingDelta: "-16%",
+                                        trailingDeltaColor: .withColorStudio(.red, shade: .shade40))
                     .background(Color(uiColor: .listForeground))
 
                     Divider()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+/// Resuable report card made for the Analytics Hub.
+///
+struct AnalyticsReportCard: View {
+
+    var body: some View {
+        Text("Content")
+    }
+}
+
+// MARK: Previews
+struct Previews: PreviewProvider {
+    static var previews: some View {
+        AnalyticsReportCard()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
@@ -5,12 +5,14 @@ import SwiftUI
 struct AnalyticsReportCard: View {
 
     let title: String
-    let totalSales: String
-    let totalGrowth: String
-    let totalGrowthColor: UIColor
-    let netSales: String
-    let netGrowth: String
-    let netGrowthColor: UIColor
+    let leadingTitle: String
+    let leadingValue: String
+    let leadingGrowth: String
+    let leadingGrowthColor: UIColor
+    let trailingTitle: String
+    let trailingValue: String
+    let trailingGrowth: String
+    let trailingGrowthColor: UIColor
 
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.titleSpacing) {
@@ -21,17 +23,17 @@ struct AnalyticsReportCard: View {
 
             HStack {
 
-                /// Total Sales
+                /// Leading Column
                 ///
                 VStack(alignment: .leading, spacing: Layout.salesColumnSpacing) {
 
-                    Text(Localization.totalSales)
+                    Text(leadingTitle)
                         .calloutStyle()
 
-                    Text(totalSales)
+                    Text(leadingValue)
                         .titleStyle()
 
-                    GrowthTag(value: totalGrowth, backgroundColor: totalGrowthColor)
+                    GrowthTag(value: leadingGrowth, backgroundColor: leadingGrowthColor)
 
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -39,13 +41,13 @@ struct AnalyticsReportCard: View {
                 /// Net Sales
                 ///
                 VStack(alignment: .leading, spacing: Layout.salesColumnSpacing) {
-                    Text(Localization.netSales)
+                    Text(trailingTitle)
                         .calloutStyle()
 
-                    Text(netSales)
+                    Text(trailingValue)
                         .titleStyle()
 
-                    GrowthTag(value: netGrowth, backgroundColor: netGrowthColor)
+                    GrowthTag(value: trailingGrowth, backgroundColor: trailingGrowthColor)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -71,11 +73,6 @@ private struct GrowthTag: View {
 
 // MARK: Constants
 private extension AnalyticsReportCard {
-    enum Localization {
-        static let totalSales = NSLocalizedString("Total Sales", comment: "Total Sales subtitle on the analytics hub report card.")
-        static let netSales = NSLocalizedString("Net Sales", comment: "Net Sales subtitle on the analytics hub report card.")
-    }
-
     enum Layout {
         static let titleSpacing: CGFloat = 24
         static let cardPadding: CGFloat = 16
@@ -89,12 +86,14 @@ private extension AnalyticsReportCard {
 struct Previews: PreviewProvider {
     static var previews: some View {
         AnalyticsReportCard(title: "REVENUE",
-                            totalSales: "$3.678",
-                            totalGrowth: "+23%",
-                            totalGrowthColor: .withColorStudio(.green, shade: .shade40),
-                            netSales: "$3.232",
-                            netGrowth: "-3%",
-                            netGrowthColor: .withColorStudio(.red, shade: .shade40))
+                            leadingTitle: "Total Sales",
+                            leadingValue: "$3.678",
+                            leadingGrowth: "+23%",
+                            leadingGrowthColor: .withColorStudio(.green, shade: .shade40),
+                            trailingTitle: "Net Sales",
+                            trailingValue: "$3.232",
+                            trailingGrowth: "-3%",
+                            trailingGrowthColor: .withColorStudio(.red, shade: .shade40))
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
@@ -5,7 +5,47 @@ import SwiftUI
 struct AnalyticsReportCard: View {
 
     var body: some View {
-        Text("Content")
+        VStack(alignment: .leading) {
+
+            Text("Title")
+                .foregroundColor(Color(.text))
+                .footnoteStyle()
+
+            HStack {
+                VStack(alignment: .leading) {
+
+                    Text("Left Subtitle")
+                        .font(.callout)
+                        .foregroundColor(Color(.textSubtle))
+
+                    Text("Left Value")
+                        .titleStyle()
+
+                    Text("Left Percentage")
+                        .font(.caption)
+                        .foregroundColor(Color(.textInverted))
+                        .padding(8)
+                        .background(Color(.systemGreen))
+
+                }
+
+                VStack(alignment: .leading) {
+
+                    Text("Right Subtitle")
+                        .font(.callout)
+                        .foregroundColor(Color(.textSubtle))
+
+                    Text("Right Value")
+                        .titleStyle()
+
+                    Text("Right Percentage")
+                        .font(.caption)
+                        .foregroundColor(Color(.textInverted))
+                        .padding(8)
+                        .background(Color(.systemGreen))
+                }
+            }
+        }
     }
 }
 
@@ -13,5 +53,6 @@ struct AnalyticsReportCard: View {
 struct Previews: PreviewProvider {
     static var previews: some View {
         AnalyticsReportCard()
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
@@ -13,7 +13,7 @@ struct AnalyticsReportCard: View {
     let netGrowthColor: UIColor
 
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: Layout.titleSpacing) {
 
             Text(title)
                 .foregroundColor(Color(.text))
@@ -23,7 +23,7 @@ struct AnalyticsReportCard: View {
 
                 /// Total Sales
                 ///
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: Layout.salesColumnSpacing) {
 
                     Text(Localization.totalSales)
                         .calloutStyle()
@@ -37,7 +37,7 @@ struct AnalyticsReportCard: View {
 
                 /// Net Sales
                 ///
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: Layout.salesColumnSpacing) {
                     Text(Localization.netSales)
                         .calloutStyle()
 
@@ -48,6 +48,7 @@ struct AnalyticsReportCard: View {
                 }
             }
         }
+        .padding(Layout.cardPadding)
     }
 }
 
@@ -74,6 +75,9 @@ private extension AnalyticsReportCard {
     }
 
     enum Layout {
+        static let titleSpacing: CGFloat = 24
+        static let cardPadding: CGFloat = 16
+        static let salesColumnSpacing: CGFloat = 10
         static let growthBackgroundPadding = EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 8)
         static let growthCornerRadius: CGFloat = 4.0
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
@@ -25,7 +25,7 @@ struct AnalyticsReportCard: View {
 
                 /// Leading Column
                 ///
-                VStack(alignment: .leading, spacing: Layout.salesColumnSpacing) {
+                VStack(alignment: .leading, spacing: Layout.columnSpacing) {
 
                     Text(leadingTitle)
                         .calloutStyle()
@@ -38,9 +38,9 @@ struct AnalyticsReportCard: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-                /// Net Sales
+                /// Trailing Column
                 ///
-                VStack(alignment: .leading, spacing: Layout.salesColumnSpacing) {
+                VStack(alignment: .leading, spacing: Layout.columnSpacing) {
                     Text(trailingTitle)
                         .calloutStyle()
 
@@ -63,11 +63,11 @@ private struct DeltaTag: View {
 
     var body: some View {
         Text(value)
-            .padding(AnalyticsReportCard.Layout.growthBackgroundPadding)
+            .padding(AnalyticsReportCard.Layout.deltaBackgroundPadding)
             .foregroundColor(Color(.textInverted))
             .captionStyle()
             .background(Color(backgroundColor))
-            .cornerRadius(AnalyticsReportCard.Layout.growthCornerRadius)
+            .cornerRadius(AnalyticsReportCard.Layout.deltaCornerRadius)
     }
 }
 
@@ -76,9 +76,9 @@ private extension AnalyticsReportCard {
     enum Layout {
         static let titleSpacing: CGFloat = 24
         static let cardPadding: CGFloat = 16
-        static let salesColumnSpacing: CGFloat = 10
-        static let growthBackgroundPadding = EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 8)
-        static let growthCornerRadius: CGFloat = 4.0
+        static let columnSpacing: CGFloat = 10
+        static let deltaBackgroundPadding = EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 8)
+        static let deltaCornerRadius: CGFloat = 4.0
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
@@ -31,11 +31,7 @@ struct AnalyticsReportCard: View {
                     Text(totalSales)
                         .titleStyle()
 
-                    Text(totalGrowth)
-                        .foregroundColor(Color(.textInverted))
-                        .captionStyle()
-                        .padding(Layout.growthBackgroundPadding)
-                        .background(Color(totalGrowthColor))
+                    GrowthTag(value: totalGrowth, backgroundColor: totalGrowthColor)
 
                 }
 
@@ -48,14 +44,25 @@ struct AnalyticsReportCard: View {
                     Text(netSales)
                         .titleStyle()
 
-                    Text(netGrowth)
-                        .foregroundColor(Color(.textInverted))
-                        .captionStyle()
-                        .padding(Layout.growthBackgroundPadding)
-                        .background(Color(netGrowthColor))
+                    GrowthTag(value: netGrowth, backgroundColor: netGrowthColor)
                 }
             }
         }
+    }
+}
+
+private struct GrowthTag: View {
+
+    let value: String
+    let backgroundColor: UIColor
+
+    var body: some View {
+        Text(value)
+            .padding(AnalyticsReportCard.Layout.growthBackgroundPadding)
+            .foregroundColor(Color(.textInverted))
+            .captionStyle()
+            .background(Color(backgroundColor))
+            .cornerRadius(AnalyticsReportCard.Layout.growthCornerRadius)
     }
 }
 
@@ -68,6 +75,7 @@ private extension AnalyticsReportCard {
 
     enum Layout {
         static let growthBackgroundPadding = EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 8)
+        static let growthCornerRadius: CGFloat = 4.0
     }
 }
 
@@ -77,10 +85,10 @@ struct Previews: PreviewProvider {
         AnalyticsReportCard(title: "REVENUE",
                             totalSales: "$3.678",
                             totalGrowth: "+23%",
-                            totalGrowthColor: .systemGreen,
+                            totalGrowthColor: .withColorStudio(.green, shade: .shade40),
                             netSales: "$3.232",
                             netGrowth: "-3%",
-                            netGrowthColor: .systemRed)
+                            netGrowthColor: .withColorStudio(.red, shade: .shade40))
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
@@ -34,6 +34,7 @@ struct AnalyticsReportCard: View {
                     GrowthTag(value: totalGrowth, backgroundColor: totalGrowthColor)
 
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
 
                 /// Net Sales
                 ///
@@ -46,6 +47,7 @@ struct AnalyticsReportCard: View {
 
                     GrowthTag(value: netGrowth, backgroundColor: netGrowthColor)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .padding(Layout.cardPadding)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
@@ -15,15 +15,14 @@ struct AnalyticsReportCard: View {
                 VStack(alignment: .leading) {
 
                     Text("Left Subtitle")
-                        .font(.callout)
-                        .foregroundColor(Color(.textSubtle))
+                        .calloutStyle()
 
                     Text("Left Value")
                         .titleStyle()
 
                     Text("Left Percentage")
-                        .font(.caption)
                         .foregroundColor(Color(.textInverted))
+                        .captionStyle()
                         .padding(8)
                         .background(Color(.systemGreen))
 
@@ -32,15 +31,14 @@ struct AnalyticsReportCard: View {
                 VStack(alignment: .leading) {
 
                     Text("Right Subtitle")
-                        .font(.callout)
-                        .foregroundColor(Color(.textSubtle))
+                        .calloutStyle()
 
                     Text("Right Value")
                         .titleStyle()
 
                     Text("Right Percentage")
-                        .font(.caption)
                         .foregroundColor(Color(.textInverted))
+                        .captionStyle()
                         .padding(8)
                         .background(Color(.systemGreen))
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
@@ -7,12 +7,12 @@ struct AnalyticsReportCard: View {
     let title: String
     let leadingTitle: String
     let leadingValue: String
-    let leadingGrowth: String
-    let leadingGrowthColor: UIColor
+    let leadingDelta: String
+    let leadingDeltaColor: UIColor
     let trailingTitle: String
     let trailingValue: String
-    let trailingGrowth: String
-    let trailingGrowthColor: UIColor
+    let trailingDelta: String
+    let trailingDeltaColor: UIColor
 
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.titleSpacing) {
@@ -33,7 +33,7 @@ struct AnalyticsReportCard: View {
                     Text(leadingValue)
                         .titleStyle()
 
-                    GrowthTag(value: leadingGrowth, backgroundColor: leadingGrowthColor)
+                    DeltaTag(value: leadingDelta, backgroundColor: leadingDeltaColor)
 
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -47,7 +47,7 @@ struct AnalyticsReportCard: View {
                     Text(trailingValue)
                         .titleStyle()
 
-                    GrowthTag(value: trailingGrowth, backgroundColor: trailingGrowthColor)
+                    DeltaTag(value: trailingDelta, backgroundColor: trailingDeltaColor)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -56,7 +56,7 @@ struct AnalyticsReportCard: View {
     }
 }
 
-private struct GrowthTag: View {
+private struct DeltaTag: View {
 
     let value: String
     let backgroundColor: UIColor
@@ -88,12 +88,12 @@ struct Previews: PreviewProvider {
         AnalyticsReportCard(title: "REVENUE",
                             leadingTitle: "Total Sales",
                             leadingValue: "$3.678",
-                            leadingGrowth: "+23%",
-                            leadingGrowthColor: .withColorStudio(.green, shade: .shade40),
+                            leadingDelta: "+23%",
+                            leadingDeltaColor: .withColorStudio(.green, shade: .shade40),
                             trailingTitle: "Net Sales",
                             trailingValue: "$3.232",
-                            trailingGrowth: "-3%",
-                            trailingGrowthColor: .withColorStudio(.red, shade: .shade40))
+                            trailingDelta: "-3%",
+                            trailingDeltaColor: .withColorStudio(.red, shade: .shade40))
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
@@ -20,9 +20,12 @@ struct AnalyticsReportCard: View {
                 .footnoteStyle()
 
             HStack {
+
+                /// Total Sales
+                ///
                 VStack(alignment: .leading) {
 
-                    Text("Left Subtitle")
+                    Text(Localization.totalSales)
                         .calloutStyle()
 
                     Text(totalSales)
@@ -31,14 +34,15 @@ struct AnalyticsReportCard: View {
                     Text(totalGrowth)
                         .foregroundColor(Color(.textInverted))
                         .captionStyle()
-                        .padding(8)
+                        .padding(Layout.growthBackgroundPadding)
                         .background(Color(totalGrowthColor))
 
                 }
 
+                /// Net Sales
+                ///
                 VStack(alignment: .leading) {
-
-                    Text("Right Subtitle")
+                    Text(Localization.netSales)
                         .calloutStyle()
 
                     Text(netSales)
@@ -47,11 +51,23 @@ struct AnalyticsReportCard: View {
                     Text(netGrowth)
                         .foregroundColor(Color(.textInverted))
                         .captionStyle()
-                        .padding(8)
-                        .background(Color(netGrowth))
+                        .padding(Layout.growthBackgroundPadding)
+                        .background(Color(netGrowthColor))
                 }
             }
         }
+    }
+}
+
+// MARK: Constants
+private extension AnalyticsReportCard {
+    enum Localization {
+        static let totalSales = NSLocalizedString("Total Sales", comment: "Total Sales subtitle on the analytics hub report card.")
+        static let netSales = NSLocalizedString("Net Sales", comment: "Net Sales subtitle on the analytics hub report card.")
+    }
+
+    enum Layout {
+        static let growthBackgroundPadding = EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 8)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/StatsCard.swift
@@ -4,10 +4,18 @@ import SwiftUI
 ///
 struct AnalyticsReportCard: View {
 
+    let title: String
+    let totalSales: String
+    let totalGrowth: String
+    let totalGrowthColor: UIColor
+    let netSales: String
+    let netGrowth: String
+    let netGrowthColor: UIColor
+
     var body: some View {
         VStack(alignment: .leading) {
 
-            Text("Title")
+            Text(title)
                 .foregroundColor(Color(.text))
                 .footnoteStyle()
 
@@ -17,14 +25,14 @@ struct AnalyticsReportCard: View {
                     Text("Left Subtitle")
                         .calloutStyle()
 
-                    Text("Left Value")
+                    Text(totalSales)
                         .titleStyle()
 
-                    Text("Left Percentage")
+                    Text(totalGrowth)
                         .foregroundColor(Color(.textInverted))
                         .captionStyle()
                         .padding(8)
-                        .background(Color(.systemGreen))
+                        .background(Color(totalGrowthColor))
 
                 }
 
@@ -33,14 +41,14 @@ struct AnalyticsReportCard: View {
                     Text("Right Subtitle")
                         .calloutStyle()
 
-                    Text("Right Value")
+                    Text(netSales)
                         .titleStyle()
 
-                    Text("Right Percentage")
+                    Text(netGrowth)
                         .foregroundColor(Color(.textInverted))
                         .captionStyle()
                         .padding(8)
-                        .background(Color(.systemGreen))
+                        .background(Color(netGrowth))
                 }
             }
         }
@@ -50,7 +58,13 @@ struct AnalyticsReportCard: View {
 // MARK: Previews
 struct Previews: PreviewProvider {
     static var previews: some View {
-        AnalyticsReportCard()
+        AnalyticsReportCard(title: "REVENUE",
+                            totalSales: "$3.678",
+                            totalGrowth: "+23%",
+                            totalGrowthColor: .systemGreen,
+                            netSales: "$3.232",
+                            netGrowth: "-3%",
+                            netGrowthColor: .systemRed)
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -559,6 +559,7 @@
 		263E38472641FF3400260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E38452641FF3400260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		263EB409242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */; };
 		2647F7B529280A7F00D59FDF /* AnalyticsHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */; };
+		2647F7BA292BE2F900D59FDF /* StatsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2647F7B9292BE2F900D59FDF /* StatsCard.swift */; };
 		265284022624937600F91BA1 /* AddOnCrossreferenceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */; };
 		265284092624ACE900F91BA1 /* AddOnCrossreferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265284082624ACE900F91BA1 /* AddOnCrossreferenceTests.swift */; };
 		2655905B27863D1300BB8457 /* MockCollectOrderPaymentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2655905A27863D1300BB8457 /* MockCollectOrderPaymentUseCase.swift */; };
@@ -2522,6 +2523,7 @@
 		26309F16277D0AEA0012797F /* SafeAreaInsetsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeAreaInsetsKey.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
 		2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubView.swift; sourceTree = "<group>"; };
+		2647F7B9292BE2F900D59FDF /* StatsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsCard.swift; sourceTree = "<group>"; };
 		265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceUseCase.swift; sourceTree = "<group>"; };
 		265284082624ACE900F91BA1 /* AddOnCrossreferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceTests.swift; sourceTree = "<group>"; };
 		2655905A27863D1300BB8457 /* MockCollectOrderPaymentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCollectOrderPaymentUseCase.swift; sourceTree = "<group>"; };
@@ -5237,6 +5239,7 @@
 			isa = PBXGroup;
 			children = (
 				2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */,
+				2647F7B9292BE2F900D59FDF /* StatsCard.swift */,
 			);
 			path = "Analytics Hub";
 			sourceTree = "<group>";
@@ -10170,6 +10173,7 @@
 				02482A8B237BE8C7007E73ED /* LinkSettingsViewController.swift in Sources */,
 				CE227097228F152400C0626C /* WooBasicTableViewCell.swift in Sources */,
 				02C27BCE282CB52F0065471A /* CardPresentPaymentReceiptEmailCoordinator.swift in Sources */,
+				2647F7BA292BE2F900D59FDF /* StatsCard.swift in Sources */,
 				451526392577D89E0076B03C /* AddAttributeViewModel.swift in Sources */,
 				DE0A2EAF281BA278007A8015 /* ProductCategorySelectorViewModel.swift in Sources */,
 				45B9C64323A91CB6007FC4C5 /* PriceInputFormatter.swift in Sources */,

--- a/WooFoundation/WooFoundation/ViewModifiers/WooStyleModifiers.swift
+++ b/WooFoundation/WooFoundation/ViewModifiers/WooStyleModifiers.swift
@@ -104,6 +104,22 @@ public struct FootnoteStyle: ViewModifier {
     }
 }
 
+public struct CalloutStyle: ViewModifier {
+    public func body(content: Content) -> some View {
+        content
+            .font(.callout)
+            .foregroundColor(Color(.textSubtle))
+    }
+}
+
+public struct CaptionStyle: ViewModifier {
+    public func body(content: Content) -> some View {
+        content
+            .font(.caption)
+            .foregroundColor(Color(.text))
+    }
+}
+
 public struct ErrorStyle: ViewModifier {
     public func body(content: Content) -> some View {
         content
@@ -200,5 +216,13 @@ public extension View {
 
     func headlineLinkStyle() -> some View {
         self.modifier(HeadlineLinkStyle())
+    }
+
+    func calloutStyle() -> some View {
+        self.modifier(CalloutStyle())
+    }
+
+    func captionStyle() -> some View {
+        self.modifier(CaptionStyle())
     }
 }


### PR DESCRIPTION
part of #8148

# Why

This PR adds the Report Card UI that will be used on the Analytics Hub view

**Note: Rotation & Accessibility will be handled in a different PR.**

# Screenshots
Light | Dark 
---- | ----
![light](https://user-images.githubusercontent.com/562080/203178770-aec39137-ffb1-49d7-ac44-c00bd918b34c.png) | ![dark](https://user-images.githubusercontent.com/562080/203178774-d4ccd534-7d48-421a-81a2-e40cb8525574.png)



# Testing instructions

- Launch the app
- Tap the "See More" button from the main dashboard
- See the report cards with dummy data.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
