### PR TITLE
[REST API] Add enum to handle WPCOM and WPOrg types of authentication. 

### DIFF
--- a/Networking/Networking/Requests/AuthenticatedRequest.swift
+++ b/Networking/Networking/Requests/AuthenticatedRequest.swift
@@ -21,7 +21,7 @@ struct AuthenticatedRequest: URLRequestConvertible {
     /// Returns the Wrapped Request, but with a WordPress.com Bearer Token set up.
     ///
     func asURLRequest() throws -> URLRequest {
-        guard let authToken = credentials.authToken else {
+        guard case let .wpcom(username: _, authToken: authToken, siteAddress: _) = credentials else {
             throw AuthenticatedRequestError.invalidCredentials
         }
 

--- a/Networking/Networking/Requests/AuthenticatedRequest.swift
+++ b/Networking/Networking/Requests/AuthenticatedRequest.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Alamofire
 
+enum AuthenticatedRequestError: Error {
+    case invalidCredentials
+}
 
 /// Wraps up a URLRequestConvertible Instance, and injects the Credentials + `Settings.userAgent` whenever the actual Request is required.
 ///
@@ -18,9 +21,13 @@ struct AuthenticatedRequest: URLRequestConvertible {
     /// Returns the Wrapped Request, but with a WordPress.com Bearer Token set up.
     ///
     func asURLRequest() throws -> URLRequest {
+        guard let authToken = credentials.authToken else {
+            throw AuthenticatedRequestError.invalidCredentials
+        }
+
         var authenticated = try request.asURLRequest()
 
-        authenticated.setValue("Bearer " + credentials.authToken, forHTTPHeaderField: "Authorization")
+        authenticated.setValue("Bearer " + authToken, forHTTPHeaderField: "Authorization")
         authenticated.setValue("application/json", forHTTPHeaderField: "Accept")
         authenticated.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
 

--- a/Networking/Networking/Requests/AuthenticatedRequest.swift
+++ b/Networking/Networking/Requests/AuthenticatedRequest.swift
@@ -21,7 +21,7 @@ struct AuthenticatedRequest: URLRequestConvertible {
     /// Returns the Wrapped Request, but with a WordPress.com Bearer Token set up.
     ///
     func asURLRequest() throws -> URLRequest {
-        guard case let .wpcom(username: _, authToken: authToken, siteAddress: _) = credentials else {
+        guard case let .wpcom(_, authToken, _) = credentials else {
             throw AuthenticatedRequestError.invalidCredentials
         }
 

--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -16,17 +16,21 @@ public struct Credentials: Equatable {
         case wporg(password: String)
     }
 
+    /// Authentication type
+    ///
+    public let authenticationType: AuthenticationType
+
     /// WordPress.com Username
     ///
     public let username: String
 
-    /// WordPress.com Authentication Token
-    ///
-    public let authToken: String
-
     /// Site Address
     ///
     public let siteAddress: String
+
+    /// WordPress.com Authentication Token
+    ///
+    public let authToken: String
 
     /// Designated Initializer
     ///
@@ -34,6 +38,7 @@ public struct Credentials: Equatable {
         self.username = username
         self.authToken = authToken
         self.siteAddress = siteAddress ?? Constants.placeholderSiteAddress
+        self.authenticationType = .wpcom(authToken: authToken)
     }
 
     /// Convenience initializer. Assigns a UUID as a placeholder for the username.

--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -45,6 +45,14 @@ public struct Credentials: Equatable {
         self.authenticationType = .wpcom(authToken: authToken)
     }
 
+    /// For WPOrg credentials
+    ///
+    public init(username: String, password: String, siteAddress: String) {
+        self.username = username
+        self.siteAddress = siteAddress
+        self.authenticationType = .wporg(password: password)
+    }
+
     /// Convenience initializer. Assigns a UUID as a placeholder for the username.
     ///
     public init(authToken: String) {

--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -33,17 +33,18 @@ public enum Credentials: Equatable {
     /// Returns true if the username is a UUID placeholder.
     ///
     public func hasPlaceholderUsername() -> Bool {
+        // Only WPCOM credentials will have placeholder `username`
         guard case let .wpcom(username, _, _) = self else {
             return false
         }
-
         return UUID(uuidString: username) != nil
     }
 
     /// Returns true if the siteAddress is a placeholder.
     ///
     public func hasPlaceholderSiteAddress() -> Bool {
-        guard case let .wporg(_, _, siteAddress) = self else {
+        // Only WPCOM credentials will have placeholder `siteAddress`
+        guard case let .wpcom(_, _, siteAddress) = self else {
             return false
         }
         return siteAddress == Constants.placeholderSiteAddress

--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -37,7 +37,16 @@ public struct Credentials: Equatable {
         return authToken
     }
 
-    /// Designated Initializer
+    /// .org site credentials password
+    ///
+    public var password: String? {
+        guard case let .wporg(password) = authenticationType else {
+            return nil
+        }
+        return password
+    }
+
+    /// For WPCOM credentials
     ///
     public init(username: String, authToken: String, siteAddress: String? = nil) {
         self.username = username

--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -2,64 +2,27 @@ import Foundation
 
 /// Authenticated Requests Credentials
 ///
-public struct Credentials: Equatable {
+public enum Credentials: Equatable {
 
-    /// Type of authentication wpcom/wporg
+    /// For WordPress.com credentials
     ///
-    public enum AuthenticationType: Equatable {
-        /// Holds WordPress.com Authentication Token
-        ///
-        case wpcom(authToken: String)
+    case wpcom(username: String, authToken: String, siteAddress: String)
 
-        /// Holds .org site credentials password
-        ///
-        case wporg(password: String)
-    }
-
-    /// Authentication type
+    /// For .org site credentials password
     ///
-    public let authenticationType: AuthenticationType
-
-    /// WordPress.com Username
     ///
-    public let username: String
-
-    /// Site Address
-    ///
-    public let siteAddress: String
-
-    /// WordPress.com Authentication Token
-    ///
-    public var authToken: String? {
-        guard case let .wpcom(authToken) = authenticationType else {
-            return nil
-        }
-        return authToken
-    }
-
-    /// .org site credentials password
-    ///
-    public var password: String? {
-        guard case let .wporg(password) = authenticationType else {
-            return nil
-        }
-        return password
-    }
+    case wporg(username: String, password: String, siteAddress: String)
 
     /// For WPCOM credentials
     ///
     public init(username: String, authToken: String, siteAddress: String? = nil) {
-        self.username = username
-        self.siteAddress = siteAddress ?? Constants.placeholderSiteAddress
-        self.authenticationType = .wpcom(authToken: authToken)
+        self = .wpcom(username: username, authToken: authToken, siteAddress: siteAddress ?? Constants.placeholderSiteAddress)
     }
 
     /// For WPOrg credentials
     ///
     public init(username: String, password: String, siteAddress: String) {
-        self.username = username
-        self.siteAddress = siteAddress
-        self.authenticationType = .wporg(password: password)
+        self = .wporg(username: username, password: password, siteAddress: siteAddress)
     }
 
     /// Convenience initializer. Assigns a UUID as a placeholder for the username.
@@ -71,12 +34,19 @@ public struct Credentials: Equatable {
     /// Returns true if the username is a UUID placeholder.
     ///
     public func hasPlaceholderUsername() -> Bool {
+        guard case let .wpcom(username, _, _) = self else {
+            return false
+        }
+
         return UUID(uuidString: username) != nil
     }
 
     /// Returns true if the siteAddress is a placeholder.
     ///
     public func hasPlaceholderSiteAddress() -> Bool {
+        guard case let .wporg(_, _, siteAddress) = self else {
+            return false
+        }
         return siteAddress == Constants.placeholderSiteAddress
     }
 }

--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -1,9 +1,20 @@
 import Foundation
 
-
 /// Authenticated Requests Credentials
 ///
 public struct Credentials: Equatable {
+
+    /// Type of authentication wpcom/wporg
+    ///
+    public enum AuthenticationType: Equatable {
+        /// Holds WordPress.com Authentication Token
+        ///
+        case wpcom(authToken: String)
+
+        /// Holds .org site credentials password
+        ///
+        case wporg(password: String)
+    }
 
     /// WordPress.com Username
     ///
@@ -16,7 +27,6 @@ public struct Credentials: Equatable {
     /// Site Address
     ///
     public let siteAddress: String
-
 
     /// Designated Initializer
     ///

--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -8,8 +8,7 @@ public enum Credentials: Equatable {
     ///
     case wpcom(username: String, authToken: String, siteAddress: String)
 
-    /// For .org site credentials password
-    ///
+    /// For .org site credentials
     ///
     case wporg(username: String, password: String, siteAddress: String)
 

--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -33,13 +33,20 @@ public enum Credentials: Equatable {
     /// Returns true if the username is a UUID placeholder.
     ///
     public func hasPlaceholderUsername() -> Bool {
-        UUID(uuidString: username) != nil
+        guard case let .wpcom(username, _, _) = self else {
+            return false
+        }
+
+        return UUID(uuidString: username) != nil
     }
 
     /// Returns true if the siteAddress is a placeholder.
     ///
     public func hasPlaceholderSiteAddress() -> Bool {
-        siteAddress == Constants.placeholderSiteAddress
+        guard case let .wporg(_, _, siteAddress) = self else {
+            return false
+        }
+        return siteAddress == Constants.placeholderSiteAddress
     }
 }
 

--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -55,3 +55,34 @@ private extension Credentials {
         static let placeholderSiteAddress = "https://wordpress.com"
     }
 }
+
+// MARK: - Helpers to read `Credentials`
+//
+public extension Credentials {
+    var username: String {
+        switch self {
+        case .wpcom(let username, _, _):
+            return username
+        case .wporg(let username, _, _):
+            return username
+        }
+    }
+
+    var siteAddress: String {
+        switch self {
+        case .wpcom(_, _, let siteAddress):
+            return siteAddress
+        case .wporg(_, _, let siteAddress):
+            return siteAddress
+        }
+    }
+
+    var secret: String {
+        switch self {
+        case .wpcom(_, let authToken, _):
+            return authToken
+        case .wporg(_, let password, _):
+            return password
+        }
+    }
+}

--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -30,13 +30,17 @@ public struct Credentials: Equatable {
 
     /// WordPress.com Authentication Token
     ///
-    public let authToken: String
+    public var authToken: String? {
+        guard case let .wpcom(authToken) = authenticationType else {
+            return nil
+        }
+        return authToken
+    }
 
     /// Designated Initializer
     ///
     public init(username: String, authToken: String, siteAddress: String? = nil) {
         self.username = username
-        self.authToken = authToken
         self.siteAddress = siteAddress ?? Constants.placeholderSiteAddress
         self.authenticationType = .wpcom(authToken: authToken)
     }

--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -33,20 +33,13 @@ public enum Credentials: Equatable {
     /// Returns true if the username is a UUID placeholder.
     ///
     public func hasPlaceholderUsername() -> Bool {
-        guard case let .wpcom(username, _, _) = self else {
-            return false
-        }
-
-        return UUID(uuidString: username) != nil
+        UUID(uuidString: username) != nil
     }
 
     /// Returns true if the siteAddress is a placeholder.
     ///
     public func hasPlaceholderSiteAddress() -> Bool {
-        guard case let .wporg(_, _, siteAddress) = self else {
-            return false
-        }
-        return siteAddress == Constants.placeholderSiteAddress
+        siteAddress == Constants.placeholderSiteAddress
     }
 }
 

--- a/Networking/NetworkingTests/Requests/AuthenticatedRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/AuthenticatedRequestTests.swift
@@ -18,14 +18,16 @@ class AuthenticatedRequestTests: XCTestCase {
 
     /// Verifies that the Bearer Token is injected, as part of the HTTP Headers.
     ///
-    func test_bearer_token_is_injected_as_request_header() {
+    func test_bearer_token_is_injected_as_request_header() throws {
         XCTAssertEqual(unauthenticatedRequest.allHTTPHeaderFields, [:])
 
         let authenticated = AuthenticatedRequest(credentials: credentials, request: unauthenticatedRequest)
         let output = try! authenticated.asURLRequest()
 
+        let authToken = try XCTUnwrap(credentials.authToken)
+
         let generated = output.allHTTPHeaderFields?["Authorization"]
-        let expected = "Bearer \(credentials.authToken)"
+        let expected = "Bearer \(authToken)"
         XCTAssertEqual(generated, expected)
     }
 

--- a/Networking/NetworkingTests/Requests/AuthenticatedRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/AuthenticatedRequestTests.swift
@@ -18,7 +18,7 @@ class AuthenticatedRequestTests: XCTestCase {
 
     /// Verifies that the Bearer Token is injected, as part of the HTTP Headers.
     ///
-    func test_bearer_token_is_injected_as_request_header() throws {
+    func test_bearer_token_is_injected_as_request_header() {
         XCTAssertEqual(unauthenticatedRequest.allHTTPHeaderFields, [:])
 
         let authenticated = AuthenticatedRequest(credentials: credentials, request: unauthenticatedRequest)

--- a/Networking/NetworkingTests/Requests/AuthenticatedRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/AuthenticatedRequestTests.swift
@@ -24,7 +24,7 @@ class AuthenticatedRequestTests: XCTestCase {
         let authenticated = AuthenticatedRequest(credentials: credentials, request: unauthenticatedRequest)
         let output = try! authenticated.asURLRequest()
 
-        guard case let .wpcom(username: _, authToken: authToken, siteAddress: _) = credentials else {
+        guard case let .wpcom(_, authToken, _) = credentials else {
             XCTFail("Missing credentials.")
             return
         }

--- a/Networking/NetworkingTests/Requests/AuthenticatedRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/AuthenticatedRequestTests.swift
@@ -24,7 +24,10 @@ class AuthenticatedRequestTests: XCTestCase {
         let authenticated = AuthenticatedRequest(credentials: credentials, request: unauthenticatedRequest)
         let output = try! authenticated.asURLRequest()
 
-        let authToken = try XCTUnwrap(credentials.authToken)
+        guard case let .wpcom(username: _, authToken: authToken, siteAddress: _) = credentials else {
+            XCTFail("Missing credentials.")
+            return
+        }
 
         let generated = output.allHTTPHeaderFields?["Authorization"]
         let expected = "Bearer \(authToken)"

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -66,27 +66,27 @@ private extension TracksProvider {
         let currentAnalyticsUsername = UserDefaults.standard[.analyticsUsername] as? String ?? ""
         let anonymousID = ServiceLocator.stores.sessionManager.anonymousUserID
         if ServiceLocator.stores.isAuthenticated,
-            let account = ServiceLocator.stores.sessionManager.defaultAccount,
-            let credentials = ServiceLocator.stores.sessionManager.defaultCredentials {
+           let account = ServiceLocator.stores.sessionManager.defaultAccount,
+           case let .wpcom(username: _, authToken: authToken, siteAddress: _) = ServiceLocator.stores.sessionManager.defaultCredentials {
             if currentAnalyticsUsername.isEmpty {
                 // No previous username logged
                 UserDefaults.standard[.analyticsUsername] = account.username
                 tracksService.switchToAuthenticatedUser(withUsername: account.username,
                                                         userID: String(account.userID),
-                                                        wpComToken: credentials.authToken,
+                                                        wpComToken: authToken,
                                                         skipAliasEventCreation: false)
             } else if currentAnalyticsUsername == account.username {
                 // Username did not change - just make sure Tracks client has it
                 tracksService.switchToAuthenticatedUser(withUsername: account.username,
                                                         userID: String(account.userID),
-                                                        wpComToken: credentials.authToken,
+                                                        wpComToken: authToken,
                                                         skipAliasEventCreation: true)
             } else {
                 // Username changed for some reason - switch back to anonymous first
                 tracksService.switchToAnonymousUser(withAnonymousID: anonymousID)
                 tracksService.switchToAuthenticatedUser(withUsername: account.username,
                                                         userID: String(account.userID),
-                                                        wpComToken: credentials.authToken,
+                                                        wpComToken: authToken,
                                                         skipAliasEventCreation: false)
             }
         } else {

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -67,7 +67,7 @@ private extension TracksProvider {
         let anonymousID = ServiceLocator.stores.sessionManager.anonymousUserID
         if ServiceLocator.stores.isAuthenticated,
            let account = ServiceLocator.stores.sessionManager.defaultAccount,
-           case let .wpcom(username: _, authToken: authToken, siteAddress: _) = ServiceLocator.stores.sessionManager.defaultCredentials {
+           case let .wpcom(_, authToken, _) = ServiceLocator.stores.sessionManager.defaultCredentials {
             if currentAnalyticsUsername.isEmpty {
                 // No previous username logged
                 UserDefaults.standard[.analyticsUsername] = account.username

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -455,9 +455,9 @@ private extension StorePickerViewController {
         }
 
         // If a site address was passed in credentials, select it
-        if let siteAddress = ServiceLocator.stores.sessionManager.defaultCredentials?.siteAddress,
+        if case let .wpcom(username: _, authToken: _, siteAddress: siteAddress) = ServiceLocator.stores.sessionManager.defaultCredentials,
            let site = sites.filter({ $0.url == siteAddress }).first,
-            site.isWooCommerceActive {
+           site.isWooCommerceActive {
             currentlySelectedSite = site
             return
         }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -455,7 +455,7 @@ private extension StorePickerViewController {
         }
 
         // If a site address was passed in credentials, select it
-        if case let .wpcom(username: _, authToken: _, siteAddress: siteAddress) = ServiceLocator.stores.sessionManager.defaultCredentials,
+        if case let .wpcom(_, _, siteAddress) = ServiceLocator.stores.sessionManager.defaultCredentials,
            let site = sites.filter({ $0.url == siteAddress }).first,
            site.isWooCommerceActive {
             currentlySelectedSite = site

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -6,6 +6,7 @@ import Foundation
 //
 extension UserDefaults {
     enum Key: String {
+        case defaultCredentialsType
         case defaultAccountID
         case defaultUsername
         case defaultSiteAddress

--- a/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
+++ b/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
@@ -37,7 +37,7 @@ extension WKWebView {
     }
 
     private func authenticatedPostData(with credentials: Credentials?, redirectTo url: URL) throws -> URLRequest {
-        guard case let .wpcom(username: username, authToken: token, siteAddress: _) = credentials else {
+        guard case let .wpcom(username, token, _) = credentials else {
             return URLRequest(url: url)
         }
 

--- a/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
+++ b/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
@@ -2,7 +2,7 @@ import Alamofire
 import Foundation
 import WebKit
 import struct WordPressAuthenticator.WordPressOrgCredentials
-import struct Yosemite.Credentials
+import enum Yosemite.Credentials
 import class Networking.UserAgent
 
 /// An extension to authenticate WPCom automatically
@@ -37,8 +37,7 @@ extension WKWebView {
     }
 
     private func authenticatedPostData(with credentials: Credentials?, redirectTo url: URL) throws -> URLRequest {
-        guard let username = credentials?.username,
-              let token = credentials?.authToken else {
+        guard case let .wpcom(username: username, authToken: token, siteAddress: _) = credentials else {
             return URLRequest(url: url)
         }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -182,6 +182,11 @@ private extension SessionManager {
             return nil
         }
 
+        // To cover the case of previous versions which don't have the credential type stored in user defaults
+        guard let defaultCredentialsType = defaults[.defaultCredentialsType] as? String else {
+            return Credentials(username: username, authToken: secret, siteAddress: siteAddress)
+        }
+
         guard let identifier = AuthenticationTypeIdentifier(rawValue: defaultCredentialsType) else {
             return nil
         }

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -177,12 +177,21 @@ private extension SessionManager {
     ///
     func loadCredentials() -> Credentials? {
         guard let username = defaults[.defaultUsername] as? String,
-            let authToken = keychain[username],
-            let siteAddress = defaults[.defaultSiteAddress] as? String else {
+              let secret = keychain[username],
+              let siteAddress = defaults[.defaultSiteAddress] as? String else {
             return nil
         }
 
-        return Credentials(username: username, authToken: authToken, siteAddress: siteAddress)
+        guard let identifier = AuthenticationTypeIdentifier(rawValue: defaultCredentialsType) else {
+            return nil
+        }
+
+        switch identifier {
+        case .wpcom:
+            return Credentials(username: username, authToken: secret, siteAddress: siteAddress)
+        case .wporg:
+            return Credentials(username: username, password: secret, siteAddress: siteAddress)
+        }
     }
 
     /// Persists the Credentials's authToken in the keychain, and username in User Settings.

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -221,8 +221,8 @@ private extension SessionManager {
     }
 }
 
-/// MARK: - Helpers to read `Credentials`
-///
+// MARK: - Helpers to read `Credentials`
+//
 private extension Credentials {
     var username: String {
         switch self {

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -184,7 +184,7 @@ private extension SessionManager {
 
         // To cover the case of previous versions which don't have the credential type stored in user defaults
         guard let defaultCredentialsType = defaults[.defaultCredentialsType] as? String else {
-            return Credentials(username: username, authToken: secret, siteAddress: siteAddress)
+            return .wpcom(username: username, authToken: secret, siteAddress: siteAddress)
         }
 
         guard let identifier = AuthenticationTypeIdentifier(rawValue: defaultCredentialsType) else {
@@ -193,9 +193,9 @@ private extension SessionManager {
 
         switch identifier {
         case .wpcom:
-            return Credentials(username: username, authToken: secret, siteAddress: siteAddress)
+            return .wpcom(username: username, authToken: secret, siteAddress: siteAddress)
         case .wporg:
-            return Credentials(username: username, password: secret, siteAddress: siteAddress)
+            return .wporg(username: username, password: secret, siteAddress: siteAddress)
         }
     }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -205,7 +205,7 @@ private extension SessionManager {
         defaults[.defaultUsername] = credentials.username
         defaults[.defaultSiteAddress] = credentials.siteAddress
         defaults[.defaultCredentialsType] = AuthenticationTypeIdentifier(type: credentials.authenticationType).rawValue
-        keychain[credentials.username] = credentials.authToken
+        keychain[credentials.username] = credentials.authToken ?? credentials.password
     }
 
     /// Nukes both, the AuthToken and Default Username.

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -204,7 +204,7 @@ private extension SessionManager {
     func saveCredentials(_ credentials: Credentials) {
         defaults[.defaultUsername] = credentials.username
         defaults[.defaultSiteAddress] = credentials.siteAddress
-        defaults[.defaultCredentialsType] = AuthenticationTypeIdentifier(type: credentials.authenticationType)
+        defaults[.defaultCredentialsType] = AuthenticationTypeIdentifier(type: credentials.authenticationType).rawValue
         keychain[credentials.username] = credentials.authToken
     }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -190,6 +190,7 @@ private extension SessionManager {
     func saveCredentials(_ credentials: Credentials) {
         defaults[.defaultUsername] = credentials.username
         defaults[.defaultSiteAddress] = credentials.siteAddress
+        defaults[.defaultCredentialsType] = AuthenticationTypeIdentifier(type: credentials.authenticationType)
         keychain[credentials.username] = credentials.authToken
     }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -163,7 +163,7 @@ private extension SessionManager {
         case wpcom = "AuthenticationType.wpcom"
         case wporg = "AuthenticationType.wporg"
 
-        init(type: Credentials.AuthenticationType) {
+        init(type: Credentials) {
             switch type {
             case .wpcom:
                 self = AuthenticationTypeIdentifier.wpcom
@@ -204,8 +204,8 @@ private extension SessionManager {
     func saveCredentials(_ credentials: Credentials) {
         defaults[.defaultUsername] = credentials.username
         defaults[.defaultSiteAddress] = credentials.siteAddress
-        defaults[.defaultCredentialsType] = AuthenticationTypeIdentifier(type: credentials.authenticationType).rawValue
-        keychain[credentials.username] = credentials.authToken ?? credentials.password
+        defaults[.defaultCredentialsType] = AuthenticationTypeIdentifier(type: credentials).rawValue
+        keychain[credentials.username] = credentials.secret
     }
 
     /// Nukes both, the AuthToken and Default Username.
@@ -218,5 +218,36 @@ private extension SessionManager {
         keychain[username] = nil
         defaults[.defaultUsername] = nil
         defaults[.defaultCredentialsType] = nil
+    }
+}
+
+/// MARK: - Helpers to read `Credentials`
+///
+private extension Credentials {
+    var username: String {
+        switch self {
+        case .wpcom(username: let username, authToken: _, siteAddress: _):
+            return username
+        case .wporg(username: let username, password: _, siteAddress: _):
+            return username
+        }
+    }
+
+    var siteAddress: String {
+        switch self {
+        case .wpcom(username: _, authToken: _, siteAddress: let siteAddress):
+            return siteAddress
+        case .wporg(username: _, password: _, siteAddress: let siteAddress):
+            return siteAddress
+        }
+    }
+
+    var secret: String {
+        switch self {
+        case .wpcom(username: _, authToken: let authToken, siteAddress: _):
+            return authToken
+        case .wporg(username: _, password: let password, siteAddress: _):
+            return password
+        }
     }
 }

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -159,6 +159,19 @@ final class SessionManager: SessionManagerProtocol {
 // MARK: - Private Methods
 //
 private extension SessionManager {
+    enum AuthenticationTypeIdentifier: String {
+        case wpcom = "AuthenticationType.wpcom"
+        case wporg = "AuthenticationType.wporg"
+
+        init(type: Credentials.AuthenticationType) {
+            switch type {
+            case .wpcom:
+                self = AuthenticationTypeIdentifier.wpcom
+            case .wporg:
+                self = AuthenticationTypeIdentifier.wporg
+            }
+        }
+    }
 
     /// Returns the Default Credentials, if any.
     ///

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -220,34 +220,3 @@ private extension SessionManager {
         defaults[.defaultCredentialsType] = nil
     }
 }
-
-// MARK: - Helpers to read `Credentials`
-//
-private extension Credentials {
-    var username: String {
-        switch self {
-        case .wpcom(username: let username, authToken: _, siteAddress: _):
-            return username
-        case .wporg(username: let username, password: _, siteAddress: _):
-            return username
-        }
-    }
-
-    var siteAddress: String {
-        switch self {
-        case .wpcom(username: _, authToken: _, siteAddress: let siteAddress):
-            return siteAddress
-        case .wporg(username: _, password: _, siteAddress: let siteAddress):
-            return siteAddress
-        }
-    }
-
-    var secret: String {
-        switch self {
-        case .wpcom(username: _, authToken: let authToken, siteAddress: _):
-            return authToken
-        case .wporg(username: _, password: let password, siteAddress: _):
-            return password
-        }
-    }
-}

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -212,5 +212,6 @@ private extension SessionManager {
 
         keychain[username] = nil
         defaults[.defaultUsername] = nil
+        defaults[.defaultCredentialsType] = nil
     }
 }

--- a/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
@@ -1,7 +1,7 @@
 import Combine
 import Foundation
 import struct Yosemite.CreateAccountResult
-import struct Yosemite.Credentials
+import enum Yosemite.Credentials
 import enum Yosemite.AccountAction
 import enum Yosemite.AccountCreationAction
 import enum Yosemite.CreateAccountError

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
@@ -50,8 +50,7 @@ struct AuthenticatedWebView: UIViewRepresentable {
     }
 
     private func authenticatedPostData() throws -> URLRequest {
-        guard let username = credentials?.username,
-              let token = credentials?.authToken else {
+        guard case let .wpcom(username: username, authToken: token, siteAddress: _) = credentials else {
             return URLRequest(url: url)
         }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
@@ -50,7 +50,7 @@ struct AuthenticatedWebView: UIViewRepresentable {
     }
 
     private func authenticatedPostData() throws -> URLRequest {
-        guard case let .wpcom(username: username, authToken: token, siteAddress: _) = credentials else {
+        guard case let .wpcom(username, token, _) = credentials else {
             return URLRequest(url: url)
         }
 

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -26,8 +26,7 @@ class AuthenticatedState: StoresManagerState {
         let storageManager = ServiceLocator.storageManager
         let network = AlamofireNetwork(credentials: credentials)
 
-        services = [
-            AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: credentials.authToken),
+        var services: [ActionsProcessor] = [
             AppSettingsStore(dispatcher: dispatcher,
                              storageManager: storageManager,
                              fileStorage: PListFileStorage(),
@@ -89,6 +88,15 @@ class AuthenticatedState: StoresManagerState {
                                fileStorage: PListFileStorage()),
             JetpackConnectionStore(dispatcher: dispatcher)
         ]
+
+
+        if let authToken = credentials.authToken {
+            services.append(AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: authToken))
+        } else {
+            DDLogInfo("No WordPress.com auth token found. AccountStore is not initialized.")
+        }
+
+        self.services = services
 
         startListeningToNotifications()
     }

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -90,7 +90,7 @@ class AuthenticatedState: StoresManagerState {
         ]
 
 
-        if let authToken = credentials.authToken {
+        if case let .wpcom(username: _, authToken: authToken, siteAddress: _) = credentials {
             services.append(AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: authToken))
         } else {
             DDLogInfo("No WordPress.com auth token found. AccountStore is not initialized.")

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -90,7 +90,7 @@ class AuthenticatedState: StoresManagerState {
         ]
 
 
-        if case let .wpcom(username: _, authToken: authToken, siteAddress: _) = credentials {
+        if case let .wpcom(_, authToken, _) = credentials {
             services.append(AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: authToken))
         } else {
             DDLogInfo("No WordPress.com auth token found. AccountStore is not initialized.")

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -294,11 +294,11 @@ private extension DefaultStoresManager {
     func replaceTempCredentialsIfNecessary(account: Account) {
         guard
             let credentials = sessionManager.defaultCredentials,
-            let authToken = credentials.authToken,
+            case let .wpcom(username: _, authToken: authToken, siteAddress: siteAddress) = credentials,
             credentials.hasPlaceholderUsername() else {
-                return
+            return
         }
-        authenticate(credentials: .init(username: account.username, authToken: authToken, siteAddress: credentials.siteAddress))
+        authenticate(credentials: .init(username: account.username, authToken: authToken, siteAddress: siteAddress))
     }
 
     /// Synchronizes the WordPress.com Sites, associated with the current credentials.
@@ -507,7 +507,9 @@ private extension DefaultStoresManager {
     ///
     func updateAndReloadWidgetInformation(with siteID: Int64?) {
         // Token to fire network requests
-        keychain.currentAuthToken = sessionManager.defaultCredentials?.authToken
+        if case let .wpcom(username: _, authToken: authToken, siteAddress: _) = sessionManager.defaultCredentials {
+            keychain.currentAuthToken = authToken
+        }
 
         // Non-critical store info
         UserDefaults.group?[.defaultStoreID] = siteID

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -294,10 +294,11 @@ private extension DefaultStoresManager {
     func replaceTempCredentialsIfNecessary(account: Account) {
         guard
             let credentials = sessionManager.defaultCredentials,
+            let authToken = credentials.authToken,
             credentials.hasPlaceholderUsername() else {
                 return
         }
-        authenticate(credentials: .init(username: account.username, authToken: credentials.authToken, siteAddress: credentials.siteAddress))
+        authenticate(credentials: .init(username: account.username, authToken: authToken, siteAddress: credentials.siteAddress))
     }
 
     /// Synchronizes the WordPress.com Sites, associated with the current credentials.

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -294,7 +294,7 @@ private extension DefaultStoresManager {
     func replaceTempCredentialsIfNecessary(account: Account) {
         guard
             let credentials = sessionManager.defaultCredentials,
-            case let .wpcom(_, authToken, siteAddress) = credentials,
+            case let .wpcom(_, authToken, siteAddress) = credentials, // Only WPCOM creds have placeholder `username`. WPOrg creds have user entered `username`
             credentials.hasPlaceholderUsername() else {
             return
         }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -294,7 +294,7 @@ private extension DefaultStoresManager {
     func replaceTempCredentialsIfNecessary(account: Account) {
         guard
             let credentials = sessionManager.defaultCredentials,
-            case let .wpcom(username: _, authToken: authToken, siteAddress: siteAddress) = credentials,
+            case let .wpcom(_, authToken, siteAddress) = credentials,
             credentials.hasPlaceholderUsername() else {
             return
         }
@@ -507,7 +507,7 @@ private extension DefaultStoresManager {
     ///
     func updateAndReloadWidgetInformation(with siteID: Int64?) {
         // Token to fire network requests
-        if case let .wpcom(username: _, authToken: authToken, siteAddress: _) = sessionManager.defaultCredentials {
+        if case let .wpcom(_, authToken, _) = sessionManager.defaultCredentials {
             keychain.currentAuthToken = authToken
         }
 

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -40,8 +40,8 @@ class SessionManagerTests: XCTestCase {
         manager.defaultCredentials = Settings.credentials2
 
         let retrieved = manager.defaultCredentials
-        XCTAssertEqual(retrieved?.password, Settings.credentials1.authToken)
-        XCTAssertEqual(retrieved?.username, Settings.credentials1.username)
+        XCTAssertEqual(retrieved?.password, Settings.credentials2.password)
+        XCTAssertEqual(retrieved?.username, Settings.credentials2.username)
     }
 
     /// Verifies that `removeDefaultCredentials` effectively nukes everything from the keychain

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -30,7 +30,7 @@ class SessionManagerTests: XCTestCase {
         // Given
         manager.defaultCredentials = Settings.wpcomCredentials
 
-        guard case let .wpcom(username: username, authToken: authToken, siteAddress: siteAddress) = manager.defaultCredentials else {
+        guard case let .wpcom(username, authToken, siteAddress) = manager.defaultCredentials else {
             XCTFail("Missing credentials.")
             return
         }

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -27,27 +27,35 @@ class SessionManagerTests: XCTestCase {
     /// Verifies that `loadDefaultCredentials` effectively returns the last stored credentials
     ///
     func testDefaultCredentialsAreProperlyPersistedForWPCOM() {
-        manager.defaultCredentials = Settings.credentials1
+        manager.defaultCredentials = Settings.wpcomCredentials
 
-        let retrieved = manager.defaultCredentials
-        XCTAssertEqual(retrieved?.authToken, Settings.credentials1.authToken)
-        XCTAssertEqual(retrieved?.username, Settings.credentials1.username)
+        guard case let .wpcom(username: username, authToken: authToken, siteAddress: siteAddress) = manager.defaultCredentials else {
+            XCTFail("Missing credentials.")
+            return
+        }
+
+        let retrieved = Credentials(username: username, authToken: authToken, siteAddress: siteAddress)
+        XCTAssertEqual(retrieved, Settings.wpcomCredentials)
     }
 
     /// Verifies that `loadDefaultCredentials` effectively returns the last stored credentials
     ///
     func testDefaultCredentialsAreProperlyPersistedForWPOrg() {
-        manager.defaultCredentials = Settings.credentials2
+        manager.defaultCredentials = Settings.wporgCredentials
 
-        let retrieved = manager.defaultCredentials
-        XCTAssertEqual(retrieved?.password, Settings.credentials2.password)
-        XCTAssertEqual(retrieved?.username, Settings.credentials2.username)
+        guard case let .wporg(username: username, password: password, siteAddress: siteAddress) = manager.defaultCredentials else {
+            XCTFail("Missing credentials.")
+            return
+        }
+
+        let retrieved = Credentials(username: username, password: password, siteAddress: siteAddress)
+        XCTAssertEqual(retrieved, Settings.wporgCredentials)
     }
 
     /// Verifies that `removeDefaultCredentials` effectively nukes everything from the keychain
     ///
     func testDefaultCredentialsAreEffectivelyNuked() {
-        manager.defaultCredentials = Settings.credentials1
+        manager.defaultCredentials = Settings.wpcomCredentials
         manager.defaultCredentials = nil
 
         XCTAssertNil(manager.defaultCredentials)
@@ -56,11 +64,11 @@ class SessionManagerTests: XCTestCase {
     /// Verifies that `saveDefaultCredentials` overrides previous stored credentials
     ///
     func testDefaultCredentialsCanBeUpdated() {
-        manager.defaultCredentials = Settings.credentials1
-        XCTAssertEqual(manager.defaultCredentials, Settings.credentials1)
+        manager.defaultCredentials = Settings.wpcomCredentials
+        XCTAssertEqual(manager.defaultCredentials, Settings.wpcomCredentials)
 
-        manager.defaultCredentials = Settings.credentials2
-        XCTAssertEqual(manager.defaultCredentials, Settings.credentials2)
+        manager.defaultCredentials = Settings.wporgCredentials
+        XCTAssertEqual(manager.defaultCredentials, Settings.wporgCredentials)
     }
 
     /// Verifies that WPCOM credentials are returned for already installed and logged in versions which don't have type stored in user defaults
@@ -81,7 +89,7 @@ class SessionManagerTests: XCTestCase {
         XCTAssertNil(defaults[UserDefaults.Key.defaultCredentialsType])
 
         let sut = SessionManager(defaults: defaults, keychainServiceName: keychainServiceName)
-        XCTAssertEqual(sut.defaultCredentials, Settings.credentials1)
+        XCTAssertEqual(sut.defaultCredentials, Settings.wpcomCredentials)
     }
 }
 
@@ -91,6 +99,6 @@ class SessionManagerTests: XCTestCase {
 private enum Settings {
     static let keychainServiceName = "com.automattic.woocommerce.tests"
     static let defaults = UserDefaults(suiteName: "sessionManagerTests")!
-    static let credentials1 = Credentials(username: "lalala", authToken: "1234", siteAddress: "https://example.com")
-    static let credentials2 = Credentials(username: "yayaya", password: "5678", siteAddress: "https://wordpress.com")
+    static let wpcomCredentials = Credentials(username: "lalala", authToken: "1234", siteAddress: "https://example.com")
+    static let wporgCredentials = Credentials(username: "yayaya", password: "5678", siteAddress: "https://wordpress.com")
 }

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -27,6 +27,7 @@ class SessionManagerTests: XCTestCase {
     /// Verifies that `loadDefaultCredentials` effectively returns the last stored credentials
     ///
     func testDefaultCredentialsAreProperlyPersistedForWPCOM() {
+        // Given
         manager.defaultCredentials = Settings.wpcomCredentials
 
         guard case let .wpcom(username: username, authToken: authToken, siteAddress: siteAddress) = manager.defaultCredentials else {
@@ -34,13 +35,17 @@ class SessionManagerTests: XCTestCase {
             return
         }
 
+        // When
         let retrieved = Credentials(username: username, authToken: authToken, siteAddress: siteAddress)
+
+        // Then
         XCTAssertEqual(retrieved, Settings.wpcomCredentials)
     }
 
     /// Verifies that `loadDefaultCredentials` effectively returns the last stored credentials
     ///
     func testDefaultCredentialsAreProperlyPersistedForWPOrg() {
+        // Given
         manager.defaultCredentials = Settings.wporgCredentials
 
         guard case let .wporg(username: username, password: password, siteAddress: siteAddress) = manager.defaultCredentials else {
@@ -48,7 +53,10 @@ class SessionManagerTests: XCTestCase {
             return
         }
 
+        // When
         let retrieved = Credentials(username: username, password: password, siteAddress: siteAddress)
+
+        // Then
         XCTAssertEqual(retrieved, Settings.wporgCredentials)
     }
 
@@ -74,6 +82,7 @@ class SessionManagerTests: XCTestCase {
     /// Verifies that WPCOM credentials are returned for already installed and logged in versions which don't have type stored in user defaults
     ///
     func test_already_installed_version_without_authentication_type_saved_returns_WPCOM_credentials() {
+        // Given
         let uuid = UUID().uuidString
 
         // Prepare user defaults
@@ -85,10 +94,14 @@ class SessionManagerTests: XCTestCase {
         let keychainServiceName = uuid
         Keychain(service: keychainServiceName)["lalala"] = "1234"
 
+        // When
+
         // Check that credential type isn't available
         XCTAssertNil(defaults[UserDefaults.Key.defaultCredentialsType])
 
         let sut = SessionManager(defaults: defaults, keychainServiceName: keychainServiceName)
+
+        // Then
         XCTAssertEqual(sut.defaultCredentials, Settings.wpcomCredentials)
     }
 }

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import WooCommerce
 import Yosemite
-
+import KeychainAccess
 
 /// SessionManager Unit Tests
 ///
@@ -10,7 +10,6 @@ class SessionManagerTests: XCTestCase {
     /// CredentialsStorage Unit-Testing Instance
     ///
     private var manager = SessionManager(defaults: Settings.defaults, keychainServiceName: Settings.keychainServiceName)
-
 
     // MARK: - Overridden Methods
 
@@ -62,6 +61,27 @@ class SessionManagerTests: XCTestCase {
 
         manager.defaultCredentials = Settings.credentials2
         XCTAssertEqual(manager.defaultCredentials, Settings.credentials2)
+    }
+
+    /// Verifies that WPCOM credentials are returned for already installed and logged in versions which don't have type stored in user defaults
+    ///
+    func test_already_installed_version_without_authentication_type_saved_returns_WPCOM_credentials() {
+        let uuid = UUID().uuidString
+
+        // Prepare user defaults
+        let defaults = UserDefaults(suiteName: uuid)!
+        defaults[UserDefaults.Key.defaultUsername] = "lalala"
+        defaults[UserDefaults.Key.defaultSiteAddress] = "https://example.com"
+
+        // Prepare keychain
+        let keychainServiceName = uuid
+        Keychain(service: keychainServiceName)["lalala"] = "1234"
+
+        // Check that credential type isn't available
+        XCTAssertNil(defaults[UserDefaults.Key.defaultCredentialsType])
+
+        let sut = SessionManager(defaults: defaults, keychainServiceName: keychainServiceName)
+        XCTAssertEqual(sut.defaultCredentials, Settings.credentials1)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -19,17 +19,15 @@ class SessionManagerTests: XCTestCase {
         manager.defaultCredentials = nil
     }
 
-
     /// Verifies that `loadDefaultCredentials` returns nil whenever there are no default credentials stored.
     ///
     func testLoadDefaultCredentialsReturnsNilWhenThereAreNoDefaultCredentials() {
         XCTAssertNil(manager.defaultCredentials)
     }
 
-
     /// Verifies that `loadDefaultCredentials` effectively returns the last stored credentials
     ///
-    func testDefaultCredentialsAreProperlyPersisted() {
+    func testDefaultCredentialsAreProperlyPersistedForWPCOM() {
         manager.defaultCredentials = Settings.credentials1
 
         let retrieved = manager.defaultCredentials
@@ -37,6 +35,15 @@ class SessionManagerTests: XCTestCase {
         XCTAssertEqual(retrieved?.username, Settings.credentials1.username)
     }
 
+    /// Verifies that `loadDefaultCredentials` effectively returns the last stored credentials
+    ///
+    func testDefaultCredentialsAreProperlyPersistedForWPOrg() {
+        manager.defaultCredentials = Settings.credentials2
+
+        let retrieved = manager.defaultCredentials
+        XCTAssertEqual(retrieved?.password, Settings.credentials1.authToken)
+        XCTAssertEqual(retrieved?.username, Settings.credentials1.username)
+    }
 
     /// Verifies that `removeDefaultCredentials` effectively nukes everything from the keychain
     ///
@@ -46,7 +53,6 @@ class SessionManagerTests: XCTestCase {
 
         XCTAssertNil(manager.defaultCredentials)
     }
-
 
     /// Verifies that `saveDefaultCredentials` overrides previous stored credentials
     ///
@@ -66,5 +72,5 @@ private enum Settings {
     static let keychainServiceName = "com.automattic.woocommerce.tests"
     static let defaults = UserDefaults(suiteName: "sessionManagerTests")!
     static let credentials1 = Credentials(username: "lalala", authToken: "1234", siteAddress: "https://example.com")
-    static let credentials2 = Credentials(username: "yayaya", authToken: "5678", siteAddress: "https://wordpress.com")
+    static let credentials2 = Credentials(username: "yayaya", password: "5678", siteAddress: "https://wordpress.com")
 }


### PR DESCRIPTION
Part of: #8432
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

To work on the REST API project, we need to hold both WPCOM and WPOrg credentials in the `Credentials` struct. 
- This PR adds an  `AuthenticationType` enum to the `Credentials` struct to do it. 
- We also altered calling places to work with optional authentication token.
- Added ability to store, retrieve and delete both type of credentials from keychain and user defaults.
- Handle the edge case of already installed and logged in app installations.

## Testing instructions
- Install the app above the existing version and test the app.
- Do a fresh install, login and test the app.

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
