### PR TITLE
Add note regarding `\u{2011}` logging a `genstrings` warning

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -107,6 +107,16 @@ private extension CardPresentModalScanningForReader {
                      """
         )
 
+        // \u{2011} (Non-Breaking Hyphen) will result in `genstrings` logging
+        //
+        // invalid unicode sequence: \u{201
+        //
+        // This is a known bug in the toolchain.
+        // The only known workaround is to use the actual character, but that would defeat the non-breaking purpose.
+        //
+        // See:
+        // - https://developer.apple.com/forums/thread/696752
+        // - https://github.com/woocommerce/woocommerce-ios/issues/8219
         static let learnMoreText = NSLocalizedString(
             "cardPresent.modalScanningForReader.learnMore.text",
             value: "%1$@ about In\u{2011}Person Payments",

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -107,22 +107,13 @@ private extension CardPresentModalScanningForReader {
                      """
         )
 
-        // \u{2011} (Non-Breaking Hyphen) will result in `genstrings` logging
-        //
-        // invalid unicode sequence: \u{201
-        //
-        // This is a known bug in the toolchain.
-        // The only known workaround is to use the actual character, but that would defeat the non-breaking purpose.
-        //
-        // See:
-        // - https://developer.apple.com/forums/thread/696752
-        // - https://github.com/woocommerce/woocommerce-ios/issues/8219
         static let learnMoreText = NSLocalizedString(
             "cardPresent.modalScanningForReader.learnMore.text",
-            value: "%1$@ about In\u{2011}Person Payments",
+            value: "%1$@ about In‑Person Payments",
             comment: """
                      A label prompting users to learn more about In-Person Payments.
-                     \u{2011} is a special character that acts as nonbreaking hyphen for "-" in the "In-Person" string.
+                     The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                     If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it.
                      %1$@ is a placeholder that always replaced with \"Learn more\" string,
                      which should be translated separately and considered part of this sentence.
                      """

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -81,22 +81,26 @@ private extension CardPresentModalScanningForReader {
 
     enum Localization {
         static let title = NSLocalizedString(
-            "Scanning for reader",
+            "cardPresent.modalScanningForReader.title",
+            value: "Scanning for reader",
             comment: "Title label for modal dialog that appears when searching for a card reader"
         )
 
         static let instruction = NSLocalizedString(
-            "To turn on your card reader, briefly press its power button.",
+            "cardPresent.modalScanningForReader.instruction",
+            value: "To turn on your card reader, briefly press its power button.",
             comment: "Label within the modal dialog that appears when searching for a card reader"
         )
 
         static let cancel = NSLocalizedString(
-            "Cancel",
+            "cardPresent.modalScanningForReader.cancelButton",
+            value: "Cancel",
             comment: "Label for a cancel button"
         )
 
         static let learnMoreLink = NSLocalizedString(
-            "Learn more",
+            "cardPresent.modalScanningForReader.learnMore.link",
+            value: "Learn more",
             comment: """
                      A label prompting users to learn more about In-Person Payments.
                      This is the link to the website, and forms part of a longer sentence which it should be considered a part of.
@@ -104,7 +108,8 @@ private extension CardPresentModalScanningForReader {
         )
 
         static let learnMoreText = NSLocalizedString(
-            "%1$@ about In\u{2011}Person Payments",
+            "cardPresent.modalScanningForReader.learnMore.text",
+            value: "%1$@ about In\u{2011}Person Payments",
             comment: """
                      A label prompting users to learn more about In-Person Payments.
                      \u{2011} is a special character that acts as nonbreaking hyphen for "-" in the "In-Person" string.


### PR DESCRIPTION
### Description
What is says in the title. See https://github.com/woocommerce/woocommerce-ios/issues/8219 for more details.

While I was at it, I adde reverse-DNS keys to all the localized strings in the context of the annotated one.

### Testing instructions
N.A.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

cc @iamgabrielma as the strings author. Just to be clear, I think you made the right call, it's just unfortunate the tooling does this to us.