### PR TITLE
Analytics Hub: Fill Products Card with data

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -147,7 +147,7 @@ private extension AnalyticsHubViewModel {
 
     static func productCard(currentPeriodStats: OrderStatsV4?, previousPeriodStats: OrderStatsV4?) -> AnalyticsProductCardViewModel {
         let itemsSold = StatsDataTextFormatter.createItemsSoldText(orderStats: currentPeriodStats)
-        let itemsSoldDelta = StatsDataTextFormatter.createOrderItemsSoldDelta(from: currentPeriodStats, to: previousPeriodStats)
+        let itemsSoldDelta = StatsDataTextFormatter.createOrderItemsSoldDelta(from: previousPeriodStats, to: currentPeriodStats)
 
         return AnalyticsProductCardViewModel(itemsSold: itemsSold,
                                              delta: itemsSoldDelta.string,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -43,9 +43,7 @@ final class AnalyticsHubViewModel: ObservableObject {
 
     /// Products Card ViewModel
     ///
-    @Published var productCard = AnalyticsProductCardViewModel(itemsSold: "3,234",
-                                                               delta: "+43%",
-                                                               deltaBackgroundColor: .withColorStudio(.green, shade: .shade50))
+    @Published var productCard = AnalyticsHubViewModel.productCard(currentPeriodStats: nil, previousPeriodStats: nil)
 
     // MARK: Private data
 
@@ -110,6 +108,8 @@ private extension AnalyticsHubViewModel {
 
                 self.revenueCard = AnalyticsHubViewModel.revenueCard(currentPeriodStats: currentOrderStats, previousPeriodStats: previousOrderStats)
                 self.ordersCard = AnalyticsHubViewModel.ordersCard(currentPeriodStats: currentOrderStats, previousPeriodStats: previousOrderStats)
+                self.productCard = AnalyticsHubViewModel.productCard(currentPeriodStats: currentOrderStats, previousPeriodStats: previousOrderStats)
+
             }.store(in: &subscriptions)
     }
 
@@ -143,6 +143,15 @@ private extension AnalyticsHubViewModel {
                                             trailingValue: StatsDataTextFormatter.createAverageOrderValueText(orderStats: currentPeriodStats),
                                             trailingDelta: orderValueDelta.string,
                                             trailingDeltaColor: Constants.deltaColor(for: orderValueDelta.direction))
+    }
+
+    static func productCard(currentPeriodStats: OrderStatsV4?, previousPeriodStats: OrderStatsV4?) -> AnalyticsProductCardViewModel {
+        let itemsSold = StatsDataTextFormatter.createItemsSoldText(orderStats: currentPeriodStats)
+        let itemsSoldDelta = StatsDataTextFormatter.createOrderItemsSoldDelta(from: currentPeriodStats, to: previousPeriodStats)
+
+        return AnalyticsProductCardViewModel(itemsSold: itemsSold,
+                                             delta: itemsSoldDelta.string,
+                                             deltaBackgroundColor: Constants.deltaColor(for: itemsSoldDelta.direction))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -137,6 +137,28 @@ struct StatsDataTextFormatter {
             return Constants.placeholderText
         }
     }
+
+    // MARK: Product Stats
+
+    /// Creates the text to display for all of items sold value.
+    ///
+    static func createItemsSoldText(orderStats: OrderStatsV4?) -> String {
+        guard let orderStats else {
+            return Constants.placeholderText
+        }
+        return Double(orderStats.totals.totalItemsSold).humanReadableString()
+    }
+
+    /// Creates the text to display for the orders item sold delta.
+    ///
+    static func createOrderItemsSoldDelta(from previousPeriod: OrderStatsV4?, to currentPeriod: OrderStatsV4?) -> DeltaPercentage {
+        guard let previousPeriod, let currentPeriod else {
+            return DeltaPercentage(value: 0) // Missing data: 0% change
+        }
+        let previousItemsSold = Double(previousPeriod.totals.totalItemsSold)
+        let currentItemsSold = Double(currentPeriod.totals.totalItemsSold)
+        return createDeltaPercentage(from: previousItemsSold, to: currentItemsSold)
+    }
 }
 
 extension StatsDataTextFormatter {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsDataTextFormatterTests.swift
@@ -384,4 +384,68 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(delta.string, "-100%")
         XCTAssertEqual(delta.direction, .negative)
     }
+
+    func test_createItemsSoldText_returns_placeholder_on_nil_stats() {
+        let text = StatsDataTextFormatter.createItemsSoldText(orderStats: nil)
+        XCTAssertEqual(text, "-")
+    }
+
+    func test_createItemsSoldText_returns_formatted_value() {
+        // Given
+        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalItemsSold: 67890))
+
+        // When
+        let text = StatsDataTextFormatter.createItemsSoldText(orderStats: orderStats)
+
+        // Then
+        XCTAssertEqual(text, "67.9k")
+    }
+
+    func test_createOrderItemsSoldDelta_returns_zero_on_nil_stats() {
+        let delta = StatsDataTextFormatter.createOrderItemsSoldDelta(from: nil, to: nil)
+        XCTAssertEqual(delta.string, "+0%")
+        XCTAssertEqual(delta.direction, .zero)
+    }
+
+    func test_createOrderItemsSoldDelta_returns_correct_positive_value() {
+        // Given
+        let previousStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalItemsSold: 100))
+        let currentStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalItemsSold: 133))
+
+        // When
+        let delta = StatsDataTextFormatter.createOrderItemsSoldDelta(from: previousStats, to: currentStats)
+
+        // Then
+        XCTAssertEqual(delta.string, "+33%")
+        XCTAssertEqual(delta.direction, .positive)
+    }
+
+    func test_createOrderItemsSoldDelta_returns_correct_negative_value() {
+        // Given
+        let previousStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalItemsSold: 100))
+        let currentStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalItemsSold: 77))
+
+        // When
+        let delta = StatsDataTextFormatter.createOrderItemsSoldDelta(from: previousStats, to: currentStats)
+
+        // Then
+        XCTAssertEqual(delta.string, "-23%")
+        XCTAssertEqual(delta.direction, .negative)
+    }
+
+
+
+//
+//    /// Creates the text to display for the orders item sold delta.
+//    ///
+//    static func createOrderItemsSoldDelta(from previousPeriod: OrderStatsV4?, to currentPeriod: OrderStatsV4?) -> DeltaPercentage {
+//        guard let previousPeriod, let currentPeriod else {
+//            return DeltaPercentage(value: 0) // Missing data: 0% change
+//        }
+//        let previousItemsSold = Double(previousPeriod.totals.totalItemsSold)
+//        let currentItemsSold = Double(currentPeriod.totals.totalItemsSold)
+//        return createDeltaPercentage(from: previousItemsSold, to: currentItemsSold)
+//    }
+
+
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsDataTextFormatterTests.swift
@@ -432,20 +432,4 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(delta.string, "-23%")
         XCTAssertEqual(delta.direction, .negative)
     }
