### PR TITLE
[Mobile Payments] Add preflight controller for reader connection management

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Yosemite
+import Combine
+
+enum CardReaderConnectionResult {
+    case connected(CardReader)
+    case canceled
+}
+
+final class CardPresentPaymentPreflightController {
+    /// Store's ID.
+    ///
+    private let siteID: Int64
+
+    /// Payment Gateway Account to use.
+    ///
+    private let paymentGatewayAccount: PaymentGatewayAccount
+
+    /// IPP Configuration.
+    ///
+    private let configuration: CardPresentPaymentsConfiguration
+
+    /// View Controller used to present alerts.
+    ///
+    private var rootViewController: UIViewController
+
+    /// Stores manager.
+    ///
+    private let stores: StoresManager
+
+    /// Analytics manager.
+    ///
+    private let analytics: Analytics
+
+    /// Stores the connected card reader
+    private var connectedReader: CardReader?
+
+
+    /// Controller to connect a card reader.
+    ///
+    private var connectionController: CardReaderConnectionController
+
+
+    private(set) var readerConnection = CurrentValueSubject<CardReaderConnectionResult?, Never>(nil)
+
+    init(siteID: Int64,
+         paymentGatewayAccount: PaymentGatewayAccount,
+         configuration: CardPresentPaymentsConfiguration,
+         rootViewController: UIViewController,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+        self.paymentGatewayAccount = paymentGatewayAccount
+        self.configuration = configuration
+        self.rootViewController = rootViewController
+        self.stores = stores
+        self.analytics = analytics
+        self.connectedReader = nil
+        let analyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: configuration,
+                                                                    stores: stores,
+                                                                    analytics: analytics)
+        // TODO: Replace this with a refactored (New)CardReaderConnectionController
+        self.connectionController = CardReaderConnectionController(
+            forSiteID: siteID,
+            knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
+            alertsProvider: CardReaderSettingsAlerts(),
+            configuration: configuration,
+            analyticsTracker: analyticsTracker)
+    }
+
+    func start() {
+        configureBackend()
+        observeConnectedReaders()
+        // If we're already connected to a reader, return it
+        if let connectedReader = connectedReader {
+            readerConnection.send(CardReaderConnectionResult.connected(connectedReader))
+        }
+
+        // TODO: Run onboarding if needed
+
+        // TODO: Ask for a Reader type if supported by device
+
+        // Attempt to find a reader and connect
+        connectionController.searchAndConnect(from: rootViewController) { result in
+            let connectionResult = result.map { connection in
+                switch connection {
+                case .connected:
+                    // TODO: pass the reader from the (New)CardReaderConnectionController
+                    guard let connectedReader = self.connectedReader else { return CardReaderConnectionResult.canceled }
+                    return CardReaderConnectionResult.connected(connectedReader)
+                case .canceled:
+                    return CardReaderConnectionResult.canceled
+                }
+            }
+
+            switch connectionResult {
+            case .success(let unwrapped):
+                self.readerConnection.send(unwrapped)
+            default:
+                break
+            }
+        }
+    }
+
+
+
+    /// Configure the CardPresentPaymentStore to use the appropriate backend
+    ///
+    private func configureBackend() {
+        let setAccount = CardPresentPaymentAction.use(paymentGatewayAccount: paymentGatewayAccount)
+        stores.dispatch(setAccount)
+    }
+
+    private func observeConnectedReaders() {
+        let action = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
+            self?.connectedReader = readers.first
+        }
+        stores.dispatch(action)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -85,20 +85,10 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     ///
     private lazy var paymentOrchestrator = PaymentCaptureOrchestrator(stores: stores)
 
-    /// Controller to connect a card reader.
-    ///
-    private lazy var connectionController = {
-        CardReaderConnectionController(forSiteID: siteID,
-                                       knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
-                                       alertsProvider: CardReaderSettingsAlerts(),
-                                       configuration: configuration,
-                                       analyticsTracker: CardReaderConnectionAnalyticsTracker(configuration: configuration,
-                                                                                              stores: stores,
-                                                                                              analytics: analytics))
-    }()
-
     /// Coordinates emailing a receipt after payment success.
     private var receiptEmailCoordinator: CardPresentPaymentReceiptEmailCoordinator?
+
+    private var cancellables: Set<AnyCancellable> = []
 
     init(siteID: Int64,
          order: Order,
@@ -121,10 +111,13 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     }
 
     /// Starts the collect payment flow.
