### PR TITLE
[Stats] Remove inaccurate totalVisitors computed property from SiteVisitStats

### DIFF
--- a/Networking/Networking/Model/Stats/SiteVisitStats.swift
+++ b/Networking/Networking/Model/Stats/SiteVisitStats.swift
@@ -40,12 +40,6 @@ public struct SiteVisitStats: Decodable, GeneratedCopiable, GeneratedFakeable {
         self.granularity = granularity
         self.items = items
     }
-
-    // MARK: Computed Properties
-
-    public var totalVisitors: Int {
-        return items?.map({ $0.visitors }).reduce(0, +) ?? 0
-    }
 }
 
 

--- a/Networking/NetworkingTests/Mapper/SiteVisitStatsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteVisitStatsMapperTests.swift
@@ -19,7 +19,6 @@ class SiteVisitStatsMapperTests: XCTestCase {
         XCTAssertEqual(dayStats.granularity, .day)
         XCTAssertEqual(dayStats.date, "2018-08-06")
         XCTAssertEqual(dayStats.items!.count, 12)
-        XCTAssertEqual(dayStats.totalVisitors, 105)
 
         let sampleItem1 = dayStats.items![0]
         XCTAssertEqual(sampleItem1.period, "2018-07-26")
@@ -44,7 +43,6 @@ class SiteVisitStatsMapperTests: XCTestCase {
         XCTAssertEqual(weekStats.granularity, .week)
         XCTAssertEqual(weekStats.date, "2018-08-06")
         XCTAssertEqual(weekStats.items!.count, 12)
-        XCTAssertEqual(weekStats.totalVisitors, 123123241)
 
         let sampleItem1 = weekStats.items![0]
         XCTAssertEqual(sampleItem1.period, "2018W05W21")
@@ -69,7 +67,6 @@ class SiteVisitStatsMapperTests: XCTestCase {
         XCTAssertEqual(monthStats.granularity, .month)
         XCTAssertEqual(monthStats.date, "2018-08-06")
         XCTAssertEqual(monthStats.items!.count, 12)
-        XCTAssertEqual(monthStats.totalVisitors, 292)
 
         let sampleItem1 = monthStats.items![0]
         XCTAssertEqual(sampleItem1.period, "2017-09-01")
@@ -94,7 +91,6 @@ class SiteVisitStatsMapperTests: XCTestCase {
         XCTAssertEqual(yearStats.granularity, .year)
         XCTAssertEqual(yearStats.date, "2018-08-06")
         XCTAssertEqual(yearStats.items!.count, 5)
-        XCTAssertEqual(yearStats.totalVisitors, 3336)
 
         let sampleItem1 = yearStats.items![0]
         XCTAssertEqual(sampleItem1.period, "2014-01-01")

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -17,9 +17,9 @@ final class StoreInfoDataService {
     ///
     private var orderStatsRemoteV4: OrderStatsRemoteV4
 
-    /// Visitors remoute source
+    /// Visitors remote source
     ///
-    private var siteVisitStatsRemote: SiteStatsRemote
+    private var siteStatsRemote: SiteStatsRemote
 
     /// Network helper.
     ///
@@ -28,7 +28,7 @@ final class StoreInfoDataService {
     init(authToken: String) {
         network = AlamofireNetwork(credentials: Credentials(authToken: authToken))
         orderStatsRemoteV4 = OrderStatsRemoteV4(network: network)
-        siteVisitStatsRemote = SiteStatsRemote(network: network)
+        siteStatsRemote = SiteStatsRemote(network: network)
     }
 
     /// Async function that fetches todays stats data.
@@ -36,16 +36,16 @@ final class StoreInfoDataService {
     func fetchTodayStats(for storeID: Int64) async throws -> Stats {
         // Prepare them to run in parallel
         async let revenueAndOrdersRequest = fetchTodaysRevenueAndOrders(for: storeID)
-        async let visitorsRequest = fetchTodaysVisitors(for: storeID)
+        async let siteStatsRequest = fetchTodaysVisitors(for: storeID)
 
         // Wait for for response
-        let (revenueAndOrders, visitors) = try await (revenueAndOrdersRequest, visitorsRequest)
+        let (revenueAndOrders, siteStats) = try await (revenueAndOrdersRequest, siteStatsRequest)
 
         // Assemble stats data
-        let conversion = visitors.totalVisitors > 0 ? Double(revenueAndOrders.totals.totalOrders) / Double(visitors.totalVisitors) : 0
+        let conversion = siteStats.visitors > 0 ? Double(revenueAndOrders.totals.totalOrders) / Double(siteStats.visitors) : 0
         return Stats(revenue: revenueAndOrders.totals.grossRevenue,
                      totalOrders: revenueAndOrders.totals.totalOrders,
-                     totalVisitors: visitors.totalVisitors,
+                     totalVisitors: siteStats.visitors,
                      conversion: min(conversion, 1))
     }
 }
@@ -74,14 +74,13 @@ private extension StoreInfoDataService {
 
     /// Async wrapper that fetches todays visitors.
     ///
-    func fetchTodaysVisitors(for storeID: Int64) async throws -> SiteVisitStats {
+    func fetchTodaysVisitors(for storeID: Int64) async throws -> SiteSummaryStats {
         try await withCheckedThrowingContinuation { continuation in
-            // `WKWebView` is accessed internally, we are foreced to dispatch the call in the main thread.
+            // `WKWebView` is accessed internally, we are forced to dispatch the call in the main thread.
             Task { @MainActor in
-                siteVisitStatsRemote.loadSiteVisitorStats(for: storeID,
-                                                          unit: .day,
-                                                          latestDateToInclude: Date().endOfDay(timezone: .current),
-                                                          quantity: 1) { result in
+                siteStatsRemote.loadSiteSummaryStats(for: storeID,
+                                                     period: .day,
+                                                     includingDate: Date().endOfDay(timezone: .current)) { result in
                     continuation.resume(with: result)
                 }
             }

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -231,10 +231,11 @@ private extension StatsStoreV4 {
                 switch result {
                 case .success(let siteVisitStats):
                     let totalViews = siteVisitStats.items?.map({ $0.views }).reduce(0, +) ?? 0
+                    let totalVisitors = siteVisitStats.items?.map({ $0.visitors }).reduce(0, +) ?? 0
                     let summaryStats = SiteSummaryStats(siteID: siteID,
                                                         date: siteVisitStats.date,
                                                         period: siteVisitStats.granularity,
-                                                        visitors: siteVisitStats.totalVisitors,
+                                                        visitors: totalVisitors,
                                                         views: totalViews)
                     onCompletion(.success(summaryStats))
                 case .failure(let error):


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8426
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes the inaccurate `totalVisitors` property from `SiteVisitStats`. The more accurate way to get a total visitor count is by getting the `SiteSummaryStats.visitors` for the same period.

### Why

The `totalVisitors` property computes a site's total visitor count for the entire requested period by adding together the visitor count for each of the intervals within the period. However, this is inaccurate because visitors are uniques, so the same visitor should only be counted once even if they visit multiple times during the entire period. In contrast, requesting `SiteSummaryStats` from remote gets the total count for the requested period from the backend.

### Changes

* This property was still being used in the Store Info Widget (`StoreInfoDataService`). The remote request is updated so we get the total visitor count from `SiteSummaryStats.visitors` instead.
* The property was also being used in `StoreStatsV4`, which is now doing the same calculation instead. This is needed in this specific context because we currently can't get a total visitor count for quarter periods from the backend (used in Analytics Hub).
* The `totalVisitors` computed property is removed from `SiteVisitStats` and related unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

This PR changes the source of the stats, but there should be no visible change in the app:

1. Build and run the app.
2. Add a widget to home screen (long press on home screen > tap + in top left > search for Woo).
3. Confirm the stats load on the widget.
4. Open the app and confirm the stats on the My Store dashboard match the widget stats.
5. Tap "See more" to open Analytics, select a quarter period ("Quarter to date" or "Last quarter") and confirm the Sessions card loads as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/8658164/208958069-c9b0f3e0-0745-42a5-8ad6-2d883bc63deb.png" width="300px">



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
