### PR TITLE
Migrate Products to the new Swift Concurrency Model

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -39,7 +39,7 @@ public protocol ProductsRemoteProtocol {
     func updateProduct(product: Product) async throws -> Product
     func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage]) async throws -> Product
     func loadProductIDs(for siteID: Int64, pageNumber: Int, pageSize: Int) async throws -> [Int64]
-    func createTemplateProduct(for siteID: Int64, template: ProductsRemote.TemplateType, completion: @escaping (Result<Int64, Error>) -> Void)
+    func createTemplateProduct(for siteID: Int64, template: ProductsRemote.TemplateType) async throws -> Int64
 }
 
 extension ProductsRemoteProtocol {
@@ -327,13 +327,13 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     /// Finishes with a completion block with the product ID.
     /// The created product has an `auto-draft` status.
     ///
-    public func createTemplateProduct(for siteID: Int64, template: ProductsRemote.TemplateType, completion: @escaping (Result<Int64, Error>) -> Void) {
+    public func createTemplateProduct(for siteID: Int64, template: ProductsRemote.TemplateType) async throws -> Int64 {
         let parameters = [ParameterKey.templateName: template.rawValue]
         let path = Path.templateProducts
         let request = JetpackRequest(wooApiVersion: .wcAdmin, method: .post, siteID: siteID, path: path, parameters: parameters)
         let mapper = EntityIDMapper()
 
-        enqueue(request, mapper: mapper, completion: completion)
+        return try await enqueue(request, mapper: mapper)
     }
 }
 

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -5,8 +5,8 @@ import Foundation
 /// The required methods are intentionally incomplete. Feel free to add the other ones.
 ///
 public protocol ProductsRemoteProtocol {
-    func addProduct(product: Product, completion: @escaping (Result<Product, Error>) -> Void)
-    func deleteProduct(for siteID: Int64, productID: Int64, completion: @escaping (Result<Product, Error>) -> Void)
+    func addProduct(product: Product) async throws -> Product
+    func deleteProduct(for siteID: Int64, productID: Int64) async throws -> Product
     func loadProduct(for siteID: Int64, productID: Int64, completion: @escaping (Result<Product, Error>) -> Void)
     func loadProducts(for siteID: Int64, by productIDs: [Int64], pageNumber: Int, pageSize: Int, completion: @escaping (Result<[Product], Error>) -> Void)
     func loadAllProducts(for siteID: Int64,
@@ -67,17 +67,13 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///     - product: the Product to be created remotely.
     ///     - completion: executed upon completion.
     ///
-    public func addProduct(product: Product, completion: @escaping (Result<Product, Error>) -> Void) {
-        do {
-            let parameters = try product.toDictionary()
-            let siteID = product.siteID
-            let path = Path.products
-            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
-            let mapper = ProductMapper(siteID: siteID)
-            enqueue(request, mapper: mapper, completion: completion)
-        } catch {
-            completion(.failure(error))
-        }
+    public func addProduct(product: Product) async throws -> Product {
+        let parameters = try product.toDictionary()
+        let siteID = product.siteID
+        let path = Path.products
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let mapper = ProductMapper(siteID: siteID)
+        return try await enqueue(request, mapper: mapper)
     }
 
     /// Deletes a specific `Product`.
@@ -87,11 +83,11 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///     - productID: the ID of the Product to be deleted remotely.
     ///     - completion: executed upon completion.
     ///
-    public func deleteProduct(for siteID: Int64, productID: Int64, completion: @escaping (Result<Product, Error>) -> Void) {
+    public func deleteProduct(for siteID: Int64, productID: Int64) async throws -> Product {
         let path = "\(Path.products)/\(productID)"
         let request = JetpackRequest(wooApiVersion: .mark3, method: .delete, siteID: siteID, path: path, parameters: nil)
         let mapper = ProductMapper(siteID: siteID)
-        enqueue(request, mapper: mapper, completion: completion)
+        return try await enqueue(request, mapper: mapper)
     }
 
     /// Retrieves all of the `Products` available.

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -19,8 +19,7 @@ public protocol ProductsRemoteProtocol {
                          productCategory: ProductCategory?,
                          orderBy: ProductsRemote.OrderKey,
                          order: ProductsRemote.Order,
-                         excludedProductIDs: [Int64],
-                         completion: @escaping (Result<[Product], Error>) -> Void)
+                         excludedProductIDs: [Int64]) async throws -> [Product]
     func searchProducts(for siteID: Int64,
                         keyword: String,
                         pageNumber: Int,
@@ -103,7 +102,6 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///     - orderBy: the key to order the remote products. Default to product name.
     ///     - order: ascending or descending order. Default to ascending.
     ///     - excludedProductIDs: a list of product IDs to be excluded from the results.
-    ///     - completion: Closure to be executed upon completion.
     ///
     public func loadAllProducts(for siteID: Int64,
                                 context: String? = nil,
@@ -115,8 +113,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                 productCategory: ProductCategory? = nil,
                                 orderBy: OrderKey = .name,
                                 order: Order = .ascending,
-                                excludedProductIDs: [Int64] = [],
-                                completion: @escaping (Result<[Product], Error>) -> Void) {
+                                excludedProductIDs: [Int64] = []) async throws -> [Product] {
         let stringOfExcludedProductIDs = excludedProductIDs.map { String($0) }
             .joined(separator: ",")
 
@@ -140,7 +137,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
         let mapper = ProductListMapper(siteID: siteID)
 
-        enqueue(request, mapper: mapper, completion: completion)
+        return try await enqueue(request, mapper: mapper)
     }
 
     /// Retrieves a specific list of `Product`s by `productID`.

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -39,7 +39,7 @@ public protocol ProductsRemoteProtocol {
                    sku: String,
                    completion: @escaping (Result<String, Error>) -> Void)
     func updateProduct(product: Product) async throws -> Product
-    func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage], completion: @escaping (Result<Product, Error>) -> Void)
+    func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage]) async throws -> Product
     func loadProductIDs(for siteID: Int64, pageNumber: Int, pageSize: Int, completion: @escaping (Result<[Int64], Error>) -> Void)
     func createTemplateProduct(for siteID: Int64, template: ProductsRemote.TemplateType, completion: @escaping (Result<Int64, Error>) -> Void)
 }
