### PR TITLE
Update WordPressShared, WordPressKit, and WordPressAuthenticator

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -35,7 +35,7 @@ end
 
 def wordpress_kit
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressKit', '~> 4.49.0'
+  pod 'WordPressKit', '~> 5.0.0'
   # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
 end
 
@@ -71,12 +71,12 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 4.3.0'
-#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+  pod 'WordPressAuthenticator', '~> 5.0.0'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
-  pod 'WordPressShared', '~> 1.15'
+  pod 'WordPressShared', '~> 2.0-beta'
 
   pod 'WordPressUI', '~> 1.12.5'
   # pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,9 +15,6 @@ PODS:
   - CocoaLumberjack/Core (3.7.4)
   - CocoaLumberjack/Swift (3.7.4):
     - CocoaLumberjack/Core
-  - FormatterKit/Resources (1.9.0)
-  - FormatterKit/TimeIntervalFormatter (1.9.0):
-    - FormatterKit/Resources
   - GoogleSignIn (6.0.2):
     - AppAuth (~> 1.4)
     - GTMAppAuth (~> 1.0)
@@ -42,29 +39,25 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (4.3.0):
-    - CocoaLumberjack (~> 3.5)
+  - WordPressAuthenticator (5.0.0):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
-    - WordPressKit (~> 4.18-beta)
-    - WordPressShared (~> 1.12-beta)
+    - WordPressKit (~> 5.0-beta)
+    - WordPressShared (~> 2.0-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.49.0):
+  - WordPressKit (5.0.0):
     - Alamofire (~> 4.8.0)
-    - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
-    - WordPressShared (~> 1.15-beta)
+    - WordPressShared (~> 2.0-beta)
     - wpxmlrpc (~> 0.9)
-  - WordPressShared (1.16.1):
-    - CocoaLumberjack (~> 3.4)
-    - FormatterKit/TimeIntervalFormatter (~> 1.8)
+  - WordPressShared (2.0.0-beta.2)
   - WordPressUI (1.12.5)
   - Wormholy (1.6.5)
   - WPMediaPicker (1.8.1)
-  - wpxmlrpc (0.9.0)
+  - wpxmlrpc (0.10.0)
   - XLPagerTabStrip (9.0.0)
   - ZendeskCommonUISDK (6.1.1)
   - ZendeskCoreSDK (2.5.1)
@@ -91,9 +84,9 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.14)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 4.3.0)
-  - WordPressKit (~> 4.49.0)
-  - WordPressShared (~> 1.15)
+  - WordPressAuthenticator (~> 5.0.0)
+  - WordPressKit (~> 5.0.0)
+  - WordPressShared (~> 2.0-beta)
   - WordPressUI (~> 1.12.5)
   - Wormholy (~> 1.6.5)
   - WPMediaPicker (~> 1.8.1)
@@ -103,12 +96,12 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
+    - WordPressShared
   trunk:
     - Alamofire
     - AppAuth
     - Automattic-Tracks-iOS
     - CocoaLumberjack
-    - FormatterKit
     - GoogleSignIn
     - Gridicons
     - GTMAppAuth
@@ -126,7 +119,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressKit
-    - WordPressShared
     - WordPressUI
     - Wormholy
     - WPMediaPicker
@@ -145,7 +137,6 @@ SPEC CHECKSUMS:
   AppAuth: 8fca6b5563a5baef2c04bee27538025e4ceb2add
   Automattic-Tracks-iOS: 63e55654f500b3e8fb35087e64575e00d12eb2f5
   CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
-  FormatterKit: 184db51bf120b633693a73624a4cede89ec51a41
   GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
@@ -162,13 +153,13 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: fd1084278edc077c48026c9080a1d9b0ca9c2304
-  WordPressKit: 96deb6ba37ea5eaec4ddcaa53eca04d653246152
-  WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
+  WordPressAuthenticator: 0cdf1bff75bd3f58fe733d6457221f27bbbdc9f4
+  WordPressKit: 202f529323b079a344f7bc1493b7ebebfd9ed4b5
+  WordPressShared: bc2ee610c4ec06cab411d04a212ad6297edd4288
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
   Wormholy: 3252bc3e55a1847ef9a0976c1377bd77bf3635fa
   WPMediaPicker: 9011a0ec1f468c039af7485c244576b4c9889a0f
