### PR TITLE
[Analytics Hub] Use cards viewmodels directly

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -4,27 +4,7 @@ import SwiftUI
 ///
 struct AnalyticsProductCard: View {
 
-    /// Items sold quantity. Needs to be formatted.
-    ///
-    let itemsSold: String
-
-    /// Delta Tag Value. Needs to be formatted
-    let delta: String
-
-    /// Delta Tag background color.
-    let deltaBackgroundColor: UIColor
-
-    /// Items Solds data to render.
-    ///
-    let itemsSoldData: [TopPerformersRow.Data]
-
-    /// Indicates if the values should be hidden (for loading state)
-    ///
-    let isRedacted: Bool
-
-    /// Indicates if there was an error loading the data for the card
-    ///
-    let showSyncError: Bool
+    let viewModel: AnalyticsProductCardViewModel
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -39,18 +19,18 @@ struct AnalyticsProductCard: View {
                 .padding(.bottom, Layout.columnSpacing)
 
             HStack {
-                Text(itemsSold)
+                Text(viewModel.itemsSold)
                     .titleStyle()
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .redacted(reason: isRedacted ? .placeholder : [])
-                    .shimmering(active: isRedacted)
+                    .redacted(reason: viewModel.isRedacted ? .placeholder : [])
+                    .shimmering(active: viewModel.isRedacted)
 
-                DeltaTag(value: delta, backgroundColor: deltaBackgroundColor)
-                    .redacted(reason: isRedacted ? .placeholder : [])
-                    .shimmering(active: isRedacted)
+                DeltaTag(value: viewModel.delta, backgroundColor: viewModel.deltaBackgroundColor)
+                    .redacted(reason: viewModel.isRedacted ? .placeholder : [])
+                    .shimmering(active: viewModel.isRedacted)
             }
 
-            if showSyncError {
+            if viewModel.showSyncError {
                 Text(Localization.noProducts)
                     .foregroundColor(Color(.text))
                     .subheadlineStyle()
@@ -58,7 +38,7 @@ struct AnalyticsProductCard: View {
                     .padding(.top, Layout.columnSpacing)
             }
 
-            TopPerformersView(itemTitle: Localization.title.localizedCapitalized, valueTitle: Localization.itemsSold, rows: itemsSoldData)
+            TopPerformersView(itemTitle: Localization.title.localizedCapitalized, valueTitle: Localization.itemsSold, rows: viewModel.itemsSoldData)
                 .padding(.top, Layout.columnSpacing)
 
         }
@@ -87,25 +67,25 @@ private extension AnalyticsProductCard {
 struct AnalyticsProductCardPreviews: PreviewProvider {
     static var previews: some View {
         let imageURL = URL(string: "https://s0.wordpress.com/i/store/mobile/plans-premium.png")
-        AnalyticsProductCard(itemsSold: "2,234",
-                             delta: "+23%",
-                             deltaBackgroundColor: .withColorStudio(.green, shade: .shade50),
-                             itemsSoldData: [
-                                .init(imageURL: imageURL, name: "Tabletop Photos", details: "Net Sales: $1,232", value: "32"),
-                                .init(imageURL: imageURL, name: "Kentya Palm", details: "Net Sales: $800", value: "10"),
-                                .init(imageURL: imageURL, name: "Love Ficus", details: "Net Sales: $599", value: "5"),
-                                .init(imageURL: imageURL, name: "Bird Of Paradise", details: "Net Sales: $23.50", value: "2"),
-                             ],
-                             isRedacted: false,
-                             showSyncError: false)
+        AnalyticsProductCard(viewModel: .init(itemsSold: "2,234",
+                                              delta: "+23%",
+                                              deltaBackgroundColor: .withColorStudio(.green, shade: .shade50),
+                                              itemsSoldData: [
+                                                .init(imageURL: imageURL, name: "Tabletop Photos", details: "Net Sales: $1,232", value: "32"),
+                                                .init(imageURL: imageURL, name: "Kentya Palm", details: "Net Sales: $800", value: "10"),
+                                                .init(imageURL: imageURL, name: "Love Ficus", details: "Net Sales: $599", value: "5"),
+                                                .init(imageURL: imageURL, name: "Bird Of Paradise", details: "Net Sales: $23.50", value: "2"),
+                                              ],
+                                              isRedacted: false,
+                                              showSyncError: false))
             .previewLayout(.sizeThatFits)
 
-        AnalyticsProductCard(itemsSold: "-",
-                             delta: "0%",
-                             deltaBackgroundColor: .withColorStudio(.gray, shade: .shade0),
-                             itemsSoldData: [],
-                             isRedacted: false,
-                             showSyncError: true)
+        AnalyticsProductCard(viewModel: .init(itemsSold: "-",
+                                              delta: "0%",
+                                              deltaBackgroundColor: .withColorStudio(.gray, shade: .shade0),
+                                              itemsSoldData: [],
+                                              isRedacted: false,
+                                              showSyncError: true))
             .previewLayout(.sizeThatFits)
             .previewDisplayName("No data")
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
@@ -43,18 +43,4 @@ extension AnalyticsProductCardViewModel {
               isRedacted: true,
               showSyncError: false)
     }
-
-}
-
-/// Convenience extension to create an `AnalyticsReportCard` from a view model.
-///
-extension AnalyticsProductCard {
-    init(viewModel: AnalyticsProductCardViewModel) {
-        self.itemsSold = viewModel.itemsSold
-        self.delta = viewModel.delta
-        self.deltaBackgroundColor = viewModel.deltaBackgroundColor
-        self.itemsSoldData = viewModel.itemsSoldData
-        self.isRedacted = viewModel.isRedacted
-        self.showSyncError = viewModel.showSyncError
-    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -4,22 +4,7 @@ import SwiftUI
 ///
 struct AnalyticsReportCard: View {
 
-    let title: String
-    let leadingTitle: String
-    let leadingValue: String
-    let leadingDelta: String
-    let leadingDeltaColor: UIColor
-    let leadingChartData: [Double]
-    let trailingTitle: String
-    let trailingValue: String
-    let trailingDelta: String
-    let trailingDeltaColor: UIColor
-    let trailingChartData: [Double]
-
-    let isRedacted: Bool
-
-    let showSyncError: Bool
-    let syncErrorMessage: String
+    let viewModel: AnalyticsReportCardViewModel
 
     // Layout metrics that scale based on accessibility changes
     @ScaledMetric private var scaledChartWidth: CGFloat = Layout.chartWidth
@@ -28,7 +13,7 @@ struct AnalyticsReportCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.titleSpacing) {
 
-            Text(title)
+            Text(viewModel.title)
                 .foregroundColor(Color(.text))
                 .footnoteStyle()
 
@@ -38,21 +23,21 @@ struct AnalyticsReportCard: View {
                 ///
                 VStack(alignment: .leading, spacing: Layout.columnInnerSpacing) {
 
-                    Text(leadingTitle)
+                    Text(viewModel.leadingTitle)
                         .calloutStyle()
 
-                    Text(leadingValue)
+                    Text(viewModel.leadingValue)
                         .titleStyle()
-                        .redacted(reason: isRedacted ? .placeholder : [])
-                        .shimmering(active: isRedacted)
+                        .redacted(reason: viewModel.isRedacted ? .placeholder : [])
+                        .shimmering(active: viewModel.isRedacted)
 
                     AdaptiveStack(horizontalAlignment: .leading) {
-                        DeltaTag(value: leadingDelta, backgroundColor: leadingDeltaColor)
+                        DeltaTag(value: viewModel.leadingDelta, backgroundColor: viewModel.leadingDeltaColor)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                            .redacted(reason: isRedacted ? .placeholder : [])
-                            .shimmering(active: isRedacted)
+                            .redacted(reason: viewModel.isRedacted ? .placeholder : [])
+                            .shimmering(active: viewModel.isRedacted)
 
-                        AnalyticsLineChart(dataPoints: leadingChartData, lineChartColor: leadingDeltaColor)
+                        AnalyticsLineChart(dataPoints: viewModel.leadingChartData, lineChartColor: viewModel.leadingDeltaColor)
                             .frame(width: scaledChartWidth, height: scaledChartHeight)
                     }
 
@@ -62,29 +47,29 @@ struct AnalyticsReportCard: View {
                 /// Trailing Column
                 ///
                 VStack(alignment: .leading, spacing: Layout.columnInnerSpacing) {
-                    Text(trailingTitle)
+                    Text(viewModel.trailingTitle)
                         .calloutStyle()
 
-                    Text(trailingValue)
+                    Text(viewModel.trailingValue)
                         .titleStyle()
-                        .redacted(reason: isRedacted ? .placeholder : [])
-                        .shimmering(active: isRedacted)
+                        .redacted(reason: viewModel.isRedacted ? .placeholder : [])
+                        .shimmering(active: viewModel.isRedacted)
 
                     AdaptiveStack(horizontalAlignment: .leading) {
-                        DeltaTag(value: trailingDelta, backgroundColor: trailingDeltaColor)
+                        DeltaTag(value: viewModel.trailingDelta, backgroundColor: viewModel.trailingDeltaColor)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                            .redacted(reason: isRedacted ? .placeholder : [])
-                            .shimmering(active: isRedacted)
+                            .redacted(reason: viewModel.isRedacted ? .placeholder : [])
+                            .shimmering(active: viewModel.isRedacted)
 
-                        AnalyticsLineChart(dataPoints: trailingChartData, lineChartColor: trailingDeltaColor)
+                        AnalyticsLineChart(dataPoints: viewModel.trailingChartData, lineChartColor: viewModel.trailingDeltaColor)
                             .frame(width: scaledChartWidth, height: scaledChartHeight)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            if showSyncError {
-               Text(syncErrorMessage)
+            if viewModel.showSyncError {
+                Text(viewModel.syncErrorMessage)
                    .foregroundColor(Color(.text))
                    .subheadlineStyle()
                    .frame(maxWidth: .infinity, alignment: .leading)
@@ -109,36 +94,36 @@ private extension AnalyticsReportCard {
 // MARK: Previews
 struct Previews: PreviewProvider {
     static var previews: some View {
-        AnalyticsReportCard(title: "REVENUE",
-                            leadingTitle: "Total Sales",
-                            leadingValue: "$3.678",
-                            leadingDelta: "+23%",
-                            leadingDeltaColor: .withColorStudio(.green, shade: .shade40),
-                            leadingChartData: [0.0, 10.0, 2.0, 20.0, 15.0, 40.0, 0.0, 10.0, 2.0, 20.0, 15.0, 50.0],
-                            trailingTitle: "Net Sales",
-                            trailingValue: "$3.232",
-                            trailingDelta: "-3%",
-                            trailingDeltaColor: .withColorStudio(.red, shade: .shade40),
-                            trailingChartData: [50.0, 15.0, 20.0, 2.0, 10.0, 0.0, 40.0, 15.0, 20.0, 2.0, 10.0, 0.0],
-                            isRedacted: false,
-                            showSyncError: false,
-                            syncErrorMessage: "")
+        AnalyticsReportCard(viewModel: .init(title: "REVENUE",
+                                             leadingTitle: "Total Sales",
+                                             leadingValue: "$3.678",
+                                             leadingDelta: "+23%",
+                                             leadingDeltaColor: .withColorStudio(.green, shade: .shade40),
+                                             leadingChartData: [0.0, 10.0, 2.0, 20.0, 15.0, 40.0, 0.0, 10.0, 2.0, 20.0, 15.0, 50.0],
+                                             trailingTitle: "Net Sales",
+                                             trailingValue: "$3.232",
+                                             trailingDelta: "-3%",
+                                             trailingDeltaColor: .withColorStudio(.red, shade: .shade40),
+                                             trailingChartData: [50.0, 15.0, 20.0, 2.0, 10.0, 0.0, 40.0, 15.0, 20.0, 2.0, 10.0, 0.0],
+                                             isRedacted: false,
+                                             showSyncError: false,
+                                             syncErrorMessage: ""))
             .previewLayout(.sizeThatFits)
 
-        AnalyticsReportCard(title: "REVENUE",
-                            leadingTitle: "Total Sales",
-                            leadingValue: "-",
-                            leadingDelta: "0%",
-                            leadingDeltaColor: .withColorStudio(.gray, shade: .shade0),
-                            leadingChartData: [],
-                            trailingTitle: "Net Sales",
-                            trailingValue: "-",
-                            trailingDelta: "0%",
-                            trailingDeltaColor: .withColorStudio(.gray, shade: .shade0),
-                            trailingChartData: [],
-                            isRedacted: false,
-                            showSyncError: true,
-                            syncErrorMessage: "Error loading revenue analytics")
+        AnalyticsReportCard(viewModel: .init(title: "REVENUE",
+                                             leadingTitle: "Total Sales",
+                                             leadingValue: "-",
+                                             leadingDelta: "0%",
+                                             leadingDeltaColor: .withColorStudio(.gray, shade: .shade0),
+                                             leadingChartData: [],
+                                             trailingTitle: "Net Sales",
+                                             trailingValue: "-",
+                                             trailingDelta: "0%",
+                                             trailingDeltaColor: .withColorStudio(.gray, shade: .shade0),
+                                             trailingChartData: [],
+                                             isRedacted: false,
+                                             showSyncError: true,
+                                             syncErrorMessage: "Error loading revenue analytics"))
             .previewLayout(.sizeThatFits)
             .previewDisplayName("No data")
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
@@ -84,24 +84,3 @@ extension AnalyticsReportCardViewModel {
               syncErrorMessage: "")
     }
 }
-
-/// Convenience extension to create an `AnalyticsReportCard` from a view model.
-///
-extension AnalyticsReportCard {
-    init(viewModel: AnalyticsReportCardViewModel) {
-        self.title = viewModel.title
-        self.leadingTitle = viewModel.leadingTitle
-        self.leadingValue = viewModel.leadingValue
-        self.leadingDelta = viewModel.leadingDelta
-        self.leadingDeltaColor = viewModel.leadingDeltaColor
-        self.leadingChartData = viewModel.leadingChartData
-        self.trailingTitle = viewModel.trailingTitle
-        self.trailingValue = viewModel.trailingValue
-        self.trailingDelta = viewModel.trailingDelta
-        self.trailingDeltaColor = viewModel.trailingDeltaColor
-        self.trailingChartData = viewModel.trailingChartData
-        self.isRedacted = viewModel.isRedacted
-        self.showSyncError = viewModel.showSyncError
-        self.syncErrorMessage = viewModel.syncErrorMessage
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCard.swift
@@ -4,17 +4,13 @@ import SwiftUI
 ///
 struct AnalyticsTimeRangeCard: View {
 
-    let timeRangeTitle: String
-    let currentRangeDescription: String
-    let previousRangeDescription: String
+    let viewModel: AnalyticsTimeRangeCardViewModel
     @Binding var selectionType: AnalyticsHubTimeRangeSelection.SelectionType
 
     @State private var showTimeRangeSelectionView: Bool = false
 
     init(viewModel: AnalyticsTimeRangeCardViewModel, selectionType: Binding<AnalyticsHubTimeRangeSelection.SelectionType>) {
-        self.timeRangeTitle = viewModel.selectedRangeTitle
-        self.currentRangeDescription = viewModel.currentRangeSubtitle
-        self.previousRangeDescription = viewModel.previousRangeSubtitle
+        self.viewModel = viewModel
         self._selectionType = selectionType
     }
 
@@ -40,11 +36,11 @@ struct AnalyticsTimeRangeCard: View {
                         .background(Circle().foregroundColor(Color(.systemGray6)))
 
                     VStack(alignment: .leading, spacing: .zero) {
-                        Text(timeRangeTitle)
+                        Text(viewModel.selectedRangeTitle)
                             .foregroundColor(Color(.text))
                             .subheadlineStyle()
 
-                        Text(currentRangeDescription)
+                        Text(viewModel.currentRangeSubtitle)
                             .foregroundColor(Color(.text))
                             .bold()
                     }
@@ -63,7 +59,7 @@ struct AnalyticsTimeRangeCard: View {
 
             Divider()
 
-            BoldableTextView(Localization.comparisonHeaderTextWith(previousRangeDescription))
+            BoldableTextView(Localization.comparisonHeaderTextWith(viewModel.previousRangeSubtitle))
                 .padding(.leading)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .calloutStyle()


### PR DESCRIPTION
## Description

This PR updates Analytics Hub cards to use its viewmodels directly instead of assigning proxy values.

## Testing

1. Build and run the app in debug/alpha mode.
2. On the dashboard screen tap the "See more" button.
3. On analytics hub screen wait for loading to finish.
4. Confirm all cards display correct data.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
