### PR TITLE
Account creation: show loading state for the continue button after tapping it

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -122,6 +122,7 @@ struct AccountCreationForm: View {
                 // CTA to submit the form.
                 Button(Localization.submitButtonTitle) {
                     Task { @MainActor in
+                        isPerformingTask = true
                         let createAccountCompleted = (try? await viewModel.createAccount()) != nil
                         isPerformingTask = false
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8247 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While testing store creation with a new account, I noticed that the Continue button doesn't show and animate a spinner after tapping it and while waiting for the API response anymore. This is a regression from a previous [refactoring on the async/await interface](https://github.com/woocommerce/woocommerce-ios/commit/5b2efe2b3cda20c88dc945a3ab2ff2fb27740f3f), and this PR just added back the missing line `isPerformingTask = true` that turns on the loading state for the form.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log out if needed
- Tap `Get started`
- Enter any credentials, and tap `Continue` --> a spinner should be shown, where it isn't shown on the latest `trunk`

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://user-images.githubusercontent.com/1945542/204438385-63388e3a-d94b-4c8f-8479-efb399f4bc4a.png" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
