### PR TITLE
[Universal Links] Link does not open the order if the link store is already selected in the app

### DIFF
--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -337,7 +337,7 @@ extension MainTabBarController {
             }
             let siteID = Int64(note.meta.identifier(forKey: .site) ?? Int.min)
 
-            switchToStore(with: siteID, onCompletion: { _ in
+            showStore(with: siteID, onCompletion: { _ in
                 presentNotificationDetails(for: note)
             })
         }
@@ -367,8 +367,16 @@ extension MainTabBarController {
                                                                               "already_read": note.read ])
     }
 
-    private static func switchToStore(with siteID: Int64, onCompletion: @escaping (Bool) -> Void) {
-        SwitchStoreUseCase(stores: ServiceLocator.stores).switchToStoreIfSiteIsStored(with: siteID) { siteChanged in
+    private static func showStore(with siteID: Int64, onCompletion: @escaping (Bool) -> Void) {
+        let stores = ServiceLocator.stores
+
+        // Already showing that store, do nothing
+        guard siteID != stores.sessionManager.defaultStoreID else {
+            onCompletion(true)
+            return
+        }
+
+        SwitchStoreUseCase(stores: stores).switchToStoreIfSiteIsStored(with: siteID) { siteChanged in
             guard siteChanged else {
                 return onCompletion(false)
             }
@@ -393,9 +401,9 @@ extension MainTabBarController {
     }
 
     static func navigateToOrderDetails(with orderID: Int64, siteID: Int64) {
-        switchToStore(with: siteID, onCompletion: { siteChanged in
+        showStore(with: siteID, onCompletion: { storeIsShown in
             switchToOrdersTab {
-                guard siteChanged else {
+                guard storeIsShown else {
                     return
                 }
                 // We give some time to the orders tab transition to finish, otherwise it might prevent the second navigation from happening

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -403,6 +403,7 @@ extension MainTabBarController {
     static func navigateToOrderDetails(with orderID: Int64, siteID: Int64) {
         showStore(with: siteID, onCompletion: { storeIsShown in
             switchToOrdersTab {
+                // It failed to show the order's store. We navigate to the orders tab and stop, as we cannot show the order details screen
                 guard storeIsShown else {
                     return
                 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8423 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When opening an order universal link from a store that is already chosen and visible in the app, it navigates to the orders tab but doesn't open the order details. When it has to switch sites, i.e the link is pointing to an order of a user's site that is not selected in the app, it works correctly.
The reason behind this is that we were returning `false` on the `switchToStore` completion callback because it actually didn't switch sites, as the site was already there. Once we got that, we took it as if the app failed to switch to the order's site in `navigateToOrderDetails`, thus not showing the order's details.
To fix it, I rename the `switchToStore` function in `MainTabBarController` to `showStore`, to make it more meaningful -we want to show the site, we don't care if we had to switch sites or it was present already- and return true if the the site was already shown. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Create a link with the format https://www.woocommerce.com/mobile/orders/details?blog_id=blog_id&order_id=order_id where `blog_id` = your site id that is selected in the app and `order_id` = an order of that site. Add that link to your email or notes app as shown in the video.
2. Tap on that link
Result: The app is opened and navigates to the Orders tab but the order details screen is not shown
Expected Result: It should show the Order Details


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### Buggy behavior

https://user-images.githubusercontent.com/1864060/207926913-fddca3d3-0bd4-4eec-8d43-ded25683d25d.MP4

### Fixed behavior

https://user-images.githubusercontent.com/1864060/207927243-bc580237-5856-4f77-813d-99a004748095.MP4

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
