### PR TITLE
Login: Remove XMLRPC dependency for the native Jetpack Installation flow

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -72,7 +72,7 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
 #  pod 'WordPressAuthenticator', '~> 4.2.0'
-   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '8ded346a260f733e7b0ca790555402f00313611e'
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'fe8180657064e74e7db3784f06b58d0857f41733'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -71,8 +71,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 4.2.0'
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+#  pod 'WordPressAuthenticator', '~> 4.2.0'
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '8ded346a260f733e7b0ca790555402f00313611e'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -71,8 +71,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-#  pod 'WordPressAuthenticator', '~> 4.2.0'
-   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'fe8180657064e74e7db3784f06b58d0857f41733'
+  pod 'WordPressAuthenticator', '~> 4.3.0-beta.1'
+#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -91,7 +91,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.14)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `8ded346a260f733e7b0ca790555402f00313611e`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `fe8180657064e74e7db3784f06b58d0857f41733`)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -140,12 +140,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: 8ded346a260f733e7b0ca790555402f00313611e
+    :commit: fe8180657064e74e7db3784f06b58d0857f41733
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: 8ded346a260f733e7b0ca790555402f00313611e
+    :commit: fe8180657064e74e7db3784f06b58d0857f41733
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -186,6 +186,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 6efcad4dd9362675d8209a2b314ac9be389a8051
+PODFILE CHECKSUM: ed2ddbaf13d280b3bbff34359b0c86112067c37d
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -42,7 +42,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (4.2.0):
+  - WordPressAuthenticator (4.3.0-beta.1):
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
@@ -91,7 +91,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.14)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 4.2.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `8ded346a260f733e7b0ca790555402f00313611e`)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -101,8 +101,6 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -140,6 +138,16 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :commit: 8ded346a260f733e7b0ca790555402f00313611e
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: 8ded346a260f733e7b0ca790555402f00313611e
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 8fca6b5563a5baef2c04bee27538025e4ceb2add
@@ -162,7 +170,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 27178591a805804bd27959f1f76ddcb94605916c
+  WordPressAuthenticator: 6ef20b546ac4f90e7ff3452979e19f6167e9f605
   WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -178,6 +186,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 8b243f1ea76d4db3aa638b50ef0d516185d01c2c
+PODFILE CHECKSUM: 6efcad4dd9362675d8209a2b314ac9be389a8051
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -91,7 +91,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.14)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `fe8180657064e74e7db3784f06b58d0857f41733`)
+  - WordPressAuthenticator (~> 4.3.0-beta.1)
   - WordPressKit (~> 4.49.0)
   - WordPressShared (~> 1.15)
   - WordPressUI (~> 1.12.5)
@@ -101,6 +101,8 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
+  https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -138,16 +140,6 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :commit: fe8180657064e74e7db3784f06b58d0857f41733
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: fe8180657064e74e7db3784f06b58d0857f41733
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 8fca6b5563a5baef2c04bee27538025e4ceb2add
@@ -170,7 +162,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 6ef20b546ac4f90e7ff3452979e19f6167e9f605
+  WordPressAuthenticator: f886178b7202cfb8adfd834fb6391b7970d18871
   WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -186,6 +178,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: ed2ddbaf13d280b3bbff34359b0c86112067c37d
+PODFILE CHECKSUM: b5975e437e8925c28bb2d91af5f3e557e82ae34a
 
 COCOAPODS: 1.11.3

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -60,6 +60,7 @@ class AuthenticationManager: Authentication {
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasisM2)
         let isSimplifiedLoginI1Enabled = ABTest.abTestLoginWithWPComOnly.variation != .control
         let isStoreCreationMVPEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
+        let isNativeJetpackSetupEnabled = ABTest.nativeJetpackSetupFlow.variation != .control
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
                                                                 wpcomScheme: ApiCredentials.dotcomAuthScheme,
