### PR TITLE
[Analytics Hub] Add data binding

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -29,27 +29,11 @@ final class AnalyticsHubViewModel: ObservableObject {
 
     /// Revenue Card ViewModel
     ///
-    @Published var revenueCard = AnalyticsReportCardViewModel(title: Localization.RevenueCard.title,
-                                                              leadingTitle: Localization.RevenueCard.leadingTitle,
-                                                              leadingValue: Constants.placeholderValue,
-                                                              leadingDelta: Constants.placeholderDelta.string,
-                                                              leadingDeltaColor: Constants.deltaColor(for: Constants.placeholderDelta.direction),
-                                                              trailingTitle: Localization.RevenueCard.trailingTitle,
-                                                              trailingValue: Constants.placeholderValue,
-                                                              trailingDelta: Constants.placeholderDelta.string,
-                                                              trailingDeltaColor: Constants.deltaColor(for: Constants.placeholderDelta.direction))
+    @Published var revenueCard = AnalyticsHubViewModel.revenueCard(currentPeriodStats: nil, previousPeriodStats: nil)
 
     /// Orders Card ViewModel
     ///
-    @Published var ordersCard = AnalyticsReportCardViewModel(title: Localization.OrderCard.title,
-                                                             leadingTitle: Localization.OrderCard.leadingTitle,
-                                                             leadingValue: Constants.placeholderValue,
-                                                             leadingDelta: Constants.placeholderDelta.string,
-                                                             leadingDeltaColor: Constants.deltaColor(for: Constants.placeholderDelta.direction),
-                                                             trailingTitle: Localization.OrderCard.trailingTitle,
-                                                             trailingValue: Constants.placeholderValue,
-                                                             trailingDelta: Constants.placeholderDelta.string,
-                                                             trailingDeltaColor: Constants.deltaColor(for: Constants.placeholderDelta.direction))
+    @Published var ordersCard = AnalyticsHubViewModel.ordersCard(currentPeriodStats: nil, previousPeriodStats: nil)
 
     /// Time Range ViewModel
     ///
@@ -157,8 +141,6 @@ private extension AnalyticsHubViewModel {
 // MARK: - Constants
 private extension AnalyticsHubViewModel {
     enum Constants {
-        static let placeholderValue = "-"
-        static let placeholderDelta = StatsDataTextFormatter.createDeltaPercentage(from: 0.0, to: 0.0)
         static func deltaColor(for direction: StatsDataTextFormatter.DeltaPercentage.Direction) -> UIColor {
             switch direction {
             case .positive:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -52,6 +52,7 @@ final class AnalyticsHubViewModel: ObservableObject {
     @Published private var previousOrderStats: OrderStatsV4? = nil
 }
 
+// MARK: Networking
 private extension AnalyticsHubViewModel {
 
     @MainActor
@@ -93,6 +94,7 @@ private extension AnalyticsHubViewModel {
     }
 }
 
+// MARK: Data - UI mapping
 private extension AnalyticsHubViewModel {
 
     func bindViewModelsWithData() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -21,7 +21,7 @@ struct AnalyticsReportCard: View {
                 .foregroundColor(Color(.text))
                 .footnoteStyle()
 
-            HStack {
+            HStack(alignment: .top) {
 
                 /// Leading Column
                 ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -12,12 +12,11 @@ struct StatsDataTextFormatter {
     ///
     static func createTotalRevenueText(orderStats: OrderStatsV4?,
                                        selectedIntervalIndex: Int?,
-                                       currencyFormatter: CurrencyFormatter?,
-                                       currencyCode: String) -> String {
+                                       currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+                                       currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue) -> String {
         if let revenue = totalRevenue(at: selectedIntervalIndex, orderStats: orderStats) {
             // If revenue is an integer, no decimal points are shown.
             let numberOfDecimals: Int? = revenue.isInteger ? 0: nil
-            let currencyFormatter = currencyFormatter ?? CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
             return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
         } else {
             return Constants.placeholderText
@@ -76,7 +75,9 @@ struct StatsDataTextFormatter {
 
     /// Creates the text to display for the average order value.
     ///
-    static func createAverageOrderValueText(orderStats: OrderStatsV4?, currencyFormatter: CurrencyFormatter, currencyCode: String) -> String {
+    static func createAverageOrderValueText(orderStats: OrderStatsV4?,
+                                            currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+                                            currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue) -> String {
         if let value = averageOrderValue(orderStats: orderStats) {
             // If order value is an integer, no decimal points are shown.
             let numberOfDecimals: Int? = value.isInteger ? 0 : nil

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
@@ -30,10 +30,11 @@ final class StoreStatsPeriodViewModel {
     /// Emits revenue stats text values based on order stats, selected time interval, and currency code.
     private(set) lazy var revenueStatsText: AnyPublisher<String, Never> = $orderStatsData.combineLatest($selectedIntervalIndex, currencySettings.$currencyCode)
         .compactMap { [weak self] orderStatsData, selectedIntervalIndex, currencyCode in
-            StatsDataTextFormatter.createTotalRevenueText(orderStats: orderStatsData.stats,
-                                                     selectedIntervalIndex: selectedIntervalIndex,
-                                                     currencyFormatter: self?.currencyFormatter,
-                                                     currencyCode: currencyCode.rawValue)
+            guard let self else { return "-" }
+            return StatsDataTextFormatter.createTotalRevenueText(orderStats: orderStatsData.stats,
+                                                                 selectedIntervalIndex: selectedIntervalIndex,
+                                                                 currencyFormatter: self.currencyFormatter,
+                                                                 currencyCode: currencyCode.rawValue)
         }
         .removeDuplicates()
         .eraseToAnyPublisher()


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/8189.

## Description

This PR adds UI binding to display the stats data. It updates cell viewmodels from OrderStatsV4 data with StatsDataTextFormatter

## Testing

1. Build and run the app in debug/alpha mode.
2. On the dashboard screen tap the "See more" button.
3. On analytics hub screen after loading finished confirm that revenue and orders cells update with correct data.
4. Tap the button to open placeholder analytics hub view.

## Screenshots

<img width=350 src="https://user-images.githubusercontent.com/3132438/204023096-65c7805e-b176-4722-a25e-56855a35074f.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.