### PR TITLE
REST API: Migrate coupon endpoints to use REST API

### DIFF
--- a/Networking/Networking/Network/MockNetwork.swift
+++ b/Networking/Networking/Network/MockNetwork.swift
@@ -191,6 +191,11 @@ private extension MockNetwork {
             return request.path
         case let request as DotcomRequest:
             return request.path
+        case let request as RESTRequest:
+            if let fallbackRequest = request.fallbackRequest {
+                return path(for: fallbackRequest)
+            }
+            fallthrough
         default:
             let targetURL = try! request.asURLRequest().url?.absoluteString
             return targetURL ?? ""

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -75,10 +75,11 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
                                      siteID: siteID,
                                      path: Path.coupons,
                                      parameters: parameters)
+        let restRequest = RESTRequest(siteURL: siteURL, fallbackRequest: request)
 
         let mapper = CouponListMapper(siteID: siteID)
 
-        enqueue(request, mapper: mapper, completion: completion)
+        enqueue(restRequest, mapper: mapper, completion: completion)
     }
 
     public func searchCoupons(for siteID: Int64,
@@ -98,10 +99,10 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
                                      siteID: siteID,
                                      path: Path.coupons,
                                      parameters: parameters)
+        let restRequest = RESTRequest(siteURL: siteURL, fallbackRequest: request)
 
         let mapper = CouponListMapper(siteID: siteID)
-
-        enqueue(request, mapper: mapper, completion: completion)
+        enqueue(restRequest, mapper: mapper, completion: completion)
     }
 
     /// Retrieves a `Coupon`.
@@ -120,10 +121,10 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
                                      method: .get,
                                      siteID: siteID,
                                      path: Path.coupons + "/\(couponID)")
-
+        let restRequest = RESTRequest(siteURL: siteURL, fallbackRequest: request)
         let mapper = CouponMapper(siteID: siteID)
 
-        enqueue(request, mapper: mapper, completion: completion)
+        enqueue(restRequest, mapper: mapper, completion: completion)
     }
 
     // MARK: - Delete Coupon
@@ -145,10 +146,10 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
                                      siteID: siteID,
                                      path: Path.coupons + "/\(couponID)",
                                      parameters: [ParameterKey.force: true])
-
+        let restRequest = RESTRequest(siteURL: siteURL, fallbackRequest: request)
         let mapper = CouponMapper(siteID: siteID)
 
-        enqueue(request, mapper: mapper, completion: completion)
+        enqueue(restRequest, mapper: mapper, completion: completion)
     }
 
     // MARK: - Update Coupon
@@ -176,9 +177,10 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
             let siteID = coupon.siteID
             let path = Path.coupons + "/\(couponID)"
             let request = JetpackRequest(wooApiVersion: .mark3, method: .put, siteID: siteID, path: path, parameters: parameters)
+            let restRequest = RESTRequest(siteURL: siteURL, fallbackRequest: request)
             let mapper = CouponMapper(siteID: siteID)
 
-            enqueue(request, mapper: mapper, completion: completion)
+            enqueue(restRequest, mapper: mapper, completion: completion)
         } catch {
             completion(.failure(error))
         }
@@ -208,9 +210,10 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
             let siteID = coupon.siteID
             let path = Path.coupons
             let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+            let restRequest = RESTRequest(siteURL: siteURL, fallbackRequest: request)
             let mapper = CouponMapper(siteID: siteID)
 
-            enqueue(request, mapper: mapper, completion: completion)
+            enqueue(restRequest, mapper: mapper, completion: completion)
         } catch {
             completion(.failure(error))
         }
@@ -244,10 +247,10 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
                                      siteID: siteID,
                                      path: Path.couponReports,
                                      parameters: parameters)
-
+        let restRequest = RESTRequest(siteURL: siteURL, fallbackRequest: request)
         let mapper = CouponReportListMapper()
 
