### PR TITLE
Login - Jetpack setup - Tracks event for authorization using different WPCOM account

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -112,6 +112,8 @@ public enum WooAnalyticsStat: String {
 
     case loginJetpackSetupGoToStoreTapped = "login_jetpack_setup_go_to_store_button_tapped"
 
+    case loginJetpackSetupAuthorizedUsingDifferentWPCOMAccount = "login_jetpack_setup_authorized_using_different_wpcom_account"
+
     // MARK: No matched site alert
     //
     case loginJetpackNoMatchedSiteErrorViewed = "login_jetpack_no_matched_site_error_viewed"

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/LoginJetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/LoginJetpackSetupCoordinator.swift
@@ -47,6 +47,7 @@ private extension LoginJetpackSetupCoordinator {
             guard let self, let email = connectedEmail else { return }
             if email != self.stores.sessionManager.defaultAccount?.email {
                 // if the user authorized Jetpack with a different account, support them to log in with that account.
+                self.analytics.track(.loginJetpackSetupAuthorizedUsingDifferentWPCOMAccount)
                 self.showVerifyWPComAccount(email: email, xmlrpc: xmlrpc)
             } else {
                 self.showStorePickerForLogin()


### PR DESCRIPTION
Part of: #8075

### Description
This PR adds a tracking event when the user authorizes Jetpack using a WPCOM account which is different from the currently logged-in account.

### Testing instructions

- Log out of the app or skip login onboarding if needed.
- On the prologue screen, select "Log In" or "Continue with WordPress.com" based on the A/B test variant you get.
- Log in with your WordPress.com account.
- On the store picker, select Add a Store > Connect an existing site.
- Enter the address of your test store and tap Continue.
- On the Jetpack error screen, select Install Jetpack or Connect Jetpack.
- When the site credential login screen is presented, enter the correct credentials for your store.
- On the Jetpack setup screen, when the setup reaches the connection step, notice that a web view is presented for approving Jetpack connection.
- Tap the "Log in with another account" on the web page and proceed to log in with a WP.com other than your logged-in account.
- Tap on the Authorize button on the web page, notice that the web view is then dismissed, and the Jetpack setup screens should then show that all steps are completed.
- Tap on Go to Store, notice that you are navigated to a new screen for verifying the password for the account you just entered on the web page.
- Check Xcode logs ensure that `login_jetpack_setup_authorized_using_different_wpcom_account` TRACKS event is tracked.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/524475/203703603-4d327647-dc87-4866-8480-5805be0cd786.png" width="300"/>

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
