### PR TITLE
Analytics Hub: Top Performers View

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -175,9 +175,16 @@ private extension AnalyticsHubViewModel {
         let itemsSold = StatsDataTextFormatter.createItemsSoldText(orderStats: currentPeriodStats)
         let itemsSoldDelta = StatsDataTextFormatter.createOrderItemsSoldDelta(from: previousPeriodStats, to: currentPeriodStats)
 
+        let imageURL = URL(string: "https://s0.wordpress.com/i/store/mobile/plans-premium.png")
         return AnalyticsProductCardViewModel(itemsSold: itemsSold,
                                              delta: itemsSoldDelta.string,
                                              deltaBackgroundColor: Constants.deltaColor(for: itemsSoldDelta.direction),
+                                             itemsSoldData: [ // Temporary data
+                                                .init(imageURL: imageURL, name: "Tabletop Photos", details: "Net Sales: $1,232", value: "32"),
+                                                .init(imageURL: imageURL, name: "Kentya Palm", details: "Net Sales: $800", value: "10"),
+                                                .init(imageURL: imageURL, name: "Love Ficus", details: "Net Sales: $599", value: "5"),
+                                                .init(imageURL: imageURL, name: "Bird Of Paradise", details: "Net Sales: $23.50", value: "2")
+                                             ],
                                              isRedacted: false)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -14,6 +14,10 @@ struct AnalyticsProductCard: View {
     /// Delta Tag background color.
     let deltaBackgroundColor: UIColor
 
+    /// Items Solds data to render.
+    ///
+    let itemsSoldData: [TopPerformersRow.Data]
+
     /// Indicates if the values should be hidden (for loading state)
     ///
     let isRedacted: Bool
@@ -42,16 +46,8 @@ struct AnalyticsProductCard: View {
                     .shimmering(active: isRedacted)
             }
 
-            let imageURL = URL(string: "https://s0.wordpress.com/i/store/mobile/plans-premium.png")
-            TopPerformersView(itemTitle: "Products",
-                              valueTitle: "Items Sold",
-                              rows: [
-                                .init(imageURL: imageURL, name: "Tabletop Photos", details: "Net Sales: $1,232", value: "32"),
-                                .init(imageURL: imageURL, name: "Kentya Palm", details: "Net Sales: $800", value: "10"),
-                                .init(imageURL: imageURL, name: "Love Ficus", details: "Net Sales: $599", value: "5"),
-                                .init(imageURL: imageURL, name: "Bird Of Paradise", details: "Net Sales: $23.50", value: "2")
-                              ])
-            .padding(.top, Layout.columnSpacing)
+            TopPerformersView(itemTitle: Localization.title.localizedCapitalized, valueTitle: Localization.itemsSold, rows: itemsSoldData)
+                .padding(.top, Layout.columnSpacing)
         }
         .padding(Layout.cardPadding)
     }
