### PR TITLE
[UI Tests] - Convert BaseScreen to ScreenObject for login-related screens

### DIFF
--- a/WooCommerce/UITestsFoundation/ScreenObject+Extension.swift
+++ b/WooCommerce/UITestsFoundation/ScreenObject+Extension.swift
@@ -23,6 +23,7 @@ public extension ScreenObject {
         return self
     }
 
+    @discardableResult
     func waitFor(element: XCUIElement, predicate: String, timeout: Int? = nil) -> Bool {
         let timeoutValue = timeout ?? 5
 

--- a/WooCommerce/UITestsFoundation/ScreenObject+Extension.swift
+++ b/WooCommerce/UITestsFoundation/ScreenObject+Extension.swift
@@ -1,4 +1,5 @@
 import ScreenObject
+import XCTest
 
 // These are implemented as extensions on `ScreenObject` locally to this target to allow us to
 // finish the transition of the screens from `BaseScreen` to `ScreenObject` and from the different
@@ -20,5 +21,14 @@ public extension ScreenObject {
     func then(_ completion: (ScreenObject) -> Void) -> Self {
         completion(self)
         return self
+    }
+
+    func waitFor(element: XCUIElement, predicate: String, timeout: Int? = nil) -> Bool {
+        let timeoutValue = timeout ?? 5
+
+        let elementPredicate = XCTNSPredicateExpectation(predicate: NSPredicate(format: predicate), object: element)
+        let result = XCTWaiter.wait(for: [elementPredicate], timeout: TimeInterval(timeoutValue))
+
+        return result == .completed
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/GetStartedScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/GetStartedScreen.swift
@@ -3,26 +3,35 @@ import XCTest
 
 public final class GetStartedScreen: ScreenObject {
 
+    private let emailFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["Email address"]
+    }
+
+    private let continueButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Get Started Email Continue Button"]
+    }
+
+    private var emailField: XCUIElement { emailFieldGetter(app) }
+    private var continueButton: XCUIElement { continueButtonGetter(app) }
+
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-              expectedElementGetters: [
-                  // swiftlint:disable opening_brace
-                  { $0.textFields["Email address"] },
-                  { $0.buttons["Get Started Email Continue Button"] },
-                  // swiftlint:enable opening_brace
-              ],
+            expectedElementGetters: [
+                emailFieldGetter,
+                continueButtonGetter
+            ],
             app: app
         )
     }
 
     public func proceedWith(email: String) throws -> PasswordScreen {
-        app.textFields["Email address"].enterText(text: email)
-        app.buttons["Get Started Email Continue Button"].tap()
+        emailField.enterText(text: email)
+        continueButton.tap()
 
         return try PasswordScreen()
     }
 
     func isEmailEntered() -> Bool {
-        return app.textFields["Email address"].value != nil
+        return emailField.value != nil
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/GetStartedScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/GetStartedScreen.swift
@@ -1,40 +1,32 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let navBar = "WordPress.GetStartedView"
-    static let emailTextField = "Email address"
-    static let continueButton = "Get Started Email Continue Button"
-}
+public final class GetStartedScreen: ScreenObject {
 
-public final class GetStartedScreen: BaseScreen {
-    private let navBar: XCUIElement
-    private let emailTextField: XCUIElement
-    private let continueButton: XCUIElement
-
-    init() {
-        let app = XCUIApplication()
-        navBar = app.navigationBars[ElementStringIDs.navBar]
-        emailTextField = app.textFields[ElementStringIDs.emailTextField]
-        continueButton = app.buttons[ElementStringIDs.continueButton]
-
-        super.init(element: emailTextField)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+              expectedElementGetters: [
+                  // swiftlint:disable opening_brace
+                  { $0.textFields["Email address"] },
+                  { $0.buttons["Get Started Email Continue Button"] },
+                  // swiftlint:enable opening_brace
+              ],
+            app: app
+        )
     }
 
-    public func proceedWith(email: String) -> PasswordScreen {
-        emailTextField.tap()
-        emailTextField.typeText(email)
-        continueButton.tap()
+    public func proceedWith(email: String) throws -> PasswordScreen {
+        app.textFields["Email address"].enterText(text: email)
+        app.buttons["Get Started Email Continue Button"].tap()
 
-        return PasswordScreen()
+        return try PasswordScreen()
     }
 
-    static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.continueButton].exists
+    func isLoaded() -> Bool {
+        return app.buttons["Get Started Email Continue Button"].exists
     }
 
-    static func isEmailEntered() -> Bool {
-        let emailTextField = XCUIApplication().textFields[ElementStringIDs.emailTextField]
-        return emailTextField.value != nil
+    func isEmailEntered() -> Bool {
+        return app.textFields["Email address"].value != nil
     }
-
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/GetStartedScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/GetStartedScreen.swift
@@ -22,10 +22,6 @@ public final class GetStartedScreen: ScreenObject {
         return try PasswordScreen()
     }
 
-    func isLoaded() -> Bool {
-        return app.buttons["Get Started Email Continue Button"].exists
-    }
-
     func isEmailEntered() -> Bool {
         return app.textFields["Email address"].value != nil
     }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
@@ -3,27 +3,33 @@ import XCTest
 
 public final class LinkOrPasswordScreen: ScreenObject {
 
+    private let passwordButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Use Password"]
+    }
+
+    private let sendLinkButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Send Link Button"]
+    }
+
+    private var passwordButton: XCUIElement { passwordButtonGetter(app) }
+
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-              expectedElementGetters: [
-                  // swiftlint:disable opening_brace
-                  { $0.buttons["Use Password"] },
-                  { $0.buttons["Send Link Button"] },
-                  // swiftlint:enable opening_brace
-              ],
+            expectedElementGetters: [
+                passwordButtonGetter,
+                sendLinkButtonGetter
+            ],
             app: app
         )
     }
 
     func proceedWithPassword() throws -> LoginPasswordScreen {
-        app.buttons["Use Password"].tap()
-
+        passwordButton.tap()
         return try LoginPasswordScreen()
     }
 
     func proceedWithLink() throws -> LoginCheckMagicLinkScreen {
-        app.buttons["Send Link Button"].tap()
-
+        passwordButton.tap()
         return try LoginCheckMagicLinkScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
@@ -1,34 +1,33 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let passwordOption = "Use Password"
-    static let linkButton = "Send Link Button"
-}
+public final class LinkOrPasswordScreen: ScreenObject {
 
-final class LinkOrPasswordScreen: BaseScreen {
-    private let passwordOption: XCUIElement
-    private let linkButton: XCUIElement
-
-    init() {
-        passwordOption = XCUIApplication().buttons[ElementStringIDs.passwordOption]
-        linkButton = XCUIApplication().buttons[ElementStringIDs.linkButton]
-
-        super.init(element: passwordOption)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+              expectedElementGetters: [
+                  // swiftlint:disable opening_brace
+                  { $0.buttons["Use Password"] },
+                  { $0.buttons["Send Link Button"] },
+                  // swiftlint:enable opening_brace
+              ],
+            app: app
+        )
     }
 
-    func proceedWithPassword() -> LoginPasswordScreen {
-        passwordOption.tap()
+    func proceedWithPassword() throws -> LoginPasswordScreen {
+        app.buttons["Use Password"].tap()
 
-        return LoginPasswordScreen()
+        return try LoginPasswordScreen()
     }
 
-    func proceedWithLink() -> LoginCheckMagicLinkScreen {
-        linkButton.tap()
+    func proceedWithLink() throws -> LoginCheckMagicLinkScreen {
+        app.buttons["Send Link Button"].tap()
 
-        return LoginCheckMagicLinkScreen()
+        return try LoginCheckMagicLinkScreen()
     }
 
-    static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.passwordOption].exists
+    func isLoaded() -> Bool {
+        return app.buttons["Use Password"].exists
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
@@ -26,8 +26,4 @@ public final class LinkOrPasswordScreen: ScreenObject {
 
         return try LoginCheckMagicLinkScreen()
     }
-
-    func isLoaded() -> Bool {
-        return app.buttons["Use Password"].exists
-    }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
@@ -3,22 +3,32 @@ import XCTest
 
 public final class LoginCheckMagicLinkScreen: ScreenObject {
 
+    private let passwordButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Use Password"]
+    }
+
+    private let mailButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Open Mail Button"]
+    }
+
+    private let mailAlertGetter: (XCUIApplication) -> XCUIElement = {
+        $0.alerts.element(boundBy: 0)
+    }
+
+    private var passwordButton: XCUIElement { passwordButtonGetter(app) }
+
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-              expectedElementGetters: [
-                  // swiftlint:disable opening_brace
-                  { $0.buttons["Use Password"] },
-                  { $0.buttons["Open Mail Button"] },
-                  { $0.alerts.element(boundBy: 0) }
-                  // swiftlint:enable opening_brace
-              ],
+            expectedElementGetters: [
+                passwordButtonGetter,
+                mailAlertGetter,
+            ],
             app: app
         )
     }
 
     func proceedWithPassword() throws -> LoginPasswordScreen {
-        app.buttons["Use Password"].tap()
-
+        passwordButton.tap()
         return try LoginPasswordScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
@@ -21,8 +21,4 @@ public final class LoginCheckMagicLinkScreen: ScreenObject {
 
         return try LoginPasswordScreen()
     }
-
-    func isLoaded() -> Bool {
-        return app.buttons["Open Mail Button"].exists
-    }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
@@ -7,10 +7,6 @@ public final class LoginCheckMagicLinkScreen: ScreenObject {
         $0.buttons["Use Password"]
     }
 
-    private let mailButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["Open Mail Button"]
-    }
-
     private let mailAlertGetter: (XCUIApplication) -> XCUIElement = {
         $0.alerts.element(boundBy: 0)
     }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
