### PR TITLE
[Mobile Payments] Show Processing alert directly after collect payment completes

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderEvent.swift
+++ b/Hardware/Hardware/CardReader/CardReaderEvent.swift
@@ -18,6 +18,9 @@ public enum CardReaderEvent: Equatable {
     /// A card was removed after client-side payment capture.
     case cardRemovedAfterClientSidePaymentCapture
 
+    /// Card details were collected, and can be used to process a payment.
+    case cardDetailsCollected
+
     /// Low battery warning.
     case lowBattery
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -524,6 +524,7 @@ private extension StripeCardReaderService {
                 }
 
                 if let intent = intent {
+                    self?.sendReaderEvent(.cardDetailsCollected)
                     promise(.success(intent))
                 }
             }

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -228,6 +228,11 @@ extension StripeCardReaderService: CardReaderService {
                 return promise(.success(()))
             }
 
+            // When this is used for a new payment, there is a new subscription to readerEvents, which won't rely the
+            // old `.removeCard` message. If there is a card inserted, we manually send a display message prompting to
+            // remove the card, and wait for that before continuing.
+            self.sendReaderEvent(CardReaderEvent.make(displayMessage: .removeCard))
+
             self.timerCancellable = Timer.publish(every: 1, tolerance: 0.1, on: .main, in: .default)
                 .autoconnect()
                 .receive(on: DispatchQueue.main)
@@ -260,12 +265,6 @@ extension StripeCardReaderService: CardReaderService {
         // steps produce a Future.
 
         // If a card was left from a previous payment attempt, we want that removed before we initiate a new payment.
-        // However, a new payment probably means a new subscription to readerEvents, which won't rely the old `.removeCard`
-        // message. If there is a card inserted, we manually send a display message prompting to remove the card,
-        // and wait for that before continuing.
-        if isChipCardInserted {
-            sendReaderEvent(CardReaderEvent.make(displayMessage: .removeCard))
-        }
         return waitForInsertedCardToBeRemoved()
             .flatMap {
                 self.createPaymentIntent(parameters)

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 11.6
 -----
-
+- [*] In-Person Payments: fixed timing issues in payments flow, which caused "Remove card" to be shown for too long [https://github.com/woocommerce/woocommerce-ios/pull/8351]
 
 11.5
 -----

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -44,6 +44,8 @@ final class CardPresentRefundOrchestrator {
                 onWaitingForInput(inputMethods)
             case .displayMessage(let message):
                 onDisplayMessage(message)
+            case .cardDetailsCollected:
+                onProcessingMessage()
             default:
                 break
             }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/LegacyPaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/LegacyPaymentCaptureOrchestrator.swift
@@ -63,7 +63,7 @@ final class LegacyPaymentCaptureOrchestrator {
                     onWaitingForInput(inputMethods)
                 case .displayMessage(let message):
                     onDisplayMessage(message)
-                case .cardRemovedAfterClientSidePaymentCapture:
+                case .cardDetailsCollected, .cardRemovedAfterClientSidePaymentCapture:
                     onProcessingMessage()
                 default:
                     break

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -75,7 +75,7 @@ final class PaymentCaptureOrchestrator {
                     onWaitingForInput(inputMethods)
                 case .displayMessage(let message):
                     onDisplayMessage(message)
-                case .cardRemovedAfterClientSidePaymentCapture:
+                case .cardDetailsCollected, .cardRemovedAfterClientSidePaymentCapture:
                     onProcessingMessage()
                 default:
                     break


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8289 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In sTAP Away, we're adding support for Apple's built in card readers to take in-person payments. We continue to use Stripe's SDK to handle payments.

During this work, we are looking to share code where practical with the bluetooth reader flows, and fix issues in those flows which were less obvious with an external reader.

One such issue is the delay between a customer tapping their card, and the app showing that we are processing the transaction.

This was made more obvious in the Tap to Pay on iPhone proof of concept, where the phone is the card reader. In that experiment, we saw that the "Tap card to pay" screen showed up for several seconds after the customer had tapped their card and the Apple reader screen had been dismissed.

This issue was also present with Bluetooth readers, and especially obvious with the WisePad 3, where the on-reader alerts showed payment was being processed, while the app continued to ask the customer to tap their card. This could lead to the merchant being unsure what's going on with the payment, and/or giving confusing directions to their customer.

This PR adds a `CardReaderEvent` for `cardDetailsCollected`. We send this when the Stripe SDK calls our completion block with success from `collectPayment`.

In our payment/refund orchestrators, we use `cardDetailsCollected` as the trigger to show the `Processing` message, which continues to display throughout authorisation, submission to WCPay, and capture. Previously, this only showed once we submitted the authorised `PaymentIntent` to WCPay.

There were some minor changes required to continue to support `Remove card` messaging when an _inserted_ card is left in the reader by mistake.

N.B. This fix is backported to the legacy flows, so should be tested both with the feature flag enabled and disabled.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Using an iPhone XS or newer on iOS 16.0 or newer

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. When asked for a reader type, tap `Tap to Pay on iPhone` and go through the Terms of Service Apple ID linking (if you've not done so before)
6. Tap the card to pay
7. Observe that the `Reader is Ready` screen only shows for a moment after the Apple screen is dismissed


Disconnect the (built in) reader in `Manage card reader` and turn off the experimental toggle


Repeat the test with the legacy bluetooth flow, tapping your card on the reader
Observe that when the card is read, `Remove Card` is quickly replaced with `Processing`


Repeat the test inserting your card
Observe that when the card is read, the `Remove Card` message is shown, and continues to show (processing may flash up in between) if the card is not removed from the reader
Observe that the merchant doesn't see the payment complete if the card is not removed.



## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before: Legacy bluetooth 

Note the long "remove card" step

https://user-images.githubusercontent.com/2472348/206483166-ea17edd8-6009-42d8-b1a9-d6ea6adcc378.mp4

### After: Legacy bluetooth

https://user-images.githubusercontent.com/2472348/206483229-6effc9dd-4e84-4920-9443-0f703924597e.mp4

### Before: Tap on Mobile

Note the long visibility of the "Reader is ready" screen after the card is read

https://user-images.githubusercontent.com/2472348/206483347-95256410-6b4a-47ab-ac66-f7c70760b56b.mp4

### After: Tap on Mobile

https://user-images.githubusercontent.com/2472348/206483509-4e0dbf26-1dd7-4f2f-aa2a-be913e01f2ce.mp4

### Full flows: before

#### Legacy

https://user-images.githubusercontent.com/2472348/206483653-267d4655-7b11-49bc-972d-bec5ca7f1c52.mp4

#### New bluetooth

https://user-images.githubusercontent.com/2472348/206483674-0989abd4-abf9-4f71-900e-cdfe1e9a68e4.mp4

#### Tap on iPhone

https://user-images.githubusercontent.com/2472348/206483692-8c75872e-2221-4c2b-bd38-615242e65a05.mp4

### Full flows: after

#### Legacy

https://user-images.githubusercontent.com/2472348/206483915-35bc6370-cd11-4217-80d0-c9ffa7ffb1c7.mp4

#### New bluetooth

https://user-images.githubusercontent.com/2472348/206483977-910eff79-dc20-4017-a6d4-e16a55f9ced7.mp4

#### Tap on iPhone

https://user-images.githubusercontent.com/2472348/206483945-f84b1bd3-5004-4f71-a023-eb561c11722f.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
