### PR TITLE
[Mobile Payments] show follow instructions during built in collect payment

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInFollowReaderInstructions.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInFollowReaderInstructions.swift
@@ -39,8 +39,7 @@ final class CardPresentModalBuiltInFollowReaderInstructions: CardPresentPayments
     init(name: String,
          amount: String,
          transactionType: CardPresentTransactionType,
-         inputMethods: CardReaderInput,
-         onCancel: @escaping () -> Void) {
+         inputMethods: CardReaderInput) {
         self.name = name
         self.amount = amount
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInFollowReaderInstructions.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInFollowReaderInstructions.swift
@@ -1,0 +1,78 @@
+import UIKit
+import Yosemite
+
+/// Modal presented under the Apple-provided built in reader modal, while the card is being collected.
+/// This may be visible for a moment or two either side of Apple's screen being shown.
+final class CardPresentModalBuiltInFollowReaderInstructions: CardPresentPaymentsModalViewModel {
+
+    /// Customer name
+    private let name: String
+
+    /// Charge amount
+    private let amount: String
+
+    let textMode: PaymentsModalTextMode = .fullInfo
+    let actionsMode: PaymentsModalActionsMode = .none
+
+    var topTitle: String {
+        name
+    }
+
+    var topSubtitle: String? {
+        amount
+    }
+
+    let image: UIImage = .cardPresentImage
+
+    let primaryButtonTitle: String? = nil
+
+    let secondaryButtonTitle: String? = nil
+
+    let auxiliaryButtonTitle: String? = nil
+
+    let bottomTitle: String? = Localization.readerIsReady
+
+    let bottomSubtitle: String?
+
+    let accessibilityLabel: String?
+
+    init(name: String,
+         amount: String,
+         transactionType: CardPresentTransactionType,
+         inputMethods: CardReaderInput,
+         onCancel: @escaping () -> Void) {
+        self.name = name
+        self.amount = amount
+
+        self.bottomSubtitle = Localization.followReaderInstructions
+
+        self.accessibilityLabel = Localization.readerIsReady + Localization.followReaderInstructions
+    }
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        //
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) {
+        //
+    }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) {
+        //
+    }
+}
+
+private extension CardPresentModalBuiltInFollowReaderInstructions {
+    enum Localization {
+        static let readerIsReady = NSLocalizedString(
+            "iPhone reader is ready",
+            comment: "Indicates the status of a built in card reader. Presented to users when payment collection starts"
+        )
+
+        static let followReaderInstructions = NSLocalizedString(
+            "Follow reader instructions to pay",
+            comment: "Label asking users to follow the built in reader instruction. Presented to users when a " +
+            "payment is going to be collected using the iPhone's built in reader"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -38,7 +38,7 @@ final class OrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
          presentingController: UIViewController) {
         self.transactionType = transactionType
         self.presentingController = presentingController
-        self.alertsProvider = CardReaderPaymentAlertsProvider(transactionType: transactionType)
+        self.alertsProvider = BluetoothCardReaderPaymentAlertsProvider(transactionType: transactionType)
     }
 
     func presentViewModel(viewModel: CardPresentPaymentsModalViewModel) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
@@ -4,7 +4,7 @@ import MessageUI
 import enum Hardware.CardReaderServiceError
 import enum Hardware.UnderlyingError
 
-final class CardReaderPaymentAlertsProvider: CardReaderTransactionAlertsProviding {
+final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsProviding {
     var name: String = ""
     var amount: String = ""
     var transactionType: CardPresentTransactionType
@@ -89,7 +89,7 @@ final class CardReaderPaymentAlertsProvider: CardReaderTransactionAlertsProvidin
     }
 }
 
-private extension CardReaderPaymentAlertsProvider {
+private extension BluetoothCardReaderPaymentAlertsProvider {
     enum Localization {
         static func errorDescription(underlyingError: UnderlyingError, transactionType: CardPresentTransactionType) -> String? {
             switch underlyingError {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
@@ -18,11 +18,11 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
                          onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         name = title
         self.amount = amount
-        return CardPresentModalTapCard(name: title,
-                                       amount: amount,
-                                       transactionType: .collectPayment,
-                                       inputMethods: inputMethods,
-                                       onCancel: onCancel)
+        return CardPresentModalBuiltInFollowReaderInstructions(name: name,
+                                              amount: amount,
+                                              transactionType: .collectPayment,
+                                              inputMethods: inputMethods,
+                                              onCancel: { })
     }
 
     func displayReaderMessage(message: String) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Yosemite
+import MessageUI
+import enum Hardware.CardReaderServiceError
+import enum Hardware.UnderlyingError
+
+final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsProviding {
+    var name: String = ""
+    var amount: String = ""
+
+    func preparingReader(onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalPreparingReader(cancelAction: onCancel)
+    }
+
+    func tapOrInsertCard(title: String,
+                         amount: String,
+                         inputMethods: Yosemite.CardReaderInput,
+                         onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        name = title
+        self.amount = amount
+        return CardPresentModalTapCard(name: title,
+                                       amount: amount,
+                                       transactionType: .collectPayment,
+                                       inputMethods: inputMethods,
+                                       onCancel: onCancel)
+    }
+
+    func displayReaderMessage(message: String) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalDisplayMessage(name: name,
+                                       amount: amount,
+                                       message: message)
+    }
+
+    func processingTransaction() -> CardPresentPaymentsModalViewModel {
+        CardPresentModalProcessing(name: name, amount: amount, transactionType: .collectPayment)
+    }
+
+    func success(printReceipt: @escaping () -> Void,
+                 emailReceipt: @escaping () -> Void,
+                 noReceiptAction: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        if MFMailComposeViewController.canSendMail() {
+            return CardPresentModalSuccess(printReceipt: printReceipt,
+                                           emailReceipt: emailReceipt,
+                                           noReceiptAction: noReceiptAction)
+        } else {
+            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, noReceiptAction: noReceiptAction)
+        }
+    }
+
+    func error(error: Error, tryAgain: @escaping () -> Void, dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        let errorDescription: String?
+        if let error = error as? CardReaderServiceError {
+            switch error {
+            case .connection(let underlyingError),
+                    .discovery(let underlyingError),
+                    .disconnection(let underlyingError),
+                    .intentCreation(let underlyingError),
+                    .paymentMethodCollection(let underlyingError),
+                    .paymentCapture(let underlyingError),
+                    .paymentCancellation(let underlyingError),
+                    .softwareUpdate(let underlyingError, _):
+                errorDescription = Localization.errorDescription(underlyingError: underlyingError)
+            default:
+                errorDescription = error.errorDescription
+            }
+        } else {
+            errorDescription = error.localizedDescription
+        }
+        return CardPresentModalError(errorDescription: errorDescription,
+                                     transactionType: .collectPayment,
+                                     primaryAction: tryAgain,
+                                     dismissCompletion: dismissCompletion)
+    }
+
+    func nonRetryableError(error: Error, dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalNonRetryableError(amount: amount, error: error, onDismiss: dismissCompletion)
+    }
+
+    func retryableError(tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalRetryableError(primaryAction: tryAgain)
+    }
+}
+
+private extension BuiltInCardReaderPaymentAlertsProvider {
+    enum Localization {
+        static func errorDescription(underlyingError: UnderlyingError) -> String? {
+            switch underlyingError {
+            case .paymentDeclinedByCardReader:
+                return NSLocalizedString("The card was declined by the iPhone card reader - please try another means of payment",
+                                         comment: "Error message when the card reader itself declines the card.")
+            case .processorAPIError:
+                return NSLocalizedString(
+                    "The payment can not be processed by the payment processor.",
+                    comment: "Error message when the payment can not be processed (i.e. order amount is below the minimum amount allowed.)"
+                )
+            case .internalServiceError:
+                return NSLocalizedString(
+                    "Sorry, this payment couldn’t be processed",
+                    comment: "Error message when the card reader service experiences an unexpected internal service error."
+                )
+            default:
+                return underlyingError.errorDescription
+            }
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
@@ -21,8 +21,7 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
         return CardPresentModalBuiltInFollowReaderInstructions(name: name,
                                               amount: amount,
                                               transactionType: .collectPayment,
-                                              inputMethods: inputMethods,
-                                              onCancel: { })
+                                              inputMethods: inputMethods)
     }
 
     func displayReaderMessage(message: String) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -145,7 +145,8 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
             switch connectionResult {
             case .connected(let reader):
                 self.connectedReader = reader
-                self.attemptPayment(alertProvider: reader.paymentAlertProvider, onCompletion: { [weak self] result in
+                let paymentAlertProvider = reader.paymentAlertProvider()
+                self.attemptPayment(alertProvider: paymentAlertProvider, onCompletion: { [weak self] result in
                     guard let self = self else { return }
                     // Inform about the collect payment state
                     switch result {
@@ -160,7 +161,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
                         return onCompleted()
                     }
                     self.presentReceiptAlert(receiptParameters: paymentData.receiptParameters,
-                                             alertProvider: reader.paymentAlertProvider(),
+                                             alertProvider: paymentAlertProvider,
                                              onCompleted: onCompleted)
                 })
             case .canceled:

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -73,10 +73,6 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     ///
     private let alertsPresenter: CardPresentPaymentAlertsPresenting
 
-    /// Payment alerts provider
-    ///
-    private let paymentAlerts: CardReaderTransactionAlertsProviding
-
     /// Stores the card reader listener subscription while trying to connect to one.
     ///
     private var readerSubscription: AnyCancellable?
@@ -113,7 +109,6 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
         self.paymentGatewayAccount = paymentGatewayAccount
         self.rootViewController = rootViewController
         self.alertsPresenter = CardPresentPaymentAlertsPresenter(rootViewController: rootViewController)
-        self.paymentAlerts = BluetoothCardReaderPaymentAlertsProvider(transactionType: .collectPayment)
         self.configuration = configuration
         self.stores = stores
         self.analytics = analytics
@@ -150,7 +145,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
             switch connectionResult {
             case .connected(let reader):
                 self.connectedReader = reader
-                self.attemptPayment(onCompletion: { [weak self] result in
+                self.attemptPayment(alertProvider: reader.paymentAlertProvider, onCompletion: { [weak self] result in
                     guard let self = self else { return }
                     // Inform about the collect payment state
                     switch result {
@@ -164,7 +159,9 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
                     guard let paymentData = try? result.get() else {
                         return onCompleted()
                     }
-                    self.presentReceiptAlert(receiptParameters: paymentData.receiptParameters, onCompleted: onCompleted)
+                    self.presentReceiptAlert(receiptParameters: paymentData.receiptParameters,
+                                             alertProvider: reader.paymentAlertProvider,
+                                             onCompleted: onCompleted)
                 })
             case .canceled:
                 self.alertsPresenter.dismiss()
@@ -177,6 +174,17 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
         .store(in: &cancellables)
 
         preflightController?.start()
+    }
+}
+
+private extension CardReader {
+    var paymentAlertProvider: CardReaderTransactionAlertsProviding {
+        switch readerType {
+        case .appleBuiltIn:
+            return BuiltInCardReaderPaymentAlertsProvider()
+        default:
+            return BluetoothCardReaderPaymentAlertsProvider(transactionType: .collectPayment)
+        }
     }
 }
 
@@ -207,16 +215,19 @@ private extension CollectOrderPaymentUseCase {
         return NotValidAmountError.belowMinimumAmount(amount: minimum)
     }
 
-    func handleTotalAmountInvalidError(_ error: Error, onCompleted: @escaping () -> ()) {
+    func handleTotalAmountInvalidError(_ error: Error,
+                                       onCompleted: @escaping () -> ()) {
         trackPaymentFailure(with: error)
         DDLogError("💳 Error: failed to capture payment for order. Order amount is below minimum or not valid")
-        self.alertsPresenter.present(viewModel: paymentAlerts.nonRetryableError(error: totalAmountInvalidError(),
-                                                                                dismissCompletion: onCompleted))
+        alertsPresenter.present(viewModel: CardPresentModalNonRetryableError(amount: formattedAmount,
+                                                                             error: totalAmountInvalidError(),
+                                                                             onDismiss: onCompleted))
     }
 
     /// Attempts to collect payment for an order.
     ///
-    func attemptPayment(onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
+    func attemptPayment(alertProvider paymentAlerts: CardReaderTransactionAlertsProviding,
+                        onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
         guard let orderTotal = orderTotal else {
             onCompletion(.failure(NotValidAmountError.other))
             return
@@ -239,7 +250,7 @@ private extension CollectOrderPaymentUseCase {
             onWaitingForInput: { [weak self] inputMethods in
                 guard let self = self else { return }
                 self.alertsPresenter.present(
-                    viewModel: self.paymentAlerts.tapOrInsertCard(
+                    viewModel: paymentAlerts.tapOrInsertCard(
                         title: Localization.collectPaymentTitle(username: self.order.billingAddress?.firstName),
                         amount: self.formattedAmount,
                         inputMethods: inputMethods,
@@ -252,11 +263,11 @@ private extension CollectOrderPaymentUseCase {
             }, onProcessingMessage: { [weak self] in
                 guard let self = self else { return }
                 // Waiting message
-                self.alertsPresenter.present(viewModel: self.paymentAlerts.processingTransaction())
+                self.alertsPresenter.present(viewModel: paymentAlerts.processingTransaction())
             }, onDisplayMessage: { [weak self] message in
                 guard let self = self else { return }
                 // Reader messages. EG: Remove Card
-                self.alertsPresenter.present(viewModel: self.paymentAlerts.displayReaderMessage(message: message))
+                self.alertsPresenter.present(viewModel: paymentAlerts.displayReaderMessage(message: message))
             }, onProcessingCompletion: { [weak self] intent in
                 self?.trackProcessingCompletion(intent: intent)
                 self?.markOrderAsPaidIfNeeded(intent: intent)
@@ -265,7 +276,7 @@ private extension CollectOrderPaymentUseCase {
                 case .success(let capturedPaymentData):
                     self?.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData, onCompletion: onCompletion)
                 case .failure(let error):
-                    self?.handlePaymentFailureAndRetryPayment(error, onCompletion: onCompletion)
+                    self?.handlePaymentFailureAndRetryPayment(error, alertProvider: paymentAlerts, onCompletion: onCompletion)
                 }
             }
         )
@@ -288,7 +299,9 @@ private extension CollectOrderPaymentUseCase {
 
     /// Log the failure reason, cancel the current payment and retry it if possible.
     ///
-    func handlePaymentFailureAndRetryPayment(_ error: Error, onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
+    func handlePaymentFailureAndRetryPayment(_ error: Error,
+                                             alertProvider paymentAlerts: CardReaderTransactionAlertsProviding,
+                                             onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
         DDLogError("Failed to collect payment: \(error.localizedDescription)")
 
         trackPaymentFailure(with: error)
@@ -305,12 +318,13 @@ private extension CollectOrderPaymentUseCase {
                                               switch result {
                                               case .success:
                                                   // Retry payment
-                                                  self.attemptPayment(onCompletion: onCompletion)
+                                                  self.attemptPayment(alertProvider: paymentAlerts,
+                                                                      onCompletion: onCompletion)
 
                                               case .failure(let cancelError):
                                                   // Inform that payment can't be retried.
                                                   self.alertsPresenter.present(
-                                                    viewModel: self.paymentAlerts.nonRetryableError(error: cancelError) {
+                                                    viewModel: paymentAlerts.nonRetryableError(error: cancelError) {
                                                       onCompletion(.failure(error))
                                                   })
                                               }
@@ -346,7 +360,9 @@ private extension CollectOrderPaymentUseCase {
 
     /// Allow merchants to print or email the payment receipt.
     ///
-    func presentReceiptAlert(receiptParameters: CardPresentReceiptParameters, onCompleted: @escaping () -> ()) {
+    func presentReceiptAlert(receiptParameters: CardPresentReceiptParameters,
+                             alertProvider paymentAlerts: CardReaderTransactionAlertsProviding,
+                             onCompleted: @escaping () -> ()) {
         // Present receipt alert
         alertsPresenter.present(viewModel: paymentAlerts.success(printReceipt: { [order, configuration, weak self] in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -113,7 +113,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
         self.paymentGatewayAccount = paymentGatewayAccount
         self.rootViewController = rootViewController
         self.alertsPresenter = CardPresentPaymentAlertsPresenter(rootViewController: rootViewController)
-        self.paymentAlerts = CardReaderPaymentAlertsProvider(transactionType: .collectPayment)
+        self.paymentAlerts = BluetoothCardReaderPaymentAlertsProvider(transactionType: .collectPayment)
         self.configuration = configuration
         self.stores = stores
         self.analytics = analytics

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -160,7 +160,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
                         return onCompleted()
                     }
                     self.presentReceiptAlert(receiptParameters: paymentData.receiptParameters,
-                                             alertProvider: reader.paymentAlertProvider,
+                                             alertProvider: reader.paymentAlertProvider(),
                                              onCompleted: onCompleted)
                 })
             case .canceled:
@@ -178,7 +178,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
 }
 
 private extension CardReader {
-    var paymentAlertProvider: CardReaderTransactionAlertsProviding {
+    func paymentAlertProvider() -> CardReaderTransactionAlertsProviding {
         switch readerType {
         case .appleBuiltIn:
             return BuiltInCardReaderPaymentAlertsProvider()

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -504,7 +504,8 @@
 		03E471CC293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471CB293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift */; };
 		03E471CE293F63B4001A58AD /* PaymentCaptureOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471CD293F63B4001A58AD /* PaymentCaptureOrchestrator.swift */; };
 		03E471D0293FA62B001A58AD /* CardReaderTransactionAlertsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471CF293FA62B001A58AD /* CardReaderTransactionAlertsProviding.swift */; };
-		03E471D2293FA8B2001A58AD /* CardReaderPaymentAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471D1293FA8B2001A58AD /* CardReaderPaymentAlertsProvider.swift */; };
+		03E471D2293FA8B2001A58AD /* BluetoothCardReaderPaymentAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471D1293FA8B2001A58AD /* BluetoothCardReaderPaymentAlertsProvider.swift */; };
+		03E471D42942096B001A58AD /* BuiltInCardReaderPaymentAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471D32942096B001A58AD /* BuiltInCardReaderPaymentAlertsProvider.swift */; };
 		03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
 		03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */; };
 		03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */; };
@@ -2525,7 +2526,8 @@
 		03E471CB293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalProgressDisplaying.swift; sourceTree = "<group>"; };
 		03E471CD293F63B4001A58AD /* PaymentCaptureOrchestrator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentCaptureOrchestrator.swift; sourceTree = "<group>"; };
 		03E471CF293FA62B001A58AD /* CardReaderTransactionAlertsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderTransactionAlertsProviding.swift; sourceTree = "<group>"; };
-		03E471D1293FA8B2001A58AD /* CardReaderPaymentAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderPaymentAlertsProvider.swift; sourceTree = "<group>"; };
+		03E471D1293FA8B2001A58AD /* BluetoothCardReaderPaymentAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothCardReaderPaymentAlertsProvider.swift; sourceTree = "<group>"; };
+		03E471D32942096B001A58AD /* BuiltInCardReaderPaymentAlertsProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuiltInCardReaderPaymentAlertsProvider.swift; sourceTree = "<group>"; };
 		03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift; sourceTree = "<group>"; };
 		03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift; sourceTree = "<group>"; };
 		03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardPresentPaymentsPlugin+CashOnDelivery.swift"; sourceTree = "<group>"; };
@@ -5663,9 +5665,10 @@
 				311D21EC264AF0E700102316 /* CardReaderSettingsAlerts.swift */,
 				03E471BF293A158C001A58AD /* CardReaderConnectionAlertsProviding.swift */,
 				03E471CF293FA62B001A58AD /* CardReaderTransactionAlertsProviding.swift */,
-				03E471D1293FA8B2001A58AD /* CardReaderPaymentAlertsProvider.swift */,
+				03E471D1293FA8B2001A58AD /* BluetoothCardReaderPaymentAlertsProvider.swift */,
 				03E471C1293A1F6B001A58AD /* BluetoothReaderConnectionAlertsProvider.swift */,
 				03E471C3293A1F8D001A58AD /* BuiltInReaderConnectionAlertsProvider.swift */,
+				03E471D32942096B001A58AD /* BuiltInCardReaderPaymentAlertsProvider.swift */,
 				3178C1F626409216000D771A /* CardReaderSettingsConnectedViewModel.swift */,
 				035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */,
 				314265B02645A07800500598 /* CardReaderSettingsConnectedViewController.swift */,
@@ -10052,7 +10055,7 @@
 				E1325EFB28FD544E00EC9B2A /* InAppPurchasesDebugView.swift in Sources */,
 				74460D4022289B7600D7316A /* Coordinator.swift in Sources */,
 				B57C743D20F5493300EEFC87 /* AccountHeaderView.swift in Sources */,
-				03E471D2293FA8B2001A58AD /* CardReaderPaymentAlertsProvider.swift in Sources */,
+				03E471D2293FA8B2001A58AD /* BluetoothCardReaderPaymentAlertsProvider.swift in Sources */,
 				03E471CA293E0A30001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift in Sources */,
 				31AD0B1126E9575F000B6391 /* CardPresentModalConnectingFailed.swift in Sources */,
 				576EA39425264C9B00AFC0B3 /* RefundConfirmationViewModel.swift in Sources */,
@@ -10699,6 +10702,7 @@
 				CE1EC8EC20B8A3FF009762BF /* LeftImageTableViewCell.swift in Sources */,
 				DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */,
 				021125992578D9C20075AD2A /* ShippingLabelPrintingInstructionsView.swift in Sources */,
+				03E471D42942096B001A58AD /* BuiltInCardReaderPaymentAlertsProvider.swift in Sources */,
 				68E952CC287536010095A23D /* SafariView.swift in Sources */,
 				D449C51C26DE6B5000D75B02 /* IconListItem.swift in Sources */,
 				CE16177A21B7192A00B82A47 /* AuthenticationConstants.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -506,6 +506,7 @@
 		03E471D0293FA62B001A58AD /* CardReaderTransactionAlertsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471CF293FA62B001A58AD /* CardReaderTransactionAlertsProviding.swift */; };
 		03E471D2293FA8B2001A58AD /* BluetoothCardReaderPaymentAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471D1293FA8B2001A58AD /* BluetoothCardReaderPaymentAlertsProvider.swift */; };
 		03E471D42942096B001A58AD /* BuiltInCardReaderPaymentAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471D32942096B001A58AD /* BuiltInCardReaderPaymentAlertsProvider.swift */; };
+		03E471D62942222E001A58AD /* CardPresentModalBuiltInFollowReaderInstructions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E471D52942222D001A58AD /* CardPresentModalBuiltInFollowReaderInstructions.swift */; };
 		03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
 		03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */; };
 		03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */; };
@@ -2528,6 +2529,7 @@
 		03E471CF293FA62B001A58AD /* CardReaderTransactionAlertsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderTransactionAlertsProviding.swift; sourceTree = "<group>"; };
 		03E471D1293FA8B2001A58AD /* BluetoothCardReaderPaymentAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothCardReaderPaymentAlertsProvider.swift; sourceTree = "<group>"; };
 		03E471D32942096B001A58AD /* BuiltInCardReaderPaymentAlertsProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuiltInCardReaderPaymentAlertsProvider.swift; sourceTree = "<group>"; };
+		03E471D52942222D001A58AD /* CardPresentModalBuiltInFollowReaderInstructions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInFollowReaderInstructions.swift; sourceTree = "<group>"; };
 		03EF24F928BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift; sourceTree = "<group>"; };
 		03EF24FB28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift; sourceTree = "<group>"; };
 		03EF24FD28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardPresentPaymentsPlugin+CashOnDelivery.swift"; sourceTree = "<group>"; };
@@ -8597,6 +8599,7 @@
 				03E471CB293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift */,
 				03E471C7293A3075001A58AD /* CardPresentModalBuiltInConnectingToReader.swift */,
 				311237ED2714DA240033C44E /* CardPresentModalDisplayMessage.swift */,
+				03E471D52942222D001A58AD /* CardPresentModalBuiltInFollowReaderInstructions.swift */,
 				D8815B0026385E3F00EDAD62 /* CardPresentModalTapCard.swift */,
 				D8815B0C263861A400EDAD62 /* CardPresentModalSuccess.swift */,
 				E16715CA26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift */,
@@ -10030,6 +10033,7 @@
 				31F92DE125E85F6A00DE04DF /* ConnectedReaderTableViewCell.swift in Sources */,
 				26C6E8E026E2B7BD00C7BB0F /* CountrySelectorViewModel.swift in Sources */,
 				0285BF7022FBD91C003A2525 /* TopPerformersSectionHeaderView.swift in Sources */,
+				03E471D62942222E001A58AD /* CardPresentModalBuiltInFollowReaderInstructions.swift in Sources */,
 				B60B5026292D308A00178C26 /* AnalyticsTimeRangeCard.swift in Sources */,
 				E138D4FC269EEAFE006EA5C6 /* InPersonPaymentsViewModel.swift in Sources */,
 				039D948F276113490044EF38 /* UIView+SuperviewConstraints.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8289 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In sTAP Away, we're adding support for Apple's built in card readers to take in-person payments. We continue to use Stripe's SDK to handle payments.

There was an obvious issue in the Tap to Pay on iPhone proof of concept, where the phone is the card reader. In that experiment, we saw that the "Tap card to pay" screen showed up for several seconds after the customer had tapped their card and the Apple reader screen had been dismissed.

This PR builds on #8351 replace the `Reader is Ready` screen with a built-in reader specific screen, that doesn't have a cancel button. This screen is not really needed by the user, as they follow the prompts from the Apple reader, but having this screen behind the Apple modal prompt prevents any extra animations of our flow off screen and back on again when the Apple screen is done.

The existing screen has a `Cancel` button, which could still be used (potentially) after the Apple screen is dismissed. We don't need this in the Tap on iPhone flow, as Apple's modal has a cancel button, so the screen added in this PR doesn't have one.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Using an iPhone XS or newer on iOS 16.0 or newer

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. When asked for a reader type, tap `Tap to Pay on iPhone` and go through the Terms of Service Apple ID linking (if you've not done so before)
6. Tap the card to pay
7. Observe that the `Follow reader instructions` screen shows briefly after the Apple screen is dismissed, and has no cancel button.

Repeat the test with the bluetooth flow, and observe that the pre-existing `Reader is ready` screen is still used, with a cancel button.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before

https://user-images.githubusercontent.com/2472348/206490187-52cd3665-082e-4ed4-ba2a-a1b3c14e6efd.mp4

### After

https://user-images.githubusercontent.com/2472348/206490250-02aafac0-d749-4069-a0ae-128965b9cf32.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
