### PR TITLE
[Analytics Hub] Sessions card data formatting

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1593,6 +1593,19 @@ extension SiteSettingGroup {
         .general
     }
 }
+extension Networking.SiteSummaryStats {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.SiteSummaryStats {
+        .init(
+            siteID: .fake(),
+            date: .fake(),
+            period: .fake(),
+            visitors: .fake(),
+            views: .fake()
+        )
+    }
+}
 extension Networking.SiteVisitStats {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1912,6 +1912,30 @@ extension Networking.SiteSetting {
     }
 }
 
+extension Networking.SiteSummaryStats {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        date: CopiableProp<String> = .copy,
+        period: CopiableProp<StatGranularity> = .copy,
+        visitors: CopiableProp<Int> = .copy,
+        views: CopiableProp<Int> = .copy
+    ) -> Networking.SiteSummaryStats {
+        let siteID = siteID ?? self.siteID
+        let date = date ?? self.date
+        let period = period ?? self.period
+        let visitors = visitors ?? self.visitors
+        let views = views ?? self.views
+
+        return Networking.SiteSummaryStats(
+            siteID: siteID,
+            date: date,
+            period: period,
+            visitors: visitors,
+            views: views
+        )
+    }
+}
+
 extension Networking.SiteVisitStats {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Stats/SiteSummaryStats.swift
+++ b/Networking/Networking/Model/Stats/SiteSummaryStats.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents site summary stats for a specific period.
 ///
-public struct SiteSummaryStats: Decodable {
+public struct SiteSummaryStats: Decodable, GeneratedCopiable, GeneratedFakeable {
     public let siteID: Int64
     public let date: String
     public let period: StatGranularity

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Yosemite
 import WooFoundation
+import struct Networking.SiteSummaryStats
 
 /// Helpers for calculating and formatting stats data for display.
 ///
@@ -116,6 +117,16 @@ struct StatsDataTextFormatter {
         let previousCount = visitorCount(at: nil, siteStats: previousPeriod)
         let currentCount = visitorCount(at: nil, siteStats: currentPeriod)
         return createDeltaPercentage(from: previousCount, to: currentCount)
+    }
+
+    /// Creates the text to display for the views count.
+    ///
+    static func createViewsCountText(siteStats: SiteSummaryStats?) -> String {
+        guard let viewsCount = siteStats?.views else {
+            return Constants.placeholderText
+        }
+
+        return Double(viewsCount).humanReadableString()
     }
 
     // MARK: Conversion Stats

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Yosemite
 import WooFoundation
-import struct Networking.SiteSummaryStats
 
 /// Helpers for calculating and formatting stats data for display.
 ///

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import Yosemite
 import WooFoundation
-import struct Networking.SiteSummaryStats
 @testable import WooCommerce
 
 /// `StatsDataTextFormatter` tests.
@@ -336,7 +335,7 @@ final class StatsDataTextFormatterTests: XCTestCase {
 
     func test_createViewsCountText_returns_expected_views_stats() {
         // Given
-        let siteVisitStats = Networking.SiteSummaryStats.fake().copy(views: 250)
+        let siteVisitStats = SiteSummaryStats.fake().copy(views: 250)
 
         // When
         let viewsCount = StatsDataTextFormatter.createViewsCountText(siteStats: siteVisitStats)
@@ -398,7 +397,7 @@ final class StatsDataTextFormatterTests: XCTestCase {
 
     func test_createConversionRateText_for_SiteSummaryStats_returns_placeholder_when_visitor_count_is_zero() {
         // Given
-        let siteVisitStats = Networking.SiteSummaryStats.fake().copy(visitors: 0)
+        let siteVisitStats = SiteSummaryStats.fake().copy(visitors: 0)
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3))
 
         // When
@@ -410,7 +409,7 @@ final class StatsDataTextFormatterTests: XCTestCase {
 
     func test_createConversionRateText_for_SiteSummaryStats_returns_one_decimal_point_when_percentage_value_has_two_decimal_points() {
         // Given
-        let siteVisitStats = Networking.SiteSummaryStats.fake().copy(visitors: 10000)
+        let siteVisitStats = SiteSummaryStats.fake().copy(visitors: 10000)
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3557))
 
         // When
@@ -422,7 +421,7 @@ final class StatsDataTextFormatterTests: XCTestCase {
 
     func test_createConversionRateText_for_SiteSummaryStats_returns_no_decimal_point_when_percentage_value_is_integer() {
         // Given
-        let siteVisitStats = Networking.SiteSummaryStats.fake().copy(visitors: 10)
+        let siteVisitStats = SiteSummaryStats.fake().copy(visitors: 10)
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3))
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
@@ -397,11 +397,11 @@ final class StatsDataTextFormatterTests: XCTestCase {
 
     func test_createConversionRateText_for_SiteSummaryStats_returns_placeholder_when_visitor_count_is_zero() {
         // Given
-        let siteVisitStats = SiteSummaryStats.fake().copy(visitors: 0)
+        let siteSummaryStats = SiteSummaryStats.fake().copy(visitors: 0)
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3))
 
         // When
-        let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteVisitStats)
+        let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteSummaryStats)
 
         // Then
         XCTAssertEqual(conversionRate, "0%")
@@ -409,11 +409,11 @@ final class StatsDataTextFormatterTests: XCTestCase {
 
     func test_createConversionRateText_for_SiteSummaryStats_returns_one_decimal_point_when_percentage_value_has_two_decimal_points() {
         // Given
-        let siteVisitStats = SiteSummaryStats.fake().copy(visitors: 10000)
+        let siteSummaryStats = SiteSummaryStats.fake().copy(visitors: 10000)
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3557))
 
         // When
-        let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteVisitStats)
+        let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteSummaryStats)
 
         // Then
         XCTAssertEqual(conversionRate, "35.6%") // order count: 3557, visitor count: 10000 => 0.3557 (35.57%)
@@ -421,11 +421,11 @@ final class StatsDataTextFormatterTests: XCTestCase {
 
     func test_createConversionRateText_for_SiteSummaryStats_returns_no_decimal_point_when_percentage_value_is_integer() {
         // Given
-        let siteVisitStats = SiteSummaryStats.fake().copy(visitors: 10)
+        let siteSummaryStats = SiteSummaryStats.fake().copy(visitors: 10)
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3))
 
         // When
-        let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteVisitStats)
+        let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteSummaryStats)
 
         // Then
         XCTAssertEqual(conversionRate, "30%") // order count: 3, visitor count: 10 => 0.3 (30%)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Yosemite
 import WooFoundation
