### PR TITLE
[Analytics Hub] Update networking to load data in parallel

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -93,7 +93,7 @@ struct AnalyticsHubView: View {
                 VStack(spacing: Layout.dividerSpacing) {
                     Divider()
 
-                    AnalyticsProductCard(viewModel: viewModel.productCard)
+                    AnalyticsProductCard(statsViewModel: viewModel.productsStatsCard, itemsViewModel: viewModel.itemsSoldCard)
                         .padding(.horizontal, insets: safeAreaInsets)
                         .background(Color(uiColor: .listForeground))
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -100,13 +100,14 @@ private extension AnalyticsHubViewModel {
         let currentTimeRange = try timeRangeSelection.unwrapCurrentTimeRange()
         let previousTimeRange = try timeRangeSelection.unwrapPreviousTimeRange()
 
-        await withThrowingTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 try await self.retrieveOrderStats(currentTimeRange: currentTimeRange, previousTimeRange: previousTimeRange)
             }
             group.addTask {
                 try await self.retrieveVisitorStats(currentTimeRange: currentTimeRange, previousTimeRange: previousTimeRange)
             }
+            try await group.waitForAll()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -202,11 +202,14 @@ private extension AnalyticsHubViewModel {
             }.store(in: &subscriptions)
 
         $timeRangeSelectionType
+            .dropFirst() // do not trigger refresh action on initial value
             .removeDuplicates()
             .sink { [weak self] newSelectionType in
                 guard let self else { return }
                 self.timeRangeSelection = AnalyticsHubTimeRangeSelection(selectionType: newSelectionType)
                 self.timeRangeCard = AnalyticsHubViewModel.timeRangeCard(timeRangeSelection: self.timeRangeSelection)
+
+                // Update data on range selection change
                 Task.init {
                     await self.updateData()
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -65,10 +65,11 @@ struct AnalyticsProductCard: View {
                     .padding(.top, Layout.columnSpacing)
             }
 
-            TopPerformersView(itemTitle: Localization.title.localizedCapitalized, valueTitle: Localization.itemsSold, rows: itemsSoldData)
+            TopPerformersView(itemTitle: Localization.title.localizedCapitalized,
+                              valueTitle: Localization.itemsSold,
+                              rows: itemsSoldData,
+                              isRedacted: isRedacted)
                 .padding(.top, Layout.columnSpacing)
-                .redacted(reason: isRedacted ? .placeholder : [])
-                .shimmering(active: isRedacted)
 
             if showItemsSoldError {
                 Text(Localization.noItemsSold)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -17,17 +17,21 @@ struct AnalyticsProductCard: View {
     /// Delta Tag text color.
     let deltaTextColor: UIColor
 
+    /// Indicates if the values should be hidden (for loading state)
+    ///
+    let isStatsRedacted: Bool
+
+    /// Indicates if there was an error loading stats part of the card.
+    ///
+    let showStatsError: Bool
+
     /// Items Solds data to render.
     ///
     let itemsSoldData: [TopPerformersRow.Data]
 
     /// Indicates if the values should be hidden (for loading state)
     ///
-    let isRedacted: Bool
-
-    /// Indicates if there was an error loading stats part of the card.
-    ///
-    let showStatsError: Bool
+    let isItemsSoldRedacted: Bool
 
     /// Indicates if there was an error loading items sold part of the card.
     ///
@@ -49,12 +53,12 @@ struct AnalyticsProductCard: View {
                 Text(itemsSold)
                     .titleStyle()
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .redacted(reason: isRedacted ? .placeholder : [])
-                    .shimmering(active: isRedacted)
+                    .redacted(reason: isStatsRedacted ? .placeholder : [])
+                    .shimmering(active: isStatsRedacted)
 
                 DeltaTag(value: delta, backgroundColor: deltaBackgroundColor, textColor: deltaTextColor)
-                    .redacted(reason: isRedacted ? .placeholder : [])
-                    .shimmering(active: isRedacted)
+                    .redacted(reason: isStatsRedacted ? .placeholder : [])
+                    .shimmering(active: isStatsRedacted)
             }
 
             if showStatsError {
@@ -68,7 +72,7 @@ struct AnalyticsProductCard: View {
             TopPerformersView(itemTitle: Localization.title.localizedCapitalized,
                               valueTitle: Localization.itemsSold,
                               rows: itemsSoldData,
-                              isRedacted: isRedacted)
+                              isRedacted: isItemsSoldRedacted)
                 .padding(.top, Layout.columnSpacing)
 
             if showItemsSoldError {
@@ -110,14 +114,15 @@ struct AnalyticsProductCardPreviews: PreviewProvider {
                              delta: "+23%",
                              deltaBackgroundColor: .withColorStudio(.green, shade: .shade50),
                              deltaTextColor: .textInverted,
+                             isStatsRedacted: false,
+                             showStatsError: false,
                              itemsSoldData: [
                                 .init(imageURL: imageURL, name: "Tabletop Photos", details: "Net Sales: $1,232", value: "32"),
                                 .init(imageURL: imageURL, name: "Kentya Palm", details: "Net Sales: $800", value: "10"),
                                 .init(imageURL: imageURL, name: "Love Ficus", details: "Net Sales: $599", value: "5"),
                                 .init(imageURL: imageURL, name: "Bird Of Paradise", details: "Net Sales: $23.50", value: "2"),
                              ],
-                             isRedacted: false,
-                             showStatsError: false,
+                             isItemsSoldRedacted: false,
                              showItemsSoldError: false)
             .previewLayout(.sizeThatFits)
 
@@ -125,9 +130,10 @@ struct AnalyticsProductCardPreviews: PreviewProvider {
                              delta: "0%",
                              deltaBackgroundColor: .withColorStudio(.gray, shade: .shade0),
                              deltaTextColor: .text,
-                             itemsSoldData: [],
-                             isRedacted: false,
+                             isStatsRedacted: false,
                              showStatsError: true,
+                             itemsSoldData: [],
+                             isItemsSoldRedacted: false,
                              showItemsSoldError: true)
             .previewLayout(.sizeThatFits)
             .previewDisplayName("No data")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
@@ -1,10 +1,10 @@
 import Foundation
 import class UIKit.UIColor
 
-/// Analytics Hub Product Card ViewModel.
+/// Analytics Hub Products Stats Card ViewModel.
 /// Used to transmit analytics products data.
 ///
-struct AnalyticsProductCardViewModel {
+struct AnalyticsProductsStatsCardViewModel {
     /// Items Sold Value
     ///
     let itemsSold: String
@@ -12,6 +12,20 @@ struct AnalyticsProductCardViewModel {
     /// Items Sold Delta Percentage
     ///
     let delta: DeltaPercentage
+
+    /// Indicates if the values should be hidden (for loading state)
+    ///
+    let isRedacted: Bool
+
+    /// Indicates if there was an error loading stats part of the card.
+    ///
+    let showStatsError: Bool
+}
+
+/// Analytics Hub Items Sold ViewModel.
+/// Used to store top performing products data.
+///
+struct AnalyticsItemsSoldViewModel {
 
     /// Items Solds data to render.
     ///
@@ -21,16 +35,12 @@ struct AnalyticsProductCardViewModel {
     ///
     let isRedacted: Bool
 
-    /// Indicates if there was an error loading stats part of the card.
-    ///
-    let showStatsError: Bool
-
     /// Indicates if there was an error loading items sold part of the card.
     ///
     let showItemsSoldError: Bool
 }
 
-extension AnalyticsProductCardViewModel {
+extension AnalyticsProductsStatsCardViewModel {
 
     /// Make redacted state of the card, replacing values with hardcoded placeholders
     ///
@@ -38,26 +48,38 @@ extension AnalyticsProductCardViewModel {
         // Values here are placeholders and will be redacted in the UI
         .init(itemsSold: "1000",
               delta: DeltaPercentage(string: "0%", direction: .zero),
-              itemsSoldData: [.init(imageURL: nil, name: "Product Name", details: "Net Sales", value: "$5678")],
               isRedacted: true,
-              showStatsError: false,
-              showItemsSoldError: false)
+              showStatsError: false)
     }
-
 }
 
-/// Convenience extension to create an `AnalyticsReportCard` from a view model.
+extension AnalyticsItemsSoldViewModel {
+
+    /// Make redacted state of the card, replacing values with hardcoded placeholders
+    ///
+    var redacted: Self {
+        // Values here are placeholders and will be redacted in the UI
+        .init(itemsSoldData: [.init(imageURL: nil, name: "Product Name", details: "Net Sales", value: "$5678")],
+              isRedacted: true,
+              showItemsSoldError: false)
+    }
+}
+
+/// Convenience extension to create an `AnalyticsProductCard` from a view model.
 ///
 extension AnalyticsProductCard {
-    init(viewModel: AnalyticsProductCardViewModel) {
-        self.itemsSold = viewModel.itemsSold
-        self.delta = viewModel.delta.string
-        self.deltaBackgroundColor = viewModel.delta.direction.deltaBackgroundColor
-        self.deltaTextColor = viewModel.delta.direction.deltaTextColor
-        self.itemsSoldData = viewModel.itemsSoldData
-        self.isRedacted = viewModel.isRedacted
-        self.showStatsError = viewModel.showStatsError
-        self.showItemsSoldError = viewModel.showItemsSoldError
+    init(statsViewModel: AnalyticsProductsStatsCardViewModel, itemsViewModel: AnalyticsItemsSoldViewModel) {
+        // Header with stats
+        self.itemsSold = statsViewModel.itemsSold
+        self.delta = statsViewModel.delta.string
+        self.deltaBackgroundColor = statsViewModel.delta.direction.deltaBackgroundColor
+        self.deltaTextColor = statsViewModel.delta.direction.deltaTextColor
+        self.isStatsRedacted = statsViewModel.isRedacted
+        self.showStatsError = statsViewModel.showStatsError
 
+        // Top performers list
+        self.itemsSoldData = itemsViewModel.itemsSoldData
+        self.isItemsSoldRedacted = itemsViewModel.isRedacted
+        self.showItemsSoldError = itemsViewModel.showItemsSoldError
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersView.swift
@@ -17,6 +17,10 @@ struct TopPerformersView: View {
     ///
     let rows: [TopPerformersRow.Data]
 
+    /// Indicates if the values should be hidden (for loading state)
+    ///
+    let isRedacted: Bool
+
     /// Used to track the text margin value from the top performers row.
     /// Text margin value: Where the row text is placed in the X position.
     /// Needed to properly layout the row divider.
@@ -42,6 +46,8 @@ struct TopPerformersView: View {
                 // Do not render the divider for the last row.
                 TopPerformersRow(data: row, showDivider: index < rows.count - 1)
             }
+            .redacted(reason: isRedacted ? .placeholder : [])
+            .shimmering(active: isRedacted)
         }
     }
 }
@@ -141,7 +147,8 @@ struct TopPerformersPreview: PreviewProvider {
                             .init(imageURL: imageURL, name: "Kentya Palm", details: "Net Sales: $800", value: "10"),
                             .init(imageURL: imageURL, name: "Love Ficus", details: "Net Sales: $599", value: "5"),
                             .init(imageURL: imageURL, name: "Bird Of Paradise", details: "Net Sales: $23.50", value: "2")
-                          ])
+                          ],
+                          isRedacted: false)
         .padding()
         .previewLayout(.sizeThatFits)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -70,7 +70,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, stores: stores)
         var loadingRevenueCard: AnalyticsReportCardViewModel?
         var loadingOrdersCard: AnalyticsReportCardViewModel?
-        var loadingProductsCard: AnalyticsProductCardViewModel?
+        var loadingProductsCard: AnalyticsProductsStatsCardViewModel?
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
             switch action {
             case let .retrieveCustomStats(_, _, _, _, _, _, completion):

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -33,12 +33,14 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(vm.revenueCard.isRedacted)
         XCTAssertFalse(vm.ordersCard.isRedacted)
-        XCTAssertFalse(vm.productCard.isRedacted)
+        XCTAssertFalse(vm.productsStatsCard.isRedacted)
+        XCTAssertFalse(vm.itemsSoldCard.isRedacted)
 
         XCTAssertEqual(vm.revenueCard.leadingValue, "$62")
         XCTAssertEqual(vm.ordersCard.leadingValue, "15")
-        XCTAssertEqual(vm.productCard.itemsSold, "5")
-        XCTAssertEqual(vm.productCard.itemsSoldData.count, 1)
+        XCTAssertEqual(vm.productsStatsCard.itemsSold, "5")
+
+        XCTAssertEqual(vm.itemsSoldCard.itemsSoldData.count, 1)
     }
 
     func test_cards_viewmodels_show_sync_error_after_getting_error_from_network() async {
@@ -61,8 +63,8 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(vm.revenueCard.showSyncError)
         XCTAssertTrue(vm.ordersCard.showSyncError)
-        XCTAssertTrue(vm.productCard.showStatsError)
-        XCTAssertTrue(vm.productCard.showItemsSoldError)
+        XCTAssertTrue(vm.productsStatsCard.showStatsError)
+        XCTAssertTrue(vm.itemsSoldCard.showItemsSoldError)
     }
 
     func test_cards_viewmodels_redacted_while_updating_from_network() async {
@@ -71,13 +73,15 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         var loadingRevenueCard: AnalyticsReportCardViewModel?
         var loadingOrdersCard: AnalyticsReportCardViewModel?
         var loadingProductsCard: AnalyticsProductsStatsCardViewModel?
+        var loadingItemsSoldCard: AnalyticsItemsSoldViewModel?
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
             switch action {
             case let .retrieveCustomStats(_, _, _, _, _, _, completion):
                 let stats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 15, totalItemsSold: 5, grossRevenue: 62))
                 loadingRevenueCard = vm.revenueCard
                 loadingOrdersCard = vm.ordersCard
-                loadingProductsCard = vm.productCard
+                loadingProductsCard = vm.productsStatsCard
+                loadingItemsSoldCard = vm.itemsSoldCard
                 completion(.success(stats))
             case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, completion):
                 let topEarners = TopEarnerStats.fake().copy(items: [.fake()])
@@ -94,5 +98,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertEqual(loadingRevenueCard?.isRedacted, true)
         XCTAssertEqual(loadingOrdersCard?.isRedacted, true)
         XCTAssertEqual(loadingProductsCard?.isRedacted, true)
+        XCTAssertEqual(loadingItemsSoldCard?.isRedacted, true)
     }
 }


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8318.

## Description

This PR updates data loading flow to prevent waiting on all requests before updating any cards.

### How

- Update `TopPerformersView` to have its own viewmodel and loading state
- Update `AnalyticsProductCard` to accept 2 separate viewmodels
- Update data flow to trigger networking requests independently

## Testing

1. Build and run the app in debug/alpha mode.
2. On the dashboard view tap the "See more" button.
3. Scroll to the bottom of a list.
4. Confirm that top performers list has its own loading state and updates separately from the rest of stats.

## Video

> Revenue and orders cards are hidden to focus on products card

https://user-images.githubusercontent.com/3132438/206773285-0fde02e4-a885-4e85-9aff-6f5b8961042e.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.