-  wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
+  wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
   ZendeskCommonUISDK: 5808802951ad2bb424f0bed4259dc3c0ce9b52ec
   ZendeskCoreSDK: 19a18e5ef2edcb18f4dbc0ea0d12bd31f515712a
@@ -178,6 +169,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: d57f522b14409f38c9fb733afac389ebebdb3ffd
+PODFILE CHECKSUM: 163bea8d6c3d10366ec3df45e35730da367abaa8
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -96,7 +96,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
-    - WordPressShared
   trunk:
     - Alamofire
     - AppAuth
@@ -119,6 +118,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressKit
+    - WordPressShared
     - WordPressUI
     - Wormholy
     - WPMediaPicker
@@ -155,7 +155,7 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
   WordPressAuthenticator: 0cdf1bff75bd3f58fe733d6457221f27bbbdc9f4
   WordPressKit: 202f529323b079a344f7bc1493b7ebebfd9ed4b5
-  WordPressShared: bc2ee610c4ec06cab411d04a212ad6297edd4288
+  WordPressShared: 04403b43f821c4ed2b84a2112ef9f64f1e7cdceb
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
   Wormholy: 3252bc3e55a1847ef9a0976c1377bd77bf3635fa
   WPMediaPicker: 9011a0ec1f468c039af7485c244576b4c9889a0f

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -54,6 +54,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Setup Components
         setupAnalytics()
         setupCocoaLumberjack()
+        setupLibraryLogger()
         setupLogLevel(.verbose)
         setupPushNotificationsManagerIfPossible()
         setupAppRatingManager()
@@ -276,12 +277,19 @@ private extension AppDelegate {
         DDLog.add(logger)
     }
 
-    /// Sets up the current Log Leve.
+    /// Sets up loggers for WordPress libraries
+    ///
+    func setupLibraryLogger() {
+        let logger = ServiceLocator.wordPressLibraryLogger
+        WPSharedSetLoggingDelegate(logger)
+        WPAuthenticatorSetLoggingDelegate(logger)
+        WPKitSetLoggingDelegate(logger)
+    }
+
+    /// Sets up the current Log Level.
     ///
     func setupLogLevel(_ level: DDLogLevel) {
-        WPSharedSetLoggingLevel(level)
-        WPAuthenticatorSetLoggingLevel(level)
-        WPKitSetLoggingLevel(level)
+        CocoaLumberjack.dynamicLogLevel = level
     }
 
     /// Setup: Notice Presenter

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -5,6 +5,7 @@ import Storage
 import Yosemite
 import Hardware
 import WooFoundation
+import WordPressShared
 
 /// Provides global dependencies.
 ///
@@ -178,6 +179,9 @@ final class ServiceLocator {
     static var fileLogger: Logs {
         return _fileLogger
     }
+
+    /// Provides an instance of `WordPressLoggingDelegate` for logging in WordPress libraries.
+    static let wordPressLibraryLogger: WordPressLoggingDelegate = WordPressLibraryLogger()
 
     /// Provides the access point to the CrashLogger
     /// - Returns: An implementation

--- a/WooCommerce/Classes/ServiceLocator/WordPressLibraryLogger.swift
+++ b/WooCommerce/Classes/ServiceLocator/WordPressLibraryLogger.swift
@@ -1,5 +1,4 @@
 import CocoaLumberjack
-import AutomatticTracks
 import WordPressShared
 
 class WordPressLibraryLogger: NSObject, WordPressLoggingDelegate {

--- a/WooCommerce/Classes/ServiceLocator/WordPressLibraryLogger.swift
+++ b/WooCommerce/Classes/ServiceLocator/WordPressLibraryLogger.swift
@@ -1,0 +1,26 @@
+import CocoaLumberjack
+import AutomatticTracks
+import WordPressShared
+
+class WordPressLibraryLogger: NSObject, WordPressLoggingDelegate {
+
+    func logError(_ str: String) {
+        DDLogError(str)
+    }
+
+    func logWarning(_ str: String) {
+        DDLogWarn(str)
+    }
+
+    func logInfo(_ str: String) {
+        DDLogInfo(str)
+    }
+
+    func logDebug(_ str: String) {
+        DDLogDebug(str)
+    }
+
+    func logVerbose(_ str: String) {
+        DDLogVerbose(str)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -992,6 +992,7 @@
 		45FBDF3C238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF3B238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift */; };
 		45FDDD65267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FDDD63267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.swift */; };
 		45FDDD66267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45FDDD64267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.xib */; };
+		4A68E3E32941D4CE004AC3DC /* WordPressLibraryLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A68E3E22941D4CE004AC3DC /* WordPressLibraryLogger.swift */; };
 		532842FC64B572D4545BD98E /* OrderFormCustomerNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53284C9FD06F2BDABC554BEE /* OrderFormCustomerNoteViewModel.swift */; };
 		532846FAFFFCA93169B5E0BC /* WaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53284FB62FF7F94F18F0D3FF /* WaitingTimeTracker.swift */; };
 		570AAB052472FACB00516C0C /* OrderDetailsDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */; };
