### PR TITLE
[Analytics Hub] Add analytics event to track when date range selection fails

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1780,6 +1780,8 @@ extension WooAnalyticsEvent {
     enum AnalyticsHub {
         enum Keys: String {
             case option
+            case calendar
+            case timezone
         }
 
         /// Tracks when the "See more" button is tapped in My Store, to open the Analytics Hub.
@@ -1798,6 +1800,15 @@ extension WooAnalyticsEvent {
         ///
         static func dateRangeOptionSelected(_ option: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .analyticsHubDateRangeOptionSelected, properties: [Keys.option.rawValue: option])
+        }
+
+        /// Tracks when the date range selection fails, due to an error generating the date range from the selection.
+        /// Includes the current device calendar and timezone, for debugging the failure.
+        ///
+        static func dateRangeSelectionFailed(for option: AnalyticsHubTimeRangeSelection.SelectionType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .analyticsHubDateRangeSelectionFailed, properties: [Keys.option.rawValue: option.rawValue,
+                                                                                            Keys.calendar.rawValue: Locale.current.calendar.debugDescription,
+                                                                                            Keys.timezone.rawValue: TimeZone.current.debugDescription])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -154,6 +154,7 @@ public enum WooAnalyticsStat: String {
     //
     case analyticsHubDateRangeButtonTapped = "analytics_hub_date_range_button_tapped"
     case analyticsHubDateRangeOptionSelected = "analytics_hub_date_range_option_selected"
+    case analyticsHubDateRangeSelectionFailed = "analytics_hub_date_range_selection_failed"
 
     // MARK: Products Onboarding Events
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -84,6 +84,7 @@ final class AnalyticsHubViewModel: ObservableObject {
             try await retrieveOrderStats()
         } catch is AnalyticsHubTimeRangeSelection.TimeRangeGeneratorError {
             dismissNotice = Notice(title: Localization.timeRangeGeneratorError, feedbackType: .error)
+            ServiceLocator.analytics.track(event: .AnalyticsHub.dateRangeSelectionFailed(for: timeRangeSelectionType))
             DDLogWarn("⚠️ Error selecting analytics time range: \(timeRangeSelectionType.description)")
         } catch {
             switchToErrorState()


### PR DESCRIPTION
Closes: #8350

## Description

Adds a new analytics event to track when date range selection fails, to detect and better understand problems with specific calendars, time zones, and dates:

* `analytics_hub_date_range_selection_failed` (Event registration: 1240-gh-tracks-events-registration)

This event is triggered when a `AnalyticsHubTimeRangeSelection.TimeRangeGeneratorError` is thrown in the Analytics Hub.

## Testing

You can force a failed date range selection by temporarily editing one of the methods that unwraps the time range to always throw an error:

https://github.com/woocommerce/woocommerce-ios/blob/0af536a4dacda18538078cb996a298a98afde553/WooCommerce/Classes/ViewRelated/Dashboard/Analytics%20Hub/Time%20Range/AnalyticsHubTimeRangeSelection.swift#L68-L73

To test:

1. Build and run the app.
2. Tap the "See more" button.
3. Confirm the event `analytics_hub_date_range_selection_failed` is triggered with custom props `option` (with the selected date range option), `calendar` (with your device calendar), and `timezone` (with your device timezone).

Alternately, you can edit one of the methods in `Date+StartAndEnd.swift` to return `nil`. In that case, the event should be triggered when you select the relevant date range in the Analytics date range selector.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