@@ -1,31 +1,28 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let passwordOption = "Use Password"
-    static let mailButton = "Open Mail Button"
-}
+public final class LoginCheckMagicLinkScreen: ScreenObject {
 
-final class LoginCheckMagicLinkScreen: BaseScreen {
-    private let passwordOption: XCUIElement
-    private let mailButton: XCUIElement
-    private let mailAlert: XCUIElement
-
-    init() {
-        let app = XCUIApplication()
-        passwordOption = app.buttons[ElementStringIDs.passwordOption]
-        mailButton = app.buttons[ElementStringIDs.mailButton]
-        mailAlert = app.alerts.element(boundBy: 0)
-
-        super.init(element: mailButton)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+              expectedElementGetters: [
+                  // swiftlint:disable opening_brace
+                  { $0.buttons["Use Password"] },
+                  { $0.buttons["Open Mail Button"] },
+                  { $0.alerts.element(boundBy: 0) }
+                  // swiftlint:enable opening_brace
+              ],
+            app: app
+        )
     }
 
-    func proceedWithPassword() -> LoginPasswordScreen {
-        passwordOption.tap()
+    func proceedWithPassword() throws -> LoginPasswordScreen {
+        app.buttons["Use Password"].tap()
 
-        return LoginPasswordScreen()
+        return try LoginPasswordScreen()
     }
 
-    static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.mailButton].exists
+    func isLoaded() -> Bool {
+        return app.buttons["Open Mail Button"].exists
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
@@ -3,34 +3,47 @@ import XCTest
 
 public final class LoginEmailScreen: ScreenObject {
 
+    private let emailButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Login Email Address"]
+    }
+
+    private let nextButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Login Email Next Button"]
+    }
+
+    private let siteAddressButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Self Hosted Login Button"]
+    }
+
+    private var emailButton: XCUIElement { emailButtonGetter(app) }
+    private var nextButton: XCUIElement { nextButtonGetter(app) }
+    private var siteAddressButton: XCUIElement { siteAddressButtonGetter(app) }
+    private var emailTextField: XCUIElement { app.textFields["Login Email Address"] }
+
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-              expectedElementGetters: [
-                  // swiftlint:disable opening_brace
-                  { $0.buttons["Login Email Address"] },
-                  { $0.buttons["Login Email Next Button"] },
-                  { $0.buttons["Self Hosted Login Button"] }
-                  // swiftlint:enable opening_brace
-              ],
+            expectedElementGetters: [
+                emailButtonGetter,
+                nextButtonGetter,
+                siteAddressButtonGetter
+            ],
             app: app
         )
     }
 
     func proceedWith(email: String) throws -> LinkOrPasswordScreen {
-        app.buttons["Login Email Address"].enterText(text: email)
-        app.buttons["Login Email Next Button"].tap()
+        emailButton.enterText(text: email)
+        nextButton.tap()
 
         return try LinkOrPasswordScreen()
     }
 
     func goToSiteAddressLogin() throws -> LoginSiteAddressScreen {
-        app.buttons["Self Hosted Login Button"].tap()
-
+        siteAddressButton.tap()
         return try LoginSiteAddressScreen()
     }
 
     func isEmailEntered() -> Bool {
-        let emailTextField = app.textFields["Login Email Address"]
         return emailTextField.value != nil
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
@@ -29,11 +29,6 @@ public final class LoginEmailScreen: ScreenObject {
         return try LoginSiteAddressScreen()
     }
 
-    func isLoaded() -> Bool {
-        let expectedElement = app.textFields["Login Email Address"]
-        return expectedElement.exists && expectedElement.isHittable
-    }
-
     func isEmailEntered() -> Bool {
         let emailTextField = app.textFields["Login Email Address"]
         return emailTextField.value != nil

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
@@ -14,7 +14,7 @@ public final class LoginEmailScreen: ScreenObject {
     private let siteAddressButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Self Hosted Login Button"]
     }
-    
+
     private let emailTextFieldGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Self Hosted Login Button"]
     }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
@@ -14,16 +14,21 @@ public final class LoginEmailScreen: ScreenObject {
     private let siteAddressButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Self Hosted Login Button"]
     }
+    
+    private let emailTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Self Hosted Login Button"]
+    }
 
     private var emailButton: XCUIElement { emailButtonGetter(app) }
     private var nextButton: XCUIElement { nextButtonGetter(app) }
     private var siteAddressButton: XCUIElement { siteAddressButtonGetter(app) }
