### PR TITLE
Fix build error in unit tests

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -89,7 +89,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
             case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, completion):
                 let topEarners = TopEarnerStats.fake().copy(items: [.fake()])
                 completion(.success(topEarners))
-            case let .retrieveSiteSummaryStats(_, _, _, _, completion):
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, completion):
                 completion(.failure(NSError(domain: "Test", code: 1)))
             default:
                 break

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -100,10 +100,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         XCTAssertEqual(conversionStatsTextValues, ["-"])
 
         // When
-        let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(siteID: siteID, items: [
-            .fake().copy(visitors: 17),
-            .fake().copy(visitors: 15)
-        ])
+        let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(siteID: siteID, items: [ .fake().copy(visitors: 17) ])
         insertSiteVisitStats(siteVisitStats, timeRange: timeRange)
 
         XCTAssertEqual(visitorStatsTextValues, ["-"])


### PR DESCRIPTION
## Description

This PR adds missing parameter in unit tests code that prevents CI from building on `trunk`.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
