### PR TITLE
Analytics Hub: Release Custom Date Ranges

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 11.7
 -----
+- [**] Analytics Hub: Now you can select custom date ranges. [https://github.com/woocommerce/woocommerce-ios/pull/8414]
 
 
 11.6

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCard.swift
@@ -162,24 +162,5 @@ extension AnalyticsTimeRangeCard {
         case monthToDate
         case quarterToDate
         case yearToDate
-
-        /// Wee need to provide a custom `allCases` in order to evict `.custom` while the feature flag is active.
-        /// We should delete this once the feature flag has been removed.
-        ///
-        static var allCases: [Range] {
-            [
-                ServiceLocator.featureFlagService.isFeatureFlagEnabled(.analyticsHub) ? .custom : nil,
-                .today,
-                .yesterday,
-                .lastWeek,
-                .lastMonth,
-                .lastQuarter,
-                .lastYear,
-                .weekToDate,
-                .monthToDate,
-                .quarterToDate,
-                yearToDate
-            ].compactMap { $0 }
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
@@ -43,6 +43,7 @@ struct RangedDatePicker: View {
                     DatePicker("", selection: $startDate, in: ...Date(), displayedComponents: [.date])
                         .datePickerStyle(.graphical)
                         .accentColor(Color(.brand))
+                        .padding(.horizontal, Layout.calendarPadding)
 
                     // End Picker
                     Text(Localization.endDate)
@@ -54,6 +55,7 @@ struct RangedDatePicker: View {
                     DatePicker("", selection: $endDate, in: ...Date(), displayedComponents: [.date])
                         .datePickerStyle(.graphical)
                         .accentColor(Color(.brand))
+                        .padding(.horizontal, Layout.calendarPadding)
                 }
                 .padding()
             }
@@ -103,6 +105,7 @@ private extension RangedDatePicker {
     }
     enum Layout {
         static let titleSpacing: CGFloat = 4.0
+        static let calendarPadding: CGFloat = -8.0
     }
 }
 


### PR DESCRIPTION
# Why

This PR does 3 things:
- Update the calendar padding following the design review recomendation
- Removes the `custom` cases outside the feature flag control
- Updates the readme

# Screenshot (For the calendar padding)

<img width="436" alt="calendar-padding" src="https://user-images.githubusercontent.com/562080/207665853-f92f8d87-4ce2-4c4d-b428-0e4b11c72b15.png">

# Notes

Please don't before #8411 && #8413  

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