-
-
-
-//
-//    /// Creates the text to display for the orders item sold delta.
-//    ///
-//    static func createOrderItemsSoldDelta(from previousPeriod: OrderStatsV4?, to currentPeriod: OrderStatsV4?) -> DeltaPercentage {
-//        guard let previousPeriod, let currentPeriod else {
-//            return DeltaPercentage(value: 0) // Missing data: 0% change
-//        }
-//        let previousItemsSold = Double(previousPeriod.totals.totalItemsSold)
-//        let currentItemsSold = Double(currentPeriod.totals.totalItemsSold)
-//        return createDeltaPercentage(from: previousItemsSold, to: currentItemsSold)
-//    }
-
-
 }


### PR DESCRIPTION
closes #8198 

# Why

This PR makes sure that the first half of the product card is filled with the fetched data. 
**Note: Currently the fetched data is static.**

# How

- Add a couple of methods to `StatsDataTextFormatter` to get the correct values for the items sold stats.
- Create the productCard view model, when data is fetched.


# Screenshots

<img width="434" alt="Screen Shot 2022-11-26 at 11 12 19 AM" src="https://user-images.githubusercontent.com/562080/204098707-d67f0c72-7270-4a4a-b1f4-a8d6587a5b2a.png">

# Testing Steps

- On the dashboard screen tap the "See more" button.
- See that the product tab is populated with data after data is loaded. 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
