### PR TITLE
Remove redundant `#available` and `@available` checks for iOS <= 15.0

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -78,11 +78,7 @@ private extension AuthenticatedWebViewController {
 
     func extendContentUnderSafeAreas() {
         webView.scrollView.clipsToBounds = false
-        if #available(iOS 15.0, *) {
-            view.backgroundColor = webView.underPageBackgroundColor
-        } else {
-            view.backgroundColor = webView.backgroundColor
-        }
+        view.backgroundColor = webView.underPageBackgroundColor
     }
 
     func configureProgressBar() {

--- a/WooCommerce/Classes/Authentication/WebAuth/WebKitViewController.swift
+++ b/WooCommerce/Classes/Authentication/WebAuth/WebKitViewController.swift
@@ -272,10 +272,7 @@ class WebKitViewController: UIViewController {
         appearance.backgroundColor = UIColor(light: .white, dark: .gray)
 
         toolBar.standardAppearance = appearance
-
-        if #available(iOS 15.0, *) {
-            toolBar.scrollEdgeAppearance = appearance
-        }
+        toolBar.scrollEdgeAppearance = appearance
 
         fixBarButtonsColorForBoldText(on: toolBar)
     }

--- a/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
@@ -24,9 +24,7 @@ extension UITabBar {
         /// This is needed because the tab bar background has the wrong color under iOS 15 (using Xcode 13).
         /// More: issue-5018
         ///
-        if #available(iOS 15.0, *) {
-            appearance.scrollEdgeAppearance = appearance.standardAppearance
-        }
+        appearance.scrollEdgeAppearance = appearance.standardAppearance
     }
 
     /// Creates an appearance object for a tabbar with the default WC style.

--- a/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
@@ -15,11 +15,7 @@ extension UIViewController {
     /// Removes the text of the navigation bar back button in the next view controller of the navigation stack.
     ///
     func removeNavigationBackBarButtonText() {
-        if #available(iOS 14.0, *) {
-            navigationItem.backButtonDisplayMode = .minimal
-        } else {
-            navigationItem.backBarButtonItem = UIBarButtonItem(image: UIImage(), style: .plain, target: nil, action: nil)
-        }
+        navigationItem.backButtonDisplayMode = .minimal
     }
 
     /// Show the X close button or a custom close button with title on the left bar button item position

--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -59,16 +59,10 @@ final class StyleManager {
 private extension StyleManager {
     class func fontForTextStyle(_ style: UIFont.TextStyle, weight: UIFont.Weight, maximumPointSize: CGFloat = maxFontSize) -> UIFont {
         let traits = [UIFontDescriptor.TraitKey.weight: weight]
-        if #available(iOS 11, *) {
-            var fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
-            fontDescriptor = fontDescriptor.addingAttributes([.traits: traits])
-            let fontToGetSize = UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
-            return UIFontMetrics(forTextStyle: style).scaledFont(for: fontToGetSize, maximumPointSize: maximumPointSize)
-        }
-
-        var scaledFontDescriptor = fontDescriptor(style, maximumPointSize: maximumPointSize)
-        scaledFontDescriptor = scaledFontDescriptor.addingAttributes([.traits: traits])
-        return UIFont(descriptor: scaledFontDescriptor, size: CGFloat(0.0))
+        var fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
+        fontDescriptor = fontDescriptor.addingAttributes([.traits: traits])
+        let fontToGetSize = UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
+        return UIFontMetrics(forTextStyle: style).scaledFont(for: fontToGetSize, maximumPointSize: maximumPointSize)
     }
 
 

--- a/WooCommerce/Classes/View Modifiers/View+AutofocusTextModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+AutofocusTextModifier.swift
@@ -27,14 +27,6 @@ extension View {
     /// Autofocus in `TextField` and `TextEditor` is available only for iOS15+
     ///
     func focused() -> some View {
-        // Conditional check has to be done inside the Group function builder,
-        // otherwise the iOS 15 modifier will be loaded into memory and the app will crash.
-        Group {
-            if #available(iOS 15.0, *) {
-                self.modifier(AutofocusTextModifier())
-            } else {
-                self
-            }
-        }
+        modifier(AutofocusTextModifier())
     }
 }

