### PR TITLE
[Analytics Hub] Add Sessions card UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -104,6 +104,17 @@ struct AnalyticsHubView: View {
                     Divider()
                 }
 
+                VStack(spacing: Layout.dividerSpacing) {
+                    Divider()
+
+                    AnalyticsReportCard(viewModel: viewModel.sessionsCard)
+                        .padding(.horizontal, insets: safeAreaInsets)
+                        .background(Color(uiColor: .listForeground))
+
+                    Divider()
+                }
+                .renderedIf(ServiceLocator.featureFlagService.isFeatureFlagEnabled(.analyticsHub))
+
                 Spacer()
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -45,6 +45,17 @@ final class AnalyticsHubViewModel: ObservableObject {
     ///
     @Published var productCard = AnalyticsHubViewModel.productCard(currentPeriodStats: nil, previousPeriodStats: nil, itemsSoldStats: nil)
 
+    /// Sessions Card ViewModel
+    ///
+    @Published var sessionsCard = AnalyticsReportCardCurrentPeriodViewModel(title: "SESSIONS",
+                                                                            leadingTitle: "Views",
+                                                                            leadingValue: "1,458",
+                                                                            trailingTitle: "Conversion Rate",
+                                                                            trailingValue: "4.5%",
+                                                                            isRedacted: false,
+                                                                            showSyncError: false,
+                                                                            syncErrorMessage: "")
+
     /// Time Range Selection Type
     ///
     @Published var timeRangeSelectionType: AnalyticsHubTimeRangeSelection.SelectionType

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -1,24 +1,24 @@
 import SwiftUI
 
-/// Resuable report card made for the Analytics Hub.
+/// Reusable report card made for the Analytics Hub.
 ///
 struct AnalyticsReportCard: View {
 
     let title: String
     let leadingTitle: String
     let leadingValue: String
-    let leadingDelta: String
-    let leadingDeltaColor: UIColor
-    let leadingDeltaTextColor: UIColor
+    let leadingDelta: String?
+    let leadingDeltaColor: UIColor?
+    let leadingDeltaTextColor: UIColor?
     let leadingChartData: [Double]
-    let leadingChartColor: UIColor
+    let leadingChartColor: UIColor?
     let trailingTitle: String
     let trailingValue: String
-    let trailingDelta: String
-    let trailingDeltaColor: UIColor
-    let trailingDeltaTextColor: UIColor
+    let trailingDelta: String?
+    let trailingDeltaColor: UIColor?
+    let trailingDeltaTextColor: UIColor?
     let trailingChartData: [Double]
-    let trailingChartColor: UIColor
+    let trailingChartColor: UIColor?
 
     let isRedacted: Bool
 
@@ -50,14 +50,18 @@ struct AnalyticsReportCard: View {
                         .shimmering(active: isRedacted)
 
                     AdaptiveStack(horizontalAlignment: .leading) {
-                        DeltaTag(value: leadingDelta, backgroundColor: leadingDeltaColor, textColor: leadingDeltaTextColor)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .redacted(reason: isRedacted ? .placeholder : [])
-                            .shimmering(active: isRedacted)
+                        if let leadingDelta, let leadingDeltaColor, let leadingDeltaTextColor {
+                            DeltaTag(value: leadingDelta, backgroundColor: leadingDeltaColor, textColor: leadingDeltaTextColor)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .redacted(reason: isRedacted ? .placeholder : [])
+                                .shimmering(active: isRedacted)
+                        }
 
-                        AnalyticsLineChart(dataPoints: leadingChartData, lineChartColor: leadingChartColor)
-                            .aspectRatio(Layout.chartAspectRatio, contentMode: .fit)
-                            .frame(maxWidth: scaledChartWidth)
+                        if leadingChartData.isNotEmpty, let leadingChartColor {
+                            AnalyticsLineChart(dataPoints: leadingChartData, lineChartColor: leadingChartColor)
+                                .aspectRatio(Layout.chartAspectRatio, contentMode: .fit)
+                                .frame(maxWidth: scaledChartWidth)
+                        }
                     }
 
                 }
@@ -75,14 +79,18 @@ struct AnalyticsReportCard: View {
                         .shimmering(active: isRedacted)
 
                     AdaptiveStack(horizontalAlignment: .leading) {
-                        DeltaTag(value: trailingDelta, backgroundColor: trailingDeltaColor, textColor: trailingDeltaTextColor)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .redacted(reason: isRedacted ? .placeholder : [])
-                            .shimmering(active: isRedacted)
+                        if let trailingDelta, let trailingDeltaColor, let trailingDeltaTextColor {
+                            DeltaTag(value: trailingDelta, backgroundColor: trailingDeltaColor, textColor: trailingDeltaTextColor)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .redacted(reason: isRedacted ? .placeholder : [])
+                                .shimmering(active: isRedacted)
+                        }
 
-                        AnalyticsLineChart(dataPoints: trailingChartData, lineChartColor: trailingChartColor)
-                            .aspectRatio(Layout.chartAspectRatio, contentMode: .fit)
-                            .frame(maxWidth: scaledChartWidth)
+                        if trailingChartData.isNotEmpty, let trailingChartColor {
+                            AnalyticsLineChart(dataPoints: trailingChartData, lineChartColor: trailingChartColor)
+                                .aspectRatio(Layout.chartAspectRatio, contentMode: .fit)
+                                .frame(maxWidth: scaledChartWidth)
+                        }
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -155,5 +163,26 @@ struct Previews: PreviewProvider {
                             syncErrorMessage: "Error loading revenue analytics")
             .previewLayout(.sizeThatFits)
             .previewDisplayName("No data")
+
+        AnalyticsReportCard(title: "SESSIONS",
+                            leadingTitle: "Views",
+                            leadingValue: "1,458",
+                            leadingDelta: nil,
+                            leadingDeltaColor: nil,
+                            leadingDeltaTextColor: nil,
+                            leadingChartData: [],
+                            leadingChartColor: nil,
+                            trailingTitle: "Conversion Rate",
+                            trailingValue: "4.5%",
+                            trailingDelta: nil,
+                            trailingDeltaColor: nil,
+                            trailingDeltaTextColor: nil,
+                            trailingChartData: [],
+                            trailingChartColor: nil,
+                            isRedacted: false,
+                            showSyncError: true,
+                            syncErrorMessage: "")
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName("Current period only")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardCurrentPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardCurrentPeriodViewModel.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Analytics Hub Report Card Current Period ViewModel.
+/// Used to transmit analytics report data for the current period (no comparison to previous periods).
+///
+struct AnalyticsReportCardCurrentPeriodViewModel {
+    /// Report Card Title.
+    ///
+    let title: String
+
+    /// First Column Title
+    ///
+    let leadingTitle: String
+
+    /// First Column Value
+    ///
+    let leadingValue: String
+
+    /// Second Column Title
+    ///
+    let trailingTitle: String
+
+    /// Second Column Value
+    ///
+    let trailingValue: String
+
+    /// Indicates if the values should be hidden (for loading state)
+    ///
+    let isRedacted: Bool
+
+    /// Indicates if there was an error loading the data for the card
+    ///
+    let showSyncError: Bool
+
+    /// Message to display if there was an error loading the data for the card
+    ///
+    let syncErrorMessage: String
+}
+
+extension AnalyticsReportCardCurrentPeriodViewModel {
+
+    /// Make redacted state of the card, replacing values with hardcoded placeholders
+    ///
+    var redacted: Self {
+        // Values here are placeholders and will be redacted in the UI
+        .init(title: title,
+              leadingTitle: leadingTitle,
+              leadingValue: "$1000",
+              trailingTitle: trailingTitle,
+              trailingValue: "$1000",
+              isRedacted: true,
+              showSyncError: false,
+              syncErrorMessage: "")
+    }
+}
+
+/// Convenience extension to create an `AnalyticsReportCard` from a view model.
+///
+extension AnalyticsReportCard {
+    init(viewModel: AnalyticsReportCardCurrentPeriodViewModel) {
+        self.title = viewModel.title
+        self.leadingTitle = viewModel.leadingTitle
+        self.leadingValue = viewModel.leadingValue
+        self.leadingDelta = nil
+        self.leadingDeltaColor = nil
+        self.leadingDeltaTextColor = nil
+        self.leadingChartData = []
+        self.leadingChartColor = nil
+        self.trailingTitle = viewModel.trailingTitle
+        self.trailingValue = viewModel.trailingValue
+        self.trailingDelta = nil
+        self.trailingDeltaColor = nil
+        self.trailingDeltaTextColor = nil
+        self.trailingChartData = []
+        self.trailingChartColor = nil
+        self.isRedacted = viewModel.isRedacted
+        self.showSyncError = viewModel.showSyncError
+        self.syncErrorMessage = viewModel.syncErrorMessage
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1480,6 +1480,7 @@
 		CC8413E523F5C49100EFC277 /* start.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011023E9E3F400157A78 /* start.sh */; };
 		CC923A1D2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC923A1C2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift */; };
 		CCA1D5FE293F537400B40560 /* DeltaPercentage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA1D5FD293F537400B40560 /* DeltaPercentage.swift */; };
+		CCA1D6022943636100B40560 /* AnalyticsReportCardCurrentPeriodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA1D6012943636100B40560 /* AnalyticsReportCardCurrentPeriodViewModel.swift */; };
 		CCB366AF274518EC007D437A /* EditableOrderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB366AE274518EC007D437A /* EditableOrderViewModelTests.swift */; };
 		CCC284112768C18500F6CC8B /* ProductInOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC284102768C18500F6CC8B /* ProductInOrder.swift */; };
 		CCCC29DD25E5757C0046B96F /* RenameAttributesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CCCC29DC25E5757C0046B96F /* RenameAttributesViewController.xib */; };
