### PR TITLE
[Mobile Payments] Built-in reader configuration update alerts

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConfigurationProgress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConfigurationProgress.swift
@@ -9,8 +9,6 @@ final class CardPresentModalBuiltInConfigurationProgress: CardPresentPaymentsMod
     let textMode: PaymentsModalTextMode = .fullInfo
     let actionsMode: PaymentsModalActionsMode
 
-    var topTitle: String
-
     var topSubtitle: String? = nil
 
     var progress: Float
@@ -21,7 +19,13 @@ final class CardPresentModalBuiltInConfigurationProgress: CardPresentPaymentsMod
 
     let auxiliaryButtonTitle: String? = nil
 
-    var bottomSubtitle: String? = nil
+    var titleComplete: String
+
+    var titleInProgress: String
+
+    var messageComplete: String?
+
+    var messageInProgress: String?
 
     var accessibilityLabel: String? {
         Localization.title
@@ -31,9 +35,10 @@ final class CardPresentModalBuiltInConfigurationProgress: CardPresentPaymentsMod
         self.progress = progress
         self.cancelAction = cancel
 
-        let isComplete = progress == 1
-        topTitle = isComplete ? Localization.titleComplete : Localization.title
-        bottomSubtitle = isComplete ? Localization.messageComplete : Localization.message
+        titleComplete = Localization.titleComplete
+        titleInProgress = Localization.title
+        messageComplete = Localization.messageComplete
+        messageInProgress = Localization.message
         actionsMode = cancel != nil ? .secondaryOnlyAction : .none
     }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConfigurationProgress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConfigurationProgress.swift
@@ -2,7 +2,7 @@ import UIKit
 
 /// Modal presented when a firmware update is being installed
 ///
