### PR TITLE
Adjust description formatting for different year ranges

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRange.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRange.swift
@@ -9,7 +9,12 @@ struct AnalyticsHubTimeRange {
             return DateFormatter.Stats.createAnalyticsHubDayMonthYearFormatter(timezone: timezone).string(from: start)
         }
 
-        let startDateDescription = DateFormatter.Stats.createAnalyticsHubDayMonthFormatter(timezone: timezone).string(from: start)
+        let startDateDescription: String
+        if start.isSameYear(as: end) {
+            startDateDescription = DateFormatter.Stats.createAnalyticsHubDayMonthFormatter(timezone: timezone).string(from: start)
+        } else {
+            startDateDescription = DateFormatter.Stats.createAnalyticsHubDayMonthYearFormatter(timezone: timezone).string(from: start)
+        }
 
         let endDateDescription: String
         if start.isSameMonth(as: end, using: calendar) {
@@ -17,6 +22,7 @@ struct AnalyticsHubTimeRange {
         } else {
             endDateDescription = DateFormatter.Stats.createAnalyticsHubDayMonthYearFormatter(timezone: timezone).string(from: end)
         }
+
         return "\(startDateDescription) - \(endDateDescription)"
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1361,6 +1361,7 @@
 		B5FD111221D3CE7700560344 /* NewNoteViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5FD111121D3CE7700560344 /* NewNoteViewController.xib */; };
 		B5FD111621D3F13700560344 /* BordersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FD111521D3F13700560344 /* BordersView.swift */; };
 		B60B5026292D308A00178C26 /* AnalyticsTimeRangeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60B5025292D308A00178C26 /* AnalyticsTimeRangeCard.swift */; };
+		B61C17722947981C002E9881 /* AnalyticsHubTimeRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61C17712947981C002E9881 /* AnalyticsHubTimeRangeTests.swift */; };
 		B622BC74289CF19400B10CEC /* WaitingTimeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B622BC73289CF19400B10CEC /* WaitingTimeTrackerTests.swift */; };
 		B626C71B287659D60083820C /* OrderCustomFieldsDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = B626C71A287659D60083820C /* OrderCustomFieldsDetails.swift */; };
 		B63AAF4B254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63AAF4A254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift */; };
@@ -3393,6 +3394,7 @@
 		B5FD111121D3CE7700560344 /* NewNoteViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NewNoteViewController.xib; sourceTree = "<group>"; };
 		B5FD111521D3F13700560344 /* BordersView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BordersView.swift; sourceTree = "<group>"; };
 		B60B5025292D308A00178C26 /* AnalyticsTimeRangeCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTimeRangeCard.swift; sourceTree = "<group>"; };
+		B61C17712947981C002E9881 /* AnalyticsHubTimeRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRangeTests.swift; sourceTree = "<group>"; };
 		B622BC73289CF19400B10CEC /* WaitingTimeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingTimeTrackerTests.swift; sourceTree = "<group>"; };
 		B626C71A287659D60083820C /* OrderCustomFieldsDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCustomFieldsDetails.swift; sourceTree = "<group>"; };
 		B63AAF4A254AD2C6000B28A2 /* URL+SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+SurveyViewControllerTests.swift"; sourceTree = "<group>"; };
@@ -7498,6 +7500,7 @@
 			children = (
 				AE4CCCEA29365CFD00B47EE8 /* AnalyticsHubViewModelTests.swift */,
 				B6440FB8292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift */,
+				B61C17712947981C002E9881 /* AnalyticsHubTimeRangeTests.swift */,
 			);
 			path = "Analytics Hub";
 			sourceTree = "<group>";
@@ -11446,6 +11449,7 @@
 				022C658C2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift in Sources */,
 				093B265927DF15100026F92D /* BulkUpdatePriceViewControllerTests.swift in Sources */,
 				2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */,
+				B61C17722947981C002E9881 /* AnalyticsHubTimeRangeTests.swift in Sources */,
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,
 				DE3404EA28B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift in Sources */,
 				02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeTests.swift
