### PR TITLE
Merge 11.4 final to trunk

### DIFF
--- a/config/Version.Public.xcconfig
+++ b/config/Version.Public.xcconfig
@@ -1,7 +1,7 @@
 VERSION_SHORT=11.4
 
 // Public long version example: VERSION_LONG=1.2.0.0
-VERSION_LONG=11.4.0.4
+VERSION_LONG=11.4.0.5
 
 // Re-map our custom version values (used by release-toolkit) to the Xcode ones
 MARKETING_VERSION=$VERSION_SHORT


### PR DESCRIPTION
Note that I haven't submitted the binary yet because we need to provide new credentials to Apple to test the app. If we need to make any changes to the code, which is unlikely, I'll open a separate PR.

I am not 100% sure why `Update app translations – Localizable.strings` & `Update metadata translations
` commits are missing. However, I believe it's because there hasn't been any new changes to GlotPress since yesterday's beta. https://github.com/woocommerce/woocommerce-ios/pull/8276

I checked `fastlane/metadata/tr/release_notes.txt` and the release notes are matching the English ones. They were [updated](https://github.com/woocommerce/woocommerce-ios/pull/8276/files#diff-cd274a543dd56e21b1d8d5fe61d77a32de8ac565b2f8823fa48ebe8e5429d7f4) in #8276 which matches my expectations.