### PR TITLE
[Analytics Hub] Prepare Networking for additional site stats endpoints

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -369,7 +369,7 @@
 		68F48B1328E3E5750045C15B /* wc-analytics-customers.json in Resources */ = {isa = PBXBuildFile; fileRef = 68F48B1228E3E5750045C15B /* wc-analytics-customers.json */; };
 		68FBC5B828928C8C00A05461 /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68FBC5B728928C8C00A05461 /* WooFoundation.framework */; };
 		74002D6A2118B26100A63C19 /* SiteVisitStatsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74002D692118B26000A63C19 /* SiteVisitStatsMapperTests.swift */; };
-		74002D6C2118B88200A63C19 /* SiteVisitStatsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74002D6B2118B88200A63C19 /* SiteVisitStatsRemoteTests.swift */; };
+		74002D6C2118B88200A63C19 /* SiteStatsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74002D6B2118B88200A63C19 /* SiteStatsRemoteTests.swift */; };
 		740211DF2193985A002248DA /* comment-moderate-spam.json in Resources */ = {isa = PBXBuildFile; fileRef = 740211DE2193985A002248DA /* comment-moderate-spam.json */; };
 		740211E121939908002248DA /* CommentRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740211E021939908002248DA /* CommentRemoteTests.swift */; };
 		740211E321939C84002248DA /* CommentResultMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740211E221939C83002248DA /* CommentResultMapper.swift */; };
@@ -419,7 +419,7 @@
 		74A1D26821189A7100931DFA /* SiteVisitStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A1D26721189A7000931DFA /* SiteVisitStats.swift */; };
 		74A1D26B21189B8100931DFA /* SiteVisitStatsItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A1D26A21189B8100931DFA /* SiteVisitStatsItem.swift */; };
 		74A1D26D21189DFF00931DFA /* SiteVisitStatsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A1D26C21189DFE00931DFA /* SiteVisitStatsMapper.swift */; };
-		74A1D26F21189EA100931DFA /* SiteVisitStatsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A1D26E21189EA000931DFA /* SiteVisitStatsRemote.swift */; };
+		74A1D26F21189EA100931DFA /* SiteStatsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A1D26E21189EA000931DFA /* SiteStatsRemote.swift */; };
 		74A7B4BC217A807400E85A8B /* SiteSettingsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A7B4BB217A807400E85A8B /* SiteSettingsMapperTests.swift */; };
 		74A7B4BE217A841400E85A8B /* broken-settings-general.json in Resources */ = {isa = PBXBuildFile; fileRef = 74A7B4BD217A841400E85A8B /* broken-settings-general.json */; };
 		74AB0ACA21948CE4008220CD /* CommentResultMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AB0AC921948CE4008220CD /* CommentResultMapperTests.swift */; };
@@ -1119,7 +1119,7 @@
 		68FBC5B728928C8C00A05461 /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NetworkingTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74002D692118B26000A63C19 /* SiteVisitStatsMapperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteVisitStatsMapperTests.swift; sourceTree = "<group>"; };
-		74002D6B2118B88200A63C19 /* SiteVisitStatsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteVisitStatsRemoteTests.swift; sourceTree = "<group>"; };
+		74002D6B2118B88200A63C19 /* SiteStatsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteStatsRemoteTests.swift; sourceTree = "<group>"; };
 		740211DE2193985A002248DA /* comment-moderate-spam.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "comment-moderate-spam.json"; sourceTree = "<group>"; };
 		740211E021939908002248DA /* CommentRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentRemoteTests.swift; sourceTree = "<group>"; };
 		740211E221939C83002248DA /* CommentResultMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentResultMapper.swift; sourceTree = "<group>"; };
@@ -1169,7 +1169,7 @@
 		74A1D26721189A7000931DFA /* SiteVisitStats.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteVisitStats.swift; sourceTree = "<group>"; };
 		74A1D26A21189B8100931DFA /* SiteVisitStatsItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteVisitStatsItem.swift; sourceTree = "<group>"; };
 		74A1D26C21189DFE00931DFA /* SiteVisitStatsMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteVisitStatsMapper.swift; sourceTree = "<group>"; };
-		74A1D26E21189EA000931DFA /* SiteVisitStatsRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteVisitStatsRemote.swift; sourceTree = "<group>"; };
+		74A1D26E21189EA000931DFA /* SiteStatsRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteStatsRemote.swift; sourceTree = "<group>"; };
 		74A7B4BB217A807400E85A8B /* SiteSettingsMapperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteSettingsMapperTests.swift; sourceTree = "<group>"; };
 		74A7B4BD217A841400E85A8B /* broken-settings-general.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "broken-settings-general.json"; sourceTree = "<group>"; };
 		74AB0AC921948CE4008220CD /* CommentResultMapperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentResultMapperTests.swift; sourceTree = "<group>"; };
@@ -1730,7 +1730,7 @@
 				31D27C942602B737002EDB1D /* SitePluginsRemoteTests.swift */,
 				453305EE2459E46000264E50 /* SitePostsRemoteTests.swift */,
 				74D5BECD217E0F98007B0348 /* SiteSettingsRemoteTests.swift */,
