### PR TITLE
Store creation M2: enable feature flag for all

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -36,7 +36,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .storeCreationMVP:
             return true
         case .storeCreationM2:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .storeCreationM2WithInAppPurchasesEnabled:
             return false
         case .justInTimeMessagesOnDashboard:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Account deletion is now supported for all users in settings or in the empty stores screen. [https://github.com/woocommerce/woocommerce-ios/pull/8179]
 - [*] In-Person Payments: We removed any references to Simple Payments from Orders, and the red badge from the Menu tab and Menu Payments icon announcing the new Payments section. [https://github.com/woocommerce/woocommerce-ios/pull/8183]
+- [internal] Store creation flow was improved with native implementation. It is available from the login prologue (`Get Started` CTA), login email error screen, and store picker (`Add a store` CTA from the empty stores screen or at the bottom of the store list). [Example testing steps in https://github.com/woocommerce/woocommerce-ios/pull/8251]
 
 11.4
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Now that the [main tasks](https://github.com/orgs/woocommerce/projects/106/views/1) were merged, it's time to ship the feature for release 11.5! 🙂 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Feel free to check the store creation native flow is shown from any of the entry points:
- Prologue screen > `Get Started` and log in or create a new account
- Store picker: `Add a store` CTA on the empty stores screen, or at the bottom of the store list
- Login email error screen

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
