### PR TITLE
[Analytics Hub] Use device timezone and calendar for stats requests

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
@@ -29,11 +29,10 @@ public class AnalyticsHubTimeRangeSelection {
         return previousTimeRangeDescription
     }
 
-    //TODO: abandon usage of the ISO 8601 Calendar and build one based on the Site calendar configuration
     init(selectionType: SelectionType,
          currentDate: Date = Date(),
-         timezone: TimeZone = TimeZone.autoupdatingCurrent,
-         calendar: Calendar = Calendar(identifier: .iso8601)) {
+         timezone: TimeZone = TimeZone.current,
+         calendar: Calendar = Locale.current.calendar) {
         var selectionData: AnalyticsHubTimeRangeData
 
         switch selectionType {


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8277

## Description
This PR updates time range logic to use timezone and calendar set on the current device.

## How
Initial idea was to use datetime preferences from remote store configuration. But that resulted in differences from dashboard and widgets setup:
https://github.com/woocommerce/woocommerce-ios/blob/0340eb2d51d896b02bfdd19c8208b2a16352d66d/WooCommerce/Classes/ViewRelated/Dashboard/Stats%20v4/StoreStatsAndTopPerformersViewController.swift#L216-L220

So I've switched to already adopted `.current` timezone & calendar usage.
If we decide to stick with store configuration, we need to update it at least in all 3 places.

## Testing instructions

1. Make sure you have paid orders on Monday and Sunday on your store.
2. Build and run the app in debug/alpha mode.
3. Switch to UK locale (first day of a week = Monday).
4. On the dashboard screen make a note of "total revenue" value tap the "See more" button.
5. On the analytics hub screen confirm that "total revenue" matches earlier value from the dashboard.
6. Compare data for day/week/month ranges between the dashboard and the analytics hub.
7. Switch to US locale (first day of a week = Sunday).
8. Compare data for day/week/month ranges between the dashboard and the analytics hub.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