@@ -3506,6 +3507,7 @@
 		CC77488D2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressTopBannerFactoryTests.swift; sourceTree = "<group>"; };
 		CC923A1C2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderStatusListViewModelTests.swift; sourceTree = "<group>"; };
 		CCA1D5FD293F537400B40560 /* DeltaPercentage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeltaPercentage.swift; sourceTree = "<group>"; };
+		CCA1D6012943636100B40560 /* AnalyticsReportCardCurrentPeriodViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportCardCurrentPeriodViewModel.swift; sourceTree = "<group>"; };
 		CCB366AE274518EC007D437A /* EditableOrderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderViewModelTests.swift; sourceTree = "<group>"; };
 		CCC284102768C18500F6CC8B /* ProductInOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInOrder.swift; sourceTree = "<group>"; };
 		CCCC29DC25E5757C0046B96F /* RenameAttributesViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RenameAttributesViewController.xib; sourceTree = "<group>"; };
@@ -5371,6 +5373,7 @@
 				26E7EE69292D688900793045 /* AnalyticsHubViewModel.swift */,
 				2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */,
 				26E7EE6B292D894100793045 /* AnalyticsReportCardViewModel.swift */,
+				CCA1D6012943636100B40560 /* AnalyticsReportCardCurrentPeriodViewModel.swift */,
 				B60B5025292D308A00178C26 /* AnalyticsTimeRangeCard.swift */,
 				B6A10E9B292E5DEE00790797 /* AnalyticsTimeRangeCardViewModel.swift */,
 				26E7EE6D29300E8100793045 /* AnalyticsProductCard.swift */,
