### PR TITLE
[Analytics Hub] Handle range selection granularity and interval

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -122,7 +122,7 @@ private extension AnalyticsHubViewModel {
                                                            unit: timeRangeSelectionType.granularity,
                                                            earliestDateToInclude: earliestDateToInclude,
                                                            latestDateToInclude: latestDateToInclude,
-                                                           quantity: timeRangeSelectionType.interval,
+                                                           quantity: timeRangeSelectionType.intervalSize,
                                                            forceRefresh: forceRefresh) { result in
                 continuation.resume(with: result)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -118,13 +118,11 @@ private extension AnalyticsHubViewModel {
                        latestDateToInclude: Date,
                        forceRefresh: Bool) async throws -> OrderStatsV4 {
         try await withCheckedThrowingContinuation { continuation in
-            let granularity = timeRangeSelectionType.granularity
-
             let action = StatsActionV4.retrieveCustomStats(siteID: siteID,
-                                                           unit: granularity,
+                                                           unit: timeRangeSelectionType.granularity,
                                                            earliestDateToInclude: earliestDateToInclude,
                                                            latestDateToInclude: latestDateToInclude,
-                                                           quantity: granularity.quantity,
+                                                           quantity: timeRangeSelectionType.interval,
                                                            forceRefresh: forceRefresh) { result in
                 continuation.resume(with: result)
             }
@@ -303,22 +301,5 @@ private extension AnalyticsHubViewModel {
 
         static let timeRangeGeneratorError = NSLocalizedString("Sorry, something went wrong. We can't load analytics for the selected date range.",
                                                                comment: "Error shown when there is a problem retrieving the dates for the selected date range.")
-    }
-}
-
-private extension StatsGranularityV4 {
-    var quantity: Int {
-        switch self {
-        case .hourly:
-            return 0
-        case .daily:
-            return 1
-        case .weekly:
-            return 2
-        case .monthly:
-            return 3
-        case .yearly:
-            return 4
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -118,15 +118,13 @@ private extension AnalyticsHubViewModel {
                        latestDateToInclude: Date,
                        forceRefresh: Bool) async throws -> OrderStatsV4 {
         try await withCheckedThrowingContinuation { continuation in
-            // TODO: get unit and quantity from the selected period
-            let unit: StatsGranularityV4 = .daily
-            let quantity = 31
+            let granularity = timeRangeSelectionType.granularity
 
             let action = StatsActionV4.retrieveCustomStats(siteID: siteID,
-                                                           unit: unit,
+                                                           unit: granularity,
                                                            earliestDateToInclude: earliestDateToInclude,
                                                            latestDateToInclude: latestDateToInclude,
-                                                           quantity: quantity,
+                                                           quantity: granularity.quantity,
                                                            forceRefresh: forceRefresh) { result in
                 continuation.resume(with: result)
             }
@@ -305,5 +303,22 @@ private extension AnalyticsHubViewModel {
 
         static let timeRangeGeneratorError = NSLocalizedString("Sorry, something went wrong. We can't load analytics for the selected date range.",
                                                                comment: "Error shown when there is a problem retrieving the dates for the selected date range.")
+    }
+}
+
+private extension StatsGranularityV4 {
+    var quantity: Int {
+        switch self {
+        case .hourly:
+            return 0
+        case .daily:
+            return 1
+        case .weekly:
+            return 2
+        case .monthly:
+            return 3
+        case .yearly:
+            return 4
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
@@ -116,6 +116,19 @@ extension AnalyticsHubTimeRangeSelection {
                 return .monthly
             }
         }
+        
+        var interval: Int {
+            switch self {
+            case .today, .yesterday:
+                return 24
+            case .weekToDate, .lastWeek:
+                return 7
+            case .monthToDate, .lastMonth, .quarterToDate, .lastQuarter:
+                return 31
+            case .yearToDate, .lastYear:
+                return 12
+            }
+        }
 
         init(_ statsTimeRange: StatsTimeRangeV4) {
             switch statsTimeRange {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
@@ -107,24 +107,28 @@ extension AnalyticsHubTimeRangeSelection {
         var granularity: StatsGranularityV4 {
             switch self {
             case .today, .yesterday:
-                return .daily
+                return .hourly
             case .weekToDate, .lastWeek:
+                return .daily
+            case .monthToDate, .lastMonth:
+                return .daily
+            case .quarterToDate, .lastQuarter:
                 return .weekly
-            case .monthToDate, .lastMonth, .quarterToDate, .lastQuarter:
-                return .monthly
             case .yearToDate, .lastYear:
                 return .monthly
             }
         }
-        
+
         var interval: Int {
             switch self {
             case .today, .yesterday:
                 return 24
             case .weekToDate, .lastWeek:
                 return 7
-            case .monthToDate, .lastMonth, .quarterToDate, .lastQuarter:
+            case .monthToDate, .lastMonth:
                 return 31
+            case .quarterToDate, .lastQuarter:
+                return 12
             case .yearToDate, .lastYear:
                 return 12
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
@@ -104,6 +104,19 @@ extension AnalyticsHubTimeRangeSelection {
             }
         }
 
+        var granularity: StatsGranularityV4 {
+            switch self {
+            case .today, .yesterday:
+                return .daily
+            case .weekToDate, .lastWeek:
+                return .weekly
+            case .monthToDate, .lastMonth, .quarterToDate, .lastQuarter:
+                return .monthly
+            case .yearToDate, .lastYear:
+                return .monthly
+            }
+        }
+
         init(_ statsTimeRange: StatsTimeRangeV4) {
             switch statsTimeRange {
             case .today:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
@@ -121,7 +121,7 @@ extension AnalyticsHubTimeRangeSelection {
             }
         }
 
-        /// The resopnse interval size that should be used to request stats from the given SelectedType
+        /// The response interval size that should be used to request stats from the given SelectedType
         /// in order to proper determine the stats charts and changes
         ///
         var intervalSize: Int {
@@ -133,7 +133,7 @@ extension AnalyticsHubTimeRangeSelection {
             case .monthToDate, .lastMonth:
                 return 31
             case .quarterToDate, .lastQuarter:
-                return 12
+                return 13
             case .yearToDate, .lastYear:
                 return 12
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
@@ -104,6 +104,8 @@ extension AnalyticsHubTimeRangeSelection {
             }
         }
 
+        /// The granularity that should be used to request stats from the given SelectedType
+        ///
         var granularity: StatsGranularityV4 {
             switch self {
             case .today, .yesterday:
@@ -119,7 +121,10 @@ extension AnalyticsHubTimeRangeSelection {
             }
         }
 
-        var interval: Int {
+        /// The resopnse interval size that should be used to request stats from the given SelectedType
+        /// in order to proper determine the stats charts and changes
+        ///
+        var intervalSize: Int {
             switch self {
             case .today, .yesterday:
                 return 24


### PR DESCRIPTION
Closes #8189

Why
==========
The stats request are currently using a fixed granularity of days with an interval size of `31`. For better request performance and a correct chart render, we need to use the correct granularity and interval based on the selected time range.

How
==========
Adds to the `SelectedType` two computed properties: `granularity` and `intervalSize`, grouping the response based on the time range nature like `days`, `weeks`, `months`, `quarters` and `years`.

How to Test
==========
1. Open the Analytics Hub
2. Do an overall test verifying if the stats reflect what is displayed in the Woo Core Analytics section and if the charts are correctly rendered based on the stats response numbers.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.