### PR TITLE
[Mobile Payments] Remove viewController from CardReaderConnectionController

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -20,9 +20,9 @@ final class CardPresentPaymentPreflightController {
     ///
     private let configuration: CardPresentPaymentsConfiguration
 
-    /// View Controller used to present alerts.
+    /// Alerts presenter to send alert view models
     ///
-    private var rootViewController: UIViewController
+    private var alertsPresenter: CardPresentPaymentAlertsPresenting
 
     /// Stores manager.
     ///
@@ -38,7 +38,7 @@ final class CardPresentPaymentPreflightController {
 
     /// Controller to connect a card reader.
     ///
-    private var connectionController: LegacyCardReaderConnectionController
+    private var connectionController: CardReaderConnectionController
 
 
     private(set) var readerConnection = CurrentValueSubject<CardReaderConnectionResult?, Never>(nil)
@@ -46,13 +46,13 @@ final class CardPresentPaymentPreflightController {
     init(siteID: Int64,
          paymentGatewayAccount: PaymentGatewayAccount,
          configuration: CardPresentPaymentsConfiguration,
-         rootViewController: UIViewController,
+         alertsPresenter: CardPresentPaymentAlertsPresenting,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.paymentGatewayAccount = paymentGatewayAccount
         self.configuration = configuration
-        self.rootViewController = rootViewController
+        self.alertsPresenter = alertsPresenter
         self.stores = stores
         self.analytics = analytics
         self.connectedReader = nil
@@ -60,10 +60,10 @@ final class CardPresentPaymentPreflightController {
                                                                     stores: stores,
                                                                     analytics: analytics)
         // TODO: Replace this with a refactored (New)LegacyCardReaderConnectionController
-        self.connectionController = LegacyCardReaderConnectionController(
+        self.connectionController = CardReaderConnectionController(
             forSiteID: siteID,
             knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
-            alertsProvider: CardReaderSettingsAlerts(),
+            alertsPresenter: alertsPresenter,
             configuration: configuration,
             analyticsTracker: analyticsTracker)
     }
@@ -81,7 +81,7 @@ final class CardPresentPaymentPreflightController {
         // TODO: Ask for a Reader type if supported by device
 
         // Attempt to find a reader and connect
-        connectionController.searchAndConnect(from: rootViewController) { result in
+        connectionController.searchAndConnect { result in
             let connectionResult = result.map { connection in
                 switch connection {
                 case .connected:

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -83,10 +83,10 @@ final class CardReaderConnectionController {
             didSetState()
         }
     }
-    private weak var fromController: UIViewController?
+
     private let siteID: Int64
     private let knownCardReaderProvider: CardReaderSettingsKnownReaderProvider
-    private let alerts: CardReaderSettingsAlertsProvider
+    private let alertsPresenter: CardPresentPaymentAlertsPresenting
     private let configuration: CardPresentPaymentsConfiguration
 
     /// Reader(s) discovered by the card reader service
@@ -139,7 +139,7 @@ final class CardReaderConnectionController {
         storageManager: StorageManagerType = ServiceLocator.storageManager,
         stores: StoresManager = ServiceLocator.stores,
         knownReaderProvider: CardReaderSettingsKnownReaderProvider,
-        alertsProvider: CardReaderSettingsAlertsProvider,
+        alertsPresenter: CardPresentPaymentAlertsPresenting,
         configuration: CardPresentPaymentsConfiguration,
         analyticsTracker: CardReaderConnectionAnalyticsTracker
     ) {
@@ -148,7 +148,7 @@ final class CardReaderConnectionController {
         self.stores = stores
         state = .idle
         knownCardReaderProvider = knownReaderProvider
-        alerts = alertsProvider
+        self.alertsPresenter = alertsPresenter
         foundReaders = []
         knownReaderID = nil
         skippedReaderIDs = []
@@ -163,12 +163,7 @@ final class CardReaderConnectionController {
         subscriptions.removeAll()
     }
 
-    func searchAndConnect(from: UIViewController?, onCompletion: @escaping (Result<ConnectionResult, Error>) -> Void) {
-        guard from != nil else {
-            return
-        }
-
-        self.fromController = from
+    func searchAndConnect(onCompletion: @escaping (Result<ConnectionResult, Error>) -> Void) {
         self.onCompletion = onCompletion
         self.state = .initializing
     }
@@ -347,7 +342,7 @@ private extension CardReaderConnectionController {
                 /// If the found-several-readers view is already presenting, update its list of found readers
                 ///
                 if case .foundSeveralReaders = self.state {
-                    self.alerts.updateSeveralReadersList(readerIDs: self.getFoundReaderIDs())
+                    self.alertsPresenter.updateSeveralReadersList(readerIDs: self.getFoundReaderIDs())
                 }
 
                 /// To avoid interrupting connecting to a known reader, ensure we are
@@ -404,10 +399,6 @@ private extension CardReaderConnectionController {
     /// If the user cancels the modal will trigger a transition to `.endSearch`
     ///
     func onSearching() {
-        guard let from = fromController else {
-            return
-        }
-
         /// If we enter this state and another reader was discovered while the
         /// "Do you want to connect to" modal was being displayed and if that reader
         /// is known and the merchant tapped keep searching on the first
@@ -438,9 +429,9 @@ private extension CardReaderConnectionController {
         /// If all else fails, display the "scanning" modal and
         /// stay in this state
         ///
-        alerts.scanningForReader(from: from, cancel: {
+        alertsPresenter.present(viewModel: CardPresentModalScanningForReader(cancel: {
             self.state = .cancel
-        })
+        }))
     }
 
     /// A (unknown) reader has been found
@@ -451,37 +442,28 @@ private extension CardReaderConnectionController {
             return
         }
 
-        guard let from = fromController else {
-            return
-        }
-
-        alerts.foundReader(
-            from: from,
-            name: candidateReader.id,
-            connect: {
-                self.state = .connectToReader
-            },
-            continueSearch: {
-                self.skippedReaderIDs.append(candidateReader.id)
-                self.candidateReader = nil
-                self.pruneSkippedReaders()
-                self.state = .searching
-            },
-            cancelSearch: { [weak self] in
-                self?.state = .cancel
-            })
+        alertsPresenter.present(
+            viewModel: CardPresentModalFoundReader(
+                name: candidateReader.id,
+                connect: {
+                    self.state = .connectToReader
+                },
+                continueSearch: {
+                    self.skippedReaderIDs.append(candidateReader.id)
+                    self.candidateReader = nil
+                    self.pruneSkippedReaders()
+                    self.state = .searching
+                },
+                cancel: { [weak self] in
+                    self?.state = .cancel
+                }))
     }
 
     /// Several readers have been found
     /// Opens a continually updating list modal for the user to pick one (or cancel the search)
     ///
     func onFoundSeveralReaders() {
-        guard let from = fromController else {
-            return
-        }
-
-        alerts.foundSeveralReaders(
-            from: from,
+        alertsPresenter.foundSeveralReaders(
             readerIDs: getFoundReaderIDs(),
             connect: { [weak self] readerID in
                 guard let self = self else {
@@ -499,10 +481,6 @@ private extension CardReaderConnectionController {
     /// A mandatory update is being installed
     ///
     func onUpdateProgress(progress: Float) {
-        guard let from = fromController else {
-            return
-        }
-
         let cancel = softwareUpdateCancelable.map { cancelable in
             return { [weak self] in
                 guard let self = self else { return }
@@ -518,16 +496,16 @@ private extension CardReaderConnectionController {
             }
         }
 
-        alerts.updateProgress(from: from,
-                              requiredUpdate: true,
-                              progress: progress,
-                              cancel: cancel)
+        alertsPresenter.present(
+            viewModel: CardPresentModalUpdateProgress(requiredUpdate: true,
+                                                      progress: progress,
+                                                      cancel: cancel))
     }
 
     /// Retry a search for a card reader
     ///
     func onRetry() {
-        alerts.dismiss()
+        alertsPresenter.dismiss()
         let action = CardPresentPaymentAction.cancelCardReaderDiscovery() { [weak self] _ in
             self?.state = .beginSearch
         }
@@ -547,10 +525,6 @@ private extension CardReaderConnectionController {
     ///
     func onConnectToReader() {
         guard let candidateReader = candidateReader else {
-            return
-        }
-
-        guard let from = fromController else {
             return
         }
 
@@ -618,7 +592,7 @@ private extension CardReaderConnectionController {
         }
         stores.dispatch(action)
 
-        alerts.connectingToReader(from: from)
+        alertsPresenter.present(viewModel: CardPresentModalConnectingToReader())
     }
 
     /// An error occurred while connecting
@@ -638,8 +612,7 @@ private extension CardReaderConnectionController {
     }
 
     private func onUpdateFailed(error: Error) {
-        guard let from = fromController,
-              case CardReaderServiceError.softwareUpdate(underlyingError: let underlyingError, batteryLevel: let batteryLevel) = error else {
+        guard case CardReaderServiceError.softwareUpdate(underlyingError: let underlyingError, batteryLevel: let batteryLevel) = error else {
             return
         }
 
@@ -648,28 +621,20 @@ private extension CardReaderConnectionController {
             // Update was cancelled, don't treat this as an error
             return
         case .readerSoftwareUpdateFailedBatteryLow:
-            alerts.updatingFailedLowBattery(
-                from: from,
-                batteryLevel: batteryLevel,
-                close: {
-                    self.state = .searching
-                }
-            )
+            alertsPresenter.present(
+                viewModel: CardPresentModalUpdateFailedLowBattery(batteryLevel: batteryLevel,
+                                                                  close: {
+                                                                      self.state = .searching
+                                                                  }))
         default:
-            alerts.updatingFailed(
-                from: from,
-                tryAgain: nil,
-                close: {
+            alertsPresenter.present(
+                viewModel: CardPresentModalUpdateFailedNonRetryable(close: {
                     self.state = .searching
-                })
+                }))
         }
     }
 
     private func showConnectionFailed(error: Error) {
-        guard let from = fromController else {
-            return
-        }
-
         let retrySearch = {
             self.state = .retry
         }
@@ -683,28 +648,37 @@ private extension CardReaderConnectionController {
         }
 
         guard case CardReaderServiceError.connection(let underlyingError) = error else {
-            return alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
+            return alertsPresenter.present(
+                viewModel: CardPresentModalConnectingFailed(continueSearch: continueSearch, cancelSearch: cancelSearch))
         }
 
         switch underlyingError {
         case .incompleteStoreAddress(let adminUrl):
-            alerts.connectingFailedIncompleteAddress(from: from,
-                                                     openWCSettings: openWCSettingsAction(adminUrl: adminUrl,
-                                                                                          from: from,
-                                                                                          retrySearch: retrySearch),
-                                                     retrySearch: retrySearch,
-                                                     cancelSearch: cancelSearch)
+            alertsPresenter.present(
+                viewModel: CardPresentModalConnectingFailedUpdateAddress(
+                    openWCSettings: openWCSettingsAction(adminUrl: adminUrl,
+                                                         retrySearch: retrySearch),
+                    retrySearch: retrySearch,
+                    cancelSearch: cancelSearch))
         case .invalidPostalCode:
-            alerts.connectingFailedInvalidPostalCode(from: from, retrySearch: retrySearch, cancelSearch: cancelSearch)
+            alertsPresenter.present(
+                viewModel: CardPresentModalConnectingFailedUpdatePostalCode(
+                    retrySearch: retrySearch,
+                    cancelSearch: cancelSearch))
         case .bluetoothConnectionFailedBatteryCriticallyLow:
-            alerts.connectingFailedCriticallyLowBattery(from: from, retrySearch: retrySearch, cancelSearch: cancelSearch)
+            alertsPresenter.present(
+                viewModel: CardPresentModalConnectingFailedChargeReader(
+                    retrySearch: retrySearch,
+                    cancelSearch: cancelSearch))
         default:
-            alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
+            alertsPresenter.present(
+                viewModel: CardPresentModalConnectingFailed(
+                    continueSearch: continueSearch,
+                    cancelSearch: cancelSearch))
         }
     }
 
     private func openWCSettingsAction(adminUrl: URL?,
-                                      from viewController: UIViewController,
                                       retrySearch: @escaping () -> Void) -> ((UIViewController) -> Void)? {
         if let adminUrl = adminUrl {
             if let site = stores.sessionManager.defaultSite,
@@ -756,27 +730,24 @@ private extension CardReaderConnectionController {
     /// Presents the error in a modal
     ///
     private func onDiscoveryFailed(error: Error) {
-        guard let from = fromController else {
-            return
-        }
-
-        alerts.scanningFailed(from: from, error: error) { [weak self] in
+        alertsPresenter.present(
+            viewModel: CardPresentModalScanningFailed(error: error) { [weak self] in
             self?.returnFailure(error: error)
-        }
+        })
     }
 
     /// Calls the completion with a success result
     ///
     private func returnSuccess(result: ConnectionResult) {
         onCompletion?(.success(result))
-        alerts.dismiss()
+        alertsPresenter.dismiss()
         state = .idle
     }
 
     /// Calls the completion with a failure result
     ///
     private func returnFailure(error: Error) {
-        alerts.dismiss()
+        alertsPresenter.dismiss()
         onCompletion?(.failure(error))
         state = .idle
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentAlertsPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentAlertsPresenter.swift
@@ -1,0 +1,126 @@
+import Foundation
+import UIKit
+
+protocol CardPresentPaymentAlertsPresenting {
+    func present(viewModel: CardPresentPaymentsModalViewModel)
+    func foundSeveralReaders(readerIDs: [String],
+                             connect: @escaping (String) -> Void,
+                             cancelSearch: @escaping () -> Void)
+    func updateSeveralReadersList(readerIDs: [String])
+    func dismiss()
+}
+
+final class CardPresentPaymentAlertsPresenter: CardPresentPaymentAlertsPresenting {
+    private var modalController: CardPresentPaymentsModalViewController?
+    private var severalFoundController: SeveralReadersFoundViewController?
+
+    let rootViewController: UIViewController
+
+    init(rootViewController: UIViewController) {
+        self.rootViewController = rootViewController
+    }
+
+    func present(viewModel: CardPresentPaymentsModalViewModel) {
+        setViewModelAndPresent(from: rootViewController, viewModel: viewModel)
+    }
+
+    private func setViewModelAndPresent(from: UIViewController, viewModel: CardPresentPaymentsModalViewModel) {
+        guard modalController == nil else {
+            modalController?.setViewModel(viewModel)
+            return
+        }
+
+        modalController = CardPresentPaymentsModalViewController(viewModel: viewModel)
+        guard let modalController = modalController else {
+            return
+        }
+
+        modalController.prepareForCardReaderModalFlow()
+
+        dismissSeveralFoundAndPresent(animated: true, from: from, present: modalController)
+    }
+
+    /// Dismisses any view controller based on `CardPresentPaymentsModalViewController`,
+    /// then presents any `SeveralReadersFoundViewController` passed to it
+    ///
+    private func dismissCommonAndPresent(animated: Bool = true, from: UIViewController? = nil, present: SeveralReadersFoundViewController? = nil) {
+        /// Dismiss any common modal
+        ///
+        guard modalController == nil else {
+            let shouldAnimateDismissal = animated && present == nil
+            modalController?.dismiss(animated: shouldAnimateDismissal, completion: { [weak self] in
+                self?.modalController = nil
+                guard let from = from, let present = present else {
+                    return
+                }
+                from.present(present, animated: false)
+            })
+            return
+        }
+
+        /// Or, if there was no common modal to dismiss, present straight-away
+        ///
+        guard let from = from, let present = present else {
+            return
+        }
+        from.present(present, animated: animated)
+    }
+
+    /// Dismisses the `SeveralReadersFoundViewController`, then presents any
+    /// `CardPresentPaymentsModalViewController` passed to it.
+    ///
+    func dismissSeveralFoundAndPresent(animated: Bool = true, from: UIViewController? = nil, present: CardPresentPaymentsModalViewController? = nil) {
+        guard severalFoundController == nil else {
+            let shouldAnimateDismissal = animated && present == nil
+            severalFoundController?.dismiss(animated: shouldAnimateDismissal, completion: { [weak self] in
+                self?.severalFoundController = nil
+                guard let from = from, let present = present else {
+                    return
+                }
+                from.present(present, animated: false)
+            })
+            return
+        }
+        /// Or, if there was no several-found modal to dismiss, present straight-away
+        ///
+        guard let from = from, let present = present else {
+            return
+        }
+        from.present(present, animated: animated)
+    }
+
+    /// Note: `foundSeveralReaders` uses a view controller distinct from the common
+    /// `CardPresentPaymentsModalViewController` to avoid further
+    /// overloading `CardPresentPaymentsModalViewModel`
+    ///
+    /// This will dismiss any view controllers using the common view model first before
+    /// presenting the several readers found modal
+    ///
+    func foundSeveralReaders(readerIDs: [String],
+                             connect: @escaping (String) -> Void,
+                             cancelSearch: @escaping () -> Void) {
+        severalFoundController = SeveralReadersFoundViewController()
+
+        if let severalFoundController = severalFoundController {
+            severalFoundController.configureController(
+                readerIDs: readerIDs,
+                connect: connect,
+                cancelSearch: cancelSearch
+            )
+            severalFoundController.prepareForCardReaderModalFlow()
+        }
+
+        dismissCommonAndPresent(animated: false, from: rootViewController, present: severalFoundController)
+    }
+
+    /// Used to update the readers list in the several readers found view
+    ///
+    func updateSeveralReadersList(readerIDs: [String]) {
+        severalFoundController?.updateReaderIDs(readerIDs: readerIDs)
+    }
+
+    func dismiss() {
+        dismissCommonAndPresent(animated: true)
+        dismissSeveralFoundAndPresent(animated: true)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -64,7 +64,11 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
 
     /// View Controller used to present alerts.
     ///
-    private var rootViewController: UIViewController
+    private let rootViewController: UIViewController
+
+    /// Alerts presenter: alerts from the various parts of the payment process are forwarded here
+    ///
+    private let alertsPresenter: CardPresentPaymentAlertsPresenting
 
     /// Stores the card reader listener subscription while trying to connect to one.
     ///
@@ -104,6 +108,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
         self.formattedAmount = formattedAmount
         self.paymentGatewayAccount = paymentGatewayAccount
         self.rootViewController = rootViewController
+        self.alertsPresenter = CardPresentPaymentAlertsPresenter(rootViewController: rootViewController)
         self.alerts = alerts
         self.configuration = configuration
         self.stores = stores
@@ -135,7 +140,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
         let preflightController = CardPresentPaymentPreflightController(siteID: siteID,
                                                                         paymentGatewayAccount: paymentGatewayAccount,
                                                                         configuration: configuration,
-                                                                        rootViewController: rootViewController)
+                                                                        alertsPresenter: alertsPresenter)
         preflightController.readerConnection.sink { [weak self] connectionResult in
             guard let self = self else { return }
             switch connectionResult {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -463,6 +463,7 @@
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
 		035DBA45292D0164003E5125 /* CollectOrderPaymentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035DBA44292D0163003E5125 /* CollectOrderPaymentUseCase.swift */; };
 		035DBA47292D0995003E5125 /* CardPresentPaymentPreflightController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035DBA46292D0994003E5125 /* CardPresentPaymentPreflightController.swift */; };
+		035DBA4B292E248C003E5125 /* CardPresentPaymentAlertsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035DBA4A292E248C003E5125 /* CardPresentPaymentAlertsPresenter.swift */; };
 		035F2308275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */; };
 		0366EAE12909A37800B51755 /* JustInTimeMessageAnnouncementCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0366EAE02909A37800B51755 /* JustInTimeMessageAnnouncementCardViewModel.swift */; };
 		036CA6B9291E8D4B00E4DF4F /* CardPresentModalPreparingReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036CA6B8291E8D4B00E4DF4F /* CardPresentModalPreparingReader.swift */; };
@@ -2436,6 +2437,7 @@
 		035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdateTypeProperty.swift; sourceTree = "<group>"; };
 		035DBA44292D0163003E5125 /* CollectOrderPaymentUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectOrderPaymentUseCase.swift; sourceTree = "<group>"; };
 		035DBA46292D0994003E5125 /* CardPresentPaymentPreflightController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentPreflightController.swift; sourceTree = "<group>"; };
+		035DBA4A292E248C003E5125 /* CardPresentPaymentAlertsPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentAlertsPresenter.swift; sourceTree = "<group>"; };
 		035F2307275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectingFailedUpdatePostalCode.swift; sourceTree = "<group>"; };
 		0366EAE02909A37800B51755 /* JustInTimeMessageAnnouncementCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessageAnnouncementCardViewModel.swift; sourceTree = "<group>"; };
 		036CA6B8291E8D4B00E4DF4F /* CardPresentModalPreparingReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalPreparingReader.swift; sourceTree = "<group>"; };
@@ -5338,6 +5340,7 @@
 			isa = PBXGroup;
 			children = (
 				035DBA44292D0163003E5125 /* CollectOrderPaymentUseCase.swift */,
+				035DBA4A292E248C003E5125 /* CardPresentPaymentAlertsPresenter.swift */,
 				268FD44627580A81008FDF9B /* LegacyCollectOrderPaymentUseCase.swift */,
 				0375799A28227EDE0083F2E1 /* CardPresentPaymentsOnboardingPresenter.swift */,
 				02C27BCD282CB52F0065471A /* CardPresentPaymentReceiptEmailCoordinator.swift */,
@@ -9958,6 +9961,7 @@
 				318477E527A33C650058C7E9 /* CardPresentModalConnectingFailedChargeReader.swift in Sources */,
 				DE46133926B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift in Sources */,
 				68E952D22875A44B0095A23D /* CardReaderType+Manual.swift in Sources */,
+				035DBA4B292E248C003E5125 /* CardPresentPaymentAlertsPresenter.swift in Sources */,
 				0211259F2578DE310075AD2A /* ShippingLabelPrintingStepView.swift in Sources */,
 				B58B4AB22108F01700076FDD /* NoticeView.swift in Sources */,
 				74B5713621CD7604008F9B8E /* SharingHelper.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8080
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In sTAP Away, we will add a screen at the start of the card reader connection flow for users with supporting hardware to choose whether to connect a bluetooth reader, or use the built in card reader.

This will involve an additional alert, at the start of the flow, to select the reader type for connection.

To help us present these new alerts without visual glitches, this PR removes the responsibility for alert presentation to a new common class, `CardPresentPaymentAlertsPresenter`. The actual code for showing the alerts is extracted from the existing `CardReaderSettingsAlerts` with minimal modifications. The refactor here is that the Connection Controller is responsible for building the view models, not presenting them, so it no longer requires a view controller.

In future, we can represent these alerts as an enum, which the connection controller can produce, which would help us in moving these views to SwiftUI if desired, but that is outside the scope of this change.

Note that this work is all behind a feature flag, and subject to further refactoring and change, so a detailed review is not required at this point.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run unit tests
Take a payment with the Tap to Pay on iPhone experimental toggle on – observe that the expected connection alerts all still show up

Note that the payment flow does not yet use the common class to display alerts, so there is still a gap between the connection flow and the payment flow, as in the existing code


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
