### PR TITLE
HACK week: Replace AlamofireNetwork with a new network using URLSession

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -709,6 +709,8 @@
 		DEC51AF92769A212009F3DF4 /* SystemStatus+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AF82769A212009F3DF4 /* SystemStatus+Settings.swift */; };
 		DEC51AFB2769C66B009F3DF4 /* SystemStatusMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AFA2769C66B009F3DF4 /* SystemStatusMapperTests.swift */; };
 		DEC51B02276AFB35009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */; };
+		DEE183F6293DB4E6008818AB /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE183F5293DB4E6008818AB /* HTTPMethod.swift */; };
+		DEE183F8293DD36A008818AB /* URLRequest+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE183F7293DD36A008818AB /* URLRequest+Woo.swift */; };
 		E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */; };
 		E137619929151C7400FD098F /* error-wp-rest-forbidden.json in Resources */ = {isa = PBXBuildFile; fileRef = E137619829151C7400FD098F /* error-wp-rest-forbidden.json */; };
 		E137619B2915222100FD098F /* WordPressApiValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E137619A2915222100FD098F /* WordPressApiValidatorTests.swift */; };
@@ -1466,6 +1468,8 @@
 		DEC51AF82769A212009F3DF4 /* SystemStatus+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemStatus+Settings.swift"; sourceTree = "<group>"; };
 		DEC51AFA2769C66B009F3DF4 /* SystemStatusMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusMapperTests.swift; sourceTree = "<group>"; };
 		DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemStatus+DropinMustUsePlugin.swift"; sourceTree = "<group>"; };
+		DEE183F5293DB4E6008818AB /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		DEE183F7293DD36A008818AB /* URLRequest+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Woo.swift"; sourceTree = "<group>"; };
 		E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationSuccess.swift; sourceTree = "<group>"; };
 		E137619829151C7400FD098F /* error-wp-rest-forbidden.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "error-wp-rest-forbidden.json"; sourceTree = "<group>"; };
 		E137619A2915222100FD098F /* WordPressApiValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressApiValidatorTests.swift; sourceTree = "<group>"; };
@@ -1805,6 +1809,7 @@
 		B557D9E5209753AA005962F4 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				DEE183F4293DB426008818AB /* Session */,
 				B5A0369F214C0F4C00774E2C /* Internal */,
 				B5BB1D0A20A204F400112D92 /* Extensions */,
 				B567AF2720A0FA0A00AB6C62 /* Mapper */,
@@ -2405,6 +2410,7 @@
 				02BDB83423EA98C800BCC63E /* String+HTML.swift */,
 				57E8FED2246616AC0057CD68 /* Result+Extensions.swift */,
 				265EFBDB285257950033BD33 /* Order+Fallbacks.swift */,
+				DEE183F7293DD36A008818AB /* URLRequest+Woo.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2561,6 +2567,14 @@
 				DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */,
 			);
 			path = SystemStatusDetails;
+			sourceTree = "<group>";
+		};
+		DEE183F4293DB426008818AB /* Session */ = {
+			isa = PBXGroup;
+			children = (
+				DEE183F5293DB4E6008818AB /* HTTPMethod.swift */,
+			);
+			path = Session;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -3038,6 +3052,7 @@
 				020D07BA23D8542000FD9580 /* UploadableMedia.swift in Sources */,
 				DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */,
 				31D27C8B26028D96002EDB1D /* SitePlugin.swift in Sources */,
+				DEE183F6293DB4E6008818AB /* HTTPMethod.swift in Sources */,
 				D89A01D426D3F8D9008195BE /* ReaderLocation.swift in Sources */,
 				74C8F06420EEB44800B6EDC9 /* OrderNote.swift in Sources */,
 				02C254AC2563781800A04423 /* ShippingLabelStatus.swift in Sources */,
@@ -3261,6 +3276,7 @@
 				74C8F06820EEB7BD00B6EDC9 /* OrderNotesMapper.swift in Sources */,
 				24F98C582502EA8800F49B68 /* FeatureFlagMapper.swift in Sources */,
 				451A9832260B9D2D0059D135 /* ShippingLabelPackagesMapper.swift in Sources */,
+				DEE183F8293DD36A008818AB /* URLRequest+Woo.swift in Sources */,
 				E1BAB2C32913FA6400C3982B /* ResponseDataValidator.swift in Sources */,
 				4501068F2399B19500E24722 /* TaxClassRemote.swift in Sources */,
 				B53EF5342180F646003E146F /* DotcomValidator.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -711,6 +711,8 @@
 		DEC51B02276AFB35009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */; };
 		DEE183F6293DB4E6008818AB /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE183F5293DB4E6008818AB /* HTTPMethod.swift */; };
 		DEE183F8293DD36A008818AB /* URLRequest+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE183F7293DD36A008818AB /* URLRequest+Woo.swift */; };
+		DEE183FA293F32DD008818AB /* URLSessionNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE183F9293F32DD008818AB /* URLSessionNetwork.swift */; };
+		DEE183FC293F6191008818AB /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE183FB293F6191008818AB /* SessionManager.swift */; };
 		E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */; };
 		E137619929151C7400FD098F /* error-wp-rest-forbidden.json in Resources */ = {isa = PBXBuildFile; fileRef = E137619829151C7400FD098F /* error-wp-rest-forbidden.json */; };
 		E137619B2915222100FD098F /* WordPressApiValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E137619A2915222100FD098F /* WordPressApiValidatorTests.swift */; };
