### PR TITLE
[Analytics Hub] Add interactions to used analytics event

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCard.swift
@@ -11,10 +11,13 @@ struct AnalyticsTimeRangeCard: View {
 
     @State private var showTimeRangeSelectionView: Bool = false
 
+    private let usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter
+
     init(viewModel: AnalyticsTimeRangeCardViewModel, selectionType: Binding<AnalyticsHubTimeRangeSelection.SelectionType>) {
         self.timeRangeTitle = viewModel.selectedRangeTitle
         self.currentRangeDescription = viewModel.currentRangeSubtitle
         self.previousRangeDescription = viewModel.previousRangeSubtitle
+        self.usageTracksEventEmitter = viewModel.usageTracksEventEmitter
         self._selectionType = selectionType
     }
 
@@ -25,6 +28,7 @@ struct AnalyticsTimeRangeCard: View {
                               items: AnalyticsHubTimeRangeSelection.SelectionType.allCases,
                               contentKeyPath: \.description,
                               selected: $selectionType) { selection in
+                    usageTracksEventEmitter.interacted()
                     ServiceLocator.analytics.track(event: .AnalyticsHub.dateRangeOptionSelected(selection.rawValue))
                 }
             }
@@ -33,6 +37,7 @@ struct AnalyticsTimeRangeCard: View {
     private func createTimeRangeContent() -> some View {
         VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
             Button(action: {
+                usageTracksEventEmitter.interacted()
                 ServiceLocator.analytics.track(event: .AnalyticsHub.dateRangeButtonTapped())
                 showTimeRangeSelectionView.toggle()
             }, label: {
@@ -103,7 +108,8 @@ struct TimeRangeCard_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = AnalyticsTimeRangeCardViewModel(selectedRangeTitle: "Month to Date",
                                                         currentRangeSubtitle: "Nov 1 - 23, 2022",
-                                                        previousRangeSubtitle: "Oct 1 - 23, 2022")
+                                                        previousRangeSubtitle: "Oct 1 - 23, 2022",
+                                                        usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter())
         AnalyticsTimeRangeCard(viewModel: viewModel, selectionType: .constant(.monthToDate))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCardViewModel.swift
@@ -15,4 +15,8 @@ struct AnalyticsTimeRangeCardViewModel {
     /// Previous Range Subtitle.
     ///
     let previousRangeSubtitle: String
+
+    /// Analytics Usage Tracks Event Emitter
+    ///
+    let usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -358,7 +358,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
 
     @objc func seeMoreButtonTapped() {
         ServiceLocator.analytics.track(event: .AnalyticsHub.seeMoreAnalyticsTapped())
-        let analyticsHubVC = AnalyticsHubHostingViewController(siteID: siteID, timeRange: timeRange)
+        let analyticsHubVC = AnalyticsHubHostingViewController(siteID: siteID, timeRange: timeRange, usageTracksEventEmitter: usageTracksEventEmitter)
         show(analyticsHubVC, sender: self)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsUsageTracksEventEmitter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsUsageTracksEventEmitter.swift
@@ -4,15 +4,18 @@ import Foundation
 /// considered as a _usage_ of the UI.
 ///
 /// See p91TBi-6Cl-p2 for more information about the algorithm.
+/// See pe5pgL-153-p2 for background about adding Analytics Hub interactions to the algorithm.
 ///
 /// The UI should call `interacted` when these events happen:
 ///
-/// - Scrolling
-/// - Pull-to-refresh
+/// - Scrolling (My Store or Analytics)
+/// - Pull-to-refresh (My Store or Analytics)
 /// - Tapping on the bars in the chart
 /// - Changing the tab
 /// - Navigating to the My Store tab
 /// - Tapping on a product in the Top Performers list
+/// - Tapping on the Analytics date range
+/// - Selecting an Analytics date range option
 ///
 /// If we ever change the algorithm in the future, we should probably consider renaming the Tracks event to avoid
 /// incorrect comparisons with old events. We should also make sure to change the Android code if we're changing anything
@@ -35,6 +38,8 @@ final class StoreStatsUsageTracksEventEmitter {
     /// - Changing the tab
     /// - Navigating to the My Store tab
     /// - Tapping on a product in the Top Performers list
+    /// - Tapping on the date range in the Analytics Hub
+    /// - Selecting a date range option in the Analytics Hub
     private let interactionsThreshold = 5
 
     /// The maximum number of seconds in between interactions before we will consider the

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -5,14 +5,18 @@ import Yosemite
 final class AnalyticsHubViewModelTests: XCTestCase {
 
     private var stores: MockStoresManager!
+    private var eventEmitter: StoreStatsUsageTracksEventEmitter!
 
     override func setUp() {
         stores = MockStoresManager(sessionManager: .makeForTesting())
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        eventEmitter = StoreStatsUsageTracksEventEmitter(analytics: analytics)
     }
 
     func test_cards_viewmodels_show_correct_data_after_updating_from_network() async {
         // Given
-        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, stores: stores)
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
 
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
             switch action {
@@ -43,7 +47,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     func test_cards_viewmodels_show_sync_error_after_getting_error_from_network() async {
         // Given
-        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, stores: stores)
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
             switch action {
             case let .retrieveCustomStats(_, _, _, _, _, _, completion):
@@ -67,7 +71,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     func test_cards_viewmodels_redacted_while_updating_from_network() async {
         // Given
-        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, stores: stores)
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
         var loadingRevenueCard: AnalyticsReportCardViewModel?
         var loadingOrdersCard: AnalyticsReportCardViewModel?
         var loadingProductsCard: AnalyticsProductCardViewModel?


### PR DESCRIPTION
Closes: #8323

## Description

Updates the `used_analytics` event to include the following interactions in the Analytics Hub:

- Scrolling
- Pull-to-refresh
- Tapping on the date range
- Selecting a date range option

## Changes

The `used_analytics` event is handled by `StoreStatsUsageTracksEventEmitter`:

* We pass an instance of `StoreStatsUsageTracksEventEmitter` into the Analytics Hub (and its subviews) from the dashboard.
* We call its `interacted()` method when the user does one of these interactions, to trigger the event.

Most of the interactions should be straightforward, but a note about scrolling: SwiftUI doesn't have a straightforward way of identifying the scroll gesture. Instead, we can use `DragGesture` to know when scrolling begins, which is sufficient for this tracking.

## Testing

Note: The `used_analytics` event is not triggered immediately after an interaction. (Currently, you have to perform 5 interactions and interact for at least 10 seconds before the event will be triggered.)

For testing, I recommend placing breakpoints where `usageTracksEventEmitter.interacted()` is called:

* `AnalyticsHubView` on L59 and L121
* `AnalyticsTimeRangeCard` on L31 and L40

To test:

1. Launch the app.
2. Tap "See more" on the My Store dashboard.
3. Scroll the Analytics screen and confirm you hit the breakpoint in `AnalyticsHubView` on L121. (You can then disable this breakpoint to make it easier to scroll.)
4. Pull to refresh the Analytics screen and confirm you hit a breakpoint.
5. Tap the date range selector and confirm you hit a breakpoint.
6. Select a new date range and confirm you hit a breakpoint.

You can also check that after at least 5 of these interactions and 10 seconds you see the `used_analytics` event triggered.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