-final class CardPresentModalBuiltInConfigurationProgress: CardPresentPaymentsModalViewModel {
+final class CardPresentModalBuiltInConfigurationProgress: CardPresentPaymentsModalViewModel, CardPresentModalProgressDisplaying {
     /// Called when cancel button is tapped
     private let cancelAction: (() -> Void)?
 
@@ -13,15 +13,13 @@ final class CardPresentModalBuiltInConfigurationProgress: CardPresentPaymentsMod
 
     var topSubtitle: String? = nil
 
-    let image: UIImage
+    var progress: Float
 
     let primaryButtonTitle: String? = nil
 
     let secondaryButtonTitle: String? = Localization.cancel
 
     let auxiliaryButtonTitle: String? = nil
-
-    let bottomTitle: String?
 
     var bottomSubtitle: String? = nil
 
@@ -30,12 +28,11 @@ final class CardPresentModalBuiltInConfigurationProgress: CardPresentPaymentsMod
     }
 
     init(progress: Float, cancel: (() -> Void)?) {
+        self.progress = progress
         self.cancelAction = cancel
 
         let isComplete = progress == 1
         topTitle = isComplete ? Localization.titleComplete : Localization.title
-        image = .softwareUpdateProgress(progress: CGFloat(progress))
-        bottomTitle = String(format: Localization.percentComplete, 100 * progress)
         bottomSubtitle = isComplete ? Localization.messageComplete : Localization.message
         actionsMode = cancel != nil ? .secondaryOnlyAction : .none
     }
@@ -59,11 +56,6 @@ private extension CardPresentModalBuiltInConfigurationProgress {
         static let titleComplete = NSLocalizedString(
             "Configuration updated",
             comment: "Dialog title that displays when a configuration update just finished installing"
-        )
-
-        static let percentComplete = NSLocalizedString(
-            "%.0f%% complete",
-            comment: "Label that describes the completed progress of a software update being installed (e.g. 15% complete). Keep the %.0f%% exactly as is"
         )
 
         static let message = NSLocalizedString(

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConfigurationProgress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConfigurationProgress.swift
@@ -1,0 +1,84 @@
+import UIKit
+
+/// Modal presented when a firmware update is being installed
+///
+final class CardPresentModalBuiltInConfigurationProgress: CardPresentPaymentsModalViewModel {
+    /// Called when cancel button is tapped
+    private let cancelAction: (() -> Void)?
+
+    let textMode: PaymentsModalTextMode = .fullInfo
+    let actionsMode: PaymentsModalActionsMode
+
+    var topTitle: String
+
+    var topSubtitle: String? = nil
+
+    let image: UIImage
+
+    let primaryButtonTitle: String? = nil
+
+    let secondaryButtonTitle: String? = Localization.cancel
+
+    let auxiliaryButtonTitle: String? = nil
+
+    let bottomTitle: String?
+
+    var bottomSubtitle: String? = nil
+
+    var accessibilityLabel: String? {
+        Localization.title
+    }
+
+    init(progress: Float, cancel: (() -> Void)?) {
+        self.cancelAction = cancel
+
+        let isComplete = progress == 1
+        topTitle = isComplete ? Localization.titleComplete : Localization.title
+        image = .softwareUpdateProgress(progress: CGFloat(progress))
+        bottomTitle = String(format: Localization.percentComplete, 100 * progress)
+        bottomSubtitle = isComplete ? Localization.messageComplete : Localization.message
+        actionsMode = cancel != nil ? .secondaryOnlyAction : .none
+    }
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {}
+
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        cancelAction?()
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {}
+}
+
+private extension CardPresentModalBuiltInConfigurationProgress {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Configuring iPhone",
+            comment: "Dialog title that displays when iPhone configuration is being updated for use as a card reader"
+        )
+
+        static let titleComplete = NSLocalizedString(
+            "Configuration updated",
+            comment: "Dialog title that displays when a configuration update just finished installing"
+        )
+
+        static let percentComplete = NSLocalizedString(
+            "%.0f%% complete",
+            comment: "Label that describes the completed progress of a software update being installed (e.g. 15% complete). Keep the %.0f%% exactly as is"
+        )
+
+        static let message = NSLocalizedString(
+            "Your iPhone needs to be configured to collect payments.",
+            comment: "Label that displays when a configuration update is happening"
+        )
+
+        static let messageComplete = NSLocalizedString(
+            "Your phone will be ready to collect payments in a moment...",
+            comment: "Dialog message that displays when a configuration update just finished installing"
+        )
+
+        static let cancel = NSLocalizedString(
+            "Cancel",
+            comment: "Label for a cancel button"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalProgressDisplaying.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalProgressDisplaying.swift
@@ -2,6 +2,11 @@ import UIKit
 
 protocol CardPresentModalProgressDisplaying: CardPresentPaymentsModalViewModel {
     var progress: Float { get }
+    var isComplete: Bool { get }
+    var titleComplete: String { get }
+    var titleInProgress: String { get }
+    var messageComplete: String? { get }
+    var messageInProgress: String? { get }
 }
 
 extension CardPresentModalProgressDisplaying {
@@ -9,8 +14,20 @@ extension CardPresentModalProgressDisplaying {
         .softwareUpdateProgress(progress: CGFloat(progress))
     }
 
+    var isComplete: Bool {
+        progress == 1
+    }
+
+    var topTitle: String {
+        isComplete ? titleComplete : titleInProgress
+    }
+
     var bottomTitle: String? {
         String(format: CardPresentModalProgressDisplayingLocalization.percentComplete, 100 * progress)
+    }
+
+    var bottomSubtitle: String? {
+        isComplete ? messageComplete : messageInProgress
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalProgressDisplaying.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalProgressDisplaying.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+protocol CardPresentModalProgressDisplaying: CardPresentPaymentsModalViewModel {
+    var progress: Float { get }
+}
+
+extension CardPresentModalProgressDisplaying {
+    var image: UIImage {
+        .softwareUpdateProgress(progress: CGFloat(progress))
+    }
+
+    var bottomTitle: String? {
+        String(format: CardPresentModalProgressDisplayingLocalization.percentComplete, 100 * progress)
+    }
+}
+
+fileprivate enum CardPresentModalProgressDisplayingLocalization {
+    static let percentComplete = NSLocalizedString(
+        "%.0f%% complete",
+        comment: "Label that describes the completed progress of an update being installed (e.g. 15% complete). Keep the %.0f%% exactly as is"
+    )
+}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalUpdateProgress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalUpdateProgress.swift
@@ -9,8 +9,6 @@ final class CardPresentModalUpdateProgress: CardPresentPaymentsModalViewModel, C
     let textMode: PaymentsModalTextMode = .fullInfo
     let actionsMode: PaymentsModalActionsMode
 
-    var topTitle: String
-
     var topSubtitle: String? = nil
 
     var progress: Float
@@ -21,7 +19,13 @@ final class CardPresentModalUpdateProgress: CardPresentPaymentsModalViewModel, C
 
     let auxiliaryButtonTitle: String? = nil
 
-    var bottomSubtitle: String? = nil
+    var titleComplete: String
+
+    var titleInProgress: String
+
+    var messageComplete: String?
+
+    var messageInProgress: String?
 
     var accessibilityLabel: String? {
         Localization.title
@@ -30,13 +34,13 @@ final class CardPresentModalUpdateProgress: CardPresentPaymentsModalViewModel, C
     init(requiredUpdate: Bool, progress: Float, cancel: (() -> Void)?) {
         self.progress = progress
         self.cancelAction = cancel
-
-        let isComplete = progress == 1
-        topTitle = isComplete ? Localization.titleComplete : Localization.title
-        if !isComplete {
-            bottomSubtitle = requiredUpdate ? Localization.messageRequired : Localization.messageOptional
-        }
         actionsMode = cancel != nil ? .secondaryOnlyAction : .none
+        titleComplete = Localization.titleComplete
+        titleInProgress = Localization.title
+
+        if !isComplete {
+            messageInProgress = requiredUpdate ? Localization.messageRequired : Localization.messageOptional
+        }
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalUpdateProgress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalUpdateProgress.swift
@@ -2,7 +2,7 @@ import UIKit
 
 /// Modal presented when a firmware update is being installed
 ///
-final class CardPresentModalUpdateProgress: CardPresentPaymentsModalViewModel {
+final class CardPresentModalUpdateProgress: CardPresentPaymentsModalViewModel, CardPresentModalProgressDisplaying {
     /// Called when cancel button is tapped
     private let cancelAction: (() -> Void)?
 
@@ -13,15 +13,13 @@ final class CardPresentModalUpdateProgress: CardPresentPaymentsModalViewModel {
 
     var topSubtitle: String? = nil
 
-    let image: UIImage
+    var progress: Float
 
     let primaryButtonTitle: String? = nil
 
     let secondaryButtonTitle: String? = Localization.cancel
 
     let auxiliaryButtonTitle: String? = nil
-
-    let bottomTitle: String?
 
     var bottomSubtitle: String? = nil
 
@@ -30,12 +28,11 @@ final class CardPresentModalUpdateProgress: CardPresentPaymentsModalViewModel {
     }
 
     init(requiredUpdate: Bool, progress: Float, cancel: (() -> Void)?) {
+        self.progress = progress
         self.cancelAction = cancel
 
         let isComplete = progress == 1
         topTitle = isComplete ? Localization.titleComplete : Localization.title
-        image = .softwareUpdateProgress(progress: CGFloat(progress))
-        bottomTitle = String(format: Localization.percentComplete, 100 * progress)
         if !isComplete {
             bottomSubtitle = requiredUpdate ? Localization.messageRequired : Localization.messageOptional
         }
@@ -61,12 +58,6 @@ private extension CardPresentModalUpdateProgress {
         static let titleComplete = NSLocalizedString(
             "Software updated",
             comment: "Dialog title that displays when a software update just finished installing"
-        )
-
-
-        static let percentComplete = NSLocalizedString(
-            "%.0f%% complete",
-            comment: "Label that describes the completed progress of a software update being installed (e.g. 15% complete). Keep the %.0f%% exactly as is"
         )
 
         static let messageRequired = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
@@ -39,8 +39,10 @@ struct BuiltInReaderConnectionAlertsProvider: CardReaderConnectionAlertsProvidin
             return CardPresentModalUpdateFailedNonRetryable(close: close)
         }
     }
-    func updateProgress(requiredUpdate: Bool, progress: Float,
+
+    func updateProgress(requiredUpdate: Bool,
+                        progress: Float,
                         cancel: (() -> Void)?) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalUpdateProgress(requiredUpdate: requiredUpdate, progress: progress, cancel: cancel)
+        CardPresentModalBuiltInConfigurationProgress(progress: progress, cancel: cancel)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -500,6 +500,7 @@
 		03E471C4293A1F8D001A58AD /* BuiltInReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471C3293A1F8D001A58AD /* BuiltInReaderConnectionAlertsProvider.swift */; };
 		03E471C6293A2E95001A58AD /* CardPresentModalBuiltInReaderCheckingDeviceSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471C5293A2E95001A58AD /* CardPresentModalBuiltInReaderCheckingDeviceSupport.swift */; };
 		03E471C8293A3076001A58AD /* CardPresentModalBuiltInConnectingToReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471C7293A3075001A58AD /* CardPresentModalBuiltInConnectingToReader.swift */; };
+		03E471CA293E0A30001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471C9293E0A2F001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift */; };
 		03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
 		03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */; };
 		03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */; };
@@ -2511,6 +2512,7 @@
 		03E471C3293A1F8D001A58AD /* BuiltInReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuiltInReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
 		03E471C5293A2E95001A58AD /* CardPresentModalBuiltInReaderCheckingDeviceSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInReaderCheckingDeviceSupport.swift; sourceTree = "<group>"; };
 		03E471C7293A3075001A58AD /* CardPresentModalBuiltInConnectingToReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInConnectingToReader.swift; sourceTree = "<group>"; };
+		03E471C9293E0A2F001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInConfigurationProgress.swift; sourceTree = "<group>"; };
 		03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift; sourceTree = "<group>"; };
 		03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift; sourceTree = "<group>"; };
 		03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardPresentPaymentsPlugin+CashOnDelivery.swift"; sourceTree = "<group>"; };
@@ -8555,6 +8557,7 @@
 			children = (
 				D8815AE626383FD600EDAD62 /* CardPresentPaymentsModalViewModel.swift */,
 				03E471C5293A2E95001A58AD /* CardPresentModalBuiltInReaderCheckingDeviceSupport.swift */,
+				03E471C9293E0A2F001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift */,
 				03E471C7293A3075001A58AD /* CardPresentModalBuiltInConnectingToReader.swift */,
 				311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */,
 				D8815B0026385E3F00EDAD62 /* CardPresentModalTapCard.swift */,
@@ -10012,6 +10015,7 @@
 				E1325EFB28FD544E00EC9B2A /* InAppPurchasesDebugView.swift in Sources */,
 				74460D4022289B7600D7316A /* Coordinator.swift in Sources */,
 				B57C743D20F5493300EEFC87 /* AccountHeaderView.swift in Sources */,
+				03E471CA293E0A30001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift in Sources */,
 				31AD0B1126E9575F000B6391 /* CardPresentModalConnectingFailed.swift in Sources */,
 				576EA39425264C9B00AFC0B3 /* RefundConfirmationViewModel.swift in Sources */,
 				DEC51B00276AEE91009F3DF4 /* SystemStatusReportViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -501,6 +501,7 @@
 		03E471C6293A2E95001A58AD /* CardPresentModalBuiltInReaderCheckingDeviceSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471C5293A2E95001A58AD /* CardPresentModalBuiltInReaderCheckingDeviceSupport.swift */; };
 		03E471C8293A3076001A58AD /* CardPresentModalBuiltInConnectingToReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471C7293A3075001A58AD /* CardPresentModalBuiltInConnectingToReader.swift */; };
 		03E471CA293E0A30001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471C9293E0A2F001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift */; };
+		03E471CC293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471CB293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift */; };
 		03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
 		03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */; };
 		03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */; };