@@ -1470,6 +1472,8 @@
 		DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemStatus+DropinMustUsePlugin.swift"; sourceTree = "<group>"; };
 		DEE183F5293DB4E6008818AB /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		DEE183F7293DD36A008818AB /* URLRequest+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Woo.swift"; sourceTree = "<group>"; };
+		DEE183F9293F32DD008818AB /* URLSessionNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionNetwork.swift; sourceTree = "<group>"; };
+		DEE183FB293F6191008818AB /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationSuccess.swift; sourceTree = "<group>"; };
 		E137619829151C7400FD098F /* error-wp-rest-forbidden.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "error-wp-rest-forbidden.json"; sourceTree = "<group>"; };
 		E137619A2915222100FD098F /* WordPressApiValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressApiValidatorTests.swift; sourceTree = "<group>"; };
@@ -1697,6 +1701,8 @@
 				B518662320A099BF00037A38 /* AlamofireNetwork.swift */,
 				B518662620A09BCC00037A38 /* MockNetwork.swift */,
 				D87F6150226591E10031A13B /* NullNetwork.swift */,
+				DEE183F9293F32DD008818AB /* URLSessionNetwork.swift */,
+				DEE183FB293F6191008818AB /* SessionManager.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -3103,6 +3109,7 @@
 				CE12FBD9221F3A6F00C59248 /* OrderStatus.swift in Sources */,
 				0359EA0F27AAC6410048DE2D /* WCPayPaymentMethodDetails.swift in Sources */,
 				7426CA1121AF30BD004E9FFC /* SiteAPIMapper.swift in Sources */,
+				DEE183FA293F32DD008818AB /* URLSessionNetwork.swift in Sources */,
 				57E8FED3246616AC0057CD68 /* Result+Extensions.swift in Sources */,
 				020D07BC23D856BF00FD9580 /* MediaRemote.swift in Sources */,
 				D823D91022377B4F00C90817 /* ShipmentTrackingProviderGroup.swift in Sources */,
@@ -3318,6 +3325,7 @@
 				DE34051928BDEE6A00CF0D97 /* JetpackConnectionURLMapper.swift in Sources */,
 				CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */,
 				077F39D426A58DE700ABEADC /* SystemStatusMapper.swift in Sources */,
+				DEE183FC293F6191008818AB /* SessionManager.swift in Sources */,
 				45152811257A81730076B03C /* ProductAttributeMapper.swift in Sources */,
 				B505F6D120BEE39600BB1B69 /* AccountRemote.swift in Sources */,
 				B567AF2B20A0FA4200AB6C62 /* OrderListMapper.swift in Sources */,