@@ -75,9 +71,16 @@ private extension AnalyticsProductCard {
 // MARK: Previews
 struct AnalyticsProductCardPreviews: PreviewProvider {
     static var previews: some View {
+        let imageURL = URL(string: "https://s0.wordpress.com/i/store/mobile/plans-premium.png")
         AnalyticsProductCard(itemsSold: "2,234",
                              delta: "+23%",
                              deltaBackgroundColor: .withColorStudio(.green, shade: .shade50),
+                             itemsSoldData: [
+                                .init(imageURL: imageURL, name: "Tabletop Photos", details: "Net Sales: $1,232", value: "32"),
+                                .init(imageURL: imageURL, name: "Kentya Palm", details: "Net Sales: $800", value: "10"),
+                                .init(imageURL: imageURL, name: "Love Ficus", details: "Net Sales: $599", value: "5"),
+                                .init(imageURL: imageURL, name: "Bird Of Paradise", details: "Net Sales: $23.50", value: "2"),
+                             ],
                              isRedacted: false)
             .previewLayout(.sizeThatFits)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -41,6 +41,17 @@ struct AnalyticsProductCard: View {
                     .redacted(reason: isRedacted ? .placeholder : [])
                     .shimmering(active: isRedacted)
             }
+
+            let imageURL = URL(string: "https://s0.wordpress.com/i/store/mobile/plans-premium.png")
+            TopPerformersView(itemTitle: "Products",
+                              valueTitle: "Items Sold",
+                              rows: [
+                                .init(imageURL: imageURL, name: "Tabletop Photos", details: "Net Sales: $1,232", value: "32"),
+                                .init(imageURL: imageURL, name: "Kentya Palm", details: "Net Sales: $800", value: "10"),
+                                .init(imageURL: imageURL, name: "Love Ficus", details: "Net Sales: $599", value: "5"),
+                                .init(imageURL: imageURL, name: "Bird Of Paradise", details: "Net Sales: $23.50", value: "2")
+                              ])
+            .padding(.top, Layout.columnSpacing)
         }
         .padding(Layout.cardPadding)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
@@ -17,6 +17,10 @@ struct AnalyticsProductCardViewModel {
     ///
     let deltaBackgroundColor: UIColor
 
+    /// Items Solds data to render.
+    ///
+    let itemsSoldData: [TopPerformersRow.Data]
+
     /// Indicates if the values should be hidden (for loading state)
     ///
     let isRedacted: Bool
@@ -31,8 +35,10 @@ extension AnalyticsProductCardViewModel {
         .init(itemsSold: "1000",
               delta: "+50%",
               deltaBackgroundColor: .lightGray,
+              itemsSoldData: [.init(imageURL: nil, name: "Product Name", details: "Net Sales", value: "$5678")],
               isRedacted: true)
     }
+
 }
 
 /// Convenience extension to create an `AnalyticsReportCard` from a view model.
@@ -42,6 +48,7 @@ extension AnalyticsProductCard {
         self.itemsSold = viewModel.itemsSold
         self.delta = viewModel.delta
         self.deltaBackgroundColor = viewModel.deltaBackgroundColor
+        self.itemsSoldData = viewModel.itemsSoldData
         self.isRedacted = viewModel.isRedacted
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersView.swift
@@ -21,7 +21,7 @@ struct TopPerformersView: View {
     /// Text margin value: Where the row text is placed in the X position.
     /// Needed to properly layout the row divider.
     ///
-    @State private var rowTextMarging: CGFloat = 0
+    @State private var rowTextMargin: CGFloat = 0
 
     var body: some View {
         VStack() {
@@ -34,14 +34,15 @@ struct TopPerformersView: View {
             }
             .foregroundColor(Color(.text))
             .subheadlineStyle()
+            .padding(.bottom, Layout.tableSpacing)
 
             // Rows
             ForEach(rows.indexed(), id: \.0.self) { index, row in
 
-                TopPerformersRow(data: row, textMarging: $rowTextMarging)
+                TopPerformersRow(data: row, textMargin: $rowTextMargin)
 
                 Divider()
-                    .padding(.leading, rowTextMarging)
+                    .padding(.leading, rowTextMargin)
                     .renderedIf(index < rows.count - 1) // Do not render the divider for the last row.
             }
         }
@@ -83,7 +84,7 @@ struct TopPerformersRow: View {
     /// Binding variable where we set in what X position the text labels begin, using the main view coordinate space.
     /// Useful for letting consumers know where to layout the row divider.
     ///
-    @Binding var textMarging: CGFloat
+    @Binding var textMargin: CGFloat
 
     var body: some View {
         HStack(alignment: .firstTextBaseline) {
@@ -107,7 +108,7 @@ struct TopPerformersRow: View {
                     // Trick to get the text labels X position relative to the main parent view.
                     GeometryReader() { proxy in
                         Color.clear.task {
-                            textMarging = proxy.frame(in: .named(Layout.mainViewCoordinaateSpace)).minX
+                            textMargin = proxy.frame(in: .named(Layout.mainViewCoordinaateSpace)).minX
                         }
                     }
                 )
@@ -119,6 +120,12 @@ struct TopPerformersRow: View {
                 .subheadlineStyle()
         }
         .coordinateSpace(name: Layout.mainViewCoordinaateSpace)
+    }
+}
+
+private extension TopPerformersView {
+    enum Layout {
+        static let tableSpacing: CGFloat = 16
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersView.swift
@@ -1,0 +1,20 @@
+import UIKit
+import SwiftUI
+
+/// View that displays a collection of top items organized in a list.
+///
+struct TopPerformersView: View {
+
+    var body: some View {
+        Text("View")
+    }
+}
+
+
+// MARK: Previews
+struct TopPerformersPreview: PreviewProvider {
+    static var previews: some View {
+        TopPerformersView()
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersView.swift
@@ -1,20 +1,149 @@
 import UIKit
 import SwiftUI
+import Kingfisher
 
 /// View that displays a collection of top items organized in a list.
 ///
 struct TopPerformersView: View {
+    /// Indicates what kind of items will be displayed.
+    ///
+    let itemTitle: String
+
+    /// Indicates what value criteria will be displayed.
+    ///
+    let valueTitle: String
+
+    /// Items to display.
+    ///
+    let rows: [TopPerformersRow.Data]
+
+    /// Used to track the text margin value from the top performers row.
+    /// Text margin value: Where the row text is placed in the X position.
+    /// Needed to properly layout the row divider.
+    ///
+    @State private var rowTextMarging: CGFloat = 0
 
     var body: some View {
-        Text("View")
+        VStack() {
+
+            // Header
+            HStack {
+                Text(itemTitle)
+                Spacer()
+                Text(valueTitle)
+            }
+            .foregroundColor(Color(.text))
+            .subheadlineStyle()
+
+            // Rows
+            ForEach(rows.indexed(), id: \.0.self) { index, row in
+
+                TopPerformersRow(data: row, textMarging: $rowTextMarging)
+
+                Divider()
+                    .padding(.leading, rowTextMarging)
+                    .renderedIf(index < rows.count - 1) // Do not render the divider for the last row.
+            }
+        }
     }
 }
 
+/// View that displays one top performer row..
+///
+struct TopPerformersRow: View {
+
+    /// Dynamic image width, also used for its height.
+    ///
+    @ScaledMetric var imageWidth = Layout.standardImageWidth
+
+    /// Type that encapsulates dependencies.
+    ///
+    struct Data {
+        /// Item image URL
+        ///
+        let imageURL: URL?
+
+        /// Item name or title.
+        ///
+        let name: String
+
+        /// Text displayed under the item name.
+        ///
+        let details: String
+
+        /// Item Value
+        ///
+        let value: String
+    }
+
+    /// Row  information to display.
+    ///
+    let data: Data
+
+    /// Binding variable where we set in what X position the text labels begin, using the main view coordinate space.
+    /// Useful for letting consumers know where to layout the row divider.
+    ///
+    @Binding var textMarging: CGFloat
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            AdaptiveStack(horizontalAlignment: .leading) {
+
+                // Image
+                KFImage(data.imageURL)
+                    .resizable()
+                    .frame(width: imageWidth, height: imageWidth)
+                    .cornerRadius(Layout.imageCornerRadius)
+
+                // Text Labels
+                VStack(alignment: .leading, spacing: Layout.textSpacing) {
+                    Text(data.name)
+                        .bodyStyle()
+                    Text(data.details)
+                        .subheadlineStyle()
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    // Trick to get the text labels X position relative to the main parent view.
+                    GeometryReader() { proxy in
+                        Color.clear.task {
+                            textMarging = proxy.frame(in: .named(Layout.mainViewCoordinaateSpace)).minX
+                        }
+                    }
+                )
+            }
+
+            // Count
+            Text(data.value)
+                .foregroundColor(Color(.text))
+                .subheadlineStyle()
+        }
+        .coordinateSpace(name: Layout.mainViewCoordinaateSpace)
+    }
+}
+
+private extension TopPerformersRow {
+    enum Layout {
+        static let standardImageWidth: CGFloat = 40
+        static let imageCornerRadius: CGFloat = 4
+        static let textSpacing: CGFloat = 2
+        static let mainViewCoordinaateSpace = "main-view-cs"
+    }
+}
 
 // MARK: Previews
 struct TopPerformersPreview: PreviewProvider {
+    static let imageURL = URL(string: "https://s0.wordpress.com/i/store/mobile/plans-premium.png")
     static var previews: some View {
-        TopPerformersView()
-            .previewLayout(.sizeThatFits)
+        TopPerformersView(itemTitle: "Products",
+                          valueTitle: "Items Sold",
+                          rows: [
+                            .init(imageURL: imageURL, name: "Tabletop Photos", details: "Net Sales: $1,232", value: "32"),
+                            .init(imageURL: imageURL, name: "Kentya Palm", details: "Net Sales: $800", value: "10"),
+                            .init(imageURL: imageURL, name: "Love Ficus", details: "Net Sales: $599", value: "5"),
+                            .init(imageURL: imageURL, name: "Bird Of Paradise", details: "Net Sales: $23.50", value: "2")
+                          ])
+        .padding()
+        .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersView.swift
@@ -39,11 +39,8 @@ struct TopPerformersView: View {
             // Rows
             ForEach(rows.indexed(), id: \.0.self) { index, row in
 
-                TopPerformersRow(data: row, textMargin: $rowTextMargin)
-
-                Divider()
-                    .padding(.leading, rowTextMargin)
-                    .renderedIf(index < rows.count - 1) // Do not render the divider for the last row.
+                // Do not render the divider for the last row.
+                TopPerformersRow(data: row, showDivider: index < rows.count - 1)
             }
         }
     }
@@ -81,45 +78,41 @@ struct TopPerformersRow: View {
     ///
     let data: Data
 
-    /// Binding variable where we set in what X position the text labels begin, using the main view coordinate space.
-    /// Useful for letting consumers know where to layout the row divider.
+    /// Indicates if the bottom divider should be displayed
     ///
-    @Binding var textMargin: CGFloat
+    let showDivider: Bool
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline) {
-            AdaptiveStack(horizontalAlignment: .leading) {
+        AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .top) {
+            // Image
+            KFImage(data.imageURL)
+                .resizable()
+                .frame(width: imageWidth, height: imageWidth)
+                .cornerRadius(Layout.imageCornerRadius)
 
-                // Image
-                KFImage(data.imageURL)
-                    .resizable()
-                    .frame(width: imageWidth, height: imageWidth)
-                    .cornerRadius(Layout.imageCornerRadius)
+            // Text Labels + Value + Divider
+            VStack {
+                // Text Labels + Value
+                HStack(alignment: .firstTextBaseline) {
+                    // Text Labels
+                    VStack(alignment: .leading, spacing: Layout.textSpacing) {
+                        Text(data.name)
+                            .bodyStyle()
+                        Text(data.details)
+                            .subheadlineStyle()
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
-                // Text Labels
-                VStack(alignment: .leading, spacing: Layout.textSpacing) {
-                    Text(data.name)
-                        .bodyStyle()
-                    Text(data.details)
+                    // Count
+                    Text(data.value)
+                        .foregroundColor(Color(.text))
                         .subheadlineStyle()
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(
-                    // Trick to get the text labels X position relative to the main parent view.
-                    GeometryReader() { proxy in
-                        Color.clear.task {
-                            textMargin = proxy.frame(in: .named(Layout.mainViewCoordinaateSpace)).minX
-                        }
-                    }
-                )
-            }
 
-            // Count
-            Text(data.value)
-                .foregroundColor(Color(.text))
-                .subheadlineStyle()
+                Divider()
+                    .renderedIf(showDivider)
+            }
         }
-        .coordinateSpace(name: Layout.mainViewCoordinaateSpace)
     }
 }
 
@@ -134,7 +127,6 @@ private extension TopPerformersRow {
         static let standardImageWidth: CGFloat = 40
         static let imageCornerRadius: CGFloat = 4
         static let textSpacing: CGFloat = 2
-        static let mainViewCoordinaateSpace = "main-view-cs"
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -656,6 +656,7 @@
 		26E7EE6E29300E8100793045 /* AnalyticsProductCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E7EE6D29300E8100793045 /* AnalyticsProductCard.swift */; };
 		26E7EE7029300F6200793045 /* DeltaTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E7EE6F29300F6200793045 /* DeltaTag.swift */; };
 		26E7EE7229301EBC00793045 /* AnalyticsProductCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E7EE7129301EBC00793045 /* AnalyticsProductCardViewModel.swift */; };
+		26E7EE7429365F0700793045 /* TopPerformersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E7EE7329365F0700793045 /* TopPerformersView.swift */; };
 		26ED9660274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26ED965F274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift */; };
 		26F65C9825DEDAF0008FAE29 /* GenerateVariationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */; };
 		26F65C9E25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */; };
@@ -2644,6 +2645,7 @@
 		26E7EE6D29300E8100793045 /* AnalyticsProductCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsProductCard.swift; sourceTree = "<group>"; };
 		26E7EE6F29300F6200793045 /* DeltaTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeltaTag.swift; sourceTree = "<group>"; };
 		26E7EE7129301EBC00793045 /* AnalyticsProductCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsProductCardViewModel.swift; sourceTree = "<group>"; };
+		26E7EE7329365F0700793045 /* TopPerformersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPerformersView.swift; sourceTree = "<group>"; };
 		26ED965F274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummaryViewModel.swift; sourceTree = "<group>"; };
 		26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCase.swift; sourceTree = "<group>"; };
 		26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCaseTests.swift; sourceTree = "<group>"; };
@@ -6446,6 +6448,7 @@
 				02AB407927827C9000929CF3 /* ChartPlaceholderView.xib */,
 				748D34E02148291E00E21A2F /* TopPerformerDataViewController.swift */,
 				748D34DC214828DC00E21A2F /* TopPerformerDataViewController.xib */,
+				26E7EE7329365F0700793045 /* TopPerformersView.swift */,
 			);
 			path = MyStore;
 			sourceTree = "<group>";
@@ -10528,6 +10531,7 @@
 				AEE1D4F525D14F88006A490B /* AttributeOptionListSelectorCommand.swift in Sources */,
 				DE2FE5812923729A0018040A /* JetpackSetupRequiredViewModel.swift in Sources */,
 				020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */,
+				26E7EE7429365F0700793045 /* TopPerformersView.swift in Sources */,
 				74AAF6A5212A04A900C612B0 /* ChartMarker.swift in Sources */,
 				CE32B11520BF8779006FBCF4 /* ButtonTableViewCell.swift in Sources */,
 				025FDD3223717D2900824006 /* EditorFactory.swift in Sources */,


### PR DESCRIPTION
Part of #8199 

# Why 

This PR adds the UI for the top items sold and integrates it into the product card with temporary data.

# How

The code is fairly straightforward with the exception of the code that handles the divider between items.

The complication is that the divider needs to be laid-out below the **product name** using the same padding value. This would have been simple if layout didn't have different forms when using accessibility fonts.

The approach that I've used is to read the geometry of the **product name** label and pass it back to the parent view using a `Binding` variable.  **Please let me know if I missed a simpler alternative!**

The `GeometryReader` exists inside a clear background to prevent it from messing with how we want the view to look.

```swift
ViewToEvaluate()
.background(
    GeometryReader() { proxy in
        Color.clear.task {
            viewMargin = proxy.frame(in: .named("custom-space")).minX
        }
    }
)
```

# Screenshots

Portrait | Landscape | Big Fonts
---- | ---- | ----
![portrait](https://user-images.githubusercontent.com/562080/204923266-72366e09-bacf-4fd2-96dc-d33989e46820.png) | ![landscape](https://user-images.githubusercontent.com/562080/204923274-5e7798dc-4922-4f26-8a38-70570ebfb3e8.png) | ![big fonts](https://user-images.githubusercontent.com/562080/204923276-82e4f8c9-8068-4512-baf1-ffdf864612eb.png)

# Testing Step

- Launch the app
- Tap the "See more" CTA on the main dashboard
- Scroll down and see the product card with temprary data

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
