### PR TITLE
[Testing] Ensure mock summary stats use correct date string

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -10,6 +10,7 @@ import WooFoundation
 final class StoreStatsPeriodViewModelTests: XCTestCase {
     private let siteID: Int64 = 300
     private let defaultSiteTimezone = TimeZone(identifier: "GMT") ?? .current
+    private let defaultDate = Date(timeIntervalSince1970: 1671123600) // Dec 15, 2022, 5:00:00 PM GMT
     private var storageManager: StorageManagerType!
     private var storage: StorageType {
         storageManager.viewStorage
@@ -78,7 +79,8 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         XCTAssertEqual(conversionStatsTextValues, ["-"])
 
         // When
-        let siteSummaryStats = Yosemite.SiteSummaryStats.fake().copy(siteID: siteID, date: "2022-12-15", visitors: 22)
+        let dateString = StatsStoreV4.buildDateString(from: defaultDate, with: .day)
+        let siteSummaryStats = Yosemite.SiteSummaryStats.fake().copy(siteID: siteID, date: dateString, visitors: 22)
         insertSiteSummaryStats(siteSummaryStats, timeRange: timeRange)
 
         // Then
@@ -121,7 +123,8 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         observeStatsEmittedValues(viewModel: viewModel)
 
         // When
-        let siteSummaryStats = Yosemite.SiteSummaryStats.fake().copy(siteID: siteID, date: "2022-12-15", visitors: 15)
+        let dateString = StatsStoreV4.buildDateString(from: defaultDate, with: .day)
+        let siteSummaryStats = Yosemite.SiteSummaryStats.fake().copy(siteID: siteID, date: dateString, visitors: 15)
         insertSiteSummaryStats(siteSummaryStats, timeRange: timeRange)
 
         XCTAssertEqual(conversionStatsTextValues, ["-"])
@@ -678,13 +681,11 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
 }
 
 private extension StoreStatsPeriodViewModelTests {
-    static let defaultDate = Date(timeIntervalSince1970: 1671123600) // Dec 15, 2022, 5:00:00 PM GMT
-
-    func createViewModel(timeRange: StatsTimeRangeV4, date: Date = defaultDate) -> StoreStatsPeriodViewModel {
+    func createViewModel(timeRange: StatsTimeRangeV4) -> StoreStatsPeriodViewModel {
         StoreStatsPeriodViewModel(siteID: siteID,
                                   timeRange: timeRange,
                                   siteTimezone: defaultSiteTimezone,
-                                  currentDate: date,
+                                  currentDate: defaultDate,
                                   currencyFormatter: currencyFormatter,
                                   currencySettings: currencySettings,
                                   storageManager: storageManager)


### PR DESCRIPTION
## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As reported in Slack (internal ref: p1671436724169599-slack-C02KUCFCSFP), two unit tests in `StoreStatsPeriodViewModelTests` can fail when they are run in timezones that are very different from GMT:

* `test_visitorStatsText_is_emitted_after_summary_stats_updated()`
* `test_conversionStatsText_is_emitted_after_order_and_summary_stats_updated()`

That happens because the view model uses [`StatsStoreV4.buildDateString`](https://github.com/woocommerce/woocommerce-ios/blob/bf2dedf86e62dbe026fec2d178ab0b6f0c8c5300/WooCommerce/Classes/ViewRelated/Dashboard/Stats%20v4/StoreStatsPeriodViewModel.swift#L147) to format the date used to fetch the summary stats from storage. This method relies on [`DateFormatter.statsDayFormatter`](https://github.com/woocommerce/woocommerce-ios/blob/bf2dedf86e62dbe026fec2d178ab0b6f0c8c5300/Networking/Networking/Extensions/DateFormatter%2BWoo.swift#L61-L66) which always uses the current device timezone. This means the date string can vary from the date string used to store the mock summary stats (`2022-12-16` instead of `2022-12-15`) when the device timezone doesn't match the timezone injected into the view model by the unit tests.

This PR fixes the issue by also using `StatsStoreV4.buildDateString` to build the date string for the mock summary stats data, to ensure it matches the date used by the view model to fetch the data from storage.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Change your macOS Time Zone setting (in Date & Time preferences) to e.g. Sydney, Australia.
2. Run the unit tests in StoreStatsPeriodViewModelTests` and confirm they pass.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.