### PR TITLE
[Mobile Payments] Duplicate CardReaderConnectionController before refactor

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -38,7 +38,7 @@ final class CardPresentPaymentPreflightController {
 
     /// Controller to connect a card reader.
     ///
-    private var connectionController: CardReaderConnectionController
+    private var connectionController: LegacyCardReaderConnectionController
 
 
     private(set) var readerConnection = CurrentValueSubject<CardReaderConnectionResult?, Never>(nil)
@@ -59,8 +59,8 @@ final class CardPresentPaymentPreflightController {
         let analyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: configuration,
                                                                     stores: stores,
                                                                     analytics: analytics)
-        // TODO: Replace this with a refactored (New)CardReaderConnectionController
-        self.connectionController = CardReaderConnectionController(
+        // TODO: Replace this with a refactored (New)LegacyCardReaderConnectionController
+        self.connectionController = LegacyCardReaderConnectionController(
             forSiteID: siteID,
             knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
             alertsProvider: CardReaderSettingsAlerts(),

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -1,0 +1,798 @@
+import Combine
+import Foundation
+import UIKit
+import Storage
+import SwiftUI
+import Yosemite
+
+/// Facilitates connecting to a card reader
+///
+final class CardReaderConnectionController {
+    private enum ControllerState {
+        /// Initial state of the controller
+        ///
+        case idle
+
+        /// Initializing (fetching payment gateway accounts)
+        ///
+        case initializing
+
+        /// Preparing for search (fetching the list of any known readers)
+        ///
+        case preparingForSearch
+
+        /// Begin search for card readers
+        ///
+        case beginSearch
+
+        /// Searching for a card reader
+        ///
+        case searching
+
+        /// Found one card reader
+        ///
+        case foundReader
+
+        /// Found two or more card readers
+        ///
+        case foundSeveralReaders
+
+        /// Attempting to connect to a card reader. The completion passed to `searchAndConnect`
+        /// will be called with a `success` `Bool` `True` result if successful, after which the view controller
+        /// passed to `searchAndConnect` will be dereferenced and the state set to `idle`
+        ///
+        case connectToReader
+
+        /// A failure occurred while connecting. The search may continue or be canceled. At this time we
+        /// do not present the detailed error from the service.
+        ///
+        case connectingFailed(Error)
+
+        /// A mandatory update is being installed
+        ///
+        case updating(progress: Float)
+
+        /// User chose to retry the connection to the card reader. Starts the search again, by dismissing modals and initializing from scratch
+        ///
+        case retry
+
+        /// User cancelled search/connecting to a card reader. The completion passed to `searchAndConnect`
+        /// will be called with a `success` `Bool` `False` result. The view controller passed to `searchAndConnect` will be
+        /// dereferenced and the state set to `idle`
+        ///
+        case cancel
+
+        /// A failure occurred. The completion passed to `searchAndConnect`
+        /// will be called with a `failure` result. The view controller passed to `searchAndConnect` will be
+        /// dereferenced and the state set to `idle`
+        ///
+        case discoveryFailed(Error)
+    }
+
+    /// The final state of the card reader connection to return without errors.
+    enum ConnectionResult {
+        case connected
+        case canceled
+    }
+
+    private let storageManager: StorageManagerType
+    private let stores: StoresManager
+
+    private var state: ControllerState {
+        didSet {
+            didSetState()
+        }
+    }
+    private weak var fromController: UIViewController?
+    private let siteID: Int64
+    private let knownCardReaderProvider: CardReaderSettingsKnownReaderProvider
+    private let alerts: CardReaderSettingsAlertsProvider
+    private let configuration: CardPresentPaymentsConfiguration
+
+    /// Reader(s) discovered by the card reader service
+    ///
+    private var foundReaders: [CardReader]
+
+    /// Reader(s) known to us (i.e. we've connected to them in the past)
+    ///
+    private var knownReaderID: String?
+
+    /// Reader(s) discovered by the card reader service that the merchant declined to connect to
+    ///
+    private var skippedReaderIDs: [String]
+
+    /// The reader we want the user to consider connecting to
+    ///
+    private var candidateReader: CardReader?
+
+    /// Tracks analytics for card reader connection events
+    ///
+    private let analyticsTracker: CardReaderConnectionAnalyticsTracker
+
+    /// Since the number of readers can go greater than 1 and then back to 1, and we don't
+    /// want to keep changing the UI from the several-readers-found list to a single prompt
+    /// and back (as this would be visually quite annoying), this flag will tell us that we've
+    /// already switched to list format for this discovery flow, so that stay in list mode
+    /// even if the number of found readers drops to less than 2
+    private var showSeveralFoundReaders: Bool = false
+
+    private var softwareUpdateCancelable: FallibleCancelable? = nil
+
+    private var subscriptions = Set<AnyCancellable>()
+
+    private var onCompletion: ((Result<ConnectionResult, Error>) -> Void)?
+
+    private(set) lazy var dataSource: CardReaderSettingsDataSource = {
+        return CardReaderSettingsDataSource(siteID: siteID, storageManager: storageManager)
+    }()
+
+    /// Gateway ID to include in tracks events
+    private var gatewayID: String? {
+        didSet {
+            didSetGatewayID()
+            analyticsTracker.setGatewayID(gatewayID: gatewayID)
+        }
+    }
+
+    init(
+        forSiteID: Int64,
+        storageManager: StorageManagerType = ServiceLocator.storageManager,
+        stores: StoresManager = ServiceLocator.stores,
+        knownReaderProvider: CardReaderSettingsKnownReaderProvider,
+        alertsProvider: CardReaderSettingsAlertsProvider,
+        configuration: CardPresentPaymentsConfiguration,
+        analyticsTracker: CardReaderConnectionAnalyticsTracker
+    ) {
+        siteID = forSiteID
+        self.storageManager = storageManager
+        self.stores = stores
+        state = .idle
+        knownCardReaderProvider = knownReaderProvider
+        alerts = alertsProvider
+        foundReaders = []
+        knownReaderID = nil
+        skippedReaderIDs = []
+        self.configuration = configuration
+        self.analyticsTracker = analyticsTracker
+
+        configureResultsControllers()
+        loadPaymentGatewayAccounts()
+    }
+
+    deinit {
+        subscriptions.removeAll()
+    }
+
+    func searchAndConnect(from: UIViewController?, onCompletion: @escaping (Result<ConnectionResult, Error>) -> Void) {
+        guard from != nil else {
+            return
+        }
+
+        self.fromController = from
+        self.onCompletion = onCompletion
+        self.state = .initializing
+    }
+}
+
+private extension CardReaderConnectionController {
+    func configureResultsControllers() {
+        dataSource.configureResultsControllers(onReload: { [weak self] in
+            guard let self = self else { return }
+            self.gatewayID = self.dataSource.cardPresentPaymentGatewayID()
+        })
+        // Sets gateway ID from initial fetch.
+        gatewayID = dataSource.cardPresentPaymentGatewayID()
+    }
+
+    func loadPaymentGatewayAccounts() {
+        let action = CardPresentPaymentAction.loadAccounts(siteID: siteID) {_ in}
+        stores.dispatch(action)
+    }
+
+    func didSetState() {
+        switch state {
+        case .idle:
+            onIdle()
+        case .initializing:
+            onInitialization()
+        case .preparingForSearch:
+            onPreparingForSearch()
+        case .beginSearch:
+            onBeginSearch()
+        case .searching:
+            onSearching()
+        case .foundReader:
+            onFoundReader()
+        case .foundSeveralReaders:
+            onFoundSeveralReaders()
+        case .retry:
+            onRetry()
+        case .cancel:
+            onCancel()
+        case .connectToReader:
+            onConnectToReader()
+        case .connectingFailed(let error):
+            onConnectingFailed(error: error)
+        case .discoveryFailed(let error):
+            onDiscoveryFailed(error: error)
+        case .updating(progress: let progress):
+            onUpdateProgress(progress: progress)
+        }
+    }
+
+    /// Once the gatewayID arrives (during initialization) it is OK to proceed with search preparations
+    ///
+    func didSetGatewayID() {
+        if case .initializing = state {
+            state = .preparingForSearch
+        }
+    }
+
+    /// To avoid presenting the "Do you want to connect to reader XXXX" prompt
+    /// repeatedly for the same reader, keep track of readers the user has tapped
+    /// "Keep Searching" for.
+    ///
+    /// If we have switched to the list view, however, don't prune
+    ///
+    func pruneSkippedReaders() {
+        guard !showSeveralFoundReaders else {
+            return
+        }
+        foundReaders = foundReaders.filter({!skippedReaderIDs.contains($0.id)})
+    }
+
+    /// Returns any found reader which is also known
+    ///
+    func getFoundKnownReader() -> CardReader? {
+        foundReaders.filter({knownReaderID == $0.id}).first
+    }
+
+    /// A helper to return an array of found reader IDs
+    ///
+    func getFoundReaderIDs() -> [String] {
+        foundReaders.compactMap({$0.id})
+    }
+
+    /// A helper to return a specific CardReader instance based on the reader ID
+    ///
+    func getFoundReaderByID(readerID: String) -> CardReader? {
+        foundReaders.first(where: {$0.id == readerID})
+    }
+
+    /// Updates the show multiple readers flag to indicate that, for this discovery flow,
+    /// we have already shown the multiple readers UI (so we don't switch back to the
+    /// single reader found UI for this particular discovery)
+    ///
+    func updateShowSeveralFoundReaders() {
+        if foundReaders.containsMoreThanOne {
+            showSeveralFoundReaders = true
+        }
+    }
+
+    /// Initial state of the controller
+    ///
+    func onIdle() {
+    }
+
+    /// Searching for a reader is about to begin. Wait, if needed, for the gateway ID to be provided from the FRC
+    ///
+    func onInitialization() {
+        if gatewayID != nil {
+            state = .preparingForSearch
+        }
+    }
+
+    /// In preparation for search, initiates a fetch for the list of known readers
+    /// Does NOT open any modal
+    /// Transitions state to `.beginSearch` after receiving the known readers list
+    ///
+    func onPreparingForSearch() {
+        /// Always start fresh - i.e. we haven't skipped connecting to any reader yet
+        ///
+        skippedReaderIDs = []
+        candidateReader = nil
+        showSeveralFoundReaders = false
+
+        /// Fetch the list of known readers - i.e. readers we should automatically connect to when we see them
+        ///
+        knownCardReaderProvider.knownReader.sink(receiveValue: { [weak self] readerID in
+            guard let self = self else {
+                return
+            }
+
+            self.knownReaderID = readerID
+
+            /// Only kick off search if we received a known reader update
+            if case .preparingForSearch = self.state {
+                self.state = .beginSearch
+            }
+        }).store(in: &subscriptions)
+    }
+
+    /// Begins the search for a card reader
+    /// Does NOT open any modal
+    /// Transitions state to `.searching`
+    /// Later, when a reader is found, state transitions to
+    /// `.foundReader` if one unknown reader is found,
+    /// `.foundMultipleReaders` if two or more readers are found,
+    /// or  to `.connectToReader` if one known reader is found
+    ///
+    func onBeginSearch() {
+        self.state = .searching
+        var didAutoAdvance = false
+
+        // TODO: make this a choice for the user, when the switch is enabled
+        let tapOnIphoneEnabled = ServiceLocator.generalAppSettings.settings.isTapToPayOnIPhoneSwitchEnabled
+        let discoveryMethod: CardReaderDiscoveryMethod = tapOnIphoneEnabled ? .localMobile : .bluetoothProximity
+
+        let action = CardPresentPaymentAction.startCardReaderDiscovery(
+            siteID: siteID,
+            discoveryMethod: discoveryMethod,
+            onReaderDiscovered: { [weak self] cardReaders in
+                guard let self = self else {
+                    return
+                }
+
+                /// Update our copy of the foundReaders, evaluate if we should switch to the list view,
+                /// and prune skipped ones
+                ///
+                self.foundReaders = cardReaders
+                self.updateShowSeveralFoundReaders()
+                self.pruneSkippedReaders()
+
+                /// Note: This completion will be called repeatedly as the list of readers
+                /// discovered changes, so some care around state must be taken here.
+                ///
+
+                /// If the found-several-readers view is already presenting, update its list of found readers
+                ///
+                if case .foundSeveralReaders = self.state {
+                    self.alerts.updateSeveralReadersList(readerIDs: self.getFoundReaderIDs())
+                }
+
+                /// To avoid interrupting connecting to a known reader, ensure we are
+                /// in the searching state before proceeding further
+                ///
+                guard case .searching = self.state else {
+                    return
+                }
+
+                /// If we have a known reader, and we haven't auto-advanced to connect
+                /// already, advance immediately to connect.
+                /// We only auto-advance once to avoid loops in case the known reader
+                /// is having connectivity issues (e.g low battery)
+                ///
+                if let foundKnownReader = self.getFoundKnownReader() {
+                    if !didAutoAdvance {
+                        didAutoAdvance = true
+                        self.candidateReader = foundKnownReader
+                        self.state = .connectToReader
+                        return
+                    }
+                }
+
+                /// If we have found multiple readers, advance to foundMultipleReaders
+                ///
+                if self.showSeveralFoundReaders {
+                    self.state = .foundSeveralReaders
+                    return
+                }
+
+                /// If we have a found reader, advance to foundReader
+                ///
+                if self.foundReaders.isNotEmpty {
+                    self.candidateReader = self.foundReaders.first
+                    self.state = .foundReader
+                    return
+                }
+            },
+            onError: { [weak self] error in
+                guard let self = self else { return }
+
+                ServiceLocator.analytics.track(
+                    event: WooAnalyticsEvent.InPersonPayments.cardReaderDiscoveryFailed(forGatewayID: self.gatewayID,
+                                                                                        error: error,
+                                                                                        countryCode: self.configuration.countryCode)
+                )
+                self.state = .discoveryFailed(error)
+            })
+
+        stores.dispatch(action)
+    }
+
+    /// Opens the scanning for reader modal
+    /// If the user cancels the modal will trigger a transition to `.endSearch`
+    ///
+    func onSearching() {
+        guard let from = fromController else {
+            return
+        }
+
+        /// If we enter this state and another reader was discovered while the
+        /// "Do you want to connect to" modal was being displayed and if that reader
+        /// is known and the merchant tapped keep searching on the first
+        /// (unknown) reader, auto-connect to that known reader
+        if let foundKnownReader = self.getFoundKnownReader() {
+            self.candidateReader = foundKnownReader
+            self.state = .connectToReader
+            return
+        }
+
+        /// If we already have found readers
+        /// display the list view if so enabled, or...
+        ///
+        if showSeveralFoundReaders {
+            self.state = .foundSeveralReaders
+            return
+        }
+
+        /// Display the single view and ask the merchant if they'd
+        /// like to connect to it
+        ///
+        if foundReaders.isNotEmpty {
+            self.candidateReader = foundReaders.first
+            self.state = .foundReader
+            return
+        }
+
+        /// If all else fails, display the "scanning" modal and
+        /// stay in this state
+        ///
+        alerts.scanningForReader(from: from, cancel: {
+            self.state = .cancel
+        })
+    }
+
+    /// A (unknown) reader has been found
+    /// Opens a confirmation modal for the user to accept the candidate reader (or keep searching)
+    ///
+    func onFoundReader() {
+        guard let candidateReader = candidateReader else {
+            return
+        }
+
+        guard let from = fromController else {
+            return
+        }
+
+        alerts.foundReader(
+            from: from,
+            name: candidateReader.id,
+            connect: {
+                self.state = .connectToReader
+            },
+            continueSearch: {
+                self.skippedReaderIDs.append(candidateReader.id)
+                self.candidateReader = nil
+                self.pruneSkippedReaders()
+                self.state = .searching
+            },
+            cancelSearch: { [weak self] in
+                self?.state = .cancel
+            })
+    }
+
+    /// Several readers have been found
+    /// Opens a continually updating list modal for the user to pick one (or cancel the search)
+    ///
+    func onFoundSeveralReaders() {
+        guard let from = fromController else {
+            return
+        }
+
+        alerts.foundSeveralReaders(
+            from: from,
+            readerIDs: getFoundReaderIDs(),
+            connect: { [weak self] readerID in
+                guard let self = self else {
+                    return
+                }
+                self.candidateReader = self.getFoundReaderByID(readerID: readerID)
+                self.state = .connectToReader
+            },
+            cancelSearch: { [weak self] in
+                self?.state = .cancel
+            }
+        )
+    }
+
+    /// A mandatory update is being installed
+    ///
+    func onUpdateProgress(progress: Float) {
+        guard let from = fromController else {
+            return
+        }
+
+        let cancel = softwareUpdateCancelable.map { cancelable in
+            return { [weak self] in
+                guard let self = self else { return }
+                self.state = .cancel
+                self.analyticsTracker.cardReaderSoftwareUpdateCancelTapped()
+                cancelable.cancel { [weak self] result in
+                    if case .failure(let error) = result {
+                        DDLogError("💳 Error: canceling software update \(error)")
+                    } else {
+                        self?.analyticsTracker.cardReaderSoftwareUpdateCanceled()
+                    }
+                }
+            }
+        }
+
+        alerts.updateProgress(from: from,
+                              requiredUpdate: true,
+                              progress: progress,
+                              cancel: cancel)
+    }
+
+    /// Retry a search for a card reader
+    ///
+    func onRetry() {
+        alerts.dismiss()
+        let action = CardPresentPaymentAction.cancelCardReaderDiscovery() { [weak self] _ in
+            self?.state = .beginSearch
+        }
+        stores.dispatch(action)
+    }
+
+    /// End the search for a card reader
+    ///
+    func onCancel() {
+        let action = CardPresentPaymentAction.cancelCardReaderDiscovery() { [weak self] _ in
+            self?.returnSuccess(result: .canceled)
+        }
+        stores.dispatch(action)
+    }
+
+    /// Connect to the candidate card reader
+    ///
+    func onConnectToReader() {
+        guard let candidateReader = candidateReader else {
+            return
+        }
+
+        guard let from = fromController else {
+            return
+        }
+
+        analyticsTracker.setCandidateReader(candidateReader)
+
+        let softwareUpdateAction = CardPresentPaymentAction.observeCardReaderUpdateState { [weak self] softwareUpdateEvents in
+            guard let self = self else { return }
+
+            softwareUpdateEvents.sink { [weak self] event in
+                guard let self = self else { return }
+
+                switch event {
+                case .started(cancelable: let cancelable):
+                    self.softwareUpdateCancelable = cancelable
+                    self.state = .updating(progress: 0)
+                case .installing(progress: let progress):
+                    if progress >= 0.995 {
+                        self.softwareUpdateCancelable = nil
+                    }
+                    self.state = .updating(progress: progress)
+                case .completed:
+                    self.softwareUpdateCancelable = nil
+                    self.state = .updating(progress: 1)
+                default:
+                    break
+                }
+            }
+            .store(in: &self.subscriptions)
+        }
+        stores.dispatch(softwareUpdateAction)
+
+        let action = CardPresentPaymentAction.connect(reader: candidateReader) { [weak self] result in
+            guard let self = self else { return }
+
+            self.analyticsTracker.setCandidateReader(nil)
+
+            switch result {
+            case .success(let reader):
+                self.knownCardReaderProvider.rememberCardReader(cardReaderID: reader.id)
+                ServiceLocator.analytics.track(
+                    event: WooAnalyticsEvent.InPersonPayments
+                        .cardReaderConnectionSuccess(forGatewayID: self.gatewayID,
+                                                     batteryLevel: reader.batteryLevel,
+                                                     countryCode: self.configuration.countryCode,
+                                                     cardReaderModel: reader.readerType.model)
+                )
+                // If we were installing a software update, introduce a small delay so the user can
+                // actually see a success message showing the installation was complete
+                if case .updating(progress: 1) = self.state {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
+                        self.returnSuccess(result: .connected)
+                    }
+                } else {
+                    self.returnSuccess(result: .connected)
+                }
+            case .failure(let error):
+                ServiceLocator.analytics.track(
+                    event: WooAnalyticsEvent.InPersonPayments.cardReaderConnectionFailed(forGatewayID: self.gatewayID,
+                                                                                         error: error,
+                                                                                         countryCode: self.configuration.countryCode,
+                                                                                         cardReaderModel: candidateReader.readerType.model)
+                )
+                self.state = .connectingFailed(error)
+            }
+        }
+        stores.dispatch(action)
+
+        alerts.connectingToReader(from: from)
+    }
+
+    /// An error occurred while connecting
+    ///
+    private func onConnectingFailed(error: Error) {
+        /// Clear our copy of found readers to avoid connecting to a reader that isn't
+        /// there while we wait for `onReaderDiscovered` to receive an update.
+        /// See also https://github.com/stripe/stripe-terminal-ios/issues/104#issuecomment-916285167
+        ///
+        self.foundReaders = []
+
+        if case CardReaderServiceError.softwareUpdate(underlyingError: let underlyingError, batteryLevel: _) = error,
+           underlyingError.isSoftwareUpdateError {
+            return onUpdateFailed(error: error)
+        }
+        showConnectionFailed(error: error)
+    }
+
+    private func onUpdateFailed(error: Error) {
+        guard let from = fromController,
+              case CardReaderServiceError.softwareUpdate(underlyingError: let underlyingError, batteryLevel: let batteryLevel) = error else {
+            return
+        }
+
+        switch underlyingError {
+        case .readerSoftwareUpdateFailedInterrupted:
+            // Update was cancelled, don't treat this as an error
+            return
+        case .readerSoftwareUpdateFailedBatteryLow:
+            alerts.updatingFailedLowBattery(
+                from: from,
+                batteryLevel: batteryLevel,
+                close: {
+                    self.state = .searching
+                }
+            )
+        default:
+            alerts.updatingFailed(
+                from: from,
+                tryAgain: nil,
+                close: {
+                    self.state = .searching
+                })
+        }
+    }
+
+    private func showConnectionFailed(error: Error) {
+        guard let from = fromController else {
+            return
+        }
+
+        let retrySearch = {
+            self.state = .retry
+        }
+
+        let continueSearch = {
+            self.state = .searching
+        }
+
+        let cancelSearch = {
+            self.state = .cancel
+        }
+
+        guard case CardReaderServiceError.connection(let underlyingError) = error else {
+            return alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
+        }
+
+        switch underlyingError {
+        case .incompleteStoreAddress(let adminUrl):
+            alerts.connectingFailedIncompleteAddress(from: from,
+                                                     openWCSettings: openWCSettingsAction(adminUrl: adminUrl,
+                                                                                          from: from,
+                                                                                          retrySearch: retrySearch),
+                                                     retrySearch: retrySearch,
+                                                     cancelSearch: cancelSearch)
+        case .invalidPostalCode:
+            alerts.connectingFailedInvalidPostalCode(from: from, retrySearch: retrySearch, cancelSearch: cancelSearch)
+        case .bluetoothConnectionFailedBatteryCriticallyLow:
+            alerts.connectingFailedCriticallyLowBattery(from: from, retrySearch: retrySearch, cancelSearch: cancelSearch)
+        default:
+            alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
+        }
+    }
+
+    private func openWCSettingsAction(adminUrl: URL?,
+                                      from viewController: UIViewController,
+                                      retrySearch: @escaping () -> Void) -> ((UIViewController) -> Void)? {
+        if let adminUrl = adminUrl {
+            if let site = stores.sessionManager.defaultSite,
+               site.isWordPressComStore {
+                return { [weak self] viewController in
+                    self?.openWCSettingsInWebview(url: adminUrl, from: viewController, retrySearch: retrySearch)
+                }
+            } else {
+                return { [weak self] _ in
+                    UIApplication.shared.open(adminUrl)
+                    self?.showIncompleteAddressErrorWithRefreshButton()
+                }
+            }
+        }
+        return nil
+    }
+    private func openWCSettingsInWebview(url adminUrl: URL,
+                                         from viewController: UIViewController,
+                                         retrySearch: @escaping () -> Void) {
+        let nav = NavigationView {
+            AuthenticatedWebView(isPresented: .constant(true),
+                                 url: adminUrl,
+                                 urlToTriggerExit: nil,
+                                 exitTrigger: nil)
+                                 .navigationTitle(Localization.adminWebviewTitle)
+                                 .navigationBarTitleDisplayMode(.inline)
+                                 .toolbar {
+                                     ToolbarItem(placement: .confirmationAction) {
+                                         Button(action: {
+                                             viewController.dismiss(animated: true) {
+                                                 retrySearch()
+                                             }
+                                         }, label: {
+                                             Text(Localization.doneButtonUpdateAddress)
+                                         })
+                                     }
+                                 }
+        }
+        .wooNavigationBarStyle()
+        let hostingController = UIHostingController(rootView: nav)
+        viewController.present(hostingController, animated: true, completion: nil)
+    }
+
+    private func showIncompleteAddressErrorWithRefreshButton() {
+        showConnectionFailed(error: CardReaderServiceError.connection(underlyingError: .incompleteStoreAddress(adminUrl: nil)))
+    }
+
+    /// An error occurred during discovery
+    /// Presents the error in a modal
+    ///
+    private func onDiscoveryFailed(error: Error) {
+        guard let from = fromController else {
+            return
+        }
+
+        alerts.scanningFailed(from: from, error: error) { [weak self] in
+            self?.returnFailure(error: error)
+        }
+    }
+
+    /// Calls the completion with a success result
+    ///
+    private func returnSuccess(result: ConnectionResult) {
+        onCompletion?(.success(result))
+        alerts.dismiss()
+        state = .idle
+    }
+
+    /// Calls the completion with a failure result
+    ///
+    private func returnFailure(error: Error) {
+        alerts.dismiss()
+        onCompletion?(.failure(error))
+        state = .idle
+    }
+}
+
+private extension CardReaderConnectionController {
+    enum Localization {
+        static let adminWebviewTitle = NSLocalizedString(
+            "WooCommerce Settings",
+            comment: "Navigation title of the webview which used by the merchant to update their store address"
+        )
+
+        static let doneButtonUpdateAddress = NSLocalizedString(
+            "Done",
+            comment: "The button title to indicate that the user has finished updating their store's address and is" +
+            "ready to close the webview. This also tries to connect to the reader again."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionController.swift
@@ -7,7 +7,7 @@ import Yosemite
 
 /// Facilitates connecting to a card reader
 ///
-final class CardReaderConnectionController {
+final class LegacyCardReaderConnectionController {
     private enum ControllerState {
         /// Initial state of the controller
         ///
@@ -174,7 +174,7 @@ final class CardReaderConnectionController {
     }
 }
 
-private extension CardReaderConnectionController {
+private extension LegacyCardReaderConnectionController {
     func configureResultsControllers() {
         dataSource.configureResultsControllers(onReload: { [weak self] in
             guard let self = self else { return }
@@ -782,7 +782,7 @@ private extension CardReaderConnectionController {
     }
 }
 
-private extension CardReaderConnectionController {
+private extension LegacyCardReaderConnectionController {
     enum Localization {
         static let adminWebviewTitle = NSLocalizedString(
             "WooCommerce Settings",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -12,12 +12,12 @@ final class CardReaderSettingsSearchingViewController: UIHostingController<CardR
 
     /// Connection Controller (helps connect readers)
     ///
-    private lazy var connectionController: CardReaderConnectionController? = {
+    private lazy var connectionController: LegacyCardReaderConnectionController? = {
         guard let viewModel = viewModel, let knownReaderProvider = viewModel.knownReaderProvider else {
             return nil
         }
 
-        return CardReaderConnectionController(
+        return LegacyCardReaderConnectionController(
             forSiteID: viewModel.siteID,
             knownReaderProvider: knownReaderProvider,
             alertsProvider: CardReaderSettingsAlerts(),

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
@@ -71,7 +71,7 @@ final class LegacyCollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProto
     /// Controller to connect a card reader.
     ///
     private lazy var connectionController = {
-        CardReaderConnectionController(forSiteID: siteID,
+        LegacyCardReaderConnectionController(forSiteID: siteID,
                                        knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
                                        alertsProvider: CardReaderSettingsAlerts(),
                                        configuration: configuration,

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -60,10 +60,10 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
     /// In-person refund orchestrator.
     private lazy var cardPresentRefundOrchestrator = CardPresentRefundOrchestrator(stores: stores)
 
-    /// Alert manager to inform merchants about card reader connection actions used in `CardReaderConnectionController`.
+    /// Alert manager to inform merchants about card reader connection actions used in `LegacyCardReaderConnectionController`.
     private let cardReaderConnectionAlerts: CardReaderSettingsAlertsProvider
 
-    /// Provides any known card reader to be used in `CardReaderConnectionController`.
+    /// Provides any known card reader to be used in `LegacyCardReaderConnectionController`.
     private let knownReaderProvider: CardReaderSettingsKnownReaderProvider
 
     /// Presents the card present onboarding flow, when required.
@@ -72,7 +72,7 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
 
     /// Controller to connect a card reader for in-person refund.
     private lazy var cardReaderConnectionController =
-    CardReaderConnectionController(forSiteID: order.siteID,
+    LegacyCardReaderConnectionController(forSiteID: order.siteID,
                                    storageManager: storageManager,
                                    stores: stores,
                                    knownReaderProvider: knownReaderProvider,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -486,6 +486,7 @@
 		03AA165E2719B7EF005CCB7B /* ReceiptActionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */; };
 		03AA16602719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */; };
 		03AFDE02282C0B82003B67CD /* InPersonPaymentsCompletedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */; };
+		03BB9EA5292E2D0C00251E9E /* CardReaderConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BB9EA4292E2D0C00251E9E /* CardReaderConnectionController.swift */; };
 		03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */; };
 		03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
 		03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */; };
@@ -2458,6 +2459,7 @@
 		03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinator.swift; sourceTree = "<group>"; };
 		03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinatorTests.swift; sourceTree = "<group>"; };
 		03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCompletedView.swift; sourceTree = "<group>"; };
+		03BB9EA4292E2D0C00251E9E /* CardReaderConnectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionController.swift; sourceTree = "<group>"; };
 		03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayCardBrand+IconsTests.swift"; sourceTree = "<group>"; };
 		03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift; sourceTree = "<group>"; };
 		03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift; sourceTree = "<group>"; };
@@ -8407,6 +8409,7 @@
 				D8815ADD26383EE600EDAD62 /* CardPresentPaymentsModalViewController.swift */,
 				037D270C28CA444F00A3F924 /* CardReaderModalFlowViewControllerProtocol.swift */,
 				D8815ADE26383EE700EDAD62 /* CardPresentPaymentsModalViewController.xib */,
+				03BB9EA4292E2D0C00251E9E /* CardReaderConnectionController.swift */,
 				31E6F21E26B3577800227E6F /* LegacyCardReaderConnectionController.swift */,
 				035DBA46292D0994003E5125 /* CardPresentPaymentPreflightController.swift */,
 				D8EE9690264D328A0033B2F9 /* ReceiptViewController.swift */,
@@ -9778,6 +9781,7 @@
 				024DF31E23743045006658FE /* TextList+AztecFormatting.swift in Sources */,
 				0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */,
 				DE4D308928507B5B00E36ADD /* CouponCreationSuccess.swift in Sources */,
+				03BB9EA5292E2D0C00251E9E /* CardReaderConnectionController.swift in Sources */,
 				B95112DA28BF79CA00D9578D /* PaymentsRoute.swift in Sources */,
 				7E6A019F2725CD76001668D5 /* FilterProductCategoryListViewModel.swift in Sources */,
 				CC53FB3C2757EC7200C4CA4F /* ProductSelectorViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -698,8 +698,8 @@
 		31B19B67263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B19B66263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift */; };
 		31C21FA426D9949000916E2E /* SeveralReadersFoundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C21FA326D9949000916E2E /* SeveralReadersFoundViewController.swift */; };
 		31C21FA626D994B700916E2E /* SeveralReadersFoundViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31C21FA526D994B700916E2E /* SeveralReadersFoundViewController.xib */; };
-		31E6F21F26B3577800227E6F /* CardReaderConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E6F21E26B3577800227E6F /* CardReaderConnectionController.swift */; };
-		31E906A326CC91A70099A985 /* CardReaderConnectionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E906A226CC91A70099A985 /* CardReaderConnectionControllerTests.swift */; };
+		31E6F21F26B3577800227E6F /* LegacyCardReaderConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E6F21E26B3577800227E6F /* LegacyCardReaderConnectionController.swift */; };
+		31E906A326CC91A70099A985 /* LegacyCardReaderConnectionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E906A226CC91A70099A985 /* LegacyCardReaderConnectionControllerTests.swift */; };
 		31EF399C26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EF399B26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift */; };
 		31F21B02263C8E150035B50A /* CardReaderSettingsSearchingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F21B01263C8E150035B50A /* CardReaderSettingsSearchingViewModelTests.swift */; };
 		31F21B5A263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F21B59263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift */; };
@@ -2665,8 +2665,8 @@
 		31B19B66263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsSearchingViewModel.swift; sourceTree = "<group>"; };
 		31C21FA326D9949000916E2E /* SeveralReadersFoundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeveralReadersFoundViewController.swift; sourceTree = "<group>"; };
 		31C21FA526D994B700916E2E /* SeveralReadersFoundViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SeveralReadersFoundViewController.xib; sourceTree = "<group>"; };
-		31E6F21E26B3577800227E6F /* CardReaderConnectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionController.swift; sourceTree = "<group>"; };
-		31E906A226CC91A70099A985 /* CardReaderConnectionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionControllerTests.swift; sourceTree = "<group>"; };
+		31E6F21E26B3577800227E6F /* LegacyCardReaderConnectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyCardReaderConnectionController.swift; sourceTree = "<group>"; };
+		31E906A226CC91A70099A985 /* LegacyCardReaderConnectionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyCardReaderConnectionControllerTests.swift; sourceTree = "<group>"; };
 		31EF399B26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsPrioritizedViewModelsProvider.swift; sourceTree = "<group>"; };
 		31F21B01263C8E150035B50A /* CardReaderSettingsSearchingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsSearchingViewModelTests.swift; sourceTree = "<group>"; };
 		31F21B59263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentPaymentsStoresManager.swift; sourceTree = "<group>"; };
@@ -8327,7 +8327,7 @@
 			children = (
 				E12AF69A26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift */,
 				D810F8F72639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift */,
-				31E906A226CC91A70099A985 /* CardReaderConnectionControllerTests.swift */,
+				31E906A226CC91A70099A985 /* LegacyCardReaderConnectionControllerTests.swift */,
 				26100B1F2722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift */,
 				03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */,
 				03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */,
@@ -8407,7 +8407,7 @@
 				D8815ADD26383EE600EDAD62 /* CardPresentPaymentsModalViewController.swift */,
 				037D270C28CA444F00A3F924 /* CardReaderModalFlowViewControllerProtocol.swift */,
 				D8815ADE26383EE700EDAD62 /* CardPresentPaymentsModalViewController.xib */,
-				31E6F21E26B3577800227E6F /* CardReaderConnectionController.swift */,
+				31E6F21E26B3577800227E6F /* LegacyCardReaderConnectionController.swift */,
 				035DBA46292D0994003E5125 /* CardPresentPaymentPreflightController.swift */,
 				D8EE9690264D328A0033B2F9 /* ReceiptViewController.swift */,
 				D8EE9691264D328A0033B2F9 /* ReceiptViewController.xib */,
@@ -10692,7 +10692,7 @@
 				DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,
 				4572641927F1EB27004E1F95 /* AddEditCouponViewModel.swift in Sources */,
-				31E6F21F26B3577800227E6F /* CardReaderConnectionController.swift in Sources */,
+				31E6F21F26B3577800227E6F /* LegacyCardReaderConnectionController.swift in Sources */,
 				02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */,
 				03FBDAF2263EE47C00ACE257 /* CouponListViewModel.swift in Sources */,
 				26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */,
@@ -10842,7 +10842,7 @@
 				02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */,
 				DE2BF4FD2846192B00FBE68A /* CouponAllowedEmailsViewModelTests.swift in Sources */,
 				FEEB2F6E268A2F7B0075A6E0 /* RoleEligibilityUseCaseTests.swift in Sources */,
-				31E906A326CC91A70099A985 /* CardReaderConnectionControllerTests.swift in Sources */,
+				31E906A326CC91A70099A985 /* LegacyCardReaderConnectionControllerTests.swift in Sources */,
 				02AB40822784297C00929CF3 /* ProductTableViewCellViewModelTests.swift in Sources */,
 				02829BAA288FA8B300951E1E /* MockUserNotification.swift in Sources */,
 				D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionControllerTests.swift
@@ -4,7 +4,7 @@ import Storage
 import Yosemite
 @testable import WooCommerce
 
-final class CardReaderConnectionControllerTests: XCTestCase {
+final class LegacyCardReaderConnectionControllerTests: XCTestCase {
     /// Dummy Site ID
     ///
     private let sampleSiteID: Int64 = 1234
@@ -42,7 +42,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         let mockPresentingViewController = UIViewController()
         let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
         let mockAlerts = MockCardReaderSettingsAlerts(mode: .cancelScanning)
-        let controller = CardReaderConnectionController(
+        let controller = LegacyCardReaderConnectionController(
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
@@ -53,7 +53,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         )
 
         // When
-        let connectionResult: CardReaderConnectionController.ConnectionResult = waitFor { promise in
+        let connectionResult: LegacyCardReaderConnectionController.ConnectionResult = waitFor { promise in
             controller.searchAndConnect(from: mockPresentingViewController) { result in
                 XCTAssertTrue(result.isSuccess)
                 if case .success(let connectionResult) = result {
@@ -78,7 +78,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         let mockPresentingViewController = UIViewController()
         let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
         let mockAlerts = MockCardReaderSettingsAlerts(mode: .connectFoundReader)
-        let controller = CardReaderConnectionController(
+        let controller = LegacyCardReaderConnectionController(
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
@@ -89,7 +89,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         )
 
         // When
-        let connectionResult: CardReaderConnectionController.ConnectionResult = waitFor { promise in
+        let connectionResult: LegacyCardReaderConnectionController.ConnectionResult = waitFor { promise in
             controller.searchAndConnect(from: mockPresentingViewController) { result in
                 if case .success(let connectionResult) = result {
                     promise(connectionResult)
@@ -121,7 +121,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         let mockPresentingViewController = UIViewController()
         let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: knownReader.id)
         let mockAlerts = MockCardReaderSettingsAlerts(mode: .connectFoundReader)
-        let controller = CardReaderConnectionController(
+        let controller = LegacyCardReaderConnectionController(
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
@@ -132,7 +132,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         )
 
         // When
-        let connectionResult: CardReaderConnectionController.ConnectionResult = waitFor { promise in
+        let connectionResult: LegacyCardReaderConnectionController.ConnectionResult = waitFor { promise in
             controller.searchAndConnect(from: mockPresentingViewController) { result in
                 if case .success(let connectionResult) = result {
                     promise(connectionResult)
@@ -159,7 +159,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         let mockPresentingViewController = UIViewController()
         let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
         let mockAlerts = MockCardReaderSettingsAlerts(mode: .closeScanFailure)
-        let controller = CardReaderConnectionController(
+        let controller = LegacyCardReaderConnectionController(
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
@@ -196,7 +196,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         let mockPresentingViewController = UIViewController()
         let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
         let mockAlerts = MockCardReaderSettingsAlerts(mode: .cancelFoundSeveral)
-        let controller = CardReaderConnectionController(
+        let controller = LegacyCardReaderConnectionController(
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
@@ -207,7 +207,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         )
 
         // When
-        let connectionResult: CardReaderConnectionController.ConnectionResult = waitFor { promise in
+        let connectionResult: LegacyCardReaderConnectionController.ConnectionResult = waitFor { promise in
             controller.searchAndConnect(from: mockPresentingViewController) { result in
                 if case .success(let connectionResult) = result {
                     promise(connectionResult)
@@ -235,7 +235,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
         let mockAlerts = MockCardReaderSettingsAlerts(mode: .cancelSearchingAfterConnectionFailure)
 
-        let controller = CardReaderConnectionController(
+        let controller = LegacyCardReaderConnectionController(
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
@@ -246,7 +246,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         )
 
         // When
-        let connectionResult: CardReaderConnectionController.ConnectionResult = waitFor { promise in
+        let connectionResult: LegacyCardReaderConnectionController.ConnectionResult = waitFor { promise in
             controller.searchAndConnect(from: mockPresentingViewController) { result in
                 if case .success(let connectionResult) = result {
                     promise(connectionResult)
@@ -279,7 +279,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
         let mockAlerts = MockCardReaderSettingsAlerts(mode: .cancelSearchingAfterConnectionFailure)
 
-        let controller = CardReaderConnectionController(
+        let controller = LegacyCardReaderConnectionController(
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
@@ -290,7 +290,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         )
 
         // When
-        let connectionResult: CardReaderConnectionController.ConnectionResult = waitFor { promise in
+        let connectionResult: LegacyCardReaderConnectionController.ConnectionResult = waitFor { promise in
             controller.searchAndConnect(from: mockPresentingViewController) { result in
                 if case .success(let connectionResult) = result {
                     promise(connectionResult)
@@ -315,7 +315,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
         let mockAlerts = MockCardReaderSettingsAlerts(mode: .connectFirstFound)
 
-        let controller = CardReaderConnectionController(
+        let controller = LegacyCardReaderConnectionController(
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
@@ -326,7 +326,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         )
 
         // When
-        let connectionResult: CardReaderConnectionController.ConnectionResult = waitFor { promise in
+        let connectionResult: LegacyCardReaderConnectionController.ConnectionResult = waitFor { promise in
             controller.searchAndConnect(from: mockPresentingViewController) { result in
                 if case .success(let connectionResult) = result {
                     promise(connectionResult)
@@ -354,7 +354,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
         let mockAlerts = MockCardReaderSettingsAlerts(mode: .continueSearchingAfterConnectionFailure)
 
-        let controller = CardReaderConnectionController(
+        let controller = LegacyCardReaderConnectionController(
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
@@ -365,7 +365,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         )
 
         // When
-        let connectionResult: CardReaderConnectionController.ConnectionResult = waitFor { promise in
+        let connectionResult: LegacyCardReaderConnectionController.ConnectionResult = waitFor { promise in
             controller.searchAndConnect(from: mockPresentingViewController) { result in
                 if case .success(let connectionResult) = result {
                     promise(connectionResult)
@@ -393,7 +393,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
         let mockAlerts = MockCardReaderSettingsAlerts(mode: .continueSearchingAfterConnectionFailure)
 
-        let controller = CardReaderConnectionController(
+        let controller = LegacyCardReaderConnectionController(
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
@@ -404,7 +404,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         )
 
         // When
-        let connectionResult: CardReaderConnectionController.ConnectionResult = waitFor { promise in
+        let connectionResult: LegacyCardReaderConnectionController.ConnectionResult = waitFor { promise in
             controller.searchAndConnect(from: mockPresentingViewController) { result in
                 if case .success(let connectionResult) = result {
                     promise(connectionResult)
@@ -430,7 +430,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         let mockPresentingViewController = UIViewController()
         let mockKnownReaderProvider = MockKnownReaderProvider(knownReader: nil)
         let mockAlerts = MockCardReaderSettingsAlerts(mode: .cancelFoundReader)
-        let controller = CardReaderConnectionController(
+        let controller = LegacyCardReaderConnectionController(
             forSiteID: sampleSiteID,
             storageManager: storageManager,
             knownReaderProvider: mockKnownReaderProvider,
@@ -441,7 +441,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         )
 
         // When
-        let connectionResult: CardReaderConnectionController.ConnectionResult = waitFor { promise in
+        let connectionResult: LegacyCardReaderConnectionController.ConnectionResult = waitFor { promise in
             controller.searchAndConnect(from: mockPresentingViewController) { result in
                 if case .success(let connectionResult) = result {
                     promise(connectionResult)
@@ -454,7 +454,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
     }
 }
 
-private extension CardReaderConnectionControllerTests {
+private extension LegacyCardReaderConnectionControllerTests {
     enum Mocks {
         static let configuration = CardPresentPaymentsConfiguration(country: "US")
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of : #8080 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In sTAP Away, we will add a screen at the start of the card reader connection flow for users with supporting hardware to choose whether to connect a bluetooth reader, or use the built in card reader.

To achieve this, we will have separate connection controllers, one for each type of reader which is specialised to connect to a particular type of reader.

This PR duplicates the existing `CardReaderConnectionController`, renames the current one `LegacyCardReaderConnectionController`, and puts us in a position to start refactoring it.

There are no effective code changes in this PR. Apologies for the length, but it is primarily a copy-paste.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Check unit tests pass
Check you can take a payment with the feature toggle off, and that `LegacyCardReaderConnectionController.searchAndConnect()` is used there (use a breakpoint to check this)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