@@ -2990,6 +2991,7 @@
 		45FBDF3B238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedAddProductImageCollectionViewCellTests.swift; sourceTree = "<group>"; };
 		45FDDD63267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSummaryTableViewCell.swift; sourceTree = "<group>"; };
 		45FDDD64267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ShippingLabelSummaryTableViewCell.xib; sourceTree = "<group>"; };
+		4A68E3E22941D4CE004AC3DC /* WordPressLibraryLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressLibraryLogger.swift; sourceTree = "<group>"; };
 		53284C9FD06F2BDABC554BEE /* OrderFormCustomerNoteViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderFormCustomerNoteViewModel.swift; sourceTree = "<group>"; };
 		53284FB62FF7F94F18F0D3FF /* WaitingTimeTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaitingTimeTracker.swift; sourceTree = "<group>"; };
 		570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OrderDetailsDataSourceTests.swift; path = "Order Details/OrderDetailsDataSourceTests.swift"; sourceTree = "<group>"; };
@@ -8676,6 +8678,7 @@
 				575472802452185300A94C3C /* PushNotification.swift */,
 				57532CAB24BFF4DA0032B84E /* MessageComposerPresenter.swift */,
 				02E19B9B284743A40010B254 /* ProductImageUploader.swift */,
+				4A68E3E22941D4CE004AC3DC /* WordPressLibraryLogger.swift */,
 			);
 			path = ServiceLocator;
 			sourceTree = "<group>";
@@ -10561,6 +10564,7 @@
 				B5980A6121AC878900EBF596 /* UIDevice+Woo.swift in Sources */,
 				EEADF624281A421A001B40F1 /* DefaultShippingValueLocalizer.swift in Sources */,
 				0263E3BB290BB21800E5F88F /* WooAnalyticsEvent+StoreCreation.swift in Sources */,
+				4A68E3E32941D4CE004AC3DC /* WordPressLibraryLogger.swift in Sources */,
 				174CA86E27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift in Sources */,
 				262C921F26EEF8B100011F92 /* Binding.swift in Sources */,
 				DE4FB7732812AE96003D20D6 /* FilterListView.swift in Sources */,


### PR DESCRIPTION
### Description

#### Library updates

Here are full change sets in the libraries:
- WordPressShared: [1.16.1 -> 2.0.0-beta.2](https://github.com/wordpress-mobile/WordPress-iOS-Shared/compare/1.16.1...2.0.0-beta.2)
- WordPressKit: [4.49.0 -> 5.0.0](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/4.49.0...5.0.0)
- WordPressAuthenticator: [4.3.0 -> 5.0.0](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/compare/4.3.0...5.0.0)

There are lots changes brought in from the WordPressKit upgrade, but I think they are mostly additive.

#### Logging in the libraries

This is the main reason I created this PR.

WordPressShared, WordPressKit, and WordPressAuthenticator used to depend on CocoaLumberjack and have their own `ddLogLevel` variable. It's strange that compiler would allow this, but this approach feels problematic anyway.

The new version of these libraries now have a function to set a logger instance, which uses the CocoaLumberjack set up in the app. Thus they no longer depend on CocoaLumberjack and also makes changing log level easier—there is only one log level variable which is in the app.

### Testing instructions

Add a few logs in the `AppDelegate.didFinishLaunching` function:
```swift
        DDLogVerbose("Test Log verbose")
        DDLogDebug("Test Log debug")
        DDLogInfo("Test Log info")
        DDLogWarn("Test Log warn")
        DDLogError("Test Log error")
```

Change the argument in the existing `setupLogLevel(.verbose)` call to change the log level, run the app and check out what test logs are printed. The printed logs should respect the log level passed to `setupLogLevel` function.

> **Note**
> Above test fails in the trunk branch as the original `setupLogLevel` function doesn't actually modify the log level.


### Screenshots
None.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
