### PR TITLE
Analytics Hub: Prepare retrieveTopEarnerStats method

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -98,6 +98,7 @@ final class DashboardViewModel {
                                                           latestDateToInclude: latestDateToInclude,
                                                           quantity: Constants.topEarnerStatsLimit,
                                                           forceRefresh: forceRefresh,
+                                                          saveInStorage: true,
                                                           onCompletion: { result in
             switch result {
             case .success:
@@ -107,7 +108,9 @@ final class DashboardViewModel {
             case .failure(let error):
                 DDLogError("⛔️ Dashboard (Top Performers) — Error synchronizing top earner stats: \(error)")
             }
-            onCompletion?(result)
+
+            let voidResult = result.map { _ in () } // Caller expects no entity in the result.
+            onCompletion?(voidResult)
         })
         stores.dispatch(action)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -52,7 +52,7 @@ final class DashboardViewModelTests: XCTestCase {
                 completion(.failure(DotcomError.empty))
             } else if case let .retrieveSiteVisitStats(_, _, _, _, completion) = action {
                 completion(.failure(DotcomError.noRestRoute))
-            } else if case let .retrieveTopEarnerStats(_, _, _, _, _, _, completion) = action {
+            } else if case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, completion) = action {
                 completion(.failure(DotcomError.noRestRoute))
             }
         }

--- a/Yosemite/Yosemite/Actions/StatsActionV4.swift
+++ b/Yosemite/Yosemite/Actions/StatsActionV4.swift
@@ -37,7 +37,8 @@ public enum StatsActionV4: Action {
         latestDateToInclude: Date,
         onCompletion: (Result<Void, Error>) -> Void)
 
