### PR TITLE
[Mobile Payments] Prevent gap between card reader connection and payment

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -12,11 +12,11 @@ struct CardPresentCapturedPaymentData {
 }
 
 /// Orchestrates the sequence of actions required to capture a payment:
-/// 1. Check if there is a card reader connected
-/// 2. Launch the reader discovering and pairing UI if there is no reader connected
-/// 3. Obtain a Payment Intent from the card reader (i.e., create a payment intent, collect a payment method, and process the payment)
-/// 4. Submit the Payment Intent to WCPay to capture a payment
-/// Steps 1 and 2 will be implemented as part of https://github.com/woocommerce/woocommerce-ios/issues/4062
+/// 1. Triggers the `preparingReader` alert
+/// 2. Creates the payment intent parameters
+/// 3. Controls (prevents during payment) wallet presentation: we don't want to use the merchant's Apple Pay for their customer's purchase!
+/// 4. Obtain a Payment Intent from the card reader (i.e., create a payment intent, collect a payment method, and process the payment)
+/// 5. Submit the Payment Intent to WCPay to capture a payment
 final class PaymentCaptureOrchestrator {
     private let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
     private let personNameComponentsFormatter = PersonNameComponentsFormatter()

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -39,11 +39,14 @@ final class PaymentCaptureOrchestrator {
                         paymentGatewayAccount: PaymentGatewayAccount,
                         paymentMethodTypes: [String],
                         stripeSmallestCurrencyUnitMultiplier: Decimal,
+                        onPreparingReader: () -> Void,
                         onWaitingForInput: @escaping (CardReaderInput) -> Void,
                         onProcessingMessage: @escaping () -> Void,
                         onDisplayMessage: @escaping (String) -> Void,
                         onProcessingCompletion: @escaping (PaymentIntent) -> Void,
                         onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> Void) {
+        onPreparingReader()
+
         /// Set state of CardPresentPaymentStore
         ///
         let setAccount = CardPresentPaymentAction.use(paymentGatewayAccount: paymentGatewayAccount)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -32,10 +32,13 @@ final class OrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
 
     private let transactionType: CardPresentTransactionType
 
+    private let alertsProvider: CardReaderTransactionAlertsProviding
+
     init(transactionType: CardPresentTransactionType,
          presentingController: UIViewController) {
         self.transactionType = transactionType
         self.presentingController = presentingController
+        self.alertsProvider = CardReaderPaymentAlertsProvider(transactionType: transactionType)
     }
 
     func presentViewModel(viewModel: CardPresentPaymentsModalViewModel) {
@@ -60,166 +63,45 @@ final class OrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
 
         // Initial presentation of the modal view controller. We need to provide
         // a customer name and an amount.
-        let viewModel = tapOrInsert(readerInputMethods: inputMethods, onCancel: onCancel)
+        let viewModel = alertsProvider.tapOrInsertCard(title: title,
+                                                       amount: amount,
+                                                       inputMethods: inputMethods,
+                                                       onCancel: onCancel)
         presentViewModel(viewModel: viewModel)
     }
 
     func displayReaderMessage(message: String) {
-        let viewModel = displayMessage(message: message)
+        let viewModel = alertsProvider.displayReaderMessage(message: message)
         presentViewModel(viewModel: viewModel)
     }
 
     func processingPayment() {
-        let viewModel = processing()
+        let viewModel = alertsProvider.processingTransaction()
         presentViewModel(viewModel: viewModel)
     }
 
     func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptAction: @escaping () -> Void) {
-        let viewModel = successViewModel(printReceipt: printReceipt,
-                                         emailReceipt: emailReceipt,
-                                         noReceiptAction: noReceiptAction)
+        let viewModel = alertsProvider.success(printReceipt: printReceipt,
+                                               emailReceipt: emailReceipt,
+                                               noReceiptAction: noReceiptAction)
         presentViewModel(viewModel: viewModel)
     }
 
     func error(error: Error, tryAgain: @escaping () -> Void, dismissCompletion: @escaping () -> Void) {
-        let viewModel = errorViewModel(error: error, tryAgain: tryAgain, dismissCompletion: dismissCompletion)
+        let viewModel = alertsProvider.error(error: error,
+                                             tryAgain: tryAgain,
+                                             dismissCompletion: dismissCompletion)
         presentViewModel(viewModel: viewModel)
     }
 
     func nonRetryableError(from: UIViewController?, error: Error, dismissCompletion: @escaping () -> Void) {
-        let viewModel = nonRetryableErrorViewModel(amount: amount, error: error, dismissCompletion: dismissCompletion)
+        let viewModel = alertsProvider.nonRetryableError(error: error,
+                                                         dismissCompletion: dismissCompletion)
         presentViewModel(viewModel: viewModel)
     }
 
     func retryableError(from: UIViewController?, tryAgain: @escaping () -> Void) {
-        let viewModel = retryableErrorViewModel(tryAgain: tryAgain)
+        let viewModel = alertsProvider.retryableError(tryAgain: tryAgain)
         presentViewModel(viewModel: viewModel)
-    }
-}
-
-private extension OrderDetailsPaymentAlerts {
-    func tapOrInsert(readerInputMethods: CardReaderInput, onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalTapCard(name: name,
-                                amount: amount,
-                                transactionType: transactionType,
-                                inputMethods: readerInputMethods,
-                                onCancel: onCancel)
-    }
-
-    func displayMessage(message: String) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalDisplayMessage(name: name, amount: amount, message: message)
-    }
-
-    func processing() -> CardPresentPaymentsModalViewModel {
-        CardPresentModalProcessing(name: name, amount: amount, transactionType: transactionType)
-    }
-
-    func successViewModel(printReceipt: @escaping () -> Void,
-                          emailReceipt: @escaping () -> Void,
-                          noReceiptAction: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        if MFMailComposeViewController.canSendMail() {
-            return CardPresentModalSuccess(printReceipt: printReceipt,
-                                           emailReceipt: emailReceipt,
-                                           noReceiptAction: noReceiptAction)
-        } else {
-            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, noReceiptAction: noReceiptAction)
-        }
-    }
-
-    func errorViewModel(error: Error,
-                        tryAgain: @escaping () -> Void,
-                        dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        let errorDescription: String?
-        if let error = error as? CardReaderServiceError {
-            switch error {
-            case .connection(let underlyingError),
-                    .discovery(let underlyingError),
-                    .disconnection(let underlyingError),
-                    .intentCreation(let underlyingError),
-                    .paymentMethodCollection(let underlyingError),
-                    .paymentCapture(let underlyingError),
-                    .paymentCancellation(let underlyingError),
-                    .refundCreation(let underlyingError),
-                    .refundPayment(let underlyingError, _),
-                    .refundCancellation(let underlyingError),
-                    .softwareUpdate(let underlyingError, _):
-                errorDescription = Localization.errorDescription(underlyingError: underlyingError, transactionType: transactionType)
-            default:
-                errorDescription = error.errorDescription
-            }
-        } else {
-            errorDescription = error.localizedDescription
-        }
-        return CardPresentModalError(errorDescription: errorDescription,
-                                     transactionType: transactionType,
-                                     primaryAction: tryAgain,
-                                     dismissCompletion: dismissCompletion)
-    }
-
-    func retryableErrorViewModel(tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalRetryableError(primaryAction: tryAgain)
-    }
-
-    func nonRetryableErrorViewModel(amount: String, error: Error, dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalNonRetryableError(amount: amount, error: error, onDismiss: dismissCompletion)
-    }
-}
-
-private extension OrderDetailsPaymentAlerts {
-    enum Localization {
-        static func errorDescription(underlyingError: UnderlyingError, transactionType: CardPresentTransactionType) -> String? {
-            switch underlyingError {
-            case .unsupportedReaderVersion:
-                switch transactionType {
-                case .collectPayment:
-                    return NSLocalizedString(
-                        "The card reader software is out-of-date - please update the card reader software before attempting to process payments",
-                        comment: "Error message when the card reader software is too far out of date to process payments."
-                    )
-                case .refund:
-                    return NSLocalizedString(
-                        "The card reader software is out-of-date - please update the card reader software before attempting to process refunds",
-                        comment: "Error message when the card reader software is too far out of date to process in-person refunds."
-                    )
-                }
-            case .paymentDeclinedByCardReader:
-                switch transactionType {
-                case .collectPayment:
-                    return NSLocalizedString("The card was declined by the card reader - please try another means of payment",
-                                             comment: "Error message when the card reader itself declines the card.")
-                case .refund:
-                    return NSLocalizedString("The card was declined by the card reader - please try another means of refund",
-                                             comment: "Error message when the card reader itself declines the card.")
-                }
-            case .processorAPIError:
-                switch transactionType {
-                case .collectPayment:
-                    return NSLocalizedString(
-                        "The payment can not be processed by the payment processor.",
-                        comment: "Error message when the payment can not be processed (i.e. order amount is below the minimum amount allowed.)"
-                    )
-                case .refund:
-                    return NSLocalizedString(
-                        "The refund can not be processed by the payment processor.",
-                        comment: "Error message when the in-person refund can not be processed (i.e. order amount is below the minimum amount allowed.)"
-                    )
-                }
-            case .internalServiceError:
-                switch transactionType {
-                case .collectPayment:
-                    return NSLocalizedString(
-                        "Sorry, this payment couldn’t be processed",
-                        comment: "Error message when the card reader service experiences an unexpected internal service error."
-                    )
-                case .refund:
-                    return NSLocalizedString(
-                        "Sorry, this refund couldn’t be processed",
-                        comment: "Error message when the card reader service experiences an unexpected internal service error."
-                    )
-                }
-            default:
-                return underlyingError.errorDescription
-            }
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -532,14 +532,12 @@ private extension BuiltInCardReaderConnectionController {
     ///
     private func returnSuccess(result: CardReaderConnectionResult) {
         onCompletion?(.success(result))
-        alertsPresenter.dismiss()
         state = .idle
     }
 
     /// Calls the completion with a failure result
     ///
     private func returnFailure(error: Error) {
-        alertsPresenter.dismiss()
         onCompletion?(.failure(error))
         state = .idle
     }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -87,7 +87,8 @@ final class CardPresentPaymentPreflightController {
         observeConnectedReaders()
         // If we're already connected to a reader, return it
         if let connectedReader = connectedReader {
-            readerConnection.send(CardReaderConnectionResult.connected(connectedReader))
+            handleConnectionResult(.success(.connected(connectedReader)))
+            return
         }
 
         // TODO: Run onboarding if needed
@@ -146,7 +147,7 @@ final class CardPresentPaymentPreflightController {
         case .success(let unwrapped):
             self.readerConnection.send(unwrapped)
         default:
-            break
+            alertsPresenter.dismiss()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -735,14 +735,12 @@ private extension CardReaderConnectionController {
     ///
     private func returnSuccess(result: CardReaderConnectionResult) {
         onCompletion?(.success(result))
-        alertsPresenter.dismiss()
         state = .idle
     }
 
     /// Calls the completion with a failure result
     ///
     private func returnFailure(error: Error) {
-        alertsPresenter.dismiss()
         onCompletion?(.failure(error))
         state = .idle
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderPaymentAlertsProvider.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Yosemite
+import MessageUI
+import enum Hardware.CardReaderServiceError
+import enum Hardware.UnderlyingError
+
+final class CardReaderPaymentAlertsProvider: CardReaderTransactionAlertsProviding {
+    var name: String = ""
+    var amount: String = ""
+    var transactionType: CardPresentTransactionType
+
+    init(transactionType: CardPresentTransactionType) {
+        self.transactionType = transactionType
+    }
+
+    func preparingReader(onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalPreparingReader(cancelAction: onCancel)
+    }
+
+    func tapOrInsertCard(title: String,
+                         amount: String,
+                         inputMethods: Yosemite.CardReaderInput,
+                         onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        name = title
+        self.amount = amount
+        return CardPresentModalTapCard(name: title,
+                                       amount: amount,
+                                       transactionType: transactionType,
+                                       inputMethods: inputMethods,
+                                       onCancel: onCancel)
+    }
+
+    func displayReaderMessage(message: String) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalDisplayMessage(name: name,
+                                       amount: amount,
+                                       message: message)
+    }
+
+    func processingTransaction() -> CardPresentPaymentsModalViewModel {
+        CardPresentModalProcessing(name: name, amount: amount, transactionType: transactionType)
+    }
+
+    func success(printReceipt: @escaping () -> Void,
+                 emailReceipt: @escaping () -> Void,
+                 noReceiptAction: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        if MFMailComposeViewController.canSendMail() {
+            return CardPresentModalSuccess(printReceipt: printReceipt,
+                                           emailReceipt: emailReceipt,
+                                           noReceiptAction: noReceiptAction)
+        } else {
+            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, noReceiptAction: noReceiptAction)
+        }
+    }
+
+    func error(error: Error, tryAgain: @escaping () -> Void, dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        let errorDescription: String?
+        if let error = error as? CardReaderServiceError {
+            switch error {
+            case .connection(let underlyingError),
+                    .discovery(let underlyingError),
+                    .disconnection(let underlyingError),
+                    .intentCreation(let underlyingError),
+                    .paymentMethodCollection(let underlyingError),
+                    .paymentCapture(let underlyingError),
+                    .paymentCancellation(let underlyingError),
+                    .refundCreation(let underlyingError),
+                    .refundPayment(let underlyingError, _),
+                    .refundCancellation(let underlyingError),
+                    .softwareUpdate(let underlyingError, _):
+                errorDescription = Localization.errorDescription(underlyingError: underlyingError, transactionType: transactionType)
+            default:
+                errorDescription = error.errorDescription
+            }
+        } else {
+            errorDescription = error.localizedDescription
+        }
+        return CardPresentModalError(errorDescription: errorDescription,
+                                     transactionType: transactionType,
+                                     primaryAction: tryAgain,
+                                     dismissCompletion: dismissCompletion)
+    }
+
+    func nonRetryableError(error: Error, dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalNonRetryableError(amount: amount, error: error, onDismiss: dismissCompletion)
+    }
+
+    func retryableError(tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalRetryableError(primaryAction: tryAgain)
+    }
+}
+
+private extension CardReaderPaymentAlertsProvider {
+    enum Localization {
+        static func errorDescription(underlyingError: UnderlyingError, transactionType: CardPresentTransactionType) -> String? {
+            switch underlyingError {
+            case .unsupportedReaderVersion:
+                switch transactionType {
+                case .collectPayment:
+                    return NSLocalizedString(
+                        "The card reader software is out-of-date - please update the card reader software before attempting to process payments",
+                        comment: "Error message when the card reader software is too far out of date to process payments."
+                    )
+                case .refund:
+                    return NSLocalizedString(
+                        "The card reader software is out-of-date - please update the card reader software before attempting to process refunds",
+                        comment: "Error message when the card reader software is too far out of date to process in-person refunds."
+                    )
+                }
+            case .paymentDeclinedByCardReader:
+                switch transactionType {
+                case .collectPayment:
+                    return NSLocalizedString("The card was declined by the card reader - please try another means of payment",
+                                             comment: "Error message when the card reader itself declines the card.")
+                case .refund:
+                    return NSLocalizedString("The card was declined by the card reader - please try another means of refund",
+                                             comment: "Error message when the card reader itself declines the card.")
+                }
+            case .processorAPIError:
+                switch transactionType {
+                case .collectPayment:
+                    return NSLocalizedString(
+                        "The payment can not be processed by the payment processor.",
+                        comment: "Error message when the payment can not be processed (i.e. order amount is below the minimum amount allowed.)"
+                    )
+                case .refund:
+                    return NSLocalizedString(
+                        "The refund can not be processed by the payment processor.",
+                        comment: "Error message when the in-person refund can not be processed (i.e. order amount is below the minimum amount allowed.)"
+                    )
+                }
+            case .internalServiceError:
+                switch transactionType {
+                case .collectPayment:
+                    return NSLocalizedString(
+                        "Sorry, this payment couldn’t be processed",
+                        comment: "Error message when the card reader service experiences an unexpected internal service error."
+                    )
+                case .refund:
+                    return NSLocalizedString(
+                        "Sorry, this refund couldn’t be processed",
+                        comment: "Error message when the card reader service experiences an unexpected internal service error."
+                    )
+                }
+            default:
+                return underlyingError.errorDescription
+            }
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTransactionAlertsProviding.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTransactionAlertsProviding.swift
@@ -1,0 +1,48 @@
+import UIKit
+import Yosemite
+
+/// Defines a protocol for card reader transaction alert providers to conform to - defining what
+/// alert viewModels such a provider is expected to provide over the course of performind
+/// a card present transaction (payment or refund.)
+///
+protocol CardReaderTransactionAlertsProviding {
+    /// A cancellable alert indicating we are preparing a reader to collect card details
+    ///
+    func preparingReader(onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+
+    /// A cancellable alert indicating the reader is ready to collect card details
+    ///
+    func tapOrInsertCard(title: String,
+                         amount: String,
+                         inputMethods: CardReaderInput,
+                         onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+
+    /// An alert to display a message from a reader
+    ///
+    func displayReaderMessage(message: String) -> CardPresentPaymentsModalViewModel
+
+    /// An alert to show that the transaction is being processed
+    ///
+    func processingTransaction() -> CardPresentPaymentsModalViewModel
+
+    /// An alert to display successful transaction and provide options related to receipts
+    ///
+    func success(printReceipt: @escaping () -> Void,
+                 emailReceipt: @escaping () -> Void,
+                 noReceiptAction: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+
+    /// An alert to display a retriable and cancellable error
+    ///
+    func error(error: Error,
+               tryAgain: @escaping () -> Void,
+               dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+
+    /// An alert to display a non-retriable and cancellable error
+    ///
+    func nonRetryableError(error: Error,
+                           dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+
+    /// An alert to display a retriable error
+    ///
+    func retryableError(tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -87,7 +87,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
 
     /// IPP payments collector.
     ///
-    private lazy var paymentOrchestrator = LegacyPaymentCaptureOrchestrator(stores: stores)
+    private lazy var paymentOrchestrator = PaymentCaptureOrchestrator(stores: stores)
 
     /// Coordinates emailing a receipt after payment success.
     private var receiptEmailCoordinator: CardPresentPaymentReceiptEmailCoordinator?

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -73,6 +73,10 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     ///
     private let alertsPresenter: CardPresentPaymentAlertsPresenting
 
+    /// Payment alerts provider
+    ///
+    private let paymentAlerts: CardReaderTransactionAlertsProviding
+
     /// Stores the card reader listener subscription while trying to connect to one.
     ///
     private var readerSubscription: AnyCancellable?
@@ -109,6 +113,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
         self.paymentGatewayAccount = paymentGatewayAccount
         self.rootViewController = rootViewController
         self.alertsPresenter = CardPresentPaymentAlertsPresenter(rootViewController: rootViewController)
+        self.paymentAlerts = CardReaderPaymentAlertsProvider(transactionType: .collectPayment)
         self.configuration = configuration
         self.stores = stores
         self.analytics = analytics
@@ -205,9 +210,8 @@ private extension CollectOrderPaymentUseCase {
     func handleTotalAmountInvalidError(_ error: Error, onCompleted: @escaping () -> ()) {
         trackPaymentFailure(with: error)
         DDLogError("💳 Error: failed to capture payment for order. Order amount is below minimum or not valid")
-        self.alertsPresenter.present(viewModel: nonRetryableErrorViewModel(amount: formattedAmount,
-                                                                           error: totalAmountInvalidError(),
-                                                                           dismissCompletion: onCompleted))
+        self.alertsPresenter.present(viewModel: paymentAlerts.nonRetryableError(error: totalAmountInvalidError(),
+                                                                                dismissCompletion: onCompleted))
     }
 
     /// Attempts to collect payment for an order.
@@ -226,7 +230,7 @@ private extension CollectOrderPaymentUseCase {
             paymentMethodTypes: configuration.paymentMethods.map(\.rawValue),
             stripeSmallestCurrencyUnitMultiplier: configuration.stripeSmallestCurrencyUnitMultiplier,
             onPreparingReader: { [weak self] in
-                self?.alertsPresenter.present(viewModel: CardPresentModalPreparingReader(cancelAction: {
+                self?.alertsPresenter.present(viewModel: paymentAlerts.preparingReader(onCancel: {
                     self?.cancelPayment(onCompleted: {
                         onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
                     })
@@ -235,10 +239,9 @@ private extension CollectOrderPaymentUseCase {
             onWaitingForInput: { [weak self] inputMethods in
                 guard let self = self else { return }
                 self.alertsPresenter.present(
-                    viewModel: CardPresentModalTapCard(
-                        name: Localization.collectPaymentTitle(username: self.order.billingAddress?.firstName),
+                    viewModel: self.paymentAlerts.tapOrInsertCard(
+                        title: Localization.collectPaymentTitle(username: self.order.billingAddress?.firstName),
                         amount: self.formattedAmount,
-                        transactionType: .collectPayment,
                         inputMethods: inputMethods,
                         onCancel: { [weak self] in
                             self?.cancelPayment {
@@ -249,19 +252,11 @@ private extension CollectOrderPaymentUseCase {
             }, onProcessingMessage: { [weak self] in
                 guard let self = self else { return }
                 // Waiting message
-                self.alertsPresenter.present(
-                    viewModel: CardPresentModalProcessing(
-                        name: Localization.collectPaymentTitle(username: self.order.billingAddress?.firstName),
-                        amount: self.formattedAmount,
-                        transactionType: .collectPayment))
+                self.alertsPresenter.present(viewModel: self.paymentAlerts.processingTransaction())
             }, onDisplayMessage: { [weak self] message in
                 guard let self = self else { return }
                 // Reader messages. EG: Remove Card
-                self.alertsPresenter.present(
-                    viewModel: CardPresentModalDisplayMessage(
-                        name: Localization.collectPaymentTitle(username: self.order.billingAddress?.firstName),
-                        amount: self.formattedAmount,
-                        message: message))
+                self.alertsPresenter.present(viewModel: self.paymentAlerts.displayReaderMessage(message: message))
             }, onProcessingCompletion: { [weak self] intent in
                 self?.trackProcessingCompletion(intent: intent)
                 self?.markOrderAsPaidIfNeeded(intent: intent)
@@ -300,7 +295,7 @@ private extension CollectOrderPaymentUseCase {
 
         // Inform about the error
         alertsPresenter.present(
-            viewModel: errorViewModel(error: error,
+            viewModel: paymentAlerts.error(error: error,
                                       tryAgain: { [weak self] in
 
                                           // Cancel current payment
@@ -314,7 +309,8 @@ private extension CollectOrderPaymentUseCase {
 
                                               case .failure(let cancelError):
                                                   // Inform that payment can't be retried.
-                                                  self.alertsPresenter.present(viewModel: self.nonRetryableErrorViewModel(amount: self.formattedAmount, error: cancelError) {
+                                                  self.alertsPresenter.present(
+                                                    viewModel: self.paymentAlerts.nonRetryableError(error: cancelError) {
                                                       onCompletion(.failure(error))
                                                   })
                                               }
@@ -352,7 +348,7 @@ private extension CollectOrderPaymentUseCase {
     ///
     func presentReceiptAlert(receiptParameters: CardPresentReceiptParameters, onCompleted: @escaping () -> ()) {
         // Present receipt alert
-        alertsPresenter.present(viewModel: successViewModel(printReceipt: { [order, configuration, weak self] in
+        alertsPresenter.present(viewModel: paymentAlerts.success(printReceipt: { [order, configuration, weak self] in
             guard let self = self else { return }
 
             // Inform about flow completion.
@@ -382,60 +378,6 @@ private extension CollectOrderPaymentUseCase {
             // Inform about flow completion.
             onCompleted()
         }))
-    }
-
-    // MARK: - Helpers to move to a PaymentAlertsProvider
-
-    func successViewModel(printReceipt: @escaping () -> Void,
-                          emailReceipt: @escaping () -> Void,
-                          noReceiptAction: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        if MFMailComposeViewController.canSendMail() {
-            return CardPresentModalSuccess(printReceipt: printReceipt,
-                                           emailReceipt: emailReceipt,
-                                           noReceiptAction: noReceiptAction)
-        } else {
-            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, noReceiptAction: noReceiptAction)
-        }
-    }
-
-    func errorViewModel(error: Error,
-                        tryAgain: @escaping () -> Void,
-                        dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        let errorDescription: String?
-        if let error = error as? CardReaderServiceError {
-            switch error {
-            case .connection(let underlyingError),
-                    .discovery(let underlyingError),
-                    .disconnection(let underlyingError),
-                    .intentCreation(let underlyingError),
-                    .paymentMethodCollection(let underlyingError),
-                    .paymentCapture(let underlyingError),
-                    .paymentCancellation(let underlyingError),
-                    .refundCreation(let underlyingError),
-                    .refundPayment(let underlyingError, _),
-                    .refundCancellation(let underlyingError),
-                    .softwareUpdate(let underlyingError, _):
-                errorDescription = PaymentAlertErrorLocalization.errorDescription(
-                    underlyingError: underlyingError,
-                    transactionType: CardPresentTransactionType.collectPayment)
-            default:
-                errorDescription = error.errorDescription
-            }
-        } else {
-            errorDescription = error.localizedDescription
-        }
-        return CardPresentModalError(errorDescription: errorDescription,
-                                     transactionType: .collectPayment,
-                                     primaryAction: tryAgain,
-                                     dismissCompletion: dismissCompletion)
-    }
-
-    func retryableErrorViewModel(tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalRetryableError(primaryAction: tryAgain)
-    }
-
-    func nonRetryableErrorViewModel(amount: String, error: Error, dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalNonRetryableError(amount: amount, error: error, onDismiss: dismissCompletion)
     }
 
     /// Presents the native email client with the provided content.
@@ -546,63 +488,6 @@ extension CollectOrderPaymentUseCase {
                 "Unable to process payment. Order total amount is below the minimum amount you can charge, which is %1$@",
                 comment: "Error message when the order amount is below the minimum amount allowed."
             )
-        }
-    }
-
-    enum PaymentAlertErrorLocalization {
-        static func errorDescription(underlyingError: UnderlyingError, transactionType: CardPresentTransactionType) -> String? {
-            switch underlyingError {
-            case .unsupportedReaderVersion:
-                switch transactionType {
-                case .collectPayment:
-                    return NSLocalizedString(
-                        "The card reader software is out-of-date - please update the card reader software before attempting to process payments",
-                        comment: "Error message when the card reader software is too far out of date to process payments."
-                    )
-                case .refund:
-                    return NSLocalizedString(
-                        "The card reader software is out-of-date - please update the card reader software before attempting to process refunds",
-                        comment: "Error message when the card reader software is too far out of date to process in-person refunds."
-                    )
-                }
-            case .paymentDeclinedByCardReader:
-                switch transactionType {
-                case .collectPayment:
-                    return NSLocalizedString("The card was declined by the card reader - please try another means of payment",
-                                             comment: "Error message when the card reader itself declines the card.")
-                case .refund:
-                    return NSLocalizedString("The card was declined by the card reader - please try another means of refund",
-                                             comment: "Error message when the card reader itself declines the card.")
-                }
-            case .processorAPIError:
-                switch transactionType {
-                case .collectPayment:
-                    return NSLocalizedString(
-                        "The payment can not be processed by the payment processor.",
-                        comment: "Error message when the payment can not be processed (i.e. order amount is below the minimum amount allowed.)"
-                    )
-                case .refund:
-                    return NSLocalizedString(
-                        "The refund can not be processed by the payment processor.",
-                        comment: "Error message when the in-person refund can not be processed (i.e. order amount is below the minimum amount allowed.)"
-                    )
-                }
-            case .internalServiceError:
-                switch transactionType {
-                case .collectPayment:
-                    return NSLocalizedString(
-                        "Sorry, this payment couldn’t be processed",
-                        comment: "Error message when the card reader service experiences an unexpected internal service error."
-                    )
-                case .refund:
-                    return NSLocalizedString(
-                        "Sorry, this refund couldn’t be processed",
-                        comment: "Error message when the card reader service experiences an unexpected internal service error."
-                    )
-                }
-            default:
-                return underlyingError.errorDescription
-            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -165,6 +165,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
                     self.presentReceiptAlert(receiptParameters: paymentData.receiptParameters, onCompleted: onCompleted)
                 })
             case .canceled:
+                self.alertsPresenter.dismiss()
                 self.trackPaymentCancelation()
                 onCancel()
             case .none:

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -240,8 +240,6 @@ final class PaymentMethodsViewModel: ObservableObject {
                         formattedAmount: self.formattedTotal,
                         paymentGatewayAccount: paymentGateway,
                         rootViewController: rootViewController,
-                        alerts: OrderDetailsPaymentAlerts(transactionType: .collectPayment,
-                                                          presentingController: rootViewController),
                         configuration: CardPresentConfigurationLoader().configuration)
 
                     self.collectPaymentsUseCase?.collectPayment(

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -503,6 +503,8 @@
 		03E471CA293E0A30001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471C9293E0A2F001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift */; };
 		03E471CC293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471CB293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift */; };
 		03E471CE293F63B4001A58AD /* PaymentCaptureOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471CD293F63B4001A58AD /* PaymentCaptureOrchestrator.swift */; };
+		03E471D0293FA62B001A58AD /* CardReaderTransactionAlertsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471CF293FA62B001A58AD /* CardReaderTransactionAlertsProviding.swift */; };
+		03E471D2293FA8B2001A58AD /* CardReaderPaymentAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471D1293FA8B2001A58AD /* CardReaderPaymentAlertsProvider.swift */; };
 		03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
 		03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */; };
 		03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */; };
@@ -2517,6 +2519,8 @@
 		03E471C9293E0A2F001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInConfigurationProgress.swift; sourceTree = "<group>"; };
 		03E471CB293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalProgressDisplaying.swift; sourceTree = "<group>"; };
 		03E471CD293F63B4001A58AD /* PaymentCaptureOrchestrator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentCaptureOrchestrator.swift; sourceTree = "<group>"; };
+		03E471CF293FA62B001A58AD /* CardReaderTransactionAlertsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderTransactionAlertsProviding.swift; sourceTree = "<group>"; };
+		03E471D1293FA8B2001A58AD /* CardReaderPaymentAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderPaymentAlertsProvider.swift; sourceTree = "<group>"; };
 		03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift; sourceTree = "<group>"; };
 		03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift; sourceTree = "<group>"; };
 		03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardPresentPaymentsPlugin+CashOnDelivery.swift"; sourceTree = "<group>"; };
@@ -5647,6 +5651,8 @@
 				311F827326CD897900DF5BAD /* CardReaderSettingsAlertsProvider.swift */,
 				311D21EC264AF0E700102316 /* CardReaderSettingsAlerts.swift */,
 				03E471BF293A158C001A58AD /* CardReaderConnectionAlertsProviding.swift */,
+				03E471CF293FA62B001A58AD /* CardReaderTransactionAlertsProviding.swift */,
+				03E471D1293FA8B2001A58AD /* CardReaderPaymentAlertsProvider.swift */,
 				03E471C1293A1F6B001A58AD /* BluetoothReaderConnectionAlertsProvider.swift */,
 				03E471C3293A1F8D001A58AD /* BuiltInReaderConnectionAlertsProvider.swift */,
 				3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */,
@@ -10022,6 +10028,7 @@
 				E1325EFB28FD544E00EC9B2A /* InAppPurchasesDebugView.swift in Sources */,
 				74460D4022289B7600D7316A /* Coordinator.swift in Sources */,
 				B57C743D20F5493300EEFC87 /* AccountHeaderView.swift in Sources */,
+				03E471D2293FA8B2001A58AD /* CardReaderPaymentAlertsProvider.swift in Sources */,
 				03E471CA293E0A30001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift in Sources */,
 				31AD0B1126E9575F000B6391 /* CardPresentModalConnectingFailed.swift in Sources */,
 				576EA39425264C9B00AFC0B3 /* RefundConfirmationViewModel.swift in Sources */,
@@ -10538,6 +10545,7 @@
 				020AF6662923C7ED007760E5 /* StoreNameForm.swift in Sources */,
 				DEC51AFD276AEAE3009F3DF4 /* SystemStatusReportView.swift in Sources */,
 				CECC759C23D61C1400486676 /* AggregateDataHelper.swift in Sources */,
+				03E471D0293FA62B001A58AD /* CardReaderTransactionAlertsProviding.swift in Sources */,
 				02645D7D27BA027B0065DC68 /* Inbox.swift in Sources */,
 				D81D9228222E7F0800FFA585 /* OrderStatusListViewController.swift in Sources */,
 				CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8321
Review after: #8328 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In sTAP Away, we're adding support for Apple's built in card readers to take in-person payments. During this work, we are looking to share code where practical with the bluetooth reader flows, and fix issues in those flows. One such issue is the gap between the connection flow and the payment flow.

Connection (except multiple readers) and Payment screens are all shown in a `CardPresentPaymentsModalViewController`, which is configured to show different view models as we move through the flow. However, with the existing implementation we dismiss the view controller after the connection flow and show a new one for the payment flow.

This results in one screen sliding offscreen downwards, and a new one immediately sliding up in its place. This is not required, and distracting for the user.

This PR uses the shared `alertsPresenter` across both flows and delegates dismissal of alerts to the use case, which fixes this visual glitch in the new flows.

N.B. there is still a timing issue in the alerts after tapping the card, in both bluetooth and tap on mobile. This will be dealt with in #8289 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Using an iPhone XS or newer on iOS 16.0 or newer

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. When asked for a reader type, tap `Tap to Pay on iPhone` and go through the Terms of Service Apple ID linking (if you've not done so before)
6. Observe that the flow goes directly from `Preparing iPhone card reader` to `Getting ready to collect payment`, without sliding one off and the other back on.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before: Tap on Mobile

https://user-images.githubusercontent.com/2472348/205985207-36e810b9-41b2-4d55-a7b6-d96b4b4361b6.mp4


### After: Tap on Mobile

https://user-images.githubusercontent.com/2472348/205985396-6193ae01-afa7-4beb-8599-4cfee21a99a4.mp4


### Before: Bluetooth

https://user-images.githubusercontent.com/2472348/205985130-a0ae0ba3-ecca-4718-a64f-7669f5a76483.mp4


### After: Bluetooth

https://user-images.githubusercontent.com/2472348/205985157-8f3bb35e-fb35-453c-af6b-b94a26096f13.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