@@ -2,6 +2,40 @@ import XCTest
 @testable import WooCommerce
 
 final class AnalyticsHubTimeRangeTests: XCTestCase {
-    func testExample() {
+    private var testTimezone: TimeZone = {
+        TimeZone(abbreviation: "UTC") ?? TimeZone.current
+    }()
+
+    private var testCalendar: Calendar = {
+        var calendar = Calendar(identifier: .iso8601)
+        calendar.timeZone = TimeZone(abbreviation: "UTC") ?? TimeZone.current
+        return calendar
+    }()
+
+    func test_when_time_range_format_is_simplified_then_describes_only_first_date() {
+        // Given
+        let startDate = startDate(from: "2022-07-01")!
+        let endDate = endDate(from: "2022-07-02")!
+        let timeRange = AnalyticsHubTimeRange(start: startDate, end: endDate)
+        
+        // When
+        let description = timeRange.formatToString(simplified: true, timezone: testTimezone, calendar: testCalendar)
+        
+        //Then
+        XCTAssertEqual(description, "Jul 1, 2022")
+    }
+
+    private func startDate(from date: String) -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = testTimezone
+        return dateFormatter.date(from: date)?.startOfDay(timezone: testTimezone)
+    }
+
+    private func endDate(from date: String) -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = testTimezone
+        return dateFormatter.date(from: date)?.endOfDay(timezone: testTimezone)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeTests.swift
@@ -25,7 +25,7 @@ final class AnalyticsHubTimeRangeTests: XCTestCase {
         XCTAssertEqual(description, "Jul 1, 2022")
     }
 
-    func test_when_time_range_format_is_not_simplified_then_describes_both_dates() {
+    func test_when_time_range_format_is_in_different_months_then_describes_both_dates() {
         // Given
         let startDate = startDate(from: "2022-07-01")!
         let endDate = endDate(from: "2022-08-02")!
@@ -50,6 +50,21 @@ final class AnalyticsHubTimeRangeTests: XCTestCase {
         //Then
         XCTAssertEqual(description, "Jul 1 - 5, 2022")
     }
+
+    func test_when_time_range_is_in_different_years_then_fully_describe_both_dates() {
+        // Given
+        let startDate = startDate(from: "2021-04-01")!
+        let endDate = endDate(from: "2022-07-15")!
+        let timeRange = AnalyticsHubTimeRange(start: startDate, end: endDate)
+
+        // When
+        let description = timeRange.formatToString(simplified: false, timezone: testTimezone, calendar: testCalendar)
+
+        //Then
+        XCTAssertEqual(description, "Apr 1, 2021 - Jul 15, 2022")
+    }
+    
+    //TODO different years same month
 
     private func startDate(from date: String) -> Date? {
         let dateFormatter = DateFormatter()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeTests.swift
@@ -17,12 +17,25 @@ final class AnalyticsHubTimeRangeTests: XCTestCase {
         let startDate = startDate(from: "2022-07-01")!
         let endDate = endDate(from: "2022-07-02")!
         let timeRange = AnalyticsHubTimeRange(start: startDate, end: endDate)
-        
+
         // When
         let description = timeRange.formatToString(simplified: true, timezone: testTimezone, calendar: testCalendar)
-        
+
         //Then
         XCTAssertEqual(description, "Jul 1, 2022")
+    }
+
+    func test_when_time_range_format_is_not_simplified_then_describes_both_dates() {
+        // Given
+        let startDate = startDate(from: "2022-07-01")!
+        let endDate = endDate(from: "2022-08-02")!
+        let timeRange = AnalyticsHubTimeRange(start: startDate, end: endDate)
+
+        // When
+        let description = timeRange.formatToString(simplified: false, timezone: testTimezone, calendar: testCalendar)
+
+        //Then
+        XCTAssertEqual(description, "Jul 1 - Aug 2, 2022")
     }
 
     private func startDate(from date: String) -> Date? {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeTests.swift
@@ -53,18 +53,16 @@ final class AnalyticsHubTimeRangeTests: XCTestCase {
 
     func test_when_time_range_is_in_different_years_then_fully_describe_both_dates() {
         // Given
-        let startDate = startDate(from: "2021-04-01")!
-        let endDate = endDate(from: "2022-07-15")!
+        let startDate = startDate(from: "2021-04-15")!
+        let endDate = endDate(from: "2022-04-15")!
         let timeRange = AnalyticsHubTimeRange(start: startDate, end: endDate)
 
         // When
         let description = timeRange.formatToString(simplified: false, timezone: testTimezone, calendar: testCalendar)
 
         //Then
-        XCTAssertEqual(description, "Apr 1, 2021 - Jul 15, 2022")
+        XCTAssertEqual(description, "Apr 15, 2021 - Apr 15, 2022")
     }
-    
-    //TODO different years same month
 
     private func startDate(from date: String) -> Date? {
         let dateFormatter = DateFormatter()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+@testable import WooCommerce
+
+final class AnalyticsHubTimeRangeTests: XCTestCase {
+    func testExample() {
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeTests.swift
@@ -38,6 +38,19 @@ final class AnalyticsHubTimeRangeTests: XCTestCase {
         XCTAssertEqual(description, "Jul 1 - Aug 2, 2022")
     }
 
+    func test_when_time_range_is_in_the_same_month_then_describe_month_only_in_the_start_date() {
+        // Given
+        let startDate = startDate(from: "2022-07-01")!
+        let endDate = endDate(from: "2022-07-05")!
+        let timeRange = AnalyticsHubTimeRange(start: startDate, end: endDate)
+
+        // When
+        let description = timeRange.formatToString(simplified: false, timezone: testTimezone, calendar: testCalendar)
+
+        //Then
+        XCTAssertEqual(description, "Jul 1 - 5, 2022")
+    }
+
     private func startDate(from date: String) -> Date? {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"


### PR DESCRIPTION
Closes: #8343

Why
==========
Depending on the current date and the range selection type, it's possible to have a selected range spanning through years. The current range description formatting does not account for that, causing some weird descriptions like this:

<img width="498" alt="image" src="https://user-images.githubusercontent.com/5920403/207393292-f10e540d-54d8-4d77-9608-03dcf8ceeb52.png">


How
==========
The solution was to adjust the start date description to verify whether it should display the year information. Since the end date always contains the year information, if the start date is in a different year than the end date, we add the year information to the start, fixing the problem.

How to Test
==========
1. Testing this alongside the Custom date range selection is recommended since it makes it easier to reproduce different year ranges.
2. Verify that ranges starting and ending in different years display the full date information. E.g. `Apr 15, 2021 - Feb 5, 2022`.
