### PR TITLE
[Mobile Payments] Implement simpler built-in reader connection flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -5,6 +5,12 @@ import Storage
 import SwiftUI
 import Yosemite
 
+/// The final state of the card reader connection to return without errors.
+enum ControllerCardReaderConnectionResult {
+    case connected
+    case canceled
+}
+
 /// Facilitates connecting to a card reader
 ///
 final class BuiltInCardReaderConnectionController {
@@ -69,12 +75,6 @@ final class BuiltInCardReaderConnectionController {
         case discoveryFailed(Error)
     }
 
-    /// The final state of the card reader connection to return without errors.
-    enum ConnectionResult {
-        case connected
-        case canceled
-    }
-
     private let storageManager: StorageManagerType
     private let stores: StoresManager
 
@@ -120,7 +120,7 @@ final class BuiltInCardReaderConnectionController {
 
     private var subscriptions = Set<AnyCancellable>()
 
-    private var onCompletion: ((Result<ConnectionResult, Error>) -> Void)?
+    private var onCompletion: ((Result<ControllerCardReaderConnectionResult, Error>) -> Void)?
 
     private(set) lazy var dataSource: CardReaderSettingsDataSource = {
         return CardReaderSettingsDataSource(siteID: siteID, storageManager: storageManager)
@@ -167,7 +167,7 @@ final class BuiltInCardReaderConnectionController {
         subscriptions.removeAll()
     }
 
-    func searchAndConnect(onCompletion: @escaping (Result<ConnectionResult, Error>) -> Void) {
+    func searchAndConnect(onCompletion: @escaping (Result<ControllerCardReaderConnectionResult, Error>) -> Void) {
         self.onCompletion = onCompletion
         self.state = .initializing
     }
@@ -738,7 +738,7 @@ private extension BuiltInCardReaderConnectionController {
 
     /// Calls the completion with a success result
     ///
-    private func returnSuccess(result: ConnectionResult) {
+    private func returnSuccess(result: ControllerCardReaderConnectionResult) {
         onCompletion?(.success(result))
         alertsPresenter.dismiss()
         state = .idle

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -100,11 +100,8 @@ final class BuiltInCardReaderConnectionController {
         }
     }
 
-    private let discoveryMethod: CardReaderDiscoveryMethod
-
     init(
         forSiteID: Int64,
-        discoveryMethod: CardReaderDiscoveryMethod,
         storageManager: StorageManagerType = ServiceLocator.storageManager,
         stores: StoresManager = ServiceLocator.stores,
         alertsPresenter: CardPresentPaymentAlertsPresenting,
@@ -112,7 +109,6 @@ final class BuiltInCardReaderConnectionController {
         analyticsTracker: CardReaderConnectionAnalyticsTracker
     ) {
         siteID = forSiteID
-        self.discoveryMethod = discoveryMethod
         self.storageManager = storageManager
         self.stores = stores
         state = .idle
@@ -221,7 +217,7 @@ private extension BuiltInCardReaderConnectionController {
 
         let action = CardPresentPaymentAction.startCardReaderDiscovery(
             siteID: siteID,
-            discoveryMethod: discoveryMethod,
+            discoveryMethod: .localMobile,
             onReaderDiscovered: { [weak self] cardReaders in
                 guard let self = self else {
                     return

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -5,12 +5,6 @@ import Storage
 import SwiftUI
 import Yosemite
 
-/// The final state of the card reader connection to return without errors.
-enum ControllerCardReaderConnectionResult {
-    case connected
-    case canceled
-}
-
 /// Facilitates connecting to a card reader
 ///
 final class BuiltInCardReaderConnectionController {
@@ -92,7 +86,7 @@ final class BuiltInCardReaderConnectionController {
 
     private var subscriptions = Set<AnyCancellable>()
 
-    private var onCompletion: ((Result<ControllerCardReaderConnectionResult, Error>) -> Void)?
+    private var onCompletion: ((Result<CardReaderConnectionResult, Error>) -> Void)?
 
     private(set) lazy var dataSource: CardReaderSettingsDataSource = {
         return CardReaderSettingsDataSource(siteID: siteID, storageManager: storageManager)
@@ -134,7 +128,7 @@ final class BuiltInCardReaderConnectionController {
         subscriptions.removeAll()
     }
 
-    func searchAndConnect(onCompletion: @escaping (Result<ControllerCardReaderConnectionResult, Error>) -> Void) {
+    func searchAndConnect(onCompletion: @escaping (Result<CardReaderConnectionResult, Error>) -> Void) {
         self.onCompletion = onCompletion
         self.state = .initializing
     }
@@ -375,10 +369,10 @@ private extension BuiltInCardReaderConnectionController {
                 // actually see a success message showing the installation was complete
                 if case .updating(progress: 1) = self.state {
                     DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
-                        self.returnSuccess(result: .connected)
+                        self.returnSuccess(result: .connected(reader))
                     }
                 } else {
-                    self.returnSuccess(result: .connected)
+                    self.returnSuccess(result: .connected(reader))
                 }
             case .failure(let error):
                 ServiceLocator.analytics.track(
@@ -538,7 +532,7 @@ private extension BuiltInCardReaderConnectionController {
 
     /// Calls the completion with a success result
     ///
-    private func returnSuccess(result: ControllerCardReaderConnectionResult) {
+    private func returnSuccess(result: CardReaderConnectionResult) {
         onCompletion?(.success(result))
         alertsPresenter.dismiss()
         state = .idle

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -122,14 +122,15 @@ final class CardPresentPaymentPreflightController {
     }
 
     private func localMobileReaderSupported() -> Bool {
-        #if !targetEnvironment(simulator)
+        #if targetEnvironment(simulator)
+        return true
+        #else
         if #available(iOS 15.4, *) {
             return PaymentCardReader.isSupported
         } else {
             return false
         }
         #endif
-        return true
     }
 
     private func handleConnectionResult(_ result: Result<CardReaderConnectionController.ConnectionResult, Error>) {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -133,7 +133,7 @@ final class CardPresentPaymentPreflightController {
         #endif
     }
 
-    private func handleConnectionResult(_ result: Result<CardReaderConnectionController.ConnectionResult, Error>) {
+    private func handleConnectionResult(_ result: Result<ControllerCardReaderConnectionResult, Error>) {
         let connectionResult = result.map { connection in
             switch connection {
             case .connected:

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -68,7 +68,6 @@ final class CardPresentPaymentPreflightController {
                                                                     analytics: analytics)
         self.connectionController = CardReaderConnectionController(
             forSiteID: siteID,
-            discoveryMethod: .bluetoothScan,
             knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
             alertsPresenter: alertsPresenter,
             configuration: configuration,
@@ -76,7 +75,6 @@ final class CardPresentPaymentPreflightController {
 
         self.builtInConnectionController = BuiltInCardReaderConnectionController(
             forSiteID: siteID,
-            discoveryMethod: .localMobile,
             alertsPresenter: alertsPresenter,
             configuration: configuration,
             analyticsTracker: analyticsTracker)

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -78,7 +78,6 @@ final class CardPresentPaymentPreflightController {
         self.builtInConnectionController = BuiltInCardReaderConnectionController(
             forSiteID: siteID,
             discoveryMethod: .localMobile,
-            knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
             alertsPresenter: alertsPresenter,
             configuration: configuration,
             analyticsTracker: analyticsTracker)

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -45,7 +45,7 @@ final class CardPresentPaymentPreflightController {
 
     /// Controller to connect a card reader.
     ///
-    private var builtInConnectionController: CardReaderConnectionController
+    private var builtInConnectionController: BuiltInCardReaderConnectionController
 
 
     private(set) var readerConnection = CurrentValueSubject<CardReaderConnectionResult?, Never>(nil)
@@ -75,7 +75,7 @@ final class CardPresentPaymentPreflightController {
             configuration: configuration,
             analyticsTracker: analyticsTracker)
 
-        self.builtInConnectionController = CardReaderConnectionController(
+        self.builtInConnectionController = BuiltInCardReaderConnectionController(
             forSiteID: siteID,
             discoveryMethod: .localMobile,
             knownReaderProvider: CardReaderSettingsKnownReaderStorage(),

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -66,7 +66,6 @@ final class CardPresentPaymentPreflightController {
         let analyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: configuration,
                                                                     stores: stores,
                                                                     analytics: analytics)
-        // TODO: Replace this with a refactored (New)LegacyCardReaderConnectionController
         self.connectionController = CardReaderConnectionController(
             forSiteID: siteID,
             discoveryMethod: .bluetoothScan,
@@ -132,13 +131,12 @@ final class CardPresentPaymentPreflightController {
         #endif
     }
 
-    private func handleConnectionResult(_ result: Result<ControllerCardReaderConnectionResult, Error>) {
+    private func handleConnectionResult(_ result: Result<CardReaderConnectionResult, Error>) {
         let connectionResult = result.map { connection in
             switch connection {
-            case .connected:
-                // TODO: pass the reader from the (New)CardReaderConnectionController
-                guard let connectedReader = self.connectedReader else { return CardReaderConnectionResult.canceled }
-                return CardReaderConnectionResult.connected(connectedReader)
+            case .connected(let reader):
+                self.connectedReader = reader
+                return CardReaderConnectionResult.connected(reader)
             case .canceled:
                 return CardReaderConnectionResult.canceled
             }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -120,7 +120,7 @@ final class CardReaderConnectionController {
 
     private var subscriptions = Set<AnyCancellable>()
 
-    private var onCompletion: ((Result<ConnectionResult, Error>) -> Void)?
+    private var onCompletion: ((Result<ControllerCardReaderConnectionResult, Error>) -> Void)?
 
     private(set) lazy var dataSource: CardReaderSettingsDataSource = {
         return CardReaderSettingsDataSource(siteID: siteID, storageManager: storageManager)
@@ -167,7 +167,7 @@ final class CardReaderConnectionController {
         subscriptions.removeAll()
     }
 
-    func searchAndConnect(onCompletion: @escaping (Result<ConnectionResult, Error>) -> Void) {
+    func searchAndConnect(onCompletion: @escaping (Result<ControllerCardReaderConnectionResult, Error>) -> Void) {
         self.onCompletion = onCompletion
         self.state = .initializing
     }
@@ -738,7 +738,7 @@ private extension CardReaderConnectionController {
 
     /// Calls the completion with a success result
     ///
-    private func returnSuccess(result: ConnectionResult) {
+    private func returnSuccess(result: ControllerCardReaderConnectionResult) {
         onCompletion?(.success(result))
         alertsPresenter.dismiss()
         state = .idle

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -69,12 +69,6 @@ final class CardReaderConnectionController {
         case discoveryFailed(Error)
     }
 
-    /// The final state of the card reader connection to return without errors.
-    enum ConnectionResult {
-        case connected
-        case canceled
-    }
-
     private let storageManager: StorageManagerType
     private let stores: StoresManager
 
@@ -120,7 +114,7 @@ final class CardReaderConnectionController {
 
     private var subscriptions = Set<AnyCancellable>()
 
-    private var onCompletion: ((Result<ControllerCardReaderConnectionResult, Error>) -> Void)?
+    private var onCompletion: ((Result<CardReaderConnectionResult, Error>) -> Void)?
 
     private(set) lazy var dataSource: CardReaderSettingsDataSource = {
         return CardReaderSettingsDataSource(siteID: siteID, storageManager: storageManager)
@@ -167,7 +161,7 @@ final class CardReaderConnectionController {
         subscriptions.removeAll()
     }
 
-    func searchAndConnect(onCompletion: @escaping (Result<ControllerCardReaderConnectionResult, Error>) -> Void) {
+    func searchAndConnect(onCompletion: @escaping (Result<CardReaderConnectionResult, Error>) -> Void) {
         self.onCompletion = onCompletion
         self.state = .initializing
     }
@@ -575,10 +569,10 @@ private extension CardReaderConnectionController {
                 // actually see a success message showing the installation was complete
                 if case .updating(progress: 1) = self.state {
                     DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
-                        self.returnSuccess(result: .connected)
+                        self.returnSuccess(result: .connected(reader))
                     }
                 } else {
-                    self.returnSuccess(result: .connected)
+                    self.returnSuccess(result: .connected(reader))
                 }
             case .failure(let error):
                 ServiceLocator.analytics.track(
@@ -738,7 +732,7 @@ private extension CardReaderConnectionController {
 
     /// Calls the completion with a success result
     ///
-    private func returnSuccess(result: ControllerCardReaderConnectionResult) {
+    private func returnSuccess(result: CardReaderConnectionResult) {
         onCompletion?(.success(result))
         alertsPresenter.dismiss()
         state = .idle

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -128,11 +128,8 @@ final class CardReaderConnectionController {
         }
     }
 
-    private let discoveryMethod: CardReaderDiscoveryMethod
-
     init(
         forSiteID: Int64,
-        discoveryMethod: CardReaderDiscoveryMethod,
         storageManager: StorageManagerType = ServiceLocator.storageManager,
         stores: StoresManager = ServiceLocator.stores,
         knownReaderProvider: CardReaderSettingsKnownReaderProvider,
@@ -141,7 +138,6 @@ final class CardReaderConnectionController {
         analyticsTracker: CardReaderConnectionAnalyticsTracker
     ) {
         siteID = forSiteID
-        self.discoveryMethod = discoveryMethod
         self.storageManager = storageManager
         self.stores = stores
         state = .idle
@@ -316,7 +312,7 @@ private extension CardReaderConnectionController {
 
         let action = CardPresentPaymentAction.startCardReaderDiscovery(
             siteID: siteID,
-            discoveryMethod: discoveryMethod,
+            discoveryMethod: .bluetoothScan,
             onReaderDiscovered: { [weak self] cardReaders in
                 guard let self = self else {
                     return

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionController.swift
@@ -321,13 +321,9 @@ private extension LegacyCardReaderConnectionController {
         self.state = .searching
         var didAutoAdvance = false
 
-        // TODO: make this a choice for the user, when the switch is enabled
-        let tapOnIphoneEnabled = ServiceLocator.generalAppSettings.settings.isTapToPayOnIPhoneSwitchEnabled
-        let discoveryMethod: CardReaderDiscoveryMethod = tapOnIphoneEnabled ? .localMobile : .bluetoothScan
-
         let action = CardPresentPaymentAction.startCardReaderDiscovery(
             siteID: siteID,
-            discoveryMethod: discoveryMethod,
+            discoveryMethod: .bluetoothScan,
             onReaderDiscovered: { [weak self] cardReaders in
                 guard let self = self else {
                     return


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8082
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In sTAP Away, we add the ability to use the built-in NFC card reader on compatible iPhones to take card payments.

The Stripe SDK we use keeps a very similar interface for built in reader connections, compared to bluetooth reader connections. The interface is almost identical, asking us to discover a reader, then connect to it, even though it's the phone's built in hardware.

The connection flows for BuiltIn and Bluetooth card readers are similar, but the built-in flow has less complexity. In particular, we only need to support one built-in reader for Tap on Mobile, so we can remove the ability to skip a reader, don't need to show a list of readers to choose between, and can always auto connect to a found reader.

Using the BuiltIn variant of the CardReaderConnectionController (duplicated in #8280) I've stripped out the unnecessary steps and code to provide the following connection flow.

1. Clear any `candidateReader`
2. Start a `localMobile` search using `CardPresentPaymentAction.startCardReaderDiscovery`
3. When the first reader is found, start connecting to it
4. If there's a "software update" (actually configuring the device), install it
5. When the reader is connected, call completion with `connected(reader)` so that Preflight can continue with its work
6. Display any errors, allowing retry where appropriate.

**N.B. There's no change to the visuals or text for the Built-in reader flow** – this PR continues to use the same alerts as the bluetooth reader flow.

The next step is to update the alerts that are shown, and then, I'll factor out the shared code.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

If you do not have a device which is provisioned for Tap on Mobile, please enable the simulated card reader and build to a simulator. 

To enable the Stripe simulated reader, in Xcode go to `Product > Scheme > Edit Scheme` and select `Run` in the sidebar, then `Arguments` in the tabs. Check the `-simulate-stripe-card-reader` box.

Using a US store with WCPay or the Stripe gateway:

1. Turn on the `Tap to Pay on iPhone` experimental feature in settings
2. Tap `Menu > Payments > Collect Payment`
3. Follow the flow to create a payment, and select Card when asked for the payment method
4. Choose Tap to Pay on iPhone
5. Observe that the connection flow proceeds and automatically connects to the built in reader.

Repeat, using the simulated reader, [after setting the software update type to](https://github.com/woocommerce/woocommerce-ios/blob/db5863f26f158e47813dfcfa8f4de6d9702a44ef/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift#L78) `.required` (change it in code and rebuild)

Observe that when you do this, the connection flow proceeds and performs the update, displaying progress as it does so.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/2472348/205089145-dd191cb1-adf0-49ae-abad-aaedaa595d15.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
