### PR TITLE
[Analytics Hub] Add pull to refresh

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -96,43 +96,6 @@ private extension AnalyticsHubView {
     }
 }
 
-/// This view simulates pull-to-refresh support on ScrollView before iOS 16.
-///
-/// On iOS 16+ it uses ScrollView.
-/// On iOS 15 it falls back to List with modifiers removing all its default rows styling.
-///
-private struct RefreshablePlainList<Content: View>: View {
-    let action: () async -> Void
-    let content: Content
-
-    init(action: @escaping () async -> Void, content: @escaping () -> Content) {
-        self.action = action
-        self.content = content()
-    }
-
-    var body: some View {
-        if #available(iOS 16, *) {
-            ScrollView {
-                content
-            }
-            .refreshable {
-                await action()
-            }
-        } else {
-            List {
-                content
-                    .listRowSeparatorTint(.clear)
-                    .listRowBackground(Color.clear)
-                    .listRowInsets(EdgeInsets.zero)
-            }
-            .listStyle(.plain)
-            .refreshable {
-                await action()
-            }
-        }
-    }
-}
-
 // MARK: Preview
 
 struct AnalyticsHubPreview: PreviewProvider {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -78,6 +78,9 @@ struct AnalyticsHubView: View {
         .task {
             await viewModel.updateData()
         }
+        .refreshable {
+            await viewModel.updateData()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -26,7 +26,9 @@ struct AnalyticsHubView: View {
     @StateObject var viewModel: AnalyticsHubViewModel
 
     var body: some View {
-        ScrollView {
+        RefreshablePlainList(action: {
+            await viewModel.updateData()
+        }) {
             VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
                 VStack(spacing: Layout.dividerSpacing) {
                     Divider()
@@ -76,9 +78,6 @@ struct AnalyticsHubView: View {
         .background(Color(uiColor: .listBackground))
         .edgesIgnoringSafeArea(.horizontal)
         .task {
-            await viewModel.updateData()
-        }
-        .refreshable {
             await viewModel.updateData()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -97,6 +97,43 @@ private extension AnalyticsHubView {
     }
 }
 
+/// This view simulates pull-to-refresh support on ScrollView before iOS 16.
+///
+/// On iOS 16+ it uses ScrollView.
+/// On iOS 15 it falls back to List with modifiers removing all its default rows styling.
+///
+private struct RefreshablePlainList<Content: View>: View {
+    let action: () async -> Void
+    let content: Content
+
+    init(action: @escaping () async -> Void, content: @escaping () -> Content) {
+        self.action = action
+        self.content = content()
+    }
+
+    var body: some View {
+        if #available(iOS 16, *) {
+            ScrollView {
+                content
+            }
+            .refreshable {
+                await action()
+            }
+        } else {
+            List {
+                content
+                    .listRowSeparatorTint(.clear)
+                    .listRowBackground(Color.clear)
+                    .listRowInsets(EdgeInsets.zero)
+            }
+            .listStyle(.plain)
+            .refreshable {
+                await action()
+            }
+        }
+    }
+}
+
 // MARK: Preview
 
 struct AnalyticsHubPreview: PreviewProvider {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RefreshablePlainList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RefreshablePlainList.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// This view simulates pull-to-refresh support on ScrollView before iOS 16.
+///
+/// On iOS 16+ it uses ScrollView.
+/// On iOS 15 it falls back to List with modifiers removing all its default rows styling.
+///
+struct RefreshablePlainList<Content: View>: View {
+    let action: () async -> Void
+    let content: Content
+
+    init(action: @escaping () async -> Void, content: @escaping () -> Content) {
+        self.action = action
+        self.content = content()
+    }
+
+    var body: some View {
+        if #available(iOS 16, *) {
+            ScrollView {
+                content
+            }
+            .refreshable {
+                await action()
+            }
+        } else {
+            List {
+                content
+                    .listRowSeparatorTint(.clear)
+                    .listRowBackground(Color.clear)
+                    .listRowInsets(EdgeInsets.zero)
+            }
+            .listStyle(.plain)
+            .refreshable {
+                await action()
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1215,6 +1215,7 @@
 		AEE1D4FF25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE1D4FE25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift */; };
 		AEE2610F26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE2610E26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift */; };
 		AEE2611126E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE2611026E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift */; };
+		AEE9A880293A3E5500227C92 /* RefreshablePlainList.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE9A87F293A3E5500227C92 /* RefreshablePlainList.swift */; };
 		B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509112D2049E27A007D25DC /* DashboardViewController.swift */; };
 		B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED021C041DF000076A9 /* Locale+Woo.swift */; };
 		B509FED321C05121000076A9 /* SupportManagerAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED221C05121000076A9 /* SupportManagerAdapter.swift */; };
@@ -3192,6 +3193,7 @@
 		AEE1D4FE25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeOptionListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		AEE2610E26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditOrderAddressFormViewModel.swift; sourceTree = "<group>"; };
 		AEE2611026E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditOrderAddressFormViewModelTests.swift; sourceTree = "<group>"; };
+		AEE9A87F293A3E5500227C92 /* RefreshablePlainList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshablePlainList.swift; sourceTree = "<group>"; };
 		B509112D2049E27A007D25DC /* DashboardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardViewController.swift; sourceTree = "<group>"; };
 		B509FED021C041DF000076A9 /* Locale+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+Woo.swift"; sourceTree = "<group>"; };
 		B509FED221C05121000076A9 /* SupportManagerAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportManagerAdapter.swift; sourceTree = "<group>"; };
@@ -6162,6 +6164,7 @@
 				036CA6F029229C9E00E4DF4F /* IndefiniteCircularProgressViewStyle.swift */,
 				DE2FE5872925DD950018040A /* JetpackInstallHeaderView.swift */,
 				26E7EE6F29300F6200793045 /* DeltaTag.swift */,
+				AEE9A87F293A3E5500227C92 /* RefreshablePlainList.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -10728,6 +10731,7 @@
 				AE8AEA8628084EC90054BDA2 /* MaxWidthPreference.swift in Sources */,
 				DE19BB1A26C3B5DC00AB70D9 /* ShippingLabelCustomsFormItemDetailsViewModel.swift in Sources */,
 				2667BFE52530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift in Sources */,
+				AEE9A880293A3E5500227C92 /* RefreshablePlainList.swift in Sources */,
 				B55BC1F121A878A30011A0C0 /* String+HTML.swift in Sources */,
 				B56C721221B5B44000E5E85B /* PushNotificationsConfiguration.swift in Sources */,
 				26FE09DF24DB871100B9BDF5 /* SurveyViewControllersFactory.swift in Sources */,


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8261

## Description

This PR adds pull-to-refresh action on the Analytics Hub view. It triggers the same action as initial screen loading.

## How

While it's very straightforward to implement on iOS 16 (583a4f1), `ScrollView` on iOS 15 doesn't add pull-to-refresh feature, supporting it only on `List`.

One approach is to implement pull-to-refresh manually. But it's a lot of boilerplate with unavoidable differences from Apple's reference implementation and a lot of edge cases. We even have on in the codebase - [`RefreshableScrollView`](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI%20Components/RefreshableScrollView.swift), but it was buggy for me (activity indicator disappeared) and felt different from OS version (refresh action triggered before ending the gesture).

I decided to fall back on native `List` implementation, removing the most of its styling/rows chrome, so it looks just like plain `ScrollView`. Since there may be small differences we don't notice, I made this fallback conditional, only on iOS 15.

`RefreshablePlainList` is private and included in the same file for now, since it conceals different types and may introduce unexpected side effects. We can move it to `ReusableViews/SwiftUI Components/` to promote general usage and additional testing.

_Question_: what is the better name for `RefreshablePlainList`? It's a ScrollView in more cases than a List, but `RefreshableScrollView` is already taken 🙂

## Testing

1. Build and run the app in debug/alpha mode.
2. On the dashboard screen tap the "See more" button.
3. On analytics hub screen wait for loading to finish.
4. Pull the scroll view and trigger refresh action.
5. Confirm the loading indicator is spinning on top of the list.
6. Confirm all the data is in loading state.
7. Wait for networking to finish.
8. Confirm the screen displays the data and the loading indicator disappears.

Try it iOS 15. Check dark mode/landscape/accessibility sizes.
`ScrollView` -> `List` migration (on iOS 15) may introduce some differences.

I've checked with object graph that there are no retain cycles in AnalyticsHubVC and its VM.

## Videos

https://user-images.githubusercontent.com/3132438/205071665-aa07a4e9-d767-4864-b5a4-1904688e809e.mp4

https://user-images.githubusercontent.com/3132438/205071691-c1119948-da31-464a-ae94-1a39056fad4e.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
