### PR TITLE
Store creation M2: store picker UI/UX updates

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
@@ -60,7 +60,7 @@ extension AccountHeaderView {
         }
     }
 
-    var isHelpButtonEnabled: Bool {
+    var isActionButtonEnabled: Bool {
         set {
             actionButton.isHidden = !newValue
             actionButton.isEnabled = newValue

--- a/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
@@ -89,7 +89,8 @@ private extension AccountHeaderView {
     }
 
     func setupHelpButton() {
-        actionButton.setImage(.ellipsisImage.withTintColor(.accent), for: .normal)
+        actionButton.setImage(.ellipsisImage, for: .normal)
+        actionButton.tintColor = .accent
         actionButton.setTitle(nil, for: .normal)
         actionButton.on(.touchUpInside) { [weak self] control in
             self?.onActionButtonTapped?()

--- a/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
@@ -3,9 +3,9 @@ import UIKit
 
 
 
-/// AccountHeaderView: Displays an Account's Details: [Gravatar + Name + Username]
+/// AccountHeaderView: Displays an Account's Details: [Gravatar + Email]
 ///
-class AccountHeaderView: UIView {
+final class AccountHeaderView: UIView {
 
     /// Account's Gravatar.
     ///
@@ -15,33 +15,25 @@ class AccountHeaderView: UIView {
         }
     }
 
-    /// Account's Full Name.
+    /// Account's email.
     ///
-    @IBOutlet private var fullnameLabel: UILabel! {
+    @IBOutlet private var emailLabel: UILabel! {
         didSet {
-            fullnameLabel.textColor = .systemColor(.label)
-            fullnameLabel.accessibilityIdentifier = "full-name-label"
+            emailLabel.textColor = .systemColor(.secondaryLabel)
+            emailLabel.font = .body
+            emailLabel.accessibilityIdentifier = "email-label"
         }
     }
 
-    /// Account's Username.
+    /// Action Button
     ///
-    @IBOutlet private var usernameLabel: UILabel! {
-        didSet {
-            usernameLabel.textColor = .systemColor(.secondaryLabel)
-            usernameLabel.accessibilityIdentifier = "username-label"
-        }
-    }
-
-    /// Help Button
-    ///
-    @IBOutlet private weak var helpButton: UIButton!
+    @IBOutlet private weak var actionButton: UIButton!
 
     @IBOutlet private var containerView: UIView!
 
-    /// Closure to be executed whenever the help button is pressed
+    /// Closure to be executed whenever the action button is pressed
     ///
-    var onHelpRequested: (() -> Void)?
+    var onActionButtonTapped: (() -> Void)?
 
     // MARK: - Overridden Methods
 
@@ -57,35 +49,24 @@ class AccountHeaderView: UIView {
 //
 extension AccountHeaderView {
 
-    /// Account's Username.
-    ///
-    var username: String? {
-        set {
-            usernameLabel.text = newValue
-        }
-        get {
-            return usernameLabel.text
-        }
-    }
-
     /// Account's Full Name
     ///
-    var fullname: String? {
+    var email: String? {
         set {
-            fullnameLabel.text = newValue
+            emailLabel.text = newValue
         }
         get {
-            return fullnameLabel.text
+            return emailLabel.text
         }
     }
 
     var isHelpButtonEnabled: Bool {
         set {
-            helpButton.isHidden = !newValue
-            helpButton.isEnabled = newValue
+            actionButton.isHidden = !newValue
+            actionButton.isEnabled = newValue
         }
         get {
-            return helpButton.isHidden
+            return actionButton.isHidden
         }
     }
 
@@ -108,27 +89,10 @@ private extension AccountHeaderView {
     }
 
     func setupHelpButton() {
-        helpButton.setTitle(Strings.helpButtonTitle, for: .normal)
-        helpButton.setTitleColor(.accent, for: .normal)
-        helpButton.on(.touchUpInside) { [weak self] control in
-            ServiceLocator.analytics.track(.sitePickerHelpButtonTapped)
-            self?.handleHelpButtonTapped(control)
+        actionButton.setImage(.ellipsisImage.withTintColor(.accent), for: .normal)
+        actionButton.setTitle(nil, for: .normal)
+        actionButton.on(.touchUpInside) { [weak self] control in
+            self?.onActionButtonTapped?()
         }
-    }
-
-    /// Handle the help button being tapped
-    ///
-    func handleHelpButtonTapped(_ sender: AnyObject) {
-        onHelpRequested?()
-    }
-}
-
-
-// MARK: - Constants!
-//
-private extension AccountHeaderView {
-
-    enum Strings {
-        static let helpButtonTitle = NSLocalizedString("Help", comment: "Help button on store picker screen.")
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
@@ -33,7 +33,7 @@ final class AccountHeaderView: UIView {
 
     /// Closure to be executed whenever the action button is pressed
     ///
-    var onActionButtonTapped: (() -> Void)?
+    var onActionButtonTapped: ((UIView) -> Void)?
 
     // MARK: - Overridden Methods
 
@@ -93,7 +93,7 @@ private extension AccountHeaderView {
         actionButton.tintColor = .accent
         actionButton.setTitle(nil, for: .normal)
         actionButton.on(.touchUpInside) { [weak self] control in
-            self?.onActionButtonTapped?()
+            self?.onActionButtonTapped?(control)
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.xib
+++ b/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -27,16 +27,10 @@
                                         <constraint firstAttribute="width" constant="60" id="cwR-2d-T4e"/>
                                     </constraints>
                                 </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="750" text="Full Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xHF-gJ-reo">
-                                    <rect key="frame" x="124" y="66" width="79" height="20.5"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="750" text="Email" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xHF-gJ-reo">
+                                    <rect key="frame" x="142" y="66" width="43" height="59"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                     <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="@username" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LiJ-G2-nZS">
-                                    <rect key="frame" x="123" y="92.5" width="81.5" height="32.5"/>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                    <color key="textColor" systemColor="scrollViewTexturedBackgroundColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                             </subviews>
@@ -73,18 +67,12 @@
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
+                <outlet property="actionButton" destination="VVa-5o-MfJ" id="jqF-NU-aZe"/>
                 <outlet property="containerView" destination="Iu9-0K-UMw" id="2vR-o9-OI1"/>
-                <outlet property="fullnameLabel" destination="xHF-gJ-reo" id="ba9-Sw-RJO"/>
+                <outlet property="emailLabel" destination="xHF-gJ-reo" id="ba9-Sw-RJO"/>
                 <outlet property="gravatarImageView" destination="vOQ-CP-fZ1" id="K0E-fC-gY9"/>
-                <outlet property="helpButton" destination="VVa-5o-MfJ" id="jqF-NU-aZe"/>
-                <outlet property="usernameLabel" destination="LiJ-G2-nZS" id="SiG-bv-eTM"/>
             </connections>
             <point key="canvasLocation" x="-7.2000000000000002" y="-309.44527736131937"/>
         </view>
     </objects>
-    <resources>
-        <systemColor name="scrollViewTexturedBackgroundColor">
-            <color red="0.43529411764705878" green="0.44313725490196082" blue="0.47450980392156861" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-    </resources>
 </document>

--- a/WooCommerce/Classes/Authentication/Epilogue/EmptyStoresTableViewCell.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EmptyStoresTableViewCell.swift
@@ -73,7 +73,7 @@ private extension EmptyStoresTableViewCell {
             comment: "Link on the store picker for users who signed in with Apple to close their WordPress.com account."
         )
         static let legend =
-            NSLocalizedString("Create your first store",
+            NSLocalizedString("Add your first store",
                               comment: "Displayed during the Login flow, whenever the user has no woo stores associated.")
         static let subtitle = NSLocalizedString("Quickly get up and selling with a beautiful online store.",
                                                 comment: "Subtitle displayed during the Login flow, whenever the user has no woo stores associated.")

--- a/WooCommerce/Classes/Authentication/Epilogue/EmptyStoresTableViewCell.xib
+++ b/WooCommerce/Classes/Authentication/Epilogue/EmptyStoresTableViewCell.xib
@@ -17,22 +17,22 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="pky-np-rBc">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="222"/>
+                        <rect key="frame" x="16" y="0.0" width="343" height="222"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="woo-no-store" translatesAutoresizingMaskIntoConstraints="NO" id="uuh-xp-DA5">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="138.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="343" height="138.5"/>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="JZd-ud-Vc8">
-                                <rect key="frame" x="0.0" y="138.5" width="375" height="49"/>
+                                <rect key="frame" x="0.0" y="138.5" width="343" height="49"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bPV-bJ-GBz">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Oil-C8-RKM">
-                                        <rect key="frame" x="0.0" y="28.5" width="375" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="28.5" width="343" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -40,7 +40,7 @@
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XF9-r3-Vq9" userLabel="Remove Apple ID Access Button">
-                                <rect key="frame" x="0.0" y="187.5" width="375" height="34.5"/>
+                                <rect key="frame" x="0.0" y="187.5" width="343" height="34.5"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Button"/>
                             </button>
@@ -50,9 +50,9 @@
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstAttribute="bottom" secondItem="pky-np-rBc" secondAttribute="bottom" constant="20" id="3Fb-5z-arL"/>
-                    <constraint firstItem="pky-np-rBc" firstAttribute="leading" secondItem="gcY-Gg-DvR" secondAttribute="leading" id="CRY-WF-Utt"/>
+                    <constraint firstItem="pky-np-rBc" firstAttribute="leading" secondItem="gcY-Gg-DvR" secondAttribute="leading" constant="16" id="CRY-WF-Utt"/>
                     <constraint firstItem="pky-np-rBc" firstAttribute="top" secondItem="gcY-Gg-DvR" secondAttribute="top" id="Gpz-kR-gFd"/>
-                    <constraint firstAttribute="trailing" secondItem="pky-np-rBc" secondAttribute="trailing" id="VqG-p3-pkv"/>
+                    <constraint firstAttribute="trailing" secondItem="pky-np-rBc" secondAttribute="trailing" constant="16" id="VqG-p3-pkv"/>
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -121,12 +121,6 @@ private extension StorePickerCoordinator {
 
     func showStorePicker() {
         showStorePicker(presentationStyle: selectedConfiguration.presentationStyle)
-        switch selectedConfiguration {
-        case .storeCreationFromLogin:
-            createStore()
-        default:
-            break
-        }
     }
 
     func showStorePicker(presentationStyle: PresentationStyle) {

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -263,9 +263,9 @@ private extension StorePickerViewController {
             }
         }()
         accountHeaderView.isActionButtonEnabled = showsActionButton
-        accountHeaderView.onActionButtonTapped = { [weak self] in
+        accountHeaderView.onActionButtonTapped = { [weak self] sourceView in
             guard let self else { return }
-            self.presentActionMenu()
+            self.presentActionMenu(from: sourceView)
         }
     }
 
@@ -315,7 +315,7 @@ private extension StorePickerViewController {
         return WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor ?? .listBackground
     }
 
-    func presentActionMenu() {
+    func presentActionMenu(from sourceView: UIView) {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
         let logOutAction = UIAlertAction(title: Localization.ActionMenu.logOut, style: .default) { [weak self] _ in
@@ -333,8 +333,8 @@ private extension StorePickerViewController {
         actionSheet.addAction(cancelAction)
 
         if let popoverController = actionSheet.popoverPresentationController {
-            popoverController.sourceView = view
-            popoverController.sourceRect = view.bounds
+            popoverController.sourceView = sourceView
+            popoverController.sourceRect = sourceView.bounds
         }
 
         present(actionSheet, animated: true)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -252,15 +252,12 @@ private extension StorePickerViewController {
             return
         }
 
-        accountHeaderView.username = "@" + defaultAccount.username
-        accountHeaderView.fullname = defaultAccount.displayName
+        accountHeaderView.email = defaultAccount.email
         accountHeaderView.downloadGravatar(with: defaultAccount.email)
         accountHeaderView.isHelpButtonEnabled = configuration == .login || configuration == .standard
-        accountHeaderView.onHelpRequested = { [weak self] in
-            guard let self = self else {
-                return
-            }
-            self.presentHelp()
+        accountHeaderView.onActionButtonTapped = { [weak self] in
+            guard let self else { return }
+            self.presentActionMenu()
         }
     }
 
@@ -308,6 +305,31 @@ private extension StorePickerViewController {
 
     func backgroundColor() -> UIColor {
         return WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor ?? .listBackground
+    }
+
+    func presentActionMenu() {
+        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        actionSheet.view.tintColor = .text
+        let logOutAction = UIAlertAction(title: Localization.ActionMenu.logOut, style: .default) { [weak self] _ in
+            self?.restartAuthentication()
+        }
+        let helpAction = UIAlertAction(title: Localization.ActionMenu.help, style: .default) { [weak self] _ in
+            guard let self else { return }
+            ServiceLocator.analytics.track(.sitePickerHelpButtonTapped)
+            self.presentHelp()
+        }
+        let cancelAction = UIAlertAction(title: Localization.cancel, style: .cancel)
+
+        actionSheet.addAction(logOutAction)
+        actionSheet.addAction(helpAction)
+        actionSheet.addAction(cancelAction)
+
+        if let popoverController = actionSheet.popoverPresentationController {
+            popoverController.sourceView = view
+            popoverController.sourceRect = view.bounds
+        }
+
+        present(actionSheet, animated: true)
     }
 
     func presentHelp() {
@@ -422,6 +444,7 @@ private extension StorePickerViewController {
         case .empty:
             updateActionButtonAndTableState(animating: false, enabled: false)
             addStoreButton.isHidden = false
+            secondaryActionButton.isHidden = true
         case .available(let sites):
             addStoreButton.isHidden = true
             if sites.allSatisfy({ $0.isWooCommerceActive == false }) {
@@ -824,6 +847,12 @@ private extension StorePickerViewController {
                                               comment: "Button to dismiss the action sheet on the store picker")
         static let addStoreButton = NSLocalizedString("Add a Store",
                                                       comment: "Button title on the store picker for store creation")
+        enum ActionMenu {
+            static let logOut = NSLocalizedString("Log out",
+                                                  comment: "Button to log out from the current account from the store picker")
+            static let help = NSLocalizedString("Help",
+                                                comment: "Button to get help from the store picker")
+        }
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -254,7 +254,15 @@ private extension StorePickerViewController {
 
         accountHeaderView.email = defaultAccount.email
         accountHeaderView.downloadGravatar(with: defaultAccount.email)
-        accountHeaderView.isHelpButtonEnabled = configuration == .login || configuration == .standard
+        let showsActionButton: Bool = {
+            switch configuration {
+            case .login, .standard, .storeCreationFromLogin:
+                return true
+            case .switchingStores, .listStores:
+                return false
+            }
+        }()
+        accountHeaderView.isActionButtonEnabled = showsActionButton
         accountHeaderView.onActionButtonTapped = { [weak self] in
             guard let self else { return }
             self.presentActionMenu()

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULAccountMismatchViewController.swift
@@ -12,12 +12,6 @@ final class ULAccountMismatchViewController: UIViewController {
     /// and support for user actions
     private let viewModel: ULAccountMismatchViewModel
 
-    /// Header View: Displays all of the Account Details
-    ///
-    private let accountHeaderView: AccountHeaderView = {
-        return AccountHeaderView.instantiateFromNib()
-    }()
-
     private var subscriptions: Set<AnyCancellable> = []
 
     @IBOutlet private weak var gravatarImageView: CircularImageView!

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -1,19 +1,19 @@
 import XCTest
 
 private struct ElementStringIDs {
-    static let displayNameField = "full-name-label"
+    static let emailField = "email-label"
     static let siteUrlField = "url-label"
     static let continueButton = "login-epilogue-continue-button"
 }
 
 public final class LoginEpilogueScreen: BaseScreen {
     private let continueButton: XCUIElement
-    private let displayNameField: XCUIElement
+    private let emailField: XCUIElement
     private let siteUrlField: XCUIElement
 
     public init() {
         let app = XCUIApplication()
-        displayNameField = app.staticTexts[ElementStringIDs.displayNameField]
+        emailField = app.staticTexts[ElementStringIDs.emailField]
         siteUrlField = app.staticTexts[ElementStringIDs.siteUrlField]
         continueButton = app.buttons[ElementStringIDs.continueButton]
 
@@ -26,11 +26,11 @@ public final class LoginEpilogueScreen: BaseScreen {
         return try MyStoreScreen()
     }
 
-    public func verifyEpilogueDisplays(displayName expectedDisplayName: String, siteUrl expectedSiteUrl: String) -> LoginEpilogueScreen {
-        let actualDisplayName = displayNameField.label
+    public func verifyEpilogueDisplays(email expectedEmail: String, siteUrl expectedSiteUrl: String) -> LoginEpilogueScreen {
+        let actualEmail = emailField.label
         let actualSiteUrl = siteUrlField.label
 
-        XCTAssertEqual(expectedDisplayName, actualDisplayName, "Display name is '\(actualDisplayName)' but should be '\(expectedDisplayName)'.")
+        XCTAssertEqual(expectedEmail, actualEmail, "Display name is '\(actualEmail)' but should be '\(expectedEmail)'.")
         XCTAssertEqual(expectedSiteUrl, actualSiteUrl, "Site URL is \(actualSiteUrl) but should be \(expectedSiteUrl)")
 
         return self

--- a/WooCommerce/WooCommerceTests/Authentication/StorePickerCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/StorePickerCoordinatorTests.swift
@@ -25,7 +25,7 @@ final class StorePickerCoordinatorTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_storeCreationFromLogin_configuration_shows_storePicker_then_presents_storeCreation() throws {
+    func test_storeCreationFromLogin_configuration_shows_storePicker() throws {
         // Given
         let coordinator = StorePickerCoordinator(navigationController, config: .storeCreationFromLogin(source: .prologue))
 
@@ -34,13 +34,8 @@ final class StorePickerCoordinatorTests: XCTestCase {
 
         // Then
         waitUntil {
-            self.navigationController.presentedViewController is WooNavigationController
+            self.navigationController.topViewController is StorePickerViewController
         }
-        // Store picker should be pushed to the navigation stack.
-        assertThat(navigationController.topViewController, isAnInstanceOf: StorePickerViewController.self)
-
-        let storeCreationNavigationController = try XCTUnwrap(navigationController.presentedViewController as? UINavigationController)
-        assertThat(storeCreationNavigationController.topViewController, isAnInstanceOf: AuthenticatedWebViewController.self)
     }
 
     func test_standard_configuration_presents_storePicker() throws {

--- a/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
@@ -10,7 +10,7 @@ class LoginFlow {
             .proceedWith(password: TestCredentials.password)
 
         return try LoginEpilogueScreen()
-            .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
+            .verifyEpilogueDisplays(email: "e2eflowtestingmobile@example.com", siteUrl: TestCredentials.siteUrl)
             .continueWithSelectedSite()
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -37,7 +37,7 @@ final class LoginTests: XCTestCase {
             .proceedWith(password: TestCredentials.password)
 
         try LoginEpilogueScreen()
-            .verifyEpilogueDisplays(displayName: TestCredentials.displayName, siteUrl: TestCredentials.siteUrl)
+            .verifyEpilogueDisplays(email: "e2eflowtestingmobile@example.com", siteUrl: TestCredentials.siteUrl)
             .continueWithSelectedSite()
 
         try TabNavComponent()

--- a/WooCommerce/WooCommerceUITests/Utils/TestCredentials.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/TestCredentials.swift
@@ -2,7 +2,6 @@
 struct TestCredentials {
     static let emailAddress: String = "t@wp.com"
     static let password: String = "pw"
-    static let displayName: String = "WooCommerce Store Owner"
     static let siteUrl: String = "http://yourwoosite.com"
     static let storeName: String = "Your WooCommerce Store"
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8180 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There are some design updates to the store picker screen, especially for the empty state where store creation is emphasized:

- The account header only shows an email since username isn't in the account creation form
- The store creation CTA becomes the only primary action in the store picker
- Other actions than store creation are now in an ellipsis menu
- After creating an account or logging in from the store creation CTA, it stays on the store picker screen instead of launching the store creation flow right away

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

There are many configurations for the store picker, and I'm still confirming the design for the non-empty state. There might be more design changes that I'll make later.

#### Store creation flow - new account

- Log out if needed
- Tap on `Get started`
- Enter the email/password to create a new account --> after an account is created successfully, it should navigate to an empty stores screen that matches the design HyVloP5FipZzyPVenH2euI-fi-2369%3A102082&t=DpwmzfbPkivo7ZcX-0
- Tap on the ellipsis menu --> an action sheet should appear with two actions: `Log out` and `Help`
- Tap on `Help` --> the help screen should be presented with `site_picker_help_button_tapped` envet tracked
- Tap on the ellipsis menu
- Tap on `Log out` --> the user should be logged out again

#### Store creation flow - existing account without a store

- Tap on `Get started`
- Tap `Log in` and enter the credentials of a WPCOM account that doesn't have any WC stores --> after logging ing successfully, it should navigate to an empty stores screen that matches the design

#### Switching stores

- Log in if needed
- Go to the Menu tab, and tap `Switch store` --> there should not be an ellipsis menu, it should look the same as before except for the account header

---
- [x] @jaclync tests iPad for menu as a popover

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

empty stores | action sheet
-- | --
![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-28 at 14 37 46](https://user-images.githubusercontent.com/1945542/204213426-d4a95120-4064-4e6a-b549-8abe88b2e0e1.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-28 at 14 37 50](https://user-images.githubusercontent.com/1945542/204213441-c3d50910-9bf6-49c4-988a-a6f90aa46a25.png)
![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-28 at 14 38 15](https://user-images.githubusercontent.com/1945542/204213449-d67bb6bc-874c-4560-a9f1-534d8f8d4a86.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2022-11-28 at 14 38 17](https://user-images.githubusercontent.com/1945542/204213453-9f400ebc-4412-45a9-a44a-ed44a25f9bfc.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->