-    /// 1. Connects to a reader
-    /// 2. Collect payment from order
-    /// 3. If successful: prints or emails receipt
-    /// 4. If failure: Allows retry
+    /// 1. Checks valid total
+    /// 2. Calls CardReaderPreflightController to get a connected reader
+    /// 3. Hands off to PaymentCaptureOrchestrator to perform the payment
+    /// 4. Shows payment messages using an alert provider appropriate to the reader type
+    /// 5. Handles receipt alerts on success
+    /// 6. Allows retry on failure
+    /// 7. Tracks payment analytics
     ///
     ///
     /// - Parameter onCollect: Closure invoked after the collect process has finished.
@@ -139,12 +132,15 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
             return handleTotalAmountInvalidError(totalAmountInvalidError(), onCompleted: onCompleted)
         }
 
-        configureBackend()
-        observeConnectedReadersForAnalytics()
-        connectReader { [weak self] result in
+        let preflightController = CardPresentPaymentPreflightController(siteID: siteID,
+                                                                        paymentGatewayAccount: paymentGatewayAccount,
+                                                                        configuration: configuration,
+                                                                        rootViewController: rootViewController)
+        preflightController.readerConnection.sink { [weak self] connectionResult in
             guard let self = self else { return }
-            switch result {
-            case .success:
+            switch connectionResult {
+            case .connected(let reader):
+                self.connectedReader = reader
                 self.attemptPayment(onCompletion: { [weak self] result in
                     guard let self = self else { return }
                     // Inform about the collect payment state
@@ -155,20 +151,22 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
                     default:
                         onCollect(result.map { _ in () }) // Transforms Result<CardPresentCapturedPaymentData, Error> to Result<Void, Error>
                     }
-
                     // Handle payment receipt
                     guard let paymentData = try? result.get() else {
                         return onCompleted()
                     }
                     self.presentReceiptAlert(receiptParameters: paymentData.receiptParameters, onCompleted: onCompleted)
                 })
-            case .failure(CollectOrderPaymentUseCaseError.flowCanceledByUser):
+            case .canceled:
                 self.trackPaymentCancelation()
                 onCancel()
-            case .failure(let error):
-                onCollect(.failure(error))
+            case .none:
+                break
             }
         }
+        .store(in: &cancellables)
+
+        preflightController.start()
     }
 }
 
@@ -205,64 +203,6 @@ private extension CollectOrderPaymentUseCase {
         self.alerts.nonRetryableError(from: self.rootViewController, error: totalAmountInvalidError(), dismissCompletion: onCompleted)
     }
 
