### PR TITLE
[Analytics Hub] Use custom timezone in isSameYear Date extension

### DIFF
--- a/WooCommerce/Classes/Extensions/Date+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Date+Woo.swift
@@ -97,8 +97,7 @@ extension Date {
 
     /// Returns `true` if `self` is in the same year as `other`.
     ///
-    func isSameYear(as otherDate: Date) -> Bool {
-        let calendar = Calendar.current
+    func isSameYear(as otherDate: Date, using calendar: Calendar = .current) -> Bool {
         guard let selfYear = calendar.dateComponents([.year], from: self).year,
             let otherYear = calendar.dateComponents([.year], from: otherDate).year else {
                 return false

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRange.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRange.swift
@@ -10,7 +10,7 @@ struct AnalyticsHubTimeRange {
         }
 
         let startDateDescription: String
-        if start.isSameYear(as: end) {
+        if start.isSameYear(as: end, using: calendar) {
             startDateDescription = DateFormatter.Stats.createAnalyticsHubDayMonthFormatter(timezone: timezone).string(from: start)
         } else {
             startDateDescription = DateFormatter.Stats.createAnalyticsHubDayMonthYearFormatter(timezone: timezone).string(from: start)


### PR DESCRIPTION
## Description

As reported in Slack (internal ref: p1671436724169599-slack-C02KUCFCSFP), two unit tests in `AnalyticsHubTimeRangeSelectionTests` can fail when they are run in timezones that are very different from GMT:

* `test_when_time_range_inits_with_lastYear_then_generate_expected_descriptions()`
* `test_when_time_range_inits_with_lastQuarter_then_generate_expected_descriptions()`

That happens because `func formatToString(...)` in `AnalyticsHubTimeRange` doesn't pass  TimeZone or Calendar (which includes timezone) into `Date.isSameYear(...)` helper extension. Extension is then uses device's timezone to produce incorrect result for ranges which are very close to year bounds.

This PR fixes the issue by adding optional `Calendar` input to `Date.isSameYear(...)` and passing appropriate Calendar from `AnalyticsHubTimeRangeSelection`.

## Testing instructions

1. Change your macOS Time Zone setting (in Date & Time preferences) to e.g. Sydney, Australia.
2. Run the unit tests in `AnalyticsHubTimeRangeSelectionTests` and confirm they pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
