### PR TITLE
Attempt fixing a flaky test case `test_user_is_entitled_to_product_returns_false_when_not_entitled`

### DIFF
--- a/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
@@ -15,7 +15,7 @@ final class InAppPurchaseStoreTests: XCTestCase {
     ///
     private var storageManager: MockStorageManager!
 
-    private var storeKitSession = try! SKTestSession(configurationFileNamed: "WooCommerceTest")
+    private var storeKitSession: SKTestSession!
 
     /// Testing SiteID
     ///
@@ -35,15 +35,19 @@ final class InAppPurchaseStoreTests: XCTestCase {
 
 
     override func setUp() {
+        super.setUp()
         network = MockNetwork(useResponseQueue: true)
         storageManager = MockStorageManager()
         store = InAppPurchaseStore(dispatcher: Dispatcher(), storageManager: storageManager, network: network)
+        storeKitSession = try! SKTestSession(configurationFileNamed: "WooCommerceTest")
         storeKitSession.disableDialogs = true
     }
 
     override func tearDown() {
         storeKitSession.resetToDefaultState()
         storeKitSession.clearTransactions()
+        storeKitSession = nil
+        super.tearDown()
     }
 
     func test_iap_supported_in_us() throws {


### PR DESCRIPTION


<!-- Remember about a good descriptive title. -->

Attempted for #8221 and a case in https://github.com/woocommerce/woocommerce-ios/issues/7425
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I'm seeing a bunch of unit tests failures in CI these days, almost half of the time in different PRs. I didn't find anything obvious in the test case, but thought that reinitializing the `SKTestSession` in each test case might help. Another thought was to mock `Transaction.currentEntitlement` in `InAppPurchaseStore.userIsEntitledToProduct` but that'd be more changes. [3 CI runs](https://buildkite.com/automattic/woocommerce-ios/builds?branch=td%2F8221-attempt-fixing-flaky-InAppPurchaseStoreTests) were all green. I'm not very familiar with StoreKit though, please feel free to correct anything!

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Feel free to run the whole YosemiteTests locally if you'd like to confirm.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
