### PR TITLE
Unit Tests - Remove timeout from Jetpack setup waitUntil expectation

### DIFF
--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/LoginJetpackSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/LoginJetpackSetupViewModelTests.swift
@@ -154,58 +154,73 @@ final class LoginJetpackSetupViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tryAgainButtonTitle, JetpackInstallStep.connection.tryAgainButtonTitle)
     }
 
-    func test_shouldShowInitialLoadingIndicator_is_correct() {
+    func test_shouldShowInitialLoadingIndicator_turns_on_correctly_when_startSetup_then_returns_true() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = LoginJetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores)
-        let plugin = SitePlugin.fake().copy(plugin: "Jetpack", status: .inactive)
-
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .retrieveJetpackPluginDetails(let completion):
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    completion(.success(plugin))
-                }
-            default:
-                break
-            }
-        }
 
         // When
         viewModel.startSetup()
 
         // Then
         XCTAssertTrue(viewModel.shouldShowInitialLoadingIndicator)
-        waitUntil {
-            viewModel.shouldShowInitialLoadingIndicator == false
-        }
+
     }
 
-    func test_shouldShowSetupSteps_is_correct() {
+    func test_shouldShowInitialLoadingIndicator_turns_off_correctly_when_retrieveJetpackPluginDetails_is_success_then_returns_false() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = LoginJetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores)
         let plugin = SitePlugin.fake().copy(plugin: "Jetpack", status: .inactive)
 
+        // When
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    completion(.success(plugin))
-                }
+                completion(.success(plugin))
             default:
                 break
             }
         }
+        viewModel.startSetup()
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowInitialLoadingIndicator)
+
+    }
+
+    func test_shouldShowSetupSteps_when_startSetup_then_returns_false() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = LoginJetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores)
 
         // When
         viewModel.startSetup()
 
         // Then
         XCTAssertFalse(viewModel.shouldShowSetupSteps)
-        waitUntil {
-            viewModel.shouldShowSetupSteps == true
+
+    }
+
+    func test_shouldShowSetupSteps_when_retrieveJetpackPluginDetails_is_success_then_returns_true() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = LoginJetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores)
+        let plugin = SitePlugin.fake().copy(plugin: "Jetpack", status: .inactive)
+
+        // When
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .retrieveJetpackPluginDetails(let completion):
+                    completion(.success(plugin))
+            default:
+                break
+            }
         }
+        viewModel.startSetup()
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowSetupSteps)
     }
 
     func test_shouldShowGoToStoreButton_is_correct() {

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/LoginJetpackSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/LoginJetpackSetupViewModelTests.swift
@@ -176,7 +176,7 @@ final class LoginJetpackSetupViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.shouldShowInitialLoadingIndicator)
-        waitUntil(timeout: 1) {
+        waitUntil {
             viewModel.shouldShowInitialLoadingIndicator == false
         }
     }
@@ -203,7 +203,7 @@ final class LoginJetpackSetupViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.shouldShowSetupSteps)
-        waitUntil(timeout: 1) {
+        waitUntil {
             viewModel.shouldShowSetupSteps == true
         }
     }
@@ -639,7 +639,7 @@ final class LoginJetpackSetupViewModelTests: XCTestCase {
         viewModel.didAuthorizeJetpackConnection()
 
         // Then
-        waitUntil(timeout: 3) {
+        waitUntil {
             viewModel.setupFailed
         }
         XCTAssertEqual(fetchJetpackUserTriggerCount, 3)
@@ -668,7 +668,7 @@ final class LoginJetpackSetupViewModelTests: XCTestCase {
         viewModel.didAuthorizeJetpackConnection()
 
         // Then
-        waitUntil(timeout: 3) {
+        waitUntil {
             viewModel.setupFailed
         }
         XCTAssertEqual(fetchJetpackUserTriggerCount, 3)


### PR DESCRIPTION
## Description
There's a couple of flaky tests related to Jetpack Setup that seem to fail both locally and CI often due to the short timeout expectation (1 second)

## Changes

This PR proposes removing the arbitrary number of seconds for a test timeout when we use `waitUntil()`, and leave these to fail if needed when pass the 5-second default threshold.

Just for consistency I changed the 3-seconds tests as well, but happy to discuss further if this is the right change as I have no context about what's an acceptable timeout threshold on these cases.

## Testing instructions
Confirm that Unit tests pass.
