### PR TITLE
Store creation M3: handle IAP ineligible scenario by showing an alert

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Plan/MockInAppPurchases.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Plan/MockInAppPurchases.swift
@@ -15,16 +15,19 @@ struct MockInAppPurchases {
     private let fetchProductsDuration: UInt64
     private let products: [WPComPlanProduct]
     private let userIsEntitledToProduct: Bool
+    private let isIAPSupported: Bool
 
     /// - Parameter fetchProductsDuration: How long to wait until the mock plan is returned, in nanoseconds.
     /// - Parameter products: WPCOM products to return for purchase.
     /// - Parameter userIsEntitledToProduct: Whether the user is entitled to the matched IAP product.
     init(fetchProductsDuration: UInt64 = 1_000_000_000,
          products: [WPComPlanProduct] = Defaults.products,
-         userIsEntitledToProduct: Bool = false) {
+         userIsEntitledToProduct: Bool = false,
+         isIAPSupported: Bool = true) {
         self.fetchProductsDuration = fetchProductsDuration
         self.products = products
         self.userIsEntitledToProduct = userIsEntitledToProduct
+        self.isIAPSupported = isIAPSupported
     }
 }
 
@@ -48,7 +51,7 @@ extension MockInAppPurchases: InAppPurchasesForWPComPlansProtocol {
     }
 
     func inAppPurchasesAreSupported() async -> Bool {
-        true
+        isIAPSupported
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/StoreCreationCoordinatorTests.swift
@@ -92,10 +92,8 @@ final class StoreCreationCoordinatorTests: XCTestCase {
 
         // Then
         waitUntil {
-            self.navigationController.presentedViewController is UINavigationController
+            (self.navigationController.presentedViewController as? UINavigationController)?.topViewController is StoreNameFormHostingController
         }
-        let storeCreationNavigationController = try XCTUnwrap(navigationController.presentedViewController as? UINavigationController)
-        assertThat(storeCreationNavigationController.topViewController, isAnInstanceOf: StoreNameFormHostingController.self)
     }
 
     func test_StoreNameFormHostingController_is_presented_when_navigationController_is_showing_another_view_with_iap_enabled() throws {
@@ -115,10 +113,32 @@ final class StoreCreationCoordinatorTests: XCTestCase {
 
         // Then
         waitUntil {
-            self.navigationController.presentedViewController is UINavigationController
+            (self.navigationController.presentedViewController as? UINavigationController)?.topViewController is StoreNameFormHostingController
         }
-        let storeCreationNavigationController = try XCTUnwrap(navigationController.presentedViewController as? UINavigationController)
-        assertThat(storeCreationNavigationController.topViewController, isAnInstanceOf: StoreNameFormHostingController.self)
+    }
+
+    func test_UIAlertController_is_presented_when_iap_is_not_supported_with_iap_enabled() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isStoreCreationM2Enabled: true,
+                                                        isStoreCreationM2WithInAppPurchasesEnabled: true)
+        let coordinator = StoreCreationCoordinator(source: .storePicker,
+                                                   navigationController: navigationController,
+                                                   featureFlagService: featureFlagService,
+                                                   purchasesManager: MockInAppPurchases(fetchProductsDuration: 0, isIAPSupported: false))
+        waitFor { promise in
+            self.navigationController.present(.init(), animated: false) {
+                promise(())
+            }
+        }
+        XCTAssertNotNil(navigationController.presentedViewController)
+
+        // When
+        coordinator.start()
+
+        // Then
+        waitUntil {
+            self.navigationController.presentedViewController is UIAlertController
+        }
     }
 
     func test_StoreNameFormHostingController_is_presented_when_navigationController_is_presenting_another_view_with_iap_disabled() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

First iteration for #8392 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

#### Why

Please see the background in p1670855348591299/1670855146.255439-slack-C0354HSNUJH. I'm going with option 1 since I'm AFK soon, and don't want our app to be blocked from release. We can update the UX later after design confirmation.

#### Implementation

