### PR TITLE
[Mobile Payments] Add Tap on Mobile entitlement back to build

### DIFF
--- a/WooCommerce/Resources/Woo-Debug.entitlements
+++ b/WooCommerce/Resources/Woo-Debug.entitlements
@@ -49,5 +49,7 @@
 	<array>
 		<string>$(AppIdentifierPrefix)com.automattic.woocommerce</string>
 	</array>
+	<key>com.apple.developer.proximity-reader.payment.acceptance</key>
+	<true/>
 </dict>
 </plist>

--- a/WooCommerce/Resources/Woo-Release.entitlements
+++ b/WooCommerce/Resources/Woo-Release.entitlements
@@ -49,5 +49,7 @@
 	<array>
 		<string>$(AppIdentifierPrefix)com.automattic.woocommerce</string>
 	</array>
+	<key>com.apple.developer.proximity-reader.payment.acceptance</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In #8212, I removed the `com.apple.developer.proximity-reader.payment.acceptance` entitlement from the app, as I had mistakenly merged it to trunk in #8172, before the entitlement was added to our development provisioning profiles. This meant that people with the latest provisioning profiles would have been unable to build the app on their devices.

This PR adds the entitlement back to the app, for debug and release flavours. The entitlement is now added to our main App ID, and our development provisioning profiles, so it’s safe to add it back to trunk without breaking dev environments for people.

It's not added on the alpha entitlements, as our Enterprise App ID doesn't have the entitlement added by Apple. We're unsure whether they'll grant it on an Enterprise app, so that's being treated as a separate request.

No rush on this: I've put it in next week's milestone

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Using a build from Xcode, on a physical iPhone (the feature is not supported on iPad.) 
You'll need to use an iPhone XS or newer, running iOS 15.4 or above.

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. When asked for a reader type, tap `Tap to Pay on iPhone` and go through the Terms of Service Apple ID linking (if you've not done so before)
6. Collect the payment by tapping a Stripe test card when prompted by the phone.

N.B. much of the flow is still under development, so it's not at all polished!

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
