### PR TITLE
[REST API] ApplicationPasswordUseCase - Unit tests

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -736,6 +736,7 @@
 		EE54C8A729486B6800A9BF61 /* ApplicationPasswordMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE54C8A629486B6800A9BF61 /* ApplicationPasswordMapper.swift */; };
 		EE8A86F1286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json in Resources */ = {isa = PBXBuildFile; fileRef = EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */; };
 		EE8DE42F294AFC58005054E7 /* generate-application-password-using-wpcom-token-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE8DE42E294AFC58005054E7 /* generate-application-password-using-wpcom-token-success.json */; };
+		EE8DE432294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DE431294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift */; };
 		EECB7EE8286555180028C888 /* media-update-product-id.json in Resources */ = {isa = PBXBuildFile; fileRef = EECB7EE7286555180028C888 /* media-update-product-id.json */; };
 		FE28F6E226840DED004465C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E126840DED004465C7 /* User.swift */; };
 		FE28F6E426842848004465C7 /* UserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E326842848004465C7 /* UserMapper.swift */; };
@@ -1503,6 +1504,7 @@
 		EE54C8A629486B6800A9BF61 /* ApplicationPasswordMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordMapper.swift; sourceTree = "<group>"; };
 		EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-update-product-id-in-wordpress-site.json"; sourceTree = "<group>"; };
 		EE8DE42E294AFC58005054E7 /* generate-application-password-using-wpcom-token-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "generate-application-password-using-wpcom-token-success.json"; sourceTree = "<group>"; };
+		EE8DE431294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultApplicationPasswordUseCaseTests.swift; sourceTree = "<group>"; };
 		EECB7EE7286555180028C888 /* media-update-product-id.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-update-product-id.json"; sourceTree = "<group>"; };
 		F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6CEE1CA2AD376C0C28AE9F6 /* Pods-NetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1847,6 +1849,7 @@
 		B557D9F0209753AA005962F4 /* NetworkingTests */ = {
 			isa = PBXGroup;
 			children = (
+				EE8DE430294B17BA005054E7 /* ApplicationPassword */,
 				DE97C3902861B8CD0042E973 /* Encoder */,
 				5726F7322460A8E30031CAAC /* Copiable */,
 				B559EBA820A0B5B100836CD4 /* Responses */,
@@ -2605,6 +2608,14 @@
 			isa = PBXGroup;
 			children = (
 				EE54C89E2947782E00A9BF61 /* ApplicationPasswordUseCase.swift */,
+			);
+			path = ApplicationPassword;
+			sourceTree = "<group>";
+		};
+		EE8DE430294B17BA005054E7 /* ApplicationPassword */ = {
+			isa = PBXGroup;
+			children = (
+				EE8DE431294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift */,
 			);
 			path = ApplicationPassword;
 			sourceTree = "<group>";
@@ -3398,6 +3409,7 @@
 				02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */,
 				74CF5E8421402C04000CED0A /* TopEarnerStatsRemoteTests.swift in Sources */,
 				45B204BA24890A8C00FE6526 /* ProductCategoryMapperTests.swift in Sources */,
+				EE8DE432294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift in Sources */,
 				74749B9522413119005C4CF2 /* ProductsRemoteTests.swift in Sources */,
 				B524194321AC622500D6FC0A /* DotcomDeviceMapperTests.swift in Sources */,
 				E1A5C27228F93ED900081046 /* InAppPurchaseOrderResultMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -730,10 +730,12 @@
 		E1BAB2C32913FA6400C3982B /* ResponseDataValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAB2C22913FA6400C3982B /* ResponseDataValidator.swift */; };
 		E1BAB2C52913FB1800C3982B /* WordPressApiValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAB2C42913FB1800C3982B /* WordPressApiValidator.swift */; };
 		E1BAB2C72913FB5800C3982B /* WordPressApiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAB2C62913FB5800C3982B /* WordPressApiError.swift */; };
+		EE338A0E294AF9BD00183934 /* ApplicationPasswordMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE338A0D294AF9BD00183934 /* ApplicationPasswordMapperTests.swift */; };
 		EE54C89F2947782E00A9BF61 /* ApplicationPasswordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE54C89E2947782E00A9BF61 /* ApplicationPasswordUseCase.swift */; };
 		EE54C8A5294859D200A9BF61 /* ApplicationPasswordNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE54C8A4294859D200A9BF61 /* ApplicationPasswordNetwork.swift */; };
 		EE54C8A729486B6800A9BF61 /* ApplicationPasswordMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE54C8A629486B6800A9BF61 /* ApplicationPasswordMapper.swift */; };
 		EE8A86F1286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json in Resources */ = {isa = PBXBuildFile; fileRef = EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */; };
