### PR TITLE
Analytics Hub: Adds a placeholder for images

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersView.swift
@@ -67,6 +67,10 @@ struct TopPerformersRow: View {
         ///
         let imageURL: URL?
 
+        /// Image placeholder.
+        ///
+        let placeHolder = UIImage.productPlaceholderImage
+
         /// Item name or title.
         ///
         let name: String
@@ -92,6 +96,7 @@ struct TopPerformersRow: View {
         AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .top) {
             // Image
             KFImage(data.imageURL)
+                .placeholder { Image(uiImage: data.placeHolder).foregroundColor(Color(.listIcon)) }
                 .resizable()
                 .frame(width: imageWidth, height: imageWidth)
                 .cornerRadius(Layout.imageCornerRadius)


### PR DESCRIPTION
Closes: #8404 

# Why 

This PR adds a placeholder image to be shown while the images from the top items sold list is are loading.

# Screenshots

<img src="https://user-images.githubusercontent.com/562080/207630683-3c0d131a-8bf4-4353-896b-a4ef85223ebc.png" width="360">

# Testing Steps

- Go to the analytics Hub
- Select a range that has product with images that hasn't been load into memory before
- See the placeholder while the image loads.


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
