### PR TITLE
Login: Jetpack setup:  Add tracks

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -114,6 +114,8 @@ public enum WooAnalyticsStat: String {
 
     case loginJetpackSetupAuthorizedUsingDifferentWPCOMAccount = "login_jetpack_setup_authorized_using_different_wpcom_account"
 
+    case loginJetpackSetupScreenTryAgainButtonTapped = "login_jetpack_setup_try_again_button_tapped"
+
     // MARK: No matched site alert
     //
     case loginJetpackNoMatchedSiteErrorViewed = "login_jetpack_no_matched_site_error_viewed"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -115,6 +115,7 @@ public enum WooAnalyticsStat: String {
     case loginJetpackSetupAuthorizedUsingDifferentWPCOMAccount = "login_jetpack_setup_authorized_using_different_wpcom_account"
 
     case loginJetpackSetupScreenTryAgainButtonTapped = "login_jetpack_setup_try_again_button_tapped"
+    case loginJetpackSetupScreenGetSupportTapped = "login_jetpack_setup_get_support_button_tapped"
 
     // MARK: No matched site alert
     //

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupView.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupView.swift
@@ -260,6 +260,7 @@ struct LoginJetpackSetupView: View {
         .fullScreenCover(isPresented: $viewModel.jetpackConnectionInterrupted) {
             LoginJetpackSetupInterruptedView(onSupport: supportHandler, onContinue: {
                 viewModel.jetpackConnectionInterrupted = false
+                viewModel.didTapContinueConnectionButton()
                 // delay for the dismissal of the interrupted screen to complete.
                 DispatchQueue.main.asyncAfter(deadline: .now() + Constants.interruptedConnectionActionHandlerDelayTime) {
                     webViewPresentationHandler()

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupView.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupView.swift
@@ -57,6 +57,11 @@ final class LoginJetpackSetupHostingController: UIHostingController<LoginJetpack
         dismiss(animated: true)
     }
 
+    @objc
+    private func dismissWebView() {
+        dismiss(animated: true)
+    }
+
     private func presentJetpackConnectionWebView() {
         guard let connectionURL = viewModel.jetpackConnectionURL else {
             return
@@ -78,7 +83,7 @@ final class LoginJetpackSetupHostingController: UIHostingController<LoginJetpack
         webView.navigationItem.leftBarButtonItem = UIBarButtonItem(title: Localization.cancel,
                                                                    style: .plain,
                                                                    target: self,
-                                                                   action: #selector(self.dismissView))
+                                                                   action: #selector(self.dismissWebView))
         let navigationController = UINavigationController(rootViewController: webView)
         self.present(navigationController, animated: true)
     }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupView.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupView.swift
@@ -22,7 +22,10 @@ final class LoginJetpackSetupHostingController: UIHostingController<LoginJetpack
         }
 
         rootView.supportHandler = { [weak self] in
-            self?.presentSupport()
+            guard let self else { return }
+
+            self.analytics.track(.loginJetpackSetupScreenGetSupportTapped, withProperties: self.viewModel.currentSetupStep?.analyticsDescription)
+            self.presentSupport()
         }
 
         rootView.cancellationHandler = dismissView
@@ -195,7 +198,6 @@ struct LoginJetpackSetupView: View {
 
                         // Support button
                         Button {
-                            // TODO: add tracks?
                             supportHandler()
                         } label: {
                             Label {

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupView.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupView.swift
@@ -232,7 +232,6 @@ struct LoginJetpackSetupView: View {
             // Error state buttons: Retry and Cancel
             VStack(spacing: Constants.contentVerticalSpacing) {
                 Button {
-                    // TODO: add tracks
                     viewModel.retryAllSteps()
                 } label: {
                     Text(viewModel.tryAgainButtonTitle)

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupView.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupView.swift
@@ -49,7 +49,8 @@ final class LoginJetpackSetupHostingController: UIHostingController<LoginJetpack
 
     @objc
     private func dismissView() {
-        analytics.track(.loginJetpackSetupScreenDismissed)
+        analytics.track(.loginJetpackSetupScreenDismissed,
+                        withProperties: viewModel.currentSetupStep?.analyticsDescription)
         dismiss(animated: true)
     }
 

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupViewModel.swift
@@ -136,6 +136,12 @@ final class LoginJetpackSetupViewModel: ObservableObject {
         currentConnectionStep = .pending
         startSetup()
     }
+
+    // MARK: - LoginJetpackSetupInterruptedView
+    func didTapContinueConnectionButton() {
+        analytics.track(.loginJetpackSetupScreenTryAgainButtonTapped,
+                        withProperties: currentSetupStep?.analyticsDescription)
+    }
 }
 
 // MARK: Private helpers

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupViewModel.swift
@@ -127,7 +127,8 @@ final class LoginJetpackSetupViewModel: ObservableObject {
     }
 
     func retryAllSteps() {
-        analytics.track(.loginJetpackSetupScreenTryAgainButtonTapped)
+        analytics.track(.loginJetpackSetupScreenTryAgainButtonTapped,
+                        withProperties: currentSetupStep?.analyticsDescription)
         setupFailed = false
         setupError = nil
         setupErrorDetail = nil

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/LoginJetpackSetupViewModel.swift
@@ -127,6 +127,7 @@ final class LoginJetpackSetupViewModel: ObservableObject {
     }
 
     func retryAllSteps() {
+        analytics.track(.loginJetpackSetupScreenTryAgainButtonTapped)
         setupFailed = false
         setupError = nil
         setupErrorDetail = nil

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallSteps.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallSteps.swift
@@ -97,6 +97,24 @@ extension JetpackInstallStep {
         }
     }
 
+    /// Description dictionary for Analytics
+    ///
+    var analyticsDescription: [String: String] {
+        let stepDescription = {
+            switch self {
+            case .installation:
+                return "installation"
+            case .activation:
+                return "activation"
+            case .connection:
+                return "connection"
+            case .done:
+                return "all_done"
+            }
+        }()
+        return ["jetpack_install_step": stepDescription]
+    }
+
     private enum Localization {
         static let installationStep = NSLocalizedString("Installing Jetpack", comment: "Name of installing Jetpack plugin step")
         static let activationStep = NSLocalizedString("Activating", comment: "Name of the activation Jetpack plugin step")

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1871,6 +1871,7 @@
 		EE0EE7A828B74EF300F6061E /* CustomHelpCenterContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0EE7A728B74EF300F6061E /* CustomHelpCenterContentTests.swift */; };
 		EE81B1382865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE81B1372865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift */; };
 		EE8DCA8028BF964700F23B23 /* MockAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */; };
+		EEAA45FD293073FE0047D125 /* JetpackInstallStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAA45FC293073FE0047D125 /* JetpackInstallStepTests.swift */; };
 		EEADF622281A40CB001B40F1 /* ShippingValueLocalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEADF621281A40CB001B40F1 /* ShippingValueLocalizer.swift */; };
 		EEADF624281A421A001B40F1 /* DefaultShippingValueLocalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEADF623281A421A001B40F1 /* DefaultShippingValueLocalizer.swift */; };
 		EEADF626281A65A9001B40F1 /* DefaultShippingValueLocalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEADF625281A65A9001B40F1 /* DefaultShippingValueLocalizerTests.swift */; };
@@ -3866,6 +3867,7 @@
 		EE0EE7A728B74EF300F6061E /* CustomHelpCenterContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHelpCenterContentTests.swift; sourceTree = "<group>"; };
 		EE81B1372865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesProductIDUpdaterTests.swift; sourceTree = "<group>"; };
 		EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthentication.swift; sourceTree = "<group>"; };
+		EEAA45FC293073FE0047D125 /* JetpackInstallStepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallStepTests.swift; sourceTree = "<group>"; };
 		EEADF621281A40CB001B40F1 /* ShippingValueLocalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingValueLocalizer.swift; sourceTree = "<group>"; };
 		EEADF623281A421A001B40F1 /* DefaultShippingValueLocalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultShippingValueLocalizer.swift; sourceTree = "<group>"; };
 		EEADF625281A65A9001B40F1 /* DefaultShippingValueLocalizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultShippingValueLocalizerTests.swift; sourceTree = "<group>"; };
@@ -8630,6 +8632,7 @@
 				DEE183EC292BD900008818AB /* LoginJetpackSetupViewModelTests.swift */,
 				EEC2D27E292CF60E0072132E /* LoginJetpackSetupHostingControllerTests.swift */,
 				EEC2D280292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift */,
+				EEAA45FC293073FE0047D125 /* JetpackInstallStepTests.swift */,
 			);
 			path = "Jetpack Setup";
 			sourceTree = "<group>";
@@ -11152,6 +11155,7 @@
 				45FBDF2D238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift in Sources */,
 				578195FC25AD1D7C004A5C12 /* OrderFulfillmentUseCaseTests.swift in Sources */,
 				094C161227B0604700B25F51 /* ProductVariationFormViewModelTests.swift in Sources */,
+				EEAA45FD293073FE0047D125 /* JetpackInstallStepTests.swift in Sources */,
 				CECC759923D6160000486676 /* AggregateDataHelperTests.swift in Sources */,
 				454453C82755171E00464AC5 /* HubMenuCoordinatorTests.swift in Sources */,
 				5767E940256D9A4A00CFA652 /* OrderListViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackInstallStepTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackInstallStepTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import WooCommerce
+
+final class JetpackInstallStepTests: XCTestCase {
+    private let testURL = "https://test.com"
+
+    func test_analyticsDescription_has_correct_key() throws {
+        // Given
+        let sut = try XCTUnwrap(JetpackInstallStep.allCases.randomElement())
+
+        // Then
+        XCTAssertEqual("jetpack_install_step", sut.analyticsDescription.keys.first)
+    }
+
+    func test_analyticsDescription_has_correct_value_for_installation_step() throws {
+        // Given
+        let sut = JetpackInstallStep.installation
+
+        // Then
+        XCTAssertEqual("installation", sut.analyticsDescription.values.first)
+    }
+
+    func test_analyticsDescription_has_correct_value_for_activation_step() throws {
+        // Given
+        let sut = JetpackInstallStep.activation
+
+        // Then
+        XCTAssertEqual("activation", sut.analyticsDescription.values.first)
+    }
+
+    func test_analyticsDescription_has_correct_value_for_connection_step() throws {
+        // Given
+        let sut = JetpackInstallStep.connection
+
+        // Then
+        XCTAssertEqual("connection", sut.analyticsDescription.values.first)
+    }
+
+    func test_analyticsDescription_has_correct_value_for_done_step() throws {
+        // Given
+        let sut = JetpackInstallStep.done
+
+        // Then
+        XCTAssertEqual("all_done", sut.analyticsDescription.values.first)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/LoginJetpackSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/LoginJetpackSetupViewModelTests.swift
@@ -540,4 +540,17 @@ final class LoginJetpackSetupViewModelTests: XCTestCase {
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_setup_error_checking_jetpack_connection" }))
     }
+
+    func test_it_tracks_correct_event_when_retying_setup() {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let viewModel = LoginJetpackSetupViewModel(siteURL: testURL, connectionOnly: false, analytics: analytics)
+
+        // When
+        viewModel.retryAllSteps()
+
+        // Then
+        XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_setup_try_again_button_tapped" }))
+    }
 }


### PR DESCRIPTION
Related to: #8075 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds and updates the following tracking events for the native Jetpack installation project.

```
login_jetpack_setup_screen_dismissed
login_jetpack_setup_get_support_button_tapped
```

### Testing instructions

Prerequisite
You need a site which doesn't have Jetpack installed.

**For Jetpack setup screen**
- Log out of the app or skip login onboarding if needed.
- On the prologue screen, select "Log In" or "Continue with WordPress.com" based on the A/B test variant you get.
- Log in with your WordPress.com account.
- In the store picker screen, select Add a Store > Connect an existing site. (Either site A or site B from the Prerequisite)
- Enter the address of your test store and tap Continue. 
- On the Jetpack error screen, select Install Jetpack or Connect Jetpack.
- You will hand on the site credential screen.
- Enter the correct credentials and continue to the Jetpack setup screen. (Ref screenshots section)
- Dismiss the screen during installation and ensure `login_jetpack_setup_screen_dismissed` is logged with the current jetpack installation step.
```
Tracked login_jetpack_setup_screen_dismissed, properties: [AnyHashable("jetpack_install_step"): "connection"]
```


**Error installing screen**

- Log out of the app or skip login onboarding if needed.
- On the prologue screen, select "Log In" or "Continue with WordPress.com" based on the A/B test variant you get.
- Log in with your WordPress.com account.
- On the store picker, select Add a Store > Connect an existing site.
- Enter the address of your test store and tap Continue.
- On the Jetpack error screen, select Install Jetpack or Connect Jetpack.
- When the site credential login screen is presented, enter the correct credentials for a shop manager or administrator account.
- When the Jetpack setup screen appears, turn off the internet connection or intercept the response with a 5xx error. You should land in the "Error installing screen" (Ref screenshot section)
- Tap "Get Support" button and ensure `login_jetpack_setup_get_support_button_tapped` is logged. This event will not have the `jetpack_install_step` value attached if the installation didn't get a chance to start. 
- Tap "Try Installing Again" and ensure that `login_jetpack_setup_try_again_button_tapped` is tracked

**For  interrupted Jetpack connection**
- Log out of the app or skip login onboarding if needed.
- On the prologue screen, select "Log In" or "Continue with WordPress.com" based on the A/B test variant you get.
- Log in with your WordPress.com account.
- On the store picker, select Add a Store > Connect an existing site.
- Enter the address of your test store and tap Continue.
- On the Jetpack error screen, select Install Jetpack or Connect Jetpack.
- When the site credential login screen is presented, enter the correct credentials for a shop manager or administrator account.
- On the Jetpack setup screen, when the setup reaches the connection step, notice that a web view is presented for approving the Jetpack connection.
- Tap Cancel to dismiss the web view, notice that a new view is presented regarding the interrupted Jetpack connection.
- Tap Continue Connection, notice that the error screen is dismissed, and the web view is displayed again. Ensure that the following event is tracked
```
Tracked login_jetpack_setup_try_again_button_tapped, properties: [AnyHashable("jetpack_install_step"): "connection"]
```
- Repeat tapping Cancel, this time tap Help, notice that the support screen is displayed. Ensure that the following event is logged
```
Tracked login_jetpack_setup_get_support_button_tapped, properties: [AnyHashable("jetpack_install_step"): "connection"]
```

### Screenshots


| Jetpack setup screen. | Error installing screen | Interrupted Jetpack connection |
| - | - | - |
| ![a1](https://user-images.githubusercontent.com/524475/203904049-2de1bc78-0456-4589-946f-4be59f6620b9.png) | ![a](https://user-images.githubusercontent.com/524475/203905098-a9a38c02-8315-4cf7-846c-a91c53538e09.png) | ![Simulator Screen Shot - iPhone 14 - 2022-11-25 at 14 17 36](https://user-images.githubusercontent.com/524475/203939155-08cfa538-97d8-423b-8d89-b43c185fd34d.png) |



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