@@ -86,7 +87,8 @@ class AuthenticationManager: Authentication {
                                                                 enableSocialLogin: !isSimplifiedLoginI1Enabled,
                                                                 emphasizeEmailForWPComPassword: true,
                                                                 wpcomPasswordInstructions:
-                                                                AuthenticationConstants.wpcomPasswordInstructions)
+                                                                AuthenticationConstants.wpcomPasswordInstructions,
+                                                                skipXMLRPCCheckForSiteDiscovery: isNativeJetpackSetupEnabled)
 
         let systemGray3LightModeColor = UIColor(red: 199/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1)
         let systemLabelLightModeColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/LoginJetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/LoginJetpackSetupCoordinator.swift
@@ -32,8 +32,8 @@ final class LoginJetpackSetupCoordinator: Coordinator {
         let siteCredentialUI = SiteCredentialLoginHostingViewController(
             siteURL: siteURL,
             connectionOnly: connectionOnly,
-            onLoginSuccess: { [weak self] xmlrpc in
-                self?.showSetupSteps(xmlrpc: xmlrpc)
+            onLoginSuccess: { [weak self] in
+                self?.showSetupSteps()
         })
         navigationController.present(UINavigationController(rootViewController: siteCredentialUI), animated: true)
     }
@@ -42,13 +42,13 @@ final class LoginJetpackSetupCoordinator: Coordinator {
 // MARK: Private helpers
 //
 private extension LoginJetpackSetupCoordinator {
-    func showSetupSteps(xmlrpc: String) {
+    func showSetupSteps() {
         let setupUI = LoginJetpackSetupHostingController(siteURL: siteURL, connectionOnly: connectionOnly, onStoreNavigation: { [weak self] connectedEmail in
             guard let self, let email = connectedEmail else { return }
             if email != self.stores.sessionManager.defaultAccount?.email {
                 // if the user authorized Jetpack with a different account, support them to log in with that account.
                 self.analytics.track(.loginJetpackSetupAuthorizedUsingDifferentWPCOMAccount)
-                self.showVerifyWPComAccount(email: email, xmlrpc: xmlrpc)
+                self.showVerifyWPComAccount(email: email)
             } else {
                 self.showStorePickerForLogin()
             }
@@ -61,10 +61,10 @@ private extension LoginJetpackSetupCoordinator {
         contentNavigationController.setViewControllers([setupUI], animated: true)
     }
 
-    func showVerifyWPComAccount(email: String, xmlrpc: String) {
+    func showVerifyWPComAccount(email: String) {
         WordPressAuthenticator.showVerifyEmailForWPCom(
             from: navigationController.presentedViewController ?? navigationController,
-            xmlrpc: xmlrpc,
+            xmlrpc: "",
             connectedEmail: email,
             siteURL: siteURL
         )

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginView.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginView.swift
@@ -7,7 +7,7 @@ final class SiteCredentialLoginHostingViewController: UIHostingController<SiteCr
     init(siteURL: String,
          connectionOnly: Bool,
          analytics: Analytics = ServiceLocator.analytics,
-         onLoginSuccess: @escaping (String) -> Void) {
+         onLoginSuccess: @escaping () -> Void) {
         self.analytics = analytics
         let viewModel = SiteCredentialLoginViewModel(siteURL: siteURL, onLoginSuccess: onLoginSuccess)
         super.init(rootView: SiteCredentialLoginView(connectionOnly: connectionOnly, viewModel: viewModel))

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -90,7 +90,7 @@ private extension SiteCredentialLoginViewModel {
             switch result {
             case .success:
                 // Success to get the details means the authentication succeeds.
-                self.successHandler()
+                self.handleCompletion()
             case .failure(let error):
                 self.handleRemoteError(error)
             }
@@ -105,7 +105,7 @@ private extension SiteCredentialLoginViewModel {
             // Error 404 means Jetpack is not installed. Allow this to come through.
             // Error 403 means the lack of permission to manage plugins. Also allow this error
             // since we want to show the error on the next screen.
-            return successHandler()
+            return handleCompletion()
         case AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 401)):
             errorMessage = Localization.wrongCredentials
         default:
@@ -114,6 +114,11 @@ private extension SiteCredentialLoginViewModel {
 
         shouldShowErrorAlert = true
         analytics.track(.loginJetpackSiteCredentialDidShowErrorAlert, withError: error)
+    }
+
+    func handleCompletion() {
+        analytics.track(.loginJetpackSiteCredentialDidFinishLogin)
+        successHandler()
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -19,7 +19,7 @@ final class SiteCredentialLoginViewModel: NSObject, ObservableObject {
     @Published var shouldShowErrorAlert = false
 
     private let stores: StoresManager
-    private let successHandler: (_ xmlrpc: String) -> Void
+    private let successHandler: () -> Void
     private let analytics: Analytics
 
     private var loginFields: LoginFields {
@@ -34,7 +34,7 @@ final class SiteCredentialLoginViewModel: NSObject, ObservableObject {
     init(siteURL: String,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
-         onLoginSuccess: @escaping (String) -> Void = { _ in }) {
+         onLoginSuccess: @escaping () -> Void = {}) {
         self.siteURL = siteURL
         self.stores = stores
         self.analytics = analytics
@@ -87,11 +87,11 @@ private extension SiteCredentialLoginViewModel {
             self.isLoggingIn = false
             switch result {
             case .success:
-                self.successHandler("")
+                self.successHandler()
             case .failure(let error):
                 if case .responseValidationFailed(reason: .unacceptableStatusCode(code: 404)) = error as? AFError {
                     // Error 404 means Jetpack is not installed. Allow this to come through.
-                    return self.successHandler("")
+                    return self.successHandler()
                 }
                 self.handleRemoteError(error)
             }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -63,25 +63,10 @@ private extension SiteCredentialLoginViewModel {
     }
 
     func loginAndAttemptFetchingJetpackPluginDetails() {
-        guard let loginURL = URL(string: siteURL + Constants.loginPath),
-              let adminURL = URL(string: siteURL + Constants.adminPath) else {
-            DDLogWarn("⚠️ Cannot construct login URL and admin URL for site \(siteURL)")
-            return
-        }
-
         // Makes sure the loading indicator is shown
         isLoggingIn = true
 
-        // Prepares the authenticator with username and password
-        let authenticator = CookieNonceAuthenticator(username: username,
-                                                     password: password,
-                                                     loginURL: loginURL,
-                                                     adminURL: adminURL,
-                                                     version: Constants.defaultWPVersion,
-                                                     nonce: nil)
-        let network = WordPressOrgNetwork(authenticator: authenticator)
-        let authenticationAction = JetpackConnectionAction.authenticate(siteURL: siteURL, network: network)
-        stores.dispatch(authenticationAction)
+        handleCookieAuthentication()
 
         // Retrieves Jetpack plugin details to see if the authentication succeeds.
         let jetpackAction = JetpackConnectionAction.retrieveJetpackPluginDetails { [weak self] result in
@@ -96,6 +81,25 @@ private extension SiteCredentialLoginViewModel {
             }
         }
         stores.dispatch(jetpackAction)
+    }
+
+    func handleCookieAuthentication() {
+        guard let loginURL = URL(string: siteURL + Constants.loginPath),
+              let adminURL = URL(string: siteURL + Constants.adminPath) else {
+            DDLogWarn("⚠️ Cannot construct login URL and admin URL for site \(siteURL)")
+            isLoggingIn = false
+            return
+        }
+        // Prepares the authenticator with username and password
+        let authenticator = CookieNonceAuthenticator(username: username,
+                                                     password: password,
+                                                     loginURL: loginURL,
+                                                     adminURL: adminURL,
+                                                     version: Constants.defaultWPVersion,
+                                                     nonce: nil)
+        let network = WordPressOrgNetwork(authenticator: authenticator)
+        let authenticationAction = JetpackConnectionAction.authenticate(siteURL: siteURL, network: network)
+        stores.dispatch(authenticationAction)
     }
 
     func handleRemoteError(_ error: Error) {

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -69,7 +69,7 @@ private extension SiteCredentialLoginViewModel {
             return
         }
 
-        // makes sure the loading indicator is shown
+        // Makes sure the loading indicator is shown
         isLoggingIn = true
 
         // Prepares the authenticator with username and password
@@ -89,6 +89,7 @@ private extension SiteCredentialLoginViewModel {
             self.isLoggingIn = false
             switch result {
             case .success:
+                // Success to get the details mean authentication succeeds.
                 self.successHandler()
             case .failure(let error):
                 if case .responseValidationFailed(reason: .unacceptableStatusCode(code: 404)) = error as? AFError {

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -72,6 +72,7 @@ private extension SiteCredentialLoginViewModel {
         // makes sure the loading indicator is shown
         isLoggingIn = true
 
+        // Prepares the authenticator with username and password
         let authenticator = CookieNonceAuthenticator(username: username,
                                                      password: password,
                                                      loginURL: loginURL,
@@ -82,6 +83,7 @@ private extension SiteCredentialLoginViewModel {
         let authenticationAction = JetpackConnectionAction.authenticate(siteURL: siteURL, network: network)
         stores.dispatch(authenticationAction)
 
+        // Retrieves Jetpack plugin details to see if the authentication succeeds.
         let jetpackAction = JetpackConnectionAction.retrieveJetpackPluginDetails { [weak self] result in
             guard let self else { return }
             self.isLoggingIn = false
@@ -130,6 +132,6 @@ extension SiteCredentialLoginViewModel {
     enum Constants {
         static let loginPath = "/wp-login.php"
         static let adminPath = "/wp-admin/"
-        static let defaultWPVersion = "5.6.0"
+        static let defaultWPVersion = "5.6.0" // a default version that supports Ajax nonce retrieval
     }
 }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -45,7 +45,7 @@ final class SiteCredentialLoginViewModel: NSObject, ObservableObject {
 
     func handleLogin() {
         analytics.track(.loginJetpackSiteCredentialInstallTapped)
-        loginAndAttemptFetchingJetpackConnection()
+        loginAndAttemptFetchingJetpackPluginDetails()
     }
 
     func resetPassword() {
@@ -62,7 +62,7 @@ private extension SiteCredentialLoginViewModel {
             .assign(to: &$primaryButtonDisabled)
     }
 
-    func loginAndAttemptFetchingJetpackConnection() {
+    func loginAndAttemptFetchingJetpackPluginDetails() {
         guard let loginURL = URL(string: siteURL + Constants.loginPath),
               let adminURL = URL(string: siteURL + Constants.adminPath) else {
             DDLogWarn("⚠️ Cannot construct login URL and admin URL for site \(siteURL)")
@@ -89,6 +89,10 @@ private extension SiteCredentialLoginViewModel {
             case .success:
                 self.successHandler("")
             case .failure(let error):
+                if case .responseValidationFailed(reason: .unacceptableStatusCode(code: 404)) = error as? AFError {
+                    // Error 404 means Jetpack is not installed. Allow this to come through.
+                    return self.successHandler("")
+                }
                 self.handleRemoteError(error)
             }
         }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -67,20 +67,7 @@ private extension SiteCredentialLoginViewModel {
         isLoggingIn = true
 
         handleCookieAuthentication()
-
-        // Retrieves Jetpack plugin details to see if the authentication succeeds.
-        let jetpackAction = JetpackConnectionAction.retrieveJetpackPluginDetails { [weak self] result in
-            guard let self else { return }
-            self.isLoggingIn = false
-            switch result {
-            case .success:
-                // Success to get the details means the authentication succeeds.
-                self.handleCompletion()
-            case .failure(let error):
-                self.handleRemoteError(error)
-            }
-        }
-        stores.dispatch(jetpackAction)
+        retrieveJetpackPluginDetails()
     }
 
     func handleCookieAuthentication() {
@@ -100,6 +87,22 @@ private extension SiteCredentialLoginViewModel {
         let network = WordPressOrgNetwork(authenticator: authenticator)
         let authenticationAction = JetpackConnectionAction.authenticate(siteURL: siteURL, network: network)
         stores.dispatch(authenticationAction)
+    }
+
+    func retrieveJetpackPluginDetails() {
+        // Retrieves Jetpack plugin details to see if the authentication succeeds.
+        let jetpackAction = JetpackConnectionAction.retrieveJetpackPluginDetails { [weak self] result in
+            guard let self else { return }
+            self.isLoggingIn = false
+            switch result {
+            case .success:
+                // Success to get the details means the authentication succeeds.
+                self.handleCompletion()
+            case .failure(let error):
+                self.handleRemoteError(error)
+            }
+        }
+        stores.dispatch(jetpackAction)
     }
 
     func handleRemoteError(_ error: Error) {

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/SiteCredentialLoginHostingViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/SiteCredentialLoginHostingViewControllerTests.swift
@@ -25,7 +25,7 @@ final class SiteCredentialLoginHostingViewControllerTests: XCTestCase {
         // Given
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewController = SiteCredentialLoginHostingViewController(siteURL: testURL, connectionOnly: true, analytics: analytics, onLoginSuccess: { _ in })
+        let viewController = SiteCredentialLoginHostingViewController(siteURL: testURL, connectionOnly: true, analytics: analytics, onLoginSuccess: {})
 
         // When
         _ = try XCTUnwrap(viewController.view)
@@ -38,7 +38,7 @@ final class SiteCredentialLoginHostingViewControllerTests: XCTestCase {
         // Given
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewController = SiteCredentialLoginHostingViewController(siteURL: testURL, connectionOnly: true, analytics: analytics, onLoginSuccess: { _ in })
+        let viewController = SiteCredentialLoginHostingViewController(siteURL: testURL, connectionOnly: true, analytics: analytics, onLoginSuccess: {})
 
         // When
         _ = try XCTUnwrap(viewController.view)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8258 
Please also review https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/711.

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Currently, we are using XMLRPC API to check the input username & password and get the URLs for login and admin pages, which is then used to construct `CookieNonceAuthenticator` for handling the authentication for REST APIs. If a site blocks access to XMLRPC, requests to its API will fail, and the authenticator cannot be created.

This PR fixes the above issue by removing the call to XMLRPC API. Instead, we are handling authentication with the following changes:
- Remove the XMLRPC check for site discovery if native Jetpack is enabled.
- Guess the login and admin URLs based on the site URL.
- Construct `CookieNonceAuthenticator` based on the guessed URLs and hardcoded WP version for Ajax nonce retrieval.
- Attempt fetching Jetpack plugin details:
  - If the request succeeds or gets a 404 or 403 error, the API can be reached. Proceed to trigger to completion closure.
  - If the request gets a 401 error, the authentication fails. An alert will be displayed with a message about incorrect credentials.
  - A generic error is displayed if the request fails with any other error.
- Remove XMLRPC from the completion callback for the site credential login screen. This should not be required for verifying a WP.com account. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Make sure you have access to a test site that doesn't have Jetpack.
- Since the native Jetpack installation flow is A/B tested, disable [the check](https://github.com/woocommerce/woocommerce-ios/blob/a1635986f6d3b6399d7bb879c1cb1fa77a2b4bc2/WooCommerce/Classes/Authentication/AuthenticationManager.swift#L764) to return Jetpack setup UI by default. Make sure to set the config `skipXMLRPCCheckForSiteDiscovery` to true in `AuthenticationManager` too. 
- Build the app and proceed to log in with a WP.com account.
- On the store picker, select Add a site > Connect to an existing site.
- Enter the address of your test site. Notice in the Xcode console that there is no message regarding any XMLRPC check.
- On the Jetpack error screen, select Install Jetpack or Connect Jetpack.
- On the site credential screen, enter incorrect credentials. Notice that an alert is displayed for incorrect credentials.
- Try again with the credentials of an account that doesn't have permission to manage plugins. Notice that the setup screen is displayed, and the permission error appears.
- Try again with the correct credentials, notice that the Jetpack Setup screen is displayed.
- On the connection web view, select Sign in with a different account.
- Log in with a WP.com account that is different from your logged-in once and authorize the connection.
- When the setup is complete, select Go to Store.
- Notice that a new screen is presented to verify the new WP.com email. Enter the password for that account, notice that the login succeeds, and you are navigated to the home screen.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/204742152-0861fb42-c773-495b-8a17-9ab3aec85fb2.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
