### PR TITLE
Move release note to 11.5

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,10 +3,10 @@
 11.5
 -----
 - [*] Account deletion is now supported for all users in settings or in the empty stores screen. [https://github.com/woocommerce/woocommerce-ios/pull/8179]
+- [*] In-Person Payments: We removed any references to Simple Payments from Orders, and the red badge from the Menu tab and Menu Payments icon announcing the new Payments section. [https://github.com/woocommerce/woocommerce-ios/pull/8183]
 
 11.4
 -----
-- [*] In-Person Payments: We removed any references to Simple Payments from Orders, and the red badge from the Menu tab and Menu Payments icon announcing the new Payments section. [https://github.com/woocommerce/woocommerce-ios/pull/8183] 
 - [*] Add System Status Report to ZenDesk support requests. [https://github.com/woocommerce/woocommerce-ios/pull/8171]
 
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8183 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Due to issue in CI, the previous [PR](https://github.com/woocommerce/woocommerce-ios/pull/8183) wasn't merged on time for 11.4, but I forgot to update the Release Notes. As it will be part of 11.5, I move the release note to the 11.5 section here.

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
