### PR TITLE
[Mobile Payments] Use `bluetoothScan` so we can connect WisePad 3 readers

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/CardReaderDiscoveryMethod.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/CardReaderDiscoveryMethod.swift
@@ -4,14 +4,14 @@ import StripeTerminal
 
 public enum CardReaderDiscoveryMethod {
     case localMobile
-    case bluetoothProximity
+    case bluetoothScan
 
     func toStripe() -> DiscoveryMethod {
         switch self {
         case .localMobile:
             return .localMobile
-        case .bluetoothProximity:
-            return .bluetoothProximity
+        case .bluetoothScan:
+            return .bluetoothScan
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -323,7 +323,7 @@ private extension CardReaderConnectionController {
 
         // TODO: make this a choice for the user, when the switch is enabled
         let tapOnIphoneEnabled = ServiceLocator.generalAppSettings.settings.isTapToPayOnIPhoneSwitchEnabled
-        let discoveryMethod: CardReaderDiscoveryMethod = tapOnIphoneEnabled ? .localMobile : .bluetoothProximity
+        let discoveryMethod: CardReaderDiscoveryMethod = tapOnIphoneEnabled ? .localMobile : .bluetoothScan
 
         let action = CardPresentPaymentAction.startCardReaderDiscovery(
             siteID: siteID,

--- a/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
+++ b/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
@@ -32,7 +32,7 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
             }
         }.store(in: &cancellables)
 
-        try! readerService.start(MockTokenProvider(), discoveryMethod: .bluetoothProximity)
+        try! readerService.start(MockTokenProvider(), discoveryMethod: .bluetoothScan)
         wait(for: [receivedReaders], timeout: Constants.expectationTimeout)
     }
 
@@ -68,7 +68,7 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
                 .fulfillOnCompletion(expectation: discoveredReaders)
         }.store(in: &cancellables)
 
-        try! readerService.start(MockTokenProvider(), discoveryMethod: .bluetoothProximity)
+        try! readerService.start(MockTokenProvider(), discoveryMethod: .bluetoothScan)
         wait(for: [discoveredReaders], timeout: Constants.expectationTimeout)
     }
 
@@ -105,7 +105,7 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
             }
         }.store(in: &self.cancellables)
 
-        try! readerService.start(MockTokenProvider(), discoveryMethod: .bluetoothProximity)
+        try! readerService.start(MockTokenProvider(), discoveryMethod: .bluetoothScan)
         wait(for: [discoveredReaders, connectedToReader, connectedreaderIsPublished], timeout: Constants.expectationTimeout)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -89,7 +89,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
 
         let action = CardPresentPaymentAction.startCardReaderDiscovery(
             siteID: sampleSiteID,
-            discoveryMethod: .bluetoothProximity,
+            discoveryMethod: .bluetoothScan,
             onReaderDiscovered: { _ in }, onError: { _ in })
 
         cardPresentStore.onAction(action)
@@ -107,7 +107,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
 
         let action = CardPresentPaymentAction.startCardReaderDiscovery(
             siteID: sampleSiteID,
-            discoveryMethod: .bluetoothProximity,
+            discoveryMethod: .bluetoothScan,
             onReaderDiscovered: { _ in
                 expectation.fulfill()
             },
@@ -126,7 +126,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                                        cardReaderService: mockCardReaderService)
 
         let action = CardPresentPaymentAction.startCardReaderDiscovery(siteID: sampleSiteID,
-                                                                       discoveryMethod: .bluetoothProximity,
+                                                                       discoveryMethod: .bluetoothScan,
                                                                        onReaderDiscovered: { _ in },
                                                                        onError: { _ in })
 
@@ -142,7 +142,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                                        cardReaderService: mockCardReaderService)
 
         let action = CardPresentPaymentAction.startCardReaderDiscovery(siteID: sampleSiteID,
-                                                                       discoveryMethod: .bluetoothProximity,
+                                                                       discoveryMethod: .bluetoothScan,
                                                                        onReaderDiscovered: { _ in },
                                                                        onError: { _ in })
 
@@ -170,7 +170,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
 
         let action = CardPresentPaymentAction.startCardReaderDiscovery(
             siteID: sampleSiteID,
-            discoveryMethod: .bluetoothProximity,
+            discoveryMethod: .bluetoothScan,
             onReaderDiscovered: { discoveredReaders in
                 XCTAssertTrue(self.mockCardReaderService.didReceiveAConfigurationProvider)
                 if discoveredReaders.count == 0 {
@@ -231,7 +231,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
 
         let startDiscoveryAction = CardPresentPaymentAction.startCardReaderDiscovery(
             siteID: sampleSiteID,
-            discoveryMethod: .bluetoothProximity,
+            discoveryMethod: .bluetoothScan,
             onReaderDiscovered: { _ in },
             onError: { _ in })
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8264 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I mistakenly changed the discovery method from `bluetoothScan` to `bluetoothProximity`, which does not allow discovery of the WisePad 3 reader we use in Canada.

This commit changes us back to use `bluetoothScan`, so Canadian merchants can continue to connect to their card readers

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Using a CA store with WCPay set up
2. Go to the `Menu` tab, and tap `Payments`
3. Tap `Manage card reader`
4. Tap `Connect Card Reader` if it doesn't start searching automatically
5. Turn on the WisePad 3 reader
6. Observe that the reader is discovered, and connects correctly
7. Attempt to take a payment - it will complete successfully

Repeat with a US store using the M2 and Chipper readers to show there's no regression.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
