### PR TITLE
[UI Test] - Add validation on new product screen and new add product tests

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -271,6 +271,7 @@ private extension ProductFormTableViewDataSource {
                        ratingCount: ratingCount,
                        averageRating: averageRating)
         cell.accessoryType = .disclosureIndicator
+        cell.accessibilityIdentifier = "product-review-cell"
     }
 
     func configureSettingsRowWithASwitch(cell: UITableViewCell, viewModel: ProductFormSection.SettingsRow.SwitchableViewModel) {

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -82,7 +82,8 @@ public final class ProductsScreen: ScreenObject {
     }
 
     public func selectProductType(productType: String) throws -> SingleProductScreen {
-        app.staticTexts[productType].tap()
+        let productTypeLabel = NSPredicate(format: "label CONTAINS[c] %@", productType)
+        app.staticTexts.containing(productTypeLabel).firstMatch.tap()
         return try SingleProductScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -46,4 +46,30 @@ public final class SingleProductScreen: ScreenObject {
         XCTAssertTrue(app.staticTexts["TIP"].exists)
         XCTAssertTrue(app.textViews[productName].exists)
     }
+
+    public func verifyProductTypeScreenLoaded(productType: String) throws -> Self {
+        let priceLabel = NSPredicate(format: "label CONTAINS[c] %@", "price")
+        let inventoryLabel = NSPredicate(format: "label CONTAINS[c] %@", "inventory")
+        let productTypeLabel = NSPredicate(format: "label CONTAINS[c] %@", productType)
+        let addVariationLabel = NSPredicate(format: "label CONTAINS[c] %@", "add variations")
+
+        // the common fields on add product screen
+        XCTAssertTrue(app.cells["product-review-cell"].exists)
+        XCTAssertTrue(app.staticTexts.containing(productTypeLabel).firstMatch.exists)
+
+        // different product types displays different fields on add product screen
+        // this is to validate that the correct screens are displayed
+        switch productType {
+        case "physical", "virtual":
+            XCTAssertTrue(app.staticTexts.containing(priceLabel).firstMatch.exists)
+            XCTAssertTrue(app.staticTexts.containing(inventoryLabel).firstMatch.exists)
+        case "variable":
+            XCTAssertTrue(app.staticTexts.containing(addVariationLabel).firstMatch.exists)
+            XCTAssertTrue(app.staticTexts.containing(inventoryLabel).firstMatch.exists)
+        default:
+            // fail test if product type doesn't exist
+            fatalError("Product Type \(productType) doesn't exist!")
+        }
+        return self
+    }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -48,10 +48,10 @@ public final class SingleProductScreen: ScreenObject {
     }
 
     public func verifyProductTypeScreenLoaded(productType: String) throws -> Self {
-        let priceLabel = NSPredicate(format: "label CONTAINS[c] %@", "price")
-        let inventoryLabel = NSPredicate(format: "label CONTAINS[c] %@", "inventory")
-        let productTypeLabel = NSPredicate(format: "label CONTAINS[c] %@", productType)
-        let addVariationLabel = NSPredicate(format: "label CONTAINS[c] %@", "add variations")
+        let addPriceLabel = NSPredicate(format: "label == 'Add Price'")
+        let inventoryLabel = NSPredicate(format: "label == 'Inventory'")
+        let productTypeLabel = NSPredicate(format: "label ==[c] '\(productType)'")
+        let addVariationLabel = NSPredicate(format: "label == 'Add variations'")
 
         // the common fields on add product screen
         XCTAssertTrue(app.cells["product-review-cell"].exists)
@@ -61,13 +61,12 @@ public final class SingleProductScreen: ScreenObject {
         // this is to validate that the correct screens are displayed
         switch productType {
         case "physical", "virtual":
-            XCTAssertTrue(app.staticTexts.containing(priceLabel).firstMatch.exists)
+            XCTAssertTrue(app.staticTexts.containing(addPriceLabel).firstMatch.exists)
             XCTAssertTrue(app.staticTexts.containing(inventoryLabel).firstMatch.exists)
         case "variable":
             XCTAssertTrue(app.staticTexts.containing(addVariationLabel).firstMatch.exists)
             XCTAssertTrue(app.staticTexts.containing(inventoryLabel).firstMatch.exists)
         default:
-            // fail test if product type doesn't exist
             fatalError("Product Type \(productType) doesn't exist!")
         }
         return self

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1129,6 +1129,7 @@
 		7E7C5F872719A93C00315B61 /* ProductCategoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C5F812719A93C00315B61 /* ProductCategoryListViewController.swift */; };
 		7E7C5F8B2719AEDA00315B61 /* EditProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C5F8A2719AEDA00315B61 /* EditProductCategoryListViewModelTests.swift */; };
 		7E7C5F8F2719BA7300315B61 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7C5F8E2719BA7300315B61 /* ProductCategoryCellViewModel.swift */; };
+		80089F182949B92D0078C671 /* ProductFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80089F172949B92D0078C671 /* ProductFlow.swift */; };
 		800A5B58275483D6009DE2CD /* OrdersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800A5B57275483D6009DE2CD /* OrdersTests.swift */; };
 		800A5B5F27548F31009DE2CD /* site_info_wordpress_com.json in Resources */ = {isa = PBXBuildFile; fileRef = 800A5B5E27548F31009DE2CD /* site_info_wordpress_com.json */; };
 		800A5B6127548F53009DE2CD /* sites_posts_password.json in Resources */ = {isa = PBXBuildFile; fileRef = 800A5B6027548F53009DE2CD /* sites_posts_password.json */; };