+		EE8DE42F294AFC58005054E7 /* generate-application-password-using-wpcom-token-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE8DE42E294AFC58005054E7 /* generate-application-password-using-wpcom-token-success.json */; };
 		EECB7EE8286555180028C888 /* media-update-product-id.json in Resources */ = {isa = PBXBuildFile; fileRef = EECB7EE7286555180028C888 /* media-update-product-id.json */; };
 		FE28F6E226840DED004465C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E126840DED004465C7 /* User.swift */; };
 		FE28F6E426842848004465C7 /* UserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E326842848004465C7 /* UserMapper.swift */; };
@@ -1495,10 +1497,12 @@
 		E1BAB2C22913FA6400C3982B /* ResponseDataValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseDataValidator.swift; sourceTree = "<group>"; };
 		E1BAB2C42913FB1800C3982B /* WordPressApiValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressApiValidator.swift; sourceTree = "<group>"; };
 		E1BAB2C62913FB5800C3982B /* WordPressApiError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressApiError.swift; sourceTree = "<group>"; };
+		EE338A0D294AF9BD00183934 /* ApplicationPasswordMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordMapperTests.swift; sourceTree = "<group>"; };
 		EE54C89E2947782E00A9BF61 /* ApplicationPasswordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordUseCase.swift; sourceTree = "<group>"; };
 		EE54C8A4294859D200A9BF61 /* ApplicationPasswordNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordNetwork.swift; sourceTree = "<group>"; };
 		EE54C8A629486B6800A9BF61 /* ApplicationPasswordMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordMapper.swift; sourceTree = "<group>"; };
 		EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-update-product-id-in-wordpress-site.json"; sourceTree = "<group>"; };
+		EE8DE42E294AFC58005054E7 /* generate-application-password-using-wpcom-token-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "generate-application-password-using-wpcom-token-success.json"; sourceTree = "<group>"; };
 		EECB7EE7286555180028C888 /* media-update-product-id.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-update-product-id.json"; sourceTree = "<group>"; };
 		F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6CEE1CA2AD376C0C28AE9F6 /* Pods-NetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -2028,6 +2032,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				EE338A0A294AF92A00183934 /* AppliicationPassword */,
 				DE9DEEF4291CF1B40070AD7C /* site-plugin-without-envelope.json */,
 				028CB714290223CB00331C09 /* account-username-suggestions.json */,
 				028CB71C2902589E00331C09 /* create-account-error-email-exists.json */,
@@ -2513,6 +2518,7 @@
 				0359EA1E27AAE4680048DE2D /* WCPayChargeMapperTests.swift */,
 				68CB801328D8A05200E169F8 /* CustomerMapperTests.swift */,
 				68F48B1028E3BBC60045C15B /* WCAnalyticsCustomerMapperTests.swift */,
+				EE338A0D294AF9BD00183934 /* ApplicationPasswordMapperTests.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -2585,6 +2591,14 @@
 				DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */,
 			);
 			path = SystemStatusDetails;
