### PR TITLE
Analytics Hub: Fix UI access from a background thread.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -67,7 +67,7 @@ final class AnalyticsHubViewModel: ObservableObject {
         do {
             try await retrieveOrderStats()
         } catch {
-            switchToErrorState()
+            await switchToErrorState()
             DDLogWarn("⚠️ Error fetching analytics data: \(error)")
         }
     }
@@ -119,12 +119,14 @@ private extension AnalyticsHubViewModel {
 // MARK: Data - UI mapping
 private extension AnalyticsHubViewModel {
 
+    @MainActor
     func switchToLoadingState() {
         self.revenueCard = revenueCard.redacted
         self.ordersCard = ordersCard.redacted
         self.productCard = productCard.redacted
     }
 
+    @MainActor
     func switchToErrorState() {
         self.currentOrderStats = nil
         self.previousOrderStats = nil


### PR DESCRIPTION
# Why

While testing the error state on the Products Card, I noticed that Xcode started to show some strange warnings about published variables being accessed from a background thread.

After a quick look, I noticed that the `switchToErrorState()` method is called from an async function.

This PR fixes that by annotating methods that update our published variables with the `@MainActor` attribute.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
