### PR TITLE
[My Store] Sync summary stats in dashboard

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -88,6 +88,26 @@ final class DashboardViewModel {
         stores.dispatch(action)
     }
 
+    /// Syncs summary stats for dashboard UI.
+    func syncSiteSummaryStats(for siteID: Int64,
+                              timeRange: StatsTimeRangeV4,
+                              latestDateToInclude: Date,
+                              onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
+        let action = StatsActionV4.retrieveSiteSummaryStats(siteID: siteID,
+                                                            period: timeRange.summaryStatsGranularity,
+                                                            quantity: 1,
+                                                            latestDateToInclude: latestDateToInclude,
+                                                            saveInStorage: true) { result in
+            if case let .failure(error) = result {
+                DDLogError("⛔️ Error synchronizing summary stats: \(error)")
+            }
+
+            let voidResult = result.map { _ in () } // Caller expects no entity in the result.
+            onCompletion?(voidResult)
+        }
+        stores.dispatch(action)
+    }
+
     /// Syncs top performers data for dashboard UI.
     func syncTopEarnersStats(for siteID: Int64,
                              siteTimezone: TimeZone,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -289,6 +289,21 @@ private extension StoreStatsAndTopPerformersViewController {
 
             group.enter()
             periodGroup.enter()
+            periodStoreStatsGroup.enter()
+            self.dashboardViewModel.syncSiteSummaryStats(for: siteID,
+                                                         timeRange: vc.timeRange,
+                                                         latestDateToInclude: latestDateToInclude) { result in
+                if case let .failure(error) = result {
+                    DDLogError("⛔️ Error synchronizing summary stats: \(error)")
+                    periodSyncError = error
+                }
+                group.leave()
+                periodGroup.leave()
+                periodStoreStatsGroup.leave()
+            }
+
+            group.enter()
+            periodGroup.enter()
             self.dashboardViewModel.syncTopEarnersStats(for: siteID,
                                                         siteTimezone: timezoneForSync,
                                                         timeRange: vc.timeRange,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -48,12 +48,17 @@ final class DashboardViewModelTests: XCTestCase {
     func test_statsVersion_remains_v4_when_non_store_stats_sync_returns_noRestRoute_error() {
         // Given
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
-            if case let .retrieveStats(_, _, _, _, _, _, completion) = action {
+            switch action {
+            case let .retrieveStats(_, _, _, _, _, _, completion):
                 completion(.failure(DotcomError.empty))
-            } else if case let .retrieveSiteVisitStats(_, _, _, _, completion) = action {
+            case let .retrieveSiteVisitStats(_, _, _, _, completion):
                 completion(.failure(DotcomError.noRestRoute))
-            } else if case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, completion) = action {
+            case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, completion):
                 completion(.failure(DotcomError.noRestRoute))
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, completion):
+                completion(.failure(DotcomError.noRestRoute))
+            default:
+                XCTFail("Received unsupported action: \(action)")
             }
         }
         let viewModel = DashboardViewModel(stores: stores)
@@ -63,6 +68,7 @@ final class DashboardViewModelTests: XCTestCase {
         viewModel.syncStats(for: sampleSiteID, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init(), forceRefresh: false)
         viewModel.syncSiteVisitStats(for: sampleSiteID, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init())
         viewModel.syncTopEarnersStats(for: sampleSiteID, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init(), forceRefresh: false)
+        viewModel.syncSiteSummaryStats(for: sampleSiteID, timeRange: .thisMonth, latestDateToInclude: .init())
 
         // Then
         XCTAssertEqual(viewModel.statsVersion, .v4)

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -51,6 +51,20 @@ extension StatsTimeRangeV4 {
         }
     }
 
+    /// Represents the period unit of the summary stats given a time range.
+    public var summaryStatsGranularity: StatGranularity {
+        switch self {
+        case .today:
+            return .day
+        case .thisWeek:
+            return .week
+        case .thisMonth:
+            return .month
+        case .thisYear:
+            return .year
+        }
+    }
+
     /// Represents the period unit of the leaderboards v4 API  given a time range.
     public var leaderboardsGranularity: StatsGranularityV4 {
         switch self {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8173
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR syncs site summary stats (`SiteSummaryStats`) when the My Store Dashboard loads, and when a new stats period is selected in the Dashboard.

Why we need this:

- Right now, we're computing a site's total visitor count by adding together the visitor count for each of the intervals within a given period (from `SiteVisitStats` data).
- What we should do in the dashboard — and we're doing already in Analytics Hub — is get the total visitor count for the entire period (from `SiteSummaryStats` data).

Once the summary data is synced, we can fetch it from storage to display it in the Dashboard. This change will be made in an upcoming PR.

Note: We aren't removing the request to sync site visit stats (`SiteVisitStats`) because we still want this data for specific intervals. That way, you can see the visitor stats for a specific interval when you select that interval in the stats chart.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

One way to test this is to  use a proxy service like Charles Proxy:

1. Build and run the app.
2. When the My Store dashboard loads, confirm there is a request to `https://public-api.wordpress.com/rest/v1.1/sites/{SITE}/stats/summary/`.
3. Select a different period (Today, This Week, This Month, This Year). Confirm a new request is made to the same endpoint, with a `period` parameter for the selected period. (The request also includes a `date` parameter for the last date in the selected period.)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
