### PR TITLE
Update the way we create fonts with custom weights.

### DIFF
--- a/WooCommerce/Classes/Extensions/UIFont+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIFont+Helpers.swift
@@ -87,8 +87,10 @@ extension UIFont {
     /// Returns a UIFont instance for the specified Style + Weight.
     ///
     class func font(forStyle style: UIFont.TextStyle, weight: UIFont.Weight) -> UIFont {
-        let targetSize = pointSize(for: style)
-        return UIFont.systemFont(ofSize: targetSize, weight: weight)
+        let descriptor = UIFontDescriptor
+            .preferredFontDescriptor(withTextStyle: style)
+            .addingAttributes([.traits: [UIFontDescriptor.TraitKey.weight: weight]])
+        return UIFont(descriptor: descriptor, size: 0)
     }
 
     /// Returns the System's Point Size for the specified Style.


### PR DESCRIPTION
# Why

During my HACK Week project, I noticed that the App had a problem when rendering accessibility fonts with customs weights. In particular, it seems that we were getting an extra big font when trying to apply a different font weight. This caused some layouts to look incorrect.

# How

Change how a font with a different weight is created. This PR uses descriptors fully instead of a scaled font with a fixed point size.

This also has the benefit to make font dynamic when changing the accessibility sizes at runtime via Xcode.

# screenshots

Before | After
--- | ---
![after-dashboard](https://user-images.githubusercontent.com/562080/208759626-8a33e3cc-9d4b-4831-b6c0-9b819f09ed47.png) | ![begore-dashboard](https://user-images.githubusercontent.com/562080/208759616-ee90ef24-68e2-43ef-91f6-81470bbb660e.png)
--- | ---
![before-login](https://user-images.githubusercontent.com/562080/208759672-c2ee9ade-400d-4b64-9383-b2570369899e.png) | ![after-login](https://user-images.githubusercontent.com/562080/208759675-c059c2d9-03a0-450f-a66f-ab6036f511c3.png)

**Note: This screens still don't look perfect and will be fixed in a next PR**

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
