### PR TITLE
[Mobile Payments] Ask user to choose a reader type to connect to

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSelectSearchType.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSelectSearchType.swift
@@ -28,6 +28,8 @@ final class CardPresentModalSelectSearchType: CardPresentPaymentsModalViewModel 
 
     private var bluetoothProximityAction: (() -> Void)
 
+    private var cancelAction: (() -> Void)
+
     func didTapPrimaryButton(in viewController: UIViewController?) {
         tapOnIphoneAction()
     }
@@ -37,16 +39,20 @@ final class CardPresentModalSelectSearchType: CardPresentPaymentsModalViewModel 
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {
-        //no-op
+        cancelAction()
     }
 
-    init(tapOnIPhoneAction: @escaping () -> Void, bluetoothAction: @escaping () -> Void) {
+    init(tapOnIPhoneAction: @escaping () -> Void,
+         bluetoothAction: @escaping () -> Void,
+         cancelAction: @escaping () -> Void) {
         textMode = .fullInfo
-        actionsMode = .twoAction
+        actionsMode = .twoActionAndAuxiliary
         primaryButtonTitle = CardReaderDiscoveryMethod.localMobile.name
         self.tapOnIphoneAction = tapOnIPhoneAction
         secondaryButtonTitle = CardReaderDiscoveryMethod.bluetoothProximity.name
         self.bluetoothProximityAction = bluetoothAction
+        auxiliaryButtonTitle = Localization.cancel
+        self.cancelAction = cancelAction
     }
 }
 
@@ -61,6 +67,10 @@ private extension CardPresentModalSelectSearchType {
             "Your iPhone can be used as a card reader, or you can connect to an external reader via bluetooth.",
             comment: "The description on the alert shown when connecting a card reader, asking the user to choose a " +
             "reader type. Only shown when supported on their device.")
+
+        static let cancel = NSLocalizedString(
+            "Cancel",
+            comment: "Cancel button title")
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSelectSearchType.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSelectSearchType.swift
@@ -6,7 +6,7 @@ final class CardPresentModalSelectSearchType: CardPresentPaymentsModalViewModel 
 
     var actionsMode: PaymentsModalActionsMode
 
-    var topTitle: String = "Select reader type"
+    var topTitle: String = Localization.title
 
     var topSubtitle: String? = nil
 
@@ -18,15 +18,15 @@ final class CardPresentModalSelectSearchType: CardPresentPaymentsModalViewModel 
 
     var auxiliaryButtonTitle: String? = nil
 
-    var bottomTitle: String? = "Your iPhone can be used as a card reader, or you can connect to an external reader via bluetooth"
+    var bottomTitle: String? = Localization.description
 
     var bottomSubtitle: String? = nil
 
     var accessibilityLabel: String? = nil
 
-    var tapOnIphoneAction: (() -> Void)
+    private var tapOnIphoneAction: (() -> Void)
 
-    var bluetoothProximityAction: (() -> Void)
+    private var bluetoothProximityAction: (() -> Void)
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
         tapOnIphoneAction()
@@ -40,23 +40,27 @@ final class CardPresentModalSelectSearchType: CardPresentPaymentsModalViewModel 
         //no-op
     }
 
-    init(options: [CardReaderDiscoveryMethod: (() -> Void)]) {
+    init(tapOnIPhoneAction: @escaping () -> Void, bluetoothAction: @escaping () -> Void) {
         textMode = .fullInfo
-        guard let tapOnIphone = options[.localMobile],
-        let bluetooth = options[.bluetoothProximity]
-        else {
-            actionsMode = .none
-            primaryButtonTitle = nil
-            tapOnIphoneAction = {}
-            secondaryButtonTitle = nil
-            bluetoothProximityAction = {}
-            return
-        }
         actionsMode = .twoAction
         primaryButtonTitle = CardReaderDiscoveryMethod.localMobile.name
-        tapOnIphoneAction = tapOnIphone
+        self.tapOnIphoneAction = tapOnIPhoneAction
         secondaryButtonTitle = CardReaderDiscoveryMethod.bluetoothProximity.name
-        bluetoothProximityAction = bluetooth
+        self.bluetoothProximityAction = bluetoothAction
+    }
+}
+
+private extension CardPresentModalSelectSearchType {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Select reader type",
+            comment: "The title for the alert shown when connecting a card reader, asking the user to choose a " +
+            "reader type. Only shown when supported on their device.")
+
+        static let description = NSLocalizedString(
+            "Your iPhone can be used as a card reader, or you can connect to an external reader via bluetooth.",
+            comment: "The description on the alert shown when connecting a card reader, asking the user to choose a " +
+            "reader type. Only shown when supported on their device.")
     }
 }
 