-    private var emailTextField: XCUIElement { app.textFields["Login Email Address"] }
+    private var emailTextField: XCUIElement { emailTextFieldGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
                 emailButtonGetter,
+                emailTextFieldGetter,
                 nextButtonGetter,
                 siteAddressButtonGetter
             ],

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
@@ -1,49 +1,41 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let navBar = "WordPress.LoginEmailView"
-    static let emailTextField = "Login Email Address"
-    static let nextButton = "Login Email Next Button"
-    static let siteAddressButton = "Self Hosted Login Button"
-}
+public final class LoginEmailScreen: ScreenObject {
 
-final class LoginEmailScreen: BaseScreen {
-    private let navBar: XCUIElement
-    private let emailTextField: XCUIElement
-    private let nextButton: XCUIElement
-    private let siteAddressButton: XCUIElement
-
-    init() {
-        let app = XCUIApplication()
-        navBar = app.navigationBars[ElementStringIDs.navBar]
-        emailTextField = app.textFields[ElementStringIDs.emailTextField]
-        nextButton = app.buttons[ElementStringIDs.nextButton]
-        siteAddressButton = app.buttons[ElementStringIDs.siteAddressButton]
-
-        super.init(element: emailTextField)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+              expectedElementGetters: [
+                  // swiftlint:disable opening_brace
+                  { $0.buttons["Login Email Address"] },
+                  { $0.buttons["Login Email Next Button"] },
+                  { $0.buttons["Self Hosted Login Button"] }
+                  // swiftlint:enable opening_brace
+              ],
+            app: app
+        )
     }
 
-    func proceedWith(email: String) -> LinkOrPasswordScreen {
-        emailTextField.tap()
-        emailTextField.typeText(email)
-        nextButton.tap()
+    func proceedWith(email: String) throws -> LinkOrPasswordScreen {
+        app.buttons["Login Email Address"].enterText(text: email)
+        app.buttons["Login Email Next Button"].tap()
 
-        return LinkOrPasswordScreen()
+        return try LinkOrPasswordScreen()
     }
 
-    func goToSiteAddressLogin() -> LoginSiteAddressScreen {
-        siteAddressButton.tap()
+    func goToSiteAddressLogin() throws -> LoginSiteAddressScreen {
+        app.buttons["Self Hosted Login Button"].tap()
 
-        return LoginSiteAddressScreen()
+        return try LoginSiteAddressScreen()
     }
 
-    static func isLoaded() -> Bool {
-        let expectedElement = XCUIApplication().textFields[ElementStringIDs.emailTextField]
+    func isLoaded() -> Bool {
+        let expectedElement = app.textFields["Login Email Address"]
         return expectedElement.exists && expectedElement.isHittable
     }
 
-    static func isEmailEntered() -> Bool {
-        let emailTextField = XCUIApplication().textFields[ElementStringIDs.emailTextField]
+    func isEmailEntered() -> Bool {
+        let emailTextField = app.textFields["Login Email Address"]
         return emailTextField.value != nil
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -15,8 +15,8 @@ public final class LoginEpilogueScreen: ScreenObject {
         $0.buttons["login-epilogue-continue-button"]
     }
 
-    private var actualEmail: String { emailLabelGetter(app).label }
-    private var actualSiteUrl: String { urlLabelGetter(app).label }
+    private var emailLabel: String { emailLabelGetter(app).label }
+    private var siteUrlLabel: String { urlLabelGetter(app).label }
     private var continueButton: XCUIElement { continueButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
@@ -37,8 +37,8 @@ public final class LoginEpilogueScreen: ScreenObject {
     }
 
     public func verifyEpilogueDisplays(email expectedEmail: String, siteUrl expectedSiteUrl: String) -> LoginEpilogueScreen {
-        XCTAssertEqual(expectedEmail, actualEmail, "Display name is '\(actualEmail)' but should be '\(expectedEmail)'.")
-        XCTAssertEqual(expectedSiteUrl, actualSiteUrl, "Site URL is \(actualSiteUrl) but should be \(expectedSiteUrl)")
+        XCTAssertEqual(expectedEmail, emailLabel, "Display name is '\(emailLabel)' but should be '\(expectedEmail)'.")
+        XCTAssertEqual(expectedSiteUrl, siteUrlLabel, "Site URL is \(siteUrlLabel) but should be \(expectedSiteUrl)")
 
         return self
     }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -3,29 +3,40 @@ import XCTest
 
 public final class LoginEpilogueScreen: ScreenObject {
 
+    private let emailLabelGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["email-label"]
+    }
+
+    private let urlLabelGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["url-label"]
+    }
+
+    private let continueButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["login-epilogue-continue-button"]
+    }
+
+    private var actualEmail: String { emailLabelGetter(app).label }
+    private var actualSiteUrl: String { urlLabelGetter(app).label }
+    private var continueButton: XCUIElement { continueButtonGetter(app) }
+
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-              expectedElementGetters: [
-                  // swiftlint:disable opening_brace
-                  { $0.staticTexts["email-label"] },
-                  { $0.staticTexts["url-label"] },
-                  { $0.buttons["login-epilogue-continue-button"] },
-                  // swiftlint:enable opening_brace
-              ],
+            expectedElementGetters: [
+                emailLabelGetter,
+                urlLabelGetter,
+                continueButtonGetter
+            ],
             app: app
         )
     }
 
     @discardableResult
     public func continueWithSelectedSite() throws -> MyStoreScreen {
-        app.buttons["login-epilogue-continue-button"].tap()
+        continueButton.tap()
         return try MyStoreScreen()
     }
 
     public func verifyEpilogueDisplays(email expectedEmail: String, siteUrl expectedSiteUrl: String) -> LoginEpilogueScreen {
-        let actualEmail = app.staticTexts["email-label"].label
-        let actualSiteUrl = app.staticTexts["url-label"].label
-
         XCTAssertEqual(expectedEmail, actualEmail, "Display name is '\(actualEmail)' but should be '\(expectedEmail)'.")
         XCTAssertEqual(expectedSiteUrl, actualSiteUrl, "Site URL is \(actualSiteUrl) but should be \(expectedSiteUrl)")
 

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -1,34 +1,30 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let emailField = "email-label"
-    static let siteUrlField = "url-label"
-    static let continueButton = "login-epilogue-continue-button"
-}
+public final class LoginEpilogueScreen: ScreenObject {
 
-public final class LoginEpilogueScreen: BaseScreen {
-    private let continueButton: XCUIElement
-    private let emailField: XCUIElement
-    private let siteUrlField: XCUIElement
-
-    public init() {
-        let app = XCUIApplication()
-        emailField = app.staticTexts[ElementStringIDs.emailField]
-        siteUrlField = app.staticTexts[ElementStringIDs.siteUrlField]
-        continueButton = app.buttons[ElementStringIDs.continueButton]
-
-        super.init(element: continueButton)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+              expectedElementGetters: [
+                  // swiftlint:disable opening_brace
+                  { $0.staticTexts["email-label"] },
+                  { $0.staticTexts["url-label"] },
+                  { $0.buttons["login-epilogue-continue-button"] },
+                  // swiftlint:enable opening_brace
+              ],
+            app: app
+        )
     }
 
     @discardableResult
     public func continueWithSelectedSite() throws -> MyStoreScreen {
-        continueButton.tap()
+        app.buttons["login-epilogue-continue-button"].tap()
         return try MyStoreScreen()
     }
 
     public func verifyEpilogueDisplays(email expectedEmail: String, siteUrl expectedSiteUrl: String) -> LoginEpilogueScreen {
-        let actualEmail = emailField.label
-        let actualSiteUrl = siteUrlField.label
+        let actualEmail = app.staticTexts["email-label"].label
+        let actualSiteUrl = app.staticTexts["url-label"].label
 
         XCTAssertEqual(expectedEmail, actualEmail, "Display name is '\(actualEmail)' but should be '\(expectedEmail)'.")
         XCTAssertEqual(expectedSiteUrl, actualSiteUrl, "Site URL is \(actualSiteUrl) but should be \(expectedSiteUrl)")

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginOnboardingScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginOnboardingScreen.swift
@@ -2,15 +2,22 @@ import ScreenObject
 import XCTest
 
 public final class LoginOnboardingScreen: ScreenObject {
+
+    private let skipOnboardingButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Login Onboarding Skip Button"]
+    }
+
+    private var skipOnboardingButton: XCUIElement { skipOnboardingButtonGetter(app) }
+
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetter: { $0.buttons["Login Onboarding Skip Button"] },
+            expectedElementGetter: skipOnboardingButtonGetter,
             app: app
         )
     }
 
     public func skipOnboarding() throws -> PrologueScreen {
-        app.buttons["Login Onboarding Skip Button"].tap()
+        skipOnboardingButton.tap()
         return try PrologueScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
@@ -39,8 +39,4 @@ public final class LoginPasswordScreen: ScreenObject {
         XCTAssert(errorLabel.waitForExistence(timeout: 3))
         return self
     }
-
-    func isLoaded() -> Bool {
-        return app.buttons["Password Next Button"].exists
-    }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
@@ -4,14 +4,28 @@ import XCUITestHelpers
 
 public final class LoginPasswordScreen: ScreenObject {
 
+    private let passwordFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.secureTextFields["Password"]
+    }
+
+    private let nextButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Password Next Button"]
+    }
+
+    private let passwordErrorLabel: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["pswdErrorLabel"]
+    }
+
+    private var passwordField: XCUIElement { passwordFieldGetter(app) }
+    private var nextButton: XCUIElement { nextButtonGetter(app) }
+    private var errorLabel: XCUIElement {passwordErrorLabel(app) }
+
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-              expectedElementGetters: [
-                  // swiftlint:disable opening_brace
-                  { $0.secureTextFields["Password"] },
-                  { $0.buttons["Password Next Button"] },
-                  // swiftlint:enable opening_brace
-              ],
+            expectedElementGetters: [
+                passwordFieldGetter,
+                nextButtonGetter
+            ],
             app: app
         )
     }