@@ -2513,6 +2514,7 @@
 		03E471C5293A2E95001A58AD /* CardPresentModalBuiltInReaderCheckingDeviceSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInReaderCheckingDeviceSupport.swift; sourceTree = "<group>"; };
 		03E471C7293A3075001A58AD /* CardPresentModalBuiltInConnectingToReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInConnectingToReader.swift; sourceTree = "<group>"; };
 		03E471C9293E0A2F001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInConfigurationProgress.swift; sourceTree = "<group>"; };
+		03E471CB293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalProgressDisplaying.swift; sourceTree = "<group>"; };
 		03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift; sourceTree = "<group>"; };
 		03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift; sourceTree = "<group>"; };
 		03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardPresentPaymentsPlugin+CashOnDelivery.swift"; sourceTree = "<group>"; };
@@ -8558,6 +8560,7 @@
 				D8815AE626383FD600EDAD62 /* CardPresentPaymentsModalViewModel.swift */,
 				03E471C5293A2E95001A58AD /* CardPresentModalBuiltInReaderCheckingDeviceSupport.swift */,
 				03E471C9293E0A2F001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift */,
+				03E471CB293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift */,
 				03E471C7293A3075001A58AD /* CardPresentModalBuiltInConnectingToReader.swift */,
 				311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */,
 				D8815B0026385E3F00EDAD62 /* CardPresentModalTapCard.swift */,