@@ -64,9 +68,13 @@ private extension CardReaderDiscoveryMethod {
     var name: String {
         switch self {
         case .bluetoothProximity:
-            return "Bluetooth reader"
+            return NSLocalizedString(
+                "Bluetooth Reader",
+                comment: "The button title on the reader type alert, for the user to choose a bluetooth reader.")
         case .localMobile:
-            return "Tap to Pay on iPhone"
+            return NSLocalizedString(
+                "Tap to Pay on iPhone",
+                comment: "The button title on the reader type alert, for the user to choose the built-in reader.")
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSelectSearchType.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSelectSearchType.swift
@@ -1,0 +1,72 @@
+import UIKit
+import Yosemite
+
+final class CardPresentModalSelectSearchType: CardPresentPaymentsModalViewModel {
+    var textMode: PaymentsModalTextMode
+
+    var actionsMode: PaymentsModalActionsMode
+
+    var topTitle: String = "Select reader type"
+
+    var topSubtitle: String? = nil
+
+    var image: UIImage = .paymentsLoading
+
+    var primaryButtonTitle: String?
+
+    var secondaryButtonTitle: String?
+
+    var auxiliaryButtonTitle: String? = nil
+
+    var bottomTitle: String? = "Your iPhone can be used as a card reader, or you can connect to an external reader via bluetooth"
+
+    var bottomSubtitle: String? = nil
+
+    var accessibilityLabel: String? = nil
+
+    var tapOnIphoneAction: (() -> Void)
+
+    var bluetoothProximityAction: (() -> Void)
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        tapOnIphoneAction()
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        bluetoothProximityAction()
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {
+        //no-op
+    }
+
+    init(options: [CardReaderDiscoveryMethod: (() -> Void)]) {
+        textMode = .fullInfo
+        guard let tapOnIphone = options[.localMobile],
+        let bluetooth = options[.bluetoothProximity]
+        else {
+            actionsMode = .none
+            primaryButtonTitle = nil
+            tapOnIphoneAction = {}
+            secondaryButtonTitle = nil
+            bluetoothProximityAction = {}
+            return
+        }
+        actionsMode = .twoAction
+        primaryButtonTitle = CardReaderDiscoveryMethod.localMobile.name
+        tapOnIphoneAction = tapOnIphone
+        secondaryButtonTitle = CardReaderDiscoveryMethod.bluetoothProximity.name
+        bluetoothProximityAction = bluetooth
+    }
+}
+
+private extension CardReaderDiscoveryMethod {
+    var name: String {
+        switch self {
+        case .bluetoothProximity:
+            return "Bluetooth reader"
+        case .localMobile:
+            return "Tap to Pay on iPhone"
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -104,16 +104,16 @@ final class CardPresentPaymentPreflightController {
         }
 
         alertsPresenter.present(viewModel: CardPresentModalSelectSearchType(
-            options: [
-                .localMobile: {
-                    self.builtInConnectionController.searchAndConnect(
-                        onCompletion: self.handleConnectionResult)
-                },
-                .bluetoothProximity: {
-                    self.connectionController.searchAndConnect(
-                        onCompletion: self.handleConnectionResult)
-                }
-            ]))
+            tapOnIPhoneAction: { [weak self] in
+                guard let self = self else { return }
+                self.builtInConnectionController.searchAndConnect(
+                    onCompletion: self.handleConnectionResult)
+            },
+            bluetoothAction: { [weak self] in
+                guard let self = self else { return }
+                self.connectionController.searchAndConnect(
+                    onCompletion: self.handleConnectionResult)
+            }))
     }
 
     private func localMobileReaderSupported() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -113,6 +113,11 @@ final class CardPresentPaymentPreflightController {
                 guard let self = self else { return }
                 self.connectionController.searchAndConnect(
                     onCompletion: self.handleConnectionResult)
+            },
+            cancelAction: { [weak self] in
+                guard let self = self else { return }
+                self.alertsPresenter.dismiss()
+                self.handleConnectionResult(.success(.canceled))
             }))
     }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -134,8 +134,11 @@ final class CardReaderConnectionController {
         }
     }
 
