### PR TITLE
Analytics Hub: Fetch & Populate data for Products Card - Items Sold

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1987,6 +1987,30 @@ extension Networking.SystemPlugin {
     }
 }
 
+extension Networking.TopEarnerStats {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        date: CopiableProp<String> = .copy,
+        granularity: CopiableProp<StatGranularity> = .copy,
+        limit: CopiableProp<String> = .copy,
+        items: NullableCopiableProp<[TopEarnerStatsItem]> = .copy
+    ) -> Networking.TopEarnerStats {
+        let siteID = siteID ?? self.siteID
+        let date = date ?? self.date
+        let granularity = granularity ?? self.granularity
+        let limit = limit ?? self.limit
+        let items = items ?? self.items
+
+        return Networking.TopEarnerStats(
+            siteID: siteID,
+            date: date,
+            granularity: granularity,
+            limit: limit,
+            items: items
+        )
+    }
+}
+
 extension Networking.TopEarnerStatsItem {
     public func copy(
         productID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Stats/TopEarnerStats.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStats.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents Top Earner (aka top performer) stats over a specific period.
 ///
-public struct TopEarnerStats: Decodable, GeneratedFakeable {
+public struct TopEarnerStats: Decodable, GeneratedFakeable, GeneratedCopiable {
     public let siteID: Int64
     public let date: String
     public let granularity: StatGranularity

--- a/WooCommerce/Classes/Model/TopEarnerStatsItem+Woo.swift
+++ b/WooCommerce/Classes/Model/TopEarnerStatsItem+Woo.swift
@@ -12,4 +12,10 @@ extension TopEarnerStatsItem {
     var formattedTotalString: String {
         return CurrencyFormatter(currencySettings: ServiceLocator.currencySettings).formatHumanReadableAmount(String(total), with: currency) ?? String()
     }
+
+    /// Returns the  total string including the currency symbol.
+    ///
+    var totalString: String {
+        CurrencyFormatter(currencySettings: ServiceLocator.currencySettings).formatAmount(Decimal(total), with: currency) ?? ""
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -229,7 +229,7 @@ private extension AnalyticsHubViewModel {
                                             syncErrorMessage: Localization.OrderCard.noOrders)
     }
 
-    /// Helper function to create a `AnalyticsReportCardViewModel` from the fetched stats.
+    /// Helper function to create a `AnalyticsProductCardViewModel` from the fetched stats.
     ///
     static func productCard(currentPeriodStats: OrderStatsV4?,
                             previousPeriodStats: OrderStatsV4?,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -37,7 +37,7 @@ final class AnalyticsHubViewModel: ObservableObject {
 
     /// Products Card ViewModel
     ///
-    @Published var productCard = AnalyticsHubViewModel.productCard(currentPeriodStats: nil, previousPeriodStats: nil)
+    @Published var productCard = AnalyticsHubViewModel.productCard(currentPeriodStats: nil, previousPeriodStats: nil, itemsSoldStats: nil)
 
     /// Time Range Selection Type
     ///
@@ -56,6 +56,10 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// Order stats for the previous time period (for comparison)
     ///
     @Published private var previousOrderStats: OrderStatsV4? = nil
+
+    /// Stats for the current top items sold. Used in the products card.
+    ///
+    @Published private var itemsSoldStats: TopEarnerStats? = nil
 
     /// Time Range selection data defining the current and previous time period
     ///
@@ -89,9 +93,15 @@ private extension AnalyticsHubViewModel {
         async let previousPeriodRequest = retrieveStats(earliestDateToInclude: previousTimeRange.start,
                                                         latestDateToInclude: previousTimeRange.end,
                                                         forceRefresh: true)
-        let (currentPeriodStats, previousPeriodStats) = try await (currentPeriodRequest, previousPeriodRequest)
+
+        async let itemsSoldRequest = retrieveTopItemsSoldStats(earliestDateToInclude: currentTimeRange.start,
+                                                               latestDateToInclude: currentTimeRange.end,
+                                                               forceRefresh: true)
+
+        let (currentPeriodStats, previousPeriodStats, itemsSoldStats) = try await (currentPeriodRequest, previousPeriodRequest, itemsSoldRequest)
         self.currentOrderStats = currentPeriodStats
         self.previousOrderStats = previousPeriodStats
+        self.itemsSoldStats = itemsSoldStats
     }
 
     @MainActor
@@ -114,6 +124,25 @@ private extension AnalyticsHubViewModel {
             stores.dispatch(action)
         }
     }
+
+    @MainActor
+    /// Retrieves top ItemsSold stats using the `retrieveTopEarnerStats` action but without saving results into storage.
+    ///
+    func retrieveTopItemsSoldStats(earliestDateToInclude: Date, latestDateToInclude: Date, forceRefresh: Bool) async throws -> TopEarnerStats {
+        try await withCheckedThrowingContinuation { continuation in
+            let action = StatsActionV4.retrieveTopEarnerStats(siteID: siteID,
+                                                              timeRange: .thisYear, // Only needed for storing purposes, we can ignore it.
+                                                              earliestDateToInclude: earliestDateToInclude,
+                                                              latestDateToInclude: latestDateToInclude,
+                                                              quantity: Constants.maxNumberOfTopItemsSold,
+                                                              forceRefresh: forceRefresh,
+                                                              saveInStorage: false,
+                                                              onCompletion: { result in
+                continuation.resume(with: result)
+            })
+            stores.dispatch(action)
+        }
+    }
 }
 
 // MARK: Data - UI mapping
@@ -128,16 +157,19 @@ private extension AnalyticsHubViewModel {
     func switchToErrorState() {
         self.currentOrderStats = nil
         self.previousOrderStats = nil
+        self.itemsSoldStats = nil
     }
 
     func bindViewModelsWithData() {
-        Publishers.CombineLatest($currentOrderStats, $previousOrderStats)
-            .sink { [weak self] currentOrderStats, previousOrderStats in
+        Publishers.CombineLatest3($currentOrderStats, $previousOrderStats, $itemsSoldStats)
+            .sink { [weak self] currentOrderStats, previousOrderStats, itemsSoldStats in
                 guard let self else { return }
 
                 self.revenueCard = AnalyticsHubViewModel.revenueCard(currentPeriodStats: currentOrderStats, previousPeriodStats: previousOrderStats)
                 self.ordersCard = AnalyticsHubViewModel.ordersCard(currentPeriodStats: currentOrderStats, previousPeriodStats: previousOrderStats)
-                self.productCard = AnalyticsHubViewModel.productCard(currentPeriodStats: currentOrderStats, previousPeriodStats: previousOrderStats)
+                self.productCard = AnalyticsHubViewModel.productCard(currentPeriodStats: currentOrderStats,
+                                                                     previousPeriodStats: previousOrderStats,
+                                                                     itemsSoldStats: itemsSoldStats)
 
             }.store(in: &subscriptions)
 
@@ -197,23 +229,36 @@ private extension AnalyticsHubViewModel {
                                             syncErrorMessage: Localization.OrderCard.noOrders)
     }
 
-    static func productCard(currentPeriodStats: OrderStatsV4?, previousPeriodStats: OrderStatsV4?) -> AnalyticsProductCardViewModel {
+    /// Helper function to create a `AnalyticsReportCardViewModel` from the fetched stats.
+    ///
+    static func productCard(currentPeriodStats: OrderStatsV4?,
+                            previousPeriodStats: OrderStatsV4?,
+                            itemsSoldStats: TopEarnerStats?) -> AnalyticsProductCardViewModel {
         let showSyncError = currentPeriodStats == nil || previousPeriodStats == nil
         let itemsSold = StatsDataTextFormatter.createItemsSoldText(orderStats: currentPeriodStats)
         let itemsSoldDelta = StatsDataTextFormatter.createOrderItemsSoldDelta(from: previousPeriodStats, to: currentPeriodStats)
 
-        let imageURL = URL(string: "https://s0.wordpress.com/i/store/mobile/plans-premium.png")
         return AnalyticsProductCardViewModel(itemsSold: itemsSold,
                                              delta: itemsSoldDelta.string,
                                              deltaBackgroundColor: Constants.deltaColor(for: itemsSoldDelta.direction),
-                                             itemsSoldData: [ // Temporary data
-                                                .init(imageURL: imageURL, name: "Tabletop Photos", details: "Net Sales: $1,232", value: "32"),
-                                                .init(imageURL: imageURL, name: "Kentya Palm", details: "Net Sales: $800", value: "10"),
-                                                .init(imageURL: imageURL, name: "Love Ficus", details: "Net Sales: $599", value: "5"),
-                                                .init(imageURL: imageURL, name: "Bird Of Paradise", details: "Net Sales: $23.50", value: "2")
-                                             ],
+                                             itemsSoldData: itemSoldRows(from: itemsSoldStats),
                                              isRedacted: false,
                                              showSyncError: showSyncError)
+    }
+
+    /// Helper functions to create `TopPerformersRow.Data` items rom the provided `TopEarnerStats`.
+    ///
+    static func itemSoldRows(from itemSoldStats: TopEarnerStats?) -> [TopPerformersRow.Data] {
+        guard let items = itemSoldStats?.items else {
+            return []
+        }
+
+        return items.map { item in
+            TopPerformersRow.Data(imageURL: URL(string: item.imageUrl ?? ""),
+                                  name: item.productName ?? "",
+                                  details: Localization.ProductCard.netSales(value: item.totalString),
+                                  value: "\(item.quantity)")
+        }
     }
 
     static func timeRangeCard(timeRangeSelection: AnalyticsHubTimeRangeSelection) -> AnalyticsTimeRangeCardViewModel {
@@ -226,6 +271,8 @@ private extension AnalyticsHubViewModel {
 // MARK: - Constants
 private extension AnalyticsHubViewModel {
     enum Constants {
+        static let maxNumberOfTopItemsSold = 5
+
         static func deltaColor(for direction: StatsDataTextFormatter.DeltaPercentage.Direction) -> UIColor {
             switch direction {
             case .positive:
@@ -251,6 +298,13 @@ private extension AnalyticsHubViewModel {
             static let trailingTitle = NSLocalizedString("Average Order Value", comment: "Label for average value of orders in the Analytics Hub")
             static let noOrders = NSLocalizedString("Unable to load order analytics",
                                                     comment: "Text displayed when there is an error loading order stats data.")
+        }
+
+        enum ProductCard {
+            static func netSales(value: String) -> String {
+                String.localizedStringWithFormat(NSLocalizedString("Net sales: %@", comment: "Label for the total sales of a product in the Analytics Hub"),
+                                                 value)
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -60,7 +60,8 @@ struct AnalyticsProductCard: View {
 
             TopPerformersView(itemTitle: Localization.title.localizedCapitalized, valueTitle: Localization.itemsSold, rows: itemsSoldData)
                 .padding(.top, Layout.columnSpacing)
-
+                .redacted(reason: isRedacted ? .placeholder : [])
+                .shimmering(active: isRedacted)
         }
         .padding(Layout.cardPadding)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -114,7 +114,7 @@ extension ProductTableViewCell.ViewModel {
         detailText = String.localizedStringWithFormat(
             NSLocalizedString("Net sales: %@",
                               comment: "Top performers — label for the total sales of a product"),
-            statsItem?.totalString(currencyFormatter: currencyFormatter) ?? ""
+            statsItem?.totalString ?? ""
         )
         accessoryText = "\(statsItem?.quantity ?? 0)"
         backgroundColor = ProductTableViewCell.Constants.backgroundColor
@@ -133,12 +133,5 @@ private extension ProductTableViewCell {
 
     enum Constants {
         static let backgroundColor: UIColor = .systemBackground
-    }
-}
-
-private extension TopEarnerStatsItem {
-    /// Returns a total string without rounding up including the currency symbol.
-    func totalString(currencyFormatter: CurrencyFormatter) -> String? {
-        return currencyFormatter.formatAmount(Decimal(total), with: currency)
     }
 }


### PR DESCRIPTION
Part of #8199 

# Why

This PR makes sure we are fetching Items sold data from Core and displaying it in the Product Card.

# How

- Request `StatsActionV4.retrieveTopEarnerStats` on the hub view model.
- Update the `ViewModel.productCard` helper method to create items sold rows with real data.
- Update the items sold section of `AnalyticsProductCard` to properly handle the loading state.
- Add a shared `topItem.totalString` convenience method to be reused from the dashboard and the analytics hub.

> Note: There are some performance improvements that could be done in order to not wait on the items-sold request and allow each card to render independently. 
> I'll be analyzing opportunities for a next PR.

# Demo

https://user-images.githubusercontent.com/562080/205168325-1fdae556-7ecf-4954-9716-b36726bb138e.mov


# Testing Steps

- Go to the Analytics Hub
- Select different time ranges
- See that the product card - items sold section is reloaded with different data.

```
Note: The data may not match the dashboard data because we are not using the correct timezone yet. 
```
https://github.com/woocommerce/woocommerce-ios/issues/8277

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