+			sourceTree = "<group>";
+		};
+		EE338A0A294AF92A00183934 /* AppliicationPassword */ = {
+			isa = PBXGroup;
+			children = (
+				EE8DE42E294AFC58005054E7 /* generate-application-password-using-wpcom-token-success.json */,
+			);
+			path = AppliicationPassword;
 			sourceTree = "<group>";
 		};
 		EE54C899294777D000A9BF61 /* ApplicationPassword */ = {
@@ -2777,6 +2791,7 @@
 				31A451D827863A2E00FE81AA /* stripe-account-restricted-overdue.json in Resources */,
 				D865CE69278CA245002C8520 /* stripe-payment-intent-unknown-status.json in Resources */,
 				0205021C27C86B9700FB1C6B /* inbox-note-without-isRead.json in Resources */,
+				EE8DE42F294AFC58005054E7 /* generate-application-password-using-wpcom-token-success.json in Resources */,
 				24F98C622502EFF600F49B68 /* feature-flags-load-all.json in Resources */,
 				DE50296128C609A300551736 /* jetpack-connected-user.json in Resources */,
 				B58D10C82114D21D00107ED4 /* generic_error.json in Resources */,
@@ -3379,6 +3394,7 @@
 				03EB998A2906AB0C00F06A39 /* JustInTimeMessagesRemoteTests.swift in Sources */,
 				DE34051D28BDF1C900CF0D97 /* JetpackConnectionURLMapperTests.swift in Sources */,
 				451A9836260B9DF90059D135 /* ShippingLabelPackagesMapperTests.swift in Sources */,
+				EE338A0E294AF9BD00183934 /* ApplicationPasswordMapperTests.swift in Sources */,
 				02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */,
 				74CF5E8421402C04000CED0A /* TopEarnerStatsRemoteTests.swift in Sources */,
 				45B204BA24890A8C00FE6526 /* ProductCategoryMapperTests.swift in Sources */,

--- a/Networking/NetworkingTests/ApplicationPassword/DefaultApplicationPasswordUseCaseTests.swift
+++ b/Networking/NetworkingTests/ApplicationPassword/DefaultApplicationPasswordUseCaseTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import Networking
+
+
+/// DefaultApplicationPasswordUseCase Unit Tests
+///
+final class DefaultApplicationPasswordUseCaseTests: XCTestCase {
+    /// Mock Network: Allows us to inject predefined responses!
+    ///
+    private var network: MockNetwork!
+
+    /// Testing SiteID
+    ///
+    private let sampleSiteID: Int64 = 123
+
+    /// Dummy WPCOM auth token
+    ///
+    private let credentials = Credentials(authToken: "dummy-token")
+
+    /// Dummy WPCOM auth token
+    ///
+    private let applicationPasswordURLSuffix = Credentials(authToken: "dummy-token")
+
+    /// URL suffixes
+    ///
+    private enum URLSuffix {
+        static let generateApplicationPassword = "users/me/application-passwords"
+        static let usersMe = "users/me"
+    }
+
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork(useResponseQueue: true)
+    }
+
+    override func tearDown() {
+        network = nil
+        super.tearDown()
+    }
+
+    func test_password_is_generated_with_correct_values_upon_success_response() async throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: URLSuffix.generateApplicationPassword,
+                                 filename: "generate-application-password-using-wpcom-token-success")
+        network.simulateResponse(requestUrlSuffix: URLSuffix.usersMe, filename: "user-complete")
+
+        let sut = DefaultApplicationPasswordUseCase(siteID: sampleSiteID,
+                                                    networkcredentials: credentials,
+                                                    network: network)
+
+        let password = try await sut.generateNewPassword()
+        XCTAssertEqual(password.password.secretValue, "passwordvalue")
+        XCTAssertEqual(password.wpOrgUsername, "test-username")
+    }
+}

--- a/Networking/NetworkingTests/ApplicationPassword/DefaultApplicationPasswordUseCaseTests.swift
+++ b/Networking/NetworkingTests/ApplicationPassword/DefaultApplicationPasswordUseCaseTests.swift
@@ -28,7 +28,6 @@ final class DefaultApplicationPasswordUseCaseTests: XCTestCase {
         static let usersMe = "users/me"
     }
 
-
     override func setUp() {
         super.setUp()
         network = MockNetwork(useResponseQueue: true)

--- a/Networking/NetworkingTests/Mapper/ApplicationPasswordMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ApplicationPasswordMapperTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import Networking
+
+
+/// ApplicationPasswordMapper Unit Tests
+///
+final class ApplicationPasswordMapperTests: XCTestCase {
+
+    /// Verifies that generate password using WPCOM token response is parsed properly
+    ///
+    func test_response_is_properly_parsed_while_generating_password_using_WPCOM_token() {
+        guard let password = mapGenerateUsingWPCOMResponse() else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(password, "passwordvalue")
+    }
+}
+
+// MARK: - Private Methods.
+//
+private extension ApplicationPasswordMapperTests {
+
+    /// Returns the ApplicationPasswordMapper output upon receiving success response
+    ///
+    func mapGenerateUsingWPCOMResponse() -> String? {
+        guard let response = Loader.contentsOf("generate-application-password-using-wpcom-token-success") else {
+            return nil
+        }
+
+        return try? ApplicationPasswordMapper().map(response: response)
+    }
+}

--- a/Networking/NetworkingTests/Responses/AppliicationPassword/generate-application-password-using-wpcom-token-success.json
+++ b/Networking/NetworkingTests/Responses/AppliicationPassword/generate-application-password-using-wpcom-token-success.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "uuid": "8ef68e6b-4670-4cfd-8ca0-456e616bcd5e",
+    "app_id": "",
+    "name": "com.automattic.woocommerce.ios-app-client.iPhone",
+    "created": "2022-12-15T06:39:38",
+    "last_used": null,
+    "last_ip": null,
+    "password": "passwordvalue",
+    "_links": {
+      "self": [
+        {
+          "href": "https://website.com/wp-json/wp/v2/users/1/application-passwords/8ef68e6b-4670-4cfd-8ca0-456e616bcd5e"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION

Closes: #8394 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
- Adds basic unit tests for mapper and use case.
- I didn't add further unit tests as we will be moving away from WPCOM auth token authentication. (Based on the decision to add double layer network)

## Testing instructions
CI Passing 

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
