### PR TITLE
Remove deprecated currentKeyWindow usage

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -89,6 +89,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupMainWindow()
         setupComponentsAppearance()
         setupNoticePresenter()
+        disableAnimationsIfNeeded()
 
         // Start app navigation.
         appCoordinator?.start()
@@ -365,22 +366,26 @@ private extension AppDelegate {
             ServiceLocator.setStores(ScreenshotStoresManager(storageManager: ServiceLocator.storageManager))
         }
 
-        if ProcessConfiguration.shouldDisableAnimations {
-            UIView.setAnimationsEnabled(false)
-
-            /// Trick found at: https://twitter.com/twannl/status/1232966604142653446
-            UIApplication
-                .shared
-                .connectedScenes
-                .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
-                .forEach {
-                    $0.layer.speed = 100
-                }
-        }
-
         if ProcessConfiguration.shouldSimulatePushNotification {
             UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) { _, _ in }
         }
+    }
+
+    func disableAnimationsIfNeeded() {
+        guard ProcessConfiguration.shouldDisableAnimations else {
+            return
+        }
+
+        UIView.setAnimationsEnabled(false)
+
+        /// Trick found at: https://twitter.com/twannl/status/1232966604142653446
+        UIApplication
+            .shared
+            .connectedScenes
+            .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+            .forEach {
+                $0.layer.speed = 100
+            }
     }
 
     /// Tracks if the application was opened via a widget tap.

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -369,7 +369,13 @@ private extension AppDelegate {
             UIView.setAnimationsEnabled(false)
 
             /// Trick found at: https://twitter.com/twannl/status/1232966604142653446
-            UIApplication.shared.currentKeyWindow?.layer.speed = 100
+            UIApplication
+                .shared
+                .connectedScenes
+                .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+                .forEach {
+                    $0.layer.speed = 100
+                }
         }
 
         if ProcessConfiguration.shouldSimulatePushNotification {

--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -91,7 +91,7 @@ extension UIAlertController {
 
     open override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
-        if let window = UIApplication.shared.currentKeyWindow {
+        if let window = view.window {
             popoverPresentationController?.sourceRect = CGRect(x: window.bounds.midX, y: window.bounds.midY, width: 0, height: 0)
         }
     }

--- a/WooCommerce/Classes/Extensions/UIApplication+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIApplication+Woo.swift
@@ -1,17 +1,6 @@
 import Foundation
 import UIKit
 
-// MARK: - UIApplication Utils
-//
-extension UIApplication {
-
-    /// Returns the keyWindow. Accessing `UIApplication.shared.keyWindow` is deprecated from iOS 13.
-    ///
-    var currentKeyWindow: UIWindow? {
-        UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-    }
-}
-
 // MARK: - UIApplication.State Woo Methods
 //
 extension UIApplication.State {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -200,7 +200,7 @@ private extension ProductPriceSettingsViewController {
     /// Displays a Notice onscreen for a given message
     ///
     func displayNotice(for message: String) {
-        UIApplication.shared.currentKeyWindow?.endEditing(true)
+        view.endEditing(true)
         let notice = Notice(title: message, feedbackType: .error)
         noticePresenter.enqueue(notice: notice)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
@@ -275,7 +275,7 @@ private extension ProductTagsViewController {
     func tagsFailedLoading() {
         DDLogError("Error loading product tags")
         dataSource = FailureDataSource()
-        UIApplication.shared.currentKeyWindow?.endEditing(true)
+        view.endEditing(true)
         let errorMessage = Strings.errorLoadingTags
         let notice = Notice(title: errorMessage, feedbackType: .error)
         ServiceLocator.noticePresenter.enqueue(notice: notice)

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/BarcodeScannerViewController.swift
@@ -206,7 +206,7 @@ private extension BarcodeScannerViewController {
 private extension BarcodeScannerViewController {
     func updatePreviewLayerOrientation() {
         if let connection = previewLayer?.connection, connection.isVideoOrientationSupported {
-            let orientation = UIApplication.shared.currentKeyWindow?.windowScene?.interfaceOrientation
+            let orientation = view.window?.windowScene?.interfaceOrientation
             let videoOrientation: AVCaptureVideoOrientation
             switch orientation {
             case .portrait:

--- a/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
@@ -171,7 +171,7 @@ private extension TextViewViewController {
     /// Displays a Notice onscreen, indicating that the text didn't pass the validation.
     ///
     func displayErrorNotice(error: String) {
-        UIApplication.shared.currentKeyWindow?.endEditing(true)
+        view.endEditing(true)
         let notice = Notice(title: error, feedbackType: .error)
         ServiceLocator.noticePresenter.enqueue(notice: notice)
     }


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/7882

## Description

This PR removes `currentKeyWindow` extension that used deprecated API and replaces its usage with accessors to specific view-related windows.

Additional fix: "disable animations" snippet moved **after** main window setup, previously it accessed `nil` window.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
