### PR TITLE
[Mobile Payments] Handle cancellation from card readers

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -509,16 +509,13 @@ private extension StripeCardReaderService {
                     /// the completion block for collectPaymentMethod will be called
                     /// with error Canceled when collectPaymentMethod is canceled
                     /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)collectPaymentMethod:delegate:completion:
-
-                    if underlyingError != .commandCancelled {
-                        DDLogError("💳 Error: collect payment method \(underlyingError)")
-                        promise(.failure(CardReaderServiceError.paymentMethodCollection(underlyingError: underlyingError)))
-                    }
-
                     if underlyingError == .commandCancelled {
-                        DDLogWarn("💳 Warning: collect payment error cancelled. We actively ignore this error \(error)")
-                        promise(.failure(CardReaderServiceError.paymentCancellation(underlyingError: underlyingError)))
+                        DDLogWarn("💳 Warning: collect payment cancelled \(error)")
+                    } else {
+                        DDLogError("💳 Error: collect payment method \(underlyingError)")
                     }
+
+                    promise(.failure(CardReaderServiceError.paymentMethodCollection(underlyingError: underlyingError)))
 
                 }
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -507,11 +507,15 @@ private extension StripeCardReaderService {
                     /// the completion block for collectPaymentMethod will be called
                     /// with error Canceled when collectPaymentMethod is canceled
                     /// https://stripe.dev/stripe-terminal-ios/docs/Classes/SCPTerminal.html#/c:objc(cs)SCPTerminal(im)collectPaymentMethod:delegate:completion:
-                    if underlyingError == .commandCancelled {
+                    if case .commandCancelled(let cancellationSource) = underlyingError {
                         DDLogWarn("💳 Warning: collect payment cancelled \(error)")
                         /// If we've not used the cancellable in the app, the cancellation must have come from the reader
-                        if self?.paymentCancellable != nil {
-                            underlyingError = .commandCancelledOnReader
+                        if case .unknown = cancellationSource {
+                            if self?.paymentCancellable != nil {
+                                underlyingError = .commandCancelled(from: .reader)
+                            } else {
+                                underlyingError = .commandCancelled(from: .app)
+                            }
                         }
                     } else {
                         DDLogError("💳 Error: collect payment method \(underlyingError)")

--- a/Hardware/Hardware/CardReader/StripeCardReader/UnderlyingError+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/UnderlyingError+Stripe.swift
@@ -26,7 +26,7 @@ extension UnderlyingError {
         case ErrorCode.Code.featureNotAvailableWithConnectedReader.rawValue:
             self = .featureNotAvailableWithConnectedReader
         case ErrorCode.Code.canceled.rawValue:
-            self = .commandCancelled
+            self = .commandCancelled(from: .unknown)
         case ErrorCode.Code.locationServicesDisabled.rawValue:
             self = .locationServicesDisabled
         case ErrorCode.Code.bluetoothDisabled.rawValue:

--- a/Hardware/Hardware/CardReader/UnderlyingError.swift
+++ b/Hardware/Hardware/CardReader/UnderlyingError.swift
@@ -29,6 +29,10 @@ public enum UnderlyingError: Error, Equatable {
     /// A command was cancelled
     case commandCancelled
 
+    /// A command was cancelled on the reader.
+    /// Note that this is not produced by Stripe, we have to infer it from commandCancelled.
+    case commandCancelledOnReader
+
     /// Access to location services is currently disabled. This may be because:
     /// - The user disabled location services in the system settings.
     /// - The user denied access to location services for your app.
@@ -285,6 +289,9 @@ extension UnderlyingError: LocalizedError {
         case .commandCancelled:
             return NSLocalizedString("The system canceled the command unexpectedly - please try again",
                                      comment: "Error message when the system cancels a command.")
+        case .commandCancelledOnReader:
+            return NSLocalizedString("The payment was canceled on the reader",
+                                     comment: "Error message when the cancel button on the reader is used.")
         case .locationServicesDisabled:
             return NSLocalizedString("Unable to access Location Services - please enable Location Services and try again",
                                      comment: "Error message when location services is not enabled for this application.")

--- a/Hardware/Hardware/CardReader/UnderlyingError.swift
+++ b/Hardware/Hardware/CardReader/UnderlyingError.swift
@@ -27,11 +27,15 @@ public enum UnderlyingError: Error, Equatable {
     case featureNotAvailableWithConnectedReader
 
     /// A command was cancelled
-    case commandCancelled
+    case commandCancelled(from: CancellationSource)
 
-    /// A command was cancelled on the reader.
-    /// Note that this is not produced by Stripe, we have to infer it from commandCancelled.
-    case commandCancelledOnReader
+    /// A command can be cancelled on the reader, or in the app.
+    /// Note that this is not produced by Stripe, we have to infer it from commandCancelled, so we start with `.unknown`.
+    public enum CancellationSource {
+        case unknown
+        case app
+        case reader
+    }
 
     /// Access to location services is currently disabled. This may be because:
     /// - The user disabled location services in the system settings.
@@ -286,12 +290,15 @@ extension UnderlyingError: LocalizedError {
         case .featureNotAvailableWithConnectedReader:
             return NSLocalizedString("Unable to perform request with the connected reader - unsupported feature - please try again with another reader",
                                      comment: "Error message when the card reader cannot be used to perform the requested task.")
-        case .commandCancelled:
-            return NSLocalizedString("The system canceled the command unexpectedly - please try again",
-                                     comment: "Error message when the system cancels a command.")
-        case .commandCancelledOnReader:
-            return NSLocalizedString("The payment was canceled on the reader",
-                                     comment: "Error message when the cancel button on the reader is used.")
+        case .commandCancelled(let cancellationSource):
+            switch cancellationSource {
+            case .reader:
+                return NSLocalizedString("The payment was canceled on the reader",
+                                         comment: "Error message when the cancel button on the reader is used.")
+            default:
+                return NSLocalizedString("The system canceled the command unexpectedly - please try again",
+                                         comment: "Error message when the system cancels a command.")
+            }
         case .locationServicesDisabled:
             return NSLocalizedString("Unable to access Location Services - please enable Location Services and try again",
                                      comment: "Error message when location services is not enabled for this application.")

--- a/Hardware/HardwareTests/ErrorCodesTests.swift
+++ b/Hardware/HardwareTests/ErrorCodesTests.swift
@@ -39,7 +39,7 @@ final class CardReaderServiceErrorTests: XCTestCase {
     }
 
     func test_stripe_cancelled_maps_to_expected_error() {
-        XCTAssertEqual(.commandCancelled, domainError(stripeCode: 2020))
+        XCTAssertEqual(.commandCancelled(from: .unknown), domainError(stripeCode: 2020))
     }
 
     func test_stripe_location_services_disabled_maps_to_expected_error() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
@@ -87,6 +87,12 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
     func retryableError(tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalRetryableError(primaryAction: tryAgain)
     }
+
+    func cancelledOnReader() -> CardPresentPaymentsModalViewModel? {
+        CardPresentModalNonRetryableError(amount: amount,
+                                          error: CardReaderServiceError.paymentMethodCollection(underlyingError: .commandCancelledOnReader),
+                                          onDismiss: { })
+    }
 }
 
 private extension BluetoothCardReaderPaymentAlertsProvider {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
@@ -90,7 +90,7 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
 
     func cancelledOnReader() -> CardPresentPaymentsModalViewModel? {
         CardPresentModalNonRetryableError(amount: amount,
-                                          error: CardReaderServiceError.paymentMethodCollection(underlyingError: .commandCancelledOnReader),
+                                          error: CardReaderServiceError.paymentMethodCollection(underlyingError: .commandCancelled(from: .reader)),
                                           onDismiss: { })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
@@ -79,6 +79,10 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
     func retryableError(tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalRetryableError(primaryAction: tryAgain)
     }
+
+    func cancelledOnReader() -> CardPresentPaymentsModalViewModel? {
+        return nil
+    }
 }
 
 private extension BuiltInCardReaderPaymentAlertsProvider {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTransactionAlertsProviding.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTransactionAlertsProviding.swift
@@ -45,4 +45,8 @@ protocol CardReaderTransactionAlertsProviding {
     /// An alert to display a retriable error
     ///
     func retryableError(tryAgain: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+
+    /// An alert to notify the merchant that the transaction was cancelled using a button on the reader
+    ///
+    func cancelledOnReader() -> CardPresentPaymentsModalViewModel?
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -274,6 +274,8 @@ private extension CollectOrderPaymentUseCase {
                 switch result {
                 case .success(let capturedPaymentData):
                     self?.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData, onCompletion: onCompletion)
+                case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelledOnReader)):
+                    self?.handlePaymentCancellationFromReader(alertProvider: paymentAlerts)
                 case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled)):
                     self?.handlePaymentCancellation()
                 case .failure(let error):
@@ -301,6 +303,14 @@ private extension CollectOrderPaymentUseCase {
     func handlePaymentCancellation() {
         trackPaymentCancelation()
         alertsPresenter.dismiss()
+    }
+
+    func handlePaymentCancellationFromReader(alertProvider paymentAlerts: CardReaderTransactionAlertsProviding) {
+        trackPaymentCancelation()
+        guard let dismissedOnReaderAlert = paymentAlerts.cancelledOnReader() else {
+            return alertsPresenter.dismiss()
+        }
+        alertsPresenter.present(viewModel: dismissedOnReaderAlert)
     }
 
     /// Log the failure reason, cancel the current payment and retry it if possible.

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -164,8 +164,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
                                              onCompleted: onCompleted)
                 })
             case .canceled:
-                self.alertsPresenter.dismiss()
-                self.trackPaymentCancelation()
+                self.handlePaymentCancellation()
                 onCancel()
             case .none:
                 break
@@ -275,6 +274,8 @@ private extension CollectOrderPaymentUseCase {
                 switch result {
                 case .success(let capturedPaymentData):
                     self?.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData, onCompletion: onCompletion)
+                case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled)):
+                    self?.handlePaymentCancellation()
                 case .failure(let error):
                     self?.handlePaymentFailureAndRetryPayment(error, alertProvider: paymentAlerts, onCompletion: onCompletion)
                 }
@@ -295,6 +296,11 @@ private extension CollectOrderPaymentUseCase {
 
         // Success Callback
         onCompletion(.success(capturedPaymentData))
+    }
+
+    func handlePaymentCancellation() {
+        trackPaymentCancelation()
+        alertsPresenter.dismiss()
     }
 
     /// Log the failure reason, cancel the current payment and retry it if possible.

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -274,10 +274,13 @@ private extension CollectOrderPaymentUseCase {
                 switch result {
                 case .success(let capturedPaymentData):
                     self?.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData, onCompletion: onCompletion)
-                case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelledOnReader)):
-                    self?.handlePaymentCancellationFromReader(alertProvider: paymentAlerts)
-                case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled)):
-                    self?.handlePaymentCancellation()
+                case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled(let cancellationSource))):
+                    switch cancellationSource {
+                    case .reader:
+                        self?.handlePaymentCancellationFromReader(alertProvider: paymentAlerts)
+                    default:
+                        self?.handlePaymentCancellation()
+                    }
                 case .failure(let error):
                     self?.handlePaymentFailureAndRetryPayment(error, alertProvider: paymentAlerts, onCompletion: onCompletion)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