@@ -9995,6 +9998,7 @@
 				E138D4FC269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift in Sources */,
 				039D948F276113490044EF38 /* UIView+SuperviewConstraints.swift in Sources */,
 				D8736B5322EF4F5900A14A29 /* NotificationsBadgeController.swift in Sources */,
+				03E471CC293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift in Sources */,
 				B541B220218A007C008FE7C1 /* NSMutableParagraphStyle+Helpers.swift in Sources */,
 				45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */,
 				6832C7CA26DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8082
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In sTAP Away, we're adding support for Apple's built in card readers to take in-person payments. We continue to use Stripe's SDK to handle payments.

Stripe's connection flow is technically very similar to the bluetooth reader flow, but conceptually, there are differences and it's important that we make it clear to users that they are using the built in reader, and don't give the wrong impression that they are connecting to a bluetooth reader, to avoid confusion.

This PR builds on #8299 by adding a specific alert view model for built-in reader configuration updates. This is very similar to the existing software update view model, so the commonalities are extracted out into a new `CardPresentModalProgressDisplaying` protocol and implemented in an extension, so the implementation can be shared.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using an iPhone (XS or above on iOS 15.4 or newer, with a passcode set and signed in to iCloud)

Update the [simulator configuration](https://github.com/woocommerce/woocommerce-ios/blob/3332b19ddb3c4b4f681bd92b0a06917d4cefefbe/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift#L78) to the following:

```
Terminal.shared.simulatorConfiguration.availableReaderUpdate = .required
```

Enable the simulated card reader in Xcode by using `Product > Scheme > Edit Scheme > Run > Arguments tab > Check -simulate-stripe-card-reader`

Run the app on device or in a simulator, and select a US store with WCPay.

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. When asked for a reader type, tap `Tap to Pay on iPhone` and go through the Terms of Service Apple ID linking (if you've not done so before)
6. Observe that specific messages for the built in reader are shown during the connecting process (note that images and text are all placeholders!)

N.B. There are known issues with the payment flow after connection. In particular, #8289, #8288, #8274, and #8085. The payment flow "works", but these issues aren't addressed yet, and some are pre-existing in the legacy flow (just a lot less obvious when you use a bluetooth reader.)

Please do note any issues you find, but give me a shout if you want to check they're known first, just to save writing out detailed repro steps.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/2472348/205636859-5ee50702-8ff0-45ad-bd34-c0c027979e50.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
