### PR TITLE
[Design] Adjust capitalization to new guidelines

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 11.8
 -----
-
+- [internal] Design: Updated capitalization for various pages, links, and buttons to match new design guidelines. [https://github.com/woocommerce/woocommerce-ios/pull/8455]
 
 11.7
 -----

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -115,7 +115,7 @@ private extension StorePickerError {
         static let title = NSLocalizedString("We couldn't load your site", comment: "Title for the default store picker error screen")
         static let body = NSLocalizedString("Please try again or reach out to us and we'll be happy to assist you!",
                                             comment: "Body text for the default store picker error screen")
-        static let troubleshoot = NSLocalizedString("Read our Troubleshooting Tips",
+        static let troubleshoot = NSLocalizedString("Read Our Troubleshooting Tips",
                                                     comment: "Text for the button to navigate to troubleshooting tips from the store picker error screen")
         static let contact = NSLocalizedString("Contact Support",
                                                comment: "Text for the button to contact support from the store picker error screen")

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -81,12 +81,12 @@ struct StorePickerError: View {
 
                 VStack(spacing: Layout.buttonsSpacing) {
                     // Primary Button
-                    Button(Localization.troubleshoot, action: troubleshootingAction)
+                    Button(Localization.troubleshoot.localizedCapitalized, action: troubleshootingAction)
                         .buttonStyle(PrimaryButtonStyle())
                         .fixedSize(horizontal: false, vertical: true)
 
                     // Secondary button
-                    Button(Localization.contact, action: contactSupportAction)
+                    Button(Localization.contact.localizedCapitalized, action: contactSupportAction)
                         .buttonStyle(SecondaryButtonStyle())
                         .fixedSize(horizontal: false, vertical: true)
 
@@ -115,7 +115,7 @@ private extension StorePickerError {
         static let title = NSLocalizedString("We couldn't load your site", comment: "Title for the default store picker error screen")
         static let body = NSLocalizedString("Please try again or reach out to us and we'll be happy to assist you!",
                                             comment: "Body text for the default store picker error screen")
-        static let troubleshoot = NSLocalizedString("Read Our Troubleshooting Tips",
+        static let troubleshoot = NSLocalizedString("Read our Troubleshooting Tips",
                                                     comment: "Text for the button to navigate to troubleshooting tips from the store picker error screen")
         static let contact = NSLocalizedString("Contact Support",
                                                comment: "Text for the button to contact support from the store picker error screen")

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -119,7 +119,7 @@ private extension StorePickerError {
                                                     comment: "Text for the button to navigate to troubleshooting tips from the store picker error screen")
         static let contact = NSLocalizedString("Contact Support",
                                                comment: "Text for the button to contact support from the store picker error screen")
-        static let back = NSLocalizedString("Back to Sites",
+        static let back = NSLocalizedString("Back to sites",
                                             comment: "Text for the button to dismiss the store picker error screen")
     }
 

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/ProductsOnboardingAnnouncementCardViewModel.swift
@@ -56,6 +56,6 @@ private extension ProductsOnboardingAnnouncementCardViewModel {
     enum Localization {
         static let title = NSLocalizedString("Add products to sell", comment: "Title for the Products onboarding banner")
         static let message = NSLocalizedString("Build your catalog by adding what you want to sell.", comment: "Message for the Products onboarding banner")
-        static let buttonTitle = NSLocalizedString("Add a Product", comment: "Title for the button on the Products onboarding banner")
+        static let buttonTitle = NSLocalizedString("Add a product", comment: "Title for the button on the Products onboarding banner")
     }
 }

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/UpsellCardReadersCampaign.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/UpsellCardReadersCampaign.swift
@@ -41,7 +41,7 @@ extension UpsellCardReadersCampaign {
             comment: "Message for the feature announcement banner intended to upsell card readers")
 
         static let cardButtonTitle = NSLocalizedString(
-            "Purchase Card Reader",
+            "Purchase card reader",
             comment: "Title for the button on the feature announcement banner intended to upsell card readers")
 
         static let dismissTitle = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -120,7 +120,7 @@ struct AccountCreationForm: View {
                 }
 
                 // CTA to submit the form.
-                Button(Localization.submitButtonTitle) {
+                Button(Localization.submitButtonTitle.localizedCapitalized) {
                     Task { @MainActor in
                         isPerformingTask = true
                         let createAccountCompleted = (try? await viewModel.createAccount()) != nil
@@ -176,7 +176,7 @@ private extension AccountCreationForm {
         static let passwordFieldPlaceholder = NSLocalizedString("Password", comment: "Placeholder of the password field on the account creation form.")
         static let tosFormat = NSLocalizedString("By continuing, you agree to our %1$@.", comment: "Terms of service format on the account creation form.")
         static let tos = NSLocalizedString("Terms of Service", comment: "Terms of service link on the account creation form.")
-        static let submitButtonTitle = NSLocalizedString("Get Started", comment: "Title of the submit button on the account creation form.")
+        static let submitButtonTitle = NSLocalizedString("Get started", comment: "Title of the submit button on the account creation form.")
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -176,7 +176,7 @@ private extension AccountCreationForm {
         static let passwordFieldPlaceholder = NSLocalizedString("Password", comment: "Placeholder of the password field on the account creation form.")
         static let tosFormat = NSLocalizedString("By continuing, you agree to our %1$@.", comment: "Terms of service format on the account creation form.")
         static let tos = NSLocalizedString("Terms of Service", comment: "Terms of service link on the account creation form.")
-        static let submitButtonTitle = NSLocalizedString("Get started", comment: "Title of the submit button on the account creation form.")
+        static let submitButtonTitle = NSLocalizedString("Get Started", comment: "Title of the submit button on the account creation form.")
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -428,7 +428,7 @@ private extension ProductSelector.Configuration {
               variableProductRowAccessibilityHint: Localization.variableProductRowAccessibilityHint)
 
     enum Localization {
-        static let title = NSLocalizedString("Select Products", comment: "Title for the screen to select products for a coupon")
+        static let title = NSLocalizedString("Select products", comment: "Title for the screen to select products for a coupon")
         static let cancel = NSLocalizedString("Cancel", comment: "Text for the cancel button in the Select Products screen")
         static let productRowAccessibilityHint = NSLocalizedString("Toggles selection for this product in a coupon.",
                                                                    comment: "Accessibility hint for selecting a product in the Select Products screen")

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
@@ -185,7 +185,7 @@ private extension CouponRestrictions {
 
     enum Localization {
         static let usageRestriction = NSLocalizedString(
-            "Usage Restrictions",
+            "Usage restrictions",
             comment: "Title for the usage restrictions section on coupon usage restrictions screen"
         )
         static let minimumSpend = NSLocalizedString(
@@ -269,7 +269,7 @@ private extension ProductSelector.Configuration {
               variableProductRowAccessibilityHint: Localization.variableProductRowAccessibilityHint)
 
     enum Localization {
-        static let title = NSLocalizedString("Exclude Products", comment: "Title for the screen to exclude products for a coupon")
+        static let title = NSLocalizedString("Exclude products", comment: "Title for the screen to exclude products for a coupon")
         static let cancel = NSLocalizedString("Cancel", comment: "Text for the cancel button in the Exclude Products screen")
         static let productRowAccessibilityHint = NSLocalizedString("Toggles selection to exclude this product in a coupon.",
                                                                    comment: "Accessibility hint for excluding a product in the Exclude Products screen")

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -487,7 +487,7 @@ private extension CouponListViewController {
         )
         static let createCouponAction = NSLocalizedString("Create Coupon",
                                                           comment: "Title of the create coupon button on the coupon list screen when it's empty")
-        static let giveFeedbackAction = NSLocalizedString("Give Feedback", comment: "Title of the feedback action button on the coupon list screen")
+        static let giveFeedbackAction = NSLocalizedString("Give feedback", comment: "Title of the feedback action button on the coupon list screen")
         static let dismissAction = NSLocalizedString("Dismiss", comment: "Title of the dismiss action button on the coupon list screen")
         static let couponDeleted = NSLocalizedString("Coupon deleted", comment: "Notice message after deleting coupon from the Coupon Details screen")
     }

--- a/WooCommerce/Classes/ViewRelated/Coupons/EnableAnalytics/EnableAnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/EnableAnalytics/EnableAnalyticsView.swift
@@ -89,7 +89,7 @@ struct EnableAnalyticsView: View {
             Spacer()
 
             // Primary Button to enable Analytics
-            Button(Localization.enableAction) {
+            Button(Localization.enableAction.localizedCapitalized) {
                 viewModel.enableAnalytics(onSuccess: {
                     setupNoticePresenterIfPossible()
                     let notice = Notice(title: Localization.analyticsEnabled, feedbackType: .success)
@@ -108,7 +108,7 @@ struct EnableAnalyticsView: View {
             .padding(.bottom, Constants.actionButtonMargin)
 
             /// Secondary Button to dismiss the view
-            Button(Localization.dismissAction) {
+            Button(Localization.dismissAction.localizedCapitalized) {
                 presentation.wrappedValue.dismiss()
             }
             .buttonStyle(SecondaryButtonStyle())
@@ -150,8 +150,8 @@ private extension EnableAnalyticsView {
             comment: "Message format on enable analytics screen for support. The %@ placeholder is a URL with more information."
         )
         static let contactSupport = NSLocalizedString("Contact support", comment: "Action button to contact support on enable analytics screen")
-        static let enableAction = NSLocalizedString("Enable Analytics", comment: "Action title to enable Analytics for a store")
-        static let dismissAction = NSLocalizedString("Not Now", comment: "Action title to dismiss enabling Analytics for a store")
+        static let enableAction = NSLocalizedString("Enable analytics", comment: "Action title to enable Analytics for a store")
+        static let dismissAction = NSLocalizedString("Not now", comment: "Action title to dismiss enabling Analytics for a store")
         static let analyticsEnabled = NSLocalizedString("Analytics enabled successfully.", comment: "Message when enabling analytics succeeds")
         static let errorEnablingAnalytics = NSLocalizedString(
             "Error enabling analytics. Please try again.",

--- a/WooCommerce/Classes/ViewRelated/Coupons/EnableAnalytics/EnableAnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/EnableAnalytics/EnableAnalyticsView.swift
@@ -150,8 +150,8 @@ private extension EnableAnalyticsView {
             comment: "Message format on enable analytics screen for support. The %@ placeholder is a URL with more information."
         )
         static let contactSupport = NSLocalizedString("Contact support", comment: "Action button to contact support on enable analytics screen")
-        static let enableAction = NSLocalizedString("Enable analytics", comment: "Action title to enable Analytics for a store")
-        static let dismissAction = NSLocalizedString("Not now", comment: "Action title to dismiss enabling Analytics for a store")
+        static let enableAction = NSLocalizedString("Enable Analytics", comment: "Action title to enable Analytics for a store")
+        static let dismissAction = NSLocalizedString("Not Now", comment: "Action title to dismiss enabling Analytics for a store")
         static let analyticsEnabled = NSLocalizedString("Analytics enabled successfully.", comment: "Message when enabling analytics succeeds")
         static let errorEnablingAnalytics = NSLocalizedString(
             "Error enabling analytics. Please try again.",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -474,12 +474,12 @@ private extension InPersonPaymentsMenuViewController {
             comment: "Title for the section related to actions inside In-Person Payments settings")
 
         static let orderCardReader = NSLocalizedString(
-            "Order card reader",
+            "Order Card Reader",
             comment: "Navigates to Card Reader ordering screen"
         )
 
         static let manageCardReader = NSLocalizedString(
-            "Manage card reader",
+            "Manage Card Reader",
             comment: "Navigates to Card Reader management screen"
         )
 
@@ -515,12 +515,12 @@ private extension InPersonPaymentsMenuViewController {
         )
 
         static let inPersonPaymentsSetupNotFinishedNotice = NSLocalizedString(
-            "In-Person Payments Setup is incomplete.",
+            "In-Person Payments setup is incomplete.",
             comment: "Shows a notice pointing out that the user didn't finish the In-Person Payments setup, so some functionalities are disabled."
         )
 
         static let inPersonPaymentsSetupNotFinishedNoticeButtonTitle = NSLocalizedString(
-            "Continue Setup",
+            "Continue setup",
             comment: "Call to Action to finish the setup of In-Person Payments in the Menu"
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -257,14 +257,14 @@ private extension InPersonPaymentsMenuViewController {
         cell.imageView?.tintColor = .text
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.configure(image: .shoppingCartIcon, text: Localization.orderCardReader)
+        cell.configure(image: .shoppingCartIcon, text: Localization.orderCardReader.localizedCapitalized)
     }
 
     func configureManageCardReader(cell: LeftImageTableViewCell) {
         cell.imageView?.tintColor = .text
         cell.accessoryType = enableManageCardReaderCell ? .disclosureIndicator : .none
         cell.selectionStyle = enableManageCardReaderCell ? .default : .none
-        cell.configure(image: .creditCardIcon, text: Localization.manageCardReader)
+        cell.configure(image: .creditCardIcon, text: Localization.manageCardReader.localizedCapitalized)
 
         updateEnabledState(in: cell, shouldBeEnabled: enableManageCardReaderCell)
     }
@@ -273,7 +273,9 @@ private extension InPersonPaymentsMenuViewController {
         cell.imageView?.tintColor = .text
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.configure(image: .rectangleOnRectangleAngled, text: Localization.managePaymentGateways, subtitle: pluginState?.preferred.pluginName ?? "")
+        cell.configure(image: .rectangleOnRectangleAngled,
+                       text: Localization.managePaymentGateways.localizedCapitalized,
+                       subtitle: pluginState?.preferred.pluginName ?? "")
 
         updateEnabledState(in: cell)
     }
@@ -282,7 +284,7 @@ private extension InPersonPaymentsMenuViewController {
         cell.imageView?.tintColor = .text
         cell.accessoryType = enableCardReaderManualsCell ? .disclosureIndicator : .none
         cell.selectionStyle = enableCardReaderManualsCell ? .default : .none
-        cell.configure(image: .cardReaderManualIcon, text: Localization.cardReaderManuals)
+        cell.configure(image: .cardReaderManualIcon, text: Localization.cardReaderManuals.localizedCapitalized)
 
         updateEnabledState(in: cell, shouldBeEnabled: enableCardReaderManualsCell)
     }
@@ -291,7 +293,7 @@ private extension InPersonPaymentsMenuViewController {
         cell.imageView?.tintColor = .text
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.configure(image: .moneyIcon, text: Localization.collectPayment)
+        cell.configure(image: .moneyIcon, text: Localization.collectPayment.localizedCapitalized)
 
         updateEnabledState(in: cell)
     }
@@ -474,12 +476,12 @@ private extension InPersonPaymentsMenuViewController {
             comment: "Title for the section related to actions inside In-Person Payments settings")
 
         static let orderCardReader = NSLocalizedString(
-            "Order Card Reader",
+            "Order card reader",
             comment: "Navigates to Card Reader ordering screen"
         )
 
         static let manageCardReader = NSLocalizedString(
-            "Manage Card Reader",
+            "Manage card reader",
             comment: "Navigates to Card Reader management screen"
         )
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -341,7 +341,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
         let button = UIButton(frame: .zero)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.applySecondaryButtonStyle()
-        button.setTitle(Localization.seeMoreButton, for: .normal)
+        button.setTitle(Localization.seeMoreButton.localizedCapitalized, for: .normal)
         button.addTarget(self, action: #selector(seeMoreButtonTapped), for: .touchUpInside)
 
         let view = UIView(frame: .zero)
@@ -383,6 +383,6 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
     }
 
     enum Localization {
-        static let seeMoreButton = NSLocalizedString("See More", comment: "Button on the stats dashboard that navigates user to the analytics hub")
+        static let seeMoreButton = NSLocalizedString("See more", comment: "Button on the stats dashboard that navigates user to the analytics hub")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -383,6 +383,6 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
     }
 
     enum Localization {
-        static let seeMoreButton = NSLocalizedString("See more", comment: "Button on the stats dashboard that navigates user to the analytics hub")
+        static let seeMoreButton = NSLocalizedString("See More", comment: "Button on the stats dashboard that navigates user to the analytics hub")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Top Banner/ErrorTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/ErrorTopBannerFactory.swift
@@ -31,7 +31,7 @@ private extension ErrorTopBannerFactory {
                                             comment: "The info of the Error Loading Data banner")
         static let troubleshoot = NSLocalizedString("Troubleshoot",
                                                     comment: "The title of the button to get troubleshooting information in the Error Loading Data banner")
-        static let contactSupport = NSLocalizedString("Contact Support",
+        static let contactSupport = NSLocalizedString("Contact support",
                                                       comment: "The title of the button to contact support in the Error Loading Data banner")
     }
 }


### PR DESCRIPTION
## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates a number of strings to conform to new design guidelines for capitalization on iOS:

**Sentence case** (only the first word is capitalized) for these elements:

- Page, sheet, and modal titles
- Text links
- Statuses/tags, inside and out of chips
- Full sentences, including placeholder text

**Title case** (the first letter of every word is capitalized) for these elements:

- Button text
- List row primary text
- List row button text
- Section titles (excluding very small section titles, which are in all caps by default)
- Tab text

We don't need to try to make an exhaustive update right now, so the changes in this PR are the results of a quick pass through the most prominent screens, to bring them in line with the new guidelines. (Internal ref: pecCkj-eD-p2)

### Changes

* To update strings to title case, I used [`localizedCapitalized`](https://developer.apple.com/documentation/foundation/nsstring/1414885-localizedcapitalized). This updates the capitalization without requiring the strings to be re-translated.
* I investigated ways to enforce title case for the elements in the guidelines (e.g. using style extensions or SwiftUI view modifiers to apply `localizedCapitalized` to strings). However, I didn't come up with anything that reliably works.
* To update strings to sentence case, I manually updated the strings. Swift doesn't give us a way to do this automatically, and after attempting to create a custom method for it I determined there isn't a safe way to do it, especially when translated strings are involved.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

You can review the changes in the screenshots below. Alternately, launch the app and explore (logged out and logged in) to confirm that the updated strings match the guidelines, and there aren't any obvious strings standing out that don't follow the guidelines.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 12 24 57](https://user-images.githubusercontent.com/8658164/208707591-2c468cc3-9313-4024-ba1b-394d88024b12.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 15 33 28](https://user-images.githubusercontent.com/8658164/208708981-a9911e7f-e4ef-4262-b443-7773dee68f03.png)
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 12 29 53](https://user-images.githubusercontent.com/8658164/208707608-de2a0245-ae0b-4921-baaf-2cef411a0f52.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 15 34 14](https://user-images.githubusercontent.com/8658164/208708993-4e6e8ee3-4a8a-4f0c-97a6-990a8f9b33a9.png)
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 12 35 58](https://user-images.githubusercontent.com/8658164/208707621-d06ba100-b247-427e-8ce6-02d5739606b0.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 15 34 23](https://user-images.githubusercontent.com/8658164/208709006-ea88f3b6-8838-496f-b832-d40b1e9d7d5b.png)
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 12 36 29](https://user-images.githubusercontent.com/8658164/208707690-c4f29f92-3397-4712-8e5e-6cec058c5f51.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 15 35 08](https://user-images.githubusercontent.com/8658164/208709021-1c12f7f0-e0e1-456d-99c8-53064a2aa8f9.png)
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 12 37 05](https://user-images.githubusercontent.com/8658164/208707705-446b8c6b-cab5-4b68-9354-2e006ef5342d.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 15 35 21](https://user-images.githubusercontent.com/8658164/208709028-9c09f19b-d4c6-40ef-81ab-dfe69e60dec0.png)
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 12 37 14](https://user-images.githubusercontent.com/8658164/208707753-92c6269c-977e-45c3-819e-bcf587f0cc69.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 15 35 29](https://user-images.githubusercontent.com/8658164/208709038-779a7628-d2d6-445f-8bf0-2977ba5107a0.png)
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 12 37 19](https://user-images.githubusercontent.com/8658164/208707766-3882daa9-9d50-42bb-880e-67bc3f65eaa6.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 15 35 32](https://user-images.githubusercontent.com/8658164/208709048-77a869fa-56fa-4afb-a2a5-67ee21a62253.png)
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 12 38 23](https://user-images.githubusercontent.com/8658164/208707835-68321170-dfb6-4416-8183-60b32aa7fcc4.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 15 36 03](https://user-images.githubusercontent.com/8658164/208709063-4db436fe-d459-4a23-a8c4-f3c89a9c1652.png)
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 12 40 14](https://user-images.githubusercontent.com/8658164/208707845-fce4df95-6367-4fc7-8596-3365ea050015.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 15 36 11](https://user-images.githubusercontent.com/8658164/208709077-1680cef2-dbe5-4b29-87b5-108668fb070f.png)
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 12 56 52](https://user-images.githubusercontent.com/8658164/208707860-0a8b602f-1e00-4a63-bf2f-05f9dbb2e422.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-20 at 15 36 53](https://user-images.githubusercontent.com/8658164/208709091-23fbb08a-e9b7-4478-87da-a3c9bb0cd9dd.png)
![Screen Shot 2022-12-20 at 3 43 01 PM](https://user-images.githubusercontent.com/8658164/208707578-2e60ba2b-eec8-4994-8e6a-67839a2e671c.png)|![Screen Shot 2022-12-20 at 3 41 20 PM](https://user-images.githubusercontent.com/8658164/208708754-8d6ab67a-c9eb-43ac-a989-8e0c27823c68.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.