### PR TITLE
[UI Tests] - Add view detailed stats chart UI test

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -354,6 +354,7 @@ private extension StoreStatsV4PeriodViewController {
                                                                       comment: "VoiceOver accessibility label for the store revenue chart's Y-axis.")
         chartAccessibilityView.isAccessibilityElement = true
         chartAccessibilityView.accessibilityTraits = .image
+        chartAccessibilityView.accessibilityIdentifier = "chart-image"
         chartAccessibilityView.accessibilityLabel = NSLocalizedString("Store revenue chart",
                                                                       comment: "VoiceOver accessibility label for the store revenue chart.")
         chartAccessibilityView.accessibilityLabel = String.localizedStringWithFormat(
@@ -690,6 +691,7 @@ private extension StoreStatsV4PeriodViewController {
     func updateStatsDataToDefaultStyles() {
         revenueData.font = Constants.revenueFont
         revenueData.textColor = Constants.statsTextColor
+        revenueData.accessibilityIdentifier = "revenue-value"
     }
 }
 

--- a/WooCommerce/UITestsFoundation/Screens/MyStore/MyStoreScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/MyStore/MyStoreScreen.swift
@@ -3,11 +3,6 @@ import XCTest
 
 public final class MyStoreScreen: ScreenObject {
 
-    // TODO: Remove force `try` once `ScreenObject` migration is completed
-    public let tabBar = try! TabNavComponent()
-    // TODO: Remove force `try` once `ScreenObject` migration is completed
-    public let periodStatsTable = try! PeriodStatsTable()
-
     static var isVisible: Bool {
         (try? MyStoreScreen().isLoaded) ?? false
     }
@@ -34,14 +29,17 @@ public final class MyStoreScreen: ScreenObject {
         return self
     }
 
+    @discardableResult
     public func goToThisWeekTab() -> MyStoreScreen {
         return tapTimeframeTab(timeframeId: "period-data-thisWeek-tab")
     }
 
+    @discardableResult
     public func goToThisMonthTab() -> MyStoreScreen {
         return tapTimeframeTab(timeframeId: "period-data-thisMonth-tab")
     }
 
+    @discardableResult
     public func goToThisYearTab() -> MyStoreScreen {
         return tapTimeframeTab(timeframeId: "period-data-thisYear-tab")
     }
@@ -68,5 +66,17 @@ public final class MyStoreScreen: ScreenObject {
     @discardableResult
     public func verifyThisYearStatsLoaded() -> MyStoreScreen {
         return verifyStatsForTimeframeLoaded(timeframe: "This Year")
+    }
+
+    public func getRevenueValue() -> String {
+        return app.staticTexts["revenue-value"].label
+    }
+
+    public func tapChart() {
+        app.images["chart-image"].tap()
+    }
+
+    public func verifyRevenueUpdated(originalRevenue: String, updatedRevenue: String) {
+        XCTAssertNotEqual(originalRevenue, updatedRevenue, "Revenue is not updated!")
     }
 }

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -43,11 +43,12 @@ class WooCommerceScreenshots: XCTestCase {
 
         // My Store
         .dismissTopBannerIfNeeded()
-        .then { ($0 as! MyStoreScreen).periodStatsTable.switchToMonthsTab() }
+        .then { ($0 as! MyStoreScreen).goToThisMonthTab() }
         .thenTakeScreenshot(named: "order-dashboard")
 
         // Orders
-        .tabBar.goToOrdersScreen()
+        try TabNavComponent()
+        .goToOrdersScreen()
         .startOrderCreation()
         .thenTakeScreenshot(named: "order-creation")
         .cancelOrderCreation()

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc-analytics/reports_revenue_stats_hour.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc-analytics/reports_revenue_stats_hour.json
@@ -19,10 +19,10 @@
     "jsonBody": {
       "data": {
         "totals": {
-          "orders_count": 2,
+          "orders_count": 80,
           "num_items_sold": 0,
           "gross_sales": 0,
-          "total_sales": 23,
+          "total_sales": 815,
           "coupons": 0,
           "coupons_count": 0,
           "refunds": 0,

--- a/WooCommerce/WooCommerceUITests/README.md
+++ b/WooCommerce/WooCommerceUITests/README.md
@@ -15,7 +15,7 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
     - [ ] Log in with Google
 2. My Store
     - [x] Stats Today, This Week, This Month, This Year load
-    - [ ] Tap chart on stats
+    - [x] View detailed chart stats
 3. Orders
    - [x] Orders list loads
    - [ ] Single Order Screen:

--- a/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
@@ -12,7 +12,6 @@ final class StatsTests: XCTestCase {
         app.launch()
 
         try LoginFlow.logInWithWPcom()
-
     }
 
     func test_load_stats_screen() throws {

--- a/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
@@ -12,6 +12,7 @@ final class StatsTests: XCTestCase {
         app.launch()
 
         try LoginFlow.logInWithWPcom()
+
     }
 
     func test_load_stats_screen() throws {
@@ -26,40 +27,32 @@ final class StatsTests: XCTestCase {
     }
 
     func test_view_detailed_chart_stats() throws {
-        var hourlyRevenue = ""
-        var dailyRevenue = ""
-        var weeklyRevenue = ""
-        var monthlyRevenue = ""
-        var yearlyRevenue = ""
+        let myStoreScreen = try MyStoreScreen()
 
-        try TabNavComponent()
+        var dailyRevenue = try TabNavComponent()
             .goToMyStoreScreen()
+            .getRevenueValue()
 
-        dailyRevenue = try MyStoreScreen().getRevenueValue()
-        try MyStoreScreen().tapChart()
-        hourlyRevenue = try MyStoreScreen().getRevenueValue()
+        myStoreScreen.tapChart()
+        let hourlyRevenue = myStoreScreen.getRevenueValue()
+        myStoreScreen.verifyRevenueUpdated(originalRevenue: dailyRevenue, updatedRevenue: hourlyRevenue)
 
-        try MyStoreScreen().verifyRevenueUpdated(originalRevenue: dailyRevenue, updatedRevenue: hourlyRevenue)
-        try MyStoreScreen().goToThisWeekTab()
+        myStoreScreen.goToThisWeekTab()
+        var weeklyRevenue = try MyStoreScreen().getRevenueValue()
+        myStoreScreen.tapChart()
+        dailyRevenue = myStoreScreen.getRevenueValue()
+        myStoreScreen.verifyRevenueUpdated(originalRevenue: weeklyRevenue, updatedRevenue: dailyRevenue)
 
-        weeklyRevenue = try MyStoreScreen().getRevenueValue()
-        try MyStoreScreen().tapChart()
-        dailyRevenue = try MyStoreScreen().getRevenueValue()
+        myStoreScreen.goToThisMonthTab()
+        var monthlyRevenue = try MyStoreScreen().getRevenueValue()
+        myStoreScreen.tapChart()
+        weeklyRevenue = myStoreScreen.getRevenueValue()
+        myStoreScreen.verifyRevenueUpdated(originalRevenue: monthlyRevenue, updatedRevenue: weeklyRevenue)
 
-        try MyStoreScreen().verifyRevenueUpdated(originalRevenue: weeklyRevenue, updatedRevenue: dailyRevenue)
-        try MyStoreScreen().goToThisMonthTab()
-
-        monthlyRevenue = try MyStoreScreen().getRevenueValue()
-        try MyStoreScreen().tapChart()
-        weeklyRevenue = try MyStoreScreen().getRevenueValue()
-
-        try MyStoreScreen().verifyRevenueUpdated(originalRevenue: monthlyRevenue, updatedRevenue: weeklyRevenue)
-        try MyStoreScreen().goToThisYearTab()
-
-        yearlyRevenue = try MyStoreScreen().getRevenueValue()
-        try MyStoreScreen().tapChart()
-        monthlyRevenue = try MyStoreScreen().getRevenueValue()
-
-        try MyStoreScreen().verifyRevenueUpdated(originalRevenue: yearlyRevenue, updatedRevenue: monthlyRevenue)
+        myStoreScreen.goToThisYearTab()
+        let yearlyRevenue = try MyStoreScreen().getRevenueValue()
+        myStoreScreen.tapChart()
+        monthlyRevenue = myStoreScreen.getRevenueValue()
+        myStoreScreen.verifyRevenueUpdated(originalRevenue: yearlyRevenue, updatedRevenue: monthlyRevenue)
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
@@ -24,4 +24,42 @@ final class StatsTests: XCTestCase {
             .goToThisYearTab()
             .verifyThisYearStatsLoaded()
     }
+
+    func test_view_detailed_chart_stats() throws {
+        var hourlyRevenue = ""
+        var dailyRevenue = ""
+        var weeklyRevenue = ""
+        var monthlyRevenue = ""
+        var yearlyRevenue = ""
+
+        try TabNavComponent()
+            .goToMyStoreScreen()
+
+        dailyRevenue = try MyStoreScreen().getRevenueValue()
+        try MyStoreScreen().tapChart()
+        hourlyRevenue = try MyStoreScreen().getRevenueValue()
+
+        try MyStoreScreen().verifyRevenueUpdated(originalRevenue: dailyRevenue, updatedRevenue: hourlyRevenue)
+        try MyStoreScreen().goToThisWeekTab()
+
+        weeklyRevenue = try MyStoreScreen().getRevenueValue()
+        try MyStoreScreen().tapChart()
+        dailyRevenue = try MyStoreScreen().getRevenueValue()
+
+        try MyStoreScreen().verifyRevenueUpdated(originalRevenue: weeklyRevenue, updatedRevenue: dailyRevenue)
+        try MyStoreScreen().goToThisMonthTab()
+
+        monthlyRevenue = try MyStoreScreen().getRevenueValue()
+        try MyStoreScreen().tapChart()
+        weeklyRevenue = try MyStoreScreen().getRevenueValue()
+
+        try MyStoreScreen().verifyRevenueUpdated(originalRevenue: monthlyRevenue, updatedRevenue: weeklyRevenue)
+        try MyStoreScreen().goToThisYearTab()
+
+        yearlyRevenue = try MyStoreScreen().getRevenueValue()
+        try MyStoreScreen().tapChart()
+        monthlyRevenue = try MyStoreScreen().getRevenueValue()
+
+        try MyStoreScreen().verifyRevenueUpdated(originalRevenue: yearlyRevenue, updatedRevenue: monthlyRevenue)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
This PR adds a new UI test that ensures that tapping on the chart on each time range would show the drilled-down version of the chart. The test validates that the revenue value after tapping on the chart should not match the cumulative revenue value. I'm not sure if the naming is clear enough to describe what the test is doing, suggestions welcomed!

### Testing instructions
Test should pass in CI and locally, feel free to also test failing scenarios (by changing the assert or failing the tap)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
