### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,17 +3,15 @@
 Closes: #
 <!-- Id number of the GitHub issue this PR addresses. -->
 
-### Description
+## Description
 <!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
 
-### Testing instructions
+## Testing instructions
 <!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
 
-### Screenshots
+## Screenshots
 <!-- Include before and after images or gifs when appropriate. -->
 
 
 ---
 - [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
-
-<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->


### PR DESCRIPTION
## Description

- updates headers to a more prominent level
- removes link to PR guideline in wc-android repo (important PR requirements are already enforced by `peril`/`danger`)
