### PR TITLE
[Analytics Hub] Improve line chart accessibility (dynamic type)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -16,6 +16,10 @@ struct AnalyticsReportCard: View {
     let trailingDeltaColor: UIColor
     let trailingChartData: [Double]
 
+    // Layout metrics that scale based on accessibility changes
+    @ScaledMetric private var scaledChartWidth: CGFloat = Layout.chartWidth
+    @ScaledMetric private var scaledChartHeight: CGFloat = Layout.chartHeight
+
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.titleSpacing) {
 
@@ -40,8 +44,7 @@ struct AnalyticsReportCard: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
 
                         AnalyticsLineChart(dataPoints: leadingChartData, lineChartColor: leadingDeltaColor)
-                            .aspectRatio(Layout.chartAspectRatio, contentMode: .fit)
-                            .frame(maxHeight: Layout.chartMaxHeight)
+                            .frame(width: scaledChartWidth, height: scaledChartHeight)
                     }
 
                 }
@@ -61,8 +64,7 @@ struct AnalyticsReportCard: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
 
                         AnalyticsLineChart(dataPoints: trailingChartData, lineChartColor: trailingDeltaColor)
-                            .aspectRatio(Layout.chartAspectRatio, contentMode: .fit)
-                            .frame(maxHeight: Layout.chartMaxHeight)
+                            .frame(width: scaledChartWidth, height: scaledChartHeight)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -79,8 +81,8 @@ private extension AnalyticsReportCard {
         static let cardPadding: CGFloat = 16
         static let columnOutterSpacing: CGFloat = 28
         static let columnInnerSpacing: CGFloat = 10
-        static let chartAspectRatio: CGFloat = 2.2
-        static let chartMaxHeight: CGFloat = 48
+        static let chartHeight: CGFloat = 32
+        static let chartWidth: CGFloat = 72
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -35,13 +35,13 @@ struct AnalyticsReportCard: View {
                     Text(leadingValue)
                         .titleStyle()
 
-                    AdaptiveStack {
+                    AdaptiveStack(horizontalAlignment: .leading) {
                         DeltaTag(value: leadingDelta, backgroundColor: leadingDeltaColor)
                             .frame(maxWidth: .infinity, alignment: .leading)
 
                         AnalyticsLineChart(dataPoints: leadingChartData, lineChartColor: leadingDeltaColor)
                             .aspectRatio(Layout.chartAspectRatio, contentMode: .fit)
-                            .frame(maxWidth: .infinity, maxHeight: Layout.chartMaxHeight, alignment: .trailing)
+                            .frame(maxHeight: Layout.chartMaxHeight)
                     }
 
                 }
@@ -56,13 +56,13 @@ struct AnalyticsReportCard: View {
                     Text(trailingValue)
                         .titleStyle()
 
-                    AdaptiveStack {
+                    AdaptiveStack(horizontalAlignment: .leading) {
                         DeltaTag(value: trailingDelta, backgroundColor: trailingDeltaColor)
                             .frame(maxWidth: .infinity, alignment: .leading)
 
                         AnalyticsLineChart(dataPoints: trailingChartData, lineChartColor: trailingDeltaColor)
                             .aspectRatio(Layout.chartAspectRatio, contentMode: .fit)
-                            .frame(maxWidth: .infinity, maxHeight: Layout.chartMaxHeight, alignment: .trailing)
+                            .frame(maxHeight: Layout.chartMaxHeight)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Closes: #8201

## Description

Improves the line chart accessibility for dynamic type:

* Makes the chart leading-aligned with larger dynamic type sizes
* Scales the chart size with dynamic type changes

Note: I used two different `@ScaledMetric` properties to set the chart height and width. I found that other approaches (e.g. using a single `@ScaledMetric` property to track the scale and using that to calculate the height/width, or setting only a scaled height and aspect ratio) did not consistently scale the chart at all dynamic type sizes.

## Testing

1. Launch the app.
2. Tap the "See More" button from the main dashboard.
3. See the Analytics view loads with charts in the Revenue and Orders cards.
4. Adjust the font size on the device. Notice the chart sizes scales to match, and at larger sizes (when the delta tag and line chart are stacked vertically) the chart is leading-aligned.

## Screenshots

/|Before|After
-|-|-
Default|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-30 at 10 38 52](https://user-images.githubusercontent.com/8658164/204774790-977dae80-d320-4d5e-b253-dadabc1e6649.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-30 at 11 26 02](https://user-images.githubusercontent.com/8658164/204784604-afe8bd5b-606f-40e5-b176-236d4e3a6d8b.png)
Small|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-30 at 10 38 58](https://user-images.githubusercontent.com/8658164/204774812-c9ab11b7-8009-4a7b-b2a3-fb06926977be.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-30 at 11 25 58](https://user-images.githubusercontent.com/8658164/204784596-927be4cb-7724-4694-8def-60ae9258dcf9.png)
Large|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-30 at 10 39 08](https://user-images.githubusercontent.com/8658164/204774825-3b61944d-db04-4633-8599-0992ee38220c.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-30 at 11 26 29](https://user-images.githubusercontent.com/8658164/204784616-fd9e41c4-1c60-4582-9bb5-7046b74ea215.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