+    private let discoveryMethod: CardReaderDiscoveryMethod
+
     init(
         forSiteID: Int64,
+        discoveryMethod: CardReaderDiscoveryMethod,
         storageManager: StorageManagerType = ServiceLocator.storageManager,
         stores: StoresManager = ServiceLocator.stores,
         knownReaderProvider: CardReaderSettingsKnownReaderProvider,
@@ -144,6 +147,7 @@ final class CardReaderConnectionController {
         analyticsTracker: CardReaderConnectionAnalyticsTracker
     ) {
         siteID = forSiteID
+        self.discoveryMethod = discoveryMethod
         self.storageManager = storageManager
         self.stores = stores
         state = .idle
@@ -315,10 +319,6 @@ private extension CardReaderConnectionController {
     func onBeginSearch() {
         self.state = .searching
         var didAutoAdvance = false
-
-        // TODO: make this a choice for the user, when the switch is enabled
-        let tapOnIphoneEnabled = ServiceLocator.generalAppSettings.settings.isTapToPayOnIPhoneSwitchEnabled
-        let discoveryMethod: CardReaderDiscoveryMethod = tapOnIphoneEnabled ? .localMobile : .bluetoothProximity
 
         let action = CardPresentPaymentAction.startCardReaderDiscovery(
             siteID: siteID,

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -92,6 +92,8 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     /// Coordinates emailing a receipt after payment success.
     private var receiptEmailCoordinator: CardPresentPaymentReceiptEmailCoordinator?
 
+    private var preflightController: CardPresentPaymentPreflightController?
+
     private var cancellables: Set<AnyCancellable> = []
 
     init(siteID: Int64,
@@ -137,11 +139,11 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
             return handleTotalAmountInvalidError(totalAmountInvalidError(), onCompleted: onCompleted)
         }
 
-        let preflightController = CardPresentPaymentPreflightController(siteID: siteID,
-                                                                        paymentGatewayAccount: paymentGatewayAccount,
-                                                                        configuration: configuration,
-                                                                        alertsPresenter: alertsPresenter)
-        preflightController.readerConnection.sink { [weak self] connectionResult in
+        preflightController = CardPresentPaymentPreflightController(siteID: siteID,
+                                                                    paymentGatewayAccount: paymentGatewayAccount,
+                                                                    configuration: configuration,
+                                                                    alertsPresenter: alertsPresenter)
+        preflightController?.readerConnection.sink { [weak self] connectionResult in
             guard let self = self else { return }
             switch connectionResult {
             case .connected(let reader):
@@ -171,7 +173,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
         }
         .store(in: &cancellables)
 
-        preflightController.start()
+        preflightController?.start()
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -488,6 +488,7 @@
 		03AA16602719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */; };
 		03AFDE02282C0B82003B67CD /* InPersonPaymentsCompletedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */; };
 		03BB9EA5292E2D0C00251E9E /* CardReaderConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BB9EA4292E2D0C00251E9E /* CardReaderConnectionController.swift */; };
+		03BB9EA7292E50B600251E9E /* CardPresentModalSelectSearchType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03BB9EA6292E50B600251E9E /* CardPresentModalSelectSearchType.swift */; };
 		03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */; };
 		03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
 		03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */; };
@@ -2462,6 +2463,7 @@
 		03AA165F2719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptActionCoordinatorTests.swift; sourceTree = "<group>"; };
 		03AFDE01282C0B82003B67CD /* InPersonPaymentsCompletedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCompletedView.swift; sourceTree = "<group>"; };
 		03BB9EA4292E2D0C00251E9E /* CardReaderConnectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionController.swift; sourceTree = "<group>"; };
+		03BB9EA6292E50B600251E9E /* CardPresentModalSelectSearchType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalSelectSearchType.swift; sourceTree = "<group>"; };
 		03CF78D027C3DBC000523706 /* WCPayCardBrand+IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCPayCardBrand+IconsTests.swift"; sourceTree = "<group>"; };
 		03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift; sourceTree = "<group>"; };
 		03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift; sourceTree = "<group>"; };
@@ -8453,6 +8455,7 @@
 				318477E427A33C650058C7E9 /* CardPresentModalConnectingFailedChargeReader.swift */,
 				031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */,
 				036CA6B8291E8D4B00E4DF4F /* CardPresentModalPreparingReader.swift */,
