### PR TITLE
[Analytics Hub] Hide Sessions card conditionally

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -113,7 +113,7 @@ struct AnalyticsHubView: View {
 
                     Divider()
                 }
-                .renderedIf(ServiceLocator.featureFlagService.isFeatureFlagEnabled(.analyticsHub))
+                .renderedIf(ServiceLocator.featureFlagService.isFeatureFlagEnabled(.analyticsHub) && viewModel.showSessionsCard)
 
                 Spacer()
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -53,6 +53,17 @@ final class AnalyticsHubViewModel: ObservableObject {
     ///
     @Published var sessionsCard = AnalyticsHubViewModel.sessionsCard(currentPeriodStats: nil, siteStats: nil)
 
+    /// Sessions Card display state
+    ///
+    var showSessionsCard: Bool {
+        switch timeRangeSelectionType {
+        case .custom:
+            return false
+        default:
+            return true
+        }
+    }
+
     /// Time Range Selection Type
     ///
     @Published var timeRangeSelectionType: AnalyticsHubTimeRangeSelection.SelectionType

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -118,4 +118,22 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertEqual(loadingItemsSoldCard?.isRedacted, true)
         XCTAssertEqual(loadingSessionsCard?.isRedacted, true)
     }
+
+    func test_session_card_is_hidden_for_custom_range() async {
+        // Given
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, stores: stores)
+        XCTAssertTrue(vm.showSessionsCard)
+
+        // When
+        vm.timeRangeSelectionType = .custom(start: Date(), end: Date())
+
+        // Then
+        XCTAssertFalse(vm.showSessionsCard)
+
+        // When
+        vm.timeRangeSelectionType = .lastMonth
+
+        // Then
+        XCTAssertTrue(vm.showSessionsCard)
+    }
 }


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8367

## Description

This PR adds a logic to hide the "Sessions" card for "custom" time range.

## Testing

1. Build and run the app in debug/alpha mode.
2. On the dashboard view tap the "See more" button.
3. Scroll to the "Sessions" card in bottom of a list, verify it's displayed.
4. On top of the list tap range selector and pick "Custom" with any start-end dates.
5. Scroll to the bottom of a list, verify the "Sessions" card is hidden.
6. Pick any non-custom range, verify "Sessions" card is displayed again.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
