### PR TITLE
Native Jetpack Installation: Replace disabled A/B test experiment with new one

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -19,7 +19,7 @@ public enum ABTest: String, CaseIterable {
     /// A/B test to measure the sign-in success rate when native Jetpack installation experience is enabled
     /// Experiment ref: pbxNRc-29W-p2
     ///
-    case nativeJetpackSetupFlow = "woocommerceios_login_jetpack_setup_flow"
+    case nativeJetpackSetupFlow = "woocommerceios_login_jetpack_setup_flow_v2"
 
     /// A/B test for the Products Onboarding banner on the My Store dashboard.
     /// Experiment ref: pbxNRc-26F-p2


### PR DESCRIPTION
Closes: #8240  

### Description
This PR replaces the mistakenly disabled A/B test experiment with a freshly cloned experiment.

- While cleaning up a few unused A/A tests by disabling them, I accidentally disabled the original native Jetpack installation A/B test experiment by mistake.
- The change is irreversible, and the experiment cannot be enabled again in Abacus.
- To fix this, 
   - I have created a new experiment by cloning the original experiment in Abacus - 20925-explat-experiment 
   - I have also updated proposal P2 with the new experiment. pbxNRc-29W-p2
- As a final step, this PR updates the codebase by replacing the old experiment name with the new cloned one.

### Testing instructions

Prerequisite: Make sure that you have a test store that is not associated with your WP.com account or doesn't have Jetpack.

#### `control` variation

- Log out of the app or skip login onboarding if needed.
- On the prologue screen, select "Log In" or "Continue with WordPress.com" based on the A/B test variant you get.
- Log in with your WordPress.com account.
- If your account doesn't have any associated site, notice that the empty store picker is displayed with the matching design as on Figma.
- Select Add a Store > Connect an existing site.
- Enter the address of your test store and tap Continue.
- You will see the existing Jetpack error screen. 
- You can install and setup Jetpack in a webview from this screen.

#### Testing the `treatment` variation

We will have to sandbox and assign a particular variation to the device to test the variations.

Prerequisites:
- Please follow the setup in PCYsg-Fq7-p2#assignments-api for proxied sandboxed API requests: connect to sandbox via ssh, and point WP.com API to the sandbox IP address (`ifconfig`) in the local matchine's `/etc/hosts`
- The you need to make an authenticated WPCOM request to PATCH the variation for your WPCOM username
- Make an API request `PATCH /wpcom/v2/experiments/0.1.0/assignments` with the following `body` and make sure it's successful:
```
{
    "variations": {
        "woocommerceios_login_jetpack_setup_flow_v2": "treatment"
    },
    "username_override": "your_wpcom_username"
}
```
- Launch the app, and let it sit for a bit
- Close and relaunch the app 
- Log out of the app or skip login onboarding if needed.
- On the prologue screen, select "Log In" or "Continue with WordPress.com" based on the A/B test variant you get.
- Log in with your WordPress.com account.
- If your account doesn't have any associated site, notice that the empty store picker is displayed with the matching design as on Figma.
- Select Add a Store > Connect an existing site.
- Enter the address of your test store and tap Continue.
- You will see the new Jetpack error screen. (Screenshot below)
- You can install and setup Jetpack in new native flow starting from this screen.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Control | Treatment |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/524475/203035274-3f7d0caf-76a0-44a8-ad6c-fb7f0b43b489.png" width=320 /> | <img src="https://user-images.githubusercontent.com/524475/203014719-3b2fc035-1aff-460a-b49c-94b86e9bd846.png" width=320 /> | 



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->