-        enqueue(request, mapper: mapper, completion: { result in
+        enqueue(restRequest, mapper: mapper, completion: { result in
             switch result {
             case .success(let couponReports):
                 if let report = couponReports.first {

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -6,33 +6,40 @@ import Foundation
 ///
 public protocol CouponsRemoteProtocol {
     func loadAllCoupons(for siteID: Int64,
+                        siteURL: String,
                         pageNumber: Int,
                         pageSize: Int,
                         completion: @escaping (Result<[Coupon], Error>) -> ())
 
     func searchCoupons(for siteID: Int64,
+                       siteURL: String,
                        keyword: String,
                        pageNumber: Int,
                        pageSize: Int,
                        completion: @escaping (Result<[Coupon], Error>) -> ())
 
     func retrieveCoupon(for siteID: Int64,
+                        siteURL: String,
                         couponID: Int64,
                         completion: @escaping (Result<Coupon, Error>) -> Void)
 
     func deleteCoupon(for siteID: Int64,
+                      siteURL: String,
                       couponID: Int64,
                       completion: @escaping (Result<Coupon, Error>) -> Void)
 
     func updateCoupon(_ coupon: Coupon,
+                      siteURL: String,
                       siteTimezone: TimeZone?,
                       completion: @escaping (Result<Coupon, Error>) -> Void)
 
     func createCoupon(_ coupon: Coupon,
+                      siteURL: String,
                       siteTimezone: TimeZone?,
                       completion: @escaping (Result<Coupon, Error>) -> Void)
 
     func loadCouponReport(for siteID: Int64,
+                          siteURL: String,
                           couponID: Int64,
                           from startDate: Date,
                           completion: @escaping (Result<CouponReport, Error>) -> Void)
@@ -48,11 +55,13 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
     ///
     /// - Parameters:
     ///     - siteID: The site for which we'll fetch coupons.
+    ///     - siteURL: Address of the site to fetch coupons for.
     ///     - pageNumber: The page number of the coupon list to be fetched.
     ///     - pageSize: The maximum number of coupons to be fetched for the current page.
     ///     - completion: Closure to be executed upon completion.
     ///
     public func loadAllCoupons(for siteID: Int64,
+                               siteURL: String,
                                pageNumber: Int = Default.pageNumber,
                                pageSize: Int = Default.pageSize,
                                completion: @escaping (Result<[Coupon], Error>) -> ()) {
@@ -73,6 +82,7 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
     }
 
     public func searchCoupons(for siteID: Int64,
+                              siteURL: String,
                               keyword: String,
                               pageNumber: Int,
                               pageSize: Int,
@@ -98,10 +108,12 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
     ///
     /// - Parameters:
     ///     - siteID: Site for which we'll fetch the coupon.
+    ///     - siteURL: Address of the site that the coupon belongs to.
     ///     - couponID: ID of the Coupon that will be retrieved.
     ///     - completion: Closure to be executed upon completion.
     ///
     public func retrieveCoupon(for siteID: Int64,
+                               siteURL: String,
                                couponID: Int64,
                                completion: @escaping (Result<Coupon, Error>) -> Void) {
         let request = JetpackRequest(wooApiVersion: .mark3,
@@ -120,10 +132,12 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
     ///
     /// - Parameters:
     ///     - siteID: Site for which we'll delete the coupon.
+    ///     - siteURL: Address of the site that the coupon belongs to.
     ///     - couponID: ID of the Coupon that will be deleted.
     ///     - completion: Closure to be executed upon completion.
     ///
     public func deleteCoupon(for siteID: Int64,
+                             siteURL: String,
                              couponID: Int64,
                              completion: @escaping (Result<Coupon, Error>) -> Void) {
         let request = JetpackRequest(wooApiVersion: .mark3,
@@ -143,10 +157,12 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
     ///
     /// - Parameters:
     ///     - coupon: The coupon to be updated remotely.
+    ///     - siteURL: Address of the site that the coupon belongs to.
     ///     - siteTimezone: the timezone configured on the site (also know as local time of the site).
     ///     - completion: Closure to be executed upon completion.
     ///
     public func updateCoupon(_ coupon: Coupon,
+                             siteURL: String,
                              siteTimezone: TimeZone? = nil,
                              completion: @escaping (Result<Coupon, Error>) -> Void) {
         do {
@@ -174,10 +190,12 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
     ///
     /// - Parameters:
     ///     - coupon: The coupon to be created remotely.
+    ///     - siteURL: Address of the site to create the coupon for.
     ///     - siteTimezone: the timezone configured on the site (also know as local time of the site).
     ///     - completion: Closure to be executed upon completion.
     ///
     public func createCoupon(_ coupon: Coupon,
+                             siteURL: String,
                              siteTimezone: TimeZone? = nil,
                              completion: @escaping (Result<Coupon, Error>) -> Void) {
         do {
@@ -203,11 +221,13 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
     ///
     /// - Parameters:
     ///     - siteID: The site from which we'll fetch the analytics report.
+    ///     - siteURL: Address of the site from which we'll fetch the analytics report.
     ///     - couponID: The coupon for which we'll fetch the analytics report.
     ///     - startDate: The start of the date range for which we'll fetch the analytics report.
     ///     - completion: Closure to be executed upon completion.
     ///
     public func loadCouponReport(for siteID: Int64,
+                                 siteURL: String,
                                  couponID: Int64,
                                  from startDate: Date,
                                  completion: @escaping (Result<CouponReport, Error>) -> Void) {

--- a/Networking/Networking/Requests/RESTRequest.swift
+++ b/Networking/Networking/Requests/RESTRequest.swift
@@ -4,7 +4,6 @@ import Alamofire
 /// Wraps up a URLRequestConvertible Instance, and injects the Authorization + User Agent whenever the actual Request is required.
 ///
 struct RESTRequest: Request {
-    
     /// URL of the site to make the request with
     ///
     let siteURL: String

--- a/Networking/Networking/Validators/ResponseDataValidator.swift
+++ b/Networking/Networking/Validators/ResponseDataValidator.swift
@@ -3,3 +3,9 @@ protocol ResponseDataValidator {
     ///
     func validate(data: Data) throws -> Void
 }
+
+struct DummyResponseDataValidator: ResponseDataValidator {
+    func validate(data: Data) throws -> Void {
+        // no-op
+    }
+}

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -10,6 +10,7 @@ final class CouponsRemoteTests: XCTestCase {
     /// Dummy Site ID
     ///
     private let sampleSiteID: Int64 = 1234
+    private let sampleSiteURL: String = "https://test.com"
 
     override func setUp() {
         super.setUp()
@@ -33,7 +34,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.loadAllCoupons(for: self.sampleSiteID) { result in
+            remote.loadAllCoupons(for: self.sampleSiteID, siteURL: self.sampleSiteURL) { result in
                 promise(result)
             }
         }
@@ -51,7 +52,7 @@ final class CouponsRemoteTests: XCTestCase {
         let remote = CouponsRemote(network: network)
 
         // When
-        remote.loadAllCoupons(for: sampleSiteID, pageNumber: 2, pageSize: 17) { _ in }
+        remote.loadAllCoupons(for: sampleSiteID, siteURL: sampleSiteURL, pageNumber: 2, pageSize: 17) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.first as? JetpackRequest)
@@ -71,7 +72,7 @@ final class CouponsRemoteTests: XCTestCase {
         let remote = CouponsRemote(network: network)
 
         // When
-        remote.loadAllCoupons(for: sampleSiteID) { _ in }
+        remote.loadAllCoupons(for: sampleSiteID, siteURL: sampleSiteURL) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.first as? JetpackRequest)
@@ -88,7 +89,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.loadAllCoupons(for: self.sampleSiteID) { result in
+            remote.loadAllCoupons(for: self.sampleSiteID, siteURL: self.sampleSiteURL) { result in
                 promise(result)
             }
         }
@@ -110,6 +111,7 @@ final class CouponsRemoteTests: XCTestCase {
         // When
         let result = waitFor { promise in
             remote.loadAllCoupons(for: self.sampleSiteID,
+                                  siteURL: self.sampleSiteURL,
                                   completion: { (result) in
                                     promise(result)
                                 })
@@ -134,7 +136,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.deleteCoupon(for: self.sampleSiteID, couponID: sampleCouponID) { result in
+            remote.deleteCoupon(for: self.sampleSiteID, siteURL: self.sampleSiteURL, couponID: sampleCouponID) { result in
                 promise(result)
             }
         }
@@ -158,6 +160,7 @@ final class CouponsRemoteTests: XCTestCase {
         // When
         let result = waitFor { promise in
             remote.deleteCoupon(for: self.sampleSiteID,
+                                siteURL: self.sampleSiteURL,
                                 couponID: sampleCouponID,
                                 completion: { (result) in
                 promise(result)
@@ -182,7 +185,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.updateCoupon(coupon) { result in
+            remote.updateCoupon(coupon, siteURL: self.sampleSiteURL) { result in
                 promise(result)
             }
         }
@@ -205,7 +208,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.updateCoupon(coupon) { (result) in
+            remote.updateCoupon(coupon, siteURL: self.sampleSiteURL) { (result) in
                 promise(result)
             }
         }
@@ -228,7 +231,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.createCoupon(coupon) { result in
+            remote.createCoupon(coupon, siteURL: self.sampleSiteURL) { result in
                 promise(result)
             }
         }
@@ -251,7 +254,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.createCoupon(coupon) { (result) in
+            remote.createCoupon(coupon, siteURL: self.sampleSiteURL) { (result) in
                 promise(result)
             }
         }
@@ -273,7 +276,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.loadCouponReport(for: self.sampleSiteID, couponID: 571, from: Date()) { (result) in
+            remote.loadCouponReport(for: self.sampleSiteID, siteURL: self.sampleSiteURL, couponID: 571, from: Date()) { (result) in
                 promise(result)
             }
         }
@@ -296,7 +299,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.loadCouponReport(for: self.sampleSiteID, couponID: 571, from: Date()) { (result) in
+            remote.loadCouponReport(for: self.sampleSiteID, siteURL: self.sampleSiteURL, couponID: 571, from: Date()) { (result) in
                 promise(result)
             }
         }
@@ -318,7 +321,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.searchCoupons(for: self.sampleSiteID, keyword: "test", pageNumber: 0, pageSize: 20) { (result) in
+            remote.searchCoupons(for: self.sampleSiteID, siteURL: self.sampleSiteURL, keyword: "test", pageNumber: 0, pageSize: 20) { (result) in
                 promise(result)
             }
         }
@@ -340,7 +343,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.searchCoupons(for: self.sampleSiteID, keyword: "test", pageNumber: 0, pageSize: 20) { (result) in
+            remote.searchCoupons(for: self.sampleSiteID, siteURL: self.sampleSiteURL, keyword: "test", pageNumber: 0, pageSize: 20) { (result) in
                 promise(result)
             }
         }
@@ -363,7 +366,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.retrieveCoupon(for: self.sampleSiteID, couponID: sampleCouponID) { (result) in
+            remote.retrieveCoupon(for: self.sampleSiteID, siteURL: self.sampleSiteURL, couponID: sampleCouponID) { (result) in
                 promise(result)
             }
         }
@@ -386,7 +389,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.retrieveCoupon(for: self.sampleSiteID, couponID: sampleCouponID) { (result) in
+            remote.retrieveCoupon(for: self.sampleSiteID, siteURL: self.sampleSiteURL, couponID: sampleCouponID) { (result) in
                 promise(result)
             }
         }

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -55,9 +55,10 @@ final class CouponsRemoteTests: XCTestCase {
         remote.loadAllCoupons(for: sampleSiteID, siteURL: sampleSiteURL, pageNumber: 2, pageSize: 17) { _ in }
 
         // Then
-        let request = try XCTUnwrap(network.requestsForResponseData.first as? JetpackRequest)
-        guard let page = request.parameters["page"] as? String,
-              let pageSize = request.parameters["per_page"] as? String else {
+        let request = network.requestsForResponseData.first
+        let jetpackRequest = try XCTUnwrap((request as? RESTRequest)?.fallbackRequest ?? request as? JetpackRequest)
+        guard let page = jetpackRequest.parameters["page"] as? String,
+              let pageSize = jetpackRequest.parameters["per_page"] as? String else {
             XCTFail("Pagination parameters not found")
             return
         }
@@ -75,8 +76,9 @@ final class CouponsRemoteTests: XCTestCase {
         remote.loadAllCoupons(for: sampleSiteID, siteURL: sampleSiteURL) { _ in }
 
         // Then
-        let request = try XCTUnwrap(network.requestsForResponseData.first as? JetpackRequest)
-        XCTAssertEqual(request.siteID, sampleSiteID)
+        let request = network.requestsForResponseData.first
+        let jetpackRequest = try XCTUnwrap((request as? RESTRequest)?.fallbackRequest ?? request as? JetpackRequest)
+        XCTAssertEqual(jetpackRequest.siteID, sampleSiteID)
     }
 
     /// Verifies that loadAllCoupons uses the SiteID passed in to build the models.

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -410,7 +410,7 @@ struct AddEditCoupon_Previews: PreviewProvider {
 
         /// Edit Coupon
         ///
-        let editingViewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon, onSuccess: { _ in })
+        let editingViewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon, siteURL: "", onSuccess: { _ in })
         AddEditCoupon(editingViewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -12,6 +12,8 @@ final class AddEditCouponViewModel: ObservableObject {
 
     private let siteID: Int64
 
+    private let siteURL: String
+
     /// Based on the Editing Option, the `AddEditCoupon` view can be in Creation or Editing mode.
     ///
     private let editingOption: EditingOption
@@ -211,6 +213,7 @@ final class AddEditCouponViewModel: ObservableObject {
     /// Init method for coupon creation
     ///
     init(siteID: Int64,
+         siteURL: String,
          discountType: Coupon.DiscountType,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -220,6 +223,7 @@ final class AddEditCouponViewModel: ObservableObject {
          timezone: TimeZone = .siteTimezone,
          onSuccess: @escaping (Coupon) -> Void) {
         self.siteID = siteID
+        self.siteURL = siteURL
         editingOption = .creation
         self.discountType = discountType
         self.stores = stores
@@ -250,6 +254,7 @@ final class AddEditCouponViewModel: ObservableObject {
     /// Init method for coupon editing
     ///
     init(existingCoupon: Coupon,
+         siteURL: String,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
@@ -261,6 +266,7 @@ final class AddEditCouponViewModel: ObservableObject {
         coupon = existingCoupon
         editingOption = .editing
         discountType = existingCoupon.discountType
+        self.siteURL = siteURL
         self.stores = stores
         self.storageManager = storageManager
         self.currencySettings = currencySettings
@@ -379,7 +385,7 @@ final class AddEditCouponViewModel: ObservableObject {
         }
 
         isLoading = true
-        let action = CouponAction.createCoupon(coupon, siteTimezone: timezone) { [weak self] result in
+        let action = CouponAction.createCoupon(coupon, siteURL: siteURL, siteTimezone: timezone) { [weak self] result in
             guard let self = self else { return }
             self.isLoading = false
             switch result {
@@ -408,7 +414,7 @@ final class AddEditCouponViewModel: ObservableObject {
         }
 
         isLoading = true
-        let action = CouponAction.updateCoupon(coupon, siteTimezone: timezone) { [weak self] result in
+        let action = CouponAction.updateCoupon(coupon, siteURL: siteURL, siteTimezone: timezone) { [weak self] result in
             guard let self = self else { return }
             self.isLoading = false
             switch result {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -462,7 +462,7 @@ private extension CouponDetails {
 #if DEBUG
 struct CouponDetails_Previews: PreviewProvider {
     static var previews: some View {
-        CouponDetails(viewModel: CouponDetailsViewModel(coupon: Coupon.sampleCoupon))
+        CouponDetails(viewModel: CouponDetailsViewModel(coupon: Coupon.sampleCoupon, siteURL: "http://test.com"))
     }
 }
 #endif

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -7,6 +7,7 @@ import WooFoundation
 ///
 final class CouponDetailsViewModel: ObservableObject {
     let siteID: Int64
+    let siteURL: String
 
     /// Code of the coupon
     ///
@@ -136,12 +137,14 @@ final class CouponDetailsViewModel: ObservableObject {
     let onDeletion: () -> Void
 
     init(coupon: Coupon,
+         siteURL: String,
          stores: StoresManager = ServiceLocator.stores,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          featureFlags: FeatureFlagService = ServiceLocator.featureFlagService,
          onUpdate: @escaping () -> Void = {},
          onDeletion: @escaping () -> Void = {}) {
         self.siteID = coupon.siteID
+        self.siteURL = siteURL
         self.coupon = coupon
         self.stores = stores
         self.currencySettings = currencySettings
@@ -153,7 +156,7 @@ final class CouponDetailsViewModel: ObservableObject {
     }
 
     func syncCoupon() {
-        let action = CouponAction.retrieveCoupon(siteID: coupon.siteID, couponID: coupon.couponID) { [weak self] result in
+        let action = CouponAction.retrieveCoupon(siteID: coupon.siteID, siteURL: siteURL, couponID: coupon.couponID) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(let coupon):
@@ -175,7 +178,7 @@ final class CouponDetailsViewModel: ObservableObject {
         hasErrorLoadingAmount = false
         // Get "ancient" date to fetch all possible reports
         let startDate = Date(timeIntervalSince1970: 1)
-        let action = CouponAction.loadCouponReport(siteID: siteID, couponID: coupon.couponID, startDate: startDate) { [weak self] result in
+        let action = CouponAction.loadCouponReport(siteID: siteID, siteURL: siteURL, couponID: coupon.couponID, startDate: startDate) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(let report):
@@ -206,7 +209,7 @@ final class CouponDetailsViewModel: ObservableObject {
 
     func deleteCoupon(onSuccess: @escaping () -> Void, onFailure: @escaping () -> Void) {
         isDeletionInProgress = true
-        let action = CouponAction.deleteCoupon(siteID: siteID, couponID: coupon.couponID) { [weak self] result in
+        let action = CouponAction.deleteCoupon(siteID: siteID, siteURL: siteURL, couponID: coupon.couponID) { [weak self] result in
             self?.isDeletionInProgress = false
             switch result {
             case .success:
@@ -278,7 +281,7 @@ private extension CouponDetailsViewModel {
     }
 
     func createAddEditCouponViewModel(with coupon: Coupon) -> AddEditCouponViewModel {
-        .init(existingCoupon: coupon, onSuccess: { [weak self] updatedCoupon in
+        .init(existingCoupon: coupon, siteURL: siteURL, onSuccess: { [weak self] updatedCoupon in
             guard let self = self else { return }
             self.updateCoupon(updatedCoupon)
             self.onUpdate()

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CouponListView: UIViewControllerRepresentable {
     let siteID: Int64
+    let siteURL: String
 
     typealias UIViewControllerType = CouponListViewController
 
@@ -16,7 +17,7 @@ struct CouponListView: UIViewControllerRepresentable {
     /// Solution proposed here: https://stackoverflow.com/a/68567095/7241994
     ///
     func makeUIViewController(context: Self.Context) -> CouponListViewController {
-        let viewController = CouponListViewController(siteID: siteID)
+        let viewController = CouponListViewController(siteID: siteID, siteURL: siteURL)
         context.coordinator.parentObserver = viewController.observe(\.parent, changeHandler: { vc, _ in
             vc.parent?.navigationItem.title = vc.title
             vc.parent?.navigationItem.rightBarButtonItems = vc.navigationItem.rightBarButtonItems

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -7,6 +7,7 @@ final class CouponListViewController: UIViewController, GhostableViewController 
     @IBOutlet private weak var tableView: UITableView!
     private let viewModel: CouponListViewModel
     private let siteID: Int64
+    private let siteURL: String
 
     /// Set when an empty state view controller is displayed.
     ///
@@ -74,9 +75,10 @@ final class CouponListViewController: UIViewController, GhostableViewController 
         return noticePresenter
     }()
 
-    init(siteID: Int64) {
+    init(siteID: Int64, siteURL: String) {
         self.siteID = siteID
-        self.viewModel = CouponListViewModel(siteID: siteID)
+        self.siteURL = siteURL
+        self.viewModel = CouponListViewModel(siteID: siteID, siteURL: siteURL)
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
 
@@ -201,6 +203,7 @@ private extension CouponListViewController {
     ///
     func startCouponCreation(discountType: Coupon.DiscountType) {
         let viewModel = AddEditCouponViewModel(siteID: siteID,
+                                               siteURL: siteURL,
                                                discountType: discountType,
                                                onSuccess: { [weak self] _ in
             self?.refreshCouponList()
@@ -225,7 +228,7 @@ extension CouponListViewController: UITableViewDelegate {
         guard let coupon = viewModel.coupon(at: indexPath) else {
             return
         }
-        let detailsViewModel = CouponDetailsViewModel(coupon: coupon, onUpdate: { [weak self] in
+        let detailsViewModel = CouponDetailsViewModel(coupon: coupon, siteURL: siteURL, onUpdate: { [weak self] in
             guard let self = self else { return }
             self.viewModel.refreshCoupons()
         }, onDeletion: { [weak self] in
@@ -288,7 +291,7 @@ private extension CouponListViewController {
         ServiceLocator.analytics.track(.couponsListSearchTapped)
         let searchViewController = SearchViewController<TitleAndSubtitleAndStatusTableViewCell, CouponSearchUICommand>(
             storeID: siteID,
-            command: CouponSearchUICommand(siteID: siteID),
+            command: CouponSearchUICommand(siteID: siteID, siteURL: siteURL),
             cellType: TitleAndSubtitleAndStatusTableViewCell.self,
             cellSeparator: .singleLine
         )

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
@@ -44,6 +44,10 @@ final class CouponListViewModel {
     ///
     private let siteID: Int64
 
+    /// URL of the currently active site
+    ///
+    private let siteURL: String
+
     /// resultsController: provides models from storage used for creation of cell ViewModels
     ///
     private let resultsController: ResultsController<StorageCoupon>
@@ -64,11 +68,13 @@ final class CouponListViewModel {
     // MARK: - Initialization and setup
     //
     init(siteID: Int64,
+         siteURL: String,
          syncingCoordinator: SyncingCoordinatorProtocol = SyncingCoordinator(),
          storesManager: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          featureFlags: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.siteID = siteID
+        self.siteURL = siteURL
         self.syncingCoordinator = syncingCoordinator
         self.storesManager = storesManager
         self.storageManager = storageManager
@@ -241,6 +247,7 @@ extension CouponListViewModel: SyncingCoordinatorDelegate {
         transitionToSyncingState(pageNumber: pageNumber, hasData: couponViewModels.isNotEmpty)
         let action = CouponAction
             .synchronizeCoupons(siteID: siteID,
+                                siteURL: siteURL,
                                 pageNumber: pageNumber,
                                 pageSize: pageSize) { [weak self] result in
                 guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -18,9 +18,11 @@ final class CouponSearchUICommand: SearchUICommand {
     var resynchronizeModels: (() -> Void) = {}
 
     private let siteID: Int64
+    private let siteURL: String
 
-    init(siteID: Int64) {
+    init(siteID: Int64, siteURL: String) {
         self.siteID = siteID
+        self.siteURL = siteURL
     }
 
     func createResultsController() -> ResultsController<StorageCoupon> {
@@ -44,7 +46,7 @@ final class CouponSearchUICommand: SearchUICommand {
     }
 
     func synchronizeModels(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
-        let action = CouponAction.searchCoupons(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize) { result in
+        let action = CouponAction.searchCoupons(siteID: siteID, siteURL: siteURL, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize) { result in
 
             if case .failure(let error) = result {
                 DDLogError("☠️ Coupon Search Failure! \(error)")
@@ -57,7 +59,7 @@ final class CouponSearchUICommand: SearchUICommand {
     }
 
     func didSelectSearchResult(model: Coupon, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
-        let detailsViewModel = CouponDetailsViewModel(coupon: model, onUpdate: { [weak self] in
+        let detailsViewModel = CouponDetailsViewModel(coupon: model, siteURL: siteURL, onUpdate: { [weak self] in
             try? self?.createResultsController().performFetch()
         }, onDeletion: {
             viewController.navigationController?.popViewController(animated: true)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -109,7 +109,7 @@ struct HubMenu: View {
                            isActive: $showingReviews) {
                 EmptyView()
             }.hidden()
-            NavigationLink(destination: CouponListView(siteID: viewModel.siteID), isActive: $showingCoupons) {
+            NavigationLink(destination: CouponListView(siteID: viewModel.siteID, siteURL: viewModel.storeURL.absoluteString), isActive: $showingCoupons) {
                 EmptyView()
             }.hidden()
             NavigationLink(destination: InAppPurchasesDebugView(), isActive: $showingIAPDebug) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/AddEditCouponViewModelTests.swift
@@ -4,20 +4,21 @@ import Combine
 @testable import WooCommerce
 
 final class AddEditCouponViewModelTests: XCTestCase {
+    private let siteURL = "https://test.com"
 
     func test_titleView_property_return_expected_values_on_creation() {
-        let viewModel1 = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        let viewModel1 = AddEditCouponViewModel(siteID: 123, siteURL: siteURL, discountType: .percent, onSuccess: { _ in })
         XCTAssertEqual(viewModel1.title, NSLocalizedString("Create coupon", comment: ""))
     }
 
     func test_titleView_property_return_expected_values_on_editing() {
-        let viewModel1 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .percent), onSuccess: { _ in })
+        let viewModel1 = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .percent), siteURL: siteURL, onSuccess: { _ in })
         XCTAssertEqual(viewModel1.title, NSLocalizedString("Edit coupon", comment: ""))
     }
 
     func test_generateRandomCouponCode_populate_correctly_the_codeField() {
         // Given
-        let viewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(code: ""), onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(code: ""), siteURL: siteURL, onSuccess: { _ in })
         XCTAssertEqual(viewModel.codeField, "")
 
         // When
@@ -35,6 +36,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let timeZone = TimeZone.current
         let expiryDate = Date().startOfDay(timezone: timeZone)
         let viewModel = AddEditCouponViewModel(existingCoupon: Coupon.sampleCoupon.copy(discountType: .percent, dateExpires: expiryDate),
+                                               siteURL: siteURL,
                                                timezone: timeZone,
                                                onSuccess: { _ in })
         assertEqual(viewModel.populatedCoupon, Coupon.sampleCoupon.copy(discountType: .percent,
@@ -83,7 +85,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_populatedCoupon_return_expected_coupon_during_creation() {
         // Given
-        let viewModel = AddEditCouponViewModel(siteID: 0, discountType: .fixedCart, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(siteID: 0, siteURL: siteURL, discountType: .fixedCart, onSuccess: { _ in })
 
         // When
         let populatedCoupon = viewModel.populatedCoupon
@@ -118,7 +120,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_validateCouponLocally_return_expected_error_if_coupon_code_is_empty() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(code: "")
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
 
         // When
         let result = viewModel.validateCouponLocally(coupon)
@@ -130,7 +132,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_validateCouponLocally_return_nil_if_coupon_code_is_not_empty() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(code: "ABCDEF")
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
 
         // When
         let result = viewModel.validateCouponLocally(coupon)
@@ -142,7 +144,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_hasChangesMade_is_correct_when_updating_discount_type() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(discountType: .percent)
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -155,7 +157,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_hasChangesMade_is_correct_when_updating_coupon_code() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(code: "ABCDEF")
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -168,7 +170,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_hasChangesMade_is_correct_when_updating_amount() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(amount: "11.22")
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -181,7 +183,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_hasChangesMade_is_correct_when_updating_expiry_date() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(dateExpires: Date())
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -194,7 +196,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_hasChangesMade_is_correct_when_updating_nil_expiry_date() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(dateExpires: Date())
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -207,7 +209,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_hasChangesMade_is_correct_when_updating_product_restrictions() {
         // Given
         let coupon = Coupon.sampleCoupon
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -220,7 +222,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_hasChangesMade_is_correct_when_updating_category_restrictions() {
         // Given
         let coupon = Coupon.sampleCoupon
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -233,7 +235,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_hasChangesMade_is_correct_when_updating_description() {
         // Given
         let coupon = Coupon.sampleCoupon
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -246,7 +248,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_hasChangesMade_is_correct_when_updating_free_shipping() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(freeShipping: false)
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -259,7 +261,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_hasChangesMade_is_correct_when_updating_usage_restrictions() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(usageLimit: 100)
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -271,7 +273,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_hasChangesMade_is_false_when_creation_is_initiated() {
         // Given
-        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(siteID: 123, siteURL: siteURL, discountType: .percent, onSuccess: { _ in })
 
         // Then
         XCTAssertFalse(viewModel.hasChangesMade)
@@ -279,7 +281,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_hasChangesMade_is_correct_when_updating_discount_type_from_creation_flow() {
         // Given
-        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(siteID: 123, siteURL: siteURL, discountType: .percent, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -291,7 +293,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_hasChangesMade_is_correct_when_updating_coupon_code_from_creation_flow() {
         // Given
-        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(siteID: 123, siteURL: siteURL, discountType: .percent, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -303,7 +305,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_hasChangesMade_is_correct_when_updating_amount_from_creation_flow() {
         // Given
-        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(siteID: 123, siteURL: siteURL, discountType: .percent, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -315,7 +317,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_hasChangesMade_is_correct_when_updating_expiry_date_from_creation_flow() {
         // Given
-        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(siteID: 123, siteURL: siteURL, discountType: .percent, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -327,7 +329,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_hasChangesMade_is_correct_when_updating_product_restrictions_from_creation_flow() {
         // Given
-        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(siteID: 123, siteURL: siteURL, discountType: .percent, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -339,7 +341,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_hasChangesMade_is_correct_when_updating_category_restrictions_from_creation_flow() {
         // Given
-        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(siteID: 123, siteURL: siteURL, discountType: .percent, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -351,7 +353,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_hasChangesMade_is_correct_when_updating_description_from_creation_flow() {
         // Given
-        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(siteID: 123, siteURL: siteURL, discountType: .percent, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -363,7 +365,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
 
     func test_hasChangesMade_is_correct_when_updating_free_shipping_from_creation_flow() {
         // Given
-        let viewModel = AddEditCouponViewModel(siteID: 123, discountType: .percent, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(siteID: 123, siteURL: siteURL, discountType: .percent, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -376,7 +378,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_hasChangesMade_is_correct_when_updating_usage_restrictions_from_creation_flow() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(usageLimit: 100)
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
         XCTAssertFalse(viewModel.hasChangesMade) // confidence check
 
         // When
@@ -391,6 +393,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "20000", discountType: .percent)
         let viewModel = AddEditCouponViewModel(
                 existingCoupon: coupon,
+                siteURL: siteURL,
                 inputWarningDurationInSeconds: 0.01,
                 onSuccess: { _ in }
         )
@@ -416,6 +419,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "invalid", discountType: .percent)
         let viewModel = AddEditCouponViewModel(
                 existingCoupon: coupon,
+                siteURL: siteURL,
                 inputWarningDurationInSeconds: 0.01,
                 onSuccess: { _ in }
         )
@@ -433,6 +437,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "200", discountType: .percent)
         let viewModel = AddEditCouponViewModel(
                 existingCoupon: coupon,
+                siteURL: siteURL,
                 inputWarningDurationInSeconds: 0.01,
                 onSuccess: { _ in }
         )
@@ -449,6 +454,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "200", discountType: .percent)
         let viewModel = AddEditCouponViewModel(
                 existingCoupon: coupon,
+                siteURL: siteURL,
                 inputWarningDurationInSeconds: 0.01,
                 onSuccess: { _ in }
         )
@@ -466,6 +472,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "invalid", discountType: .percent)
         let viewModel = AddEditCouponViewModel(
                 existingCoupon: coupon,
+                siteURL: siteURL,
                 inputWarningDurationInSeconds: 0.01,
                 onSuccess: { _ in }
         )
@@ -482,6 +489,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "200", discountType: .fixedCart)
         let viewModel = AddEditCouponViewModel(
                 existingCoupon: coupon,
+                siteURL: siteURL,
                 inputWarningDurationInSeconds: 0.01,
                 onSuccess: { _ in }
         )
@@ -499,6 +507,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "100", discountType: .fixedCart)
         let viewModel = AddEditCouponViewModel(
                 existingCoupon: coupon,
+                siteURL: siteURL,
                 inputWarningDurationInSeconds: 0.01,
                 onSuccess: { _ in }
         )
@@ -516,6 +525,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
         let coupon = Coupon.sampleCoupon.copy(amount: "20000")
         let viewModel = AddEditCouponViewModel(
             existingCoupon: coupon,
+            siteURL: siteURL,
             inputWarningDurationInSeconds: 0.01,
             onSuccess: { _ in }
         )
@@ -536,7 +546,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_discount_type_changed_to_percent_doesnt_convert_valid_amount() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(amount: "99.9")
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
 
         // When
         viewModel.discountType = .percent
@@ -548,7 +558,7 @@ final class AddEditCouponViewModelTests: XCTestCase {
     func test_discount_type_changed_to_percent_converts_invalid_amount_to_zero() {
         // Given
         let coupon = Coupon.sampleCoupon.copy(amount: "invalid")
-        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, onSuccess: { _ in })
+        let viewModel = AddEditCouponViewModel(existingCoupon: coupon, siteURL: siteURL, onSuccess: { _ in })
 
         // When
         viewModel.discountType = .percent

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/CouponListViewModelTests.swift
@@ -17,10 +17,12 @@ final class CouponListViewModelTests: XCTestCase {
         mockStorageManager.viewStorage
     }
 
+    private let sampleSiteURL = "https://test.com"
+
     override func setUp() {
         super.setUp()
         createMocks()
-        sut = CouponListViewModel(siteID: 123)
+        sut = CouponListViewModel(siteID: 123, siteURL: sampleSiteURL)
     }
 
     private func createMocks() {
@@ -34,10 +36,12 @@ final class CouponListViewModelTests: XCTestCase {
         mockStorageManager.insertSampleCoupon(readOnlyCoupon: coupon)
         if let stores = injectedStores {
             sut = CouponListViewModel(siteID: 123,
+                                      siteURL: sampleSiteURL,
                                       storesManager: stores,
                                       storageManager: mockStorageManager)
         } else {
             sut = CouponListViewModel(siteID: 123,
+                                      siteURL: sampleSiteURL,
                                       storageManager: mockStorageManager)
         }
         sut.buildCouponViewModels()
@@ -56,6 +60,7 @@ final class CouponListViewModelTests: XCTestCase {
     func test_viewDidLoad_calls_synchronizeFirstPage_on_syncCoordinator() {
         // Given
         sut = CouponListViewModel(siteID: 123,
+                                  siteURL: sampleSiteURL,
                                   syncingCoordinator: mockSyncingCoordinator)
 
         // When
@@ -76,6 +81,7 @@ final class CouponListViewModelTests: XCTestCase {
     func test_sync_sends_correct_synchronize_coupons_action_to_store() throws {
         // Given
         sut = CouponListViewModel(siteID: 123,
+                                  siteURL: sampleSiteURL,
                                   storesManager: mockStoresManager)
         // When
         sut.sync(pageNumber: 4, pageSize: 8, reason: nil, onCompletion: nil)
@@ -83,7 +89,7 @@ final class CouponListViewModelTests: XCTestCase {
         // Then
         let action = try XCTUnwrap(mockStoresManager.receivedActions.last as? CouponAction)
         switch action {
-        case let .synchronizeCoupons(siteID, pageNumber, pageSize, _):
+        case let .synchronizeCoupons(siteID, _, pageNumber, pageSize, _):
             XCTAssertEqual(siteID, 123)
             XCTAssertEqual(pageNumber, 4)
             XCTAssertEqual(pageSize, 8)
@@ -133,7 +139,7 @@ final class CouponListViewModelTests: XCTestCase {
 
     func test_refreshCoupons_calls_resynchronize_on_syncCoordinator() {
         // Given
-        sut = CouponListViewModel(siteID: 123, syncingCoordinator: mockSyncingCoordinator)
+        sut = CouponListViewModel(siteID: 123, siteURL: sampleSiteURL, syncingCoordinator: mockSyncingCoordinator)
 
         // When
         sut.refreshCoupons()
@@ -156,7 +162,7 @@ final class CouponListViewModelTests: XCTestCase {
 
     func test_tableWillDisplayCellAtIndexPath_calls_ensureNextPageIsSynchronized_on_syncCoordinator() {
         // Given
-        sut = CouponListViewModel(siteID: 123, syncingCoordinator: mockSyncingCoordinator)
+        sut = CouponListViewModel(siteID: 123, siteURL: sampleSiteURL, syncingCoordinator: mockSyncingCoordinator)
 
         // When
         sut.tableWillDisplayCell(at: IndexPath(row: 3, section: 0))
@@ -176,7 +182,7 @@ final class CouponListViewModelTests: XCTestCase {
 
     func test_shouldDisplayFeedbackBanner_returns_false_if_state_is_initialized() {
         // Given
-        sut = CouponListViewModel(siteID: 123, syncingCoordinator: mockSyncingCoordinator)
+        sut = CouponListViewModel(siteID: 123, siteURL: sampleSiteURL, syncingCoordinator: mockSyncingCoordinator)
         XCTAssertEqual(sut.state, .empty) // confidence check
 
         // Then
@@ -384,6 +390,7 @@ final class CouponListViewModelTests: XCTestCase {
             }
         }
         sut = CouponListViewModel(siteID: 123,
+                                  siteURL: sampleSiteURL,
                                   storesManager: stores)
 
         // When
@@ -411,13 +418,14 @@ final class CouponListViewModelTests: XCTestCase {
         }
         stores.whenReceivingAction(ofType: CouponAction.self) { action in
             switch action {
-            case let .synchronizeCoupons(_, _, _, onCompletion):
+            case let .synchronizeCoupons(_, _, _, _, onCompletion):
                 onCompletion(.success(true))
             default:
                 break
             }
         }
         sut = CouponListViewModel(siteID: sampleSiteID,
+                                  siteURL: sampleSiteURL,
                                   storesManager: stores,
                                   storageManager: mockStorageManager)
 
@@ -443,6 +451,7 @@ final class CouponListViewModelTests: XCTestCase {
             }
         }
         sut = CouponListViewModel(siteID: sampleSiteID,
+                                  siteURL: sampleSiteURL,
                                   storesManager: stores,
                                   storageManager: mockStorageManager)
 
@@ -456,7 +465,7 @@ final class CouponListViewModelTests: XCTestCase {
     func test_state_is_empty_when_all_coupons_gets_deleted() {
         // Given
         mockStorageManager.insertSampleCoupon(readOnlyCoupon: Coupon.fake().copy(siteID: 123))
-        sut = CouponListViewModel(siteID: 123, storageManager: mockStorageManager)
+        sut = CouponListViewModel(siteID: 123, siteURL: sampleSiteURL, storageManager: mockStorageManager)
         assertEqual(.coupons, sut.state)
 
         // When

--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -7,6 +7,7 @@ public enum CouponAction: Action {
     /// Retrieves and stores Coupons for a site
     ///
     /// - `siteID`: the site for which coupons should be fetched.
+    /// - `siteURL`: Address of the site to fetch coupons for.
     /// - `pageNumber`: page of results based on the `pageSize` provided. 1-indexed.
     /// - `pageSize`: number of results per page.
     /// - `onCompletion`: invoked when the sync operation finishes.
@@ -14,6 +15,7 @@ public enum CouponAction: Action {
     ///     - `result.failure(Error)`: error indicates issues syncing the specified page.
     ///
     case synchronizeCoupons(siteID: Int64,
+                            siteURL: String,
                             pageNumber: Int,
                             pageSize: Int,
                             onCompletion: (Result<Bool, Error>) -> Void)
@@ -21,41 +23,49 @@ public enum CouponAction: Action {
     /// Deletes a coupon for a site given its ID
     ///
     /// - `siteID`: ID of the site that the coupon belongs to.
+    /// - `siteURL`: Address of the site that the coupon belongs to.
     /// - `couponID`: ID of the coupon to be deleted.
     /// - `onCompletion`: invoked when the deletion finishes.
     ///
     case deleteCoupon(siteID: Int64,
+                      siteURL: String,
                       couponID: Int64,
                       onCompletion: (Result<Void, Error>) -> Void)
 
     /// Updates a coupon for a site given its ID and returns the updated coupon if the request succeeds.
     ///
     /// - `coupon`: the coupon to be updated.
+    /// - `siteURL`: Address of the site that the coupon belongs to.
     /// - `siteTimezone`: the timezone configured on the site (also know as local time of the site).
     /// - `onCompletion`: invoked when the update finishes.
     ///
     case updateCoupon(_ coupon: Coupon,
+                      siteURL: String,
                       siteTimezone: TimeZone?,
                       onCompletion: (Result<Coupon, Error>) -> Void)
 
     /// Creates a coupon for a site given its ID and returns the created coupon if the request succeeds.
     ///
     /// - `coupon`: the coupon to be created.
+    /// - `siteURL`: Address of the site to create the coupon for.
     /// - `siteTimezone`: the timezone configured on the site (also know as local time of the site).
     /// - `onCompletion`: invoked when the creation finishes.
     ///
     case createCoupon(_ coupon: Coupon,
+                      siteURL: String,
                       siteTimezone: TimeZone?,
                       onCompletion: (Result<Coupon, Error>) -> Void)
 
     /// Loads analytics report for a coupon with the specified coupon ID and site ID.
     ///
     /// - `siteID`: ID of the site that the coupon belongs to.
+    /// - `siteURL`: Address of the site from which we'll fetch the analytics report.
     /// - `couponID`: ID of the coupon to load analytics report for.
     /// - `startDate`: the start of the date range to fetch report for.
     /// - `onCompletion`: invoked when the creation finishes.
     ///
     case loadCouponReport(siteID: Int64,
+                          siteURL: String,
                           couponID: Int64,
                           startDate: Date,
                           onCompletion: (Result<CouponReport, Error>) -> Void)
@@ -63,12 +73,14 @@ public enum CouponAction: Action {
     /// Search Coupons matching a given keyword for a site
     ///
     /// - `siteID`: the site for which coupons should be fetched.
+    /// - `siteURL`: address of the site to search coupons for.
     /// - `keyword`: the keyword to match the results with.
     /// - `pageNumber`: page of results based on the `pageSize` provided. 1-indexed.
     /// - `pageSize`: number of results per page.
     /// - `onCompletion`: invoked when the search finishes.
     ///
     case searchCoupons(siteID: Int64,
+                       siteURL: String,
                        keyword: String,
                        pageNumber: Int,
                        pageSize: Int,
@@ -77,10 +89,12 @@ public enum CouponAction: Action {
     /// Retrieve a Coupon for a site given the coupon ID
     ///
     /// - `siteID`: the site for which coupons should be fetched.
+    /// - `siteURL`: address of the site that the coupon belongs to.
     /// - `couponID`: ID of the coupon to be retrieved.
     /// - `onCompletion`: invoked upon completion.
     ///
     case retrieveCoupon(siteID: Int64,
+                        siteURL: String,
                         couponID: Int64,
                         onCompletion: (Result<Coupon, Error>) -> Void)
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
@@ -39,6 +39,7 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
 
     // MARK: - CouponsRemoteProtocol conformance
     func loadAllCoupons(for siteID: Int64,
+                        siteURL: String,
                         pageNumber: Int,
                         pageSize: Int,
                         completion: @escaping (Result<[Coupon], Error>) -> ()) {
@@ -51,6 +52,7 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     }
 
     func searchCoupons(for siteID: Int64,
+                       siteURL: String,
                        keyword: String,
                        pageNumber: Int,
                        pageSize: Int,
@@ -63,6 +65,7 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     }
 
     func deleteCoupon(for siteID: Int64,
+                      siteURL: String,
                       couponID: Int64,
                       completion: @escaping (Result<Coupon, Error>) -> Void) {
         didCallDeleteCoupon = true
@@ -71,6 +74,7 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     }
 
     func updateCoupon(_ coupon: Coupon,
+                      siteURL: String,
                       siteTimezone: TimeZone?,
                       completion: @escaping (Result<Coupon, Error>) -> Void) {
         didCallUpdateCoupon = true
@@ -78,20 +82,25 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     }
 
     func createCoupon(_ coupon: Coupon,
+                      siteURL: String,
                       siteTimezone: TimeZone?,
                       completion: @escaping (Result<Coupon, Error>) -> Void) {
         didCallCreateCoupon = true
         spyCreateCoupon = coupon
     }
 
-    func loadCouponReport(for siteID: Int64, couponID: Int64, from startDate: Date, completion: @escaping (Result<CouponReport, Error>) -> Void) {
+    func loadCouponReport(for siteID: Int64,
+                          siteURL: String,
+                          couponID: Int64,
+                          from startDate: Date,
+                          completion: @escaping (Result<CouponReport, Error>) -> Void) {
         didCallLoadCouponReport = true
         spyLoadCouponReportDate = startDate
         spyLoadCouponReportSiteID = siteID
         spyLoadCouponReportCouponID = couponID
     }
 
-    func retrieveCoupon(for siteID: Int64, couponID: Int64, completion: @escaping (Result<Coupon, Error>) -> Void) {
+    func retrieveCoupon(for siteID: Int64, siteURL: String, couponID: Int64, completion: @escaping (Result<Coupon, Error>) -> Void) {
         didCallRetrieveCoupon = true
         spyRetrieveSiteID = siteID
         spyRetrieveCouponID = couponID

--- a/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
@@ -48,6 +48,7 @@ final class CouponStoreTests: XCTestCase {
     /// SiteID
     ///
     private let sampleSiteID: Int64 = 120934
+    private let sampleSiteURL: String = "https://test.com"
 
     /// Default page number
     ///
@@ -84,6 +85,7 @@ final class CouponStoreTests: XCTestCase {
         setUpUsingSpyRemote()
         // Given
         let action = CouponAction.synchronizeCoupons(siteID: 1092,
+                                                     siteURL: sampleSiteURL,
                                                      pageNumber: 12,
                                                      pageSize: 3) { _ in }
 
@@ -106,6 +108,7 @@ final class CouponStoreTests: XCTestCase {
         // When
         let result: Result<Bool, Error> = waitFor { promise in
             let action = CouponAction.synchronizeCoupons(siteID: 1092,
+                                                         siteURL: self.sampleSiteURL,
                                                          pageNumber: 12,
                                                          pageSize: 3) { result in
                 promise(result)
@@ -127,6 +130,7 @@ final class CouponStoreTests: XCTestCase {
         let result: Result<Bool, Error> = waitFor { promise in
             let action: CouponAction
             action = .synchronizeCoupons(siteID: self.sampleSiteID,
+                                         siteURL: self.sampleSiteURL,
                                          pageNumber: self.defaultPageNumber,
                                          pageSize: 2) { result in
                 promise(result)
@@ -149,6 +153,7 @@ final class CouponStoreTests: XCTestCase {
         let result: Result<Bool, Error> = waitFor { promise in
             let action: CouponAction
             action = .synchronizeCoupons(siteID: self.sampleSiteID,
+                                         siteURL: self.sampleSiteURL,
                                          pageNumber: self.defaultPageNumber,
                                          pageSize: 10) { result in
                 promise(result)
@@ -171,6 +176,7 @@ final class CouponStoreTests: XCTestCase {
         let result: Result<Bool, Error> = waitFor { promise in
             let action: CouponAction
             action = .synchronizeCoupons(siteID: self.sampleSiteID,
+                                         siteURL: self.sampleSiteURL,
                                          pageNumber: self.defaultPageNumber,
                                          pageSize: self.defaultPageSize) { result in
                 promise(result)
@@ -194,6 +200,7 @@ final class CouponStoreTests: XCTestCase {
         let result: Result<Bool, Error> = waitFor { promise in
             let action: CouponAction
             action = .synchronizeCoupons(siteID: self.sampleSiteID,
+                                         siteURL: self.sampleSiteURL,
                                          pageNumber: 1,
                                          pageSize: self.defaultPageSize) { result in
                 promise(result)
@@ -217,6 +224,7 @@ final class CouponStoreTests: XCTestCase {
         let result: Result<Bool, Error> = waitFor { promise in
             let action: CouponAction
             action = .synchronizeCoupons(siteID: self.sampleSiteID,
+                                         siteURL: self.sampleSiteURL,
                                          pageNumber: 2,
                                          pageSize: self.defaultPageSize) { result in
                 promise(result)
@@ -232,7 +240,7 @@ final class CouponStoreTests: XCTestCase {
     func test_deleteCoupon_calls_remote_using_correct_request_parameters() {
         setUpUsingSpyRemote()
         // Given
-        let action = CouponAction.deleteCoupon(siteID: sampleSiteID, couponID: 10) { _ in }
+        let action = CouponAction.deleteCoupon(siteID: sampleSiteID, siteURL: sampleSiteURL, couponID: 10) { _ in }
 
         // When
         store.onAction(action)
@@ -255,7 +263,7 @@ final class CouponStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let action = CouponAction.deleteCoupon(siteID: self.sampleSiteID, couponID: sampleCouponID) { result in
+            let action = CouponAction.deleteCoupon(siteID: self.sampleSiteID, siteURL: self.sampleSiteURL, couponID: sampleCouponID) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -278,7 +286,7 @@ final class CouponStoreTests: XCTestCase {
         // When
         let result: Result<Void, Error> = waitFor { promise in
             let action: CouponAction
-            action = .deleteCoupon(siteID: self.sampleSiteID, couponID: sampleCouponID) { result in
+            action = .deleteCoupon(siteID: self.sampleSiteID, siteURL: self.sampleSiteURL, couponID: sampleCouponID) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -294,7 +302,7 @@ final class CouponStoreTests: XCTestCase {
         // Given
         let sampleCouponID: Int64 = 720
         let coupon = Coupon.fake().copy(siteID: sampleSiteID, couponID: sampleCouponID, amount: "10", discountType: .percent)
-        let action = CouponAction.updateCoupon(coupon, siteTimezone: nil) { _ in }
+        let action = CouponAction.updateCoupon(coupon, siteURL: self.sampleSiteURL, siteTimezone: nil) { _ in }
 
         // When
         store.onAction(action)
@@ -317,7 +325,7 @@ final class CouponStoreTests: XCTestCase {
         // When
         let updatedCoupon = sampleCoupon.copy(amount: "9")
         let result: Result<Networking.Coupon, Error> = waitFor { promise in
-            let action = CouponAction.updateCoupon(updatedCoupon, siteTimezone: nil) { result in
+            let action = CouponAction.updateCoupon(updatedCoupon, siteURL: self.sampleSiteURL, siteTimezone: nil) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -343,7 +351,7 @@ final class CouponStoreTests: XCTestCase {
         let updatedCoupon = sampleCoupon.copy(amount: "10.00", discountType: .fixedCart)
         let result: Result<Networking.Coupon, Error> = waitFor { promise in
             let action: CouponAction
-            action = .updateCoupon(updatedCoupon, siteTimezone: nil) { result in
+            action = .updateCoupon(updatedCoupon, siteURL: self.sampleSiteURL, siteTimezone: nil) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -362,7 +370,7 @@ final class CouponStoreTests: XCTestCase {
         // Given
         let sampleCouponID: Int64 = 720
         let coupon = Coupon.fake().copy(siteID: sampleSiteID, couponID: sampleCouponID, amount: "10", discountType: .percent)
-        let action = CouponAction.createCoupon(coupon, siteTimezone: nil) { _ in }
+        let action = CouponAction.createCoupon(coupon, siteURL: self.sampleSiteURL, siteTimezone: nil) { _ in }
 
         // When
         store.onAction(action)
@@ -382,7 +390,7 @@ final class CouponStoreTests: XCTestCase {
 
         // When
         let result: Result<Networking.Coupon, Error> = waitFor { promise in
-            let action = CouponAction.createCoupon(sampleCoupon, siteTimezone: nil) { result in
+            let action = CouponAction.createCoupon(sampleCoupon, siteURL: self.sampleSiteURL, siteTimezone: nil) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -404,7 +412,7 @@ final class CouponStoreTests: XCTestCase {
         // When
         let result: Result<Networking.Coupon, Error> = waitFor { promise in
             let action: CouponAction
-            action = .createCoupon(sampleCoupon, siteTimezone: nil) { result in
+            action = .createCoupon(sampleCoupon, siteURL: self.sampleSiteURL, siteTimezone: nil) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -423,7 +431,7 @@ final class CouponStoreTests: XCTestCase {
         // Given
         let sampleCouponID: Int64 = 571
         let sampleDate = Date(timeIntervalSince1970: 1)
-        let action = CouponAction.loadCouponReport(siteID: sampleSiteID, couponID: sampleCouponID, startDate: sampleDate) { _ in }
+        let action = CouponAction.loadCouponReport(siteID: sampleSiteID, siteURL: sampleSiteURL, couponID: sampleCouponID, startDate: sampleDate) { _ in }
 
         // When
         store.onAction(action)
@@ -444,7 +452,7 @@ final class CouponStoreTests: XCTestCase {
 
         // When
         let result: Result<Networking.CouponReport, Error> = waitFor { promise in
-            let action = CouponAction.loadCouponReport(siteID: self.sampleSiteID, couponID: sampleCouponID, startDate: sampleDate) { result in
+            let action = CouponAction.loadCouponReport(siteID: self.sampleSiteID, siteURL: self.sampleSiteURL, couponID: sampleCouponID, startDate: sampleDate) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -463,7 +471,7 @@ final class CouponStoreTests: XCTestCase {
 
         // When
         let result: Result<Networking.CouponReport, Error> = waitFor { promise in
-            let action = CouponAction.loadCouponReport(siteID: self.sampleSiteID, couponID: sampleCouponID, startDate: sampleDate) { result in
+            let action = CouponAction.loadCouponReport(siteID: self.sampleSiteID, siteURL: self.sampleSiteURL, couponID: sampleCouponID, startDate: sampleDate) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -481,6 +489,7 @@ final class CouponStoreTests: XCTestCase {
         let expectedPageNumber = 1
         let expectedPageSize = 20
         let action = CouponAction.searchCoupons(siteID: sampleSiteID,
+                                                siteURL: sampleSiteURL,
                                                 keyword: expectedKeyword,
                                                 pageNumber: expectedPageNumber,
                                                 pageSize: expectedPageSize) { _ in }
@@ -503,7 +512,7 @@ final class CouponStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let action = CouponAction.searchCoupons(siteID: self.sampleSiteID, keyword: "test keyword", pageNumber: 1, pageSize: 20) { result in
+            let action = CouponAction.searchCoupons(siteID: self.sampleSiteID, siteURL: self.sampleSiteURL, keyword: "test keyword", pageNumber: 1, pageSize: 20) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -522,7 +531,7 @@ final class CouponStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let action = CouponAction.searchCoupons(siteID: self.sampleSiteID, keyword: "test keyword", pageNumber: 1, pageSize: 20) { result in
+            let action = CouponAction.searchCoupons(siteID: self.sampleSiteID, siteURL: self.sampleSiteURL, keyword: "test keyword", pageNumber: 1, pageSize: 20) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -541,7 +550,7 @@ final class CouponStoreTests: XCTestCase {
         setUpUsingSpyRemote()
         // Given
         let sampleCouponID: Int64 = 134
-        let action = CouponAction.retrieveCoupon(siteID: sampleSiteID, couponID: sampleCouponID) { _ in }
+        let action = CouponAction.retrieveCoupon(siteID: sampleSiteID, siteURL: sampleSiteURL, couponID: sampleCouponID) { _ in }
 
         // When
         store.onAction(action)
@@ -560,7 +569,7 @@ final class CouponStoreTests: XCTestCase {
 
         // When
         let result: Result<Networking.Coupon, Error> = waitFor { promise in
-            let action = CouponAction.retrieveCoupon(siteID: self.sampleSiteID, couponID: sampleCouponID) { result in
+            let action = CouponAction.retrieveCoupon(siteID: self.sampleSiteID, siteURL: self.sampleSiteURL, couponID: sampleCouponID) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -579,7 +588,7 @@ final class CouponStoreTests: XCTestCase {
 
         // When
         let result: Result<Networking.Coupon, Error> = waitFor { promise in
-            let action = CouponAction.retrieveCoupon(siteID: self.sampleSiteID, couponID: sampleCouponID) { result in
+            let action = CouponAction.retrieveCoupon(siteID: self.sampleSiteID, siteURL: self.sampleSiteURL, couponID: sampleCouponID) { result in
                 promise(result)
             }
             self.store.onAction(action)

--- a/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
@@ -452,7 +452,10 @@ final class CouponStoreTests: XCTestCase {
 
         // When
         let result: Result<Networking.CouponReport, Error> = waitFor { promise in
-            let action = CouponAction.loadCouponReport(siteID: self.sampleSiteID, siteURL: self.sampleSiteURL, couponID: sampleCouponID, startDate: sampleDate) { result in
+            let action = CouponAction.loadCouponReport(siteID: self.sampleSiteID,
+                                                       siteURL: self.sampleSiteURL,
+                                                       couponID: sampleCouponID,
+                                                       startDate: sampleDate) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -471,7 +474,10 @@ final class CouponStoreTests: XCTestCase {
 
         // When
         let result: Result<Networking.CouponReport, Error> = waitFor { promise in
-            let action = CouponAction.loadCouponReport(siteID: self.sampleSiteID, siteURL: self.sampleSiteURL, couponID: sampleCouponID, startDate: sampleDate) { result in
+            let action = CouponAction.loadCouponReport(siteID: self.sampleSiteID,
+                                                       siteURL: self.sampleSiteURL,
+                                                       couponID: sampleCouponID,
+                                                       startDate: sampleDate) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -512,7 +518,10 @@ final class CouponStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let action = CouponAction.searchCoupons(siteID: self.sampleSiteID, siteURL: self.sampleSiteURL, keyword: "test keyword", pageNumber: 1, pageSize: 20) { result in
+            let action = CouponAction.searchCoupons(siteID: self.sampleSiteID,
+                                                    siteURL: self.sampleSiteURL,
+                                                    keyword: "test keyword",
+                                                    pageNumber: 1, pageSize: 20) { result in
                 promise(result)
             }
             self.store.onAction(action)
@@ -531,7 +540,11 @@ final class CouponStoreTests: XCTestCase {
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
-            let action = CouponAction.searchCoupons(siteID: self.sampleSiteID, siteURL: self.sampleSiteURL, keyword: "test keyword", pageNumber: 1, pageSize: 20) { result in
+            let action = CouponAction.searchCoupons(siteID: self.sampleSiteID,
+                                                    siteURL: self.sampleSiteURL,
+                                                    keyword: "test keyword",
+                                                    pageNumber: 1,
+                                                    pageSize: 20) { result in
                 promise(result)
             }
             self.store.onAction(action)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #8390 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR added changes to coupon endpoints to call REST requests with Jetpack requests as fallback. Changes include:
- Updated the `RESTRequest` with an initializer that accepts a site URL and a Jetpack request.
- Updated `CouponsRemote`, `CouponAction`, and `CouponStore` to accept site URL as input.
- Updated the UI layer following changes in the Yosemite layer.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Navigate to Menu > Coupons. If the option is unavailable, navigate to Settings > Experimental Features > Enable coupon management.
- Notice that the coupon list is loaded properly.
- Try searching, creating, editing, deleting coupons. Everything should work as before. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
