### PR TITLE
Store creation enhancement: show an alert when it times out waiting for Jetpack site

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -484,7 +484,14 @@ private extension StoreCreationCoordinator {
             .replaceError(with: nil)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] site in
-                guard let self, let site else { return }
+                guard let self else { return }
+                guard let site else {
+                    navigationController.dismiss(animated: true) { [weak self] in
+                        guard let self else { return }
+                        self.showJetpackSiteTimeoutAlert(from: self.navigationController)
+                    }
+                    return
+                }
                 self.showSuccessView(from: navigationController, site: site)
             }
     }
@@ -537,6 +544,16 @@ private extension StoreCreationCoordinator {
             self?.analytics.track(event: .StoreCreation.siteCreationSitePreviewed())
         }
         navigationController.pushViewController(successView, animated: true)
+    }
+
+    @MainActor
+    func showJetpackSiteTimeoutAlert(from navigationController: UINavigationController) {
+        let alertController = UIAlertController(title: Localization.WaitingForJetpackSite.TimeoutAlert.title,
+                                                message: Localization.WaitingForJetpackSite.TimeoutAlert.message,
+                                                preferredStyle: .alert)
+        alertController.view.tintColor = .text
+        _ = alertController.addCancelActionWithTitle(Localization.WaitingForJetpackSite.TimeoutAlert.cancelActionTitle) { _ in }
+        navigationController.present(alertController, animated: true)
     }
 }
 
@@ -621,6 +638,21 @@ private extension StoreCreationCoordinator {
                 comment: "Title of the in-progress view when waiting for the site to become a Jetpack site " +
                 "after WPCOM plan purchase in the store creation flow."
             )
+
+            enum TimeoutAlert {
+                static let title = NSLocalizedString(
+                    "Store creation still in progress",
+                    comment: "Title of the alert when the created store never becomes a Jetpack site in the store creation flow."
+                )
+                static let message = NSLocalizedString(
+                    "The new store will be available soon in the store picker. If you have any issues, please contact support.",
+                    comment: "Message of the alert when the created store never becomes a Jetpack site in the store creation flow."
+                )
+                static let cancelActionTitle = NSLocalizedString(
+                    "OK",
+                    comment: "Button title to dismiss the alert when the created store never becomes a Jetpack site in the store creation flow."
+                )
+            }
         }
     }
 


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Related to https://github.com/woocommerce/woocommerce-ios/issues/8118
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Right now, after the checkout step, we wait for the newly created site to become a Jetpack site with 10 retries every 5 seconds. However, when the site still hasn't become a Jetpack site after 10 retries, the app currently just hangs on the installation screen and there's nothing to do except for relaunching the app. In this PR, at the end of the retries, if the site is still not a Jetpack site the store creation flow is dismissed and an alert is presented. The alert informs the merchant that the new site should appear in the store picker shortly and they can contact support if any issues.

### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://user-images.githubusercontent.com/1945542/207537511-908478b0-17f1-4772-aad4-357e22ccea62.png" width="300" />

https://user-images.githubusercontent.com/1945542/207537529-0e357361-72e6-4dec-a23b-aac1d7a72a8a.mov




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