@@ -23,19 +37,16 @@ public final class LoginPasswordScreen: ScreenObject {
     }
 
     func tryProceed(password: String) -> LoginPasswordScreen {
-        XCTAssert(app.secureTextFields["Password"].waitForIsHittable(timeout: 3))
-        app.secureTextFields["Password"].paste(text: password)
+        XCTAssert(passwordField.waitForIsHittable(timeout: 3))
+        passwordField.paste(text: password)
 
-        XCTAssert(app.buttons["Password Next Button"].waitForIsHittable(timeout: 3))
-        app.buttons["Password Next Button"].tap()
+        XCTAssert(nextButton.waitForIsHittable(timeout: 3))
+        nextButton.tap()
 
         return self
     }
 
     func verifyLoginError() -> LoginPasswordScreen {
-        let errorLabel = app.staticTexts["pswdErrorLabel"]
-        _ = errorLabel.waitForExistence(timeout: 2)
-
         XCTAssert(errorLabel.waitForExistence(timeout: 3))
         return self
     }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
@@ -1,52 +1,46 @@
+import ScreenObject
 import XCTest
 import XCUITestHelpers
 
-private struct ElementStringIDs {
-    static let passwordTextField = "Password"
-    static let loginButton = "Password Next Button"
-    static let errorLabel = "pswdErrorLabel"
-}
+public final class LoginPasswordScreen: ScreenObject {
 
-final class LoginPasswordScreen: BaseScreen {
-    private let passwordTextField: XCUIElement
-    private let loginButton: XCUIElement
-
-    init() {
-        passwordTextField = XCUIApplication().secureTextFields[ElementStringIDs.passwordTextField]
-        loginButton = XCUIApplication().buttons[ElementStringIDs.loginButton]
-        super.init(element: passwordTextField)
-
-        XCTAssert(passwordTextField.waitForExistence(timeout: 3))
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+              expectedElementGetters: [
+                  // swiftlint:disable opening_brace
+                  { $0.secureTextFields["Password"] },
+                  { $0.buttons["Password Next Button"] },
+                  // swiftlint:enable opening_brace
+              ],
+            app: app
+        )
     }
 
-    func proceedWith(password: String) -> LoginEpilogueScreen {
+    func proceedWith(password: String) throws -> LoginEpilogueScreen {
         _ = tryProceed(password: password)
 
-        return LoginEpilogueScreen()
+        return try LoginEpilogueScreen()
     }
 
     func tryProceed(password: String) -> LoginPasswordScreen {
-        XCTAssert(passwordTextField.waitForIsHittable(timeout: 3))
+        XCTAssert(app.secureTextFields["Password"].waitForIsHittable(timeout: 3))
+        app.secureTextFields["Password"].paste(text: password)
 
-        passwordTextField.paste(text: password)
-
-        XCTAssert(loginButton.waitForExistence(timeout: 3))
-        XCTAssert(loginButton.waitForIsHittable(timeout: 3))
-
-        loginButton.tap()
+        XCTAssert(app.buttons["Password Next Button"].waitForIsHittable(timeout: 3))
+        app.buttons["Password Next Button"].tap()
 
         return self
     }
 
     func verifyLoginError() -> LoginPasswordScreen {
-        let errorLabel = app.staticTexts[ElementStringIDs.errorLabel]
+        let errorLabel = app.staticTexts["pswdErrorLabel"]
         _ = errorLabel.waitForExistence(timeout: 2)
 
         XCTAssert(errorLabel.waitForExistence(timeout: 3))
         return self
     }
 
-    static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.loginButton].exists
+    func isLoaded() -> Bool {
+        return app.buttons["Password Next Button"].exists
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
@@ -20,8 +20,4 @@ public final class LoginSiteAddressScreen: ScreenObject {
         app.buttons["Site Address Next Button"].tap()
         return try GetStartedScreen()
     }
-
-    func isLoaded() -> Bool {
-        return app.buttons["Site Address Next Button"].exists
-    }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
@@ -3,21 +3,31 @@ import XCTest
 
 public final class LoginSiteAddressScreen: ScreenObject {
 
+    private let nextButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Site Address Next Button"]
+    }
+
+    private let siteAddressFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["Site address"]
+    }
+
+    private var nextButton: XCUIElement { nextButtonGetter(app) }
+    private var siteAddressField: XCUIElement { siteAddressFieldGetter(app) }
+
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-              expectedElementGetters: [
-                  // swiftlint:disable opening_brace
-                  { $0.buttons["Site Address Next Button"] },
-                  { $0.textFields["Site address"] }
-                  // swiftlint:enable opening_brace
-              ],
+            expectedElementGetters: [
+                nextButtonGetter,
+                siteAddressFieldGetter
+            ],
             app: app
         )
     }
 
     public func proceedWith(siteUrl: String) throws -> GetStartedScreen {
-        app.textFields["Site address"].enterText(text: siteUrl)
-        app.buttons["Site Address Next Button"].tap()
+        siteAddressField.enterText(text: siteUrl)
+        nextButton.tap()
+
         return try GetStartedScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
@@ -1,42 +1,27 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let navBar = "WordPressAuthenticator.LoginSiteAddressView"
-    static let nextButton = "Site Address Next Button"
+public final class LoginSiteAddressScreen: ScreenObject {
 
-    // TODO: clean up comments when unifiedSiteAddress is permanently enabled.
-
-    // For original Site Address. This matches accessibilityIdentifier in Login.storyboard.
-    // Leaving here for now in case unifiedSiteAddress is disabled.
-    // static let siteAddressTextField = "usernameField"
-
-    // For unified Site Address. This matches TextFieldTableViewCell.accessibilityIdentifier.
-    static let siteAddressTextField = "Site address"
-}
-
-public final class LoginSiteAddressScreen: BaseScreen {
-    private let navBar: XCUIElement
-    private let siteAddressTextField: XCUIElement
-    private let nextButton: XCUIElement
-
-    init() {
-        let app = XCUIApplication()
-        navBar = app.navigationBars[ElementStringIDs.navBar]
-        siteAddressTextField = app.textFields[ElementStringIDs.siteAddressTextField]
-        nextButton = app.buttons[ElementStringIDs.nextButton]
-
-        super.init(element: siteAddressTextField)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+              expectedElementGetters: [
+                  // swiftlint:disable opening_brace
+                  { $0.buttons["Site Address Next Button"] },
+                  { $0.textFields["Site address"] }
+                  // swiftlint:enable opening_brace
+              ],
+            app: app
+        )
     }
 
-    public func proceedWith(siteUrl: String) -> GetStartedScreen {
-        siteAddressTextField.tap()
-        siteAddressTextField.typeText(siteUrl)
-        nextButton.tap()
-
-        return GetStartedScreen()
+    public func proceedWith(siteUrl: String) throws -> GetStartedScreen {
+        app.textFields["Site address"].enterText(text: siteUrl)
+        app.buttons["Site Address Next Button"].tap()
+        return try GetStartedScreen()
     }
 
-    static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.nextButton].exists
+    func isLoaded() -> Bool {
+        return app.buttons["Site Address Next Button"].exists
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -1,39 +1,30 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let navBar = "WordPressAuthenticator.LoginSelfHostedView"
-    static let usernameTextField = "usernameField"
-    static let passwordTextField = "passwordField"
-    static let nextButton = "submitButton"
-}
+public final class LoginUsernamePasswordScreen: ScreenObject {
 
-final class LoginUsernamePasswordScreen: BaseScreen {
-    private let navBar: XCUIElement
-    private let usernameTextField: XCUIElement
-    private let passwordTextField: XCUIElement
-    private let nextButton: XCUIElement
-
-    init() {
-        let app = XCUIApplication()
-        navBar = app.navigationBars[ElementStringIDs.navBar]
-        usernameTextField = app.textFields[ElementStringIDs.usernameTextField]
-        passwordTextField = app.secureTextFields[ElementStringIDs.passwordTextField]
-        nextButton = app.buttons[ElementStringIDs.nextButton]
-
-        super.init(element: passwordTextField)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+              expectedElementGetters: [
+                  // swiftlint:disable opening_brace
+                  { $0.buttons["submitButton"] },
+                  { $0.textFields["usernameField"] },
+                  { $0.textFields["passwordField"] }
+                  // swiftlint:enable opening_brace
+              ],
+            app: app
+        )
     }
 
-    func proceedWith(username: String, password: String) -> LoginEpilogueScreen {
-        usernameTextField.tap()
-        usernameTextField.typeText(username)
-        passwordTextField.tap()
-        passwordTextField.typeText(password)
-        nextButton.tap()
+    func proceedWith(username: String, password: String) throws -> LoginEpilogueScreen {
+        app.textFields["usernameField"].enterText(text: username)
+        app.textFields["passwordField"].enterText(text: password)
+        app.buttons["submitButton"].tap()
 
-        return LoginEpilogueScreen()
+        return try LoginEpilogueScreen()
     }
 
-    static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.nextButton].exists
+    func isLoaded() -> Bool {
+        return app.buttons["submitButton"].exists
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -23,8 +23,4 @@ public final class LoginUsernamePasswordScreen: ScreenObject {
 
         return try LoginEpilogueScreen()
     }
-
-    func isLoaded() -> Bool {
-        return app.buttons["submitButton"].exists
-    }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -3,23 +3,37 @@ import XCTest
 
 public final class LoginUsernamePasswordScreen: ScreenObject {
 
+    private let submitButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["submitButton"]
+    }
+
+    private let usernameFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["usernameField"]
+    }
+
+    private let passwordFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["passwordField"]
+    }
+
+    private var submitButton: XCUIElement { submitButtonGetter(app) }
+    private var usernameField: XCUIElement { usernameFieldGetter(app) }
+    private var passwordField: XCUIElement { passwordFieldGetter(app) }
+
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-              expectedElementGetters: [
-                  // swiftlint:disable opening_brace
-                  { $0.buttons["submitButton"] },
-                  { $0.textFields["usernameField"] },
-                  { $0.textFields["passwordField"] }
-                  // swiftlint:enable opening_brace
-              ],
+            expectedElementGetters: [
+                submitButtonGetter,
+                usernameFieldGetter,
+                passwordFieldGetter
+            ],
             app: app
         )
     }
 
     func proceedWith(username: String, password: String) throws -> LoginEpilogueScreen {
-        app.textFields["usernameField"].enterText(text: username)
-        app.textFields["passwordField"].enterText(text: password)
-        app.buttons["submitButton"].tap()
+        usernameField.enterText(text: username)
+        passwordField.enterText(text: password)
+        submitButton.tap()
 
         return try LoginEpilogueScreen()
     }