In `StoreCreationCoordinator`, it currently throws various `PlanPurchaseError`s at the beginning after checking a series of IAP conditions:

https://github.com/woocommerce/woocommerce-ios/blob/618b3a0855a8fdbe0908f7d964f27878ae56b5ad/WooCommerce/Classes/Authentication/Store%20Creation/StoreCreationCoordinator.swift#L79-L97

Then in the catch closure, we currently show the M1 webview if there's an error. However, when we launch IAP with the `storeCreationM2WithInAppPurchasesEnabled` feature flag enabled, we can't fall back to the webview implementation. Therefore, I updated the error handling to show an alert if the `storeCreationM2WithInAppPurchasesEnabled` feature flag is enabled.

In order to not present the alert before the in-progress view is presented in case the result comes back immediately like when using a mock `MockInAppPurchases`, I updated the `presentStoreCreation` function to `async` to wait for the presentation completion.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

It's the easiest to test with a mock implementation using `MockInAppPurchases`.

#### IAP is not supported

- In code, change [this line](https://github.com/woocommerce/woocommerce-ios/blob/618b3a0855a8fdbe0908f7d964f27878ae56b5ad/WooCommerce/Classes/Authentication/Store%20Creation/StoreCreationCoordinator.swift#L31) to `return MockInAppPurchases(isIAPSupported: false)`. Also, in `DefaultFeatureFlagService`, return `true` for `storeCreationM2WithInAppPurchasesEnabled` feature flag
- Launch the app
- Log in if needed
- Go to the Menu tab, and tap `Switch store`
- On the store picker, tap `+ Add a store`
- Tap `Create a new store` --> the in-progress view should be shown first. after a bit, an alert should be shown that indicates store creation isn't supported for the country

#### User is already entitled to the plan

- In code, change [this line](https://github.com/woocommerce/woocommerce-ios/blob/618b3a0855a8fdbe0908f7d964f27878ae56b5ad/WooCommerce/Classes/Authentication/Store%20Creation/StoreCreationCoordinator.swift#L31) to `return MockInAppPurchases(userIsEntitledToProduct: true)`. Also, in `DefaultFeatureFlagService`, return `true` for `storeCreationM2WithInAppPurchasesEnabled` feature flag
- Launch the app
- Log in if needed
- Go to the Menu tab, and tap `Switch store`
- On the store picker, tap `+ Add a store`
- Tap `Create a new store` --> the in-progress view should be shown first. after a bit, an alert should be shown that indicates store creation isn't supported because their account is already associated with another store

#### Other errors, like product cannot be fetched

- In code, change [this line](https://github.com/woocommerce/woocommerce-ios/blob/618b3a0855a8fdbe0908f7d964f27878ae56b5ad/WooCommerce/Classes/Authentication/Store%20Creation/StoreCreationCoordinator.swift#L31) to `return MockInAppPurchases(products: [])`. Also, in `DefaultFeatureFlagService`, return `true` for `storeCreationM2WithInAppPurchasesEnabled` feature flag
- Launch the app
- Log in if needed
- Go to the Menu tab, and tap `Switch store`
- On the store picker, tap `+ Add a store`
- Tap `Create a new store` --> the in-progress view should be shown first. after a bit, an alert should be shown that indicates store creation isn't supported in the app

---

- [x] @jaclync tests with actual IAP following the testing guide in PdfdoF-1Ej-p2

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Please feel free to suggest any improvements to the copy:

IAP not supported | user already purchased the plan | any other errors
-- | -- | --
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-13 at 14 46 11](https://user-images.githubusercontent.com/1945542/207253417-20847bf8-132e-46a1-901e-e76f28f6e9db.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-13 at 14 48 16](https://user-images.githubusercontent.com/1945542/207253434-a32f6b67-5ff6-4206-bb5e-f0b2245421e3.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-13 at 14 49 19](https://user-images.githubusercontent.com/1945542/207253439-d240404d-6d6b-48fd-b106-0217ab11ab81.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->