### PR TITLE
Update logged-out A/A test name and re-add logged-in A/A test

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -8,8 +8,12 @@ public enum ABTest: String, CaseIterable {
     case null
 
     /// A/A test to make sure there is no bias in the logged out state.
+    /// Experiment ref: pbxNRc-1QS-p2
+    case aaTestLoggedIn = "woocommerceios_explat_aa_test_logged_in_202212_v2"
+
+    /// A/A test to make sure there is no bias in the logged out state.
     /// Experiment ref: pbxNRc-1S0-p2
-    case aaTestLoggedOut = "woocommerceios_explat_aa_test_logged_out_202211"
+    case aaTestLoggedOut = "woocommerceios_explat_aa_test_logged_out_202212_v2"
 
     /// A/B test to measure the sign-in success rate when only WPCom login is enabled.
     /// Experiment ref: pbxNRc-27s-p2
@@ -39,7 +43,7 @@ public enum ABTest: String, CaseIterable {
     /// When adding a new experiment, add it to the appropriate case depending on its context (logged-in or logged-out experience).
     public var context: ExperimentContext {
         switch self {
-        case .productsOnboardingBanner, .productsOnboardingTemplateProducts, .nativeJetpackSetupFlow:
+        case .aaTestLoggedIn, .productsOnboardingBanner, .productsOnboardingTemplateProducts, .nativeJetpackSetupFlow:
             return .loggedIn
         case .aaTestLoggedOut, .abTestLoginWithWPComOnly:
             return .loggedOut


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8235 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Since we had [an attempted fix](https://github.com/woocommerce/woocommerce-ios/pull/8170) for the previous A/A tests where there is a bias toward the control variant, I created another pair of A/A tests (logged-in/logged-out) so that we can see if the bias issue is fixed.

A note on the experiment name: `woocommerceios_explat_aa_test_logged_out_202212` and `woocommerceios_explat_aa_test_logged_in_202212` experiment names were already taken by @selanthiraiyan's previous PRs that were closed. I re-cloned the experiments with `*_v2` names since we can't reuse the same experiment name.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: a sandbox is required for testing manual assignments on A/B experiments, you can request one if you don't have one - it'd be useful for testing IAP later as well.

There are no visual differences for the A/A tests, you can test it by setting a breakpoint in the logged-out and logged-in state.

#### Logged-out state

Prerequisites:
- Please follow the setup in PCYsg-Fq7-p2#assignments-api for proxied sandboxed API requests: connect to sandbox via ssh, and point WP.com API to the sandbox IP address (`ifconfig`) in the local matchine's `/etc/hosts`
- The you need to make an authenticated WPCOM request to manually assign the variant
- Find the anon ID of the device by setting a breakpoint in `ExPlatService` on the line `urlComponents.queryItems?.append(URLQueryItem.init(name: "anon_id", value: anonId))` and launching the app
- Make an API request `PATCH /wpcom/v2/experiments/0.1.0/assignments` with the following `body` and make sure it's successful:
```
{
    "variations": {
        "woocommerceios_explat_aa_test_logged_out_202212_v2": "treatment"
    },
    "anon_id": "{{anon_id}}",
    "username_override": ""
}
```

- In code, set a breakpoint at a logged-out action callback like `StoreCreationCoordinator.start`
- Launch the app
- Log out of the app or skip login onboarding if needed
- Tap on `Get Started` or any other actions that trigger the breakpoint set in the first step. When the breakpoint is hit, check the A/A test variant by `po ABTest.aaTestLoggedOut.variation` in the debug console --> it should say `treatment: nil`

#### Logged-in state

Prerequisites:
- Make an API request `PATCH /wpcom/v2/experiments/0.1.0/assignments` with the following `body` and the bearer token for the wpcom account (I'd use an A8C account in this case), make sure it's successful:
```
{
    "variations": {
        "woocommerceios_explat_aa_test_logged_in_202212_v2": "treatment"
    }
}
```

- In code, set a breakpoint at a logged-in action callback like [in `HubMenu`](https://github.com/woocommerce/woocommerce-ios/blob/dacfd4cdc3be2a45d9e2777b7ed4ad0fccb62926/WooCommerce/Classes/ViewRelated/Hub%20Menu/HubMenu.swift#L52) when an element is tapped
- Launch the app
- Log in to a store
- Go to the Menu tab, and tap on any element in the menu. Or any other actions that trigger the breakpoint set in the first step. When the breakpoint is hit, check the A/A test variant by `po ABTest.aaTestLoggedIn.variation` in the debug console --> it should say `treatment: nil`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