@@ -10568,6 +10571,7 @@
 				EEADF624281A421A001B40F1 /* DefaultShippingValueLocalizer.swift in Sources */,
 				0263E3BB290BB21800E5F88F /* WooAnalyticsEvent+StoreCreation.swift in Sources */,
 				4A68E3E32941D4CE004AC3DC /* WordPressLibraryLogger.swift in Sources */,
+				CCA1D6022943636100B40560 /* AnalyticsReportCardCurrentPeriodViewModel.swift in Sources */,
 				174CA86E27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift in Sources */,
 				262C921F26EEF8B100011F92 /* Binding.swift in Sources */,
 				DE4FB7732812AE96003D20D6 /* FilterListView.swift in Sources */,


### PR DESCRIPTION
Closes: #8362

## Description

This PR adds the UI for the Sessions card in the Analytics Hub, using temporary placeholder data. The card is behind the `analyticsHub` feature flag.

## Changes

* Adds a new `AnalyticsReportCardCurrentPeriodViewModel` view model, which can be used for the `AnalyticsReportCard` when we only want to display data for the current period (no delta percentage or chart to compare to the previous period).
* Adjusts the `AnalyticsReportCard` view to make the delta percentage and chart subviews optional.
* Adds the Sessions card to the `AnalyticsHubView`, only rendered if the `analyticsHub` feature flag is enabled.
* Adds the Sessions card view model to the main hub view model, filling it with placeholder data for now.

## Testing

1. Build and run the app with the `analyticsHub` feature flag enabled.
2. Tap "See more" on the My Store dashboard to open Analytics.
3. Scroll to the bottom of the screen and confirm the Sessions card appears as expected.

## Screenshots

<img src="https://user-images.githubusercontent.com/8658164/206712463-eb390813-6639-45d4-9860-b8557c4443d6.png" width="300px">


## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
