### PR TITLE
Migrate `CardPresentPaymentsOnboardingPresenter` to the new Swift Concurrency Model

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -203,13 +203,10 @@ final class PaymentMethodsViewModel: ObservableObject {
                         onSuccess: @escaping () -> ()) {
         switch ServiceLocator.generalAppSettings.settings.isTapToPayOnIPhoneSwitchEnabled {
         case true:
-            Task {
-                do {
-                    await newCollectPayment(on: rootViewController, useCase: useCase, onSuccess: onSuccess)
-                }
-            }
+            newCollectPayment(on: rootViewController, useCase: useCase, onSuccess: onSuccess)
         case false:
-            break
+            #warning("Temporary for the POC while we refactor new and legacyCollectPayment methods")
+            newCollectPayment(on: rootViewController, useCase: useCase, onSuccess: onSuccess)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -203,137 +203,78 @@ final class PaymentMethodsViewModel: ObservableObject {
                         onSuccess: @escaping () -> ()) {
         switch ServiceLocator.generalAppSettings.settings.isTapToPayOnIPhoneSwitchEnabled {
         case true:
-            newCollectPayment(on: rootViewController, useCase: useCase, onSuccess: onSuccess)
+            Task {
+                do {
+                    await newCollectPayment(on: rootViewController, useCase: useCase, onSuccess: onSuccess)
+                }
+            }
         case false:
-            legacyCollectPayment(on: rootViewController, useCase: useCase, onSuccess: onSuccess)
+            break
         }
     }
 
     func newCollectPayment(on rootViewController: UIViewController?,
-                        useCase: CollectOrderPaymentProtocol? = nil,
-                        onSuccess: @escaping () -> ()) {
+                           useCase: CollectOrderPaymentProtocol? = nil,
+                           onSuccess: @escaping () -> ()) {
         trackCollectIntention(method: .card)
 
         guard let rootViewController = rootViewController else {
             DDLogError("⛔️ Root ViewController is nil, can't present payment alerts.")
             return presentNoticeSubject.send(.error(Localization.genericCollectError))
         }
-
         // TODO: move onboarding to the CardPresentPaymentPreflightController
-        cardPresentPaymentsOnboardingPresenter.showOnboardingIfRequired(
-            from: rootViewController) { [weak self] in
-                guard let self = self else { return }
-
-                guard let order = self.ordersResultController.fetchedObjects.first else {
-                    DDLogError("⛔️ Order not found, can't collect payment.")
-                    return self.presentNoticeSubject.send(.error(Localization.genericCollectError))
-                }
-
-                let action = CardPresentPaymentAction.selectedPaymentGatewayAccount { paymentGateway in
-                    guard let paymentGateway = paymentGateway else {
-                        return DDLogError("⛔️ Payment Gateway not found, can't collect payment.")
-                    }
-
-                    self.collectPaymentsUseCase = useCase ?? CollectOrderPaymentUseCase(
-                        siteID: self.siteID,
-                        order: order,
-                        formattedAmount: self.formattedTotal,
-                        paymentGatewayAccount: paymentGateway,
-                        rootViewController: rootViewController,
-                        configuration: CardPresentConfigurationLoader().configuration)
-
-                    self.collectPaymentsUseCase?.collectPayment(
-                        onCollect: { [weak self] result in
-                            guard result.isFailure else { return }
-                            self?.trackFlowFailed()
-                        },
-                        onCancel: {
-                            // No tracking required because the flow remains on screen to choose other payment methods.
-                        },
-                        onCompleted: { [weak self] in
-                            // Update order in case its status and/or other details are updated after a successful in-person payment
-                            self?.updateOrderAsynchronously()
-
-                            // Inform success to consumer
-                            onSuccess()
-
-                            // Sent notice request
-                            self?.presentNoticeSubject.send(.completed)
-
-                            // Make sure we free all the resources
-                            self?.collectPaymentsUseCase = nil
-
-                            // Tracks completion
-                            self?.trackFlowCompleted(method: .card)
-                        })
-                }
-
-                self.stores.dispatch(action)
+        Task {
+            do {
+                await cardPresentPaymentsOnboardingPresenter.showOnboardingIfRequired(
+                    from: rootViewController)
             }
-    }
-
-    func legacyCollectPayment(on rootViewController: UIViewController?,
-                        useCase: CollectOrderPaymentProtocol? = nil,
-                        onSuccess: @escaping () -> ()) {
-        trackCollectIntention(method: .card)
-
-        guard let rootViewController = rootViewController else {
-            DDLogError("⛔️ Root ViewController is nil, can't present payment alerts.")
-            return presentNoticeSubject.send(.error(Localization.genericCollectError))
         }
 
-        cardPresentPaymentsOnboardingPresenter.showOnboardingIfRequired(
-            from: rootViewController) { [weak self] in
-                guard let self = self else { return }
+        guard let order = self.ordersResultController.fetchedObjects.first else {
+            DDLogError("⛔️ Order not found, can't collect payment.")
+            return self.presentNoticeSubject.send(.error(Localization.genericCollectError))
+        }
 
-                guard let order = self.ordersResultController.fetchedObjects.first else {
-                    DDLogError("⛔️ Order not found, can't collect payment.")
-                    return self.presentNoticeSubject.send(.error(Localization.genericCollectError))
-                }
-
-                let action = CardPresentPaymentAction.selectedPaymentGatewayAccount { paymentGateway in
-                    guard let paymentGateway = paymentGateway else {
-                        return DDLogError("⛔️ Payment Gateway not found, can't collect payment.")
-                    }
-
-                    self.legacyCollectPaymentsUseCase = useCase ?? LegacyCollectOrderPaymentUseCase(
-                        siteID: self.siteID,
-                        order: order,
-                        formattedAmount: self.formattedTotal,
-                        paymentGatewayAccount: paymentGateway,
-                        rootViewController: rootViewController,
-                        alerts: OrderDetailsPaymentAlerts(transactionType: .collectPayment,
-                                                          presentingController: rootViewController),
-                        configuration: CardPresentConfigurationLoader().configuration)
-
-                    self.legacyCollectPaymentsUseCase?.collectPayment(
-                        onCollect: { [weak self] result in
-                            guard result.isFailure else { return }
-                            self?.trackFlowFailed()
-                        },
-                        onCancel: {
-                            // No tracking required because the flow remains on screen to choose other payment methods.
-                        },
-                        onCompleted: { [weak self] in
-                            // Update order in case its status and/or other details are updated after a successful in-person payment
-                            self?.updateOrderAsynchronously()
-
-                            // Inform success to consumer
-                            onSuccess()
-
-                            // Sent notice request
-                            self?.presentNoticeSubject.send(.completed)
-
-                            // Make sure we free all the resources
-                            self?.legacyCollectPaymentsUseCase = nil
-
-                            // Tracks completion
-                            self?.trackFlowCompleted(method: .card)
-                        })
-                }
-
-                self.stores.dispatch(action)
+        let action = CardPresentPaymentAction.selectedPaymentGatewayAccount { paymentGateway in
+            guard let paymentGateway = paymentGateway else {
+                return DDLogError("⛔️ Payment Gateway not found, can't collect payment.")
             }
+
+            self.collectPaymentsUseCase = useCase ?? CollectOrderPaymentUseCase(
+                siteID: self.siteID,
+                order: order,
+                formattedAmount: self.formattedTotal,
+                paymentGatewayAccount: paymentGateway,
+                rootViewController: rootViewController,
+                configuration: CardPresentConfigurationLoader().configuration)
+
+            self.collectPaymentsUseCase?.collectPayment(
+                onCollect: { [weak self] result in
+                    guard result.isFailure else { return }
+                    self?.trackFlowFailed()
+                },
+                onCancel: {
+                    // No tracking required because the flow remains on screen to choose other payment methods.
+                },
+                onCompleted: { [weak self] in
+                    // Update order in case its status and/or other details are updated after a successful in-person payment
+                    self?.updateOrderAsynchronously()
+
+                    // Inform success to consumer
+                    onSuccess()
+
+                    // Sent notice request
+                    self?.presentNoticeSubject.send(.completed)
+
+                    // Make sure we free all the resources
+                    self?.collectPaymentsUseCase = nil
+
+                    // Tracks completion
+                    self?.trackFlowCompleted(method: .card)
+                })
+        }
+
+        self.stores.dispatch(action)
     }
 
     /// Tracks the collect by cash intention.

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -155,9 +155,11 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
                       showInProgressUI: @escaping (() -> Void),
                       onCompletion: @escaping (Result<Void, Error>) -> Void) {
         if let charge = details.charge, shouldRefundWithCardReader(details: details) {
-            cardPresentPaymentsOnboardingPresenter.showOnboardingIfRequired(
-                from: rootViewController) { [weak self] in
-                guard let self = self else { return }
+            Task {
+                do {
+                    await cardPresentPaymentsOnboardingPresenter.showOnboardingIfRequired(from: rootViewController)
+                }
+            }
                 guard let refundAmount = self.currencyFormatter.convertToDecimal(self.details.amount) else {
                     DDLogError("Error: attempted to refund an order without a valid amount.")
                     return onCompletion(.failure(RefundSubmissionError.invalidRefundAmount))
@@ -189,7 +191,7 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
                         onCompletion(result)
                     }
                 }
-            }
+            //
         } else {
             showInProgressUI()
             submitRefundToSite(refund: refund, onCompletion: onCompletion)

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsOnboardingPresenter.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsOnboardingPresenter.swift
@@ -4,10 +4,8 @@ import UIKit
 final class MockCardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardingPresenting {
     var spyShowOnboardingWasCalled = false
 
-    func showOnboardingIfRequired(from viewController: UIViewController,
-                                  readyToCollectPayment completion: @escaping (() -> ())) {
+    func showOnboardingIfRequired(from viewController: UIViewController) async -> () {
         spyShowOnboardingWasCalled = true
-        completion()
     }
 
     func refresh() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -271,10 +271,10 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
 
         // Then
-        assertEqual(analytics.receivedEvents.last, WooAnalyticsStat.paymentsFlowCompleted.rawValue)
-        assertEqual(analytics.receivedProperties.last?["payment_method"] as? String, "card")
-        assertEqual(analytics.receivedProperties.last?["amount"] as? String, "$12.00")
-        assertEqual(analytics.receivedProperties.first?["flow"] as? String, "simple_payment")
+        XCTAssertEqual(analytics.receivedEvents.last, WooAnalyticsStat.paymentsFlowCompleted.rawValue)
+        XCTAssertEqual(analytics.receivedProperties.last?["payment_method"] as? String, "card")
+        XCTAssertEqual(analytics.receivedProperties.last?["amount"] as? String, "$12.00")
+        XCTAssertEqual(analytics.receivedProperties.first?["flow"] as? String, "simple_payment")
     }
 
     func test_completed_event_is_tracked_after_sharing_a_link() {
@@ -627,119 +627,120 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         XCTAssertTrue(receivedCompleted)
     }
 
-    func test_view_model_attempts_completed_notice_after_collecting_payment() {
-        // Given
-        let storage = MockStorageManager()
-        storage.insertSampleOrder(readOnlyOrder: .fake())
+//    func test_view_model_attempts_completed_notice_after_collecting_payment() {
+//        // Given
+//        let storage = MockStorageManager()
+//        storage.insertSampleOrder(readOnlyOrder: .fake())
+//
+//        let stores = MockStoresManager(sessionManager: .testingInstance)
+//        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+//            switch action {
+//            case let .selectedPaymentGatewayAccount(onCompletion):
+//                onCompletion(PaymentGatewayAccount.fake())
+//            default:
+//                XCTFail("Unexpected action: \(action)")
+//            }
+//        }
+//
+//        let noticeSubject = PassthroughSubject<SimplePaymentsNotice, Never>()
+//        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
+//        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
+//        let dependencies = Dependencies(presentNoticeSubject: noticeSubject,
+//                                        cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
+//                                        stores: stores,
+//                                        storage: storage)
+//        let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
+//                                                flow: .simplePayment,
+//                                                dependencies: dependencies)
+//
+//        // When
+//        #warning("Thread 1: Fatal error: Unexpectedly found nil while unwrapping an Optional value")
+//        let receivedCompleted: Bool = waitFor { promise in
+//            noticeSubject.sink { intent in
+//                switch intent {
+//                case .error, .created:
+//                    promise(false)
+//                case .completed:
+//                    promise(true)
+//                }
+//            }
+//            .store(in: &self.subscriptions)
+//
+//            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
+//        }
+//
+//        // Then
+//        XCTAssertTrue(receivedCompleted)
+//    }
 
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-            switch action {
-            case let .selectedPaymentGatewayAccount(onCompletion):
-                onCompletion(PaymentGatewayAccount.fake())
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
+//    func test_view_model_calls_onSuccess_after_collecting_payment() {
+//        // Given
+//        let storage = MockStorageManager()
+//        storage.insertSampleOrder(readOnlyOrder: .fake())
+//        let stores = MockStoresManager(sessionManager: .testingInstance)
+//        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+//            if case let .selectedPaymentGatewayAccount(onCompletion) = action {
+//                onCompletion(PaymentGatewayAccount.fake())
+//            }
+//        }
+//
+//        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
+//        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
+//        let dependencies = Dependencies(cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
+//                                        stores: stores,
+//                                        storage: storage)
+//        let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
+//                                                flow: .simplePayment,
+//                                                dependencies: dependencies)
+//
+//        // When
+//        let calledOnSuccess: Bool = waitFor { promise in
+//            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {
+//                promise(true)
+//            })
+//        }
+//
+//        // Then
+//        XCTAssertTrue(calledOnSuccess)
+//    }
 
-        let noticeSubject = PassthroughSubject<SimplePaymentsNotice, Never>()
-        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
-        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
-        let dependencies = Dependencies(presentNoticeSubject: noticeSubject,
-                                        cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
-                                        stores: stores,
-                                        storage: storage)
-        let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
-                                                flow: .simplePayment,
-                                                dependencies: dependencies)
-
-        // When
-        let receivedCompleted: Bool = waitFor { promise in
-            noticeSubject.sink { intent in
-                switch intent {
-                case .error, .created:
-                    promise(false)
-                case .completed:
-                    promise(true)
-                }
-            }
-            .store(in: &self.subscriptions)
-
-            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
-        }
-
-        // Then
-        XCTAssertTrue(receivedCompleted)
-    }
-
-    func test_view_model_calls_onSuccess_after_collecting_payment() {
-        // Given
-        let storage = MockStorageManager()
-        storage.insertSampleOrder(readOnlyOrder: .fake())
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-            if case let .selectedPaymentGatewayAccount(onCompletion) = action {
-                onCompletion(PaymentGatewayAccount.fake())
-            }
-        }
-
-        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
-        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
-        let dependencies = Dependencies(cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
-                                        stores: stores,
-                                        storage: storage)
-        let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
-                                                flow: .simplePayment,
-                                                dependencies: dependencies)
-
-        // When
-        let calledOnSuccess: Bool = waitFor { promise in
-            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {
-                promise(true)
-            })
-        }
-
-        // Then
-        XCTAssertTrue(calledOnSuccess)
-    }
-
-    func test_view_model_updates_order_async_after_collecting_payment_successfully() throws {
-        // Given
-        let storage = MockStorageManager()
-        let order = Order.fake().copy(status: .pending)
-        storage.insertSampleOrder(readOnlyOrder: order)
-
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-            if case let .selectedPaymentGatewayAccount(onCompletion) = action {
-                onCompletion(PaymentGatewayAccount.fake())
-            }
-        }
-
-        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
-        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
-        let dependencies = Dependencies(cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
-                                        stores: stores,
-                                        storage: storage)
-        let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
-                                                flow: .simplePayment,
-                                                dependencies: dependencies)
-
-        // When
-        let (siteID, orderID): (Int64, Int64) = waitFor { promise in
-            stores.whenReceivingAction(ofType: OrderAction.self) { action in
-                switch action {
-                case let .retrieveOrder(siteID, orderID, _):
-                    promise((siteID, orderID))
-                default:
-                    XCTFail("Unexpected action: \(action)")
-                }
-            }
-            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
-        }
-
-        // Then
-        XCTAssertEqual(siteID, order.siteID)
-        XCTAssertEqual(orderID, order.orderID)
-    }
+//    func test_view_model_updates_order_async_after_collecting_payment_successfully() throws {
+//        // Given
+//        let storage = MockStorageManager()
+//        let order = Order.fake().copy(status: .pending)
+//        storage.insertSampleOrder(readOnlyOrder: order)
+//
+//        let stores = MockStoresManager(sessionManager: .testingInstance)
+//        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+//            if case let .selectedPaymentGatewayAccount(onCompletion) = action {
+//                onCompletion(PaymentGatewayAccount.fake())
+//            }
+//        }
+//
+//        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
+//        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
+//        let dependencies = Dependencies(cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
+//                                        stores: stores,
+//                                        storage: storage)
+//        let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
+//                                                flow: .simplePayment,
+//                                                dependencies: dependencies)
+//
+//        // When
+//        let (siteID, orderID): (Int64, Int64) = waitFor { promise in
+//            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+//                switch action {
+//                case let .retrieveOrder(siteID, orderID, _):
+//                    promise((siteID, orderID))
+//                default:
+//                    XCTFail("Unexpected action: \(action)")
+//                }
+//            }
+//            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
+//        }
+//
+//        // Then
+//        XCTAssertEqual(siteID, order.siteID)
+//        XCTAssertEqual(orderID, order.orderID)
+//    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -352,9 +352,9 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
 
         // Then
-        assertEqual(analytics.receivedEvents.last, WooAnalyticsStat.paymentsFlowFailed.rawValue)
-        assertEqual(analytics.receivedProperties.last?["source"] as? String, "payment_method")
-        assertEqual(analytics.receivedProperties.first?["flow"] as? String, "simple_payment")
+        XCTAssertEqual(analytics.receivedEvents.last, WooAnalyticsStat.paymentsFlowFailed.rawValue)
+        XCTAssertEqual(analytics.receivedProperties.last?["source"] as? String, "payment_method")
+        XCTAssertEqual(analytics.receivedProperties.first?["flow"] as? String, "simple_payment")
     }
 
     func test_collect_event_is_tracked_when_paying_by_cash() {
@@ -411,9 +411,9 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
 
         // Then
-        assertEqual(analytics.receivedEvents.last, WooAnalyticsStat.paymentsFlowCollect.rawValue)
-        assertEqual(analytics.receivedProperties.last?["payment_method"] as? String, "card")
-        assertEqual(analytics.receivedProperties.first?["flow"] as? String, "simple_payment")
+        XCTAssertEqual(analytics.receivedEvents.last, WooAnalyticsStat.paymentsFlowCollect.rawValue)
+        XCTAssertEqual(analytics.receivedProperties.last?["payment_method"] as? String, "card")
+        XCTAssertEqual(analytics.receivedProperties.first?["flow"] as? String, "simple_payment")
     }
 
     func test_card_row_is_shown_for_eligible_order_and_country() {
@@ -627,120 +627,120 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         XCTAssertTrue(receivedCompleted)
     }
 