-    /// Synchronizes `TopEarnerStats` for the provided siteID, time range, and date.
+    /// Retrieves `TopEarnerStats` for the provided siteID, time range, and date.
+    /// Conditionally saves it to storage.
     ///
     case retrieveTopEarnerStats(siteID: Int64,
                                 timeRange: StatsTimeRangeV4,
@@ -45,5 +46,6 @@ public enum StatsActionV4: Action {
                                 latestDateToInclude: Date,
                                 quantity: Int,
                                 forceRefresh: Bool,
-                                onCompletion: (Result<Void, Error>) -> Void)
+                                saveInStorage: Bool,
+                                onCompletion: (Result<TopEarnerStats, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
@@ -14,7 +14,7 @@ struct MockStatsActionV4Handler: MockActionHandler {
                 retrieveStats(siteID: siteID, timeRange: timeRange, onCompletion: onCompletion)
             case .retrieveSiteVisitStats(let siteID, _, let timeRange, _, let onCompletion):
                 retrieveSiteVisitStats(siteID: siteID, timeRange: timeRange, onCompletion: onCompletion)
-            case .retrieveTopEarnerStats(let siteID, let timeRange, _, _, _, _, let onCompletion):
+            case .retrieveTopEarnerStats(let siteID, let timeRange, _, _, _, _, _, let onCompletion):
                 retrieveTopEarnerStats(siteID: siteID, timeRange: timeRange, onCompletion: onCompletion)
             default: unimplementedAction(action: action)
         }
@@ -52,19 +52,19 @@ struct MockStatsActionV4Handler: MockActionHandler {
         }
     }
 
-    func retrieveTopEarnerStats(siteID: Int64, timeRange: StatsTimeRangeV4, onCompletion: @escaping (Result<Void, Error>) -> ()) {
+    func retrieveTopEarnerStats(siteID: Int64, timeRange: StatsTimeRangeV4, onCompletion: @escaping (Result<TopEarnerStats, Error>) -> ()) {
         let store = StatsStoreV4(dispatcher: Dispatcher(), storageManager: storageManager, network: NullNetwork())
 
         switch timeRange {
-            case .today:
-                success(onCompletion)
-            case .thisWeek:
-                success(onCompletion)
-            case .thisMonth:
-                store.upsertStoredTopEarnerStats(readOnlyStats: objectGraph.thisMonthTopProducts)
-                onCompletion(.success(()))
-            case .thisYear:
-                success(onCompletion)
+        case .today:
+            onCompletion(.success(objectGraph.thisMonthTopProducts))
+        case .thisWeek:
+            onCompletion(.success(objectGraph.thisMonthTopProducts))
+        case .thisMonth:
+            store.upsertStoredTopEarnerStats(readOnlyStats: objectGraph.thisMonthTopProducts)
+            onCompletion(.success(objectGraph.thisMonthTopProducts))
+        case .thisYear:
+            onCompletion(.success(objectGraph.thisMonthTopProducts))
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -80,6 +80,7 @@ public final class StatsStoreV4: Store {
                                      let latestDateToInclude,
                                      let quantity,
                                      let forceRefresh,
+                                     let saveInStorage,
                                      let onCompletion):
             retrieveTopEarnerStats(siteID: siteID,
                                    timeRange: timeRange,
@@ -87,6 +88,7 @@ public final class StatsStoreV4: Store {
                                    latestDateToInclude: latestDateToInclude,
                                    quantity: quantity,
                                    forceRefresh: forceRefresh,
+                                   saveInStorage: saveInStorage,
                                    onCompletion: onCompletion)
         }
     }
@@ -178,6 +180,7 @@ private extension StatsStoreV4 {
     }
 
     /// Retrieves the top earner stats associated with the provided Site ID (if any!).
+    ///  Saves to storage if required,
     ///
     func retrieveTopEarnerStats(siteID: Int64,
                                 timeRange: StatsTimeRangeV4,
@@ -185,29 +188,37 @@ private extension StatsStoreV4 {
                                 latestDateToInclude: Date,
                                 quantity: Int,
                                 forceRefresh: Bool,
-                                onCompletion: @escaping (Result<Void, Error>) -> Void) {
+                                saveInStorage: Bool,
+                                onCompletion: @escaping (Result<TopEarnerStats, Error>) -> Void) {
         Task { @MainActor in
             do {
-                try await loadTopEarnerStats(siteID: siteID,
-                                                      timeRange: timeRange,
-                                                      earliestDateToInclude: earliestDateToInclude,
-                                                      latestDateToInclude: latestDateToInclude,
-                                                      quantity: quantity,
-                                                      forceRefresh: forceRefresh)
-                onCompletion(.success(()))
+                let topEarnersStats = try await loadTopEarnerStats(siteID: siteID,
+                                                                   timeRange: timeRange,
+                                                                   earliestDateToInclude: earliestDateToInclude,
+                                                                   latestDateToInclude: latestDateToInclude,
+                                                                   quantity: quantity,
+                                                                   forceRefresh: forceRefresh)
+                if saveInStorage {
+                    upsertStoredTopEarnerStats(readOnlyStats: topEarnersStats)
+                }
+                onCompletion(.success(topEarnersStats))
             } catch {
-                if let error = error as? DotcomError, error == .noRestRoute {
-                    let result = await Result {
-                        try await loadTopEarnerStatsWithDeprecatedAPI(siteID: siteID,
-                                                                      timeRange: timeRange,
-                                                                      earliestDateToInclude: earliestDateToInclude,
-                                                                      latestDateToInclude: latestDateToInclude,
-                                                                      quantity: quantity,
-                                                                      forceRefresh: forceRefresh)
-                    }
+                guard let error = error as? DotcomError, error == .noRestRoute else {
+                    return onCompletion(.failure(error))
+                }
 
-                    onCompletion(result)
-                } else {
+                do {
+                    let topEarnersStats = try await loadTopEarnerStatsWithDeprecatedAPI(siteID: siteID,
+                                                                                        timeRange: timeRange,
+                                                                                        earliestDateToInclude: earliestDateToInclude,
+                                                                                        latestDateToInclude: latestDateToInclude,
+                                                                                        quantity: quantity,
+                                                                                        forceRefresh: forceRefresh)
+                    if saveInStorage {
+                        upsertStoredTopEarnerStats(readOnlyStats: topEarnersStats)
+                    }
+                    onCompletion(.success(topEarnersStats))
+                } catch {
                     onCompletion(.failure(error))
                 }
             }
@@ -220,8 +231,8 @@ private extension StatsStoreV4 {
                             earliestDateToInclude: Date,
                             latestDateToInclude: Date,
                             quantity: Int,
-                            forceRefresh: Bool) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) -> Void in
+                            forceRefresh: Bool) async throws -> TopEarnerStats {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<TopEarnerStats, Error>) -> Void in
             let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
             let earliestDate = dateFormatter.string(from: earliestDateToInclude)
             let latestDate = dateFormatter.string(from: latestDateToInclude)
@@ -237,16 +248,12 @@ private extension StatsStoreV4 {
 
                 switch result {
                 case .success(let leaderboards):
-                    self.convertAndStoreLeaderboardsIntoTopEarners(siteID: siteID,
-                                                                   granularity: timeRange.topEarnerStatsGranularity,
-                                                                   date: latestDateToInclude,
-                                                                   leaderboards: leaderboards,
-                                                                   quantity: quantity) { result in
-                        if case let .failure(error) = result {
-                            continuation.resume(throwing: error)
-                        } else {
-                            continuation.resume(returning: (()))
-                        }
+                    self.convertLeaderboardsIntoTopEarners(siteID: siteID,
+                                                           granularity: timeRange.topEarnerStatsGranularity,
+                                                           date: latestDateToInclude,
+                                                           leaderboards: leaderboards,
+                                                           quantity: quantity) { result in
+                        continuation.resume(with: result)
                     }
                 case .failure(let error):
                     continuation.resume(throwing: error)
@@ -261,8 +268,8 @@ private extension StatsStoreV4 {
                                              earliestDateToInclude: Date,
                                              latestDateToInclude: Date,
                                              quantity: Int,
-                                             forceRefresh: Bool) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) -> Void in
+                                             forceRefresh: Bool) async throws -> TopEarnerStats {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<TopEarnerStats, Error>) -> Void in
             let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
             let earliestDate = dateFormatter.string(from: earliestDateToInclude)
             let latestDate = dateFormatter.string(from: latestDateToInclude)
@@ -278,16 +285,12 @@ private extension StatsStoreV4 {
 
                 switch result {
                 case .success(let leaderboards):
-                    self.convertAndStoreLeaderboardsIntoTopEarners(siteID: siteID,
-                                                                   granularity: timeRange.topEarnerStatsGranularity,
-                                                                   date: latestDateToInclude,
-                                                                   leaderboards: leaderboards,
-                                                                   quantity: quantity) { result in
-                        if case let .failure(error) = result {
-                            continuation.resume(throwing: error)
-                        } else {
-                            continuation.resume(returning: ())
-                        }
+                    self.convertLeaderboardsIntoTopEarners(siteID: siteID,
+                                                           granularity: timeRange.topEarnerStatsGranularity,
+                                                           date: latestDateToInclude,
+                                                           leaderboards: leaderboards,
+                                                           quantity: quantity) { result in
+                        continuation.resume(with: result)
                     }
                 case .failure(let error):
                     continuation.resume(throwing: error)
@@ -435,15 +438,15 @@ extension StatsStoreV4 {
 //
 private extension StatsStoreV4 {
 
-    /// Converts and stores a top-product `leaderboard` into a `StatsTopEarner`
+    /// Converts a top-product `leaderboard` into a `StatsTopEarner`
     /// Since  a `leaderboard` does not contain the necessary product information, this method fetches the related product before starting the conversion.
     ///
-    func convertAndStoreLeaderboardsIntoTopEarners(siteID: Int64,
-                                                   granularity: StatGranularity,
-                                                   date: Date,
-                                                   leaderboards: [Leaderboard],
-                                                   quantity: Int,
-                                                   onCompletion: @escaping (Result<Void, Error>) -> Void) {
+    func convertLeaderboardsIntoTopEarners(siteID: Int64,
+                                           granularity: StatGranularity,
+                                           date: Date,
+                                           leaderboards: [Leaderboard],
+                                           quantity: Int,
+                                           onCompletion: @escaping (Result<TopEarnerStats, Error>) -> Void) {
 
         // Find the top products leaderboard by its ID
         guard let topProducts = leaderboards.first(where: { $0.id == Constants.topProductsID }) else {
@@ -457,13 +460,13 @@ private extension StatsStoreV4 {
 
             switch topProductsResult {
             case .success(let products):
-                self.mergeAndStoreTopProductsAndStoredProductsIntoTopEarners(siteID: siteID,
-                                                                             granularity: granularity,
-                                                                             date: date,
-                                                                             topProducts: topProducts,
-                                                                             storedProducts: products,
-                                                                             quantityLimit: quantity)
-                onCompletion(.success(()))
+                let topEarners = self.mergeTopProductsAndStoredProductsIntoTopEarners(siteID: siteID,
+                                                                                      granularity: granularity,
+                                                                                      date: date,
+                                                                                      topProducts: topProducts,
+                                                                                      storedProducts: products,
+                                                                                      quantityLimit: quantity)
+                onCompletion(.success((topEarners)))
             case .failure(let error):
                 onCompletion(.failure(error))
             }
@@ -507,24 +510,21 @@ private extension StatsStoreV4 {
         return products.map { $0.toReadOnly() }
     }
 
-    /// Merges and stores a top-product leaderboard with an array of stored products into  a `TopEarnerStats` object
+    /// Merges a top-product leaderboard with an array of stored products into  a `TopEarnerStats` object
     ///
-    func mergeAndStoreTopProductsAndStoredProductsIntoTopEarners(siteID: Int64,
-                                                                 granularity: StatGranularity,
-                                                                 date: Date,
-                                                                 topProducts: Leaderboard,
-                                                                 storedProducts: [Product],
-                                                                 quantityLimit: Int) {
+    func mergeTopProductsAndStoredProductsIntoTopEarners(siteID: Int64,
+                                                         granularity: StatGranularity,
+                                                         date: Date,
+                                                         topProducts: Leaderboard,
+                                                         storedProducts: [Product],
+                                                         quantityLimit: Int) -> TopEarnerStats {
         let statsDate = Self.buildDateString(from: date, with: granularity)
         let statsItems = LeaderboardStatsConverter.topEarnerStatsItems(from: topProducts, using: storedProducts)
-        let stats = TopEarnerStats(siteID: siteID,
-                                   date: statsDate,
-                                   granularity: granularity,
-                                   limit: String(quantityLimit),
-                                   items: statsItems
-        )
-
-        upsertStoredTopEarnerStats(readOnlyStats: stats)
+        return TopEarnerStats(siteID: siteID,
+                              date: statsDate,
+                              granularity: granularity,
+                              limit: String(quantityLimit),
+                              items: statsItems)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -264,13 +264,14 @@ final class StatsStoreV4Tests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.TopEarnerStats.self), 0)
 
         // When
-        let result: Result<Void, Error> = waitFor { promise in
+        let result: Result<Networking.TopEarnerStats, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveTopEarnerStats(siteID: self.sampleSiteID,
                                                               timeRange: .thisYear,
                                                               earliestDateToInclude: DateFormatter.dateFromString(with: "2020-01-01T00:00:00"),
                                                               latestDateToInclude: DateFormatter.dateFromString(with: "2020-07-22T12:00:00"),
                                                               quantity: 3,
-                                                              forceRefresh: false) { result in
+                                                              forceRefresh: false,
+                                                              saveInStorage: true) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -299,7 +300,8 @@ final class StatsStoreV4Tests: XCTestCase {
                                                               earliestDateToInclude: DateFormatter.dateFromString(with: "2020-01-01T00:00:00"),
                                                               latestDateToInclude: DateFormatter.dateFromString(with: "2020-07-22T12:00:00"),
                                                               quantity: quantity,
-                                                              forceRefresh: false) { _ in
+                                                              forceRefresh: false,
+                                                              saveInStorage: true) { result in
                 promise(())
             }
             store.onAction(action)
@@ -323,7 +325,8 @@ final class StatsStoreV4Tests: XCTestCase {
                                                               earliestDateToInclude: DateFormatter.dateFromString(with: "2020-01-01T00:00:00"),
                                                               latestDateToInclude: DateFormatter.dateFromString(with: "2020-07-22T12:00:00"),
                                                               quantity: 1,
-                                                              forceRefresh: true) { _ in
+                                                              forceRefresh: true,
+                                                              saveInStorage: true) { result in
                 promise(())
             }
             store.onAction(action)
@@ -368,13 +371,14 @@ final class StatsStoreV4Tests: XCTestCase {
         store.upsertStoredTopEarnerStats(readOnlyStats: sampleTopEarnerStats())
 
         // When
-        let result: Result<Void, Error> = waitFor { promise in
+        let result: Result<Networking.TopEarnerStats, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveTopEarnerStats(siteID: self.sampleSiteID,
                                                               timeRange: .thisYear,
                                                               earliestDateToInclude: DateFormatter.dateFromString(with: "2020-01-01T00:00:00"),
                                                               latestDateToInclude: DateFormatter.dateFromString(with: "2020-07-22T12:00:00"),
                                                               quantity: 3,
-                                                              forceRefresh: false) { result in
+                                                              forceRefresh: false,
+                                                              saveInStorage: true) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -398,13 +402,14 @@ final class StatsStoreV4Tests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.TopEarnerStats.self), 0)
 
         // When
-        let result: Result<Void, Error> = waitFor { promise in
+        let result: Result<Networking.TopEarnerStats, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveTopEarnerStats(siteID: self.sampleSiteID,
                                                               timeRange: .thisYear,
                                                               earliestDateToInclude: DateFormatter.dateFromString(with: "2020-01-01T00:00:00"),
                                                               latestDateToInclude: DateFormatter.dateFromString(with: "2020-07-22T12:00:00"),
                                                               quantity: 3,
-                                                              forceRefresh: false) { result in
+                                                              forceRefresh: false,
+                                                              saveInStorage: true) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -427,13 +432,14 @@ final class StatsStoreV4Tests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/stats/top-earners/", filename: "generic_error")
 
         // When
-        let result: Result<Void, Error> = waitFor { promise in
+        let result: Result<Networking.TopEarnerStats, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveTopEarnerStats(siteID: self.sampleSiteID,
                                                               timeRange: .thisMonth,
                                                               earliestDateToInclude: Date(),
                                                               latestDateToInclude: Date(),
                                                               quantity: 3,
-                                                              forceRefresh: false) { result in
+                                                              forceRefresh: false,
+                                                              saveInStorage: true) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -450,13 +456,14 @@ final class StatsStoreV4Tests: XCTestCase {
         let store = StatsStoreV4(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         // When
-        let result: Result<Void, Error> = waitFor { promise in
+        let result: Result<Networking.TopEarnerStats, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveTopEarnerStats(siteID: self.sampleSiteID,
                                                               timeRange: .thisMonth,
                                                               earliestDateToInclude: Date(),
                                                               latestDateToInclude: Date(),
                                                               quantity: 3,
-                                                              forceRefresh: false) { result in
+                                                              forceRefresh: false,
+                                                              saveInStorage: true) { result in
                 promise(result)
             }
             store.onAction(action)


### PR DESCRIPTION
Related to: #8199 

# Why

The top performers feature on the dashboard relies on the `StoreStatsV4.retrieveTopEarnerStats` method. This method, however, stores results on the storage layer and does not returns the top performers on its completion block.

As we want to reuse that method for the top performers on the product card, but without messing with the current dashboard, this PR updates the `StoreStatsV4.retrieveTopEarnerStats` so it can be used by both consumers.

# How

- Update `StoreStatsV4.retrieveTopEarnerStats` so it returns the `TopEarnersStats` on its completion block.

- Update `StoreStatsV4.retrieveTopEarnerStats` so we can decide if we want to save results to the storage layer conditionally.

# Demo

https://user-images.githubusercontent.com/562080/205143541-81243a1a-4ba1-467a-ad3b-78aa190c8b68.mov

# Testing

- Open the app and verify that the top performers section on the dashboard continues to work as expected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