-				74002D6B2118B88200A63C19 /* SiteVisitStatsRemoteTests.swift */,
+				74002D6B2118B88200A63C19 /* SiteStatsRemoteTests.swift */,
 				45ED4F13239E8F2E004F1BE3 /* TaxClassRemoteTests.swift */,
 				74CF5E8321402C04000CED0A /* TopEarnerStatsRemoteTests.swift */,
 				AE2D6622272A8F6E004A2C3A /* TelemetryRemoteTests.swift */,
@@ -1873,7 +1873,7 @@
 				7426CA0C21AF27B9004E9FFC /* SiteAPIRemote.swift */,
 				31D27C802602889C002EDB1D /* SitePluginsRemote.swift */,
 				74046E1A217A684D007DD7BF /* SiteSettingsRemote.swift */,
-				74A1D26E21189EA000931DFA /* SiteVisitStatsRemote.swift */,
+				74A1D26E21189EA000931DFA /* SiteStatsRemote.swift */,
 				4568E2212459ADC60007E478 /* SitePostsRemote.swift */,
 				4501068E2399B19500E24722 /* TaxClassRemote.swift */,
 				74ABA1D0213F22CA00FFAD30 /* TopEarnersStatsRemote.swift */,
@@ -3125,7 +3125,7 @@
 				7412A8EC21B6E286005D182A /* ReportOrderTotalsMapper.swift in Sources */,
 				451A97CD260A01A40059D135 /* ShippingLabelStoreOptions.swift in Sources */,
 				02C254A8256373AB00A04423 /* ShippingLabel.swift in Sources */,
-				74A1D26F21189EA100931DFA /* SiteVisitStatsRemote.swift in Sources */,
+				74A1D26F21189EA100931DFA /* SiteStatsRemote.swift in Sources */,
 				029BA4F4255D72EC006171FD /* ShippingLabelPrintData.swift in Sources */,
 				24F98C562502EA4800F49B68 /* FeatureFlag.swift in Sources */,
 				02AF07EA27492DBC00B2D81E /* WordPressMedia.swift in Sources */,
@@ -3442,7 +3442,7 @@
 				45152831257A8E1A0076B03C /* ProductAttributeMapperTests.swift in Sources */,
 				26B2F74924C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift in Sources */,
 				45CCFCE827A2E5020012E8CB /* InboxNoteListMapperTests.swift in Sources */,
-				74002D6C2118B88200A63C19 /* SiteVisitStatsRemoteTests.swift in Sources */,
+				74002D6C2118B88200A63C19 /* SiteStatsRemoteTests.swift in Sources */,
 				0212683524C046CB00F8A892 /* MockNetwork+Path.swift in Sources */,
 				68BD37B328D9B8BD00C2A517 /* CustomerRemoteTests.swift in Sources */,
 				B554FA932180C17200C54DFF /* NoteHashListMapperTests.swift in Sources */,

--- a/Networking/Networking/Remote/SiteStatsRemote.swift
+++ b/Networking/Networking/Remote/SiteStatsRemote.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// SiteVisitStats: Remote Endpoints
+/// SiteStats: Remote Endpoints
 ///