@@ -293,6 +293,9 @@ private extension LegacyCollectOrderPaymentUseCase {
                 switch result {
                 case .success(let capturedPaymentData):
                     self?.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData, onCompletion: onCompletion)
+                case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled)):
+                    self?.trackPaymentCancelation()
+                    onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
                 case .failure(let error):
                     self?.handlePaymentFailureAndRetryPayment(error, onCompletion: onCompletion)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
@@ -293,7 +293,8 @@ private extension LegacyCollectOrderPaymentUseCase {
                 switch result {
                 case .success(let capturedPaymentData):
                     self?.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData, onCompletion: onCompletion)
-                case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled)):
+                case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelledOnReader)),
+                        .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled)):
                     self?.trackPaymentCancelation()
                     onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
                 case .failure(let error):

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
@@ -293,8 +293,7 @@ private extension LegacyCollectOrderPaymentUseCase {
                 switch result {
                 case .success(let capturedPaymentData):
                     self?.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData, onCompletion: onCompletion)
-                case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelledOnReader)),
-                        .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled)):
+                case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled(_))):
                     self?.trackPaymentCancelation()
                     onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
                 case .failure(let error):


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8085 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In sTAP Away, we're adding support for Apple's built in card readers to take in-person payments. We continue to use Stripe's SDK to handle payments.