@@ -295,17 +295,14 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         return try await enqueue(request, mapper: mapper)
     }
 
-    public func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage], completion: @escaping (Result<Product, Error>) -> Void) {
-        do {
-            let parameters = try ([ParameterKey.images: images]).toDictionary()
-            let path = "\(Path.products)/\(productID)"
-            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
-            let mapper = ProductMapper(siteID: siteID)
-
-            enqueue(request, mapper: mapper, completion: completion)
-        } catch {
-            completion(.failure(error))
-        }
+    public func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage]) async throws -> Product {
+        
+        let parameters = try ([ParameterKey.images: images]).toDictionary()
+        let path = "\(Path.products)/\(productID)"
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let mapper = ProductMapper(siteID: siteID)
+        
+        return try await enqueue(request, mapper: mapper)
     }
 
     /// Retrieves IDs for all of the `Products` available.

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -35,9 +35,7 @@ public protocol ProductsRemoteProtocol {
                              pageNumber: Int,
                              pageSize: Int,
                              completion: @escaping (Result<[Product], Error>) -> Void)
-    func searchSku(for siteID: Int64,
-                   sku: String,
-                   completion: @escaping (Result<String, Error>) -> Void)
+    func searchSku(for siteID: Int64, sku: String) async throws -> String
     func updateProduct(product: Product) async throws -> Product
     func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage]) async throws -> Product
     func loadProductIDs(for siteID: Int64, pageNumber: Int, pageSize: Int) async throws -> [Int64]
