### PR TITLE
[Analytics Hub] Move the analytics hub see more button out of the Feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 11.6
 -----
-
+- [***] We added a new Analytics Hub inside the My Store area of the app. Simply click on the See More button under the store stats to check more detailed information on Revenue, Orders and Products. [https://github.com/woocommerce/woocommerce-ios/pull/8356]
 
 11.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -292,9 +292,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
             ])
 
         // Analytics Hub ("See more") button
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.analyticsHub) {
-            stackView.addArrangedSubview(analyticsHubButtonView)
-        }
+        stackView.addArrangedSubview(analyticsHubButtonView)
 
         // In-app Feedback Card
         stackView.addArrangedSubviews(inAppFeedbackCardViewsForStackView)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8354

### Description
This PR removes the `see more` button from the Feature Flag constraint, making the Analytics Hub effectively available to all of our user base.

The Custom selection range and `visitors and views` stats are still under development and should be behind the feature flag. However, since both features are still unmerged in the trunk branch, we should expect the flags adjustment to happen in their respective PRs, as suggested [in this comment](https://github.com/woocommerce/woocommerce-ios/pull/8339/files#r1043532900).

### Testing instructions

Simply test the Analytics Hub entry point with the disabled feature flag and verify that the Hub is working and showing up as expected.

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
