### PR TITLE
Remove `auxiliaryButtonImage` from `CardPresentModalScanningForReader`

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -21,8 +21,6 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
 
     let auxiliaryButtonTitle: String? = nil
 
-    let auxiliaryButtonimage: UIImage? = .infoOutlineImage
-
     var auxiliaryAttributedButtonTitle: NSAttributedString? {
         let result = NSMutableAttributedString(
             string: .localizedStringWithFormat(

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -32,9 +32,6 @@ protocol CardPresentPaymentsModalViewModel {
     /// Provides a title as a NSAttributedString for an auxiliary button
     var auxiliaryAttributedButtonTitle: NSAttributedString? { get }
 
-    /// Provides an image for the auxiliary button
-    var auxiliaryButtonimage: UIImage? { get }
-
     /// The title in the bottom section of the modal. Right below the image
     var bottomTitle: String? { get }
 
@@ -106,10 +103,6 @@ extension CardPresentPaymentsModalViewModel {
     /// Default implementation for NSAttributedString auxiliary button title.
     /// If is not set directly by each Modal's ViewModel, it will default to nil
     var auxiliaryAttributedButtonTitle: NSAttributedString? {
-        get { return nil }
-    }
-
-    var auxiliaryButtonimage: UIImage? {
         get { return nil }
     }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -318,12 +318,10 @@ private extension CardPresentPaymentsModalViewController {
         UIView.performWithoutAnimation {
             auxiliaryButton.setTitle(viewModel.auxiliaryButtonTitle, for: .normal)
             auxiliaryButton.setAttributedTitle(viewModel.auxiliaryAttributedButtonTitle, for: .normal)
-            auxiliaryButton.setImage(viewModel.auxiliaryButtonimage, for: .normal)
-            if viewModel.auxiliaryButtonimage != nil {
-                var config = UIButton.Configuration.plain()
-                config.imagePadding = Constants.buttonTitleAndImageSpacing
-                auxiliaryButton.configuration = config
-            }
+            var config = UIButton.Configuration.plain()
+            config.contentInsets = Constants.auxiliaryButtonInsets
+            config.titleAlignment = .leading
+            auxiliaryButton.configuration = config
             view.layoutIfNeeded()
         }
     }
@@ -418,7 +416,7 @@ private extension CardPresentPaymentsModalViewController {
         static let extraInfoCustomInsets = UIEdgeInsets(top: 12, left: 10, bottom: 12, right: 10)
         static let modalHeight: CGFloat = 382
         static let modalWidth: CGFloat = 280
-        static let buttonTitleAndImageSpacing: CGFloat = 8
+        static let auxiliaryButtonInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
     }
 }
 


### PR DESCRIPTION
Reported on https://github.com/woocommerce/woocommerce-ios/pull/8312#issuecomment-1337677578

### Description
This PR removes the `auxiliaryButtonimage` property from `CardPresentModalScanningForReader` which outputs a `(¡)` image along the button's text on different modal views through the CardPresent flow.

### Context
With the usage of the new UIButton configuration API we have found some conflicts in the way we're dealing with button content configuration through this flow, in this case we have opted for removing the image temporarily as was the source of different design glitches. 

We have opened a [related issue to keep track of it](https://github.com/woocommerce/woocommerce-ios/issues/8332), and restore the image in the future, when we migrate the modals to SwiftUI and apply the new button configuration API.

| Before | After |
|--|--|
|<img src="https://user-images.githubusercontent.com/8739/205684818-dca5ebf7-424c-45de-bf12-86cdf0a33f63.png"> | <img src="https://user-images.githubusercontent.com/3812076/206127921-18a3093b-6c11-43bd-8fe6-34bbb76c6726.png"> | 

| Before | After |
|--|--|
| <img src="https://user-images.githubusercontent.com/8739/205684834-75b508a6-6632-4ef5-9272-9b2f03cdcc93.png"> | <img src="https://user-images.githubusercontent.com/3812076/206129327-90b5f842-7679-402c-b732-134aa804b0fd.png"> |

### Changes
- Remove `auxiliaryButtonimage` property
- Add usage of `UIButton.Configuration` when styling the button

### Testing instructions
- Go to Menu > Manage Card Reader > Disconnect the reader if is connected > Tap on Connect Card Reader
- See `Learn More about In-Person Payments` button. This is more easily checked by commenting out `discoveredReadersSubject.send(wooReaders)` [here](https://github.com/woocommerce/woocommerce-ios/blob/trunk/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift#L683), so the flow doesn't move forward to the next step.
- See `Cancel` button when the app prompts to connect a reader.

I'd left out of this PR further improvements like moving button `title` and `attributedTitle` to the button configuration because this needs more extensive testing. These are left to be done along [this issue](https://github.com/woocommerce/woocommerce-ios/issues/8332).
