### PR TITLE
Lint `.strings` generation in CI

### DIFF
--- a/.buildkite/commands/lint-localized-strings-format.sh
+++ b/.buildkite/commands/lint-localized-strings-format.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -eu
+
+echo "--- :writing_hand: Copy Files"
+SECRETS_DIR=~/.configure/woocommerce-ios/secrets
+mkdir -pv $SECRETS_DIR
+cp -v fastlane/env/project.env.example $SECRETS_DIR/project.env
+
+lint_localized_strings_format

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,18 +55,20 @@ steps:
           context: "Unit Tests"
 
   #################
-  # Lint Translations
+  # Linters
   #################
-  - label: "🧹 Lint Translations"
-    command: "gplint /workdir/WooCommerce/Resources/AppStoreStrings.pot"
-    plugins:
-      - docker#v3.8.0:
-          image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
-    agents:
-      queue: "default"
-    notify:
-      - github_commit_status:
-          context: "Lint Translations"
+  - group: Linters
+    steps:
+      - label: "🧹 Lint Translations"
+        command: "gplint /workdir/WooCommerce/Resources/AppStoreStrings.pot"
+        plugins:
+          - docker#v3.8.0:
+              image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
+        agents:
+          queue: "default"
+        notify:
+          - github_commit_status:
+              context: "Lint Translations"
 
   #################
   # UI Tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,6 +70,11 @@ steps:
           - github_commit_status:
               context: "Lint Translations"
 
+      - label: ":sleuth_or_spy: Lint Localized Strings Format"
+        command: .buildkite/commands/lint-localized-strings-format.sh
+        plugins: *common_plugins
+        env: *common_env
+
   #################
   # UI Tests
   #################

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.8.0
+    - automattic/bash-cache#2.12.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         # This is not necessarily the actual name of the repo or the GitHub organization

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -976,8 +976,15 @@ platform :ios do
     configure_validate
   end
 
+  # Generates the `.strings` file to be imported by GlotPress, by parsing source code (using `genstrings` under the hood).
+  #
+  #
+  # @option [Boolean] skip_commit (default: false) If true, does not commit the changes made to the `.strings` file.
+  #
+  # @called_by complete_code_freeze
+  #
   desc 'Updates the main `Localizable.strings` file — that will be imported by GlotPress — from code and `Info.plist` files'
-  lane :generate_strings_file_for_glotpress do
+  lane :generate_strings_file_for_glotpress do |options|
     cocoapods
 
     en_lproj_path = File.join(RESOURCES_FOLDER, 'en.lproj')
@@ -1005,6 +1012,8 @@ platform :ios do
       paths_to_merge: MANUALLY_MAINTAINED_STRINGS_FILES,
       destination: File.join(en_lproj_path, 'Localizable.strings')
     )
+
+    next if options.fetch(:skip_commit, false)
 
     git_commit(
       path: en_lproj_path,


### PR DESCRIPTION
### Description

Same as https://github.com/wordpress-mobile/WordPress-iOS/pull/19553 and https://github.com/Automattic/pocket-casts-ios/pull/545

Adds a new CI check to give us faster feedback on whether the frozen `.strings` generation will work during code freeze. This way, if a PR breaks the process, we can address it immediately, without loss of context.


### Testing instructions

Notice how the step passed in this build. You can see how the check catches an issue in this [Jetpack/WordPress iOS demo build](https://buildkite.com/automattic/wordpress-ios/builds/10908#01848e60-7644-4858-8b11-a2a72b2f84be).

![](https://user-images.githubusercontent.com/1218433/203909571-76a8ab4f-ea69-40f0-8ad6-72dfbad2236d.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
