### PR TITLE
[My Store] Use stored site summary stats for visitors and conversion rate

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 11.7
 -----
 - [**] Analytics Hub: Now you can select custom date ranges. [https://github.com/woocommerce/woocommerce-ios/pull/8414]
+- [*] My Store: We fixed an issue with Visitors and Conversion stats where sometimes visitors could be counted more than once in the selected period. [https://github.com/woocommerce/woocommerce-ios/pull/8427]
 
 
 11.6

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -100,7 +100,7 @@ struct StatsDataTextFormatter {
 
     // MARK: Views and Visitors Stats
 
-    /// Creates the text to display for the visitor count.
+    /// Creates the text to display for the visitor count based on SiteVisitStats data and a given interval.
     ///
     static func createVisitorCountText(siteStats: SiteVisitStats?, selectedIntervalIndex: Int?) -> String {
         if let visitorCount = visitorCount(at: selectedIntervalIndex, siteStats: siteStats) {
@@ -110,12 +110,14 @@ struct StatsDataTextFormatter {
         }
     }
 
-    /// Creates the text to display for the visitor count delta.
+    /// Creates the text to display for the visitor count based on SiteSummaryStats data.
     ///
-    static func createVisitorCountDelta(from previousPeriod: SiteVisitStats?, to currentPeriod: SiteVisitStats?) -> DeltaPercentage {
-        let previousCount = visitorCount(at: nil, siteStats: previousPeriod)
-        let currentCount = visitorCount(at: nil, siteStats: currentPeriod)
-        return createDeltaPercentage(from: previousCount, to: currentCount)
+    static func createVisitorCountText(siteStats: SiteSummaryStats?) -> String {
+        guard let visitorCount = siteStats?.visitors else {
+            return Constants.placeholderText
+        }
+
+        return Double(visitorCount).humanReadableString()
     }
 
     /// Creates the text to display for the views count.
@@ -130,7 +132,7 @@ struct StatsDataTextFormatter {
 
     // MARK: Conversion Stats
 
-    /// Creates the text to display for the conversion rate.
+    /// Creates the text to display for the conversion rate based on SiteVisitStats data and a given interval.
     ///
     static func createConversionRateText(orderStats: OrderStatsV4?, siteStats: SiteVisitStats?, selectedIntervalIndex: Int?) -> String {
         guard let visitors = visitorCount(at: selectedIntervalIndex, siteStats: siteStats),
@@ -218,7 +220,7 @@ private extension StatsDataTextFormatter {
         return numberFormatter
     }()
 
-    /// Retrieves the visitor count for the provided order stats and, optionally, a specific interval.
+    /// Retrieves the visitor count for the provided site stats and a specific interval.
     ///
     static func visitorCount(at selectedIndex: Int?, siteStats: SiteVisitStats?) -> Double? {
         let siteStatsItems = siteStats?.items?.sorted(by: { (lhs, rhs) -> Bool in
@@ -226,8 +228,6 @@ private extension StatsDataTextFormatter {
         }) ?? []
         if let selectedIndex, selectedIndex < siteStatsItems.count {
             return Double(siteStatsItems[selectedIndex].visitors)
-        } else if let siteStats {
-            return Double(siteStats.totalVisitors)
         } else {
             return nil
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -102,7 +102,7 @@ struct StatsDataTextFormatter {
 
     /// Creates the text to display for the visitor count based on SiteVisitStats data and a given interval.
     ///
-    static func createVisitorCountText(siteStats: SiteVisitStats?, selectedIntervalIndex: Int?) -> String {
+    static func createVisitorCountText(siteStats: SiteVisitStats?, selectedIntervalIndex: Int) -> String {
         if let visitorCount = visitorCount(at: selectedIntervalIndex, siteStats: siteStats) {
             return Double(visitorCount).humanReadableString()
         } else {
@@ -134,7 +134,7 @@ struct StatsDataTextFormatter {
 
     /// Creates the text to display for the conversion rate based on SiteVisitStats data and a given interval.
     ///
-    static func createConversionRateText(orderStats: OrderStatsV4?, siteStats: SiteVisitStats?, selectedIntervalIndex: Int?) -> String {
+    static func createConversionRateText(orderStats: OrderStatsV4?, siteStats: SiteVisitStats?, selectedIntervalIndex: Int) -> String {
         guard let visitors = visitorCount(at: selectedIntervalIndex, siteStats: siteStats),
               let orders = orderCount(at: selectedIntervalIndex, orderStats: orderStats) else {
             return Constants.placeholderText
@@ -222,11 +222,11 @@ private extension StatsDataTextFormatter {
 
     /// Retrieves the visitor count for the provided site stats and a specific interval.
     ///
-    static func visitorCount(at selectedIndex: Int?, siteStats: SiteVisitStats?) -> Double? {
+    static func visitorCount(at selectedIndex: Int, siteStats: SiteVisitStats?) -> Double? {
         let siteStatsItems = siteStats?.items?.sorted(by: { (lhs, rhs) -> Bool in
             return lhs.period < rhs.period
         }) ?? []
-        if let selectedIndex, selectedIndex < siteStatsItems.count {
+        if selectedIndex < siteStatsItems.count {
             return Double(siteStatsItems[selectedIndex].visitors)
         } else {
             return nil

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -78,7 +78,10 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
     // MARK: Child View Controllers
 
     private lazy var storeStatsPeriodViewController: StoreStatsV4PeriodViewController = {
-        StoreStatsV4PeriodViewController(siteID: siteID, timeRange: timeRange, usageTracksEventEmitter: usageTracksEventEmitter)
+        StoreStatsV4PeriodViewController(siteID: siteID,
+                                         timeRange: timeRange,
+                                         currentDate: currentDate,
+                                         usageTracksEventEmitter: usageTracksEventEmitter)
     }()
 
     private lazy var inAppFeedbackCardViewController = InAppFeedbackCardViewController()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
@@ -41,20 +41,31 @@ final class StoreStatsPeriodViewModel {
 
     /// Emits visitor stats text values based on site visit stats and selected time interval.
     private(set) lazy var visitorStatsText: AnyPublisher<String, Never> =
-    Publishers.CombineLatest($siteStats.eraseToAnyPublisher(), $selectedIntervalIndex.eraseToAnyPublisher())
-        .compactMap { siteStats, selectedIntervalIndex in
-            StatsDataTextFormatter.createVisitorCountText(siteStats: siteStats, selectedIntervalIndex: selectedIntervalIndex)
+    Publishers.CombineLatest3($siteStats.eraseToAnyPublisher(), $selectedIntervalIndex.eraseToAnyPublisher(), $summaryStats.eraseToAnyPublisher())
+        .compactMap { siteStats, selectedIntervalIndex, summaryStats in
+            if let selectedIntervalIndex {
+                return StatsDataTextFormatter.createVisitorCountText(siteStats: siteStats, selectedIntervalIndex: selectedIntervalIndex)
+            } else {
+                return StatsDataTextFormatter.createVisitorCountText(siteStats: summaryStats)
+            }
         }
         .removeDuplicates()
         .eraseToAnyPublisher()
 
     /// Emits conversion stats text values based on order stats, site visit stats, and selected time interval.
     private(set) lazy var conversionStatsText: AnyPublisher<String, Never> =
-    Publishers.CombineLatest3($orderStatsData.eraseToAnyPublisher(), $siteStats.eraseToAnyPublisher(), $selectedIntervalIndex.eraseToAnyPublisher())
-        .compactMap { orderStatsData, siteStats, selectedIntervalIndex in
-            StatsDataTextFormatter.createConversionRateText(orderStats: orderStatsData.stats,
-                                                            siteStats: siteStats,
-                                                            selectedIntervalIndex: selectedIntervalIndex)
+    Publishers.CombineLatest4($orderStatsData.eraseToAnyPublisher(),
+                              $siteStats.eraseToAnyPublisher(),
+                              $selectedIntervalIndex.eraseToAnyPublisher(),
+                              $summaryStats.eraseToAnyPublisher())
+        .compactMap { orderStatsData, siteStats, selectedIntervalIndex, summaryStats in
+            if let selectedIntervalIndex {
+                return StatsDataTextFormatter.createConversionRateText(orderStats: orderStatsData.stats,
+                                                                       siteStats: siteStats,
+                                                                       selectedIntervalIndex: selectedIntervalIndex)
+            } else {
+                return StatsDataTextFormatter.createConversionRateText(orderStats: orderStatsData.stats, siteStats: summaryStats)
+            }
         }
         .removeDuplicates()
         .eraseToAnyPublisher()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -128,6 +128,7 @@ final class StoreStatsV4PeriodViewController: UIViewController {
     ///
     init(siteID: Int64,
          timeRange: StatsTimeRangeV4,
+         currentDate: Date,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter) {
@@ -136,6 +137,7 @@ final class StoreStatsV4PeriodViewController: UIViewController {
         self.viewModel = StoreStatsPeriodViewModel(siteID: siteID,
                                                    timeRange: timeRange,
                                                    siteTimezone: siteTimezone,
+                                                   currentDate: currentDate,
                                                    currencyFormatter: currencyFormatter,
                                                    currencySettings: currencySettings)
         self.usageTracksEventEmitter = usageTracksEventEmitter

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
@@ -292,21 +292,18 @@ final class StatsDataTextFormatterTests: XCTestCase {
 
     // MARK: Views and Visitors Stats
 
-    // This test reflects the current method for computing total visitor count.
-    // It needs to be updated once this issue is fixed: https://github.com/woocommerce/woocommerce-ios/issues/8173
-    func test_createVisitorCountText_returns_expected_visitor_stats() {
+    func test_createVisitorCountText_for_SiteSummaryStats_returns_expected_visitor_stats() {
         // Given
-        let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(items: [.fake().copy(period: "1", visitors: 17),
-                                                                         .fake().copy(period: "0", visitors: 5)])
+        let siteSummaryStats = Yosemite.SiteSummaryStats.fake().copy(visitors: 20)
 
         // When
-        let visitorCount = StatsDataTextFormatter.createVisitorCountText(siteStats: siteVisitStats, selectedIntervalIndex: nil)
+        let visitorCount = StatsDataTextFormatter.createVisitorCountText(siteStats: siteSummaryStats)
 
         // Then
-        XCTAssertEqual(visitorCount, "22")
+        XCTAssertEqual(visitorCount, "20")
     }
 
-    func test_createVisitorCountText_returns_expected_text_for_selected_interval() {
+    func test_createVisitorCountText_for_SiteVisitStats_returns_expected_text_for_selected_interval() {
         // Given
         let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(items: [.fake().copy(period: "1", visitors: 17),
                                                                          .fake().copy(period: "0", visitors: 5)])
@@ -318,19 +315,6 @@ final class StatsDataTextFormatterTests: XCTestCase {
 
         // Then
         XCTAssertEqual(visitorCount, "17")
-    }
-
-    func test_createVisitorCountDelta_returns_expected_delta() {
-        // Given
-        let previousSiteStats = SiteVisitStats.fake().copy(items: [.fake().copy(period: "0", visitors: 10)])
-        let currentSiteStats = SiteVisitStats.fake().copy(items: [.fake().copy(period: "0", visitors: 15)])
-
-        // When
-        let visitorCountDelta = StatsDataTextFormatter.createVisitorCountDelta(from: previousSiteStats, to: currentSiteStats)
-
-        // Then
-        XCTAssertEqual(visitorCountDelta.string, "+50%")
-        XCTAssertEqual(visitorCountDelta.direction, .positive)
     }
 
     func test_createViewsCountText_returns_expected_views_stats() {
@@ -352,7 +336,7 @@ final class StatsDataTextFormatterTests: XCTestCase {
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3))
 
         // When
-        let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteVisitStats, selectedIntervalIndex: nil)
+        let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteVisitStats, selectedIntervalIndex: 0)
 
         // Then
         XCTAssertEqual(conversionRate, "0%")
@@ -364,7 +348,7 @@ final class StatsDataTextFormatterTests: XCTestCase {
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3557))
 
         // When
-        let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteVisitStats, selectedIntervalIndex: nil)
+        let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteVisitStats, selectedIntervalIndex: 0)
 
         // Then
         XCTAssertEqual(conversionRate, "35.6%") // order count: 3557, visitor count: 10000 => 0.3557 (35.57%)
@@ -376,23 +360,10 @@ final class StatsDataTextFormatterTests: XCTestCase {
         let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 3))
 
         // When
-        let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteVisitStats, selectedIntervalIndex: nil)
-
-        // Then
-        XCTAssertEqual(conversionRate, "30%") // order count: 3, visitor count: 10 => 0.3 (30%)
-    }
-
-    func test_createConversionRateText_for_SiteVisitStats_returns_expected_text_for_selected_interval() {
-        // Given
-        let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(items: [.fake().copy(visitors: 10)])
-        let orderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 2),
-                                                  intervals: [.fake().copy(subtotals: .fake().copy(totalOrders: 1))])
-
-        // When
         let conversionRate = StatsDataTextFormatter.createConversionRateText(orderStats: orderStats, siteStats: siteVisitStats, selectedIntervalIndex: 0)
 
         // Then
-        XCTAssertEqual(conversionRate, "10%")
+        XCTAssertEqual(conversionRate, "30%") // order count: 3, visitor count: 10 => 0.3 (30%)
     }
 
     func test_createConversionRateText_for_SiteSummaryStats_returns_placeholder_when_visitor_count_is_zero() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -153,23 +153,20 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         observeStatsEmittedValues(viewModel: viewModel)
 
         // When
-        let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(siteID: siteID, items: [
-            .fake().copy(visitors: 17),
-            .fake().copy(visitors: 15)
-        ])
+        let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(siteID: siteID, items: [.fake().copy(visitors: 15)])
         insertSiteVisitStats(siteVisitStats, timeRange: timeRange)
 
         XCTAssertEqual(conversionStatsTextValues, ["-"])
 
         let orderStats = OrderStatsV4(siteID: siteID,
                                       granularity: timeRange.intervalGranularity,
-                                      totals: .fake().copy(totalOrders: 3, grossRevenue: 62.7),
-                                      intervals: [.fake()])
+                                      totals: .fake(),
+                                      intervals: [ .fake().copy(subtotals: .fake().copy(totalOrders: 3, grossRevenue: 62.7)) ])
         insertOrderStats(orderStats, timeRange: timeRange)
 
         XCTAssertEqual(conversionStatsTextValues, ["-"])
 
-        viewModel.selectedIntervalIndex = 1
+        viewModel.selectedIntervalIndex = 0
 
         // Then
         XCTAssertEqual(conversionStatsTextValues, ["-", "20%"]) // order count: 3, visitor count: 15 => 0.2 (20%)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -10,6 +10,7 @@ import WooFoundation
 final class StoreStatsPeriodViewModelTests: XCTestCase {
     private let siteID: Int64 = 300
     private let defaultSiteTimezone = TimeZone(identifier: "GMT") ?? .current
+    private let defaultDate = Date(timeIntervalSince1970: 1671123600) // Dec 15, 2022, 5:00:00 PM GMT
     private var storageManager: StorageManagerType!
     private var storage: StorageType {
         storageManager.viewStorage
@@ -66,7 +67,32 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         XCTAssertEqual(conversionStatsTextValues, ["-"])
     }
 
-    func test_visitorStatsText_is_emitted_after_visitor_stats_updated() {
+    func test_visitorStatsText_is_emitted_after_summary_stats_updated() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .today
+        let viewModel = createViewModel(timeRange: timeRange)
+        observeStatsEmittedValues(viewModel: viewModel)
+
+        XCTAssertEqual(orderStatsTextValues, ["-"])
+        XCTAssertEqual(revenueStatsTextValues, ["-"])
+        XCTAssertEqual(visitorStatsTextValues, ["-"])
+        XCTAssertEqual(conversionStatsTextValues, ["-"])
+
+        // When
+        let siteSummaryStats = Yosemite.SiteSummaryStats.fake().copy(siteID: siteID,
+                                                                     date: "2022-12-15",
+                                                                     period: timeRange.summaryStatsGranularity,
+                                                                     visitors: 22)
+        insertSiteSummaryStats(siteSummaryStats)
+
+        // Then
+        XCTAssertEqual(orderStatsTextValues, ["-"])
+        XCTAssertEqual(revenueStatsTextValues, ["-"])
+        XCTAssertEqual(visitorStatsTextValues, ["-", "22"])
+        XCTAssertEqual(conversionStatsTextValues, ["-"])
+    }
+
+    func test_visitorStatsText_is_emitted_after_visitor_stats_updated_and_selecting_interval() {
         // Given
         let timeRange: StatsTimeRangeV4 = .today
         let viewModel = createViewModel(timeRange: timeRange)
@@ -80,18 +106,47 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         // When
         let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(siteID: siteID, items: [
             .fake().copy(visitors: 17),
-            .fake().copy(visitors: 5)
+            .fake().copy(visitors: 15)
         ])
         insertSiteVisitStats(siteVisitStats, timeRange: timeRange)
+
+        XCTAssertEqual(visitorStatsTextValues, ["-"])
+
+        viewModel.selectedIntervalIndex = 0
 
         // Then
         XCTAssertEqual(orderStatsTextValues, ["-"])
         XCTAssertEqual(revenueStatsTextValues, ["-"])
-        XCTAssertEqual(visitorStatsTextValues, ["-", "22"])
+        XCTAssertEqual(visitorStatsTextValues, ["-", "17"])
         XCTAssertEqual(conversionStatsTextValues, ["-"])
     }
 
-    func test_conversionStatsText_is_emitted_after_order_and_visitor_stats_updated() {
+    func test_conversionStatsText_is_emitted_after_order_and_summary_stats_updated() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .today
+        let viewModel = createViewModel(timeRange: timeRange)
+        observeStatsEmittedValues(viewModel: viewModel)
+
+        // When
+        let siteSummaryStats = Yosemite.SiteSummaryStats.fake().copy(siteID: siteID,
+                                                                     date: "2022-12-15",
+                                                                     period: timeRange.summaryStatsGranularity,
+                                                                     visitors: 15)
+        insertSiteSummaryStats(siteSummaryStats)
+
+        XCTAssertEqual(conversionStatsTextValues, ["-"])
+
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake().copy(totalOrders: 3, grossRevenue: 62.7),
+                                      intervals: [.fake()])
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        // Then
+        XCTAssertEqual(conversionStatsTextValues, ["-", "20%"]) // order count: 3, visitor count: 15 => 0.2 (20%)
+    }
+
+    func test_conversionStatsText_is_emitted_after_order_and_visitors_stats_updated_and_selecting_interval() {
         // Given
         let timeRange: StatsTimeRangeV4 = .today
         let viewModel = createViewModel(timeRange: timeRange)
@@ -99,8 +154,8 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
 
         // When
         let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(siteID: siteID, items: [
-            .fake().copy(visitors: 10),
-            .fake().copy(visitors: 5)
+            .fake().copy(visitors: 17),
+            .fake().copy(visitors: 15)
         ])
         insertSiteVisitStats(siteVisitStats, timeRange: timeRange)
 
@@ -111,6 +166,10 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
                                       totals: .fake().copy(totalOrders: 3, grossRevenue: 62.7),
                                       intervals: [.fake()])
         insertOrderStats(orderStats, timeRange: timeRange)
+
+        XCTAssertEqual(conversionStatsTextValues, ["-"])
+
+        viewModel.selectedIntervalIndex = 1
 
         // Then
         XCTAssertEqual(conversionStatsTextValues, ["-", "20%"]) // order count: 3, visitor count: 15 => 0.2 (20%)
@@ -636,7 +695,7 @@ private extension StoreStatsPeriodViewModelTests {
         StoreStatsPeriodViewModel(siteID: siteID,
                                   timeRange: timeRange,
                                   siteTimezone: defaultSiteTimezone,
-                                  currentDate: Date(),
+                                  currentDate: defaultDate,
                                   currencyFormatter: currencyFormatter,
                                   currencySettings: currencySettings,
                                   storageManager: storageManager)
@@ -690,6 +749,12 @@ private extension StoreStatsPeriodViewModelTests {
             newStorageItem.update(with: readOnlyItem)
             storageSiteVisitStats.addToItems(newStorageItem)
         }
+        storage.saveIfNeeded()
+    }
+
+    func insertSiteSummaryStats(_ readOnlySiteSummaryStats: Yosemite.SiteSummaryStats) {
+        let storageSiteSummaryStats = storage.insertNewObject(ofType: StorageSiteSummaryStats.self)
+        storageSiteSummaryStats.update(with: readOnlySiteSummaryStats)
         storage.saveIfNeeded()
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -10,7 +10,6 @@ import WooFoundation
 final class StoreStatsPeriodViewModelTests: XCTestCase {
     private let siteID: Int64 = 300
     private let defaultSiteTimezone = TimeZone(identifier: "GMT") ?? .current
-    private let defaultDate = Date(timeIntervalSince1970: 1671123600) // Dec 15, 2022, 5:00:00 PM GMT
     private var storageManager: StorageManagerType!
     private var storage: StorageType {
         storageManager.viewStorage
@@ -79,11 +78,8 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         XCTAssertEqual(conversionStatsTextValues, ["-"])
 
         // When
-        let siteSummaryStats = Yosemite.SiteSummaryStats.fake().copy(siteID: siteID,
-                                                                     date: "2022-12-15",
-                                                                     period: timeRange.summaryStatsGranularity,
-                                                                     visitors: 22)
-        insertSiteSummaryStats(siteSummaryStats)
+        let siteSummaryStats = Yosemite.SiteSummaryStats.fake().copy(siteID: siteID, date: "2022-12-15", visitors: 22)
+        insertSiteSummaryStats(siteSummaryStats, timeRange: timeRange)
 
         // Then
         XCTAssertEqual(orderStatsTextValues, ["-"])
@@ -128,11 +124,8 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         observeStatsEmittedValues(viewModel: viewModel)
 
         // When
-        let siteSummaryStats = Yosemite.SiteSummaryStats.fake().copy(siteID: siteID,
-                                                                     date: "2022-12-15",
-                                                                     period: timeRange.summaryStatsGranularity,
-                                                                     visitors: 15)
-        insertSiteSummaryStats(siteSummaryStats)
+        let siteSummaryStats = Yosemite.SiteSummaryStats.fake().copy(siteID: siteID, date: "2022-12-15", visitors: 15)
+        insertSiteSummaryStats(siteSummaryStats, timeRange: timeRange)
 
         XCTAssertEqual(conversionStatsTextValues, ["-"])
 
@@ -688,11 +681,13 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
 }
 
 private extension StoreStatsPeriodViewModelTests {
-    func createViewModel(timeRange: StatsTimeRangeV4) -> StoreStatsPeriodViewModel {
+    static private let defaultDate = Date(timeIntervalSince1970: 1671123600) // Dec 15, 2022, 5:00:00 PM GMT
+
+    func createViewModel(timeRange: StatsTimeRangeV4, date: Date = defaultDate) -> StoreStatsPeriodViewModel {
         StoreStatsPeriodViewModel(siteID: siteID,
                                   timeRange: timeRange,
                                   siteTimezone: defaultSiteTimezone,
-                                  currentDate: defaultDate,
+                                  currentDate: date,
                                   currencyFormatter: currencyFormatter,
                                   currencySettings: currencySettings,
                                   storageManager: storageManager)
@@ -749,8 +744,9 @@ private extension StoreStatsPeriodViewModelTests {
         storage.saveIfNeeded()
     }
 
-    func insertSiteSummaryStats(_ readOnlySiteSummaryStats: Yosemite.SiteSummaryStats) {
+    func insertSiteSummaryStats(_ readOnlySiteSummaryStats: Yosemite.SiteSummaryStats, timeRange: StatsTimeRangeV4) {
         let storageSiteSummaryStats = storage.insertNewObject(ofType: StorageSiteSummaryStats.self)
+        storageSiteSummaryStats.period = timeRange.summaryStatsGranularity.rawValue
         storageSiteSummaryStats.update(with: readOnlySiteSummaryStats)
         storage.saveIfNeeded()
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -681,7 +681,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
 }
 
 private extension StoreStatsPeriodViewModelTests {
-    static private let defaultDate = Date(timeIntervalSince1970: 1671123600) // Dec 15, 2022, 5:00:00 PM GMT
+    static let defaultDate = Date(timeIntervalSince1970: 1671123600) // Dec 15, 2022, 5:00:00 PM GMT
 
     func createViewModel(timeRange: StatsTimeRangeV4, date: Date = defaultDate) -> StoreStatsPeriodViewModel {
         StoreStatsPeriodViewModel(siteID: siteID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -636,6 +636,7 @@ private extension StoreStatsPeriodViewModelTests {
         StoreStatsPeriodViewModel(siteID: siteID,
                                   timeRange: timeRange,
                                   siteTimezone: defaultSiteTimezone,
+                                  currentDate: Date(),
                                   currencyFormatter: currencyFormatter,
                                   currencySettings: currencySettings,
                                   storageManager: storageManager)

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -225,6 +225,7 @@ public typealias StorageShippingLineTax = Storage.ShippingLineTax
 public typealias StorageSite = Storage.Site
 public typealias StorageSitePlugin = Storage.SitePlugin
 public typealias StorageSiteSetting = Storage.SiteSetting
+public typealias StorageSiteSummaryStats = Storage.SiteSummaryStats
 public typealias StorageSiteVisitStats = Storage.SiteVisitStats
 public typealias StorageSiteVisitStatsItem = Storage.SiteVisitStatsItem
 public typealias StorageStateOfACountry = Storage.StateOfACountry


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8173
⚠️ Depends on #8424 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the My Store dashboard to use site summary stats (`SiteSummaryStats`) for the "Visitors" and "Conversion" stats for the selected period.

Why we need this:

- Right now, we're computing a site's total visitor count for the entire period by adding together the visitor count for each of the intervals within the period (from `SiteVisitStats` data).
- What we should do in the dashboard — and we're doing already in Analytics Hub — is get the total visitor count for the entire period from `SiteSummaryStats` data. We should continue to get the visitor count for specific intervals from `SiteVisitStats`, to show when an interval is selected in the stats chart.

Note: We should remove the inaccurate `totalVisitors` computed property from `SiteVisitStats`. However, while making these changes I discovered we're also using this property in the store info widget. I've opened #8426 to track that.

### Changes

* Updates the `StatsDataTextFormatter` to have separate methods for getting the visitor count text using `SiteVisitStats` (for a single interval) or using `SiteSummaryStats` (for the entire period). Also removes an unused method.
* Updates `StoreStatsPeriodViewModel` to fetch the `SiteSummaryStats` from storage for the selected time period, and to use those stats for the visitor and conversion text unless a specific interval is selected.
* Updates and adds relevant unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Confirm the "Visitors" and "Conversion" stats load on the My Store dashboard.
3. Confirm you can select a specific interval in the stats chart and the "Visitors" and "Conversion" stats update to reflect the selected interval.
4. Select a different period (Today, This Week, This Month, This Year) and confirm the "Visitors" and "Conversion" stats load as expected for that period.
5. Tap "See more" and confirm the "Conversion" stat on My Store matches the "Conversion Rate" stats in the Sessions card in Analytics.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

/|Dashboard|Analytics
-|-|-
Before|![before-dashboard](https://user-images.githubusercontent.com/8658164/207929246-124690aa-2d03-42dc-86eb-f4f2e218c905.png)|![before-analytics](https://user-images.githubusercontent.com/8658164/207929284-d55a5de1-3714-46d9-862d-f46a506c85f7.png)
After|![after-dashboard](https://user-images.githubusercontent.com/8658164/207929295-7814ed16-5c80-4767-a039-97b12978ddc5.png)|![after-analytics](https://user-images.githubusercontent.com/8658164/207929305-97621934-9860-4661-8f40-20e8105c4ca7.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
