### PR TITLE
[Just In Time Messages] Hide announcement when navigation bar is short

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -607,7 +607,7 @@ private extension DashboardViewController {
         if self.traitCollection.userInterfaceIdiom == .pad {
             collapsedNavigationBarHeight = Constants.iPadCollapsedNavigationBarHeight
         } else {
-            collapsedNavigationBarHeight = Constants.collapsedNavigationBarHeight
+            collapsedNavigationBarHeight = Constants.iPhoneCollapsedNavigationBarHeight
         }
         return navigationBarHeight <= collapsedNavigationBarHeight
     }
@@ -627,7 +627,7 @@ private extension DashboardViewController {
         static let horizontalMargin = CGFloat(16)
         static let storeNameTextColor: UIColor = .secondaryLabel
         static let backgroundColor: UIColor = .systemBackground
-        static let collapsedNavigationBarHeight = CGFloat(44)
+        static let iPhoneCollapsedNavigationBarHeight = CGFloat(44)
         static let iPadCollapsedNavigationBarHeight = CGFloat(50)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -119,7 +119,7 @@ final class DashboardViewController: UIViewController {
         configureBottomJetpackBenefitsBanner()
         observeSiteForUIUpdates()
         observeBottomJetpackBenefitsBannerVisibilityUpdates()
-        observeNavigationBarHeightForStoreNameLabelVisibility()
+        observeNavigationBarHeightForHeaderExtrasVisibility()
         observeStatsVersionForDashboardUIUpdates()
         observeAnnouncements()
         observeShowWebViewSheet()
@@ -145,16 +145,16 @@ final class DashboardViewController: UIViewController {
         return true
     }
 
-    internal override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.willTransition(to: newCollection, with: coordinator)
-        updateAnnouncementCardVisibility(with: newCollection)
+    /// Hide the announcement card when the navigation bar is compact
+    ///
+    func updateAnnouncementCardVisibility() {
+        announcementView?.isHidden = navigationBarIsShort
     }
 
-    /// Hide the announcement card in compact (landscape phone)
+    /// Hide the store name when the navigation bar is compact
     ///
-    func updateAnnouncementCardVisibility(with newCollection: UITraitCollection) {
-        let shouldHideCard = newCollection.verticalSizeClass == .compact
-        announcementView?.isHidden = shouldHideCard
+    func updateStoreNameLabelVisibility() {
+        storeNameLabel.isHidden = !shouldShowStoreNameAsSubtitle || navigationBarIsShort
     }
 }
 
@@ -377,7 +377,7 @@ private extension DashboardViewController {
         let indexAfterHeader = (headerStackView.arrangedSubviews.firstIndex(of: innerStackView) ?? -1) + 1
         headerStackView.insertArrangedSubview(uiView, at: indexAfterHeader)
 
-        updateAnnouncementCardVisibility(with: traitCollection)
+        updateAnnouncementCardVisibility()
 
         hostingController.didMove(toParent: self)
         hostingController.view.layoutIfNeeded()
@@ -406,6 +406,7 @@ private extension DashboardViewController {
         }
         shouldShowStoreNameAsSubtitle = true
         storeNameLabel.text = siteName
+        updateStoreNameLabelVisibility()
     }
 }
 
@@ -584,19 +585,31 @@ private extension DashboardViewController {
             }.store(in: &subscriptions)
     }
 
-    func observeNavigationBarHeightForStoreNameLabelVisibility() {
+    func observeNavigationBarHeightForHeaderExtrasVisibility() {
         navigationController?.navigationBar.publisher(for: \.frame, options: [.initial, .new])
-            .map { $0.height }
             .removeDuplicates()
-            .sink(receiveValue: { [weak self] navigationBarHeight in
-                guard let self = self else { return }
-
-                guard self.shouldShowStoreNameAsSubtitle else {
-                    return
-                }
-                self.storeNameLabel.isHidden = navigationBarHeight <= Constants.collapsedNavigationBarHeight
+            .sink(receiveValue: { [weak self] _ in
+                guard let self else { return }
+                self.updateStoreNameLabelVisibility()
+                self.updateAnnouncementCardVisibility()
             })
             .store(in: &subscriptions)
+    }
+
+    /// Returns true if the navigation bar has a compact height as opposed to showing a large title
+    ///
+    var navigationBarIsShort: Bool {
+        guard let navigationBarHeight = navigationController?.navigationBar.frame.height else {
+            return false
+        }
+
+        let collapsedNavigationBarHeight: CGFloat
+        if self.traitCollection.userInterfaceIdiom == .pad {
+            collapsedNavigationBarHeight = Constants.iPadCollapsedNavigationBarHeight
+        } else {
+            collapsedNavigationBarHeight = Constants.collapsedNavigationBarHeight
+        }
+        return navigationBarHeight <= collapsedNavigationBarHeight
     }
 }
 
@@ -615,5 +628,6 @@ private extension DashboardViewController {
         static let storeNameTextColor: UIColor = .secondaryLabel
         static let backgroundColor: UIColor = .systemBackground
         static let collapsedNavigationBarHeight = CGFloat(44)
+        static let iPadCollapsedNavigationBarHeight = CGFloat(50)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8048
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR hides the JITM announcement view in My store as the view scrolls down. To do this, I've hooked into existing logic to hide the store title when the navigation bar isn't showing a large title. I've simplified this logic a bit and also extended it to support iPad, which has a taller (50px) navigation bar.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

See pdfdoF-1uc-p2#comment-2581 for details of setting up your store to be eligible for the test JITM

With a US store that is eligible for the test JITM, on a debug/alpha build of the app

#### On iPhone

1. Go to My store, and verify that the In-person card payments message is shown, and the store name shows below the "My store" title
2. As you scroll down the view and the "My store" title becomes smaller, the store name and message should disappear
3. As you scroll back up and the "My store" title becomes large, the store name and message should reappear
4. Rotate to landscape, both the store name and message should not be visible regardless of scroll position on iPhone. On an iPad, it should behave similarly to iPhone portrait.

I've noticed an issue where things are not correct when rotating back from landscape to portrait on iPhone, but I can't figure out why:

1. Start with portrait
2. Scroll down enough that the message hides
3. Rotate to landscape
4. Scroll to top
5. Rotate to portrait. The navigation bar still shows in small text.
6. Scroll up a little bit. The navigation bar switches to large text but the store name and message don't appear
7. Scroll down enough to make the title small and back up, and the store name and message will appear.

While debugging, it seems like the code was being called and setting the right visibility on the message, but it wasn't having any effect, and haven't figured out why.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/8739/203983782-6f10dbdb-20a6-446e-a237-517cca76e4b2.mov



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
