### PR TITLE
Change deprecated kUUTypeUTF8PlainText for UTType

### DIFF
--- a/Networking/Networking/Model/Product/ProductDownloadDragAndDrop.swift
+++ b/Networking/Networking/Model/Product/ProductDownloadDragAndDrop.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreServices
 import Codegen
+import UniformTypeIdentifiers
 
 /// A wrapper around `ProductDownload`, to make it compatible in using as Drag and Drop data source in a table view. Represents a `ProductDownload` entity.
 /// To make a data draggable and droppable, on an Table/Collection view,
@@ -42,7 +43,7 @@ extension ProductDownloadDragAndDrop: NSItemProviderWriting {
     /// Gets called by the system to get information about our encoded data representation while Dragging
     ///
     public static var writableTypeIdentifiersForItemProvider: [String] {
-        return [(kUTTypeUTF8PlainText) as String]
+        [UTType.utf8PlainText.identifier]
     }
 
     public func loadData(withTypeIdentifier typeIdentifier: String,
@@ -69,7 +70,7 @@ extension ProductDownloadDragAndDrop: NSItemProviderReading {
     ///  In this case it's kUTTypeUTF8PlainText
     ///
     public static var readableTypeIdentifiersForItemProvider: [String] {
-        return [(kUTTypeUTF8PlainText) as String]
+        [UTType.utf8PlainText.identifier]
     }
 
     public static func object(withItemProviderData data: Data, typeIdentifier: String) throws -> Self {


### PR DESCRIPTION
### Description
By updating the minimum release version to iOS 15 recently, we've seen some deprecation warnings. This PR fixes the case for uses of `kUUTypeUTF8PlainText`

### Changes
Changed the two references of `kUUTypeUTF8PlainText` for `UTType.utf8PlainText.identifier`, in the `ProductDownloadDragAndDrop` class.

This type is used when we need to represent plain text encoded as UTF-8, this is needed in this case when we attempt to drag and drop elements from our table view. The system will call the `writableTypeIdentifiersForItemProvider` and `readableTypeIdentifiersForItemProvider` methods to get information about our encoded data representation while dragging and dropping those elements around.

### Testing instructions
- Create or edit a "Virtual and Downloadable" product from `wp-admin`
- Add several downloadable files.
- Go the app and navigate to the "Downloadable Files" view
- Try to drag and drop the cells to reorder the files, this should work as expected

### Screenshots

| Downloadable files | Drag and drop |
|--|--|
| <img width="700" src="https://user-images.githubusercontent.com/3812076/203532538-b8219032-6fb5-4d21-8785-9e13d9f0c947.png"> | <img width="400" src="https://user-images.githubusercontent.com/3812076/203532670-ab322561-cb26-460f-b94f-5383082f51b1.gif"> |
