### PR TITLE
[Products Onboarding] Release onboarding banner and product templates

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -25,10 +25,6 @@ public enum ABTest: String, CaseIterable {
     ///
     case nativeJetpackSetupFlow = "woocommerceios_login_jetpack_setup_flow_v2"
 
-    /// A/B test for the Products Onboarding product creation type bottom sheet after tapping the "Add Product" CTA.
-    /// Experiment ref: pbxNRc-28r-p2
-    case productsOnboardingTemplateProducts = "woocommerceios_products_onboarding_template_products"
-
     /// Returns a variation for the given experiment
     public var variation: Variation {
         ExPlat.shared?.experiment(rawValue) ?? .control
@@ -39,7 +35,7 @@ public enum ABTest: String, CaseIterable {
     /// When adding a new experiment, add it to the appropriate case depending on its context (logged-in or logged-out experience).
     public var context: ExperimentContext {
         switch self {
-        case .aaTestLoggedIn, .productsOnboardingTemplateProducts, .nativeJetpackSetupFlow:
+        case .aaTestLoggedIn, .nativeJetpackSetupFlow:
             return .loggedIn
         case .aaTestLoggedOut, .abTestLoginWithWPComOnly:
             return .loggedOut

--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -25,10 +25,6 @@ public enum ABTest: String, CaseIterable {
     ///
     case nativeJetpackSetupFlow = "woocommerceios_login_jetpack_setup_flow_v2"
 
-    /// A/B test for the Products Onboarding banner on the My Store dashboard.
-    /// Experiment ref: pbxNRc-26F-p2
-    case productsOnboardingBanner = "woocommerceios_products_onboarding_first_product_banner"
-
     /// A/B test for the Products Onboarding product creation type bottom sheet after tapping the "Add Product" CTA.
     /// Experiment ref: pbxNRc-28r-p2
     case productsOnboardingTemplateProducts = "woocommerceios_products_onboarding_template_products"
@@ -43,7 +39,7 @@ public enum ABTest: String, CaseIterable {
     /// When adding a new experiment, add it to the appropriate case depending on its context (logged-in or logged-out experience).
     public var context: ExperimentContext {
         switch self {
-        case .aaTestLoggedIn, .productsOnboardingBanner, .productsOnboardingTemplateProducts, .nativeJetpackSetupFlow:
+        case .aaTestLoggedIn, .productsOnboardingTemplateProducts, .nativeJetpackSetupFlow:
             return .loggedIn
         case .aaTestLoggedOut, .abTestLoginWithWPComOnly:
             return .loggedOut

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Account deletion is now supported for all users in settings or in the empty stores screen (in the ellipsis menu). [https://github.com/woocommerce/woocommerce-ios/pull/8179, https://github.com/woocommerce/woocommerce-ios/pull/8272]
 - [*] In-Person Payments: We removed any references to Simple Payments from Orders, and the red badge from the Menu tab and Menu Payments icon announcing the new Payments section. [https://github.com/woocommerce/woocommerce-ios/pull/8183]
 - [internal] Store creation flow was improved with native implementation. It is available from the login prologue (`Get Started` CTA), login email error screen, and store picker (`Add a store` CTA from the empty stores screen or at the bottom of the store list). [Example testing steps in https://github.com/woocommerce/woocommerce-ios/pull/8251]
+- [internal] New stores have two new Products onboarding features: A banner with an `Add a Product` CTA on the My Store screen, and the option to add new products using templates. [https://github.com/woocommerce/woocommerce-ios/pull/8294]
 
 11.4
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -3,7 +3,6 @@ import Combine
 import enum Networking.DotcomError
 import enum Storage.StatsVersion
 import protocol Experiments.FeatureFlagService
-import enum Experiments.ABTest
 
 /// Syncs data for dashboard stats UI and determines the state of the dashboard UI based on stats version.
 final class DashboardViewModel {
@@ -147,14 +146,9 @@ final class DashboardViewModel {
         stores.dispatch(action)
     }
 
-    /// Sets the view model for the products onboarding banner if the user hasn't dismissed it before,
-    /// and if the user is part of the treatment group for the products onboarding A/B test.
+    /// Sets the view model for the products onboarding banner if the user hasn't dismissed it before.
     ///
     private func setProductsOnboardingBannerIfNeeded() {
-        guard ABTest.productsOnboardingBanner.variation == .treatment(nil) else {
-            return
-        }
-
         let getVisibility = AppSettingsAction.getFeatureAnnouncementVisibility(campaign: .productsOnboarding) { [weak self] result in
             guard let self else { return }
             if case let .success(isVisible) = result, isVisible {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -3,7 +3,6 @@ import Yosemite
 import WooFoundation
 import protocol Storage.StorageManagerType
 import class Networking.ProductsRemote
-import enum Experiments.ABTest
 
 /// Controls navigation for the flow to add a product given a navigation controller.
 /// This class is not meant to be retained so that its life cycle is throughout the navigation. Example usage:
@@ -18,7 +17,6 @@ final class AddProductCoordinator: Coordinator {
     private let sourceBarButtonItem: UIBarButtonItem?
     private let sourceView: UIView?
     private let productImageUploader: ProductImageUploaderProtocol
-    private let isProductCreationTypeEnabled: Bool
     private let storage: StorageManagerType
 
     /// ResultController to to track the current product count.
@@ -37,7 +35,6 @@ final class AddProductCoordinator: Coordinator {
     init(siteID: Int64,
          sourceBarButtonItem: UIBarButtonItem,
          sourceNavigationController: UINavigationController,
-         isProductCreationTypeEnabled: Bool = ABTest.productsOnboardingTemplateProducts.variation == .treatment(nil),
          storage: StorageManagerType = ServiceLocator.storageManager,
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader) {
         self.siteID = siteID
@@ -45,14 +42,12 @@ final class AddProductCoordinator: Coordinator {
         self.sourceView = nil
         self.navigationController = sourceNavigationController
         self.productImageUploader = productImageUploader
-        self.isProductCreationTypeEnabled = isProductCreationTypeEnabled
         self.storage = storage
     }
 
     init(siteID: Int64,
          sourceView: UIView,
          sourceNavigationController: UINavigationController,
-         isProductCreationTypeEnabled: Bool = ABTest.productsOnboardingTemplateProducts.variation == .treatment(nil),
          storage: StorageManagerType = ServiceLocator.storageManager,
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader) {
         self.siteID = siteID
@@ -60,7 +55,6 @@ final class AddProductCoordinator: Coordinator {
         self.sourceView = sourceView
         self.navigationController = sourceNavigationController
         self.productImageUploader = productImageUploader
-        self.isProductCreationTypeEnabled = isProductCreationTypeEnabled
         self.storage = storage
     }
 
@@ -84,10 +78,10 @@ final class AddProductCoordinator: Coordinator {
 private extension AddProductCoordinator {
 
     /// Defines if the product creation bottom sheet should be presented.
-    /// Currently returns `true` when the feature is enabled and the store is eligible for displaying template options.
+    /// Currently returns `true` when the store is eligible for displaying template options.
     ///
     func shouldPresentProductCreationBottomSheet() -> Bool {
-        isProductCreationTypeEnabled && isTemplateOptionsEligible()
+        isTemplateOptionsEligible()
     }
 
     /// Returns `true` when the number of products is fewer than 3.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -91,7 +91,6 @@ final class DashboardViewModelTests: XCTestCase {
 
     func test_products_onboarding_announcements_take_precedence() {
         // Given
-        MockABTesting.setVariation(.treatment(nil), for: .productsOnboardingBanner)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .checkProductsOnboardingEligibility(_, completion):
@@ -127,7 +126,6 @@ final class DashboardViewModelTests: XCTestCase {
 
     func test_onboarding_announcement_not_displayed_when_previously_dismissed() {
         // Given
-        MockABTesting.setVariation(.treatment(nil), for: .productsOnboardingBanner)
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .checkProductsOnboardingEligibility(_, completion):


### PR DESCRIPTION
Closes: #8292

## Description

This releases the Products Onboarding banner and product templates to all eligible users:

* The onboarding banner will be visible on the My Store dashboard for any store with no products.
* The product templates will be available when adding a new product on a store with < 3 products.

## Changes

* Removes the A/B experiments for the banner and template products, and the checks that limited those features to users in the experiments.

## Testing

1. Launch the app.
2. Select a store with no products.
3. On my My Store screen, confirm the "Add products to sell" banner appears.
4. On the Products tab, tap the "+" to add a product and confirm you see the options to "Start with a template" or "Add manually."

## Screenshots

Banner|Template products
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-02 at 10 42 31](https://user-images.githubusercontent.com/8658164/205275065-60833aa2-e3b9-43aa-979b-1a7d323d72d2.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-02 at 10 42 35](https://user-images.githubusercontent.com/8658164/205275076-b44d4ba7-c95a-4a96-b71d-c7c0393b27f1.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
