### PR TITLE
[Just In Time Messages] Animate hiding of message in My Store screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -59,6 +59,8 @@ final class DashboardViewController: UIViewController {
     /// When we hide the header, we disable this constraint so the content view can grow to fill the screen
     private var contentTopToHeaderConstraint: NSLayoutConstraint?
 
+    /// Stores an animator for showing/hiding the header view while there is an animation in progress
+    /// so we can interrupt and reverse if needed
     private var headerAnimator: UIViewPropertyAnimator?
 
     // Used to trick the navigation bar for large title (ref: issue 3 in p91TBi-45c-p2).

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -59,16 +59,7 @@ final class DashboardViewController: UIViewController {
     /// When we hide the header, we disable this constraint so the content view can grow to fill the screen
     private var contentTopToHeaderConstraint: NSLayoutConstraint?
 
-    private lazy var hideHeaderAnimator = {
-        let animator = UIViewPropertyAnimator(duration: Constants.animationDurationSeconds, curve: .easeOut)
-        animator.pausesOnCompletion = true
-        animator.addAnimations { [weak self] in
-            self?.contentTopToHeaderConstraint?.isActive = false
-            self?.headerStackView.alpha = 0
-            self?.view.layoutIfNeeded()
-        }
-        return animator
-    }()
+    private var headerAnimator: UIViewPropertyAnimator?
 
     // Used to trick the navigation bar for large title (ref: issue 3 in p91TBi-45c-p2).
     private let hiddenScrollView = UIScrollView()
@@ -164,22 +155,42 @@ final class DashboardViewController: UIViewController {
         return true
     }
 
-    func startHeaderAnimation() {
-        hideHeaderAnimator.startAnimation()
+    func showHeader() {
+        contentTopToHeaderConstraint?.isActive = true
+        headerStackView.alpha = 1
+        view.layoutIfNeeded()
     }
 
-    func hideHeaderWithAnimation() {
-        hideHeaderAnimator.isReversed = false
-        hideHeaderAnimator.startAnimation()
+    func hideHeader() {
+        contentTopToHeaderConstraint?.isActive = false
+        headerStackView.alpha = 0
+        view.layoutIfNeeded()
     }
 
     func showHeaderWithAnimation() {
-        // If the view hasn't been hidden yet, don't bother trying to animate showing it
-        guard hideHeaderAnimator.state == .active else {
-            return
-        }
-        hideHeaderAnimator.isReversed = true
-        hideHeaderAnimator.startAnimation()
+        headerAnimator?.stopAnimation(true)
+        headerAnimator = UIViewPropertyAnimator.runningPropertyAnimator(
+            withDuration: Constants.animationDurationSeconds,
+            delay: 0,
+            animations: { [weak self] in
+                self?.showHeader()
+            },
+            completion: { [weak self] position in
+                self?.headerAnimator = nil
+            })
+    }
+
+    func hideHeaderWithAnimation() {
+        headerAnimator?.stopAnimation(true)
+        headerAnimator = UIViewPropertyAnimator.runningPropertyAnimator(
+            withDuration: Constants.animationDurationSeconds,
+            delay: 0,
+            animations: { [weak self] in
+                self?.hideHeader()
+            },
+            completion: { [weak self] position in
+                self?.headerAnimator = nil
+            })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -189,8 +189,8 @@ private extension DashboardViewController {
 
     func showHeader(animated: Bool) {
         if animated {
-            animateHeaderVisibility {
-                self.showHeaderWithoutAnimation()
+            animateHeaderVisibility { [weak self] in
+                self?.showHeaderWithoutAnimation()
             }
         } else {
             showHeaderWithoutAnimation()
@@ -199,8 +199,8 @@ private extension DashboardViewController {
 
     func hideHeader(animated: Bool) {
         if animated {
-            animateHeaderVisibility {
-                self.hideHeaderWithoutAnimation()
+            animateHeaderVisibility { [weak self] in
+                self?.hideHeaderWithoutAnimation()
             }
         } else {
             hideHeaderWithoutAnimation()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8048 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In #8228 we started hiding the message without animation as the stats view scrolled. This PR both adds animation and simplifies the logic.

After wrestling with SwiftUI and Auto Layout for almost a week, this seems to be the solution that works for now:

- We show/hide the whole header stack view as the navigation bar collapses instead of messing with individual views
- Using affine transforms caused problems with `UIHostingController`. The header was rendered in the right place, but it was reserving the original space, not letting the stats grow upwards.
- Updating the top constraint for the header view to a negative offset almost worked, but the header stack height would change as it moved, making it hard to guess how much we should offset it
- The final solution was to detach the constraint pinning the bottom of the header view and the top of the content view, so the content can grow to fit the screen. Instead of moving the header, it stays behind as the content grows. We also animate making it transparent for a smoother transition
- We use `UIViewPropertyAnimator`, so we can correctly cancel any animation in progress, in case the user starts scrolling in the other direction while the animation is in progress. That would stop the animation in the current position, and start a new one in the opposite direction.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

See pdfdoF-1uc-p2#comment-2581 for details of setting up your store to be eligible for the test JITM

With a US store that is eligible for the test JITM, on a debug/alpha build of the app

1. Go to My store, and verify that the In-person card payments message is shown, and the store name shows below the "My store" title
2. As you scroll down the view and the "My store" title becomes smaller, the store name and message should disappear with animation
3. As you scroll back up and the "My store" title becomes large, the store name and message should reappear with animation
4. Rotate to landscape, both the store name and message should not be visible regardless of scroll position on iPhone. On an iPad, it should behave similarly to iPhone portrait.

This also seems to fix the rotation issues described in #8228

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/8739/205271798-c0694a91-7e4f-42be-b43d-44e34c8364d6.mov


https://user-images.githubusercontent.com/8739/205272940-aeef0279-3dba-4c02-92f8-e77d0b9c64e5.mov




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