-    /// Configure the CardPresentPaymentStore to use the appropriate backend
-    ///
-    func configureBackend() {
-        let setAccount = CardPresentPaymentAction.use(paymentGatewayAccount: paymentGatewayAccount)
-        stores.dispatch(setAccount)
-    }
-
-    /// Attempts to connect to a reader.
-    /// Finishes with success immediately if a reader is already connected.
-    ///
-    func connectReader(onCompletion: @escaping (Result<Void, Error>) -> ()) {
-        // `checkCardReaderConnected` action will return a publisher that:
-        // - Sends one value if there is no reader connected.
-        // - Completes when a reader is connected.
-        let readerConnected = CardPresentPaymentAction.publishCardReaderConnections() { [weak self] connectPublisher in
-            guard let self = self else { return }
-            self.readerSubscription = connectPublisher
-                .sink(receiveValue: { [weak self] readers in
-                    guard let self = self else { return }
-
-                    if readers.isNotEmpty {
-                        // Dismiss the current connection alert before notifying the completion.
-                        // If no presented controller is found(because the reader was already connected), just notify the completion.
-                        if let connectionController = self.rootViewController.presentedViewController {
-                            connectionController.dismiss(animated: true) {
-                                onCompletion(.success(()))
-                            }
-                        } else {
-                            onCompletion(.success(()))
-                        }
-
-                        // Nil the subscription since we are done with the connection.
-                        self.readerSubscription = nil
-                    } else {
-                        // Attempt reader connection
-                        self.connectionController.searchAndConnect(from: self.rootViewController) { [weak self] result in
-                            guard let self = self else { return }
-                            switch result {
-                            case let .success(connectionResult):
-                                switch connectionResult {
-                                case .canceled:
-                                    self.readerSubscription = nil
-                                    onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
-                                case .connected:
-                                    // Connected case will be handled in `if readers.isNotEmpty`.
-                                    break
-                                }
-                            case .failure(let error):
-                                self.readerSubscription = nil
-                                onCompletion(.failure(error))
-                            }
-                        }
-                    }
-                })
-        }
-        stores.dispatch(readerConnected)
-    }
-
     /// Attempts to collect payment for an order.
     ///
     func attemptPayment(onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
@@ -273,6 +213,7 @@ private extension CollectOrderPaymentUseCase {
         }
 
         // Show preparing reader alert
+        // TODO: Move this tho the (New)PaymentCaptureOrchestrator
         alerts.preparingReader(onCancel: { [weak self] in
             self?.cancelPayment(onCompleted: {
                 onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
@@ -459,13 +400,6 @@ private extension CollectOrderPaymentUseCase {
 
 // MARK: Analytics
 private extension CollectOrderPaymentUseCase {
-    func observeConnectedReadersForAnalytics() {
-        let action = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
-            self?.connectedReader = readers.first
-        }
-        stores.dispatch(action)
-    }
-
     func trackProcessingCompletion(intent: PaymentIntent) {
         guard let paymentMethod = intent.paymentMethod() else {
             return

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -101,6 +101,8 @@ final class PaymentMethodsViewModel: ObservableObject {
     ///
     private var legacyCollectPaymentsUseCase: CollectOrderPaymentProtocol?
 
+    private var collectPaymentsUseCase: CollectOrderPaymentProtocol?
+
     private let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
 
     private let upsellCardReadersCampaign = UpsellCardReadersCampaign(source: .paymentMethods)
@@ -197,6 +199,82 @@ final class PaymentMethodsViewModel: ObservableObject {
     /// - parameter useCase: Assign a custom useCase object for testing purposes. If not provided `CollectOrderPaymentUseCase` will be used.
     ///
     func collectPayment(on rootViewController: UIViewController?,
+                        useCase: CollectOrderPaymentProtocol? = nil,
+                        onSuccess: @escaping () -> ()) {
+        switch ServiceLocator.generalAppSettings.settings.isTapToPayOnIPhoneSwitchEnabled {
+        case true:
+            newCollectPayment(on: rootViewController, useCase: useCase, onSuccess: onSuccess)
+        case false:
+            legacyCollectPayment(on: rootViewController, useCase: useCase, onSuccess: onSuccess)
+        }
+    }
+
+    func newCollectPayment(on rootViewController: UIViewController?,
+                        useCase: CollectOrderPaymentProtocol? = nil,
+                        onSuccess: @escaping () -> ()) {
+        trackCollectIntention(method: .card)
+
+        guard let rootViewController = rootViewController else {
+            DDLogError("⛔️ Root ViewController is nil, can't present payment alerts.")
+            return presentNoticeSubject.send(.error(Localization.genericCollectError))
+        }
+
+        // TODO: move onboarding to the CardPresentPaymentPreflightController
+        cardPresentPaymentsOnboardingPresenter.showOnboardingIfRequired(
+            from: rootViewController) { [weak self] in
+                guard let self = self else { return }
+
+                guard let order = self.ordersResultController.fetchedObjects.first else {
+                    DDLogError("⛔️ Order not found, can't collect payment.")
+                    return self.presentNoticeSubject.send(.error(Localization.genericCollectError))
+                }
+
+                let action = CardPresentPaymentAction.selectedPaymentGatewayAccount { paymentGateway in
+                    guard let paymentGateway = paymentGateway else {
+                        return DDLogError("⛔️ Payment Gateway not found, can't collect payment.")
+                    }
+
+                    self.collectPaymentsUseCase = useCase ?? CollectOrderPaymentUseCase(
+                        siteID: self.siteID,
+                        order: order,
+                        formattedAmount: self.formattedTotal,
+                        paymentGatewayAccount: paymentGateway,
+                        rootViewController: rootViewController,
+                        alerts: OrderDetailsPaymentAlerts(transactionType: .collectPayment,
+                                                          presentingController: rootViewController),
+                        configuration: CardPresentConfigurationLoader().configuration)
+
+                    self.collectPaymentsUseCase?.collectPayment(
+                        onCollect: { [weak self] result in
+                            guard result.isFailure else { return }
+                            self?.trackFlowFailed()
+                        },
+                        onCancel: {
+                            // No tracking required because the flow remains on screen to choose other payment methods.
+                        },
+                        onCompleted: { [weak self] in
+                            // Update order in case its status and/or other details are updated after a successful in-person payment
+                            self?.updateOrderAsynchronously()
+
+                            // Inform success to consumer
+                            onSuccess()
+
+                            // Sent notice request
+                            self?.presentNoticeSubject.send(.completed)
+
+                            // Make sure we free all the resources
+                            self?.collectPaymentsUseCase = nil
+
+                            // Tracks completion
+                            self?.trackFlowCompleted(method: .card)
+                        })
+                }
+
+                self.stores.dispatch(action)
+            }
+    }
+
+    func legacyCollectPayment(on rootViewController: UIViewController?,
                         useCase: CollectOrderPaymentProtocol? = nil,
                         onSuccess: @escaping () -> ()) {
         trackCollectIntention(method: .card)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -462,6 +462,7 @@
 		035BA3A8291000E90056F0AD /* JustInTimeMessageAnnouncementCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035BA3A7291000E90056F0AD /* JustInTimeMessageAnnouncementCardViewModelTests.swift */; };
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
 		035DBA45292D0164003E5125 /* CollectOrderPaymentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035DBA44292D0163003E5125 /* CollectOrderPaymentUseCase.swift */; };
+		035DBA47292D0995003E5125 /* CardPresentPaymentPreflightController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035DBA46292D0994003E5125 /* CardPresentPaymentPreflightController.swift */; };
 		035F2308275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */; };
 		0366EAE12909A37800B51755 /* JustInTimeMessageAnnouncementCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0366EAE02909A37800B51755 /* JustInTimeMessageAnnouncementCardViewModel.swift */; };
 		036CA6B9291E8D4B00E4DF4F /* CardPresentModalPreparingReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036CA6B8291E8D4B00E4DF4F /* CardPresentModalPreparingReader.swift */; };
@@ -2433,6 +2434,7 @@
 		035BA3A7291000E90056F0AD /* JustInTimeMessageAnnouncementCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessageAnnouncementCardViewModelTests.swift; sourceTree = "<group>"; };
 		035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdateTypeProperty.swift; sourceTree = "<group>"; };
 		035DBA44292D0163003E5125 /* CollectOrderPaymentUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectOrderPaymentUseCase.swift; sourceTree = "<group>"; };
+		035DBA46292D0994003E5125 /* CardPresentPaymentPreflightController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentPreflightController.swift; sourceTree = "<group>"; };
 		035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectingFailedUpdatePostalCode.swift; sourceTree = "<group>"; };
 		0366EAE02909A37800B51755 /* JustInTimeMessageAnnouncementCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessageAnnouncementCardViewModel.swift; sourceTree = "<group>"; };
 		036CA6B8291E8D4B00E4DF4F /* CardPresentModalPreparingReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalPreparingReader.swift; sourceTree = "<group>"; };
@@ -8406,6 +8408,7 @@
 				037D270C28CA444F00A3F924 /* CardReaderModalFlowViewControllerProtocol.swift */,
 				D8815ADE26383EE700EDAD62 /* CardPresentPaymentsModalViewController.xib */,
 				31E6F21E26B3577800227E6F /* CardReaderConnectionController.swift */,
+				035DBA46292D0994003E5125 /* CardPresentPaymentPreflightController.swift */,
 				D8EE9690264D328A0033B2F9 /* ReceiptViewController.swift */,
 				D8EE9691264D328A0033B2F9 /* ReceiptViewController.xib */,
 				31C21FA326D9949000916E2E /* SeveralReadersFoundViewController.swift */,
@@ -10080,6 +10083,7 @@
 				02162729237965E8000208D2 /* ProductFormTableViewModel.swift in Sources */,
 				DEF3300C270444070073AE29 /* ShippingLabelSelectedRate.swift in Sources */,
 				CE2A9FBF23BFB1BE002BEC1C /* LedgerTableViewCell.swift in Sources */,
+				035DBA47292D0995003E5125 /* CardPresentPaymentPreflightController.swift in Sources */,
 				B58B4AC02108FF6100076FDD /* Array+Helpers.swift in Sources */,
 				028AFFB32484ED2800693C09 /* Dictionary+Logging.swift in Sources */,
 				45BBFBC1274FD94300213001 /* HubMenuCoordinator.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8080 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In sTAP Away, we will add a screen at the start of the card reader connection flow for users with supporting hardware to choose whether to connect a bluetooth reader, or use the built in card reader.

This PR adds a `CardPresentPaymentPreflightController` which will orchestrate the connection process. The responsibility of this preflight controller is to provide a connected reader, having handled onboarding, reader type selection, and reader connection. This currently has some logic extracted from the use case to handle the connection of a reader.

Note that this PR breaks tracking of payment flow failure when there is an error from the connection process. This will be added back in future.

In a future PR, this the preflight controller will include the alert for the user to choose the discovery method.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

N.B. on this branch, when the feature flag is on, Tap on Mobile will always be used. If you do not have a device which is provisioned for this, please enable the simulated card reader and build to a simulator. 

To enable the Stripe simulated reader, in Xcode go to `Product > Scheme > Edit Scheme` and select `Run` in the sidebar, then `Arguments` in the tabs. Check the `-simulate-stripe-card-reader` box.

1. Turn on the `Tap to Pay on iPhone` experimental feature in settings
2. Tap `Menu > Payments > Collect Payment`
3. Follow the flow to create a payment, and select Card when asked for the payment method
4. Connect to the reader
5. Verify that you can take a payment.

Disconnect the reader (in the Manage card reader menu), then repeat with the switch off, and use a bluetooth reader or simulator

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
