### PR TITLE
Use HTTPS in `test.com` test URL

### DIFF
--- a/Networking/NetworkingTests/Remote/JetpackConnectionRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/JetpackConnectionRemoteTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class JetpackConnectionRemoteTests: XCTestCase {
 
-    private let siteURL = "http://test.com"
+    private let siteURL = "https://test.com"
 
     /// Dummy Network Wrapper
     ///

--- a/Networking/NetworkingTests/Requests/WordPressOrgRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/WordPressOrgRequestTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class WordPressOrgRequestTests: XCTestCase {
 
-    private let baseURL = "http://test.com"
+    private let baseURL = "https://test.com"
     private let path = "/test/request"
 
     func test_request_url_is_correct() throws {
@@ -14,7 +14,7 @@ final class WordPressOrgRequestTests: XCTestCase {
         let url = try XCTUnwrap(request.asURLRequest().url)
 
         // Then
-        let expectedURL = "http://test.com/wp-json/test/request"
+        let expectedURL = "https://test.com/wp-json/test/request"
         assertEqual(url.absoluteString, expectedURL)
     }
 

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -6,6 +6,9 @@ import Yosemite
 
 /// Test cases for `AuthenticationManager`.
 final class AuthenticationManagerTests: XCTestCase {
+
+    let testSiteURL = "http://test.com"
+
     /// We do not allow automatic WPCOM account sign-up if the user entered an email that is not
     /// registered in WordPress.com. This configuration is set up in
     /// `WordPressAuthenticatorConfiguration` in `AuthenticationManager.initialize()`.
@@ -158,15 +161,14 @@ final class AuthenticationManagerTests: XCTestCase {
     func test_it_shows_error_upon_login_epilogue_if_the_self_hosted_site_does_not_have_jetpack() {
         // Given
         let manager = AuthenticationManager()
-        let testSite = "http://test.com"
-        let siteInfo = siteInfo(url: testSite,
+        let siteInfo = siteInfo(url: testSiteURL,
                                 exists: true,
                                 hasWordPress: true,
                                 isWordPressCom: false,
                                 hasJetpack: false,
                                 isJetpackActive: false,
                                 isJetpackConnected: false)
-        let wpcomCredentials = WordPressComCredentials(authToken: "abc", isJetpackLogin: false, multifactor: false, siteURL: testSite)
+        let wpcomCredentials = WordPressComCredentials(authToken: "abc", isJetpackLogin: false, multifactor: false, siteURL: testSiteURL)
         let credentials = AuthenticatorCredentials(wpcom: wpcomCredentials, wporg: nil)
         let navigationController = UINavigationController()
 
@@ -185,15 +187,14 @@ final class AuthenticationManagerTests: XCTestCase {
     func test_it_shows_account_mismatch_upon_login_epilogue_if_the_site_has_active_jetpack_but_not_connected() {
         // Given
         let manager = AuthenticationManager()
-        let testSite = "http://test.com"
-        let siteInfo = siteInfo(url: testSite,
+        let siteInfo = siteInfo(url: testSiteURL,
                                 exists: true,
                                 hasWordPress: true,
                                 isWordPressCom: false,
                                 hasJetpack: true,
                                 isJetpackActive: true,
                                 isJetpackConnected: false)
-        let wpcomCredentials = WordPressComCredentials(authToken: "abc", isJetpackLogin: false, multifactor: false, siteURL: testSite)
+        let wpcomCredentials = WordPressComCredentials(authToken: "abc", isJetpackLogin: false, multifactor: false, siteURL: testSiteURL)
         let credentials = AuthenticatorCredentials(wpcom: wpcomCredentials, wporg: nil)
         let navigationController = UINavigationController()
 
@@ -209,8 +210,7 @@ final class AuthenticationManagerTests: XCTestCase {
     func test_it_can_display_jetpack_error_for_org_site_credentials_sign_in() {
         // Given
         let manager = AuthenticationManager()
-        let testSite = "http://test.com"
-        let siteInfo = WordPressComSiteInfo(remote: ["isWordPress": true, "hasJetpack": false, "urlAfterRedirects": testSite])
+        let siteInfo = WordPressComSiteInfo(remote: ["isWordPress": true, "hasJetpack": false, "urlAfterRedirects": testSiteURL])
         let wporgCredentials = WordPressOrgCredentials(username: "cba", password: "password", xmlrpc: "http://test.com/xmlrpc.php", options: [:])
         let credentials = AuthenticatorCredentials(wpcom: nil, wporg: wporgCredentials)
         let navigationController = UINavigationController()
@@ -227,7 +227,6 @@ final class AuthenticationManagerTests: XCTestCase {
     func test_errorViewController_display_account_mismatch_screen_if_no_site_matches_the_given_self_hosted_site() {
         // Given
         let manager = AuthenticationManager()
-        let testSite = "http://test.com"
         let navigationController = UINavigationController()
         let storage = MockStorageManager()
         let matcher = ULAccountMatcher(storageManager: storage)
@@ -235,7 +234,7 @@ final class AuthenticationManagerTests: XCTestCase {
         let credentials = AuthenticatorCredentials(wpcom: nil, wporg: wporgCredentials)
 
         // When
-        let controller = manager.errorViewController(for: testSite, with: matcher, credentials: credentials, navigationController: navigationController) {}
+        let controller = manager.errorViewController(for: testSiteURL, with: matcher, credentials: credentials, navigationController: navigationController) {}
 
         // Then
         XCTAssertNotNil(controller)
@@ -245,13 +244,12 @@ final class AuthenticationManagerTests: XCTestCase {
     func test_errorViewController_returns_account_mismatch_if_no_site_matches_the_given_url() {
         // Given
         let manager = AuthenticationManager()
-        let testSite = "http://test.com"
         let navigationController = UINavigationController()
         let storage = MockStorageManager()
         let matcher = ULAccountMatcher(storageManager: storage)
 
         // When
-        let controller = manager.errorViewController(for: testSite, with: matcher, navigationController: navigationController) {}
+        let controller = manager.errorViewController(for: testSiteURL, with: matcher, navigationController: navigationController) {}
 
         // Then
         XCTAssertNotNil(controller)
@@ -263,7 +261,6 @@ final class AuthenticationManagerTests: XCTestCase {
         let manager = AuthenticationManager()
         let navigationController = UINavigationController()
 
-        let testSiteURL = "http://test.com"
         let testSite = Site.fake().copy(siteID: 1234, name: "Test", url: testSiteURL, isWooCommerceActive: false)
 
         let storage = MockStorageManager()
@@ -284,7 +281,6 @@ final class AuthenticationManagerTests: XCTestCase {
         let manager = AuthenticationManager()
         let navigationController = UINavigationController()
 
-        let testSiteURL = "http://test.com"
         let testSite = Site.fake().copy(siteID: 1234, name: "Test", url: testSiteURL, isWooCommerceActive: true)
 
         let storage = MockStorageManager()
@@ -303,7 +299,6 @@ final class AuthenticationManagerTests: XCTestCase {
         // Given
         let navigationController = UINavigationController()
 
-        let testSiteURL = "http://test.com"
         let testSite = Site.fake().copy(siteID: 1234, name: "Test", url: testSiteURL, isWooCommerceActive: false) // No Woo
 
         let storage = MockStorageManager()
@@ -326,7 +321,6 @@ final class AuthenticationManagerTests: XCTestCase {
         // Given
         let navigationController = UINavigationController()
 
-        let testSiteURL = "http://test.com"
         let testSite = Site.fake().copy(siteID: 1234, name: "Test", url: testSiteURL, isWooCommerceActive: true)
 
         let storage = MockStorageManager()

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -7,7 +7,7 @@ import Yosemite
 /// Test cases for `AuthenticationManager`.
 final class AuthenticationManagerTests: XCTestCase {
 
-    let testSiteURL = "http://test.com"
+    let testSiteURL = "https://test.com"
 
     /// We do not allow automatic WPCOM account sign-up if the user entered an email that is not
     /// registered in WordPress.com. This configuration is set up in

--- a/Yosemite/YosemiteTests/Stores/JetpackConnectionStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/JetpackConnectionStoreTests.swift
@@ -229,7 +229,6 @@ final class JetpackConnectionStoreTests: XCTestCase {
 
     func test_fetchJetpackUser_properly_relays_errors() {
         // Given
-        let siteURL = "http://test.com"
         let urlSuffix = "/jetpack/v4/connection/data"
         let error = NetworkError.unacceptableStatusCode(statusCode: 500)
         network.simulateError(requestUrlSuffix: urlSuffix, error: error)

--- a/Yosemite/YosemiteTests/Stores/JetpackConnectionStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/JetpackConnectionStoreTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class JetpackConnectionStoreTests: XCTestCase {
 
-    private let siteURL = "http://test.com"
+    private let siteURL = "https://test.com"
 
     /// Mock Dispatcher
     ///


### PR DESCRIPTION
### Description
I got a runtime warning when running the unit tests:

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/1218433/206275919-f517392e-5807-4e4a-83aa-0facd054ca9b.png">

### Testing instructions
If CI is green we're good. This can be further verified by running the unit tests locally and verifying there's no warning about `test.com`


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
