### PR TITLE
[Mobile Payments] Rollback StripeTerminal to 2.7 pending fix for lldb po issue

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -53,7 +53,7 @@ def cocoa_lumberjack
 end
 
 def stripe_terminal
-  pod 'StripeTerminal', '~> 2.14'
+  pod 'StripeTerminal', '~> 2.7'
 end
 
 # Main Target!

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -36,7 +36,7 @@ PODS:
   - Sentry/Core (7.25.1)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
-  - StripeTerminal (2.14.0)
+  - StripeTerminal (2.7.0)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (2.0.0)
   - WordPress-Aztec-iOS (1.11.0)
@@ -89,7 +89,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 4.2.2)
   - Kingfisher (~> 7.2.2)
   - Sourcery (~> 1.0.3)
-  - StripeTerminal (~> 2.14)
+  - StripeTerminal (~> 2.7)
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (~> 4.2.0)
   - WordPressKit (~> 4.49.0)
@@ -157,7 +157,7 @@ SPEC CHECKSUMS:
   Sentry: dd29c18c32b0af9269949f079cf631d581ca76ca
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
-  StripeTerminal: 9bb367c9efa7bcddf2602cc29f8962390d87b6a6
+  StripeTerminal: 237b759168a00c7f55b97c743cd8a4921866c46b
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
@@ -178,6 +178,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 8b243f1ea76d4db3aa638b50ef0d516185d01c2c
+PODFILE CHECKSUM: 3eb40bbfcf83cb0e4f4b28bc5b6229c27ae4cbf7
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When using `po` to inspect variables in `lldb`, developers found they faced various errors such as:

```
error: expression failed to parse:
error: virtual filesystem overlay file '/Users/bric/stripe/terminal/main/build/iphonesimulator/Build/Intermediates.noindex/ArchiveIntermediates/StripeTerminal/IntermediateBuildFilesPath/StripeTerminal.build/Release-iphonesimulator/StripeTerminal.build/all-product-headers.yaml' not found
error: virtual filesystem overlay file '/Users/bric/stripe/terminal/main/build/iphonesimulator/Build/Intermediates.noindex/ArchiveIntermediates/StripeTerminal/IntermediateBuildFilesPath/StripeTerminal.build/Release-iphonesimulator/StripeTerminal.build/all-product-headers.yaml' not found

error: couldn't IRGen expression. Please check the above error messages for possible root causes.
```

and 

```
warning: Swift error in scratch context: error: failed to load module 'WooCommerce'
.
Shared Swift state for WooCommerce has developed fatal errors and is being discarded.
REPL definitions and persistent names/types will be lost.

error: expression failed to parse:
unknown error
```

I believe that the only way to fix this is with a new build of the StripeTerminal dependency: raising an issue on their repo to get it fixed.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Check that you can still take an IPP payment and connect to reader successfully.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