--- a/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
@@ -21,7 +21,7 @@ public final class PasswordScreen: ScreenObject {
 
     public func tryProceed(password: String) throws -> PasswordScreen {
         let continueButton = app.buttons["Continue Button"]
-        
+
         app.secureTextFields["Password"].enterText(text: password)
         continueButton.tap()
         if continueButton.exists && !continueButton.isHittable {

--- a/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
@@ -1,33 +1,28 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let navBar = "WordPress.PasswordView"
-    static let passwordTextField = "Password"
-    static let continueButton = "Continue Button"
-    static let errorLabel = "Password Error"
-}
+public final class PasswordScreen: ScreenObject {
 
-public final class PasswordScreen: BaseScreen {
-    private let navBar: XCUIElement
-    private let passwordTextField: XCUIElement
-    private let continueButton: XCUIElement
-
-    init() {
-        let app = XCUIApplication()
-        navBar = app.navigationBars[ElementStringIDs.navBar]
-        passwordTextField = app.secureTextFields[ElementStringIDs.passwordTextField]
-        continueButton = app.buttons[ElementStringIDs.continueButton]
-
-        super.init(element: passwordTextField)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+              expectedElementGetters: [
+                  // swiftlint:disable opening_brace
+                  { $0.secureTextFields["Password"] },
+                  { $0.buttons["Continue Button"] },
+                  // swiftlint:enable opening_brace
+              ],
+            app: app
+        )
     }
 
-    public func proceedWith(password: String) {
-        _ = tryProceed(password: password)
+    public func proceedWith(password: String) throws {
+        _ = try tryProceed(password: password)
     }
 
-    public func tryProceed(password: String) -> PasswordScreen {
-        passwordTextField.tap()
-        passwordTextField.typeText(password)
+    public func tryProceed(password: String) throws -> PasswordScreen {
+        let continueButton = app.buttons["Continue Button"]
+        
+        app.secureTextFields["Password"].enterText(text: password)
         continueButton.tap()
         if continueButton.exists && !continueButton.isHittable {
             waitFor(element: continueButton, predicate: "isEnabled == true")
@@ -35,15 +30,15 @@ public final class PasswordScreen: BaseScreen {
         return self
     }
 
-    public func verifyLoginError() -> PasswordScreen {
-        let errorLabel = app.cells[ElementStringIDs.errorLabel]
+    public func verifyLoginError() throws -> PasswordScreen {
+        let errorLabel = app.cells["Password Error"]
         _ = errorLabel.waitForExistence(timeout: 2)
 
         XCTAssertTrue(errorLabel.exists)
         return self
     }
 
-    static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.continueButton].exists
+    func isLoaded() -> Bool {
+        return app.buttons["Continue Button"].exists
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
@@ -3,14 +3,28 @@ import XCTest
 
 public final class PasswordScreen: ScreenObject {
 
+    private let passwordFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.secureTextFields["Password"]
+    }
+
+    private let continueButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Continue Button"]
+    }
+
+    private let passwordErrorLabelGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["Password Error"]
+    }
+
+    private var passwordField: XCUIElement { passwordFieldGetter(app) }
+    private var continueButton: XCUIElement { continueButtonGetter(app) }
+    private var passwordErrorLabel: XCUIElement { passwordErrorLabelGetter(app) }
+
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-              expectedElementGetters: [
-                  // swiftlint:disable opening_brace
-                  { $0.secureTextFields["Password"] },
-                  { $0.buttons["Continue Button"] },
-                  // swiftlint:enable opening_brace
-              ],
+            expectedElementGetters: [
+                passwordFieldGetter,
+                continueButtonGetter
+            ],
             app: app
         )
     }
@@ -20,21 +34,19 @@ public final class PasswordScreen: ScreenObject {
     }
 
     public func tryProceed(password: String) throws -> PasswordScreen {
-        let continueButton = app.buttons["Continue Button"]
-
-        app.secureTextFields["Password"].enterText(text: password)
+        passwordField.enterText(text: password)
         continueButton.tap()
         if continueButton.exists && !continueButton.isHittable {
             waitFor(element: continueButton, predicate: "isEnabled == true")
         }
+
         return self
     }
 
     public func verifyLoginError() throws -> PasswordScreen {
-        let errorLabel = app.cells["Password Error"]
-        _ = errorLabel.waitForExistence(timeout: 2)
+        _ = passwordErrorLabel.waitForExistence(timeout: 2)
+        XCTAssertTrue(passwordErrorLabel.exists)
 
-        XCTAssertTrue(errorLabel.exists)
         return self
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
@@ -37,8 +37,4 @@ public final class PasswordScreen: ScreenObject {
         XCTAssertTrue(errorLabel.exists)
         return self
     }
-
-    func isLoaded() -> Bool {
-        return app.buttons["Continue Button"].exists
-    }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
@@ -10,15 +10,15 @@ public final class PrologueScreen: ScreenObject {
         )
     }
 
-    public func selectContinueWithWordPress() -> GetStartedScreen {
+    public func selectContinueWithWordPress() throws -> GetStartedScreen {
         Self.findContinueButton(in: app).tap()
-        return GetStartedScreen()
+        return try GetStartedScreen()
     }
 
-    public func selectSiteAddress() -> LoginSiteAddressScreen {
+    public func selectSiteAddress() throws -> LoginSiteAddressScreen {
         app.buttons["Prologue Self Hosted Button"].tap()
 
-        return LoginSiteAddressScreen()
+        return try LoginSiteAddressScreen()
     }
 
     @discardableResult

--- a/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
@@ -16,7 +16,10 @@ public final class PrologueScreen: ScreenObject {
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetter: continueButtonGetter,
+            expectedElementGetters: [
+                continueButtonGetter,
+                selectSiteButtonGetter
+            ],
             app: app
         )
     }

--- a/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
@@ -3,21 +3,31 @@ import XCTest
 
 public final class PrologueScreen: ScreenObject {
 
+    private let continueButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Prologue Continue Button"]
+    }
+
+    private let selectSiteButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Prologue Self Hosted Button"]
+    }
+
+    private var continueButton: XCUIElement { continueButtonGetter(app) }
+    private var selectSiteButton: XCUIElement { selectSiteButtonGetter(app) }
+
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetter: { Self.findContinueButton(in: $0) },
+            expectedElementGetter: continueButtonGetter,
             app: app
         )
     }
 
     public func selectContinueWithWordPress() throws -> GetStartedScreen {
-        Self.findContinueButton(in: app).tap()
+        continueButton.tap()
         return try GetStartedScreen()
     }
 
     public func selectSiteAddress() throws -> LoginSiteAddressScreen {
-        app.buttons["Prologue Self Hosted Button"].tap()
-
+        selectSiteButton.tap()
         return try LoginSiteAddressScreen()
     }
 
@@ -26,14 +36,8 @@ public final class PrologueScreen: ScreenObject {
         XCTAssertTrue(isLoaded)
         return self
     }
-}
 
-extension PrologueScreen {
-    static func findContinueButton(in app: XCUIApplication) -> XCUIElement {
-        app.buttons["Prologue Continue Button"]
-    }
-
-    public static func isSiteAddressLoginAvailable(in app: XCUIApplication = .init()) -> Bool {
-        app.buttons["Prologue Self Hosted Button"].waitForExistence(timeout: 1)
+    public func isSiteAddressLoginAvailable() throws -> Bool {
+        selectSiteButton.waitForExistence(timeout: 1)
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -13,7 +13,7 @@ final class LoginTests: XCTestCase {
 
     func test_site_address_login_logout() throws {
         // do not test this case for simplified login since site address login is not available
-        guard PrologueScreen.isSiteAddressLoginAvailable() else {
+        guard try PrologueScreen().isSiteAddressLoginAvailable() else {
             return
         }
         try PrologueScreen()


### PR DESCRIPTION
## Description
Some of the screens on WCiOS are still subclasses of `BaseScreen` instead of `ScreenObject`, this can sometimes lead to confusion, especially for someone unfamiliar with the codebase. This PR converts all `BaseScreen` references in login-related screens to `ScreenObject`. 

This is similar to the effort done by @mokagio [last year on WPiOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/17641). There will be a follow-up PR to remove all other references to `BaseScreen`.

## Testing instructions
All UI Tests should still pass in the CI