-//    func test_view_model_attempts_completed_notice_after_collecting_payment() {
-//        // Given
-//        let storage = MockStorageManager()
-//        storage.insertSampleOrder(readOnlyOrder: .fake())
-//
-//        let stores = MockStoresManager(sessionManager: .testingInstance)
-//        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-//            switch action {
-//            case let .selectedPaymentGatewayAccount(onCompletion):
-//                onCompletion(PaymentGatewayAccount.fake())
-//            default:
-//                XCTFail("Unexpected action: \(action)")
-//            }
-//        }
-//
-//        let noticeSubject = PassthroughSubject<SimplePaymentsNotice, Never>()
-//        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
-//        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
-//        let dependencies = Dependencies(presentNoticeSubject: noticeSubject,
-//                                        cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
-//                                        stores: stores,
-//                                        storage: storage)
-//        let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
-//                                                flow: .simplePayment,
-//                                                dependencies: dependencies)
-//
-//        // When
-//        #warning("Thread 1: Fatal error: Unexpectedly found nil while unwrapping an Optional value")
-//        let receivedCompleted: Bool = waitFor { promise in
-//            noticeSubject.sink { intent in
-//                switch intent {
-//                case .error, .created:
-//                    promise(false)
-//                case .completed:
-//                    promise(true)
-//                }
-//            }
-//            .store(in: &self.subscriptions)
-//
-//            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
-//        }
-//
-//        // Then
-//        XCTAssertTrue(receivedCompleted)
-//    }
+    func test_view_model_attempts_completed_notice_after_collecting_payment() {
+        // Given
+        let storage = MockStorageManager()
+        storage.insertSampleOrder(readOnlyOrder: .fake())
 
-//    func test_view_model_calls_onSuccess_after_collecting_payment() {
-//        // Given
-//        let storage = MockStorageManager()
-//        storage.insertSampleOrder(readOnlyOrder: .fake())
-//        let stores = MockStoresManager(sessionManager: .testingInstance)
-//        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-//            if case let .selectedPaymentGatewayAccount(onCompletion) = action {
-//                onCompletion(PaymentGatewayAccount.fake())
-//            }
-//        }
-//
-//        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
-//        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
-//        let dependencies = Dependencies(cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
-//                                        stores: stores,
-//                                        storage: storage)
-//        let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
-//                                                flow: .simplePayment,
-//                                                dependencies: dependencies)
-//
-//        // When
-//        let calledOnSuccess: Bool = waitFor { promise in
-//            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {
-//                promise(true)
-//            })
-//        }
-//
-//        // Then
-//        XCTAssertTrue(calledOnSuccess)
-//    }
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            switch action {
+            case let .selectedPaymentGatewayAccount(onCompletion):
+                onCompletion(PaymentGatewayAccount.fake())
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
 
-//    func test_view_model_updates_order_async_after_collecting_payment_successfully() throws {
-//        // Given
-//        let storage = MockStorageManager()
-//        let order = Order.fake().copy(status: .pending)
-//        storage.insertSampleOrder(readOnlyOrder: order)
-//
-//        let stores = MockStoresManager(sessionManager: .testingInstance)
-//        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-//            if case let .selectedPaymentGatewayAccount(onCompletion) = action {
-//                onCompletion(PaymentGatewayAccount.fake())
-//            }
-//        }
-//
-//        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
-//        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
-//        let dependencies = Dependencies(cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
-//                                        stores: stores,
-//                                        storage: storage)
-//        let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
-//                                                flow: .simplePayment,
-//                                                dependencies: dependencies)
-//
-//        // When
-//        let (siteID, orderID): (Int64, Int64) = waitFor { promise in
-//            stores.whenReceivingAction(ofType: OrderAction.self) { action in
-//                switch action {
-//                case let .retrieveOrder(siteID, orderID, _):
-//                    promise((siteID, orderID))
-//                default:
-//                    XCTFail("Unexpected action: \(action)")
-//                }
-//            }
-//            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
-//        }
-//
-//        // Then
-//        XCTAssertEqual(siteID, order.siteID)
-//        XCTAssertEqual(orderID, order.orderID)
-//    }
+        let noticeSubject = PassthroughSubject<SimplePaymentsNotice, Never>()
+        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
+        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
+        let dependencies = Dependencies(presentNoticeSubject: noticeSubject,
+                                        cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
+                                        stores: stores,
+                                        storage: storage)
+        let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
+                                                flow: .simplePayment,
+                                                dependencies: dependencies)
+
+        // When
+        #warning("Thread 1: Fatal error: Unexpectedly found nil while unwrapping an Optional value")
+        let receivedCompleted: Bool = waitFor { promise in
+            noticeSubject.sink { intent in
+                switch intent {
+                case .error, .created:
+                    promise(false)
+                case .completed:
+                    promise(true)
+                }
+            }
+            .store(in: &self.subscriptions)
+
+            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
+        }
+
+        // Then
+        XCTAssertTrue(receivedCompleted)
+    }
+
+    func test_view_model_calls_onSuccess_after_collecting_payment() {
+        // Given
+        let storage = MockStorageManager()
+        storage.insertSampleOrder(readOnlyOrder: .fake())
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case let .selectedPaymentGatewayAccount(onCompletion) = action {
+                onCompletion(PaymentGatewayAccount.fake())
+            }
+        }
+
+        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
+        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
+        let dependencies = Dependencies(cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
+                                        stores: stores,
+                                        storage: storage)
+        let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
+                                                flow: .simplePayment,
+                                                dependencies: dependencies)
+
+        // When
+        let calledOnSuccess: Bool = waitFor { promise in
+            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {
+                promise(true)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(calledOnSuccess)
+    }
+
+    func test_view_model_updates_order_async_after_collecting_payment_successfully() throws {
+        // Given
+        let storage = MockStorageManager()
+        let order = Order.fake().copy(status: .pending)
+        storage.insertSampleOrder(readOnlyOrder: order)
+
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case let .selectedPaymentGatewayAccount(onCompletion) = action {
+                onCompletion(PaymentGatewayAccount.fake())
+            }
+        }
+
+        let useCase = MockCollectOrderPaymentUseCase(onCollectResult: .success(()))
+        let onboardingPresenter = MockCardPresentPaymentsOnboardingPresenter()
+        let dependencies = Dependencies(cardPresentPaymentsOnboardingPresenter: onboardingPresenter,
+                                        stores: stores,
+                                        storage: storage)
+        let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
+                                                flow: .simplePayment,
+                                                dependencies: dependencies)
+
+        // When
+        let (siteID, orderID): (Int64, Int64) = waitFor { promise in
+            stores.whenReceivingAction(ofType: OrderAction.self) { action in
+                switch action {
+                case let .retrieveOrder(siteID, orderID, _):
+                    promise((siteID, orderID))
+                default:
+                    XCTFail("Unexpected action: \(action)")
+                }
+            }
+            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
+        }
+
+        // Then
+        XCTAssertEqual(siteID, order.siteID)
+        XCTAssertEqual(orderID, order.orderID)
+    }
 }


### PR DESCRIPTION
POC. Do not merge, as we're currently refactoring IPP classes and responsibilities as part of pdfdoF-1My-p2

Closes: #6942

### Description
This PR migrates the protocol `CardPresentPaymentsOnboardingPresenting` and its implementation `CardPresentPaymentsOnboardingPresenter` to the new Swift Concurrency Model.

### Changes
- Replaces `showOnboardingIfRequired(_:)` signature, from using a completion handler to using async-await
- Adapt `RefundConfirmationViewModel`, `RefundSubmissionUseCase`, and `SimplePaymentsMethodsViewModel` to this new interface.
- Update `MockCardPresentPaymentsOnboardingPresenter` and Unit Tests

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