-public class SiteVisitStatsRemote: Remote {
+public class SiteStatsRemote: Remote {
 
     /// Fetch the visitor stats for a given site up to the current day, week, month, or year (depending on the given granularity of the `unit` parameter).
     ///
@@ -19,7 +19,7 @@ public class SiteVisitStatsRemote: Remote {
                                      latestDateToInclude: Date,
                                      quantity: Int,
                                      completion: @escaping (Result<SiteVisitStats, Error>) -> Void) {
-        let path = "\(Constants.sitesPath)/\(siteID)/\(Constants.siteVisitStatsPath)/"
+        let path = "\(Path.sites)/\(siteID)/\(Path.siteVisitStats)/"
         let dateFormatter = DateFormatter.Stats.statsDayFormatter
         if let siteTimezone = siteTimezone {
             dateFormatter.timeZone = siteTimezone
@@ -27,7 +27,7 @@ public class SiteVisitStatsRemote: Remote {
         let parameters = [ParameterKeys.unit: unit.rawValue,
                           ParameterKeys.date: dateFormatter.string(from: latestDateToInclude),
                           ParameterKeys.quantity: String(quantity),
-                          ParameterKeys.statFields: Constants.visitorStatFieldValue]
+                          ParameterKeys.statFields: ParameterValues.visitors]
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path, parameters: parameters)
         let mapper = SiteVisitStatsMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
@@ -37,11 +37,10 @@ public class SiteVisitStatsRemote: Remote {
 
 // MARK: - Constants!
 //
-private extension SiteVisitStatsRemote {
-    enum Constants {
-        static let sitesPath: String             = "sites"
-        static let siteVisitStatsPath: String    = "stats/visits"
-        static let visitorStatFieldValue: String = "visitors"
+private extension SiteStatsRemote {
+    enum Path {
+        static let sites: String             = "sites"
+        static let siteVisitStats: String    = "stats/visits"
     }
 
     enum ParameterKeys {
@@ -49,5 +48,9 @@ private extension SiteVisitStatsRemote {
         static let date: String       = "date"
         static let quantity: String   = "quantity"
         static let statFields: String = "stat_fields"
+    }
+
+    enum ParameterValues {
+        static let visitors: String = "visitors"
     }
 }

--- a/Networking/NetworkingTests/Remote/SiteStatsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteStatsRemoteTests.swift
@@ -2,9 +2,9 @@ import XCTest
 @testable import Networking
 
 
-/// SiteVisitStatsRemote Unit Tests
+/// SiteStatsRemote Unit Tests
 ///
-class SiteVisitStatsRemoteTests: XCTestCase {
+class SiteStatsRemoteTests: XCTestCase {
 
     /// Dummy Network Wrapper
     ///
@@ -25,7 +25,7 @@ class SiteVisitStatsRemoteTests: XCTestCase {
     ///
     func test_loadSiteVisitorStats_properly_returns_parsed_stats() throws {
         // Given
-        let remote = SiteVisitStatsRemote(network: network)
+        let remote = SiteStatsRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/stats/visits/", filename: "site-visits-day")
 
         // When
@@ -45,7 +45,7 @@ class SiteVisitStatsRemoteTests: XCTestCase {
     ///
     func test_loadSiteVisitorStats_properly_relays_netwoking_errors() {
         // Given
-        let remote = SiteVisitStatsRemote(network: network)
+        let remote = SiteStatsRemote(network: network)
 
         // When
         let result: Result<SiteVisitStats, Error> = waitFor { promise in

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -19,7 +19,7 @@ final class StoreInfoDataService {
 
     /// Visitors remoute source
     ///
-    private var siteVisitStatsRemote: SiteVisitStatsRemote
+    private var siteVisitStatsRemote: SiteStatsRemote
 
     /// Network helper.
     ///
@@ -28,7 +28,7 @@ final class StoreInfoDataService {
     init(authToken: String) {
         network = AlamofireNetwork(credentials: Credentials(authToken: authToken))
         orderStatsRemoteV4 = OrderStatsRemoteV4(network: network)
-        siteVisitStatsRemote = SiteVisitStatsRemote(network: network)
+        siteVisitStatsRemote = SiteStatsRemote(network: network)
     }
 
     /// Async function that fetches todays stats data.

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -6,13 +6,13 @@ import WooFoundation
 // MARK: - StatsStoreV4
 //
 public final class StatsStoreV4: Store {
-    private let siteVisitStatsRemote: SiteVisitStatsRemote
+    private let siteVisitStatsRemote: SiteStatsRemote
     private let leaderboardsRemote: LeaderboardsRemote
     private let orderStatsRemote: OrderStatsRemoteV4
     private let productsRemote: ProductsRemote
 
     public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
-        self.siteVisitStatsRemote = SiteVisitStatsRemote(network: network)
+        self.siteVisitStatsRemote = SiteStatsRemote(network: network)
         self.leaderboardsRemote = LeaderboardsRemote(network: network)
         self.orderStatsRemote = OrderStatsRemoteV4(network: network)
         self.productsRemote = ProductsRemote(network: network)

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -25,7 +25,7 @@ At the time of writing this document, these are the subclasses of `Remote`:
 * `ShipmentsRemote` All things Shipment Tracking, from tracking providers to actual tracking associated to an order
 * `SiteAPIRemote` Loads the API information associated to a site.
 * `SiteSettingsRemote` Loads a site’s settings
-* `SiteVisitStatsremote` fetches visitor stats for a given site
+* `SiteStatsremote` fetches Jetpack stats for a given site
 * `TaxClassesRemote` fetches tax classes for a given site.
 * `TopEarnersStatsRemote`fetches the top earner stats for a given site.
 


### PR DESCRIPTION
Part of: #8363

## Description

In preparation for adding support for another site stats endpoint (`/rest/v1.1/sites/{SITE}/stats/summary`), this PR renames `SiteVisitStatsRemote` to `SiteStatsRemote`. It also separates its `Constants` enum into separate enums for the endpoint paths, parameter keys, and parameter values, for clarity.

This will prepare `SiteStatsRemote` to include multiple Jetpack stats endpoints (under `/rest/v1.1/sites/{SITE}/stats`), and avoid naming confusion when those stats return more than just visitor stats.

## Testing

1. Launch the app.
2. Confirm stats load as expected (including Visitor stats) on the My Store dashboard.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
