### PR TITLE
Fix Notice View when navigating to a view without tab bar

### DIFF
--- a/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
@@ -6,7 +6,7 @@ import WordPressUI
 
 /// NoticePresenter: Coordinates Notice rendering, in both, FG and BG execution modes.
 ///
-class DefaultNoticePresenter: NSObject, NoticePresenter {
+class DefaultNoticePresenter: NoticePresenter {
 
     /// UIKit Feedback Gen!
     ///
@@ -205,8 +205,6 @@ private extension DefaultNoticePresenter {
         }
     }
 
-
-
     func makeBottomConstraintForNoticeContainer(_ container: UIView) -> NSLayoutConstraint {
         guard let presentingViewController = presentingViewController else {
             fatalError("NoticePresenter requires a presentingViewController!")
@@ -225,9 +223,9 @@ private extension DefaultNoticePresenter {
             }
 
             return container.bottomAnchor.constraint(equalTo: tabBarController.tabBar.topAnchor)
-        } else {
-            return container.bottomAnchor.constraint(equalTo: presentingViewController.view.bottomAnchor)
         }
+
+        return container.bottomAnchor.constraint(equalTo: presentingViewController.view.bottomAnchor)
     }
 
     var offscreenBottomOffset: CGFloat {

--- a/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
@@ -218,6 +218,8 @@ private extension DefaultNoticePresenter {
                         return
                     }
 
+                    // If the tab bar hides we also hide the notice, as trying to rearrange the notice accordingly might bring unexpected results
+                    // due to the internal logic of UITabBarController e.g they remove/recreate the tab bar when navigation happens
                     container.isHidden = true
                 }
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8224 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Here we fix a misplacement of the notice (the one that shows the _Order Created!_ message) when navigating to a view without the tab bar. The reason behind this is that we **constrain the notice container's bottom to the tab bar's top**. Because of this, when we the **tab bar is removed**, the notice loses its bottom anchor, resulting in the view moving to the top of the screen.

In the scenario described in this issue, we navigate to the Manage Card Readers view with the notice on the screen, the tab bar is then removed, and the notice -without a bottom constraint to follow- is moved to the upper part of the screen, hiding the back button.

To fix it I consider a few approaches:
* Leave the tab bar in the Manage Card Readers screen. Discarded because it was a design reason to remove it.
* Add the notice to the selected controller of the tab bar. I discarded this option because the notice disappears if we change tabs.
* Instead of constraining to the tab bar, **constrain to the view's bottom, with the tab bar height as padding**. This makes it independent of the tab bar, without moving to the top when the tab bar disappears. ~~**This is my final choice**~~. I discarded it because it required updating the constraints when the device orientation changes, which is not safe as the views might not have common ancestors, thus crashing as @joshheald  explained [here](https://github.com/woocommerce/woocommerce-ios/pull/8263#issuecomment-1332424133)
* Listen to the tab bar visibility via KVO and update the constraints of the notice view. I discarded it because, as the tab bar is removed or recreated internally in the UITabBarController, we might try to add constraints to views without a common ancestor, thus crashing.
* Listen for the tab bar visibility via KVO and hide the container if the tab bar is hidden. This is not optimal UI-wise, as the notice will be moved on top for a while until the navigation animation stops and the tab bar is hidden. I opted for this however as:
      * It's safe (no messing with constraints, no crash)
      * It hides the notice asap, thus uncovering the back button
      * The root issue is complex and might require a major refactor of this class. The UI issue we have is an edge case and it's not worthy of further analysis.
In this case, we don't unhide the notice if the tab bar is unhidden because it would still show the notice on top.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Payments
2. Create a Simple Payment with whatever payment method. The notice with _Order Created!_ should appear. You should be navigated back to the Payments Menu.
3. Go to Manage Card Reader. The notice goes up for a while but soon disappears.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### Before
https://user-images.githubusercontent.com/17252150/203953891-431551aa-e2bf-4d5c-9967-b0beda56ecd4.MP4

### After

Uploading Simulator Screen Recording - iPhone 14 - 2022-12-01 at 13.24.21.mp4…

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
