### PR TITLE
[Analytics Hub] Add network actions

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -5,8 +5,8 @@ import SwiftUI
 /// Hosting Controller for the `AnalyticsHubView` view.
 ///
 final class AnalyticsHubHostingViewController: UIHostingController<AnalyticsHubView> {
-    init(timeRange: StatsTimeRangeV4) {
-        let viewModel = AnalyticsHubViewModel()
+    init(siteID: Int64, timeRange: StatsTimeRangeV4) {
+        let viewModel = AnalyticsHubViewModel(siteID: siteID)
         super.init(rootView: AnalyticsHubView(viewModel: viewModel))
     }
 
@@ -81,7 +81,7 @@ private extension AnalyticsHubView {
 struct AnalyticsHubPreview: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            AnalyticsHubView(viewModel: AnalyticsHubViewModel())
+            AnalyticsHubView(viewModel: AnalyticsHubViewModel(siteID: 123))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -5,6 +5,15 @@ import Yosemite
 ///
 final class AnalyticsHubViewModel: ObservableObject {
 
+    private let siteID: Int64
+    private let stores: StoresManager
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.stores = stores
+    }
+
     /// Revenue Card ViewModel
     ///
     @Published var revenueCard = AnalyticsReportCardViewModel(title: "REVENUE",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -357,7 +357,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
     }
 
     @objc func seeMoreButtonTapped() {
-        let analyticsHubVC = AnalyticsHubHostingViewController(timeRange: timeRange)
+        let analyticsHubVC = AnalyticsHubHostingViewController(siteID: siteID, timeRange: timeRange)
         show(analyticsHubVC, sender: self)
     }
 }

--- a/Yosemite/Yosemite/Actions/StatsActionV4.swift
+++ b/Yosemite/Yosemite/Actions/StatsActionV4.swift
@@ -19,6 +19,16 @@ public enum StatsActionV4: Action {
         forceRefresh: Bool,
         onCompletion: (Result<Void, Error>) -> Void)
 
+    /// Retrieves `OrderStats` for the provided siteID, and time range, without saving them to the Storage layer.
+    ///
+    case retrieveCustomStats(siteID: Int64,
+                             unit: StatsGranularityV4,
+                             earliestDateToInclude: Date,
+                             latestDateToInclude: Date,
+                             quantity: Int,
+                             forceRefresh: Bool,
+                             onCompletion: (Result<OrderStatsV4, Error>) -> Void)
+
     /// Synchronizes `SiteVisitStats` for the provided siteID, time range, and date.
     ///
     case retrieveSiteVisitStats(siteID: Int64,

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -50,6 +50,20 @@ public final class StatsStoreV4: Store {
                           quantity: quantity,
                           forceRefresh: forceRefresh,
                           onCompletion: onCompletion)
+        case .retrieveCustomStats(let siteID,
+                                  let unit,
+                                  let earliestDateToInclude,
+                                  let latestDateToInclude,
+                                  let quantity,
+                                  let forceRefresh,
+                                  let onCompletion):
+            retrieveCustomStats(siteID: siteID,
+                                unit: unit,
+                                earliestDateToInclude: earliestDateToInclude,
+                                latestDateToInclude: latestDateToInclude,
+                                quantity: quantity,
+                                forceRefresh: forceRefresh,
+                                onCompletion: onCompletion)
         case .retrieveSiteVisitStats(let siteID,
                                      let siteTimezone,
                                      let timeRange,
@@ -118,6 +132,24 @@ private extension StatsStoreV4 {
                 onCompletion(.failure(error))
             }
         }
+    }
+
+    /// Retrieves the order stats for the provided siteID, and time range, without saving them to the Storage layer.
+    ///
+    func retrieveCustomStats(siteID: Int64,
+                             unit: StatsGranularityV4,
+                             earliestDateToInclude: Date,
+                             latestDateToInclude: Date,
+                             quantity: Int,
+                             forceRefresh: Bool,
+                             onCompletion: @escaping (Result<OrderStatsV4, Error>) -> Void) {
+        orderStatsRemote.loadOrderStats(for: siteID,
+                                        unit: unit,
+                                        earliestDateToInclude: earliestDateToInclude,
+                                        latestDateToInclude: latestDateToInclude,
+                                        quantity: quantity,
+                                        forceRefresh: forceRefresh,
+                                        completion: onCompletion)
     }
 
     /// Retrieves the site visit stats associated with the provided Site ID (if any!).


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/8189

## Description

This PR adds 2 network requests in `AnalyticsHubViewModel` that fetch stats data for current and previous period.
Input dates are hardcoded for current/previous month now, should later use input from time range selector.
Results are stored in existing @Published vars without any UI binding yet.

## Testing

Add a breakpoint/`print(...)` in the end of `AnalyticsHubViewModel`s initializer, check `currentOrderStats` and `previousOrderStats` values.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.