+				03BB9EA6292E50B600251E9E /* CardPresentModalSelectSearchType.swift */,
 				D8EE9697264D3CCB0033B2F9 /* ReceiptViewModel.swift */,
 				D8752EF6265E60F4008ACC80 /* PaymentCaptureCelebration.swift */,
 				03AA165D2719B7EF005CCB7B /* ReceiptActionCoordinator.swift */,
@@ -10081,6 +10084,7 @@
 				DEC6C51A2747758D006832D3 /* JetpackInstallView.swift in Sources */,
 				DE37517C28DC5FC6000163CB /* Authenticator.swift in Sources */,
 				AED089F227C794BC0020AE10 /* View+CurrencySymbol.swift in Sources */,
+				03BB9EA7292E50B600251E9E /* CardPresentModalSelectSearchType.swift in Sources */,
 				D85806292642BA5400A8AB6C /* PaymentCaptureOrchestrator.swift in Sources */,
 				E1E636BB26FB467A00C9D0D7 /* Comparable+Woo.swift in Sources */,
 				450C2CB024CF006A00D570DD /* ProductTagsDataSource.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -38,7 +38,7 @@ public struct CardPresentPaymentsConfiguration {
                 paymentMethods: [.cardPresent],
                 currencies: [.USD],
                 paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID],
-                supportedReaders: [.chipper, .stripeM2],
+                supportedReaders: [.chipper, .stripeM2, .appleBuiltIn],
                 supportedPluginVersions: [
                     .init(plugin: .wcPay, minimumVersion: "3.2.1"),
                     .init(plugin: .stripe, minimumVersion: "6.2.0")

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -35,7 +35,7 @@ final class MockCardReaderService: CardReaderService {
     /// Boolean flag Indicates that clients have provided a CardReaderConfigProvider
     var didReceiveAConfigurationProvider = false
 
-    /// DiscoveryMethod recieved on starting a payment
+    /// DiscoveryMethod received on starting a payment
     var spyStartDiscoveryMethod: CardReaderDiscoveryMethod? = nil
 
     /// Boolean flag Indicates that clients have called the cancel payment method


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8080 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In this PR, we add a screen at the start of the card reader connection flow for users with supporting hardware to choose whether to connect a bluetooth reader, or use the built in card reader.

Aside from the feature flag, this screen shows for US stores only, when the app is run on an eligible device (an iPhone running iOS 15.4 and above, with an NFC chip)

When the user selects Tap on iPhone, the `localMobile` discovery method is used for the reader connection. When they select Bluetooth reader, the `bluetoothProximity` method is used.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

If you do not have a device which is provisioned for Tap on Mobile, please enable the simulated card reader and build to a simulator. 

To enable the Stripe simulated reader, in Xcode go to `Product > Scheme > Edit Scheme` and select `Run` in the sidebar, then `Arguments` in the tabs. Check the `-simulate-stripe-card-reader` box.

1. Turn on the `Tap to Pay on iPhone` experimental feature in settings
2. Tap `Menu > Payments > Collect Payment`
3. Follow the flow to create a payment, and select Card when asked for the payment method
4. Choose a reader type to connect to (Tap to Pay on iPhone or Bluetooth reader)
5. Verify that you can connect to that reader and take a payment

Disconnect the reader (in the Manage card reader menu), then repeat with the other option.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/2472348/203839625-f326cd77-05fe-490c-bde5-17000bdeb67f.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