+import struct Networking.SiteSummaryStats
 @testable import WooCommerce
 
 /// `StatsDataTextFormatter` tests.
@@ -331,6 +332,17 @@ final class StatsDataTextFormatterTests: XCTestCase {
         // Then
         XCTAssertEqual(visitorCountDelta.string, "+50%")
         XCTAssertEqual(visitorCountDelta.direction, .positive)
+    }
+
+    func test_createViewsCountText_returns_expected_views_stats() {
+        // Given
+        let siteVisitStats = Networking.SiteSummaryStats.fake().copy(views: 250)
+
+        // When
+        let viewsCount = StatsDataTextFormatter.createViewsCountText(siteStats: siteVisitStats)
+
+        // Then
+        XCTAssertEqual(viewsCount, "250")
     }
 
     // MARK: Conversion Stats

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
@@ -347,7 +347,7 @@ final class StatsDataTextFormatterTests: XCTestCase {
 
     // MARK: Conversion Stats
 
-    func test_createConversionRateText_returns_placeholder_when_visitor_count_is_zero() {
+    func test_createConversionRateText_for_SiteVisitStats_returns_placeholder_when_visitor_count_is_zero() {
         // Given
         let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(items: [.fake().copy(visitors: 0)])
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3))
@@ -359,7 +359,7 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(conversionRate, "0%")
     }
 
-    func test_createConversionRateText_returns_one_decimal_point_when_percentage_value_has_two_decimal_points() {
+    func test_createConversionRateText_for_SiteVisitStats_returns_one_decimal_point_when_percentage_value_has_two_decimal_points() {
         // Given
         let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(items: [.fake().copy(visitors: 10000)])
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3557))
@@ -371,7 +371,7 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(conversionRate, "35.6%") // order count: 3557, visitor count: 10000 => 0.3557 (35.57%)
     }
 
-    func test_createConversionRateText_returns_no_decimal_point_when_percentage_value_is_integer() {
+    func test_createConversionRateText_for_SiteVisitStats_returns_no_decimal_point_when_percentage_value_is_integer() {
         // Given
         let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(items: [.fake().copy(visitors: 10)])
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3))
@@ -383,7 +383,7 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(conversionRate, "30%") // order count: 3, visitor count: 10 => 0.3 (30%)
     }
 
-    func test_createConversionRateText_returns_expected_text_for_selected_interval() {
+    func test_createConversionRateText_for_SiteVisitStats_returns_expected_text_for_selected_interval() {
         // Given
         let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(items: [.fake().copy(visitors: 10)])
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 2),
@@ -394,6 +394,42 @@ final class StatsDataTextFormatterTests: XCTestCase {
 
         // Then
         XCTAssertEqual(conversionRate, "10%")
+    }
+
+    func test_createConversionRateText_for_SiteSummaryStats_returns_placeholder_when_visitor_count_is_zero() {
+        // Given
+        let siteVisitStats = Networking.SiteSummaryStats.fake().copy(visitors: 0)
+        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3))
+
+        // When
+        let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteVisitStats)
+
+        // Then
+        XCTAssertEqual(conversionRate, "0%")
+    }
+
+    func test_createConversionRateText_for_SiteSummaryStats_returns_one_decimal_point_when_percentage_value_has_two_decimal_points() {
+        // Given
+        let siteVisitStats = Networking.SiteSummaryStats.fake().copy(visitors: 10000)
+        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3557))
+
+        // When
+        let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteVisitStats)
+
+        // Then
+        XCTAssertEqual(conversionRate, "35.6%") // order count: 3557, visitor count: 10000 => 0.3557 (35.57%)
+    }
+
+    func test_createConversionRateText_for_SiteSummaryStats_returns_no_decimal_point_when_percentage_value_is_integer() {
+        // Given
+        let siteVisitStats = Networking.SiteSummaryStats.fake().copy(visitors: 10)
+        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3))
+
+        // When
+        let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteVisitStats)
+
+        // Then
+        XCTAssertEqual(conversionRate, "30%") // order count: 3, visitor count: 10 => 0.3 (30%)
     }
 
     // MARK: Delta Calculations

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -125,6 +125,7 @@ public typealias SitePlugin = Networking.SitePlugin
 public typealias SitePluginStatusEnum = Networking.SitePluginStatusEnum
 public typealias SiteSetting = Networking.SiteSetting
 public typealias SiteSettingGroup = Networking.SiteSettingGroup
+public typealias SiteSummaryStats = Networking.SiteSummaryStats
 public typealias SiteVisitStats = Networking.SiteVisitStats
 public typealias SiteVisitStatsItem = Networking.SiteVisitStatsItem
 public typealias StateOfACountry = Networking.StateOfACountry


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8364

## Description

This PR adds helper methods to format "views" and "conversion rate" for upcoming "sessions" analytics card.

## Testing

No functionality is exposed in the app yet, so just check unit tests.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
