### PR TITLE
COUW: Small UI adjustments

### DIFF
--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -24,7 +24,7 @@ final class StyleManager {
         return .font(forStyle: .subheadline, weight: .regular)
     }
 
-    static var subheadlineSemiBold: UIFont {
+    static var subheadlineSemiBoldFont: UIFont {
         return .font(forStyle: .subheadline, weight: .semibold)
     }
 

--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -24,6 +24,10 @@ final class StyleManager {
         return .font(forStyle: .subheadline, weight: .regular)
     }
 
+    static var subheadlineSemiBold: UIFont {
+        return .font(forStyle: .subheadline, weight: .semibold)
+    }
+
     static var subheadlineBoldFont: UIFont {
         return self.fontForTextStyle(.subheadline,
         weight: .bold,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -239,6 +239,7 @@ private extension SettingsViewController {
     }
 
     func configureCloseAccount(cell: BasicTableViewCell) {
+        cell.accessoryType = .none
         cell.selectionStyle = .default
         cell.textLabel?.textAlignment = .center
         cell.textLabel?.textColor = .error
@@ -247,6 +248,7 @@ private extension SettingsViewController {
 
     func configureLogout(cell: BasicTableViewCell) {
         cell.selectionStyle = .default
+        cell.accessoryType = .none
         cell.textLabel?.textAlignment = .center
         cell.textLabel?.textColor = .error
         cell.textLabel?.text = Localization.logout

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -487,7 +487,10 @@ private extension StoreStatsAndTopPerformersViewController {
 
             guard changeCurrentIndex == true else { return }
             oldCell?.label.textColor = .textSubtle
+            oldCell?.label.font = StyleManager.subheadlineFont
+
             newCell?.label.textColor = .primary
+            newCell?.label.font = StyleManager.subheadlineSemiBold
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -491,7 +491,7 @@ private extension StoreStatsAndTopPerformersViewController {
             oldCell?.label.font = StyleManager.subheadlineFont
 
             newCell?.label.textColor = .primary
-            newCell?.label.font = StyleManager.subheadlineSemiBold
+            newCell?.label.font = StyleManager.subheadlineSemiBoldFont
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -477,6 +477,7 @@ private extension StoreStatsAndTopPerformersViewController {
         settings.style.buttonBarItemTitleColor = .textSubtle
         settings.style.buttonBarItemsShouldFillAvailableWidth = false
         settings.style.buttonBarItemLeftRightMargin = TabStrip.buttonLeftRightMargin
+        settings.style.buttonBarHeight = TabStrip.tabHeight
 
         changeCurrentIndexProgressive = {
             (oldCell: ButtonBarViewCell?,
@@ -546,6 +547,7 @@ private extension StoreStatsAndTopPerformersViewController {
     enum TabStrip {
         static let buttonLeftRightMargin: CGFloat   = 16.0
         static let selectedBarHeight: CGFloat       = 3.0
+        static let tabHeight: CGFloat               = 36.0
     }
 
     enum Constants {


### PR DESCRIPTION

# Why

This PR applies design changes required in peaMlT-3i-p2

Specifically:

- Reduces spacing between the title store and the period tabs in the dashboard.
- Applies semi-bold font to selected period tab.
- Removes accessory indicators for Close & Logout buttons in settings

# Screenshots

Dashboard | Settings
--- | ---
![dashboard](https://user-images.githubusercontent.com/562080/208947671-6de8305d-fff5-4c23-999c-3d6d44a120a5.png) | ![accessory buttons](https://user-images.githubusercontent.com/562080/208947669-d7eb85ef-0619-4a0f-87e5-55e24a73f4f4.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
