### PR TITLE
Fix flaky IAP `userIsEntitledToProduct` test

### DIFF
--- a/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
@@ -178,13 +178,9 @@ final class InAppPurchaseStoreTests: XCTestCase {
     func test_user_is_entitled_to_product_returns_false_when_not_entitled() throws {
         // When
         Task {
-            do {
-                let isEntitled = try await userIsEntitledToProduct()
-                // Then
-                XCTAssertFalse(try isEntitled.get())
-            } catch {
-                XCTAssert(error is WordPressApiError)
-            }
+            let isEntitled = try await userIsEntitledToProduct()
+            // Then
+            XCTAssertFalse(try isEntitled.get())
         }
     }
 
@@ -194,13 +190,9 @@ final class InAppPurchaseStoreTests: XCTestCase {
 
         // When
         Task {
-            do {
-                let isEntitled = try await userIsEntitledToProduct()
-                // Then
-                XCTAssertTrue( try isEntitled.get())
-            } catch {
-                XCTAssert(error is WordPressApiError)
-            }
+            let isEntitled = try await userIsEntitledToProduct()
+            // Then
+            XCTAssertTrue( try isEntitled.get())
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
@@ -181,7 +181,7 @@ final class InAppPurchaseStoreTests: XCTestCase {
             do {
                 let isEntitled = try await userIsEntitledToProduct()
                 // Then
-                XCTAssertFalse(isEntitled)
+                XCTAssertFalse(try isEntitled.get())
             } catch {
                 XCTAssert(error is WordPressApiError)
             }
@@ -197,7 +197,7 @@ final class InAppPurchaseStoreTests: XCTestCase {
             do {
                 let isEntitled = try await userIsEntitledToProduct()
                 // Then
-                XCTAssertTrue(isEntitled)
+                XCTAssertTrue( try isEntitled.get())
             } catch {
                 XCTAssert(error is WordPressApiError)
             }
@@ -207,10 +207,10 @@ final class InAppPurchaseStoreTests: XCTestCase {
 
 private extension InAppPurchaseStoreTests {
     // Returns whether the user is entitled the product identified with the passed ID
-    func userIsEntitledToProduct() async throws -> Bool {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            let action = InAppPurchaseAction.userIsEntitledToProduct(productID: self.sampleProductID) { _ in
-                continuation.resume(returning: (true))
+    func userIsEntitledToProduct() async throws -> Result<Bool, Error> {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Result, Never>) in
+            let action = InAppPurchaseAction.userIsEntitledToProduct(productID: self.sampleProductID) { result in
+                    continuation.resume(returning: result)
             }
             self.store.onAction(action)
         }


### PR DESCRIPTION
## Description
This PR attempts to fix a flaky test around `userIsEntitledToProduct`, which makes CI fail very often.

By wrapping the action dispatch in an async wrapper, we are sure that the result is only thrown when the dispatch is completed.  

The rationale behind wrapping this in a `CheckedContinuation` is that the original interface and function signature are `async throws`, and the usage of completion handlers is a limitation set by overriding Actions in our Store dispatcher.

Happy to discuss if this is a good approach to resolve this, or is there any other way we could improve IAP test flakiness 🙇 