### PR TITLE
[Analytics Hub] Fix dynamic size issues

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -27,7 +27,6 @@ struct AnalyticsReportCard: View {
 
     // Layout metrics that scale based on accessibility changes
     @ScaledMetric private var scaledChartWidth: CGFloat = Layout.chartWidth
-    @ScaledMetric private var scaledChartHeight: CGFloat = Layout.chartHeight
 
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.titleSpacing) {
@@ -57,7 +56,8 @@ struct AnalyticsReportCard: View {
                             .shimmering(active: isRedacted)
 
                         AnalyticsLineChart(dataPoints: leadingChartData, lineChartColor: leadingChartColor)
-                            .frame(width: scaledChartWidth, height: scaledChartHeight)
+                            .aspectRatio(Layout.chartAspectRatio, contentMode: .fit)
+                            .frame(maxWidth: scaledChartWidth)
                     }
 
                 }
@@ -81,7 +81,8 @@ struct AnalyticsReportCard: View {
                             .shimmering(active: isRedacted)
 
                         AnalyticsLineChart(dataPoints: trailingChartData, lineChartColor: trailingChartColor)
-                            .frame(width: scaledChartWidth, height: scaledChartHeight)
+                            .aspectRatio(Layout.chartAspectRatio, contentMode: .fit)
+                            .frame(maxWidth: scaledChartWidth)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -107,6 +108,7 @@ private extension AnalyticsReportCard {
         static let columnInnerSpacing: CGFloat = 10
         static let chartHeight: CGFloat = 32
         static let chartWidth: CGFloat = 72
+        static let chartAspectRatio: CGFloat = 2.25
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCard.swift
@@ -49,6 +49,7 @@ struct AnalyticsTimeRangeCard: View {
                             .bold()
                     }
                     .padding(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                     Image(uiImage: .chevronDownImage)


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8279

## Description

This PR updates analytics hub layout to prevent screen bounds overflow on large text size.

### How

Main reason for view overflow is the fixed frame size for line charts in report cards. The fix is to pin their aspect ratio instead and suggest max width from the scaled property. Suggesting max width prevents view from growing too big to occupy all parents space.

## Testing

1. Build and run the app in debug/alpha mode.
2. Select biggest accessibility text size in the iOS settings.
3. On the dashboard view tap the "See more" button.
4. After view loads confirm that nothing in UI expands out of the screen width.
5. Confirm no text is truncated.

## Screenshots

before|after
--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/206244682-78d14b43-6768-4611-966e-8fe0caf9bb3c.png)|![Simulator Screen Shot - 3](https://user-images.githubusercontent.com/3132438/206244695-264bebca-6d1d-490b-9dd0-9cb3a3a3f811.png)
![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/206244771-057bfe05-8dcc-4149-b005-58580bf0f194.png)|![Simulator Screen Shot - 4](https://user-images.githubusercontent.com/3132438/206244780-dfa91bf3-a9a9-4d23-a47f-5c9d1b2f4fa9.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