@@ -3136,6 +3137,7 @@
 		7E7C5F812719A93C00315B61 /* ProductCategoryListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewController.swift; sourceTree = "<group>"; };
 		7E7C5F8A2719AEDA00315B61 /* EditProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
 		7E7C5F8E2719BA7300315B61 /* ProductCategoryCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductCategoryCellViewModel.swift; sourceTree = "<group>"; };
+		80089F172949B92D0078C671 /* ProductFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFlow.swift; sourceTree = "<group>"; };
 		800A5B57275483D6009DE2CD /* OrdersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersTests.swift; sourceTree = "<group>"; };
 		800A5B5E27548F31009DE2CD /* site_info_wordpress_com.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = site_info_wordpress_com.json; sourceTree = "<group>"; };
 		800A5B6027548F53009DE2CD /* sites_posts_password.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = sites_posts_password.json; sourceTree = "<group>"; };
@@ -6780,6 +6782,7 @@
 			children = (
 				80E6FC742763579D0086CD67 /* MockDataReader.swift */,
 				800A5B9D275623FC009DE2CD /* LoginFlow.swift */,
+				80089F172949B92D0078C671 /* ProductFlow.swift */,
 			);
 			path = Flows;
 			sourceTree = "<group>";
@@ -11522,6 +11525,7 @@
 				80C3626F277453E8005CEAD3 /* ReviewsTests.swift in Sources */,
 				80E6FC79276C3FD60086CD67 /* MockDataReader.swift in Sources */,
 				CCDC49CD23FFFFF4003166BA /* LoginTests.swift in Sources */,
+				80089F182949B92D0078C671 /* ProductFlow.swift in Sources */,
 				800A5B58275483D6009DE2CD /* OrdersTests.swift in Sources */,
 				80AD2CA427858BAB00A63DE8 /* StatsTests.swift in Sources */,
 				800A5BCB2759CE4B009DE2CD /* ProductsTests.swift in Sources */,

--- a/WooCommerce/WooCommerceUITests/Flows/ProductFlow.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/ProductFlow.swift
@@ -1,0 +1,17 @@
+import UITestsFoundation
+import XCTest
+
+class ProductFlow {
+
+    static func addAndVerifyNewProduct(productType: String) throws {
+        let product = try GetMocks.readNewProductData()
+
+        try TabNavComponent().goToProductsScreen()
+            .tapAddProduct()
+            .selectProductType(productType: productType)
+            .verifyProductTypeScreenLoaded(productType: productType)
+            .addProductTitle(productTitle: product.name)
+            .publishProduct()
+            .verifyNewProductScreenLoaded(productName: product.name)
+    }
+}

--- a/WooCommerce/WooCommerceUITests/README.md
+++ b/WooCommerce/WooCommerceUITests/README.md
@@ -44,8 +44,8 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
 4. Products
     - [x] Products list and single product screens load
     - [x] Add new product - Simple physical product
-    - [ ] Add new product - Simple virtual product
-    - [ ] Add new product - Variable product
+    - [x] Add new product - Simple virtual product
+    - [x] Add new product - Variable product
     - [ ] Add new product - Grouped product
     - [ ] Add new product - External product
     - [ ] Search for product

--- a/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
@@ -3,14 +3,6 @@ import XCTest
 
 final class ProductsTests: XCTestCase {
 
-    let productTypes = [
-        "physical": "Simple physical product",
-        "virtual": "Simple virtual product",
-        "variable": "Variable product",
-        "grouped": "Grouped product",
-        "external": "External product"
-    ]
-
     override func setUpWithError() throws {
         continueAfterFailure = false
 
@@ -33,13 +25,14 @@ final class ProductsTests: XCTestCase {
     }
 
     func test_add_simple_physical_product() throws {
-        let product = try GetMocks.readNewProductData()
+        try ProductFlow.addAndVerifyNewProduct(productType: "physical")
+    }
 
-        try TabNavComponent().goToProductsScreen()
-            .tapAddProduct()
-            .selectProductType(productType: productTypes["physical"]!)
-            .addProductTitle(productTitle: product.name)
-            .publishProduct()
-            .verifyNewProductScreenLoaded(productName: product.name)
+    func test_add_simple_virtual_product() throws {
+        try ProductFlow.addAndVerifyNewProduct(productType: "virtual")
+    }
+
+    func test_add_variable_product() throws {
+        try ProductFlow.addAndVerifyNewProduct(productType: "variable")
     }
 }


### PR DESCRIPTION
### Description
This PR adds a new validation (`verifyProductTypeScreenLoaded()`) for the add product test to validate that the correct product screen is displayed. This also adds 2 new add product (virtual and variable) UI tests.

### Testing instructions
Tests should pass in CI and locally. The tests should also fail when the expected fields are not displayed on screen.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
