### PR TITLE
[Analytics Hub] Update colors for delta tag and chart with 0% change

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -200,12 +200,14 @@ private extension AnalyticsHubViewModel {
                                             leadingDeltaColor: Constants.deltaColor(for: totalDelta.direction),
                                             leadingDeltaTextColor: Constants.deltaTextColor(for: totalDelta.direction),
                                             leadingChartData: StatsIntervalDataParser.getChartData(for: .totalRevenue, from: currentPeriodStats),
+                                            leadingChartColor: Constants.chartColor(for: totalDelta.direction),
                                             trailingTitle: Localization.RevenueCard.trailingTitle,
                                             trailingValue: StatsDataTextFormatter.createNetRevenueText(orderStats: currentPeriodStats),
                                             trailingDelta: netDelta.string,
                                             trailingDeltaColor: Constants.deltaColor(for: netDelta.direction),
                                             trailingDeltaTextColor: Constants.deltaTextColor(for: netDelta.direction),
                                             trailingChartData: StatsIntervalDataParser.getChartData(for: .netRevenue, from: currentPeriodStats),
+                                            trailingChartColor: Constants.chartColor(for: netDelta.direction),
                                             isRedacted: false,
                                             showSyncError: showSyncError,
                                             syncErrorMessage: Localization.RevenueCard.noRevenue)
@@ -224,12 +226,14 @@ private extension AnalyticsHubViewModel {
                                             leadingDeltaColor: Constants.deltaColor(for: ordersCountDelta.direction),
                                             leadingDeltaTextColor: Constants.deltaTextColor(for: ordersCountDelta.direction),
                                             leadingChartData: StatsIntervalDataParser.getChartData(for: .orderCount, from: currentPeriodStats),
+                                            leadingChartColor: Constants.chartColor(for: ordersCountDelta.direction),
                                             trailingTitle: Localization.OrderCard.trailingTitle,
                                             trailingValue: StatsDataTextFormatter.createAverageOrderValueText(orderStats: currentPeriodStats),
                                             trailingDelta: orderValueDelta.string,
                                             trailingDeltaColor: Constants.deltaColor(for: orderValueDelta.direction),
                                             trailingDeltaTextColor: Constants.deltaTextColor(for: orderValueDelta.direction),
                                             trailingChartData: StatsIntervalDataParser.getChartData(for: .averageOrderValue, from: currentPeriodStats),
+                                            trailingChartColor: Constants.chartColor(for: orderValueDelta.direction),
                                             isRedacted: false,
                                             showSyncError: showSyncError,
                                             syncErrorMessage: Localization.OrderCard.noOrders)