--- a/Networking/Networking/Extensions/URLRequest+Woo.swift
+++ b/Networking/Networking/Extensions/URLRequest+Woo.swift
@@ -1,16 +1,14 @@
 import Foundation
 
 extension URLRequest {
-    /// Creates an instance with the specified `method`, `urlString` and `headers`.
+    /// Creates an instance with the specified `method`, `url` and `headers`.
     ///
     /// - parameter url:     The URL.
     /// - parameter method:  The HTTP method.
     /// - parameter headers: The HTTP headers. `nil` by default.
     ///
     /// - returns: The new `URLRequest` instance.
-    init(url: URL, method: HTTPMethod, headers: [String: String]? = nil) throws {
-        let url = try url.asURL()
-
+    init(url: URL, method: HTTPMethod, headers: [String: String]? = nil) {
         self.init(url: url)
 
         httpMethod = method.rawValue

--- a/Networking/Networking/Extensions/URLRequest+Woo.swift
+++ b/Networking/Networking/Extensions/URLRequest+Woo.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+extension URLRequest {
+    /// Creates an instance with the specified `method`, `urlString` and `headers`.
+    ///
+    /// - parameter url:     The URL.
+    /// - parameter method:  The HTTP method.
+    /// - parameter headers: The HTTP headers. `nil` by default.
+    ///
+    /// - returns: The new `URLRequest` instance.
+    init(url: URL, method: HTTPMethod, headers: [String: String]? = nil) throws {
+        let url = try url.asURL()
+
+        self.init(url: url)
+
+        httpMethod = method.rawValue
+
+        if let headers = headers {
+            for (headerField, headerValue) in headers {
+                setValue(headerValue, forHTTPHeaderField: headerField)
+            }
+        }
+    }
+}

--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -44,9 +44,8 @@ public class AlamofireNetwork: Network {
     ///       the upper layers can properly detect "Jetpack Tunnel" Errors.
     ///     - Yes. We do the above because the Jetpack Tunnel endpoint doesn't properly relay the correct statusCode.
     ///
-    public func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) {
+    public func responseData(for request: Request, completion: @escaping (Data?, Error?) -> Void) {
         let request = createRequest(wrapping: request)
-
         Alamofire.request(request)
             .responseData { response in
                 completion(response.value, response.networkingError)
@@ -62,9 +61,8 @@ public class AlamofireNetwork: Network {
     ///     - request: Request that should be performed.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func responseData(for request: URLRequestConvertible, completion: @escaping (Swift.Result<Data, Error>) -> Void) {
+    public func responseData(for request: Request, completion: @escaping (Swift.Result<Data, Error>) -> Void) {
         let request = createRequest(wrapping: request)
-
         Alamofire.request(request).responseData { response in
             completion(response.result.toSwiftResult())
         }
@@ -78,9 +76,8 @@ public class AlamofireNetwork: Network {
     ///
     /// - Parameter request: Request that should be performed.
     /// - Returns: A publisher that emits the result of the given request.
-    public func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Swift.Result<Data, Error>, Never> {
+    public func responseDataPublisher(for request: Request) -> AnyPublisher<Swift.Result<Data, Error>, Never> {
         let request = createRequest(wrapping: request)
-
         return Future() { promise in
             Alamofire.request(request).responseData { response in
                 let result = response.result.toSwiftResult()
@@ -90,10 +87,9 @@ public class AlamofireNetwork: Network {
     }
 
     public func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void,
-                                        to request: URLRequestConvertible,
+                                        to request: Request,
                                         completion: @escaping (Data?, Error?) -> Void) {
         let request = createRequest(wrapping: request)
-
         backgroundSessionManager.upload(multipartFormData: multipartFormData, with: request) { (encodingResult) in
             switch encodingResult {
             case .success(let upload, _, _):
@@ -108,12 +104,11 @@ public class AlamofireNetwork: Network {
 }
 
 private extension AlamofireNetwork {
-    func createRequest(wrapping request: URLRequestConvertible) -> URLRequestConvertible {
+    func createRequest(wrapping request: Request) -> Request {
         credentials.map { AuthenticatedRequest(credentials: $0, request: request) } ??
         UnauthenticatedRequest(request: request)
     }
 }
-
 
 // MARK: - Alamofire.DataResponse: Helper Methods
 //

--- a/Networking/Networking/Network/MockNetwork.swift
+++ b/Networking/Networking/Network/MockNetwork.swift
@@ -25,12 +25,12 @@ class MockNetwork: Network {
 
     /// Keeps a collection of all of the `responseData` requests.
     ///
-    var requestsForResponseData = [URLRequestConvertible]()
+    var requestsForResponseData = [Request]()
 
     /// Note: If the useResponseQueue param is `true`, any responses added via `simulateResponse` will stored in a FIFO queue
     /// and used once for a matching request (then removed from the queue). Subsequent requests will use the next response in the queue, and so on.
     ///
-    /// If the useResponseQueue param is `false`, any responses added via `simulateResponse` will stored in an array and can
+    /// If the kuseResponseQueue param is `false`, any responses added via `simulateResponse` will stored in an array and can
     /// be reused multiple times.
     ///
     /// - Parameter useResponseQueue: Use the response queue. Default is `false`.
@@ -44,7 +44,7 @@ class MockNetwork: Network {
     /// Whenever the Request's URL matches any of the "Mocked Up Patterns", we'll return the specified response file, loaded as *Data*.
     /// Otherwise, an error will be relayed back (.notFound!).
     ///
-    func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) {
+    func responseData(for request: Request, completion: @escaping (Data?, Error?) -> Void) {
         responseData(for: request) { result in
             switch result {
             case .success(let data):
@@ -58,7 +58,7 @@ class MockNetwork: Network {
     /// Whenever the Request's URL matches any of the "Mocked Up Patterns", we'll return the
     /// specified response file, loaded as *Data*. Otherwise, an error will be relayed back (.notFound!).
     ///
-    func responseData(for request: URLRequestConvertible, completion: @escaping (Swift.Result<Data, Error>) -> Void) {
+    func responseData(for request: Request, completion: @escaping (Swift.Result<Data, Error>) -> Void) {
         requestsForResponseData.append(request)
 
         if let error = error(for: request) {
@@ -74,7 +74,7 @@ class MockNetwork: Network {
         completion(.success(data))
     }
 
-    func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Swift.Result<Data, Error>, Never> {
+    func responseDataPublisher(for request: Request) -> AnyPublisher<Swift.Result<Data, Error>, Never> {
         requestsForResponseData.append(request)
 
         if let error = error(for: request) {
@@ -89,7 +89,7 @@ class MockNetwork: Network {
     }
 
     func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void,
-                                 to request: URLRequestConvertible,
+                                 to request: Request,
                                  completion: @escaping (Data?, Error?) -> Void) {
         responseData(for: request, completion: completion)
     }
@@ -150,7 +150,7 @@ private extension MockNetwork {
     ///   * the FIFO response queue (where the response is removed from the queue when this func returns)
     ///   * the responseMap (array)
     ///
-    func filename(for request: URLRequestConvertible) -> String? {
+    func filename(for request: Request) -> String? {
         let searchPath = path(for: request)
         if useResponseQueue {
             if let keyAndQueue = responseQueue.first(where: { searchPath.hasSuffix($0.key) }) {
@@ -170,7 +170,7 @@ private extension MockNetwork {
 
     /// Returns the Mock Error for a given URLRequestConvertible.
     ///
-    private func error(for request: URLRequestConvertible) -> Error? {
+    private func error(for request: Request) -> Error? {
         let searchPath = path(for: request)
         for (pattern, error) in errorMap where searchPath.hasSuffix(pattern) {
             return error
@@ -181,7 +181,7 @@ private extension MockNetwork {
 
     /// Returns the "Request Path" for a given URLRequestConvertible instance.
     ///
-    private func path(for request: URLRequestConvertible) -> String {
+    private func path(for request: Request) -> String {
         switch request {
         case let request as AuthenticatedRequest:
             return path(for: request.request)

--- a/Networking/Networking/Network/MockNetwork.swift
+++ b/Networking/Networking/Network/MockNetwork.swift
@@ -1,7 +1,5 @@
 import Combine
 import Foundation
-import Alamofire
-
 
 /// Network Mock: Allows us to simulate HTTP Responses.
 ///

--- a/Networking/Networking/Network/Network.swift
+++ b/Networking/Networking/Network/Network.swift
@@ -1,6 +1,5 @@
 import Combine
 import Foundation
-import Alamofire
 
 /// Constructs `multipart/form-data` for uploads within an HTTP or HTTPS body.
 ///
@@ -27,7 +26,7 @@ public protocol Network {
     ///     - request: Request that should be performed.
     ///     - completion: Closure to be executed upon completion.
     ///
-    func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void)
+    func responseData(for request: Request, completion: @escaping (Data?, Error?) -> Void)
 
     /// Executes the specified Network Request. Upon completion, the payload will be sent back to
     /// the caller as a Data instance.
@@ -36,7 +35,7 @@ public protocol Network {
     ///     - request: Request that should be performed.
     ///     - completion: Closure to be executed upon completion.
     ///
-    func responseData(for request: URLRequestConvertible,
+    func responseData(for request: Request,
                       completion: @escaping (Swift.Result<Data, Error>) -> Void)
 
     /// Executes the specified Network Request. Upon completion, the payload or error will be emitted to the publisher.
@@ -45,7 +44,7 @@ public protocol Network {
     ///     - request: Request that should be performed.
     ///
     /// - Returns: A publisher that emits the result of the given request.
-    func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Swift.Result<Data, Error>, Never>
+    func responseDataPublisher(for request: Request) -> AnyPublisher<Swift.Result<Data, Error>, Never>
 
     /// Executes the specified Network Request for file uploads. Upon completion, the payload will be sent back to the caller as a Data instance.
     ///
@@ -54,6 +53,6 @@ public protocol Network {
     ///   - request: Request that should be performed.
     ///   - completion: Closure to be executed upon completion.
     func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void,
-                                 to request: URLRequestConvertible,
+                                 to request: Request,
                                  completion: @escaping (Data?, Error?) -> Void)
 }

--- a/Networking/Networking/Network/NetworkError.swift
+++ b/Networking/Networking/Network/NetworkError.swift
@@ -16,6 +16,8 @@ public enum NetworkError: Error, Equatable {
     /// Any statusCode that's not in the [200, 300) range!
     ///
     case unacceptableStatusCode(statusCode: Int)
+
+    case invalidRequest
 }
 
 

--- a/Networking/Networking/Network/NullNetwork.swift
+++ b/Networking/Networking/Network/NullNetwork.swift
@@ -1,6 +1,5 @@
 import Combine
 import Foundation
-import Alamofire
 
 /// Implementation of the `Network` protocol, following the
 /// [Null object pattern](https://en.wikipedia.org/wiki/Null_object_pattern)
@@ -12,18 +11,18 @@ public final class NullNetwork: Network {
 
     public init() { }
 
-    public func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) { }
+    public func responseData(for request: Request, completion: @escaping (Data?, Error?) -> Void) { }
 
-    public func responseData(for request: URLRequestConvertible,
+    public func responseData(for request: Request,
                              completion: @escaping (Swift.Result<Data, Error>) -> Void) {
 
     }
 
-    public func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Swift.Result<Data, Error>, Never> {
+    public func responseDataPublisher(for request: Request) -> AnyPublisher<Swift.Result<Data, Error>, Never> {
         Empty<Swift.Result<Data, Error>, Never>().eraseToAnyPublisher()
     }
 
     public func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void,
-                                        to request: URLRequestConvertible,
+                                        to request: Request,
                                         completion: @escaping (Data?, Error?) -> Void) { }
 }

--- a/Networking/Networking/Network/SessionManager.swift
+++ b/Networking/Networking/Network/SessionManager.swift
@@ -46,7 +46,6 @@ final class SessionManager {
     /// - parameter urlRequest: The URL request.
     ///
     /// - returns: The created `DataRequest`.
-    @discardableResult
     func request(_ urlRequest: Request) async throws -> Data {
         guard let originalRequest = urlRequest.urlRequest else {
             throw NetworkError.invalidRequest

--- a/Networking/Networking/Network/SessionManager.swift
+++ b/Networking/Networking/Network/SessionManager.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Manages network requests with a native URLSession.
+///
+final class SessionManager {
+    /// The underlying session.
+    let session: URLSession
+
+    /// A default instance of `SessionManager`, used by top-level Alamofire request methods, and suitable for use
+    /// directly for any ad hoc requests.
+    static let `default`: SessionManager = {
+        let configuration = URLSessionConfiguration.default
+        configuration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders
+
+        return SessionManager(configuration: configuration)
+    }()
+
+    /// Creates default values for the "Accept-Encoding", "Accept-Language" and "User-Agent" headers.
+    static let defaultHTTPHeaders: [String: String] = {
+        // Accept-Encoding HTTP Header; see https://tools.ietf.org/html/rfc7230#section-4.2.3
+        let acceptEncoding: String = "gzip;q=1.0, compress;q=0.5"
+
+        // Accept-Language HTTP Header; see https://tools.ietf.org/html/rfc7231#section-5.3.5
+        let acceptLanguage = Locale.preferredLanguages.prefix(6).enumerated().map { index, languageCode in
+            let quality = 1.0 - (Double(index) * 0.1)
+            return "\(languageCode);q=\(quality)"
+        }.joined(separator: ", ")
+
+        return [
+            "Accept-Encoding": acceptEncoding,
+            "Accept-Language": acceptLanguage,
+            "User-Agent": UserAgent.defaultUserAgent
+        ]
+    }()
+
+    init(configuration: URLSessionConfiguration = URLSessionConfiguration.default) {
+        self.session = URLSession(configuration: configuration, delegate: nil, delegateQueue: nil)
+    }
+
+    deinit {
+        session.invalidateAndCancel()
+    }
+
+    /// Creates a `DataRequest` to retrieve the contents of a URL based on the specified `urlRequest`.
+    ///
+    /// - parameter urlRequest: The URL request.
+    ///
+    /// - returns: The created `DataRequest`.
+    @discardableResult
+    func request(_ urlRequest: Request) async throws -> Data {
+        guard let originalRequest = urlRequest.urlRequest else {
+            throw NetworkError.invalidRequest
+        }
+        let (data, _) = try await session.data(for: originalRequest)
+        return data
+    }
+}

--- a/Networking/Networking/Network/URLSessionNetwork.swift
+++ b/Networking/Networking/Network/URLSessionNetwork.swift
@@ -65,7 +65,10 @@ public final class URLSessionNetwork: Network {
         }.eraseToAnyPublisher()
     }
 
-    public func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void, to request: Request, completion: @escaping (Data?, Error?) -> Void) {
+    public func uploadMultipartFormData(
+        multipartFormData: @escaping (MultipartFormData) -> Void,
+        to request: Request,
+        completion: @escaping (Data?, Error?) -> Void) {
         // TODO
     }
 }

--- a/Networking/Networking/Network/URLSessionNetwork.swift
+++ b/Networking/Networking/Network/URLSessionNetwork.swift
@@ -1,0 +1,78 @@
+import Combine
+import Foundation
+
+/// A network to handle requests using a native session manager.
+///
+public final class URLSessionNetwork: Network {
+    /// WordPress.com Credentials.
+    ///
+    private let credentials: Credentials?
+    private let sessionManager: SessionManager = .default
+
+    public var session: URLSession { sessionManager.session }
+
+    public required init(credentials: Credentials?) {
+        self.credentials = credentials
+    }
+
+    public func responseData(for request: Request, completion: @escaping (Data?, Error?) -> Void) {
+        let request = createRequest(wrapping: request)
+        Task {
+            do {
+                let data = try await sessionManager.request(request)
+                await MainActor.run {
+                    completion(data, nil)
+                }
+            } catch {
+                await MainActor.run {
+                    completion(nil, error)
+                }
+            }
+        }
+    }
+
+    public func responseData(for request: Request, completion: @escaping (Result<Data, Error>) -> Void) {
+        let request = createRequest(wrapping: request)
+        Task {
+            do {
+                let data = try await sessionManager.request(request)
+                await MainActor.run {
+                    completion(.success(data))
+                }
+            } catch {
+                await MainActor.run {
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+
+    public func responseDataPublisher(for request: Request) -> AnyPublisher<Result<Data, Error>, Never> {
+        let request = createRequest(wrapping: request)
+        return Future() { promise in
+            Task {
+                do {
+                    let data = try await self.sessionManager.request(request)
+                    await MainActor.run {
+                        promise(Result.success(.success(data)))
+                    }
+                } catch {
+                    await MainActor.run {
+                        promise(Result.success(.failure(error)))
+                    }
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+
+    public func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void, to request: Request, completion: @escaping (Data?, Error?) -> Void) {
+        // TODO
+    }
+}
+
+private extension URLSessionNetwork {
+    func createRequest(wrapping request: Request) -> Request {
+        credentials.map { AuthenticatedRequest(credentials: $0, request: request) } ??
+        UnauthenticatedRequest(request: request)
+    }
+}

--- a/Networking/Networking/Network/WordPressOrgNetwork.swift
+++ b/Networking/Networking/Network/WordPressOrgNetwork.swift
@@ -32,7 +32,7 @@ public final class WordPressOrgNetwork: Network {
         self.userAgent = userAgent
     }
 
-    public func responseData(for request: URLRequestConvertible) async throws -> Data? {
+    public func responseData(for request: Request) async throws -> Data? {
         return try await withCheckedThrowingContinuation { [weak self] continuation in
             guard let self = self else { return }
 
@@ -60,7 +60,7 @@ public final class WordPressOrgNetwork: Network {
     ///     - request: Request that should be performed.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) {
+    public func responseData(for request: Request, completion: @escaping (Data?, Error?) -> Void) {
         sessionManager.request(request)
             .validate()
             .responseData { response in
@@ -77,7 +77,7 @@ public final class WordPressOrgNetwork: Network {
     ///     - request: Request that should be performed.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func responseData(for request: URLRequestConvertible, completion: @escaping (Swift.Result<Data, Error>) -> Void) {
+    public func responseData(for request: Request, completion: @escaping (Swift.Result<Data, Error>) -> Void) {
         sessionManager.request(request)
             .validate()
             .responseData { response in
@@ -93,7 +93,7 @@ public final class WordPressOrgNetwork: Network {
     ///
     /// - Parameter request: Request that should be performed.
     /// - Returns: A publisher that emits the result of the given request.
-    public func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Swift.Result<Data, Error>, Never> {
+    public func responseDataPublisher(for request: Request) -> AnyPublisher<Swift.Result<Data, Error>, Never> {
         return Future() { [weak self] promise in
             guard let self = self else { return }
             self.sessionManager.request(request).validate().responseData { response in
@@ -104,7 +104,7 @@ public final class WordPressOrgNetwork: Network {
     }
 
     public func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void,
-                                        to request: URLRequestConvertible,
+                                        to request: Request,
                                         completion: @escaping (Data?, Error?) -> Void) {
         backgroundSessionManager.upload(multipartFormData: multipartFormData, with: request) { (encodingResult) in
             switch encodingResult {

--- a/Networking/Networking/Remote/InAppPurchasesRemote.swift
+++ b/Networking/Networking/Remote/InAppPurchasesRemote.swift
@@ -1,4 +1,3 @@
-import Alamofire
 import Foundation
 
 /// In-app Purchases Endpoints

--- a/Networking/Networking/Remote/JetpackConnectionRemote.swift
+++ b/Networking/Networking/Remote/JetpackConnectionRemote.swift
@@ -63,7 +63,7 @@ public final class JetpackConnectionRemote: Remote {
 
         let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
         do {
-            let request = try URLRequest(url: url, method: .get)
+            let request = try URLRequest(url: url, method: Networking.HTTPMethod.get)
             let task = session.dataTask(with: request) { [weak self] data, response, error in
                 if let result = self?.accountConnectionURL {
                     DispatchQueue.main.async {

--- a/Networking/Networking/Remote/JetpackConnectionRemote.swift
+++ b/Networking/Networking/Remote/JetpackConnectionRemote.swift
@@ -62,27 +62,23 @@ public final class JetpackConnectionRemote: Remote {
         }
 
         let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
-        do {
-            let request = try URLRequest(url: url, method: Networking.HTTPMethod.get)
-            let task = session.dataTask(with: request) { [weak self] data, response, error in
-                if let result = self?.accountConnectionURL {
-                    DispatchQueue.main.async {
-                        completion(.success(result))
-                    }
-                    return
-                }
-                // We don't expect any response here since we'll cancel the task as soon as a redirect request is received.
-                // So always complete with a failure here.
-                let returnedError = error ?? ConnectionError.accountConnectionURLNotFound
+        let request = URLRequest(url: url, method: Networking.HTTPMethod.get)
+        let task = session.dataTask(with: request) { [weak self] data, response, error in
+            if let result = self?.accountConnectionURL {
                 DispatchQueue.main.async {
-                    completion(.failure(returnedError))
+                    completion(.success(result))
                 }
                 return
             }
-            task.resume()
-        } catch {
-            completion(.failure(error))
+            // We don't expect any response here since we'll cancel the task as soon as a redirect request is received.
+            // So always complete with a failure here.
+            let returnedError = error ?? ConnectionError.accountConnectionURLNotFound
+            DispatchQueue.main.async {
+                completion(.failure(returnedError))
+            }
+            return
         }
+        task.resume()
     }
 
     /// Fetches the user connection state with the site's Jetpack.

--- a/Networking/Networking/Requests/AuthenticatedRequest.swift
+++ b/Networking/Networking/Requests/AuthenticatedRequest.swift
@@ -4,7 +4,7 @@ import Alamofire
 
 /// Wraps up a URLRequestConvertible Instance, and injects the Credentials + `Settings.userAgent` whenever the actual Request is required.
 ///
-struct AuthenticatedRequest: URLRequestConvertible {
+struct AuthenticatedRequest: Request {
 
     /// WordPress.com Credentials.
     ///
@@ -12,7 +12,7 @@ struct AuthenticatedRequest: URLRequestConvertible {
 
     /// Request that should be authenticated.
     ///
-    let request: URLRequestConvertible
+    let request: Request
 
 
     /// Returns the Wrapped Request, but with a WordPress.com Bearer Token set up.

--- a/Networking/Networking/Requests/AuthenticatedRequest.swift
+++ b/Networking/Networking/Requests/AuthenticatedRequest.swift
@@ -1,8 +1,6 @@
 import Foundation
-import Alamofire
 
-
-/// Wraps up a URLRequestConvertible Instance, and injects the Credentials + `Settings.userAgent` whenever the actual Request is required.
+/// Wraps up a Request Instance, and injects the Credentials + `Settings.userAgent` whenever the actual Request is required.
 ///
 struct AuthenticatedRequest: Request {
 

--- a/Networking/Networking/Requests/DotcomRequest.swift
+++ b/Networking/Networking/Requests/DotcomRequest.swift
@@ -44,7 +44,7 @@ struct DotcomRequest: Request {
     ///
     func asURLRequest() throws -> URLRequest {
         let dotcomURL = URL(string: Settings.wordpressApiBaseURL + wordpressApiVersion.path + path)!
-        let dotcomRequest = try URLRequest(url: dotcomURL, method: method, headers: headers)
+        let dotcomRequest = URLRequest(url: dotcomURL, method: method, headers: headers)
 
         return try URLEncoding().encode(dotcomRequest, with: parameters)
     }

--- a/Networking/Networking/Requests/DotcomRequest.swift
+++ b/Networking/Networking/Requests/DotcomRequest.swift
@@ -1,6 +1,4 @@
 import Foundation
-import Alamofire
-
 
 /// Represents a WordPress.com Request
 ///
@@ -48,7 +46,7 @@ struct DotcomRequest: Request {
         let dotcomURL = URL(string: Settings.wordpressApiBaseURL + wordpressApiVersion.path + path)!
         let dotcomRequest = try URLRequest(url: dotcomURL, method: method, headers: headers)
 
-        return try URLEncoding.default.encode(dotcomRequest, with: parameters)
+        return try URLEncoding().encode(dotcomRequest, with: parameters)
     }
 
     func responseDataValidator() -> ResponseDataValidator {

--- a/Networking/Networking/Requests/JetpackRequest.swift
+++ b/Networking/Networking/Requests/JetpackRequest.swift
@@ -1,6 +1,4 @@
 import Foundation
-import Alamofire
-
 
 /// Represents a Jetpack-Tunneled WordPress.com Endpoint
 ///
@@ -63,7 +61,7 @@ struct JetpackRequest: Request {
         let dotcomEndpoint = DotcomRequest(wordpressApiVersion: JetpackRequest.wordpressApiVersion, method: dotcomMethod, path: dotcomPath)
         let dotcomRequest = try dotcomEndpoint.asURLRequest()
 
-        return try dotcomEncoder.encode(dotcomRequest, with: dotcomParams)
+        return try URLEncoding().encode(dotcomRequest, with: dotcomParams)
     }
 
     func responseDataValidator() -> ResponseDataValidator {
@@ -80,12 +78,6 @@ private extension JetpackRequest {
     ///
     var dotcomPath: String {
         return "jetpack-blogs/" + String(siteID) + "/rest-api/"
-    }
-
-    /// Returns the WordPress.com Parameters Encoder
-    ///
-    var dotcomEncoder: ParameterEncoding {
-        return dotcomMethod == .get ? URLEncoding.queryString : URLEncoding.httpBody
     }
 
     /// Returns the WordPress.com HTTP Method

--- a/Networking/Networking/Requests/Request.swift
+++ b/Networking/Networking/Requests/Request.swift
@@ -14,6 +14,10 @@ public protocol Request: URLRequestConvertible {
     func responseDataValidator() -> ResponseDataValidator
 }
 
+/// Makes URLRequest conform to Request
+///
+extension URLRequest: Request {}
+
 /// Default implementation
 ///
 extension Request {

--- a/Networking/Networking/Requests/Request.swift
+++ b/Networking/Networking/Requests/Request.swift
@@ -1,6 +1,7 @@
+import Foundation
 import Alamofire
 
-protocol Request: URLRequestConvertible {
+public protocol Request: URLRequestConvertible {
     /// Returns a URL request or throws if an `Error` was encountered.
     ///
     /// - throws: An `Error` if the underlying `URLRequest` is `nil`.
@@ -11,4 +12,22 @@ protocol Request: URLRequestConvertible {
     /// Returns a closure that tries to parse a response looking for an error
     ///
     func responseDataValidator() -> ResponseDataValidator
+}
+
+/// Default implementation
+///
+extension Request {
+    public func responseDataValidator() -> ResponseDataValidator {
+        DummyValidator()
+    }
+}
+
+/// WordPress.com Response Validator
+///
+struct DummyValidator: ResponseDataValidator {
+    /// A dummy validator to bypass requirement for data validator in `Request` types by default
+    ///
+    func validate(data: Data) throws {
+        // no-op
+    }
 }

--- a/Networking/Networking/Requests/UnauthenticatedRequest.swift
+++ b/Networking/Networking/Requests/UnauthenticatedRequest.swift
@@ -4,11 +4,11 @@ import protocol Alamofire.URLRequestConvertible
 
 /// Wraps up a `URLRequestConvertible` instance, and injects the `UserAgent.defaultUserAgent`.
 ///
-struct UnauthenticatedRequest: URLRequestConvertible {
+struct UnauthenticatedRequest: Request {
 
     /// Request that does not require WPCOM authentication.
     ///
-    let request: URLRequestConvertible
+    let request: Request
 
     /// Returns the wrapped request, with a custom user-agent header.
     ///

--- a/Networking/Networking/Requests/WordPressOrgRequest.swift
+++ b/Networking/Networking/Requests/WordPressOrgRequest.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 /// Represents a WordPress.org REST API Endpoint
 ///
@@ -28,7 +27,7 @@ struct WordPressOrgRequest: Request {
         let url = URL(string: baseURL + Settings.basePath + path.removingPrefix("/"))!
         let request = try URLRequest(url: url, method: method, headers: nil)
 
-        return try URLEncoding.default.encode(request, with: parameters)
+        return try URLEncoding().encode(request, with: parameters)
     }
 
     func responseDataValidator() -> ResponseDataValidator {

--- a/Networking/Networking/Requests/WordPressOrgRequest.swift
+++ b/Networking/Networking/Requests/WordPressOrgRequest.swift
@@ -25,7 +25,7 @@ struct WordPressOrgRequest: Request {
     ///
     func asURLRequest() throws -> URLRequest {
         let url = URL(string: baseURL + Settings.basePath + path.removingPrefix("/"))!
-        let request = try URLRequest(url: url, method: method, headers: nil)
+        let request = URLRequest(url: url, method: method, headers: nil)
 
         return try URLEncoding().encode(request, with: parameters)
     }

--- a/Networking/Networking/Session/HTTPMethod.swift
+++ b/Networking/Networking/Session/HTTPMethod.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+/// HTTP method definitions.
+enum HTTPMethod: String {
+    case options = "OPTIONS"
+    case get     = "GET"
+    case head    = "HEAD"
+    case post    = "POST"
+    case put     = "PUT"
+    case patch   = "PATCH"
+    case delete  = "DELETE"
+    case trace   = "TRACE"
+    case connect = "CONNECT"
+}
+
+enum URLEncodingError: Error {
+    case missingURL
+}
+
+/// Creates a url-encoded query string to be set as or appended to any existing URL query string or set as the HTTP
+/// body of the URL request. Whether the query string is set or appended to any existing URL query string or set as
+/// the HTTP body depends on the HTTP request method.
+public struct URLEncoding {
+    /// Makes initializer public
+    public init() {
+        // no-op
+    }
+
+    /// Creates a URL request by encoding parameters and applying them onto an existing request.
+    ///
+    /// - parameter urlRequest: The request to have parameters applied.
+    /// - parameter parameters: The parameters to apply.
+    ///
+    /// - throws: An `Error` if the encoding process encounters an error.
+    ///
+    /// - returns: The encoded request.
+    public func encode(_ urlRequest: Request, with parameters: [String: Any]?) throws -> URLRequest {
+        var urlRequest = try urlRequest.asURLRequest()
+
+        guard let parameters = parameters else { return urlRequest }
+
+        if let method = HTTPMethod(rawValue: urlRequest.httpMethod ?? "GET"), encodesParametersInURL(with: method) {
+            guard let url = urlRequest.url else {
+                throw URLEncodingError.missingURL
+            }
+
+            if var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false), !parameters.isEmpty {
+                let percentEncodedQuery = (urlComponents.percentEncodedQuery.map { $0 + "&" } ?? "") + query(parameters)
+                urlComponents.percentEncodedQuery = percentEncodedQuery
+                urlRequest.url = urlComponents.url
+            }
+        } else {
+            if urlRequest.value(forHTTPHeaderField: "Content-Type") == nil {
+                urlRequest.setValue("application/x-www-form-urlencoded; charset=utf-8", forHTTPHeaderField: "Content-Type")
+            }
+
+            urlRequest.httpBody = query(parameters).data(using: .utf8, allowLossyConversion: false)
+        }
+
+        return urlRequest
+    }
+}
+
+private extension URLEncoding {
+    func encodesParametersInURL(with method: HTTPMethod) -> Bool {
+        switch method {
+        case .get, .head, .delete:
+            return true
+        default:
+            return false
+        }
+    }
+
+    func query(_ parameters: [String: Any]) -> String {
+        var components: [(String, String)] = []
+
+        for key in parameters.keys.sorted(by: <) {
+            let value = parameters[key]!
+            components += queryComponents(fromKey: key, value: value)
+        }
+        return components.map { "\($0)=\($1)" }.joined(separator: "&")
+    }
+
+    /// Creates percent-escaped, URL encoded query string components from the given key-value pair using recursion.
+    ///
+    /// - parameter key:   The key of the query component.
+    /// - parameter value: The value of the query component.
+    ///
+    /// - returns: The percent-escaped, URL encoded query string components.
+    func queryComponents(fromKey key: String, value: Any) -> [(String, String)] {
+        var components: [(String, String)] = []
+
+        if let dictionary = value as? [String: Any] {
+            for (nestedKey, value) in dictionary {
+                components += queryComponents(fromKey: "\(key)[\(nestedKey)]", value: value)
+            }
+        } else if let array = value as? [Any] {
+            for value in array {
+                components += queryComponents(fromKey: "\(key)[]", value: value)
+            }
+        } else if let value = value as? NSNumber {
+            if CFBooleanGetTypeID() == CFGetTypeID(value) {
+                components.append((escape(key), escape(value.boolValue ? "1" : "0")))
+            } else {
+                components.append((escape(key), escape("\(value)")))
+            }
+        } else if let bool = value as? Bool {
+            components.append((escape(key), escape(bool ? "1" : "0")))
+        } else {
+            components.append((escape(key), escape("\(value)")))
+        }
+
+        return components
+    }
+
+    func escape(_ string: String) -> String {
+        let generalDelimitersToEncode = ":#[]@" // does not include "?" or "/" due to RFC 3986 - Section 3.4
+        let subDelimitersToEncode = "!$&'()*+,;="
+
+        var allowedCharacterSet = CharacterSet.urlQueryAllowed
+        allowedCharacterSet.remove(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
+
+        let escaped = string.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) ?? string
+        return escaped
+    }
+}

--- a/Networking/Networking/Validators/ResponseDataValidator.swift
+++ b/Networking/Networking/Validators/ResponseDataValidator.swift
@@ -1,4 +1,4 @@
-protocol ResponseDataValidator {
+public protocol ResponseDataValidator {
     /// Throws an error contained in a given Data Instance (if any).
     ///
     func validate(data: Data) throws -> Void

--- a/Networking/NetworkingTests/Requests/AuthenticatedRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/AuthenticatedRequestTests.swift
@@ -2,9 +2,6 @@ import Foundation
 import XCTest
 @testable import Networking
 
-
-extension URLRequest: Request {}
-
 /// AuthenticatedRequest Unit Tests
 ///
 class AuthenticatedRequestTests: XCTestCase {

--- a/Networking/NetworkingTests/Requests/AuthenticatedRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/AuthenticatedRequestTests.swift
@@ -3,6 +3,8 @@ import XCTest
 @testable import Networking
 
 
+extension URLRequest: Request {}
+
 /// AuthenticatedRequest Unit Tests
 ///
 class AuthenticatedRequestTests: XCTestCase {

--- a/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
+++ b/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
@@ -1,9 +1,9 @@
-import Alamofire
 import Foundation
 import WebKit
 import struct WordPressAuthenticator.WordPressOrgCredentials
 import struct Yosemite.Credentials
 import class Networking.UserAgent
+import struct Networking.URLEncoding
 
 /// An extension to authenticate WPCom automatically
 ///
@@ -24,7 +24,7 @@ extension WKWebView {
                           "pwd": credentials.password,
                           "redirect_to": redirectLink ?? ""]
 
-        return try URLEncoding.default.encode(request, with: parameters)
+        return try URLEncoding().encode(request, with: parameters)
     }
 
     func authenticateForWPComAndRedirect(to url: URL, credentials: Credentials?) {
@@ -50,6 +50,6 @@ extension WKWebView {
                           "redirect_to": url.absoluteString,
                           "authorization": "Bearer " + token]
 
-        return try URLEncoding.default.encode(request, with: parameters)
+        return try URLEncoding().encode(request, with: parameters)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 import WebKit
-import Alamofire
+import struct Networking.URLEncoding
 import class Networking.UserAgent
 
 // Bridge UIKit `WKWebView` component to SwiftUI for URLs that need authentication on WPCom
@@ -63,7 +63,7 @@ struct AuthenticatedWebView: UIViewRepresentable {
                           "redirect_to": url.absoluteString,
                           "authorization": "Bearer " + token]
 
-        return try URLEncoding.default.encode(request, with: parameters)
+        return try URLEncoding().encode(request, with: parameters)
     }
 
     /// For all test cases, to test against the staging server

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import WebKit
-import Alamofire
 import class Networking.UserAgent
 
 /// Mirror of AuthenticatedWebView, for equivalent display of URLs in `WKWebView` that do not need authentication on WPCom.

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -24,7 +24,7 @@ class AuthenticatedState: StoresManagerState {
     ///
     init(credentials: Credentials) {
         let storageManager = ServiceLocator.storageManager
-        let network = AlamofireNetwork(credentials: credentials)
+        let network = URLSessionNetwork(credentials: credentials)
 
         services = [
             AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: credentials.authToken),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part 1 of a POC for HACK week in December 2022.
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR prepares the Networking layer to replace Alamofire with a native implementation of network handling with `URLSession`. Changes include:
- Replaced the use of `URLRequestConvertible` with the existing `Request`. 
- Copied Alamofire's `URLEncoding` & `HTTPMethod` since we want to reuse most of the logic here. Replace Alamofire's with the copied ones.
- Added an extension for `URLRequest` to construct a request with URL, HTTP method, and headers.
- Created a simple `SessionManager` that operates with a `URLSession`.
- Created a new network `URLSessionNetwork` and replaced `AlamofireNetwork` with it.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Log in to the app and do a smoke test on the features. Make sure that all network requests still work as before. Uploading media will be handled in a subsequent PR.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
