### PR TITLE
[Analytics Hub] Add new standard tracks events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1773,3 +1773,31 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - Analytics Hub
+//
+extension WooAnalyticsEvent {
+    enum AnalyticsHub {
+        enum Keys: String {
+            case option
+        }
+
+        /// Tracks when the "See more" button is tapped in My Store, to open the Analytics Hub.
+        ///
+        static func seeMoreAnalyticsTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardSeeMoreAnalyticsTapped, properties: [:])
+        }
+
+        /// Tracks when the date range selector button is tapped.
+        ///
+        static func dateRangeButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .analyticsHubDateRangeButtonTapped, properties: [:])
+        }
+
+        /// Tracks when a date range option is selected like “today”, “yesterday”, or “custom”.
+        ///
+        static func dateRangeOptionSelected(_ option: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .analyticsHubDateRangeOptionSelected, properties: [Keys.option.rawValue: option])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -130,6 +130,7 @@ public enum WooAnalyticsStat: String {
     case dashboardPulledToRefresh = "dashboard_pulled_to_refresh"
     case dashboardNewOrdersButtonTapped = "dashboard_unfulfilled_orders_button_tapped"
     case dashboardShareStoreButtonTapped = "dashboard_share_your_store_button_tapped"
+    case dashboardSeeMoreAnalyticsTapped = "dashboard_see_more_analytics_tapped"
 
     // MARK: Dashboard Data/Action Events
     //
@@ -148,6 +149,11 @@ public enum WooAnalyticsStat: String {
     case dashboardNewStatsRevertedBannerDismissTapped = "dashboard_new_stats_reverted_banner_dismiss_tapped"
     case dashboardNewStatsRevertedBannerLearnMoreTapped = "dashboard_new_stats_reverted_banner_learn_more_tapped"
     case usedAnalytics = "used_analytics"
+
+    // MARK: Analytics Hub Events
+    //
+    case analyticsHubDateRangeButtonTapped = "analytics_hub_date_range_button_tapped"
+    case analyticsHubDateRangeOptionSelected = "analytics_hub_date_range_option_selected"
 
     // MARK: Products Onboarding Events
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCard.swift
@@ -24,13 +24,16 @@ struct AnalyticsTimeRangeCard: View {
                 SelectionList(title: Localization.timeRangeSelectionTitle,
                               items: AnalyticsHubTimeRangeSelection.SelectionType.allCases,
                               contentKeyPath: \.description,
-                              selected: $selectionType)
+                              selected: $selectionType) { selection in
+                    ServiceLocator.analytics.track(event: .AnalyticsHub.dateRangeOptionSelected(selection.rawValue))
+                }
             }
     }
 
     private func createTimeRangeContent() -> some View {
         VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
             Button(action: {
+                ServiceLocator.analytics.track(event: .AnalyticsHub.dateRangeButtonTapped())
                 showTimeRangeSelectionView.toggle()
             }, label: {
                 HStack {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
@@ -92,14 +92,14 @@ public class AnalyticsHubTimeRangeSelection {
 // MARK: - Time Range Selection Type
 extension AnalyticsHubTimeRangeSelection {
     enum SelectionType: String, CaseIterable {
-        case today
-        case yesterday
-        case lastWeek
-        case lastMonth
-        case lastYear
-        case weekToDate
-        case monthToDate
-        case yearToDate
+        case today = "Today"
+        case yesterday = "Yesterday"
+        case lastWeek = "Last Week"
+        case lastMonth = "Last Month"
+        case lastYear = "Last Year"
+        case weekToDate = "Week to Date"
+        case monthToDate = "Month to Date"
+        case yearToDate = "Year to Date"
 
         var description: String {
             switch self {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
@@ -91,7 +91,7 @@ public class AnalyticsHubTimeRangeSelection {
 
 // MARK: - Time Range Selection Type
 extension AnalyticsHubTimeRangeSelection {
-    enum SelectionType: CaseIterable {
+    enum SelectionType: String, CaseIterable {
         case today
         case yesterday
         case lastWeek

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -357,6 +357,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
     }
 
     @objc func seeMoreButtonTapped() {
+        ServiceLocator.analytics.track(event: .AnalyticsHub.seeMoreAnalyticsTapped())
         let analyticsHubVC = AnalyticsHubHostingViewController(siteID: siteID, timeRange: timeRange)
         show(analyticsHubVC, sender: self)
     }


### PR DESCRIPTION
Part of: #8323

## Description

Adds new analytics events for the Analytics Hub:

* `_dashboard_see_more_analytics_tapped` (Event registration: 1231-gh-tracks-events-registration)
* `_analytics_hub_date_range_button_tapped` (Event registration: 1232-gh-tracks-events-registration)
* `_analytics_hub_date_range_option_selected` with `option` event prop (Event registration: 1233-gh-tracks-events-registration)

Note: Updates to the existing `used_analytics` event will be done in another PR.

## Testing

1. Launch the app.
2. Tap "See more" on the My Store dashboard and confirm the `_dashboard_see_more_analytics_tapped` event is triggered.
3. On the Analytics screen, tap the date range selector and confirm the `_analytics_hub_date_range_button_tapped` event is triggered.
4. In the date range selector, tap on a new date range and confirm the `_analytics_hub_date_range_option_selected` event is triggered and includes an `option` property with the selected date range (untranslated, matching the `option` values used in the Android analytics event).

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