@@ -264,9 +262,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///     - sku: Product SKU to search for.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func searchSku(for siteID: Int64,
-                               sku: String,
-                               completion: @escaping (Result<String, Error>) -> Void) {
+    public func searchSku(for siteID: Int64, sku: String) async throws -> String {
         let parameters = [
             ParameterKey.sku: sku,
             ParameterKey.fields: ParameterValues.skuFieldValues
@@ -276,7 +272,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
         let mapper = ProductSkuMapper()
 
-        enqueue(request, mapper: mapper, completion: completion)
+        return try await enqueue(request, mapper: mapper)
     }
 
     /// Updates a specific `Product`.

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -7,7 +7,7 @@ import Foundation
 public protocol ProductsRemoteProtocol {
     func addProduct(product: Product) async throws -> Product
     func deleteProduct(for siteID: Int64, productID: Int64) async throws -> Product
-    func loadProduct(for siteID: Int64, productID: Int64, completion: @escaping (Result<Product, Error>) -> Void)
+    func loadProduct(for siteID: Int64, productID: Int64) async throws -> Product
     func loadProducts(for siteID: Int64, by productIDs: [Int64], pageNumber: Int, pageSize: Int, completion: @escaping (Result<[Product], Error>) -> Void)
     func loadAllProducts(for siteID: Int64,
                          context: String?,
@@ -186,14 +186,13 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     /// - Parameters:
     ///     - siteID: Site which hosts the Product.
     ///     - productID: Identifier of the Product.
-    ///     - completion: Closure to be executed upon completion.
     ///
-    public func loadProduct(for siteID: Int64, productID: Int64, completion: @escaping (Result<Product, Error>) -> Void) {
+    public func loadProduct(for siteID: Int64, productID: Int64) async throws -> Product {
         let path = "\(Path.products)/\(productID)"
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = ProductMapper(siteID: siteID)
 
-        enqueue(request, mapper: mapper, completion: completion)
+        return try await enqueue(request, mapper: mapper)
     }
 
     /// Retrieves all of the `Product`s available.

--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -170,13 +170,12 @@ final class RetrieveProductReviewFromNoteUseCase {
         if let productInStorage = derivedStorage?.loadProduct(siteID: siteID, productID: productID) {
             return next(productInStorage.toReadOnly())
         }
-
-        productsRemote.loadProduct(for: siteID, productID: productID) { result in
-            switch result {
-            case .failure(let error):
+        Task {
+            do {
+                let result = try await productsRemote.loadProduct(for: siteID, productID: productID)
+                next(result)
+            } catch {
                 abort(error)
-            case .success(let product):
-                next(product)
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -320,7 +320,6 @@ private extension ProductStore {
     func deleteProduct(siteID: Int64, productID: Int64, onCompletion: @escaping (Result<Product, ProductUpdateError>) -> Void) {
         Task {
             do {
-                // TODO: Double check the logic for this one. Why are we calling the deleteProduct async method.
                 let product = try await remote.deleteProduct(for: siteID, productID: productID)
                 self.deleteStoredProduct(siteID: siteID, productID: productID)
                 onCompletion(.success(product))

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -412,14 +412,12 @@ private extension ProductStore {
     /// The created product is not stored locally.
     ///
     func createTemplateProduct(siteID: Int64, template: ProductsRemote.TemplateType, onCompletion: @escaping (Result<Product, Error>) -> Void) {
-        remote.createTemplateProduct(for: siteID, template: template) { [remote] result in
-            switch result {
-            case .success(let productID):
-                Task {
-                    let result = try await remote.loadProduct(for: siteID, productID: productID)
-                    onCompletion(.success(result))
-                }
-            case .failure(let error):
+        Task {
+            do {
+                let productID = try await remote.createTemplateProduct(for: siteID, template: template)
+                let product = try await remote.loadProduct(for: siteID, productID: productID)
+                onCompletion(.success(product))
+            } catch {
                 onCompletion(.failure(error))
             }
         }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -399,11 +399,11 @@ private extension ProductStore {
         }
 
         // If there are no locally stored products, then check remote.
-        remote.loadProductIDs(for: siteID, pageNumber: 1, pageSize: 1) { result in
-            switch result {
-            case .success(let ids):
-                onCompletion(.success(ids.isEmpty))
-            case .failure(let error):
+        Task {
+            do {
+                let result = try await remote.loadProductIDs(for: siteID, pageNumber: 1, pageSize: 1)
+                onCompletion(.success(result.isEmpty))
+            } catch {
                 onCompletion(.failure(error))
             }
         }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -308,7 +308,6 @@ private extension ProductStore {
                     }
                     onCompletion(.success(storageProduct.toReadOnly()))
                 }
-
             } catch {
                 onCompletion(.failure(ProductUpdateError(error: error)))
             }
@@ -320,7 +319,9 @@ private extension ProductStore {
     func deleteProduct(siteID: Int64, productID: Int64, onCompletion: @escaping (Result<Product, ProductUpdateError>) -> Void) {
         Task {
             do {
+                // TODO: Double check the logic for this one. Why are we calling the deleteProduct async method.
                 let product = try await remote.deleteProduct(for: siteID, productID: productID)
+                self.deleteStoredProduct(siteID: siteID, productID: productID)
                 onCompletion(.success(product))
             } catch {
                 onCompletion(.failure(ProductUpdateError(error: error)))

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -370,13 +370,12 @@ private extension ProductStore {
             onCompletion(true)
             return
         }
-
-        remote.searchSku(for: siteID, sku: sku) { result in
-            switch result {
-            case .success(let checkResult):
+        Task {
+            do {
+                let checkResult = try await remote.searchSku(for: siteID, sku: sku)
                 let isValid = checkResult != sku
                 onCompletion(isValid)
-            case .failure:
+            } catch {
                 onCompletion(true)
             }
         }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -217,7 +217,6 @@ private extension ProductStore {
         let itemIDs = order.items.map { $0.productID }
         let productIDs = itemIDs.uniqued()  // removes duplicate product IDs
         let storage = storageManager.viewStorage
-        
         // In order to pass `missingIDs` into the asynchronous context, we need to make these non-mutating to avoid race conditions
         let missingIDs: [Int64] = {
             var IDs = [Int64]()
@@ -235,7 +234,7 @@ private extension ProductStore {
             onCompletion(nil)
             return
         }
-        
+
         Task {
             do {
                 let products = try await remote.loadProducts(for: order.siteID, by: missingIDs)

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -137,33 +137,35 @@ private extension ProductStore {
                         productCategory: ProductCategory?,
                         excludedProductIDs: [Int64],
                         onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        switch filter {
-        case .all:
-            remote.searchProducts(for: siteID,
-                                  keyword: keyword,
-                                  pageNumber: pageNumber,
-                                  pageSize: pageSize,
-                                  stockStatus: stockStatus,
-                                  productStatus: productStatus,
-                                  productType: productType,
-                                  productCategory: productCategory,
-                                  excludedProductIDs: excludedProductIDs) { [weak self] result in
-                self?.handleSearchResults(siteID: siteID,
-                                          keyword: keyword,
-                                          filter: filter,
-                                          result: result,
-                                          onCompletion: onCompletion)
-            }
-        case .sku:
-            remote.searchProductsBySKU(for: siteID,
-                                       keyword: keyword,
-                                       pageNumber: pageNumber,
-                                       pageSize: pageSize) { [weak self] result in
-                self?.handleSearchResults(siteID: siteID,
-                                          keyword: keyword,
-                                          filter: filter,
-                                          result: result,
-                                          onCompletion: onCompletion)
+        Task {
+            switch filter {
+            case .all:
+                let products = try await remote.searchProducts(for: siteID,
+                                                               keyword: keyword,
+                                                               pageNumber: pageNumber,
+                                                               pageSize: pageSize,
+                                                               stockStatus: stockStatus,
+                                                               productStatus: productStatus,
+                                                               productType: productType,
+                                                               productCategory: productCategory,
+                                                               excludedProductIDs: excludedProductIDs)
+                handleSearchResults(
+                    siteID: siteID,
+                    keyword: keyword,
+                    filter: filter,
+                    result: Result.success(products),
+                    onCompletion: onCompletion)
+            case .sku:
+                let products = try await remote.searchProductsBySKU(for: siteID,
+                                                                    keyword: keyword,
+                                                                    pageNumber: pageNumber,
+                                                                    pageSize: pageSize)
+                handleSearchResults(
+                    siteID: siteID,
+                    keyword: keyword,
+                    filter: filter,
+                    result: Result.success(products),
+                    onCompletion: onCompletion)
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -291,6 +291,7 @@ private extension ProductStore {
                 if case ProductLoadError.notFound = error {
                     self.deleteStoredProduct(siteID: siteID, productID: productID)
                 }
+                onCompletion(.failure(error))
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -492,9 +492,13 @@ private extension StatsStoreV4 {
                 // Return the complete array of products that corresponds to a top product leaderboard
                 let products = try await productsRemote.loadProducts(for: siteID, by: missingProductsIDs)
                 let completeTopProducts = products + topStoredProducts
-                completion(.success(completeTopProducts))
+                await MainActor.run(body: {
+                    completion(.success(completeTopProducts))
+                })
             } catch {
-                completion(.failure(error))
+                await MainActor.run(body: {
+                    completion(.failure(error))
+                })
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -487,15 +487,14 @@ private extension StatsStoreV4 {
         }
 
         // Fetch the products that we have not downloaded and stored yet
-        productsRemote.loadProducts(for: siteID, by: missingProductsIDs) { result in
-            switch result {
-            case .success(let products):
+        Task {
+            do {
                 // Return the complete array of products that corresponds to a top product leaderboard
+                let products = try await productsRemote.loadProducts(for: siteID, by: missingProductsIDs)
                 let completeTopProducts = products + topStoredProducts
                 completion(.success(completeTopProducts))
-
-            case .failure:
-                completion(result)
+            } catch {
+                completion(.failure(error))
             }
         }
     }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -83,23 +83,9 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         return Product.fake()
     }
 
-    func loadProduct(for siteID: Int64,
-                     productID: Int64,
-                     completion: @escaping (Result<Product, Error>) -> Void) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
-                return
-            }
-
-            self.invocationCountOfLoadProduct += 1
-
-            let key = ResultKey(siteID: siteID, productIDs: [productID])
-            if let result = self.productLoadingResults[key] {
-                completion(result)
-            } else {
-                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
-            }
-        }
+    func loadProduct(for siteID: Int64, productID: Int64) async throws -> Product {
+        // TODO: Mock loadProduct. We no longer use the Result<Product, Error> signature
+        return Product.fake()
     }
 
     func loadProducts(for siteID: Int64, by productIDs: [Int64], pageNumber: Int, pageSize: Int, completion: @escaping (Result<[Product], Error>) -> Void) {

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -88,19 +88,10 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         return Product.fake()
     }
 
-    func loadProducts(for siteID: Int64, by productIDs: [Int64], pageNumber: Int, pageSize: Int, completion: @escaping (Result<[Product], Error>) -> Void) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
-                return
-            }
-
-            let key = ResultKey(siteID: siteID, productIDs: productIDs)
-            if let result = self.productsLoadingResults[key] {
-                completion(result)
-            } else {
-                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
-            }
-        }
+    func loadProducts(for siteID: Int64, by productIDs: [Int64], pageNumber: Int, pageSize: Int) -> [Product] {
+        // TODO: Mock loadProducts. We no longer use the Result<[Product], Error> signature
+        return [Product.fake()]
+        
     }
 
     func loadAllProducts(for siteID: Int64,
@@ -113,9 +104,9 @@ extension MockProductsRemote: ProductsRemoteProtocol {
                          productCategory: ProductCategory?,
                          orderBy: ProductsRemote.OrderKey,
                          order: ProductsRemote.Order,
-                         excludedProductIDs: [Int64],
-                         completion: @escaping (Result<[Product], Error>) -> Void) {
+                         excludedProductIDs: [Int64])  async throws -> [Product] {
         // no-op
+        return [Product.fake()]
     }
 
     func searchProducts(for siteID: Int64,
@@ -126,49 +117,46 @@ extension MockProductsRemote: ProductsRemoteProtocol {
                         productStatus: ProductStatus?,
                         productType: ProductType?,
                         productCategory: ProductCategory?,
-                        excludedProductIDs: [Int64],
-                        completion: @escaping (Result<[Product], Error>) -> Void) {
+                        excludedProductIDs: [Int64]) async throws -> [Product] {
         searchProductTriggered = true
         searchProductWithStockStatus = stockStatus
         searchProductWithProductType = productType
         searchProductWithProductStatus = productStatus
         searchProductWithProductCategory = productCategory
+        // Check:
+        return [Product.fake()]
     }
 
     func searchProductsBySKU(for siteID: Int64,
                              keyword: String,
                              pageNumber: Int,
-                             pageSize: Int,
-                             completion: @escaping (Result<[Product], Error>) -> Void) {
+                             pageSize: Int) async throws -> [Product] {
         // no-op
+        return [Product.fake()]
     }
 
-    func searchSku(for siteID: Int64, sku: String, completion: @escaping (Result<String, Error>) -> Void) {
+    func searchSku(for siteID: Int64, sku: String) async throws -> String {
         // no-op
+        return ""
     }
 
-    func updateProduct(product: Product, completion: @escaping (Result<Product, Error>) -> Void) {
+    func updateProduct(product: Product) async throws -> Product {
         // no-op
+        return Product.fake()
     }
 
-    func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage], completion: @escaping (Result<Product, Error>) -> Void) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-
-            let key = ResultKey(siteID: siteID, productIDs: [productID])
-            if let result = self.updateProductImagesResultsBySiteID[key] {
-                completion(result)
-            } else {
-                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
-            }
-        }
+    func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage]) async throws -> Product {
+        // TODO: Mock loadProducts. We no longer use the Result<Product, Error> signature
+        return Product.fake()
     }
 
-    func loadProductIDs(for siteID: Int64, pageNumber: Int, pageSize: Int, completion: @escaping (Result<[Int64], Error>) -> Void) {
+    func loadProductIDs(for siteID: Int64, pageNumber: Int, pageSize: Int) async throws -> [Int64] {
         // no-op
+        return []
     }
 
-    func createTemplateProduct(for siteID: Int64, template: ProductsRemote.TemplateType, completion: @escaping (Result<Int64, Error>) -> Void) {
+    func createTemplateProduct(for siteID: Int64, template: ProductsRemote.TemplateType) async throws -> Int64 {
         // no-op
+        return 0
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -73,32 +73,14 @@ final class MockProductsRemote {
 // MARK: - ProductsEndpointsProviding
 
 extension MockProductsRemote: ProductsRemoteProtocol {
-    func addProduct(product: Product, completion: @escaping (Result<Product, Error>) -> Void) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
-                return
-            }
-
-            if let result = self.addProductResultsBySiteID[product.siteID] {
-                completion(result)
-            } else {
-                XCTFail("\(String(describing: self)) Could not find Result for site ID \(product.siteID)")
-            }
-        }
+    func addProduct(product: Product) async throws -> Product {
+        // TODO: Mock addProduct. We no longer use the Result<Product, Error> signature
+        return product
     }
 
-    func deleteProduct(for siteID: Int64, productID: Int64, completion: @escaping (Result<Product, Error>) -> Void) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
-                return
-            }
-
-            if let result = self.deleteProductResultsBySiteID[siteID] {
-                completion(result)
-            } else {
-                XCTFail("\(String(describing: self)) Could not find Result for site ID \(siteID)")
-            }
-        }
+    func deleteProduct(for siteID: Int64, productID: Int64) async throws -> Product {
+        // TODO: Mock deleteProduct. We no longer use the Result<Product, Error> signature
+        return Product.fake()
     }
 
     func loadProduct(for siteID: Int64,

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -74,23 +74,56 @@ final class MockProductsRemote {
 
 extension MockProductsRemote: ProductsRemoteProtocol {
     func addProduct(product: Product) async throws -> Product {
-        // TODO: Mock addProduct. We no longer use the Result<Product, Error> signature
-        return product
+        if let result = self.addProductResultsBySiteID[product.siteID] {
+            switch result {
+            case .success(let product):
+                return product
+            case .failure(let error):
+                throw error
+            }
+        }
+        fatalError("MockProductsRemote: addProduct not returning a Product or throwing an Error")
     }
 
     func deleteProduct(for siteID: Int64, productID: Int64) async throws -> Product {
-        // TODO: Mock deleteProduct. We no longer use the Result<Product, Error> signature
-        return Product.fake()
+        if let result = self.deleteProductResultsBySiteID[siteID] {
+            switch result {
+            case .success(let product):
+                return product
+            case .failure(let error):
+                throw error
+            }
+        }
+        fatalError("MockProductsRemote: deleteProduct not returning a Product or throwing an Error")
     }
 
     func loadProduct(for siteID: Int64, productID: Int64) async throws -> Product {
-        // TODO: Mock loadProduct. We no longer use the Result<Product, Error> signature
-        return Product.fake()
+        self.invocationCountOfLoadProduct += 1
+        let key = ResultKey(siteID: siteID, productIDs: [productID])
+
+        if let result = self.productLoadingResults[key] {
+            switch result {
+            case .success(let product):
+                return product
+            case .failure(let error):
+                throw error
+            }
+        }
+        fatalError("MockProductsRemote: loadProduct not returning a Product or throwing an Error")
     }
 
-    func loadProducts(for siteID: Int64, by productIDs: [Int64], pageNumber: Int, pageSize: Int) -> [Product] {
-        // TODO: Mock loadProducts. We no longer use the Result<[Product], Error> signature
-        return [Product.fake()]
+    func loadProducts(for siteID: Int64, by productIDs: [Int64], pageNumber: Int, pageSize: Int) async throws -> [Product] {
+        let key = ResultKey(siteID: siteID, productIDs: productIDs)
+
+        if let result = self.productsLoadingResults[key] {
+            switch result {
+            case .success(let products):
+                return products
+            case .failure(let error):
+                throw error
+            }
+        }
+        fatalError("MockProductsRemote: loadProducts not returning [Product] or throwing an Error")
     }
 
     func loadAllProducts(for siteID: Int64,

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -178,8 +178,16 @@ extension MockProductsRemote: ProductsRemoteProtocol {
     }
 
     func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage]) async throws -> Product {
-        // TODO: Mock loadProducts. We no longer use the Result<Product, Error> signature
-        return Product.fake()
+        let key = ResultKey(siteID: siteID, productIDs: [productID])
+        if let result = self.updateProductImagesResultsBySiteID[key] {
+            switch result {
+            case .success(let product):
+                return product
+            case .failure(let error):
+                throw error
+            }
+        }
+        fatalError("MockProductsRemote: updateProductImages not returning a Product or throwing an Error")
     }
 
     func loadProductIDs(for siteID: Int64, pageNumber: Int, pageSize: Int) async throws -> [Int64] {

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -155,7 +155,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         searchProductWithProductType = productType
         searchProductWithProductStatus = productStatus
         searchProductWithProductCategory = productCategory
-        // Check:
+
         return [Product.fake()]
     }
 

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -91,7 +91,6 @@ extension MockProductsRemote: ProductsRemoteProtocol {
     func loadProducts(for siteID: Int64, by productIDs: [Int64], pageNumber: Int, pageSize: Int) -> [Product] {
         // TODO: Mock loadProducts. We no longer use the Result<[Product], Error> signature
         return [Product.fake()]
-        
     }
 
     func loadAllProducts(for siteID: Int64,

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1056,19 +1056,25 @@ final class ProductStoreTests: XCTestCase {
         let filteredProductCategory: Networking.ProductCategory = .init(categoryID: 123, siteID: sampleSiteID, parentID: 1, name: "Test", slug: "test")
 
         // When
-        let searchAction = ProductAction.searchProducts(siteID: sampleSiteID,
-                                                        keyword: "hiii",
-                                                        pageNumber: defaultPageNumber,
-                                                        pageSize: defaultPageSize,
-                                                        stockStatus: filteredStockStatus,
-                                                        productStatus: filteredProductStatus,
-                                                        productType: filteredProductType,
-                                                        productCategory: filteredProductCategory,
-                                                        excludedProductIDs: [],
-                                                        onCompletion: { _ in })
-        productStore.onAction(searchAction)
+
 
         // Then
+        waitForExpectation() { expectation in
+            let searchAction = ProductAction.searchProducts(siteID: sampleSiteID,
+                                                            keyword: "hiii",
+                                                            pageNumber: defaultPageNumber,
+                                                            pageSize: defaultPageSize,
+                                                            stockStatus: filteredStockStatus,
+                                                            productStatus: filteredProductStatus,
+                                                            productType: filteredProductType,
+                                                            productCategory: filteredProductCategory,
+                                                            excludedProductIDs: [],
+                                                            onCompletion: { _ in
+                expectation.fulfill()
+            })
+            productStore.onAction(searchAction)
+        }
+    
         XCTAssertTrue(remote.searchProductTriggered)
         assertEqual(filteredStockStatus, remote.searchProductWithStockStatus)
         assertEqual(filteredProductType, remote.searchProductWithProductType)
@@ -1456,8 +1462,13 @@ final class ProductStoreTests: XCTestCase {
         // Action
         let pageNumber = 6
         let pageSize = 36
-        let action = ProductAction.retrieveProducts(siteID: sampleSiteID, productIDs: [sampleProductID], pageNumber: pageNumber, pageSize: pageSize) { _ in }
-        productStore.onAction(action)
+
+        waitForExpectation() { expectation in
+            let action = ProductAction.retrieveProducts(siteID: sampleSiteID, productIDs: [sampleProductID], pageNumber: pageNumber, pageSize: pageSize) { _ in
+                expectation.fulfill()
+            }
+            productStore.onAction(action)
+        }
 
         // Assert
         guard let queryParameters = network.queryParameters else {

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1074,7 +1074,7 @@ final class ProductStoreTests: XCTestCase {
             })
             productStore.onAction(searchAction)
         }
-    
+
         XCTAssertTrue(remote.searchProductTriggered)
         assertEqual(filteredStockStatus, remote.searchProductWithStockStatus)
         assertEqual(filteredProductType, remote.searchProductWithProductType)


### PR DESCRIPTION
POC for moving Networking to async await.

### Description

With this PR we migrate `Products` to the new Swift Concurrency Model by replacing completion closures, DispatchGroup, and GCD for asynchronous functions whenever is possible. 

### Changes
- `ProductsRemoteProtocol`: All method signatures now use `async throws` rather than completion handlers, as well as their implementations. 
- `ProductsRemote`: Following the protocol changes, each function implementation has been changed as well to use the updated `async throws` signature.
- Adapted Unit Tests to `async throws`
- Adapted `MockProductsRemote`

### Testing instructions
- [x] addProduct
- [x] deleteProduct
- [x] loadProduct
- [x] loadProducts
- [x] searchProducts
- [x] searchProductsBySKU
- [x] searchSku
- [x] updateProduct
- [x] updateProductImages
- [x] loadProductIDs
- [x] createTemplateProduct



