### PR TITLE
[Analytics Hub] Update decimals handling logic

### DIFF
--- a/WooCommerce/Classes/Extensions/Decimal+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Decimal+Helpers.swift
@@ -8,7 +8,7 @@ extension Decimal {
         NSDecimalNumber(decimal: whole).intValue
     }
 
-    private func rounded(_ roundingMode: NSDecimalNumber.RoundingMode = .up, scale: Int = 0) -> Self {
+    func rounded(_ roundingMode: NSDecimalNumber.RoundingMode = .up, scale: Int = 0) -> Self {
         var result = Self()
         var number = self
         NSDecimalRound(&result, &number, scale, roundingMode)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -16,7 +16,7 @@ struct StatsDataTextFormatter {
                                        currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue) -> String {
         if let revenue = totalRevenue(at: selectedIntervalIndex, orderStats: orderStats) {
             // If revenue is an integer, no decimal points are shown.
-            let numberOfDecimals: Int? = revenue.isInteger ? 0: nil
+            let numberOfDecimals: Int? = revenue.rounded(to: 2).isInteger ? 0 : nil
             return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
         } else {
             return Constants.placeholderText
@@ -41,7 +41,7 @@ struct StatsDataTextFormatter {
         }
 
         // If revenue is an integer, no decimal points are shown.
-        let numberOfDecimals: Int? = revenue.isInteger ? 0 : nil
+        let numberOfDecimals: Int? = revenue.rounded(to: 2).isInteger ? 0 : nil
         return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
     }
 
@@ -80,7 +80,7 @@ struct StatsDataTextFormatter {
                                             currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue) -> String {
         if let value = averageOrderValue(orderStats: orderStats) {
             // If order value is an integer, no decimal points are shown.
-            let numberOfDecimals: Int? = value.isInteger ? 0 : nil
+            let numberOfDecimals: Int? = value.rounded(to: 2).isInteger ? 0 : nil
             return currencyFormatter.formatAmount(value, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
         } else {
             return Constants.placeholderText
@@ -278,5 +278,19 @@ private extension StatsDataTextFormatter {
 
     enum Constants {
         static let placeholderText = "-"
+    }
+
+
+}
+
+private extension Decimal {
+    func rounded(to scale: Int16) -> Self {
+        let numberHandler = NSDecimalNumberHandler(roundingMode: .plain,
+                                                   scale: scale,
+                                                   raiseOnExactness: false,
+                                                   raiseOnOverflow: false,
+                                                   raiseOnUnderflow: false,
+                                                   raiseOnDivideByZero: false)
+        return (self as NSDecimalNumber).rounding(accordingToBehavior: numberHandler) as Decimal
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -13,10 +13,10 @@ struct StatsDataTextFormatter {
     static func createTotalRevenueText(orderStats: OrderStatsV4?,
                                        selectedIntervalIndex: Int?,
                                        currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
-                                       currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue) -> String {
+                                       currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue,
+                                       numberOfFractionDigits: Int = ServiceLocator.currencySettings.fractionDigits) -> String {
         if let revenue = totalRevenue(at: selectedIntervalIndex, orderStats: orderStats) {
             // If revenue is an integer, no decimal points are shown.
-            let numberOfFractionDigits = ServiceLocator.currencySettings.fractionDigits
             let numberOfDecimals: Int? = revenue.rounded(.plain, scale: numberOfFractionDigits).isInteger ? 0 : nil
             return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
         } else {
@@ -36,13 +36,13 @@ struct StatsDataTextFormatter {
     ///
     static func createNetRevenueText(orderStats: OrderStatsV4?,
                                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
-                                     currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue) -> String {
+                                     currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue,
+                                     numberOfFractionDigits: Int = ServiceLocator.currencySettings.fractionDigits) -> String {
         guard let revenue = orderStats?.totals.netRevenue else {
             return Constants.placeholderText
         }
 
         // If revenue is an integer, no decimal points are shown.
-        let numberOfFractionDigits = ServiceLocator.currencySettings.fractionDigits
         let numberOfDecimals: Int? = revenue.rounded(.plain, scale: numberOfFractionDigits).isInteger ? 0 : nil
         return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
     }
@@ -79,10 +79,10 @@ struct StatsDataTextFormatter {
     ///
     static func createAverageOrderValueText(orderStats: OrderStatsV4?,
                                             currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
-                                            currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue) -> String {
+                                            currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue,
+                                            numberOfFractionDigits: Int = ServiceLocator.currencySettings.fractionDigits) -> String {
         if let value = averageOrderValue(orderStats: orderStats) {
             // If order value is an integer, no decimal points are shown.
-            let numberOfFractionDigits = ServiceLocator.currencySettings.fractionDigits
             let numberOfDecimals: Int? = value.rounded(.plain, scale: numberOfFractionDigits).isInteger ? 0 : nil
             return currencyFormatter.formatAmount(value, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
         } else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -16,7 +16,7 @@ struct StatsDataTextFormatter {
                                        currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue) -> String {
         if let revenue = totalRevenue(at: selectedIntervalIndex, orderStats: orderStats) {
             // If revenue is an integer, no decimal points are shown.
-            let numberOfDecimals: Int? = revenue.rounded(to: 2).isInteger ? 0 : nil
+            let numberOfDecimals: Int? = revenue.rounded(.plain, scale: 2).isInteger ? 0 : nil
             return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
         } else {
             return Constants.placeholderText
@@ -41,7 +41,7 @@ struct StatsDataTextFormatter {
         }
 
         // If revenue is an integer, no decimal points are shown.
-        let numberOfDecimals: Int? = revenue.rounded(to: 2).isInteger ? 0 : nil
+        let numberOfDecimals: Int? = revenue.rounded(.plain, scale: 2).isInteger ? 0 : nil
         return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
     }
 
@@ -80,7 +80,7 @@ struct StatsDataTextFormatter {
                                             currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue) -> String {
         if let value = averageOrderValue(orderStats: orderStats) {
             // If order value is an integer, no decimal points are shown.
-            let numberOfDecimals: Int? = value.rounded(to: 2).isInteger ? 0 : nil
+            let numberOfDecimals: Int? = value.rounded(.plain, scale: 2).isInteger ? 0 : nil
             return currencyFormatter.formatAmount(value, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
         } else {
             return Constants.placeholderText
@@ -281,16 +281,4 @@ private extension StatsDataTextFormatter {
     }
 
 
-}
-
-private extension Decimal {
-    func rounded(to scale: Int16) -> Self {
-        let numberHandler = NSDecimalNumberHandler(roundingMode: .plain,
-                                                   scale: scale,
-                                                   raiseOnExactness: false,
-                                                   raiseOnOverflow: false,
-                                                   raiseOnUnderflow: false,
-                                                   raiseOnDivideByZero: false)
-        return (self as NSDecimalNumber).rounding(accordingToBehavior: numberHandler) as Decimal
-    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -16,7 +16,8 @@ struct StatsDataTextFormatter {
                                        currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue) -> String {
         if let revenue = totalRevenue(at: selectedIntervalIndex, orderStats: orderStats) {
             // If revenue is an integer, no decimal points are shown.
-            let numberOfDecimals: Int? = revenue.rounded(.plain, scale: 2).isInteger ? 0 : nil
+            let numberOfFractionDigits = ServiceLocator.currencySettings.fractionDigits
+            let numberOfDecimals: Int? = revenue.rounded(.plain, scale: numberOfFractionDigits).isInteger ? 0 : nil
             return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
         } else {
             return Constants.placeholderText
@@ -41,7 +42,8 @@ struct StatsDataTextFormatter {
         }
 
         // If revenue is an integer, no decimal points are shown.
-        let numberOfDecimals: Int? = revenue.rounded(.plain, scale: 2).isInteger ? 0 : nil
+        let numberOfFractionDigits = ServiceLocator.currencySettings.fractionDigits
+        let numberOfDecimals: Int? = revenue.rounded(.plain, scale: numberOfFractionDigits).isInteger ? 0 : nil
         return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
     }
 
@@ -80,7 +82,8 @@ struct StatsDataTextFormatter {
                                             currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue) -> String {
         if let value = averageOrderValue(orderStats: orderStats) {
             // If order value is an integer, no decimal points are shown.
-            let numberOfDecimals: Int? = value.rounded(.plain, scale: 2).isInteger ? 0 : nil
+            let numberOfFractionDigits = ServiceLocator.currencySettings.fractionDigits
+            let numberOfDecimals: Int? = value.rounded(.plain, scale: numberOfFractionDigits).isInteger ? 0 : nil
             return currencyFormatter.formatAmount(value, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
         } else {
             return Constants.placeholderText

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsDataTextFormatterTests.swift
@@ -26,6 +26,20 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(totalRevenue, "$62")
     }
 
+    func test_createTotalRevenueText_does_not_return_decimal_points_for_rounded_integer_value() {
+        // Given
+        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 62.0000000000002))
+
+        // When
+        let totalRevenue = StatsDataTextFormatter.createTotalRevenueText(orderStats: orderStats,
+                                                                    selectedIntervalIndex: nil,
+                                                                    currencyFormatter: currencyFormatter,
+                                                                    currencyCode: currencyCode.rawValue)
+
+        // Then
+        XCTAssertEqual(totalRevenue, "$62")
+    }
+
     func test_createTotalRevenueText_returns_decimal_points_from_currency_settings_for_noninteger_value() {
         // Given
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 62.856))
@@ -78,6 +92,19 @@ final class StatsDataTextFormatterTests: XCTestCase {
     func test_createNetRevenueText_does_not_return_decimal_points_for_integer_value() {
         // Given
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(netRevenue: 62))
+
+        // When
+        let netRevenue = StatsDataTextFormatter.createNetRevenueText(orderStats: orderStats,
+                                                                     currencyFormatter: currencyFormatter,
+                                                                     currencyCode: currencyCode.rawValue)
+
+        // Then
+        XCTAssertEqual(netRevenue, "$62")
+    }
+
+    func test_createNetRevenueText_does_not_return_decimal_points_for_rounded_integer_value() {
+        // Given
+        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(netRevenue: 62.0000000000002))
 
         // When
         let netRevenue = StatsDataTextFormatter.createNetRevenueText(orderStats: orderStats,
@@ -162,6 +189,19 @@ final class StatsDataTextFormatterTests: XCTestCase {
     func test_createAverageOrderValueText_does_not_return_decimal_points_for_integer_value() {
         // Given
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(averageOrderValue: 62))
+
+        // When
+        let averageOrderValue = StatsDataTextFormatter.createAverageOrderValueText(orderStats: orderStats,
+                                                                              currencyFormatter: currencyFormatter,
+                                                                              currencyCode: currencyCode.rawValue)
+
+        // Then
+        XCTAssertEqual(averageOrderValue, "$62")
+    }
+
+    func test_createAverageOrderValueText_does_not_return_decimal_points_for_rounded_integer_value() {
+        // Given
+        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(averageOrderValue: 62.0000000000002))
 
         // When
         let averageOrderValue = StatsDataTextFormatter.createAverageOrderValueText(orderStats: orderStats,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsDataTextFormatterTests.swift
@@ -43,6 +43,9 @@ final class StatsDataTextFormatterTests: XCTestCase {
     func test_createTotalRevenueText_returns_expected_number_of_fractional_digits() {
         // Given
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 62.0023))
+        let customCurrencySettings = CurrencySettings()
+        customCurrencySettings.fractionDigits = 3
+        let currencyFormatter = CurrencyFormatter(currencySettings: customCurrencySettings)
 
         // When
         let totalRevenue = StatsDataTextFormatter.createTotalRevenueText(orderStats: orderStats,
@@ -133,6 +136,9 @@ final class StatsDataTextFormatterTests: XCTestCase {
     func test_createNetRevenueText_returns_expected_number_of_fractional_digits() {
         // Given
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(netRevenue: 62.0023))
+        let customCurrencySettings = CurrencySettings()
+        customCurrencySettings.fractionDigits = 3
+        let currencyFormatter = CurrencyFormatter(currencySettings: customCurrencySettings)
 
         // When
         let netRevenue = StatsDataTextFormatter.createNetRevenueText(orderStats: orderStats,
@@ -244,6 +250,9 @@ final class StatsDataTextFormatterTests: XCTestCase {
     func test_createAverageOrderValueText_returns_expected_number_of_fractional_digits() {
         // Given
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(averageOrderValue: 62.0023))
+        let customCurrencySettings = CurrencySettings()
+        customCurrencySettings.fractionDigits = 3
+        let currencyFormatter = CurrencyFormatter(currencySettings: customCurrencySettings)
 
         // When
         let averageOrderValue = StatsDataTextFormatter.createAverageOrderValueText(orderStats: orderStats,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsDataTextFormatterTests.swift
@@ -40,6 +40,21 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(totalRevenue, "$62")
     }
 
+    func test_createTotalRevenueText_returns_expected_number_of_fractional_digits() {
+        // Given
+        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 62.0023))
+
+        // When
+        let totalRevenue = StatsDataTextFormatter.createTotalRevenueText(orderStats: orderStats,
+                                                                         selectedIntervalIndex: nil,
+                                                                         currencyFormatter: currencyFormatter,
+                                                                         currencyCode: currencyCode.rawValue,
+                                                                         numberOfFractionDigits: 3)
+
+        // Then
+        XCTAssertEqual(totalRevenue, "$62.002")
+    }
+
     func test_createTotalRevenueText_returns_decimal_points_from_currency_settings_for_noninteger_value() {
         // Given
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 62.856))
@@ -113,6 +128,20 @@ final class StatsDataTextFormatterTests: XCTestCase {
 
         // Then
         XCTAssertEqual(netRevenue, "$62")
+    }
+
+    func test_createNetRevenueText_returns_expected_number_of_fractional_digits() {
+        // Given
+        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(netRevenue: 62.0023))
+
+        // When
+        let netRevenue = StatsDataTextFormatter.createNetRevenueText(orderStats: orderStats,
+                                                                     currencyFormatter: currencyFormatter,
+                                                                     currencyCode: currencyCode.rawValue,
+                                                                     numberOfFractionDigits: 3)
+
+        // Then
+        XCTAssertEqual(netRevenue, "$62.002")
     }
 
     func test_createNetRevenueText_returns_decimal_points_from_currency_settings_for_noninteger_value() {
@@ -210,6 +239,20 @@ final class StatsDataTextFormatterTests: XCTestCase {
 
         // Then
         XCTAssertEqual(averageOrderValue, "$62")
+    }
+
+    func test_createAverageOrderValueText_returns_expected_number_of_fractional_digits() {
+        // Given
+        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(averageOrderValue: 62.0023))
+
+        // When
+        let averageOrderValue = StatsDataTextFormatter.createAverageOrderValueText(orderStats: orderStats,
+                                                                                   currencyFormatter: currencyFormatter,
+                                                                                   currencyCode: currencyCode.rawValue,
+                                                                                   numberOfFractionDigits: 3)
+
+        // Then
+        XCTAssertEqual(averageOrderValue, "$62.002")
     }
 
     func test_createAverageOrderValueText_returns_decimal_points_from_currency_settings_for_noninteger_value() {


### PR DESCRIPTION
## Description

This PR updates `StatsDataTextFormatter` to round decimals to properly hide non-significant zero numbers.

## Testing

Hardcode `grossRevenue` or `netRevenue` in `OrderStatsV4` to have a very small number after the comma.
Or check unit tests status.

## Screenshots

before|after
--|--
![1](https://user-images.githubusercontent.com/3132438/204312403-72945f1b-4801-48da-b474-a7289d3019cd.png)|![2](https://user-images.githubusercontent.com/3132438/204312411-0cc7fe4e-4222-445d-b211-d20a75842477.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.