--- a/WooCommerce/Classes/View Modifiers/View+AutofocusTextModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+AutofocusTextModifier.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 /// Autofocus for `TextField` and `TextEditor` in iOS 15 and later
 ///
-@available(iOS 15.0, *)
 struct AutofocusTextModifier: ViewModifier {
 
     @FocusState private var textFieldIsFocused: Bool

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -154,12 +154,8 @@ final class CouponListViewController: UIViewController, GhostableViewController 
                 snapshot.appendSections([.main])
                 snapshot.appendItems(viewModels, toSection: Section.main)
 
-                if #available(iOS 15.0, *) {
-                    // minimally reloads the list without computing diff or animation
-                    self.dataSource.applySnapshotUsingReloadData(snapshot)
-                } else {
-                    self.dataSource.apply(snapshot)
-                }
+                // minimally reloads the list without computing diff or animation
+                self.dataSource.applySnapshotUsingReloadData(snapshot)
             }
             .store(in: &subscriptions)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -128,9 +128,7 @@ private extension TopPerformerDataViewController {
         tableView.applyFooterViewForHidingExtraRowPlaceholders()
 
         // Removes extra top padding in iOS 15+.
-        if #available(iOS 15.0, *) {
-            tableView.sectionHeaderTopPadding = 0
-        }
+        tableView.sectionHeaderTopPadding = 0
     }
 
     func configureResultsController() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -135,7 +135,6 @@ private extension OrderCustomerSectionContent {
     }
 }
 
-@available(iOS 15.0, *)
 struct OrderCustomerSection_Previews: PreviewProvider {
     static var previews: some View {
         let emptyViewModel = EditableOrderViewModel.CustomerDataViewModel(billingAddress: nil, shippingAddress: nil)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundCoordinatingController.swift
@@ -134,12 +134,6 @@ private extension IssueRefundCoordinatingController {
         let viewProperties = InProgressViewProperties(title: Localization.issuingRefund, message: "")
         let inProgressViewController = InProgressViewController(viewProperties: viewProperties)
 
-        // Before iOS 13, a modal with transparent background requires certain
-        // `modalPresentationStyle` to prevent the view from turning dark after being presented.
-        if #available(iOS 13.0, *) {} else {
-            inProgressViewController.modalPresentationStyle = .overCurrentContext
-        }
-
         present(inProgressViewController, animated: true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/DatePickerTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/DatePickerTableViewCell.swift
@@ -33,11 +33,7 @@ extension DatePickerTableViewCell {
     }
 
     static func getDefaultCellHeight() -> CGFloat {
-        if #available(iOS 14, *) {
-            return CGFloat(50)
-        }
-
-        return CGFloat(216)
+        return CGFloat(50)
     }
 }
 
@@ -47,8 +43,6 @@ private extension DatePickerTableViewCell {
     }
 
     func configureDatePicker() {
-        if #available(iOS 14, *) {
-            picker.preferredDatePickerStyle = .compact
-        }
+        picker.preferredDatePickerStyle = .compact
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/InfiniteScrollIndicator.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/InfiniteScrollIndicator.swift
@@ -6,12 +6,8 @@ struct InfiniteScrollIndicator: View {
     let showContent: Bool
 
     var body: some View {
-        if #available(iOS 15.0, *) {
-            createProgressView()
-                .listRowSeparator(.hidden, edges: .bottom)
-        } else {
-            createProgressView()
-        }
+        createProgressView()
+            .listRowSeparator(.hidden, edges: .bottom)
     }
 
     @ViewBuilder func createProgressView() -> some View {

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
@@ -29,13 +29,7 @@ private struct StoreInfoView: View {
     @Environment(\.sizeCategory) var category
 
     var accessibilityCategory: ContentSizeCategory {
-        if #available(iOS 15.0, *) {
-            return .extraLarge
-        } else {
-            // iOS 14 has margins issue with extraLarge text size, so fallback to accessibility style earlier
-            // https://github.com/woocommerce/woocommerce-ios/issues/7797
-            return .large
-        }
+        return .extraLarge
     }
 
     var body: some View {


### PR DESCRIPTION
### Description

The app's deployment target is iOS 15.0, so all those checks would always result `true`.

### Testing instructions

Unless I made a mistake in removing a check, which should come up during code review, if CI is green we're good to merge. 
Still, I run the app and clicked around a bit.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
