### PR TITLE
[Stats] Use custom timezone for retrieveSiteSummaryStats stats action

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -222,6 +222,7 @@ private extension AnalyticsHubViewModel {
 
         return try await withCheckedThrowingContinuation { continuation in
             let action = StatsActionV4.retrieveSiteSummaryStats(siteID: siteID,
+                                                                siteTimezone: .current,
                                                                 period: period,
                                                                 quantity: timeRangeSelectionType.quantity,
                                                                 latestDateToInclude: latestDateToInclude,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -90,10 +90,12 @@ final class DashboardViewModel {
 
     /// Syncs summary stats for dashboard UI.
     func syncSiteSummaryStats(for siteID: Int64,
+                              siteTimezone: TimeZone,
                               timeRange: StatsTimeRangeV4,
                               latestDateToInclude: Date,
                               onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
         let action = StatsActionV4.retrieveSiteSummaryStats(siteID: siteID,
+                                                            siteTimezone: siteTimezone,
                                                             period: timeRange.summaryStatsGranularity,
                                                             quantity: 1,
                                                             latestDateToInclude: latestDateToInclude,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -291,6 +291,7 @@ private extension StoreStatsAndTopPerformersViewController {
             periodGroup.enter()
             periodStoreStatsGroup.enter()
             self.dashboardViewModel.syncSiteSummaryStats(for: siteID,
+                                                         siteTimezone: timezoneForSync,
                                                          timeRange: vc.timeRange,
                                                          latestDateToInclude: latestDateToInclude) { result in
                 if case let .failure(error) = result {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -26,7 +26,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
             case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, completion):
                 let topEarners = TopEarnerStats.fake().copy(items: [.fake()])
                 completion(.success(topEarners))
-            case let .retrieveSiteSummaryStats(_, _, _, _, _, completion):
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
                 let siteStats = SiteSummaryStats.fake().copy(visitors: 30, views: 53)
                 completion(.success(siteStats))
             default:
@@ -61,7 +61,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                 completion(.failure(NSError(domain: "Test", code: 1)))
             case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, completion):
                 completion(.failure(NSError(domain: "Test", code: 1)))
-            case let .retrieveSiteSummaryStats(_, _, _, _, _, completion):
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
                 completion(.failure(NSError(domain: "Test", code: 1)))
             default:
                 break
@@ -89,7 +89,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
             case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, completion):
                 let topEarners = TopEarnerStats.fake().copy(items: [.fake()])
                 completion(.success(topEarners))
-            case let .retrieveSiteSummaryStats(_, _, _, _, _, completion):
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
                 completion(.failure(NSError(domain: "Test", code: 1)))
             default:
                 break
@@ -130,7 +130,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
             case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, completion):
                 let topEarners = TopEarnerStats.fake().copy(items: [.fake()])
                 completion(.success(topEarners))
-            case let .retrieveSiteSummaryStats(_, _, _, _, _, completion):
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
                 let siteStats = SiteSummaryStats.fake()
                 loadingSessionsCard = vm.sessionsCard
                 completion(.success(siteStats))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -55,7 +55,7 @@ final class DashboardViewModelTests: XCTestCase {
                 completion(.failure(DotcomError.noRestRoute))
             case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, completion):
                 completion(.failure(DotcomError.noRestRoute))
-            case let .retrieveSiteSummaryStats(_, _, _, _, _, completion):
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
                 completion(.failure(DotcomError.noRestRoute))
             default:
                 XCTFail("Received unsupported action: \(action)")
@@ -68,7 +68,7 @@ final class DashboardViewModelTests: XCTestCase {
         viewModel.syncStats(for: sampleSiteID, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init(), forceRefresh: false)
         viewModel.syncSiteVisitStats(for: sampleSiteID, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init())
         viewModel.syncTopEarnersStats(for: sampleSiteID, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init(), forceRefresh: false)
-        viewModel.syncSiteSummaryStats(for: sampleSiteID, timeRange: .thisMonth, latestDateToInclude: .init())
+        viewModel.syncSiteSummaryStats(for: sampleSiteID, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init())
 
         // Then
         XCTAssertEqual(viewModel.statsVersion, .v4)

--- a/Yosemite/Yosemite/Actions/StatsActionV4.swift
+++ b/Yosemite/Yosemite/Actions/StatsActionV4.swift
@@ -53,6 +53,7 @@ public enum StatsActionV4: Action {
     /// Conditionally saves them to storage, if a single period is retrieved.
     ///
     case retrieveSiteSummaryStats(siteID: Int64,
+                                  siteTimezone: TimeZone,
                                   period: StatGranularity,
                                   quantity: Int,
                                   latestDateToInclude: Date,

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -91,12 +91,14 @@ public final class StatsStoreV4: Store {
                                    saveInStorage: saveInStorage,
                                    onCompletion: onCompletion)
         case .retrieveSiteSummaryStats(let siteID,
+                                       let siteTimezone,
                                        let period,
                                        let quantity,
                                        let latestDateToInclude,
                                        let saveInStorage,
                                        let onCompletion):
             retrieveSiteSummaryStats(siteID: siteID,
+                                     siteTimezone: siteTimezone,
                                      period: period,
                                      quantity: quantity,
                                      latestDateToInclude: latestDateToInclude,
@@ -195,6 +197,7 @@ private extension StatsStoreV4 {
     /// Conditionally saves them to storage, if a single period is retrieved.
     ///
     func retrieveSiteSummaryStats(siteID: Int64,
+                                  siteTimezone: TimeZone,
                                   period: StatGranularity,
                                   quantity: Int,
                                   latestDateToInclude: Date,
@@ -202,6 +205,7 @@ private extension StatsStoreV4 {
                                   onCompletion: @escaping (Result<SiteSummaryStats, Error>) -> Void) {
         if quantity == 1 {
             siteStatsRemote.loadSiteSummaryStats(for: siteID,
+                                                 siteTimezone: siteTimezone,
                                                  period: period,
                                                  includingDate: latestDateToInclude) { [weak self] result in
                 switch result {
@@ -220,6 +224,7 @@ private extension StatsStoreV4 {
             // We should only do this for periods of a month or greater; otherwise the visitor total is inaccurate.
             // See: pe5uwI-5c-p2
             siteStatsRemote.loadSiteVisitorStats(for: siteID,
+                                                 siteTimezone: siteTimezone,
                                                  unit: period,
                                                  latestDateToInclude: latestDateToInclude,
                                                  quantity: quantity) { result in

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -516,6 +516,7 @@ final class StatsStoreV4Tests: XCTestCase {
         // When
         let result: Result<Networking.SiteSummaryStats, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveSiteSummaryStats(siteID: self.sampleSiteID,
+                                                                siteTimezone: .current,
                                                                 period: .day,
                                                                 quantity: 1,
                                                                 latestDateToInclude: DateFormatter.dateFromString(with: "2022-12-09T17:06:55"),
@@ -540,6 +541,7 @@ final class StatsStoreV4Tests: XCTestCase {
         // When
         let _: Void = waitFor { promise in
             let action = StatsActionV4.retrieveSiteSummaryStats(siteID: self.sampleSiteID,
+                                                                siteTimezone: .init(identifier: "GMT") ?? .current,
                                                                 period: .month,
                                                                 quantity: 3,
                                                                 latestDateToInclude: DateFormatter.dateFromString(with: "2022-12-31T17:06:55"),
@@ -567,6 +569,7 @@ final class StatsStoreV4Tests: XCTestCase {
         // When
         let result: Result<Networking.SiteSummaryStats, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveSiteSummaryStats(siteID: self.sampleSiteID,
+                                                                siteTimezone: .current,
                                                                 period: .month,
                                                                 quantity: 3,
                                                                 latestDateToInclude: DateFormatter.dateFromString(with: "2022-12-31T17:06:55"),
@@ -592,6 +595,7 @@ final class StatsStoreV4Tests: XCTestCase {
         // When
         let result: Result<Networking.SiteSummaryStats, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveSiteSummaryStats(siteID: self.sampleSiteID,
+                                                                siteTimezone: .current,
                                                                 period: .day,
                                                                 quantity: 1,
                                                                 latestDateToInclude: DateFormatter.dateFromString(with: "2022-12-09T17:06:55"),
@@ -614,6 +618,7 @@ final class StatsStoreV4Tests: XCTestCase {
         // When
         let result: Result<Networking.SiteSummaryStats, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveSiteSummaryStats(siteID: self.sampleSiteID,
+                                                                siteTimezone: .current,
                                                                 period: .day,
                                                                 quantity: 1,
                                                                 latestDateToInclude: DateFormatter.dateFromString(with: "2022-12-09T17:06:55"),
@@ -638,6 +643,7 @@ final class StatsStoreV4Tests: XCTestCase {
         // When
         let result: Result<Networking.SiteSummaryStats, Error> = waitFor { promise in
             let action = StatsActionV4.retrieveSiteSummaryStats(siteID: self.sampleSiteID,
+                                                                siteTimezone: .current,
                                                                 period: .day,
                                                                 quantity: 1,
                                                                 latestDateToInclude: DateFormatter.dateFromString(with: "2022-12-09T17:06:55"),


### PR DESCRIPTION
## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As reported in Slack (internal ref: p1671436724169599-slack-C02KUCFCSFP), a unit test in `StatsStoreV4Tests` can fail when it is run in timezones that are very different from GMT:

* `test_retrieveSiteSummaryStats_makes_expected_network_request_for_multiple_periods()`

That happens because the network request uses the current device timezone by default to make the request. For this test, that changes the date and causes a test failure. However, the method making that request can take a custom timezone as a parameter.

This PR fixes the issue by adding a `TimeZone` parameter to `StatsActionV4.retrieveSiteSummaryStats`. This allows us to inject the timezone used for the remote request in unit tests. (In the app we always use the current device timezone, but this will also ensure we can easily change that if we ever decide to use a different timezone to sync these stats.)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Change your macOS Time Zone setting (in Date & Time preferences) to e.g. Sydney, Australia.
2. Run the unit tests and confirm they pass. Note that there are some `AnalyticsHubTimeRangeSelectionTests` failures in this branch that are being addressed in https://github.com/woocommerce/woocommerce-ios/pull/8448.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.