During this work, we are looking to share code where practical with the bluetooth reader flows, and fix issues in those flows which were less obvious with an external reader. One such issue is cancelation from card readers, including Apple's built in card reader.

On the built-in reader modal which Apple provide, there is a `x` button to cancel the payment. On the WisePad 3 reader, there are customer-facing buttons, and tapping the red `x` button when collecting card details will cancel the payment.

In both these cases, we should end the payment flow. For the WisePad 3 reader, we should inform the merchant that the payment was canceled, so they understand how the external device is impacting the payment flow.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Using an iPhone XS or newer on iOS 16.0 or newer on a US store

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. When asked for a reader type, tap `Tap to Pay on iPhone` and go through the Terms of Service Apple ID linking (if you've not done so before)
6. Tap the `x` on Apple's screen to cancel
7. Observe that the modal is dismissed, and the payment flow behind it is also dismissed
8. Observe that the `card_present_collect_payment_canceled` tracks event is logged as expected

### On a CA store using a physical WisePad 3 reader – new flow

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. Wait for the reader to connect and ask for the card to be tapped or inserted
6. Press the red `x` button on the reader
7. Observe that the payment canceled error (see below) is shown
8. Observe that the `card_present_collect_payment_canceled` tracks event is logged as expected

### On a CA store using a physical WisePad 3 reader – existing flow

1. Navigate to `Menu > Settings > Experimental features`
2. Turn off `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. Wait for the reader to connect and ask for the card to be tapped or inserted
6. Press the red `x` button on the reader
7. Observe that the payment flow is dismissed
8. Observe that the `card_present_collect_payment_canceled` tracks event is logged as expected

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### WisePad 3 reader screen
![payment canceled on reader](https://user-images.githubusercontent.com/2472348/206717773-dafd4b67-1ea7-42fd-8d8b-c97f49d5556f.jpg)

### Apple built in reader flow

https://user-images.githubusercontent.com/2472348/206719025-b64e6b25-c6cd-4202-b573-66d50ccd6cd8.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
