### PR TITLE
[Analytics Hub] Add formatters for net revenue stats data

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -34,14 +34,15 @@ struct StatsDataTextFormatter {
 
     /// Creates the text to display for the net revenue.
     ///
-    static func createNetRevenueText(orderStats: OrderStatsV4?, currencyFormatter: CurrencyFormatter?, currencyCode: String) -> String {
+    static func createNetRevenueText(orderStats: OrderStatsV4?,
+                                     currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+                                     currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue) -> String {
         guard let revenue = orderStats?.totals.netRevenue else {
             return Constants.placeholderText
         }
 
         // If revenue is an integer, no decimal points are shown.
         let numberOfDecimals: Int? = revenue.isInteger ? 0 : nil
-        let currencyFormatter = currencyFormatter ?? CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
         return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -32,6 +32,27 @@ struct StatsDataTextFormatter {
         return createDeltaPercentage(from: previousRevenue, to: currentRevenue)
     }
 
+    /// Creates the text to display for the net revenue.
+    ///
+    static func createNetRevenueText(orderStats: OrderStatsV4?, currencyFormatter: CurrencyFormatter?, currencyCode: String) -> String {
+        guard let revenue = orderStats?.totals.netRevenue else {
+            return Constants.placeholderText
+        }
+
+        // If revenue is an integer, no decimal points are shown.
+        let numberOfDecimals: Int? = revenue.isInteger ? 0 : nil
+        let currencyFormatter = currencyFormatter ?? CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+        return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
+    }
+
+    /// Creates the text to display for the net revenue delta.
+    ///
+    static func createNetRevenueDelta(from previousPeriod: OrderStatsV4?, to currentPeriod: OrderStatsV4?) -> DeltaPercentage {
+        let previousRevenue = previousPeriod?.totals.netRevenue
+        let currentRevenue = currentPeriod?.totals.netRevenue
+        return createDeltaPercentage(from: previousRevenue, to: currentRevenue)
+    }
+
     // MARK: Orders Stats
 
     /// Creates the text to display for the order count.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsDataTextFormatterTests.swift
@@ -75,6 +75,45 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(totalRevenueDelta.direction, .positive)
     }
 
+    func test_createNetRevenueText_does_not_return_decimal_points_for_integer_value() {
+        // Given
+        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(netRevenue: 62))
+
+        // When
+        let netRevenue = StatsDataTextFormatter.createNetRevenueText(orderStats: orderStats,
+                                                                     currencyFormatter: currencyFormatter,
+                                                                     currencyCode: currencyCode.rawValue)
+
+        // Then
+        XCTAssertEqual(netRevenue, "$62")
+    }
+
+    func test_createNetRevenueText_returns_decimal_points_from_currency_settings_for_noninteger_value() {
+        // Given
+        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(netRevenue: 62.856))
+
+        // When
+        let netRevenue = StatsDataTextFormatter.createNetRevenueText(orderStats: orderStats,
+                                                                     currencyFormatter: currencyFormatter,
+                                                                     currencyCode: currencyCode.rawValue)
+
+        // Then
+        XCTAssertEqual(netRevenue, "$62.86")
+    }
+
+    func test_createNetRevenueDelta_returns_expected_delta() {
+        // Given
+        let previousOrderStats = OrderStatsV4.fake().copy(totals: .fake().copy(netRevenue: 10))
+        let currentOrderStats = OrderStatsV4.fake().copy(totals: .fake().copy(netRevenue: 15))
+
+        // When
+        let netRevenueDelta = StatsDataTextFormatter.createNetRevenueDelta(from: previousOrderStats, to: currentOrderStats)
+
+        // Then
+        XCTAssertEqual(netRevenueDelta.string, "+50%")
+        XCTAssertEqual(netRevenueDelta.direction, .positive)
+    }
+
     // MARK: Orders Stats
 
     func test_createOrderCountText_returns_expected_order_count() {


### PR DESCRIPTION
Part of #8150

## Description

This PR adds methods to retrieve and format the net revenue value and delta used for the "Net Sales" column on the Revenue Analytics card:

<img src="https://user-images.githubusercontent.com/8658164/203807281-7b0e49f3-7d6f-442b-b8f6-1932f2a92786.png" width="300px">

## Testing

These methods aren't yet used in the app; confirm the unit tests are checking the correct values and tests pass.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
