### PR TITLE
Remove an unnecessary `await` call

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -80,7 +80,7 @@ final class AnalyticsHubViewModel: ObservableObject {
             dismissNotice = Notice(title: Localization.timeRangeGeneratorError, feedbackType: .error)
             DDLogWarn("⚠️ Error selecting analytics time range: \(timeRangeSelectionType.description)")
         } catch {
-            await switchToErrorState()
+            switchToErrorState()
             DDLogWarn("⚠️ Error fetching analytics data: \(error)")
         }
     }


### PR DESCRIPTION
### Description

The compiler warned:

> No 'async' operations occur within 'await' expression

![image](https://user-images.githubusercontent.com/1218433/205946148-89effb51-98f8-4261-a0b9-a64b2e34e01f.png)

### Testing instructions
If CI builds and doesn't emit the warning, we're good.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