@@ -298,6 +302,17 @@ private extension AnalyticsHubViewModel {
                 return .textInverted
             case .zero:
                 return .text
+            }
+        }
+
+        static func chartColor(for direction: StatsDataTextFormatter.DeltaPercentage.Direction) -> UIColor {
+            switch direction {
+            case .positive:
+                return .withColorStudio(.green, shade: .shade50)
+            case .negative:
+                return .withColorStudio(.red, shade: .shade40)
+            case .zero:
+                return .withColorStudio(.gray, shade: .shade30)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -197,17 +197,17 @@ private extension AnalyticsHubViewModel {
                                             leadingValue: StatsDataTextFormatter.createTotalRevenueText(orderStats: currentPeriodStats,
                                                                                                         selectedIntervalIndex: nil),
                                             leadingDelta: totalDelta.string,
-                                            leadingDeltaColor: Constants.deltaColor(for: totalDelta.direction),
-                                            leadingDeltaTextColor: Constants.deltaTextColor(for: totalDelta.direction),
+                                            leadingDeltaColor: totalDelta.direction.deltaBackgroundColor,
+                                            leadingDeltaTextColor: totalDelta.direction.deltaTextColor,
                                             leadingChartData: StatsIntervalDataParser.getChartData(for: .totalRevenue, from: currentPeriodStats),
-                                            leadingChartColor: Constants.chartColor(for: totalDelta.direction),
+                                            leadingChartColor: totalDelta.direction.chartColor,
                                             trailingTitle: Localization.RevenueCard.trailingTitle,
                                             trailingValue: StatsDataTextFormatter.createNetRevenueText(orderStats: currentPeriodStats),
                                             trailingDelta: netDelta.string,
-                                            trailingDeltaColor: Constants.deltaColor(for: netDelta.direction),
-                                            trailingDeltaTextColor: Constants.deltaTextColor(for: netDelta.direction),
+                                            trailingDeltaColor: netDelta.direction.deltaBackgroundColor,
+                                            trailingDeltaTextColor: netDelta.direction.deltaTextColor,
                                             trailingChartData: StatsIntervalDataParser.getChartData(for: .netRevenue, from: currentPeriodStats),
-                                            trailingChartColor: Constants.chartColor(for: netDelta.direction),
+                                            trailingChartColor: netDelta.direction.chartColor,
                                             isRedacted: false,
                                             showSyncError: showSyncError,
                                             syncErrorMessage: Localization.RevenueCard.noRevenue)
@@ -223,17 +223,17 @@ private extension AnalyticsHubViewModel {
                                             leadingValue: StatsDataTextFormatter.createOrderCountText(orderStats: currentPeriodStats,
                                                                                                       selectedIntervalIndex: nil),
                                             leadingDelta: ordersCountDelta.string,
-                                            leadingDeltaColor: Constants.deltaColor(for: ordersCountDelta.direction),
-                                            leadingDeltaTextColor: Constants.deltaTextColor(for: ordersCountDelta.direction),
+                                            leadingDeltaColor: ordersCountDelta.direction.deltaBackgroundColor,
+                                            leadingDeltaTextColor: ordersCountDelta.direction.deltaTextColor,
                                             leadingChartData: StatsIntervalDataParser.getChartData(for: .orderCount, from: currentPeriodStats),
-                                            leadingChartColor: Constants.chartColor(for: ordersCountDelta.direction),
+                                            leadingChartColor: ordersCountDelta.direction.chartColor,
                                             trailingTitle: Localization.OrderCard.trailingTitle,
                                             trailingValue: StatsDataTextFormatter.createAverageOrderValueText(orderStats: currentPeriodStats),
                                             trailingDelta: orderValueDelta.string,
-                                            trailingDeltaColor: Constants.deltaColor(for: orderValueDelta.direction),
-                                            trailingDeltaTextColor: Constants.deltaTextColor(for: orderValueDelta.direction),
+                                            trailingDeltaColor: orderValueDelta.direction.deltaBackgroundColor,
+                                            trailingDeltaTextColor: orderValueDelta.direction.deltaTextColor,
                                             trailingChartData: StatsIntervalDataParser.getChartData(for: .averageOrderValue, from: currentPeriodStats),
-                                            trailingChartColor: Constants.chartColor(for: orderValueDelta.direction),
+                                            trailingChartColor: orderValueDelta.direction.chartColor,
                                             isRedacted: false,
                                             showSyncError: showSyncError,
                                             syncErrorMessage: Localization.OrderCard.noOrders)
@@ -251,8 +251,8 @@ private extension AnalyticsHubViewModel {
 
         return AnalyticsProductCardViewModel(itemsSold: itemsSold,
                                              delta: itemsSoldDelta.string,
-                                             deltaBackgroundColor: Constants.deltaColor(for: itemsSoldDelta.direction),
-                                             deltaTextColor: Constants.deltaTextColor(for: itemsSoldDelta.direction),
+                                             deltaBackgroundColor: itemsSoldDelta.direction.deltaBackgroundColor,
+                                             deltaTextColor: itemsSoldDelta.direction.deltaTextColor,
                                              itemsSoldData: itemSoldRows(from: itemsSoldStats),
                                              isRedacted: false,
                                              showStatsError: showStatsError,
@@ -285,36 +285,6 @@ private extension AnalyticsHubViewModel {
 private extension AnalyticsHubViewModel {
     enum Constants {
         static let maxNumberOfTopItemsSold = 5
-
-        static func deltaColor(for direction: StatsDataTextFormatter.DeltaPercentage.Direction) -> UIColor {
-            switch direction {
-            case .positive:
-                return .withColorStudio(.green, shade: .shade50)
-            case .negative:
-                return .withColorStudio(.red, shade: .shade40)
-            case .zero:
-                return .withColorStudio(.gray, shade: .shade0)
-            }
-        }
-        static func deltaTextColor(for direction: StatsDataTextFormatter.DeltaPercentage.Direction) -> UIColor {
-            switch direction {
-            case .positive, .negative:
-                return .textInverted
-            case .zero:
-                return .text
-            }
-        }
-
-        static func chartColor(for direction: StatsDataTextFormatter.DeltaPercentage.Direction) -> UIColor {
-            switch direction {
-            case .positive:
-                return .withColorStudio(.green, shade: .shade50)
-            case .negative:
-                return .withColorStudio(.red, shade: .shade40)
-            case .zero:
-                return .withColorStudio(.gray, shade: .shade30)
-            }
-        }
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -198,11 +198,13 @@ private extension AnalyticsHubViewModel {
                                                                                                         selectedIntervalIndex: nil),
                                             leadingDelta: totalDelta.string,
                                             leadingDeltaColor: Constants.deltaColor(for: totalDelta.direction),
+                                            leadingDeltaTextColor: Constants.deltaTextColor(for: totalDelta.direction),
                                             leadingChartData: StatsIntervalDataParser.getChartData(for: .totalRevenue, from: currentPeriodStats),
                                             trailingTitle: Localization.RevenueCard.trailingTitle,
                                             trailingValue: StatsDataTextFormatter.createNetRevenueText(orderStats: currentPeriodStats),
                                             trailingDelta: netDelta.string,
                                             trailingDeltaColor: Constants.deltaColor(for: netDelta.direction),
+                                            trailingDeltaTextColor: Constants.deltaTextColor(for: netDelta.direction),
                                             trailingChartData: StatsIntervalDataParser.getChartData(for: .netRevenue, from: currentPeriodStats),
                                             isRedacted: false,
                                             showSyncError: showSyncError,
@@ -220,11 +222,13 @@ private extension AnalyticsHubViewModel {
                                                                                                       selectedIntervalIndex: nil),
                                             leadingDelta: ordersCountDelta.string,
                                             leadingDeltaColor: Constants.deltaColor(for: ordersCountDelta.direction),
+                                            leadingDeltaTextColor: Constants.deltaTextColor(for: ordersCountDelta.direction),
                                             leadingChartData: StatsIntervalDataParser.getChartData(for: .orderCount, from: currentPeriodStats),
                                             trailingTitle: Localization.OrderCard.trailingTitle,
                                             trailingValue: StatsDataTextFormatter.createAverageOrderValueText(orderStats: currentPeriodStats),
                                             trailingDelta: orderValueDelta.string,
                                             trailingDeltaColor: Constants.deltaColor(for: orderValueDelta.direction),
+                                            trailingDeltaTextColor: Constants.deltaTextColor(for: orderValueDelta.direction),
                                             trailingChartData: StatsIntervalDataParser.getChartData(for: .averageOrderValue, from: currentPeriodStats),
                                             isRedacted: false,
                                             showSyncError: showSyncError,
@@ -244,6 +248,7 @@ private extension AnalyticsHubViewModel {
         return AnalyticsProductCardViewModel(itemsSold: itemsSold,
                                              delta: itemsSoldDelta.string,
                                              deltaBackgroundColor: Constants.deltaColor(for: itemsSoldDelta.direction),
+                                             deltaTextColor: Constants.deltaTextColor(for: itemsSoldDelta.direction),
                                              itemsSoldData: itemSoldRows(from: itemsSoldStats),
                                              isRedacted: false,
                                              showStatsError: showStatsError,
@@ -281,8 +286,18 @@ private extension AnalyticsHubViewModel {
             switch direction {
             case .positive:
                 return .withColorStudio(.green, shade: .shade50)
-            case .negative, .zero:
+            case .negative:
                 return .withColorStudio(.red, shade: .shade40)
+            case .zero:
+                return .withColorStudio(.gray, shade: .shade0)
+            }
+        }
+        static func deltaTextColor(for direction: StatsDataTextFormatter.DeltaPercentage.Direction) -> UIColor {
+            switch direction {
+            case .positive, .negative:
+                return .textInverted
+            case .zero:
+                return .text
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -14,6 +14,9 @@ struct AnalyticsProductCard: View {
     /// Delta Tag background color.
     let deltaBackgroundColor: UIColor
 
+    /// Delta Tag text color.
+    let deltaTextColor: UIColor
+
     /// Items Solds data to render.
     ///
     let itemsSoldData: [TopPerformersRow.Data]
@@ -49,7 +52,7 @@ struct AnalyticsProductCard: View {
                     .redacted(reason: isRedacted ? .placeholder : [])
                     .shimmering(active: isRedacted)
 
-                DeltaTag(value: delta, backgroundColor: deltaBackgroundColor)
+                DeltaTag(value: delta, backgroundColor: deltaBackgroundColor, textColor: deltaTextColor)
                     .redacted(reason: isRedacted ? .placeholder : [])
                     .shimmering(active: isRedacted)
             }
@@ -105,6 +108,7 @@ struct AnalyticsProductCardPreviews: PreviewProvider {
         AnalyticsProductCard(itemsSold: "2,234",
                              delta: "+23%",
                              deltaBackgroundColor: .withColorStudio(.green, shade: .shade50),
+                             deltaTextColor: .textInverted,
                              itemsSoldData: [
                                 .init(imageURL: imageURL, name: "Tabletop Photos", details: "Net Sales: $1,232", value: "32"),
                                 .init(imageURL: imageURL, name: "Kentya Palm", details: "Net Sales: $800", value: "10"),
@@ -119,6 +123,7 @@ struct AnalyticsProductCardPreviews: PreviewProvider {
         AnalyticsProductCard(itemsSold: "-",
                              delta: "0%",
                              deltaBackgroundColor: .withColorStudio(.gray, shade: .shade0),
+                             deltaTextColor: .text,
                              itemsSoldData: [],
                              isRedacted: false,
                              showStatsError: true,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
@@ -17,6 +17,10 @@ struct AnalyticsProductCardViewModel {
     ///
     let deltaBackgroundColor: UIColor
 
+    /// Delta text color.
+    ///
+    let deltaTextColor: UIColor
+
     /// Items Solds data to render.
     ///
     let itemsSoldData: [TopPerformersRow.Data]
@@ -43,6 +47,7 @@ extension AnalyticsProductCardViewModel {
         .init(itemsSold: "1000",
               delta: "+50%",
               deltaBackgroundColor: .lightGray,
+              deltaTextColor: .text,
               itemsSoldData: [.init(imageURL: nil, name: "Product Name", details: "Net Sales", value: "$5678")],
               isRedacted: true,
               showStatsError: false,
@@ -58,6 +63,7 @@ extension AnalyticsProductCard {
         self.itemsSold = viewModel.itemsSold
         self.delta = viewModel.delta
         self.deltaBackgroundColor = viewModel.deltaBackgroundColor
+        self.deltaTextColor = viewModel.deltaTextColor
         self.itemsSoldData = viewModel.itemsSoldData
         self.isRedacted = viewModel.isRedacted
         self.showStatsError = viewModel.showStatsError

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -9,11 +9,13 @@ struct AnalyticsReportCard: View {
     let leadingValue: String
     let leadingDelta: String
     let leadingDeltaColor: UIColor
+    let leadingDeltaTextColor: UIColor
     let leadingChartData: [Double]
     let trailingTitle: String
     let trailingValue: String
     let trailingDelta: String
     let trailingDeltaColor: UIColor
+    let trailingDeltaTextColor: UIColor
     let trailingChartData: [Double]
 
     let isRedacted: Bool
@@ -47,7 +49,7 @@ struct AnalyticsReportCard: View {
                         .shimmering(active: isRedacted)
 
                     AdaptiveStack(horizontalAlignment: .leading) {
-                        DeltaTag(value: leadingDelta, backgroundColor: leadingDeltaColor)
+                        DeltaTag(value: leadingDelta, backgroundColor: leadingDeltaColor, textColor: leadingDeltaTextColor)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .redacted(reason: isRedacted ? .placeholder : [])
                             .shimmering(active: isRedacted)
@@ -71,7 +73,7 @@ struct AnalyticsReportCard: View {
                         .shimmering(active: isRedacted)
 
                     AdaptiveStack(horizontalAlignment: .leading) {
-                        DeltaTag(value: trailingDelta, backgroundColor: trailingDeltaColor)
+                        DeltaTag(value: trailingDelta, backgroundColor: trailingDeltaColor, textColor: trailingDeltaTextColor)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .redacted(reason: isRedacted ? .placeholder : [])
                             .shimmering(active: isRedacted)
@@ -114,11 +116,13 @@ struct Previews: PreviewProvider {
                             leadingValue: "$3.678",
                             leadingDelta: "+23%",
                             leadingDeltaColor: .withColorStudio(.green, shade: .shade40),
+                            leadingDeltaTextColor: .textInverted,
                             leadingChartData: [0.0, 10.0, 2.0, 20.0, 15.0, 40.0, 0.0, 10.0, 2.0, 20.0, 15.0, 50.0],
                             trailingTitle: "Net Sales",
                             trailingValue: "$3.232",
                             trailingDelta: "-3%",
                             trailingDeltaColor: .withColorStudio(.red, shade: .shade40),
+                            trailingDeltaTextColor: .textInverted,
                             trailingChartData: [50.0, 15.0, 20.0, 2.0, 10.0, 0.0, 40.0, 15.0, 20.0, 2.0, 10.0, 0.0],
                             isRedacted: false,
                             showSyncError: false,
@@ -130,11 +134,13 @@ struct Previews: PreviewProvider {
                             leadingValue: "-",
                             leadingDelta: "0%",
                             leadingDeltaColor: .withColorStudio(.gray, shade: .shade0),
+                            leadingDeltaTextColor: .text,
                             leadingChartData: [],
                             trailingTitle: "Net Sales",
                             trailingValue: "-",
                             trailingDelta: "0%",
                             trailingDeltaColor: .withColorStudio(.gray, shade: .shade0),
+                            trailingDeltaTextColor: .text,
                             trailingChartData: [],
                             isRedacted: false,
                             showSyncError: true,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -11,12 +11,14 @@ struct AnalyticsReportCard: View {
     let leadingDeltaColor: UIColor
     let leadingDeltaTextColor: UIColor
     let leadingChartData: [Double]
+    let leadingChartColor: UIColor
     let trailingTitle: String
     let trailingValue: String
     let trailingDelta: String
     let trailingDeltaColor: UIColor
     let trailingDeltaTextColor: UIColor
     let trailingChartData: [Double]
+    let trailingChartColor: UIColor
 
     let isRedacted: Bool
 
@@ -54,7 +56,7 @@ struct AnalyticsReportCard: View {
                             .redacted(reason: isRedacted ? .placeholder : [])
                             .shimmering(active: isRedacted)
 
-                        AnalyticsLineChart(dataPoints: leadingChartData, lineChartColor: leadingDeltaColor)
+                        AnalyticsLineChart(dataPoints: leadingChartData, lineChartColor: leadingChartColor)
                             .frame(width: scaledChartWidth, height: scaledChartHeight)
                     }
 
@@ -78,7 +80,7 @@ struct AnalyticsReportCard: View {
                             .redacted(reason: isRedacted ? .placeholder : [])
                             .shimmering(active: isRedacted)
 
-                        AnalyticsLineChart(dataPoints: trailingChartData, lineChartColor: trailingDeltaColor)
+                        AnalyticsLineChart(dataPoints: trailingChartData, lineChartColor: trailingChartColor)
                             .frame(width: scaledChartWidth, height: scaledChartHeight)
                     }
                 }
@@ -118,12 +120,14 @@ struct Previews: PreviewProvider {
                             leadingDeltaColor: .withColorStudio(.green, shade: .shade40),
                             leadingDeltaTextColor: .textInverted,
                             leadingChartData: [0.0, 10.0, 2.0, 20.0, 15.0, 40.0, 0.0, 10.0, 2.0, 20.0, 15.0, 50.0],
+                            leadingChartColor: .withColorStudio(.green, shade: .shade40),
                             trailingTitle: "Net Sales",
                             trailingValue: "$3.232",
                             trailingDelta: "-3%",
                             trailingDeltaColor: .withColorStudio(.red, shade: .shade40),
                             trailingDeltaTextColor: .textInverted,
                             trailingChartData: [50.0, 15.0, 20.0, 2.0, 10.0, 0.0, 40.0, 15.0, 20.0, 2.0, 10.0, 0.0],
+                            trailingChartColor: .withColorStudio(.red, shade: .shade40),
                             isRedacted: false,
                             showSyncError: false,
                             syncErrorMessage: "")
@@ -136,12 +140,14 @@ struct Previews: PreviewProvider {
                             leadingDeltaColor: .withColorStudio(.gray, shade: .shade0),
                             leadingDeltaTextColor: .text,
                             leadingChartData: [],
+                            leadingChartColor: .withColorStudio(.gray, shade: .shade30),
                             trailingTitle: "Net Sales",
                             trailingValue: "-",
                             trailingDelta: "0%",
                             trailingDeltaColor: .withColorStudio(.gray, shade: .shade0),
                             trailingDeltaTextColor: .text,
                             trailingChartData: [],
+                            trailingChartColor: .withColorStudio(.gray, shade: .shade30),
                             isRedacted: false,
                             showSyncError: true,
                             syncErrorMessage: "Error loading revenue analytics")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
@@ -33,6 +33,10 @@ struct AnalyticsReportCardViewModel {
     ///
     let leadingChartData: [Double]
 
+    /// First Column Chart Color
+    ///
+    let leadingChartColor: UIColor
+
     /// Second Column Title
     ///
     let trailingTitle: String
@@ -56,6 +60,10 @@ struct AnalyticsReportCardViewModel {
     /// Second Column Chart Data
     ///
     let trailingChartData: [Double]
+
+    /// Second Column Chart Color
+    ///
+    let trailingChartColor: UIColor
 
     /// Indicates if the values should be hidden (for loading state)
     ///
@@ -83,12 +91,14 @@ extension AnalyticsReportCardViewModel {
               leadingDeltaColor: .lightGray,
               leadingDeltaTextColor: .text,
               leadingChartData: [],
+              leadingChartColor: .lightGray,
               trailingTitle: trailingTitle,
               trailingValue: "$1000",
               trailingDelta: "+50%",
               trailingDeltaColor: .lightGray,
               trailingDeltaTextColor: .text,
               trailingChartData: [],
+              trailingChartColor: .lightGray,
               isRedacted: true,
               showSyncError: false,
               syncErrorMessage: "")
@@ -106,12 +116,14 @@ extension AnalyticsReportCard {
         self.leadingDeltaColor = viewModel.leadingDeltaColor
         self.leadingDeltaTextColor = viewModel.leadingDeltaTextColor
         self.leadingChartData = viewModel.leadingChartData
+        self.leadingChartColor = viewModel.leadingChartColor
         self.trailingTitle = viewModel.trailingTitle
         self.trailingValue = viewModel.trailingValue
         self.trailingDelta = viewModel.trailingDelta
         self.trailingDeltaColor = viewModel.trailingDeltaColor
         self.trailingDeltaTextColor = viewModel.trailingDeltaTextColor
         self.trailingChartData = viewModel.trailingChartData
+        self.trailingChartColor = viewModel.trailingChartColor
         self.isRedacted = viewModel.isRedacted
         self.showSyncError = viewModel.showSyncError
         self.syncErrorMessage = viewModel.syncErrorMessage

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
@@ -25,6 +25,10 @@ struct AnalyticsReportCardViewModel {
     ///
     let leadingDeltaColor: UIColor
 
+    /// First Column delta text color.
+    ///
+    let leadingDeltaTextColor: UIColor
+
     /// First Column Chart Data
     ///
     let leadingChartData: [Double]
@@ -44,6 +48,10 @@ struct AnalyticsReportCardViewModel {
     /// Second Column Delta Background Color
     ///
     let trailingDeltaColor: UIColor
+
+    /// Second Column delta text color.
+    ///
+    let trailingDeltaTextColor: UIColor
 
     /// Second Column Chart Data
     ///
@@ -73,11 +81,13 @@ extension AnalyticsReportCardViewModel {
               leadingValue: "$1000",
               leadingDelta: "+50%",
               leadingDeltaColor: .lightGray,
+              leadingDeltaTextColor: .text,
               leadingChartData: [],
               trailingTitle: trailingTitle,
               trailingValue: "$1000",
               trailingDelta: "+50%",
               trailingDeltaColor: .lightGray,
+              trailingDeltaTextColor: .text,
               trailingChartData: [],
               isRedacted: true,
               showSyncError: false,
@@ -94,11 +104,13 @@ extension AnalyticsReportCard {
         self.leadingValue = viewModel.leadingValue
         self.leadingDelta = viewModel.leadingDelta
         self.leadingDeltaColor = viewModel.leadingDeltaColor
+        self.leadingDeltaTextColor = viewModel.leadingDeltaTextColor
         self.leadingChartData = viewModel.leadingChartData
         self.trailingTitle = viewModel.trailingTitle
         self.trailingValue = viewModel.trailingValue
         self.trailingDelta = viewModel.trailingDelta
         self.trailingDeltaColor = viewModel.trailingDeltaColor
+        self.trailingDeltaTextColor = viewModel.trailingDeltaTextColor
         self.trailingChartData = viewModel.trailingChartData
         self.isRedacted = viewModel.isRedacted
         self.showSyncError = viewModel.showSyncError

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -220,6 +220,40 @@ extension StatsDataTextFormatter {
             case positive
             case negative
             case zero
+
+            /// Background color for a `DeltaTag`
+            var deltaBackgroundColor: UIColor {
+                switch self {
+                case .positive:
+                    return Constants.green
+                case .negative:
+                    return Constants.red
+                case .zero:
+                    return Constants.lightGray
+                }
+            }
+
+            /// Text color for a `DeltaTag`
+            var deltaTextColor: UIColor {
+                switch self {
+                case .positive, .negative:
+                    return .textInverted
+                case .zero:
+                    return .text
+                }
+            }
+
+            /// Line color for an `AnalyticsLineChart`
+            var chartColor: UIColor {
+                switch self {
+                case .positive:
+                    return Constants.green
+                case .negative:
+                    return Constants.red
+                case .zero:
+                    return Constants.darkGray
+                }
+            }
         }
     }
 }
@@ -292,6 +326,10 @@ private extension StatsDataTextFormatter {
 
     enum Constants {
         static let placeholderText = "-"
+        static let green: UIColor = .withColorStudio(.green, shade: .shade50)
+        static let red: UIColor = .withColorStudio(.red, shade: .shade40)
+        static let lightGray: UIColor = .withColorStudio(.gray, shade: .shade0)
+        static let darkGray: UIColor = .withColorStudio(.gray, shade: .shade30)
     }
 
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/DeltaTag.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/DeltaTag.swift
@@ -13,10 +13,14 @@ struct DeltaTag: View {
     ///
     let backgroundColor: UIColor
 
+    /// Text color.
+    ///
+    let textColor: UIColor
+
     var body: some View {
         Text(value)
             .padding(Layout.backgroundPadding)
-            .foregroundColor(Color(.textInverted))
+            .foregroundColor(Color(textColor))
             .captionStyle()
             .background(Color(backgroundColor))
             .cornerRadius(Layout.cornerRadius)
@@ -31,13 +35,15 @@ private extension DeltaTag {
     }
 }
 
-// MARK: Peviews
+// MARK: Previews
 struct DeltaTagPreviews: PreviewProvider {
     static var previews: some View {
         VStack {
-            DeltaTag(value: "+3.23%", backgroundColor: .systemGreen)
+            DeltaTag(value: "+3.23%", backgroundColor: .systemGreen, textColor: .textInverted)
 
-            DeltaTag(value: "-3.23%", backgroundColor: .systemRed)
+            DeltaTag(value: "-3.23%", backgroundColor: .systemRed, textColor: .textInverted)
+
+            DeltaTag(value: "0%", backgroundColor: .lightGray, textColor: .text)
         }
         .previewLayout(.sizeThatFits)
     }


### PR DESCRIPTION
Closes: #8243

## Description

This updates the Analytics Hub to use a gray color (instead of red) for stats with a 0% change from the previous period:

* 0% delta tag has a light gray background with black text.
* 0% chart has a dark gray line.

## Changes

* The colors are now computed properties on `DeltaPercentage.Direction`, since they are inherently linked to the delta direction.
* Each of the three colors (delta background color, delta text color, and chart color) are set on the relevant cards in the Analytics Hub.

**Note:** The original idea behind `DeltaPercentage` was to just be a representation of the formatted string/direction in `StatsDataTextFormatter`. Given that so many report card values depend on the `DeltaPercentage`, I think it makes sense to extract that struct from the formatter as its own entity. Then, we can pass the `DeltaPercentage` itself to the analytics card view models (rather than passing each of the values separately). I'll open a separate PR so we can review that idea.

## Testing

1. Ensure you have at least one stat in the Analytic Hub with 0% change from the previous period.
2. Build and run the app.
3. Tap "See more" on the My Store dashboard.
4. Confirm the 0% stat uses gray colors for the delta tag and chart.

## Screenshots

Before|After
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-05 at 22 05 36](https://user-images.githubusercontent.com/8658164/205752350-bc322814-8b41-4a28-8223-cea37626094e.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-05 at 22 04 08](https://user-images.githubusercontent.com/8658164/205752315-ae4390ab-958d-43cb-9d6c-32e4f16432e6.png)
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-05 at 22 07 24](https://user-images.githubusercontent.com/8658164/205753176-581c6136-b227-40b0-8a94-eb311a044bfc.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-05 at 22 10 21](https://user-images.githubusercontent.com/8658164/205753247-d25ade31-52a0-4112-baf2-7209401b9560.png)

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
