### PR TITLE
[Mobile Payments] Make Preparing Reader background one color

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -104,8 +104,8 @@ private extension CardPresentPaymentsModalViewController {
     func createLoadingIndicator() {
         let loadingIndicator = ProgressView()
             .progressViewStyle(IndefiniteCircularProgressViewStyle(size: 96.0))
-            .background(Color(.tertiarySystemBackground))
         let host = ConstraintsUpdatingHostingController(rootView: loadingIndicator)
+        host.view.backgroundColor = .tertiarySystemBackground
         add(host)
 
         guard let index = mainStackView.arrangedSubviews.firstIndex(of: imageView) else {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8222
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

On the Preparing Reader modal, the borders of the hosting controller view can be bigger than the spinner view itself – this is the case on iPad.

It was observed that in dark mode, this shows with two black bars, above and below the spinner.

This changes the background specifier to be on the hosting controller’s view, not the spinner contained within it, which corrects the background color issue.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->


1. On an iPad with dark mode enabled
2. Navigate to `Menu > Payments > Collect Payment`
3. Go through the payment flow and select `Card` on the payment method screen
4. Wait to connect to a reader: once this is done, you will briefly see the Preparing reader screen
5. Observe that there are no black bars at the top and bottom of the spinner

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/203949752-5fe3bcf7-5529-4b2a-95d2-4b8c42ead08f.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
