### PR TITLE
Analytics Hub: Adjust UI for landscape orientation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -20,6 +20,9 @@ final class AnalyticsHubHostingViewController: UIHostingController<AnalyticsHubV
 ///
 struct AnalyticsHubView: View {
 
+    /// Environment safe areas
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+
     @StateObject var viewModel: AnalyticsHubViewModel
 
     var body: some View {
@@ -29,6 +32,7 @@ struct AnalyticsHubView: View {
                     Divider()
                     Text("Placeholder for Time Range Selection")
                         .padding(.leading)
+                        .padding(.horizontal, insets: safeAreaInsets)
                         .frame(maxWidth: .infinity, minHeight: 84, alignment: .leading)
                         .background(Color(uiColor: .listForeground))
 
@@ -40,7 +44,8 @@ struct AnalyticsHubView: View {
                     Divider()
 
                     AnalyticsReportCard(viewModel: viewModel.revenueCard)
-                    .background(Color(uiColor: .listForeground))
+                        .padding(.horizontal, insets: safeAreaInsets)
+                        .background(Color(uiColor: .listForeground))
 
                     Divider()
                 }
@@ -49,7 +54,8 @@ struct AnalyticsHubView: View {
                     Divider()
 
                     AnalyticsReportCard(viewModel: viewModel.ordersCard)
-                    .background(Color(uiColor: .listForeground))
+                        .padding(.horizontal, insets: safeAreaInsets)
+                        .background(Color(uiColor: .listForeground))
 
                     Divider()
                 }
@@ -60,6 +66,7 @@ struct AnalyticsHubView: View {
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
         .background(Color(uiColor: .listBackground))
+        .edgesIgnoringSafeArea(.horizontal)
     }
 }
 


### PR DESCRIPTION
closes #8148

# Why

This PR makes sure the Analytics Hub Main View looks good in landscape orientation.

Portrait | landscape | Big Fonts
--- | --- | ---
![normal](https://user-images.githubusercontent.com/562080/203609963-01a438f0-7456-49fd-a77d-606b70a20a16.png) | ![lanscape](https://user-images.githubusercontent.com/562080/203609968-8f3c3014-9e95-4b2b-a5a7-e26beadae989.png) | ![Accessibility](https://user-images.githubusercontent.com/562080/203609973-6490179d-4195-445b-bf04-25fa96104d58.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
