### PR TITLE
[Error Handling] Improve logging when handling Authentication errors

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -76,7 +76,7 @@ private extension StorePickerViewModel {
             try resultsController.performFetch()
             state = StorePickerState(sites: resultsController.fetchedObjects)
         } catch {
-            DDLogError("Unable to re-fetch sites and update state: \(error)")
+            DDLogError("⛔️ Unable to re-fetch sites and update state: \(error)")
         }
     }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewModel.swift
@@ -72,8 +72,12 @@ final class StorePickerViewModel {
 // MARK: - Private helpers
 private extension StorePickerViewModel {
     func refetchSitesAndUpdateState() {
-        try? resultsController.performFetch()
-        state = StorePickerState(sites: resultsController.fetchedObjects)
+        do {
+            try resultsController.performFetch()
+            state = StorePickerState(sites: resultsController.fetchedObjects)
+        } catch {
+            DDLogError("Unable to re-fetch sites and update state: \(error)")
+        }
     }
 
     func synchronizeSites(selectedSiteID: Int64?, onCompletion: @escaping (Result<Void, Error>) -> Void) {

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -146,6 +146,10 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
     }
 
     private func refreshStoredSites() {
-        try? resultsController.performFetch()
+        do {
+            try resultsController.performFetch()
+        } catch {
+            DDLogError("Unable to refresh stored sites: \(error) ")
+        }
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -149,7 +149,7 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
         do {
             try resultsController.performFetch()
         } catch {
-            DDLogError("Unable to refresh stored sites: \(error) ")
+            DDLogError("⛔️ Unable to refresh stored sites: \(error) ")
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
+++ b/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
@@ -64,6 +64,10 @@ final class ULAccountMatcher {
 
     /// Refreshes locally stored sites that were synced previously.
     func refreshStoredSites() {
-        try? resultsController.performFetch()
+        do {
+            try resultsController.performFetch()
+        } catch {
+            DDLogError("Unable to refresh locally stored sites: \(error)")
+        }
     }
 }

--- a/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
+++ b/WooCommerce/Classes/Authentication/ULAccountMatcher.swift
@@ -67,7 +67,7 @@ final class ULAccountMatcher {
         do {
             try resultsController.performFetch()
         } catch {
-            DDLogError("Unable to refresh locally stored sites: \(error)")
+            DDLogError("⛔️ Unable to refresh locally stored sites: \(error)")
         }
     }
 }

--- a/WooCommerce/Classes/Tools/Logging/WooCrashLoggingStack.swift
+++ b/WooCommerce/Classes/Tools/Logging/WooCrashLoggingStack.swift
@@ -26,7 +26,11 @@ struct WooCrashLoggingStack: CrashLoggingStack {
         /// Upload any remaining files any time the app becomes active
         let willEnterForeground = UIApplication.willEnterForegroundNotification
         NotificationCenter.default.addObserver(forName: willEnterForeground, object: nil, queue: nil, using: self.willEnterForeground)
-        _ = try? crashLogging.start()
+        do {
+            _ = try crashLogging.start()
+        } catch {
+            DDLogError("⛔️ Unable to start WooCrashLoggingStack: \(error)")
+        }
     }
 
     func crash() {

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -283,7 +283,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         do {
             try pluginResultsController.performFetch()
         } catch {
-            DDLogError("Unable to fetch plugins from storage: \(error)")
+            DDLogError("⛔️ Unable to fetch plugins from storage: \(error)")
         }
         observeZendeskNotifications()
     }

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -280,7 +280,11 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     ///
     fileprivate override init() {
         super.init()
-        try? pluginResultsController.performFetch()
+        do {
+            try pluginResultsController.performFetch()
+        } catch {
+            DDLogError("Unable to fetch plugins from storage: \(error)")
+        }
         observeZendeskNotifications()
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Related to: https://github.com/woocommerce/woocommerce-ios/issues/8458
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
When working with methods that may throw an error we don't enforce handling these gracefully, which results in plenty of `try?` usage across the codebase, causing silent failures that are not logged to the Logging stack.

This PR changes some cases of ` try?` usage around Authentication for `do-catch` blocks instead, logging the errors via `DDLogError(_:)`

## Changes
As the usage is sparse across the app, I tried to keep the changes subject-related:
- Added `do-catch` blocks to authentication-related classes like `ULAccountMatcher`, `StorePickerViewModel`, and `SwitchStoreUseCase`.
- Added `do-catch` blocks to app initialization-related classes, like `Logging`, and `ZendeskManager`.

## Testing instructions
Confirm that Unit Tests pass.
