### PR TITLE
Introduce `Quarter to Date` and `Last Quarter` ranges

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
@@ -51,6 +51,8 @@ public class AnalyticsHubTimeRangeSelection {
             selectionData = AnalyticsHubWeekToDateRangeData(referenceDate: currentDate, timezone: timezone, calendar: calendar)
         case .monthToDate:
             selectionData = AnalyticsHubMonthToDateRangeData(referenceDate: currentDate, timezone: timezone, calendar: calendar)
+        case .quarterToDate:
+            selectionData = AnalyticsHubQuarterToDateRangeData(referenceDate: currentDate, timezone: timezone, calendar: calendar)
         case .yearToDate:
             selectionData = AnalyticsHubYearToDateRangeData(referenceDate: currentDate, timezone: timezone, calendar: calendar)
         }
@@ -100,6 +102,7 @@ extension AnalyticsHubTimeRangeSelection {
         case lastYear
         case weekToDate
         case monthToDate
+        case quarterToDate
         case yearToDate
 
         var description: String {
@@ -118,6 +121,8 @@ extension AnalyticsHubTimeRangeSelection {
                 return Localization.weekToDate
             case .monthToDate:
                 return Localization.monthToDate
+            case .quarterToDate:
+                return Localization.quarterToDate
             case .yearToDate:
                 return Localization.yearToDate
             }
@@ -152,6 +157,7 @@ extension AnalyticsHubTimeRangeSelection {
         static let lastYear = NSLocalizedString("Last Year", comment: "Title of the Analytics Hub Last Year selection range")
         static let weekToDate = NSLocalizedString("Week to Date", comment: "Title of the Analytics Hub Week to Date selection range")
         static let monthToDate = NSLocalizedString("Month to Date", comment: "Title of the Analytics Hub Month to Date selection range")
+        static let quarterToDate = NSLocalizedString("Quarter to Date", comment: "Title of the Analytics Hub Quarter to Date selection range")
         static let yearToDate = NSLocalizedString("Year to Date", comment: "Title of the Analytics Hub Year to Date selection range")
         static let selectionTitle = NSLocalizedString("Date Range", comment: "Title of the range selection list")
         static let noCurrentPeriodAvailable = NSLocalizedString("No current period available",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
@@ -73,6 +73,7 @@ extension AnalyticsHubTimeRangeSelection {
         case yesterday
         case lastWeek
         case lastMonth
+        case lastQuarter
         case lastYear
         case weekToDate
         case monthToDate
@@ -89,6 +90,8 @@ extension AnalyticsHubTimeRangeSelection {
                 return Localization.lastWeek
             case .lastMonth:
                 return Localization.lastMonth
+            case .lastQuarter:
+                return Localization.lastQuarter
             case .lastYear:
                 return Localization.lastYear
             case .weekToDate:
@@ -129,6 +132,8 @@ private extension AnalyticsHubTimeRangeSelection.SelectionType {
             return AnalyticsHubLastWeekRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
         case .lastMonth:
             return AnalyticsHubLastMonthRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
+        case .lastQuarter:
+            return AnalyticsHubLastMonthRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
         case .lastYear:
             return AnalyticsHubLastYearRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
         case .weekToDate:
@@ -155,6 +160,7 @@ extension AnalyticsHubTimeRangeSelection {
         static let yesterday = NSLocalizedString("Yesterday", comment: "Title of the Analytics Hub Yesterday selection range")
         static let lastWeek = NSLocalizedString("Last Week", comment: "Title of the Analytics Hub Last Week selection range")
         static let lastMonth = NSLocalizedString("Last Month", comment: "Title of the Analytics Hub Last Month selection range")
+        static let lastQuarter = NSLocalizedString("Last Quarter", comment: "Title of the Analytics Hub Last Quarter selection range")
         static let lastYear = NSLocalizedString("Last Year", comment: "Title of the Analytics Hub Last Year selection range")
         static let weekToDate = NSLocalizedString("Week to Date", comment: "Title of the Analytics Hub Week to Date selection range")
         static let monthToDate = NSLocalizedString("Month to Date", comment: "Title of the Analytics Hub Month to Date selection range")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
@@ -133,7 +133,7 @@ private extension AnalyticsHubTimeRangeSelection.SelectionType {
         case .lastMonth:
             return AnalyticsHubLastMonthRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
         case .lastQuarter:
-            return AnalyticsHubLastMonthRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
+            return AnalyticsHubLastQuarterRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
         case .lastYear:
             return AnalyticsHubLastYearRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
         case .weekToDate:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
@@ -34,42 +34,16 @@ public class AnalyticsHubTimeRangeSelection {
          currentDate: Date = Date(),
          timezone: TimeZone = TimeZone.autoupdatingCurrent,
          calendar: Calendar = Calendar(identifier: .iso8601)) {
-        var selectionData: AnalyticsHubTimeRangeData
-
-        switch selectionType {
-        case .today:
-            selectionData = AnalyticsHubTodayRangeData(referenceDate: currentDate, timezone: timezone, calendar: calendar)
-        case .yesterday:
-            selectionData = AnalyticsHubYesterdayRangeData(referenceDate: currentDate, timezone: timezone, calendar: calendar)
-        case .lastWeek:
-            selectionData = AnalyticsHubLastWeekRangeData(referenceDate: currentDate, timezone: timezone, calendar: calendar)
-        case .lastMonth:
-            selectionData = AnalyticsHubLastMonthRangeData(referenceDate: currentDate, timezone: timezone, calendar: calendar)
-        case .lastYear:
-            selectionData = AnalyticsHubLastYearRangeData(referenceDate: currentDate, timezone: timezone, calendar: calendar)
-        case .weekToDate:
-            selectionData = AnalyticsHubWeekToDateRangeData(referenceDate: currentDate, timezone: timezone, calendar: calendar)
-        case .monthToDate:
-            selectionData = AnalyticsHubMonthToDateRangeData(referenceDate: currentDate, timezone: timezone, calendar: calendar)
-        case .quarterToDate:
-            selectionData = AnalyticsHubQuarterToDateRangeData(referenceDate: currentDate, timezone: timezone, calendar: calendar)
-        case .yearToDate:
-            selectionData = AnalyticsHubYearToDateRangeData(referenceDate: currentDate, timezone: timezone, calendar: calendar)
-        }
-
+        let selectionData = selectionType.toRangeData(referenceDate: currentDate, timezone: timezone, calendar: calendar)
         let currentTimeRange = selectionData.currentTimeRange
         let previousTimeRange = selectionData.previousTimeRange
+        let useShortFormat = selectionType == .today || selectionType == .yesterday
+
         self.currentTimeRange = currentTimeRange
         self.previousTimeRange = previousTimeRange
-
-        let simplifiedDescription = selectionType == .today || selectionType == .yesterday
-        self.formattedCurrentRangeText = currentTimeRange?.formatToString(simplified: simplifiedDescription,
-                                                                          timezone: timezone,
-                                                                          calendar: calendar)
-        self.formattedPreviousRangeText = previousTimeRange?.formatToString(simplified: simplifiedDescription,
-                                                                            timezone: timezone,
-                                                                            calendar: calendar)
         self.rangeSelectionDescription = selectionType.description
+        self.formattedCurrentRangeText = currentTimeRange?.formatToString(simplified: useShortFormat, timezone: timezone, calendar: calendar)
+        self.formattedPreviousRangeText = previousTimeRange?.formatToString(simplified: useShortFormat, timezone: timezone, calendar: calendar)
     }
 
     /// Unwrap the generated selected `AnalyticsHubTimeRange` based on the `selectedTimeRange`
@@ -142,6 +116,33 @@ extension AnalyticsHubTimeRangeSelection {
         }
     }
 }
+
+// MARK: - SelectionType helper functions
+private extension AnalyticsHubTimeRangeSelection.SelectionType {
+    func toRangeData(referenceDate: Date, timezone: TimeZone, calendar: Calendar) -> AnalyticsHubTimeRangeData {
+        switch self {
+        case .today:
+            return AnalyticsHubTodayRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
+        case .yesterday:
+            return AnalyticsHubYesterdayRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
+        case .lastWeek:
+            return AnalyticsHubLastWeekRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
+        case .lastMonth:
+            return AnalyticsHubLastMonthRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
+        case .lastYear:
+            return AnalyticsHubLastYearRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
+        case .weekToDate:
+            return AnalyticsHubWeekToDateRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
+        case .monthToDate:
+            return AnalyticsHubMonthToDateRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
+        case .quarterToDate:
+            return AnalyticsHubQuarterToDateRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
+        case .yearToDate:
+            return AnalyticsHubYearToDateRangeData(referenceDate: referenceDate, timezone: timezone, calendar: calendar)
+        }
+    }
+}
+
 // MARK: - Constants
 extension AnalyticsHubTimeRangeSelection {
     enum TimeRangeGeneratorError: Error {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/Range Data Generation/AnalyticsHubLastQuarterRangeData.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/Range Data Generation/AnalyticsHubLastQuarterRangeData.swift
@@ -7,10 +7,12 @@ struct AnalyticsHubLastQuarterRangeData: AnalyticsHubTimeRangeData {
     let previousDateEnd: Date?
 
     init(referenceDate: Date, timezone: TimeZone, calendar: Calendar) {
-        self.currentDateEnd = referenceDate.endOfQuarter(timezone: timezone, calendar: calendar)
-        self.currentDateStart = referenceDate.startOfQuarter(timezone: timezone, calendar: calendar)
-        let previousDateEnd = calendar.date(byAdding: .month, value: -3, to: referenceDate)
-        self.previousDateEnd = previousDateEnd?.endOfQuarter(timezone: timezone, calendar: calendar)
-        self.previousDateStart = previousDateEnd?.startOfQuarter(timezone: timezone, calendar: calendar)
+        let oneQuarterAgo = calendar.date(byAdding: .month, value: -3, to: referenceDate)
+        self.currentDateEnd = oneQuarterAgo?.endOfQuarter(timezone: timezone, calendar: calendar)
+        self.currentDateStart = oneQuarterAgo?.startOfQuarter(timezone: timezone, calendar: calendar)
+
+        let twoQuartersAgo = calendar.date(byAdding: .month, value: -6, to: referenceDate)
+        self.previousDateEnd = twoQuartersAgo?.endOfQuarter(timezone: timezone, calendar: calendar)
+        self.previousDateStart = twoQuartersAgo?.startOfQuarter(timezone: timezone, calendar: calendar)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/Range Data Generation/AnalyticsHubLastQuarterRangeData.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/Range Data Generation/AnalyticsHubLastQuarterRangeData.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct AnalyticsHubLastQuarterRangeData: AnalyticsHubTimeRangeData {
+    let currentDateStart: Date?
+    let currentDateEnd: Date?
+    let previousDateStart: Date?
+    let previousDateEnd: Date?
+
+    init(referenceDate: Date, timezone: TimeZone, calendar: Calendar) {
+        self.currentDateEnd = referenceDate.endOfQuarter(timezone: timezone, calendar: calendar)
+        self.currentDateStart = referenceDate.startOfQuarter(timezone: timezone, calendar: calendar)
+        let previousDateEnd = calendar.date(byAdding: .month, value: -3, to: referenceDate)
+        self.previousDateEnd = previousDateEnd?.endOfQuarter(timezone: timezone, calendar: calendar)
+        self.previousDateStart = previousDateEnd?.startOfQuarter(timezone: timezone, calendar: calendar)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/Range Data Generation/AnalyticsHubLastQuarterRangeData.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/Range Data Generation/AnalyticsHubLastQuarterRangeData.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+/// Responsible for defining two ranges of data, one starting from the first day of the last quarter
+/// until the final day of that same quarter, and the previous one as two quarters ago, also starting
+/// from the first day until the final day of that quarter. E. g.
+///
+/// Today: 29 Jul 2022
+/// Current range: Apr 1 until Jun 30, 2022
+/// Previous range: Jan 1 until Mar 31, 2022
+///
 struct AnalyticsHubLastQuarterRangeData: AnalyticsHubTimeRangeData {
     let currentDateStart: Date?
     let currentDateEnd: Date?

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/Range Data Generation/AnalyticsHubQuarterToDateRangeData.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/Range Data Generation/AnalyticsHubQuarterToDateRangeData.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+/// Responsible for defining two ranges of data, one starting from the first day of the current quarter
+/// until the current date and the previous one, starting from the first day of the previous quarter
+/// until the same relative day of the previous quarter. E. g.
+///
+/// Today: 15 Feb 2022
+/// Current range: Jan 1 until Feb 15, 2022
+/// Previous range: Oct 1 until Nov 15, 2021
+///
 struct AnalyticsHubQuarterToDateRangeData: AnalyticsHubTimeRangeData {
     let currentDateStart: Date?
     let currentDateEnd: Date?

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/Range Data Generation/AnalyticsHubQuarterToDateRangeData.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/Range Data Generation/AnalyticsHubQuarterToDateRangeData.swift
@@ -9,7 +9,7 @@ struct AnalyticsHubQuarterToDateRangeData: AnalyticsHubTimeRangeData {
     init(referenceDate: Date, timezone: TimeZone, calendar: Calendar) {
         self.currentDateEnd = referenceDate
         self.currentDateStart = referenceDate.startOfQuarter(timezone: timezone, calendar: calendar)
-        let previousDateEnd = calendar.date(byAdding: .quarter, value: -1, to: referenceDate)
+        let previousDateEnd = calendar.date(byAdding: .month, value: -3, to: referenceDate)
         self.previousDateEnd = previousDateEnd
         self.previousDateStart = previousDateEnd?.startOfQuarter(timezone: timezone, calendar: calendar)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/Range Data Generation/AnalyticsHubQuarterToDateRangeData.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/Range Data Generation/AnalyticsHubQuarterToDateRangeData.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct AnalyticsHubQuarterToDateRangeData: AnalyticsHubTimeRangeData {
+    let currentDateStart: Date?
+    let currentDateEnd: Date?
+    let previousDateStart: Date?
+    let previousDateEnd: Date?
+
+    init(referenceDate: Date, timezone: TimeZone, calendar: Calendar) {
+        self.currentDateEnd = referenceDate
+        self.currentDateStart = referenceDate.startOfQuarter(timezone: timezone, calendar: calendar)
+        let previousDateEnd = calendar.date(byAdding: .quarter, value: -1, to: referenceDate)
+        self.previousDateEnd = previousDateEnd
+        self.previousDateStart = previousDateEnd?.startOfQuarter(timezone: timezone, calendar: calendar)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1356,6 +1356,7 @@
 		B622BC74289CF19400B10CEC /* WaitingTimeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B622BC73289CF19400B10CEC /* WaitingTimeTrackerTests.swift */; };
 		B626C71B287659D60083820C /* OrderCustomFieldsDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = B626C71A287659D60083820C /* OrderCustomFieldsDetails.swift */; };
 		B63AAF4B254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63AAF4A254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift */; };
+		B63D9009293E56E300BB5C9D /* AnalyticsHubQuarterToDateRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63D9008293E56E300BB5C9D /* AnalyticsHubQuarterToDateRangeData.swift */; };
 		B6440FB6292E72DA0012D506 /* AnalyticsHubTimeRangeSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6440FB5292E72DA0012D506 /* AnalyticsHubTimeRangeSelection.swift */; };
 		B6440FB9292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6440FB8292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift */; };
 		B651474527D644FF00C9C4E6 /* CustomerNoteSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B651474427D644FF00C9C4E6 /* CustomerNoteSection.swift */; };
@@ -3375,6 +3376,7 @@
 		B622BC73289CF19400B10CEC /* WaitingTimeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingTimeTrackerTests.swift; sourceTree = "<group>"; };
 		B626C71A287659D60083820C /* OrderCustomFieldsDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomFieldsDetails.swift; sourceTree = "<group>"; };
 		B63AAF4A254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+SurveyViewControllerTests.swift"; sourceTree = "<group>"; };
+		B63D9008293E56E300BB5C9D /* AnalyticsHubQuarterToDateRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubQuarterToDateRangeData.swift; sourceTree = "<group>"; };
 		B6440FB5292E72DA0012D506 /* AnalyticsHubTimeRangeSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRangeSelection.swift; sourceTree = "<group>"; };
 		B6440FB8292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRangeSelectionTests.swift; sourceTree = "<group>"; };
 		B651474427D644FF00C9C4E6 /* CustomerNoteSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerNoteSection.swift; sourceTree = "<group>"; };
@@ -7488,6 +7490,7 @@
 				B6C78B8B293BADAA008934A1 /* AnalyticsHubLastWeekRangeData.swift */,
 				B6C78B8D293BAE68008934A1 /* AnalyticsHubLastMonthRangeData.swift */,
 				B6C78B8F293BAF37008934A1 /* AnalyticsHubLastYearRangeData.swift */,
+				B63D9008293E56E300BB5C9D /* AnalyticsHubQuarterToDateRangeData.swift */,
 			);
 			path = "Range Data Generation";
 			sourceTree = "<group>";
@@ -10720,6 +10723,7 @@
 				57EBC92024EEE61800C1D45B /* WooAnalyticsEvent.swift in Sources */,
 				57CDABB9252E9BEB00BED88C /* ButtonTableFooterView.swift in Sources */,
 				021940E8291FDBF90090354E /* StoreCreationSummaryView.swift in Sources */,
+				B63D9009293E56E300BB5C9D /* AnalyticsHubQuarterToDateRangeData.swift in Sources */,
 				02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */,
 				45D875D22611EA2100226C3F /* ListHeaderView.swift in Sources */,
 				DE2FE58D292617C30018040A /* SiteCredentialLoginViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1362,6 +1362,7 @@
 		B651474527D644FF00C9C4E6 /* CustomerNoteSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B651474427D644FF00C9C4E6 /* CustomerNoteSection.swift */; };
 		B66D6CEC29396A3E0075D4AF /* AnalyticsHubTimeRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66D6CEB29396A3E0075D4AF /* AnalyticsHubTimeRangeData.swift */; };
 		B687940C27699D420092BCA0 /* RefundFeesCalculationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B687940B27699D410092BCA0 /* RefundFeesCalculationUseCase.swift */; };
+		B6930BDA293FD1EE00C6FFDB /* AnalyticsHubLastQuarterRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6930BD9293FD1EE00C6FFDB /* AnalyticsHubLastQuarterRangeData.swift */; };
 		B6A10E9C292E5DEE00790797 /* AnalyticsTimeRangeCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A10E9B292E5DEE00790797 /* AnalyticsTimeRangeCardViewModel.swift */; };
 		B6C78B8C293BADAA008934A1 /* AnalyticsHubLastWeekRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C78B8B293BADAA008934A1 /* AnalyticsHubLastWeekRangeData.swift */; };
 		B6C78B8E293BAE68008934A1 /* AnalyticsHubLastMonthRangeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C78B8D293BAE68008934A1 /* AnalyticsHubLastMonthRangeData.swift */; };
@@ -3382,6 +3383,7 @@
 		B651474427D644FF00C9C4E6 /* CustomerNoteSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerNoteSection.swift; sourceTree = "<group>"; };
 		B66D6CEB29396A3E0075D4AF /* AnalyticsHubTimeRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRangeData.swift; sourceTree = "<group>"; };
 		B687940B27699D410092BCA0 /* RefundFeesCalculationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundFeesCalculationUseCase.swift; sourceTree = "<group>"; };
+		B6930BD9293FD1EE00C6FFDB /* AnalyticsHubLastQuarterRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubLastQuarterRangeData.swift; sourceTree = "<group>"; };
 		B6A10E9B292E5DEE00790797 /* AnalyticsTimeRangeCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTimeRangeCardViewModel.swift; sourceTree = "<group>"; };
 		B6C78B8B293BADAA008934A1 /* AnalyticsHubLastWeekRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubLastWeekRangeData.swift; sourceTree = "<group>"; };
 		B6C78B8D293BAE68008934A1 /* AnalyticsHubLastMonthRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubLastMonthRangeData.swift; sourceTree = "<group>"; };
@@ -7482,15 +7484,16 @@
 		B66D6CEF293A4D990075D4AF /* Range Data Generation */ = {
 			isa = PBXGroup;
 			children = (
-				B6F3796929378B3900718561 /* AnalyticsHubMonthToDateRangeData.swift */,
-				B6F3796B293794A000718561 /* AnalyticsHubYearToDateRangeData.swift */,
-				B6F3796D293796BC00718561 /* AnalyticsHubWeekToDateRangeData.swift */,
 				B6F3796F293798ED00718561 /* AnalyticsHubTodayRangeData.swift */,
 				B6E7DB63293A7C390049B001 /* AnalyticsHubYesterdayRangeData.swift */,
 				B6C78B8B293BADAA008934A1 /* AnalyticsHubLastWeekRangeData.swift */,
 				B6C78B8D293BAE68008934A1 /* AnalyticsHubLastMonthRangeData.swift */,
+				B6930BD9293FD1EE00C6FFDB /* AnalyticsHubLastQuarterRangeData.swift */,
 				B6C78B8F293BAF37008934A1 /* AnalyticsHubLastYearRangeData.swift */,
+				B6F3796D293796BC00718561 /* AnalyticsHubWeekToDateRangeData.swift */,
+				B6F3796929378B3900718561 /* AnalyticsHubMonthToDateRangeData.swift */,
 				B63D9008293E56E300BB5C9D /* AnalyticsHubQuarterToDateRangeData.swift */,
+				B6F3796B293794A000718561 /* AnalyticsHubYearToDateRangeData.swift */,
 			);
 			path = "Range Data Generation";
 			sourceTree = "<group>";
@@ -10964,6 +10967,7 @@
 				02C88775245036D400E4470F /* FilterProductListViewModel.swift in Sources */,
 				4590B6A8261F0F8300A6FCE0 /* SegmentedView.swift in Sources */,
 				DE77889826FCA39B008DFF44 /* TitleAndSubtitleRow.swift in Sources */,
+				B6930BDA293FD1EE00C6FFDB /* AnalyticsHubLastQuarterRangeData.swift in Sources */,
 				02DE5CA9279F857D007CBEF3 /* Double+Rounding.swift in Sources */,
 				02A65301246AA63600755A01 /* ProductDetailsFactory.swift in Sources */,
 				D449C51D26DE6B5000D75B02 /* LargeTitle.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -7498,10 +7498,10 @@
 		B6F379662937831D00718561 /* Time Range */ = {
 			isa = PBXGroup;
 			children = (
-				B66D6CEB29396A3E0075D4AF /* AnalyticsHubTimeRangeData.swift */,
 				B66D6CEF293A4D990075D4AF /* Range Data Generation */,
-				B6440FB5292E72DA0012D506 /* AnalyticsHubTimeRangeSelection.swift */,
 				B6F379672937836700718561 /* AnalyticsHubTimeRange.swift */,
+				B66D6CEB29396A3E0075D4AF /* AnalyticsHubTimeRangeData.swift */,
+				B6440FB5292E72DA0012D506 /* AnalyticsHubTimeRangeSelection.swift */,
 			);
 			path = "Time Range";
 			sourceTree = "<group>";

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeSelectionTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeSelectionTests.swift
@@ -206,6 +206,23 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         XCTAssertEqual(previousRangeDescription, "Jan 1 - Dec 31, 2020")
     }
 
+    func test_when_time_range_inits_with_quarterToDate_then_generate_expected_descriptions() throws {
+        // Given
+        let today = currentDate(from: "2022-05-15")
+        let timeRange = AnalyticsHubTimeRangeSelection(selectionType: .quarterToDate,
+                                                       currentDate: today,
+                                                       timezone: testTimezone,
+                                                       calendar: testCalendar)
+
+        // When
+        let currentRangeDescription = timeRange.currentRangeDescription
+        let previousRangeDescription = timeRange.previousRangeDescription
+
+        // Then
+        XCTAssertEqual(currentRangeDescription, "Jan 1 - Feb 15, 2022")
+        XCTAssertEqual(previousRangeDescription, "Apr 1 - May 15, 2021")
+    }
+
     func test_when_time_range_inits_with_monthToDate_then_generate_expected_descriptions() throws {
         // Given
         let today = currentDate(from: "2022-07-31")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeSelectionTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeSelectionTests.swift
@@ -86,10 +86,10 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
 
         // Then
         XCTAssertEqual(currentTimeRange.start, startDate(from: "2022-01-01"))
-        XCTAssertEqual(currentTimeRange.end, currentDate(from: "2022-03-31"))
+        XCTAssertEqual(currentTimeRange.end, endDate(from: "2022-03-31"))
 
         XCTAssertEqual(previousTimeRange.start, startDate(from: "2021-10-01"))
-        XCTAssertEqual(previousTimeRange.end, currentDate(from: "2021-12-31"))
+        XCTAssertEqual(previousTimeRange.end, endDate(from: "2021-12-31"))
     }
 
     func test_when_time_range_inits_with_monthToDate_then_generate_expected_ranges() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeSelectionTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeSelectionTests.swift
@@ -52,6 +52,26 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         XCTAssertEqual(previousTimeRange.end, endDate(from: "2018-12-31"))
     }
 
+    func test_when_time_range_inits_with_quarterToDate_then_generate_expected_ranges() throws {
+        // Given
+        let today = currentDate(from: "2022-02-15")
+        let timeRange = AnalyticsHubTimeRangeSelection(selectionType: .quarterToDate,
+                                                       currentDate: today,
+                                                       timezone: testTimezone,
+                                                       calendar: testCalendar)
+
+        // When
+        let currentTimeRange = try timeRange.unwrapCurrentTimeRange()
+        let previousTimeRange = try timeRange.unwrapPreviousTimeRange()
+
+        // Then
+        XCTAssertEqual(currentTimeRange.start, startDate(from: "2022-01-01"))
+        XCTAssertEqual(currentTimeRange.end, currentDate(from: "2022-02-15"))
+
+        XCTAssertEqual(previousTimeRange.start, startDate(from: "2021-10-01"))
+        XCTAssertEqual(previousTimeRange.end, currentDate(from: "2021-11-15"))
+    }
+
     func test_when_time_range_inits_with_monthToDate_then_generate_expected_ranges() throws {
         // Given
         let today = currentDate(from: "2010-07-31")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeSelectionTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeSelectionTests.swift
@@ -72,6 +72,26 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         XCTAssertEqual(previousTimeRange.end, currentDate(from: "2021-11-15"))
     }
 
+    func test_when_time_range_inits_with_lastQuarter_then_generate_expected_ranges() throws {
+        // Given
+        let today = currentDate(from: "2022-05-15")
+        let timeRange = AnalyticsHubTimeRangeSelection(selectionType: .lastQuarter,
+                                                       currentDate: today,
+                                                       timezone: testTimezone,
+                                                       calendar: testCalendar)
+
+        // When
+        let currentTimeRange = try timeRange.unwrapCurrentTimeRange()
+        let previousTimeRange = try timeRange.unwrapPreviousTimeRange()
+
+        // Then
+        XCTAssertEqual(currentTimeRange.start, startDate(from: "2022-01-01"))
+        XCTAssertEqual(currentTimeRange.end, currentDate(from: "2022-03-31"))
+
+        XCTAssertEqual(previousTimeRange.start, startDate(from: "2021-10-01"))
+        XCTAssertEqual(previousTimeRange.end, currentDate(from: "2021-12-31"))
+    }
+
     func test_when_time_range_inits_with_monthToDate_then_generate_expected_ranges() throws {
         // Given
         let today = currentDate(from: "2010-07-31")
@@ -241,6 +261,23 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         // Then
         XCTAssertEqual(currentRangeDescription, "Jan 1 - Feb 15, 2022")
         XCTAssertEqual(previousRangeDescription, "Oct 1 - Nov 15, 2021")
+    }
+
+    func test_when_time_range_inits_with_lastQuarter_then_generate_expected_descriptions() throws {
+        // Given
+        let today = currentDate(from: "2022-05-15")
+        let timeRange = AnalyticsHubTimeRangeSelection(selectionType: .lastQuarter,
+                                                       currentDate: today,
+                                                       timezone: testTimezone,
+                                                       calendar: testCalendar)
+
+        // When
+        let currentRangeDescription = timeRange.currentRangeDescription
+        let previousRangeDescription = timeRange.previousRangeDescription
+
+        // Then
+        XCTAssertEqual(currentRangeDescription, "Jan 1 - Mar 31, 2022")
+        XCTAssertEqual(previousRangeDescription, "Oct 1 - Dec 31, 2021")
     }
 
     func test_when_time_range_inits_with_monthToDate_then_generate_expected_descriptions() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeSelectionTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeSelectionTests.swift
@@ -208,7 +208,7 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
 
     func test_when_time_range_inits_with_quarterToDate_then_generate_expected_descriptions() throws {
         // Given
-        let today = currentDate(from: "2022-05-15")
+        let today = currentDate(from: "2022-02-15")
         let timeRange = AnalyticsHubTimeRangeSelection(selectionType: .quarterToDate,
                                                        currentDate: today,
                                                        timezone: testTimezone,
@@ -220,7 +220,7 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
 
         // Then
         XCTAssertEqual(currentRangeDescription, "Jan 1 - Feb 15, 2022")
-        XCTAssertEqual(previousRangeDescription, "Apr 1 - May 15, 2021")
+        XCTAssertEqual(previousRangeDescription, "Oct 1 - Nov 15, 2021")
     }
 
     func test_when_time_range_inits_with_monthToDate_then_generate_expected_descriptions() throws {

--- a/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
+++ b/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
@@ -105,53 +105,36 @@ public extension Date {
         }
 
         var components = calendar.dateComponents([.month, .year], from: startOfMonth)
-
-        let quarterFirstMonth: Int
         switch components.month {
         case 1, 2, 3:
-            quarterFirstMonth = 1
+            components.month = 1
         case 4, 5, 6:
-            quarterFirstMonth = 4
+            components.month = 4
         case 7, 8, 9:
-            quarterFirstMonth = 7
+            components.month = 7
         case 10, 11, 12:
-            quarterFirstMonth = 10
+            components.month = 10
         default:
             return nil
         }
-        components.month = quarterFirstMonth
+
         return calendar.date(from: components)
     }
 
     /// Returns self's end of quarter in the given time zone.
     func endOfQuarter(timezone: TimeZone, calendar: Calendar) -> Date? {
-        guard let startOfMonth = startOfMonth(timezone: timezone) else {
+        guard let startOfQuarter = startOfQuarter(timezone: timezone, calendar: calendar) else {
             return nil
         }
 
-        var components = calendar.dateComponents([.month, .day, .year], from: startOfMonth)
-
-        switch components.month {
-        case 1, 2, 3:
-            components.month = 3
-        case 4, 5, 6:
-            components.month = 6
-        case 7, 8, 9:
-            components.month = 9
-        case 10, 11, 12:
-            components.month = 12
-        default:
-            return nil
-        }
-
-        guard let quarterLastMonth = calendar.date(from: components) else {
+        guard let endOfQuarter = calendar.date(byAdding: .month, value: 2, to: startOfQuarter) else {
             return nil
         }
 
         var oneMonthUnit = DateComponents()
         oneMonthUnit.month = 1
         oneMonthUnit.second = -1
-        return calendar.date(byAdding: oneMonthUnit, to: quarterLastMonth)
+        return calendar.date(byAdding: oneMonthUnit, to: endOfQuarter)
     }
 
     // MARK: Year

--- a/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
+++ b/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
@@ -127,14 +127,10 @@ public extension Date {
             return nil
         }
 
-        guard let endOfQuarter = calendar.date(byAdding: .month, value: 2, to: startOfQuarter) else {
-            return nil
-        }
-
         var oneMonthUnit = DateComponents()
-        oneMonthUnit.month = 1
+        oneMonthUnit.month = 3
         oneMonthUnit.second = -1
-        return calendar.date(byAdding: oneMonthUnit, to: endOfQuarter)
+        return calendar.date(byAdding: oneMonthUnit, to: startOfQuarter)
     }
 
     // MARK: Year

--- a/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
+++ b/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
@@ -103,18 +103,18 @@ public extension Date {
         guard let startOfMonth = startOfMonth(timezone: timezone) else {
             return nil
         }
-        
+
         var components = calendar.dateComponents([.month, .day, .year], from: startOfMonth)
-        
+
         let quarterFirstMonth: Int
         switch components.month {
-        case 1,2,3:
+        case 1, 2, 3:
             quarterFirstMonth = 1
-        case 4,5,6:
+        case 4, 5, 6:
             quarterFirstMonth = 4
-        case 7,8,9:
+        case 7, 8, 9:
             quarterFirstMonth = 7
-        case 10,11,12:
+        case 10, 11, 12:
             quarterFirstMonth = 10
         default:
             return nil
@@ -128,18 +128,18 @@ public extension Date {
         guard let endOfMonth = endOfMonth(timezone: timezone) else {
             return nil
         }
-        
+
         var components = calendar.dateComponents([.month, .day, .year], from: endOfMonth)
-        
+
         let quarterLastMonth: Int
         switch components.month {
-        case 1,2,3:
+        case 1, 2, 3:
             quarterLastMonth = 3
-        case 4,5,6:
+        case 4, 5, 6:
             quarterLastMonth = 6
-        case 7,8,9:
+        case 7, 8, 9:
             quarterLastMonth = 9
-        case 10,11,12:
+        case 10, 11, 12:
             quarterLastMonth = 12
         default:
             return nil

--- a/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
+++ b/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
@@ -104,7 +104,7 @@ public extension Date {
             return nil
         }
 
-        var components = calendar.dateComponents([.month, .day, .year], from: startOfMonth)
+        var components = calendar.dateComponents([.month, .year], from: startOfMonth)
 
         let quarterFirstMonth: Int
         switch components.month {
@@ -125,27 +125,33 @@ public extension Date {
 
     /// Returns self's end of quarter in the given time zone.
     func endOfQuarter(timezone: TimeZone, calendar: Calendar) -> Date? {
-        guard let endOfMonth = endOfMonth(timezone: timezone) else {
+        guard let startOfMonth = startOfMonth(timezone: timezone) else {
             return nil
         }
 
-        var components = calendar.dateComponents([.month, .day, .year], from: endOfMonth)
+        var components = calendar.dateComponents([.month, .day, .year], from: startOfMonth)
 
-        let quarterLastMonth: Int
         switch components.month {
         case 1, 2, 3:
-            quarterLastMonth = 3
+            components.month = 3
         case 4, 5, 6:
-            quarterLastMonth = 6
+            components.month = 6
         case 7, 8, 9:
-            quarterLastMonth = 9
+            components.month = 9
         case 10, 11, 12:
-            quarterLastMonth = 12
+            components.month = 12
         default:
             return nil
         }
-        components.month = quarterLastMonth
-        return calendar.date(from: components)
+
+        guard let quarterLastMonth = calendar.date(from: components) else {
+            return nil
+        }
+
+        var oneMonthUnit = DateComponents()
+        oneMonthUnit.month = 1
+        oneMonthUnit.second = -1
+        return calendar.date(byAdding: oneMonthUnit, to: quarterLastMonth)
     }
 
     // MARK: Year

--- a/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
+++ b/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
@@ -96,6 +96,26 @@ public extension Date {
         return calendar.date(byAdding: components, to: startOfMonth)
     }
 
+    // MARK: Quarter
+
+    /// Returns self's start of quarter in the given time zone.
+    func startOfQuarter(timezone: TimeZone, calendar: Calendar) -> Date? {
+        let components = calendar.dateComponents([.year, .quarter], from: startOfDay(timezone: timezone))
+        return calendar.date(from: components)
+    }
+
+    /// Returns self's end of quarter in the given time zone.
+    func endOfQuarter(timezone: TimeZone, calendar: Calendar) -> Date? {
+        guard let startOfQuarter = startOfQuarter(timezone: timezone, calendar: calendar) else {
+            return nil
+        }
+
+        var components = DateComponents()
+        components.quarter = 1
+        components.second = -1
+        return calendar.date(byAdding: components, to: startOfQuarter)
+    }
+
     // MARK: Year
 
     /// Returns self's start of year in the given time zone.

--- a/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
+++ b/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
@@ -100,7 +100,26 @@ public extension Date {
 
     /// Returns self's start of quarter in the given time zone.
     func startOfQuarter(timezone: TimeZone, calendar: Calendar) -> Date? {
-        let components = calendar.dateComponents([.year, .quarter], from: startOfDay(timezone: timezone))
+        guard let startOfMonth = startOfMonth(timezone: timezone) else {
+            return nil
+        }
+        
+        var components = calendar.dateComponents([.month, .day, .year], from: startOfMonth)
+        
+        let quarterFirstMonth: Int
+        switch components.month {
+        case 1,2,3:
+            quarterFirstMonth = 1
+        case 4,5,6:
+            quarterFirstMonth = 4
+        case 7,8,9:
+            quarterFirstMonth = 7
+        case 10,11,12:
+            quarterFirstMonth = 10
+        default:
+            return nil
+        }
+        components.month = quarterFirstMonth
         return calendar.date(from: components)
     }
 

--- a/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
+++ b/WooFoundation/WooFoundation/Extensions/Date+StartAndEnd.swift
@@ -125,14 +125,27 @@ public extension Date {
 
     /// Returns self's end of quarter in the given time zone.
     func endOfQuarter(timezone: TimeZone, calendar: Calendar) -> Date? {
-        guard let startOfQuarter = startOfQuarter(timezone: timezone, calendar: calendar) else {
+        guard let endOfMonth = endOfMonth(timezone: timezone) else {
             return nil
         }
-
-        var components = DateComponents()
-        components.quarter = 1
-        components.second = -1
-        return calendar.date(byAdding: components, to: startOfQuarter)
+        
+        var components = calendar.dateComponents([.month, .day, .year], from: endOfMonth)
+        
+        let quarterLastMonth: Int
+        switch components.month {
+        case 1,2,3:
+            quarterLastMonth = 3
+        case 4,5,6:
+            quarterLastMonth = 6
+        case 7,8,9:
+            quarterLastMonth = 9
+        case 10,11,12:
+            quarterLastMonth = 12
+        default:
+            return nil
+        }
+        components.month = quarterLastMonth
+        return calendar.date(from: components)
     }
 
     // MARK: Year


### PR DESCRIPTION
Closes #8146

Why
==========
The final part of issue #8146 is to deliver the `Yesterday`, `Last Week`, `Last Month`, `Last Year`, `Last Quarter` and `Quarter to Date` ranges. This one aims to the `Last Quarter`, and `Quarter to Date` ranges as the final batch of ranges.

How
==========
This PR introduces the `Last Quarter`, and `Quarter to Date` ranges, alongside the respective data structs and unit tests, updating the SelectionType and adding the three options to the Date range picker view.

Screen Capture
==========
https://user-images.githubusercontent.com/5920403/206017713-b06a0afb-4f83-4bfc-9adf-47a9a78af943.mp4

How to Test
==========
1. Open the Analytics Hub
2. Hit the Date range selection view
3. Verify that the `Last Quarter`, and `Quarter to Date` options are now available. 
4. Verify that the `Quarter to Date` now compares the current quarter to the previous one.
5. Verify that the `Last Quarter` now compares the previous full quarter with the full quarter before it.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.