### PR TITLE
Address `windows` deprecation warning

### DIFF
--- a/WooCommerce/Classes/Extensions/UIApplication+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIApplication+Woo.swift
@@ -8,7 +8,15 @@ extension UIApplication {
     /// Returns the keyWindow. Accessing `UIApplication.shared.keyWindow` is deprecated from iOS 13.
     ///
     var currentKeyWindow: UIWindow? {
-        UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+        // See https://stackoverflow.com/a/58031897/809944
+        UIApplication
+            .shared
+            // Get all of the currently connected UIScene instances
+            .connectedScenes
+            // Filter the connected UIScene instances for those that are UIWindowScene instances
+            // and map to their keyWindow property
+            .compactMap { ($0 as? UIWindowScene)?.keyWindow }
+            .first
     }
 }
 


### PR DESCRIPTION
### Description

The compiler said:

> 'windows' was deprecated in iOS 15.0: Use UIWindowScene.windows on a relevant window scene instead

### Testing instructions
I looked at the code using this property but I'm not user how to exercise the app to trigger one of those code paths.
@woocommerce/ios-developers can some help validate this tweak? Thanks!

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
