### PR TITLE
Temporarily remove mistakenly merged entitlement

### DIFF
--- a/WooCommerce/Resources/Woo-Debug.entitlements
+++ b/WooCommerce/Resources/Woo-Debug.entitlements
@@ -49,7 +49,5 @@
 	<array>
 		<string>$(AppIdentifierPrefix)com.automattic.woocommerce</string>
 	</array>
-	<key>com.apple.developer.proximity-reader.payment.acceptance</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I mistakenly merged #8172, which includes an entitlement not yet in our provisioning profiles. This will prevent the app from being built in Debug schemes, on physical test devices.

This PR temporarily removes the entitlement so the app can be built again.

The code which requires the entitlement is all behind a feature flag, which is toggled off by default, so this will have no impact on people continuing to work in other areas of the app.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run the app on a physical device
Ensure that the experimental toggle `Tap to Pay on iPhone` is off
Attempt to collect an in-person payment
Observe that you are able to collect a payment using a bluetooth reader.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
