### PR TITLE
REST API: Fetch site info after authenticating without WPCom

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -676,6 +676,7 @@
 		DE2095BF279583A100171F1C /* CouponReportListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2095BE279583A100171F1C /* CouponReportListMapper.swift */; };
 		DE2095C127966EC800171F1C /* coupon-reports.json in Resources */ = {isa = PBXBuildFile; fileRef = DE2095C027966EC800171F1C /* coupon-reports.json */; };
 		DE2E8E9D29530EEF002E4B14 /* WordPressSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8E9C29530EEF002E4B14 /* WordPressSite.swift */; };
+		DE2E8E9F295310C5002E4B14 /* WordPressSiteMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8E9E295310C5002E4B14 /* WordPressSiteMapper.swift */; };
 		DE34051328BDCA5100CF0D97 /* WordPressOrgRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */; };
 		DE34051528BDEB1900CF0D97 /* WordPressOrgNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */; };
 		DE34051728BDEB6D00CF0D97 /* JetpackConnectionRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */; };
@@ -1448,6 +1449,7 @@
 		DE2095BE279583A100171F1C /* CouponReportListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapper.swift; sourceTree = "<group>"; };
 		DE2095C027966EC800171F1C /* coupon-reports.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-reports.json"; sourceTree = "<group>"; };
 		DE2E8E9C29530EEF002E4B14 /* WordPressSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSite.swift; sourceTree = "<group>"; };
+		DE2E8E9E295310C5002E4B14 /* WordPressSiteMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteMapper.swift; sourceTree = "<group>"; };
 		DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgRequest.swift; sourceTree = "<group>"; };
 		DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressOrgNetwork.swift; sourceTree = "<group>"; };
 		DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackConnectionRemote.swift; sourceTree = "<group>"; };
@@ -2403,6 +2405,7 @@
 				68CB800D28D8901B00E169F8 /* CustomerMapper.swift */,
 				68F48B0C28E3B2E80045C15B /* WCAnalyticsCustomerMapper.swift */,
 				EE54C8A629486B6800A9BF61 /* ApplicationPasswordMapper.swift */,
+				DE2E8E9E295310C5002E4B14 /* WordPressSiteMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -3193,6 +3196,7 @@
 				B5C151BB217EC34100C7BDC1 /* KeyedDecodingContainer+Woo.swift in Sources */,
 				933A2732222234F800C2143A /* Logging.swift in Sources */,
 				CE50346021B5799F007573C6 /* SitePlan.swift in Sources */,
+				DE2E8E9F295310C5002E4B14 /* WordPressSiteMapper.swift in Sources */,
 				B59325CC217E2B4C000B0E8E /* NoteListMapper.swift in Sources */,
 				B505F6CD20BEE37E00BB1B69 /* AccountMapper.swift in Sources */,
 				B554FA8F2180BC7000C54DFF /* NoteHashListMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -679,6 +679,7 @@
 		DE2E8E9F295310C5002E4B14 /* WordPressSiteMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8E9E295310C5002E4B14 /* WordPressSiteMapper.swift */; };
 		DE2E8EA12953115C002E4B14 /* WordPressSiteRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EA02953115C002E4B14 /* WordPressSiteRemote.swift */; };
 		DE2E8EA9295416C9002E4B14 /* wordpress-site-info.json in Resources */ = {isa = PBXBuildFile; fileRef = DE2E8EA8295416C9002E4B14 /* wordpress-site-info.json */; };
+		DE2E8EAB2954170D002E4B14 /* WordPressSiteMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EAA2954170D002E4B14 /* WordPressSiteMapperTests.swift */; };
 		DE34051328BDCA5100CF0D97 /* WordPressOrgRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */; };
 		DE34051528BDEB1900CF0D97 /* WordPressOrgNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */; };
 		DE34051728BDEB6D00CF0D97 /* JetpackConnectionRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */; };
@@ -1454,6 +1455,7 @@
 		DE2E8E9E295310C5002E4B14 /* WordPressSiteMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteMapper.swift; sourceTree = "<group>"; };
 		DE2E8EA02953115C002E4B14 /* WordPressSiteRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteRemote.swift; sourceTree = "<group>"; };
 		DE2E8EA8295416C9002E4B14 /* wordpress-site-info.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wordpress-site-info.json"; sourceTree = "<group>"; };
+		DE2E8EAA2954170D002E4B14 /* WordPressSiteMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteMapperTests.swift; sourceTree = "<group>"; };
 		DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgRequest.swift; sourceTree = "<group>"; };
 		DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressOrgNetwork.swift; sourceTree = "<group>"; };
 		DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackConnectionRemote.swift; sourceTree = "<group>"; };
@@ -2477,6 +2479,7 @@
 			isa = PBXGroup;
 			children = (
 				B505F6D220BEE3A500BB1B69 /* AccountMapperTests.swift */,
+				DE2E8EAA2954170D002E4B14 /* WordPressSiteMapperTests.swift */,
 				9387A6EF226E3F15001B53D7 /* AccountSettingsMapperTests.swift */,
 				077F39DB26A58F4800ABEADC /* SystemPluginMapperTests.swift */,
 				DEC51AFA2769C66B009F3DF4 /* SystemStatusMapperTests.swift */,
@@ -3491,6 +3494,7 @@
 				DE6F308727966FEF004E1C9A /* CouponReportListMapperTests.swift in Sources */,
 				4599FC5A24A626B70056157A /* ProductTagListMapperTests.swift in Sources */,
 				68F48B1128E3BBC60045C15B /* WCAnalyticsCustomerMapperTests.swift in Sources */,
+				DE2E8EAB2954170D002E4B14 /* WordPressSiteMapperTests.swift in Sources */,
 				D88D5A4F230BD276007B6E01 /* ProductReviewListMapperTests.swift in Sources */,
 				B567AF3120A0FB8F00AB6C62 /* JetpackRequestTests.swift in Sources */,
 				7412A8F221B6E47A005D182A /* ReportRemoteTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -683,6 +683,7 @@
 		DE2E8EAD295418D8002E4B14 /* WordPressSiteRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EAC295418D8002E4B14 /* WordPressSiteRemoteTests.swift */; };
 		DE2E8EB1295464C5002E4B14 /* URLRequest+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EB0295464C5002E4B14 /* URLRequest+Request.swift */; };
 		DE2E8EB329546501002E4B14 /* PlaceholderDataValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EB229546501002E4B14 /* PlaceholderDataValidator.swift */; };
+		DE2E8EB529546648002E4B14 /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EB429546648002E4B14 /* WooConstants.swift */; };
 		DE34051328BDCA5100CF0D97 /* WordPressOrgRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */; };
 		DE34051528BDEB1900CF0D97 /* WordPressOrgNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */; };
 		DE34051728BDEB6D00CF0D97 /* JetpackConnectionRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */; };
@@ -1462,6 +1463,7 @@
 		DE2E8EAC295418D8002E4B14 /* WordPressSiteRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteRemoteTests.swift; sourceTree = "<group>"; };
 		DE2E8EB0295464C5002E4B14 /* URLRequest+Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Request.swift"; sourceTree = "<group>"; };
 		DE2E8EB229546501002E4B14 /* PlaceholderDataValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderDataValidator.swift; sourceTree = "<group>"; };
+		DE2E8EB429546648002E4B14 /* WooConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooConstants.swift; sourceTree = "<group>"; };
 		DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgRequest.swift; sourceTree = "<group>"; };
 		DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressOrgNetwork.swift; sourceTree = "<group>"; };
 		DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackConnectionRemote.swift; sourceTree = "<group>"; };
@@ -1966,6 +1968,7 @@
 				45551F112523E7F1007EF104 /* UserAgent.swift */,
 				B557DA0A20975D7E005962F4 /* WooAPIVersion.swift */,
 				B557DA0C20975DB1005962F4 /* WordPressAPIVersion.swift */,
+				DE2E8EB429546648002E4B14 /* WooConstants.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -3351,6 +3354,7 @@
 				CCF48B282628A4EB0034EA83 /* ShippingLabelAccountSettingsMapper.swift in Sources */,
 				B5BB1D1220A255EC00112D92 /* OrderStatusEnum.swift in Sources */,
 				DE50295928C5BD0200551736 /* JetpackUser.swift in Sources */,
+				DE2E8EB529546648002E4B14 /* WooConstants.swift in Sources */,
 				0359EA1727AAC7740048DE2D /* WCPayCardFunding.swift in Sources */,
 				D88E229425AC9B420023F3B1 /* OrderFeeTaxStatus.swift in Sources */,
 				B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -677,6 +677,7 @@
 		DE2095C127966EC800171F1C /* coupon-reports.json in Resources */ = {isa = PBXBuildFile; fileRef = DE2095C027966EC800171F1C /* coupon-reports.json */; };
 		DE2E8E9D29530EEF002E4B14 /* WordPressSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8E9C29530EEF002E4B14 /* WordPressSite.swift */; };
 		DE2E8E9F295310C5002E4B14 /* WordPressSiteMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8E9E295310C5002E4B14 /* WordPressSiteMapper.swift */; };
+		DE2E8EA12953115C002E4B14 /* WordPressSiteRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EA02953115C002E4B14 /* WordPressSiteRemote.swift */; };
 		DE34051328BDCA5100CF0D97 /* WordPressOrgRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */; };
 		DE34051528BDEB1900CF0D97 /* WordPressOrgNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */; };
 		DE34051728BDEB6D00CF0D97 /* JetpackConnectionRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */; };
@@ -1450,6 +1451,7 @@
 		DE2095C027966EC800171F1C /* coupon-reports.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-reports.json"; sourceTree = "<group>"; };
 		DE2E8E9C29530EEF002E4B14 /* WordPressSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSite.swift; sourceTree = "<group>"; };
 		DE2E8E9E295310C5002E4B14 /* WordPressSiteMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteMapper.swift; sourceTree = "<group>"; };
+		DE2E8EA02953115C002E4B14 /* WordPressSiteRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteRemote.swift; sourceTree = "<group>"; };
 		DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgRequest.swift; sourceTree = "<group>"; };
 		DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressOrgNetwork.swift; sourceTree = "<group>"; };
 		DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackConnectionRemote.swift; sourceTree = "<group>"; };
@@ -1925,6 +1927,7 @@
 				023930622918FF5400B2632F /* DomainRemote.swift */,
 				021940E1291E3CFD0090354E /* SiteRemote.swift */,
 				02EF1663292DADDE00D90AD6 /* PaymentRemote.swift */,
+				DE2E8EA02953115C002E4B14 /* WordPressSiteRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -3318,6 +3321,7 @@
 				26455E2A25F669F0008A1D32 /* ProductAttributeTermMapper.swift in Sources */,
 				0359EA1127AAC6740048DE2D /* WCPayPaymentMethodType.swift in Sources */,
 				E16C59B528F8640B007D55BB /* InAppPurchaseOrderResultMapper.swift in Sources */,
+				DE2E8EA12953115C002E4B14 /* WordPressSiteRemote.swift in Sources */,
 				026CF61A237D607A009563D4 /* ProductVariationAttribute.swift in Sources */,
 				D8FBFF1A22D4DF7A006E3336 /* OrderStatsV4.swift in Sources */,
 				03EB99882906A78400F06A39 /* JustInTimeMessagesRemote.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -681,6 +681,8 @@
 		DE2E8EA9295416C9002E4B14 /* wordpress-site-info.json in Resources */ = {isa = PBXBuildFile; fileRef = DE2E8EA8295416C9002E4B14 /* wordpress-site-info.json */; };
 		DE2E8EAB2954170D002E4B14 /* WordPressSiteMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EAA2954170D002E4B14 /* WordPressSiteMapperTests.swift */; };
 		DE2E8EAD295418D8002E4B14 /* WordPressSiteRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EAC295418D8002E4B14 /* WordPressSiteRemoteTests.swift */; };
+		DE2E8EB1295464C5002E4B14 /* URLRequest+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EB0295464C5002E4B14 /* URLRequest+Request.swift */; };
+		DE2E8EB329546501002E4B14 /* PlaceholderDataValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EB229546501002E4B14 /* PlaceholderDataValidator.swift */; };
 		DE34051328BDCA5100CF0D97 /* WordPressOrgRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */; };
 		DE34051528BDEB1900CF0D97 /* WordPressOrgNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */; };
 		DE34051728BDEB6D00CF0D97 /* JetpackConnectionRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */; };
@@ -1458,6 +1460,8 @@
 		DE2E8EA8295416C9002E4B14 /* wordpress-site-info.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wordpress-site-info.json"; sourceTree = "<group>"; };
 		DE2E8EAA2954170D002E4B14 /* WordPressSiteMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteMapperTests.swift; sourceTree = "<group>"; };
 		DE2E8EAC295418D8002E4B14 /* WordPressSiteRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteRemoteTests.swift; sourceTree = "<group>"; };
+		DE2E8EB0295464C5002E4B14 /* URLRequest+Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Request.swift"; sourceTree = "<group>"; };
+		DE2E8EB229546501002E4B14 /* PlaceholderDataValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderDataValidator.swift; sourceTree = "<group>"; };
 		DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgRequest.swift; sourceTree = "<group>"; };
 		DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressOrgNetwork.swift; sourceTree = "<group>"; };
 		DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackConnectionRemote.swift; sourceTree = "<group>"; };
@@ -1821,6 +1825,7 @@
 				B53EF5332180F646003E146F /* DotcomValidator.swift */,
 				E1BAB2C42913FB1800C3982B /* WordPressApiValidator.swift */,
 				E1BAB2C22913FA6400C3982B /* ResponseDataValidator.swift */,
+				DE2E8EB229546501002E4B14 /* PlaceholderDataValidator.swift */,
 			);
 			path = Validators;
 			sourceTree = "<group>";
@@ -2461,6 +2466,7 @@
 				02BDB83423EA98C800BCC63E /* String+HTML.swift */,
 				57E8FED2246616AC0057CD68 /* Result+Extensions.swift */,
 				265EFBDB285257950033BD33 /* Order+Fallbacks.swift */,
+				DE2E8EB0295464C5002E4B14 /* URLRequest+Request.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3227,6 +3233,7 @@
 				68F48B0928E3AF750045C15B /* WCAnalyticsCustomer.swift in Sources */,
 				74159625224D4045003C21CF /* SiteSettingGroup.swift in Sources */,
 				26B2F74D24C696E70065CCC8 /* LeaderboardRowContent.swift in Sources */,
+				DE2E8EB1295464C5002E4B14 /* URLRequest+Request.swift in Sources */,
 				31799AF8270508C600D78179 /* RemoteReaderLocation.swift in Sources */,
 				D8FBFF1122D3B3FC006E3336 /* OrderStatsV4Mapper.swift in Sources */,
 				4595827C264D5B3F000A4413 /* ShippingLabelPackageSelected.swift in Sources */,
@@ -3423,6 +3430,7 @@
 				2676F4CE290AE6BB00C7A15B /* EntityIDMapper.swift in Sources */,
 				CE0A0F1B223989670075ED8D /* ProductsRemote.swift in Sources */,
 				0359EA1527AAC7460048DE2D /* WCPayCardBrand.swift in Sources */,
+				DE2E8EB329546501002E4B14 /* PlaceholderDataValidator.swift in Sources */,
 				2665032E261F4FBF0079A159 /* ProductAddOnOption.swift in Sources */,
 				E18152C028F85D4A0011A0EC /* InAppPurchasesProductMapper.swift in Sources */,
 				028296F7237D588700E84012 /* ProductVariation.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -675,6 +675,7 @@
 		DE2095BD27956D7900171F1C /* CouponReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2095BC27956D7900171F1C /* CouponReport.swift */; };
 		DE2095BF279583A100171F1C /* CouponReportListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2095BE279583A100171F1C /* CouponReportListMapper.swift */; };
 		DE2095C127966EC800171F1C /* coupon-reports.json in Resources */ = {isa = PBXBuildFile; fileRef = DE2095C027966EC800171F1C /* coupon-reports.json */; };
+		DE2E8E9D29530EEF002E4B14 /* WordPressSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8E9C29530EEF002E4B14 /* WordPressSite.swift */; };
 		DE34051328BDCA5100CF0D97 /* WordPressOrgRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */; };
 		DE34051528BDEB1900CF0D97 /* WordPressOrgNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */; };
 		DE34051728BDEB6D00CF0D97 /* JetpackConnectionRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */; };
@@ -1446,6 +1447,7 @@
 		DE2095BC27956D7900171F1C /* CouponReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReport.swift; sourceTree = "<group>"; };
 		DE2095BE279583A100171F1C /* CouponReportListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapper.swift; sourceTree = "<group>"; };
 		DE2095C027966EC800171F1C /* coupon-reports.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-reports.json"; sourceTree = "<group>"; };
+		DE2E8E9C29530EEF002E4B14 /* WordPressSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSite.swift; sourceTree = "<group>"; };
 		DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgRequest.swift; sourceTree = "<group>"; };
 		DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressOrgNetwork.swift; sourceTree = "<group>"; };
 		DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackConnectionRemote.swift; sourceTree = "<group>"; };
@@ -2035,6 +2037,7 @@
 				0359EA0E27AAC6410048DE2D /* WCPayPaymentMethodDetails.swift */,
 				0359EA1027AAC6740048DE2D /* WCPayPaymentMethodType.swift */,
 				E1BAB2C62913FB5800C3982B /* WordPressApiError.swift */,
+				DE2E8E9C29530EEF002E4B14 /* WordPressSite.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -3372,6 +3375,7 @@
 				CE6BFEEA2236E191005C79FB /* ProductType.swift in Sources */,
 				CE6D666C2379E19D007835A1 /* Array+Woo.swift in Sources */,
 				CCF48B1E26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift in Sources */,
+				DE2E8E9D29530EEF002E4B14 /* WordPressSite.swift in Sources */,
 				DEC51AE927687AAF009F3DF4 /* SystemPluginMapper.swift in Sources */,
 				B557DA0B20975D7E005962F4 /* WooAPIVersion.swift in Sources */,
 				45150A9E26836A57006922EA /* CountryListMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -680,6 +680,7 @@
 		DE2E8EA12953115C002E4B14 /* WordPressSiteRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EA02953115C002E4B14 /* WordPressSiteRemote.swift */; };
 		DE2E8EA9295416C9002E4B14 /* wordpress-site-info.json in Resources */ = {isa = PBXBuildFile; fileRef = DE2E8EA8295416C9002E4B14 /* wordpress-site-info.json */; };
 		DE2E8EAB2954170D002E4B14 /* WordPressSiteMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EAA2954170D002E4B14 /* WordPressSiteMapperTests.swift */; };
+		DE2E8EAD295418D8002E4B14 /* WordPressSiteRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EAC295418D8002E4B14 /* WordPressSiteRemoteTests.swift */; };
 		DE34051328BDCA5100CF0D97 /* WordPressOrgRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */; };
 		DE34051528BDEB1900CF0D97 /* WordPressOrgNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */; };
 		DE34051728BDEB6D00CF0D97 /* JetpackConnectionRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */; };
@@ -1456,6 +1457,7 @@
 		DE2E8EA02953115C002E4B14 /* WordPressSiteRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteRemote.swift; sourceTree = "<group>"; };
 		DE2E8EA8295416C9002E4B14 /* wordpress-site-info.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wordpress-site-info.json"; sourceTree = "<group>"; };
 		DE2E8EAA2954170D002E4B14 /* WordPressSiteMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteMapperTests.swift; sourceTree = "<group>"; };
+		DE2E8EAC295418D8002E4B14 /* WordPressSiteRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteRemoteTests.swift; sourceTree = "<group>"; };
 		DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgRequest.swift; sourceTree = "<group>"; };
 		DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressOrgNetwork.swift; sourceTree = "<group>"; };
 		DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackConnectionRemote.swift; sourceTree = "<group>"; };
@@ -1787,6 +1789,7 @@
 				0239306A291A96F800B2632F /* DomainRemoteTests.swift */,
 				02616F8B292132800095BC00 /* SiteRemoteTests.swift */,
 				02EF166D292F0C5800D90AD6 /* PaymentRemoteTests.swift */,
+				DE2E8EAC295418D8002E4B14 /* WordPressSiteRemoteTests.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -3447,6 +3450,7 @@
 				74D5BECE217E0F98007B0348 /* SiteSettingsRemoteTests.swift in Sources */,
 				D8FBFF1C22D51C34006E3336 /* OrderStatsRemoteV4Tests.swift in Sources */,
 				CE6D666F2379E82A007835A1 /* ArrayWooTests.swift in Sources */,
+				DE2E8EAD295418D8002E4B14 /* WordPressSiteRemoteTests.swift in Sources */,
 				45D685FC23D0C739005F87D0 /* ProductSkuMapperTests.swift in Sources */,
 				CEC4BF95234E7F34008D9195 /* RefundListMapperTests.swift in Sources */,
 				74A7B4BC217A807400E85A8B /* SiteSettingsMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -678,6 +678,7 @@
 		DE2E8E9D29530EEF002E4B14 /* WordPressSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8E9C29530EEF002E4B14 /* WordPressSite.swift */; };
 		DE2E8E9F295310C5002E4B14 /* WordPressSiteMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8E9E295310C5002E4B14 /* WordPressSiteMapper.swift */; };
 		DE2E8EA12953115C002E4B14 /* WordPressSiteRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EA02953115C002E4B14 /* WordPressSiteRemote.swift */; };
+		DE2E8EA9295416C9002E4B14 /* wordpress-site-info.json in Resources */ = {isa = PBXBuildFile; fileRef = DE2E8EA8295416C9002E4B14 /* wordpress-site-info.json */; };
 		DE34051328BDCA5100CF0D97 /* WordPressOrgRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */; };
 		DE34051528BDEB1900CF0D97 /* WordPressOrgNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */; };
 		DE34051728BDEB6D00CF0D97 /* JetpackConnectionRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */; };
@@ -1452,6 +1453,7 @@
 		DE2E8E9C29530EEF002E4B14 /* WordPressSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSite.swift; sourceTree = "<group>"; };
 		DE2E8E9E295310C5002E4B14 /* WordPressSiteMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteMapper.swift; sourceTree = "<group>"; };
 		DE2E8EA02953115C002E4B14 /* WordPressSiteRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteRemote.swift; sourceTree = "<group>"; };
+		DE2E8EA8295416C9002E4B14 /* wordpress-site-info.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wordpress-site-info.json"; sourceTree = "<group>"; };
 		DE34051228BDCA5100CF0D97 /* WordPressOrgRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgRequest.swift; sourceTree = "<group>"; };
 		DE34051428BDEB1900CF0D97 /* WordPressOrgNetwork.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressOrgNetwork.swift; sourceTree = "<group>"; };
 		DE34051628BDEB6D00CF0D97 /* JetpackConnectionRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackConnectionRemote.swift; sourceTree = "<group>"; };
@@ -2052,6 +2054,7 @@
 			children = (
 				EE338A0A294AF92A00183934 /* AppliicationPassword */,
 				DE9DEEF4291CF1B40070AD7C /* site-plugin-without-envelope.json */,
+				DE2E8EA8295416C9002E4B14 /* wordpress-site-info.json */,
 				028CB714290223CB00331C09 /* account-username-suggestions.json */,
 				028CB71C2902589E00331C09 /* create-account-error-email-exists.json */,
 				028CB71D2902589E00331C09 /* create-account-error-invalid-email.json */,
@@ -3000,6 +3003,7 @@
 				31A451D127863A2E00FE81AA /* stripe-account-rejected-other.json in Resources */,
 				74ABA1CA213F19FE00FFAD30 /* top-performers-year.json in Resources */,
 				31A451CF27863A2E00FE81AA /* stripe-account-rejected-terms-of-service.json in Resources */,
+				DE2E8EA9295416C9002E4B14 /* wordpress-site-info.json in Resources */,
 				268EC45C26C169F600716F5C /* order-with-faulty-attributes.json in Resources */,
 				45AB8B0F24AA29DC00B5B36E /* product-tags-created.json in Resources */,
 				3158FE8426129F3A00E566B9 /* wcpay-account-unknown-status.json in Resources */,

--- a/Networking/Networking/Extensions/URLRequest+Request.swift
+++ b/Networking/Networking/Extensions/URLRequest+Request.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Makes URLRequest conform to Request.
+extension URLRequest: Request {
+    func responseDataValidator() -> ResponseDataValidator {
+        PlaceholderDataValidator()
+    }
+}

--- a/Networking/Networking/Mapper/SitePluginMapper.swift
+++ b/Networking/Networking/Mapper/SitePluginMapper.swift
@@ -9,16 +9,12 @@ struct SitePluginMapper: Mapper {
     ///
     private let siteID: Int64
 
-    private let withDataEnvelope: Bool
-
     /// Initialized a mapper to serialize site plugins.
     /// - Parameters:
     ///   - siteID: Identifier for the site. Only required in authenticated state.
-    ///   - withDataEnvelope: Whether site plugin details are wrapped inside a `data` field.
     ///
-    init(siteID: Int64 = -1, withDataEnvelope: Bool = true) {
+    init(siteID: Int64 = WooConstants.placeholderSiteID) {
         self.siteID = siteID
-        self.withDataEnvelope = withDataEnvelope
     }
 
     /// (Attempts) to convert a dictionary into SitePlugin.
@@ -29,11 +25,11 @@ struct SitePluginMapper: Mapper {
             .siteID: siteID
         ]
 
-        if withDataEnvelope {
+        do {
             return try decoder.decode(SitePluginEnvelope.self, from: response).plugin
+        } catch {
+            return try decoder.decode(SitePlugin.self, from: response)
         }
-
-        return try decoder.decode(SitePlugin.self, from: response)
     }
 }
 

--- a/Networking/Networking/Mapper/WordPressSiteMapper.swift
+++ b/Networking/Networking/Mapper/WordPressSiteMapper.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Mapper for `WordPressSite`.
+///
+struct WordPressSiteMapper: Mapper {
+
+    func map(response: Data) throws -> WordPressSite {
+        let decoder = JSONDecoder()
+        return try decoder.decode(WordPressSite.self, from: response)
+    }
+}

--- a/Networking/Networking/Model/WordPressSite.swift
+++ b/Networking/Networking/Model/WordPressSite.swift
@@ -37,7 +37,7 @@ public extension WordPressSite {
     /// Converts to `Site` with placeholder values for unknown fields.
     ///
     var asSite: Site {
-        .init(siteID: Constants.placeholderSiteID, // Placeholder site ID
+        .init(siteID: WooConstants.placeholderSiteID, // Placeholder site ID
               name: name,
               description: description,
               url: url,
@@ -67,7 +67,6 @@ private extension WordPressSite {
     }
 
     enum Constants {
-        static let placeholderSiteID: Int64 = -1
         static let adminPath = "/wp-admin"
         static let loginPath = "/wp-login.php"
     }

--- a/Networking/Networking/Model/WordPressSite.swift
+++ b/Networking/Networking/Model/WordPressSite.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents basic information for a WordPress site.
 ///
-struct WordPressSite: Decodable, Equatable {
+public struct WordPressSite: Decodable, Equatable {
     
     /// Site's Name.
     ///

--- a/Networking/Networking/Model/WordPressSite.swift
+++ b/Networking/Networking/Model/WordPressSite.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Represents basic information for a WordPress site.
 ///
 public struct WordPressSite: Decodable, Equatable {
-    
+
     /// Site's Name.
     ///
     public let name: String
@@ -30,6 +30,28 @@ public struct WordPressSite: Decodable, Equatable {
         self.url = url
         self.timezone = timezone
         self.gmtOffset = gmtOffset
+    }
+}
+
+public extension WordPressSite {
+    /// Converts to `Site` with placeholder values for unknown fields.
+    ///
+    func asSite() -> Site {
+        Site(siteID: -1,
+             name: name,
+             description: description,
+             url: url,
+             adminURL: "",
+             loginURL: "",
+             frameNonce: "",
+             plan: "",
+             isJetpackThePluginInstalled: false,
+             isJetpackConnected: false,
+             isWooCommerceActive: true,
+             isWordPressComStore: false,
+             jetpackConnectionActivePlugins: [],
+             timezone: timezone,
+             gmtOffset: gmtOffset)
     }
 }
 

--- a/Networking/Networking/Model/WordPressSite.swift
+++ b/Networking/Networking/Model/WordPressSite.swift
@@ -22,9 +22,9 @@ public struct WordPressSite: Decodable, Equatable {
 
     /// Return the website UTC time offset, showing the difference in hours and minutes from UTC, from the westernmost (−12:00) to the easternmost (+14:00).
     ///
-    public let gmtOffset: Double
+    public let gmtOffset: String
 
-    public init(name: String, description: String, url: String, timezone: String, gmtOffset: Double) {
+    public init(name: String, description: String, url: String, timezone: String, gmtOffset: String) {
         self.name = name
         self.description = description
         self.url = url
@@ -37,12 +37,12 @@ public extension WordPressSite {
     /// Converts to `Site` with placeholder values for unknown fields.
     ///
     func asSite() -> Site {
-        Site(siteID: -1,
+        .init(siteID: -1, // Placeholder site ID
              name: name,
              description: description,
              url: url,
-             adminURL: "",
-             loginURL: "",
+             adminURL: url + "/wp-admin", // this would not work for sites with custom URLs
+             loginURL: url + "/wp-login.php", // this would not work for sites with custom URLs
              frameNonce: "",
              plan: "",
              isJetpackThePluginInstalled: false,
@@ -51,7 +51,7 @@ public extension WordPressSite {
              isWordPressComStore: false,
              jetpackConnectionActivePlugins: [],
              timezone: timezone,
-             gmtOffset: gmtOffset)
+             gmtOffset: Double(gmtOffset) ?? 0)
     }
 }
 

--- a/Networking/Networking/Model/WordPressSite.swift
+++ b/Networking/Networking/Model/WordPressSite.swift
@@ -36,34 +36,39 @@ public struct WordPressSite: Decodable, Equatable {
 public extension WordPressSite {
     /// Converts to `Site` with placeholder values for unknown fields.
     ///
-    func asSite() -> Site {
-        .init(siteID: -1, // Placeholder site ID
-             name: name,
-             description: description,
-             url: url,
-             adminURL: url + "/wp-admin", // this would not work for sites with custom URLs
-             loginURL: url + "/wp-login.php", // this would not work for sites with custom URLs
-             frameNonce: "",
-             plan: "",
-             isJetpackThePluginInstalled: false,
-             isJetpackConnected: false,
-             isWooCommerceActive: true,
-             isWordPressComStore: false,
-             jetpackConnectionActivePlugins: [],
-             timezone: timezone,
-             gmtOffset: Double(gmtOffset) ?? 0)
+    var asSite: Site {
+        .init(siteID: Constants.placeholderSiteID, // Placeholder site ID
+              name: name,
+              description: description,
+              url: url,
+              adminURL: url + Constants.adminPath, // this would not work for sites with custom URLs
+              loginURL: url + Constants.loginPath, // this would not work for sites with custom URLs
+              frameNonce: "",
+              plan: "",
+              isJetpackThePluginInstalled: false,
+              isJetpackConnected: false,
+              isWooCommerceActive: true, // we expect to only call this after checking Woo is active
+              isWordPressComStore: false,
+              jetpackConnectionActivePlugins: [],
+              timezone: timezone,
+              gmtOffset: Double(gmtOffset) ?? 0)
     }
 }
 
 /// Defines all of the WordPressSite CodingKeys
 ///
 private extension WordPressSite {
-
     enum CodingKeys: String, CodingKey {
         case name
         case description
         case url
         case timezone = "timezone_string"
         case gmtOffset = "gmt_offset"
+    }
+
+    enum Constants {
+        static let placeholderSiteID: Int64 = -1
+        static let adminPath = "/wp-admin"
+        static let loginPath = "/wp-login.php"
     }
 }

--- a/Networking/Networking/Model/WordPressSite.swift
+++ b/Networking/Networking/Model/WordPressSite.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Represents basic information for a WordPress site.
+///
+struct WordPressSite: Decodable, Equatable {
+    
+    /// Site's Name.
+    ///
+    public let name: String
+
+    /// Site's Description.
+    ///
+    public let description: String
+
+    /// Site's URL.
+    ///
+    public let url: String
+
+    /// Time zone identifier of the site (TZ database name).
+    ///
+    public let timezone: String
+
+    /// Return the website UTC time offset, showing the difference in hours and minutes from UTC, from the westernmost (−12:00) to the easternmost (+14:00).
+    ///
+    public let gmtOffset: Double
+
+    public init(name: String, description: String, url: String, timezone: String, gmtOffset: Double) {
+        self.name = name
+        self.description = description
+        self.url = url
+        self.timezone = timezone
+        self.gmtOffset = gmtOffset
+    }
+}
+
+/// Defines all of the WordPressSite CodingKeys
+///
+private extension WordPressSite {
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case description
+        case url
+        case timezone = "timezone_string"
+        case gmtOffset = "gmt_offset"
+    }
+}

--- a/Networking/Networking/Network/NetworkError.swift
+++ b/Networking/Networking/Network/NetworkError.swift
@@ -16,6 +16,8 @@ public enum NetworkError: Error, Equatable {
     /// Any statusCode that's not in the [200, 300) range!
     ///
     case unacceptableStatusCode(statusCode: Int)
+
+    case invalidURL
 }
 
 

--- a/Networking/Networking/Network/RequestAuthenticator.swift
+++ b/Networking/Networking/Network/RequestAuthenticator.swift
@@ -73,7 +73,9 @@ final class RequestAuthenticator {
     /// Attempts creating a request with WPCOM token if possible.
     ///
     private func authenticateUsingWPCOMTokenIfPossible(_ request: URLRequestConvertible) -> URLRequestConvertible {
-        credentials.map { AuthenticatedRequest(credentials: $0, request: request) } ??
-        UnauthenticatedRequest(request: request)
+        if let credentials, case .wpcom = credentials {
+            return AuthenticatedRequest(credentials: credentials, request: request)
+        }
+        return UnauthenticatedRequest(request: request)
     }
 }

--- a/Networking/Networking/Remote/JetpackConnectionRemote.swift
+++ b/Networking/Networking/Remote/JetpackConnectionRemote.swift
@@ -18,7 +18,7 @@ public final class JetpackConnectionRemote: Remote {
     public func retrieveJetpackPluginDetails(completion: @escaping (Result<SitePlugin, Error>) -> Void) {
         let path = "\(Path.plugins)/\(Constants.jetpackPluginName)"
         let request = WordPressOrgRequest(baseURL: siteURL, method: .get, path: path)
-        let mapper = SitePluginMapper(withDataEnvelope: false)
+        let mapper = SitePluginMapper()
         enqueue(request, mapper: mapper, completion: completion)
     }
 
@@ -27,7 +27,7 @@ public final class JetpackConnectionRemote: Remote {
     public func installJetpackPlugin(completion: @escaping (Result<SitePlugin, Error>) -> Void) {
         let parameters: [String: Any] = [Field.slug.rawValue: Constants.jetpackPluginSlug]
         let request = WordPressOrgRequest(baseURL: siteURL, method: .post, path: Path.plugins, parameters: parameters)
-        let mapper = SitePluginMapper(withDataEnvelope: false)
+        let mapper = SitePluginMapper()
         enqueue(request, mapper: mapper, completion: completion)
     }
 
@@ -37,7 +37,7 @@ public final class JetpackConnectionRemote: Remote {
         let path = "\(Path.plugins)/\(Constants.jetpackPluginName)"
         let parameters: [String: Any] = [Field.status.rawValue: Constants.activeStatus]
         let request = WordPressOrgRequest(baseURL: siteURL, method: .put, path: path, parameters: parameters)
-        let mapper = SitePluginMapper(withDataEnvelope: false)
+        let mapper = SitePluginMapper()
         enqueue(request, mapper: mapper, completion: completion)
     }
 

--- a/Networking/Networking/Remote/WordPressSiteRemote.swift
+++ b/Networking/Networking/Remote/WordPressSiteRemote.swift
@@ -4,12 +4,18 @@ import Foundation
 ///
 public final class WordPressSiteRemote: Remote {
     public func fetchSiteInfo(for siteURL: String) async throws -> WordPressSite {
-        let path = "/wp-json"
+        let path = Path.root
         guard let url = URL(string: siteURL + path) else {
             throw NetworkError.invalidURL
         }
         let request = try URLRequest(url: url, method: .get)
         let mapper = WordPressSiteMapper()
         return try await enqueue(request, mapper: mapper)
+    }
+}
+
+private extension WordPressSiteRemote {
+    enum Path {
+        static let root = "/wp-json"
     }
 }

--- a/Networking/Networking/Remote/WordPressSiteRemote.swift
+++ b/Networking/Networking/Remote/WordPressSiteRemote.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Endpoints for WordPress site information.
+///
+public final class WordPressSiteRemote: Remote {
+    public func fetchSiteInfo(for siteURL: String) async throws -> WordPressSite {
+        let path = "/wp-json/"
+        guard let url = URL(string: siteURL + path) else {
+            throw NetworkError.invalidURL
+        }
+        let request = try URLRequest(url: url, method: .get)
+        let mapper = WordPressSiteMapper()
+        return try await enqueue(request, mapper: mapper)
+    }
+}

--- a/Networking/Networking/Remote/WordPressSiteRemote.swift
+++ b/Networking/Networking/Remote/WordPressSiteRemote.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 public final class WordPressSiteRemote: Remote {
     public func fetchSiteInfo(for siteURL: String) async throws -> WordPressSite {
-        let path = "/wp-json/"
+        let path = "/wp-json"
         guard let url = URL(string: siteURL + path) else {
             throw NetworkError.invalidURL
         }

--- a/Networking/Networking/Requests/Request.swift
+++ b/Networking/Networking/Requests/Request.swift
@@ -12,3 +12,9 @@ protocol Request: URLRequestConvertible {
     ///
     func responseDataValidator() -> ResponseDataValidator
 }
+
+extension URLRequest: Request {
+    func responseDataValidator() -> ResponseDataValidator {
+        PlaceholderDataValidator()
+    }
+}

--- a/Networking/Networking/Requests/Request.swift
+++ b/Networking/Networking/Requests/Request.swift
@@ -12,9 +12,3 @@ protocol Request: URLRequestConvertible {
     ///
     func responseDataValidator() -> ResponseDataValidator
 }
-
-extension URLRequest: Request {
-    func responseDataValidator() -> ResponseDataValidator {
-        PlaceholderDataValidator()
-    }
-}

--- a/Networking/Networking/Settings/WooConstants.swift
+++ b/Networking/Networking/Settings/WooConstants.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Constants to be shared in Networking layer.
+///
+enum WooConstants {
+    /// Placeholder site ID to be used when the user is logged in without WPCom.
+    static let placeholderSiteID: Int64 = -1
+}

--- a/Networking/Networking/Validators/PlaceholderDataValidator.swift
+++ b/Networking/Networking/Validators/PlaceholderDataValidator.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Placeholder implementation for `ResponseDataValidator`.
+///
+final class PlaceholderDataValidator: ResponseDataValidator {
+    func validate(data: Data) throws {
+        // no-op
+    }
+}

--- a/Networking/Networking/Validators/ResponseDataValidator.swift
+++ b/Networking/Networking/Validators/ResponseDataValidator.swift
@@ -3,11 +3,3 @@ protocol ResponseDataValidator {
     ///
     func validate(data: Data) throws -> Void
 }
-
-/// Placeholder implementation for `ResponseDataValidator`.
-///
-final class PlaceholderDataValidator: ResponseDataValidator {
-    func validate(data: Data) throws {
-        // no-op
-    }
-}

--- a/Networking/Networking/Validators/ResponseDataValidator.swift
+++ b/Networking/Networking/Validators/ResponseDataValidator.swift
@@ -3,3 +3,11 @@ protocol ResponseDataValidator {
     ///
     func validate(data: Data) throws -> Void
 }
+
+/// Placeholder implementation for `ResponseDataValidator`.
+///
+final class PlaceholderDataValidator: ResponseDataValidator {
+    func validate(data: Data) throws {
+        // no-op
+    }
+}

--- a/Networking/NetworkingTests/Mapper/SitePluginMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SitePluginMapperTests.swift
@@ -69,6 +69,6 @@ private extension SitePluginMapperTests {
             return nil
         }
 
-        return try? SitePluginMapper(withDataEnvelope: false).map(response: response)
+        return try? SitePluginMapper().map(response: response)
     }
 }

--- a/Networking/NetworkingTests/Mapper/WordPressSiteMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WordPressSiteMapperTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import Networking
+
+
+/// WordPressSiteMapper Unit Tests
+///
+final class WordPressSiteMapperTests: XCTestCase {
+
+    func test_response_is_properly_parsed() throws {
+        let site = try XCTUnwrap(mapWordPressSiteInfoResponse())
+        XCTAssertEqual(site.name, "My WordPress Site")
+        XCTAssertEqual(site.description, "Just another WordPress site")
+        XCTAssertEqual(site.url, "https://test.com")
+        XCTAssertEqual(site.gmtOffset, "0")
+        XCTAssertEqual(site.timezone, "")
+    }
+}
+
+// MARK: - Private Methods.
+//
+private extension WordPressSiteMapperTests {
+
+    /// Returns the WordPressSiteMapper output upon receiving success response
+    ///
+    func mapWordPressSiteInfoResponse() -> WordPressSite? {
+        guard let response = Loader.contentsOf("wordpress-site-info") else {
+            return nil
+        }
+
+        return try? WordPressSiteMapper().map(response: response)
+    }
+}

--- a/Networking/NetworkingTests/Remote/WordPressSiteRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WordPressSiteRemoteTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import Networking
+
+final class WordPressSiteRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    let network = MockNetwork()
+
+    let sampleSiteURL = "https://test.com"
+
+    /// Repeat always!
+    ///
+    override func setUp() {
+        network.removeAllSimulatedResponses()
+    }
+
+    /// Verifies that fetchSiteInfo properly parses the sample response.
+    ///
+    func test_fetchSiteInfo_properly_returns_plugins() async throws {
+        let remote = WordPressSiteRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "wp-json", filename: "wordpress-site-info")
+
+        // When
+        let site = try await remote.fetchSiteInfo(for: sampleSiteURL)
+
+        // Then
+        XCTAssertEqual(site.name, "My WordPress Site")
+    }
+
+    /// Verifies that fetchSiteInfo properly relays Networking Layer errors.
+    ///
+    func test_fetchSiteInfo_properly_relays_networking_errors() async {
+        let remote = WordPressSiteRemote(network: network)
+        network.simulateError(requestUrlSuffix: "wp-json", error: NetworkError.notFound)
+
+        // When
+        var fetchError: Error?
+        do {
+            let _ = try await remote.fetchSiteInfo(for: sampleSiteURL)
+        } catch {
+            fetchError = error
+        }
+
+        // Then
+        XCTAssertNotNil(fetchError)
+        XCTAssertTrue(fetchError is NetworkError)
+    }
+
+}

--- a/Networking/NetworkingTests/Remote/WordPressSiteRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WordPressSiteRemoteTests.swift
@@ -17,7 +17,7 @@ final class WordPressSiteRemoteTests: XCTestCase {
 
     /// Verifies that fetchSiteInfo properly parses the sample response.
     ///
-    func test_fetchSiteInfo_properly_returns_plugins() async throws {
+    func test_fetchSiteInfo_properly_returns_site() async throws {
         let remote = WordPressSiteRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "wp-json", filename: "wordpress-site-info")
 

--- a/Networking/NetworkingTests/Responses/wordpress-site-info.json
+++ b/Networking/NetworkingTests/Responses/wordpress-site-info.json
@@ -1,0 +1,9 @@
+{
+    "name": "My WordPress Site",
+    "description": "Just another WordPress site",
+    "url": "https://test.com",
+    "home": "https://test.com",
+    "gmt_offset": "0",
+    "timezone_string": "",
+    "authentication": [],
+}

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -803,7 +803,6 @@ private extension AuthenticationManager {
                              in navigationController: UINavigationController,
                              source: SignInSource?) {
         // TODO: check if application password is enabled & check for role eligibility & check for Woo
-        // TODO: fetch site info and update default store.
         // then navigate to home screen immediately with a placeholder store ID
         startStorePicker(with: WooConstants.placeholderStoreID, in: navigationController)
     }

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -92,6 +92,17 @@ final class SessionManager: SessionManagerProtocol {
         }
     }
 
+    /// URL of the default store.
+    ///
+    var defaultStoreURL: String? {
+        switch defaultCredentials {
+        case .none:
+            return nil
+        case .some(let wrapped):
+            return wrapped.siteAddress
+        }
+    }
+
     /// Roles for the default Store Site.
     ///
     var defaultRoles: [User.Role] {

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -85,7 +85,8 @@ class AuthenticatedState: StoresManagerState {
                                storageManager: storageManager,
                                network: network,
                                fileStorage: PListFileStorage()),
-            JetpackConnectionStore(dispatcher: dispatcher)
+            JetpackConnectionStore(dispatcher: dispatcher),
+            WordPressSiteStore(network: network, dispatcher: dispatcher)
         ]
 
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -510,11 +510,11 @@ private extension DefaultStoresManager {
                                                     isWordPressComStore: info.isWPCom)
                         self.sessionManager.defaultSite = updatedSite
                     case .failure(let error):
-                        DDLogWarn("⚠️ Cannot fetch generic site info: \(error)")
+                        DDLogError("⛔️ Cannot fetch generic site info: \(error)")
                     }
                 }
             case .failure(let error):
-                DDLogWarn("⚠️ Cannot fetch WordPress site info: \(error)")
+                DDLogError("⛔️ Cannot fetch WordPress site info: \(error)")
             }
         }
         dispatch(action)

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -500,7 +500,8 @@ private extension DefaultStoresManager {
             switch result {
             case .success(let site):
                 self.sessionManager.defaultSite = site
-                /// Fetch more site info if possible
+                /// Trigger the `v1.1/connect/site-info` API to get information about
+                /// the site's Jetpack status and whether it's a WPCom site.
                 WordPressAuthenticator.fetchSiteInfo(for: url) { [weak self] result in
                     guard let self else { return }
                     switch result {

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -7,6 +7,7 @@ import class Networking.WordPressOrgNetwork
 import KeychainAccess
 import class WidgetKit.WidgetCenter
 import Experiments
+import WordPressAuthenticator
 
 // MARK: - DefaultStoresManager
 //
@@ -471,7 +472,13 @@ private extension DefaultStoresManager {
             return
         }
 
-        restoreSessionSiteAndSynchronizeIfNeeded(with: siteID)
+        if siteID == WooConstants.placeholderStoreID,
+           let url = sessionManager.defaultStoreURL {
+            restoreSessionSite(with: url)
+        } else {
+            restoreSessionSiteAndSynchronizeIfNeeded(with: siteID)
+        }
+
         synchronizeSettings(with: siteID) {
             ServiceLocator.selectedSiteSettings.refresh()
             ServiceLocator.shippingSettingsService.update(siteID: siteID)
@@ -483,6 +490,34 @@ private extension DefaultStoresManager {
         synchronizeSitePlugins(siteID: siteID)
 
         sendTelemetryIfNeeded(siteID: siteID)
+    }
+
+    /// Load the site with the specified URL into the session if possible.
+    ///
+    func restoreSessionSite(with url: String) {
+        let action = WordPressSiteAction.fetchSiteInfo(siteURL: url) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let site):
+                self.sessionManager.defaultSite = site
+                /// Fetch more site info if possible
+                WordPressAuthenticator.fetchSiteInfo(for: url) { [weak self] result in
+                    guard let self else { return }
+                    switch result {
+                    case .success(let info):
+                        let updatedSite = site.copy(isJetpackThePluginInstalled: info.hasJetpack,
+                                                    isJetpackConnected: info.isJetpackConnected,
+                                                    isWordPressComStore: info.isWPCom)
+                        self.sessionManager.defaultSite = site
+                    case .failure(let error):
+                        DDLogWarn("⚠️ Cannot fetch generic site info: \(error)")
+                    }
+                }
+            case .failure(let error):
+                DDLogWarn("⚠️ Cannot fetch WordPress site info: \(error)")
+            }
+        }
+        dispatch(action)
     }
 
     /// Loads the specified siteID into the Session, if possible.

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -508,7 +508,7 @@ private extension DefaultStoresManager {
                         let updatedSite = site.copy(isJetpackThePluginInstalled: info.hasJetpack,
                                                     isJetpackConnected: info.isJetpackConnected,
                                                     isWordPressComStore: info.isWPCom)
-                        self.sessionManager.defaultSite = site
+                        self.sessionManager.defaultSite = updatedSite
                     case .failure(let error):
                         DDLogWarn("⚠️ Cannot fetch generic site info: \(error)")
                     }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -385,6 +385,8 @@
 		D8C11A5622DFB0BE00D4A88D /* OrderStatsV4Totals+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5522DFB0BE00D4A88D /* OrderStatsV4Totals+ReadOnlyConvertible.swift */; };
 		D8C11A5822DFB2FF00D4A88D /* OrderStatsV4Interval+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5722DFB2FF00D4A88D /* OrderStatsV4Interval+ReadOnlyConvertible.swift */; };
 		D8C11A5A22DFC21600D4A88D /* StatsStoreV4Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5922DFC21600D4A88D /* StatsStoreV4Tests.swift */; };
+		DE2E8EA52953F77A002E4B14 /* WordPressSiteAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EA42953F77A002E4B14 /* WordPressSiteAction.swift */; };
+		DE2E8EA72953F85C002E4B14 /* WordPressSiteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EA62953F85C002E4B14 /* WordPressSiteStore.swift */; };
 		DE3404FC28BC5E7800CF0D97 /* JetpackConnectionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404FB28BC5E7800CF0D97 /* JetpackConnectionAction.swift */; };
 		DE3404FE28BC5F4200CF0D97 /* JetpackConnectionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404FD28BC5F4200CF0D97 /* JetpackConnectionStore.swift */; };
 		DE34050828BC706B00CF0D97 /* DeauthenticatedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34050728BC706B00CF0D97 /* DeauthenticatedStore.swift */; };
@@ -820,6 +822,8 @@
 		D8C11A5522DFB0BE00D4A88D /* OrderStatsV4Totals+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Totals+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D8C11A5722DFB2FF00D4A88D /* OrderStatsV4Interval+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D8C11A5922DFC21600D4A88D /* StatsStoreV4Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsStoreV4Tests.swift; sourceTree = "<group>"; };
+		DE2E8EA42953F77A002E4B14 /* WordPressSiteAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteAction.swift; sourceTree = "<group>"; };
+		DE2E8EA62953F85C002E4B14 /* WordPressSiteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteStore.swift; sourceTree = "<group>"; };
 		DE3404FB28BC5E7800CF0D97 /* JetpackConnectionAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackConnectionAction.swift; sourceTree = "<group>"; };
 		DE3404FD28BC5F4200CF0D97 /* JetpackConnectionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackConnectionStore.swift; sourceTree = "<group>"; };
 		DE34050728BC706B00CF0D97 /* DeauthenticatedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeauthenticatedStore.swift; sourceTree = "<group>"; };
@@ -1429,6 +1433,7 @@
 				DE3404FD28BC5F4200CF0D97 /* JetpackConnectionStore.swift */,
 				68BD37B428DB2E9800C2A517 /* CustomerStore.swift */,
 				02E3B622290267D3007E0F13 /* AccountCreationStore.swift */,
+				DE2E8EA62953F85C002E4B14 /* WordPressSiteStore.swift */,
 				02393066291A02AC00B2632F /* DomainStore.swift */,
 				021940E5291E8AD80090354E /* SiteStore.swift */,
 				02EF1665292DB65000D90AD6 /* PaymentStore.swift */,
@@ -1682,6 +1687,7 @@
 				02393064291A018600B2632F /* DomainAction.swift */,
 				021940E3291E8A660090354E /* SiteAction.swift */,
 				02EF1667292DB68C00D90AD6 /* PaymentAction.swift */,
+				DE2E8EA42953F77A002E4B14 /* WordPressSiteAction.swift */,
 			);
 			path = Actions;
 			sourceTree = "<group>";
@@ -2037,6 +2043,7 @@
 				0271E1662509CF0100633F7A /* AnyError.swift in Sources */,
 				45ED6096257E7472007B4AC6 /* ProductAttributeStore.swift in Sources */,
 				077F39E026A5A6F500ABEADC /* SystemStatusStore.swift in Sources */,
+				DE2E8EA52953F77A002E4B14 /* WordPressSiteAction.swift in Sources */,
 				02FF054D23D983F30058E6E7 /* MediaFileManager.swift in Sources */,
 				02137901270AB204006430F7 /* MockUserActionHandler.swift in Sources */,
 				B56C1EC220EAE2E500D749F9 /* ReadOnlyConvertible.swift in Sources */,
@@ -2109,6 +2116,7 @@
 				022F00BE24725BAF008CD97F /* NotificationCountStore.swift in Sources */,
 				31799AFA27050D9C00D78179 /* WCPayReaderLocation+ReaderLocation.swift in Sources */,
 				7499936620EFBC7200CF01CD /* OrderNoteStore.swift in Sources */,
+				DE2E8EA72953F85C002E4B14 /* WordPressSiteStore.swift in Sources */,
 				74858DB421C02B5A00754F3E /* OrderNote+ReadOnlyType.swift in Sources */,
 				0248B3652459018100A271A4 /* ResultsController+FilterProducts.swift in Sources */,
 				02E262C2238CF74D00B79588 /* StorageShippingSettingsService.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 		D8C11A5A22DFC21600D4A88D /* StatsStoreV4Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5922DFC21600D4A88D /* StatsStoreV4Tests.swift */; };
 		DE2E8EA52953F77A002E4B14 /* WordPressSiteAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EA42953F77A002E4B14 /* WordPressSiteAction.swift */; };
 		DE2E8EA72953F85C002E4B14 /* WordPressSiteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EA62953F85C002E4B14 /* WordPressSiteStore.swift */; };
+		DE2E8EAF29541C32002E4B14 /* WordPressSiteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2E8EAE29541C32002E4B14 /* WordPressSiteStore.swift */; };
 		DE3404FC28BC5E7800CF0D97 /* JetpackConnectionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404FB28BC5E7800CF0D97 /* JetpackConnectionAction.swift */; };
 		DE3404FE28BC5F4200CF0D97 /* JetpackConnectionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404FD28BC5F4200CF0D97 /* JetpackConnectionStore.swift */; };
 		DE34050828BC706B00CF0D97 /* DeauthenticatedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34050728BC706B00CF0D97 /* DeauthenticatedStore.swift */; };
@@ -824,6 +825,7 @@
 		D8C11A5922DFC21600D4A88D /* StatsStoreV4Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsStoreV4Tests.swift; sourceTree = "<group>"; };
 		DE2E8EA42953F77A002E4B14 /* WordPressSiteAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteAction.swift; sourceTree = "<group>"; };
 		DE2E8EA62953F85C002E4B14 /* WordPressSiteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteStore.swift; sourceTree = "<group>"; };
+		DE2E8EAE29541C32002E4B14 /* WordPressSiteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressSiteStore.swift; sourceTree = "<group>"; };
 		DE3404FB28BC5E7800CF0D97 /* JetpackConnectionAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackConnectionAction.swift; sourceTree = "<group>"; };
 		DE3404FD28BC5F4200CF0D97 /* JetpackConnectionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackConnectionStore.swift; sourceTree = "<group>"; };
 		DE34050728BC706B00CF0D97 /* DeauthenticatedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeauthenticatedStore.swift; sourceTree = "<group>"; };
@@ -1499,6 +1501,7 @@
 				02DAE7F7291A9F11009342B7 /* DomainStoreTests.swift */,
 				02616F912921E1530095BC00 /* SiteStoreTests.swift */,
 				02F2722C292F18BF00C36419 /* PaymentStoreTests.swift */,
+				DE2E8EAE29541C32002E4B14 /* WordPressSiteStore.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -2292,6 +2295,7 @@
 				D8652E44263079B000350F37 /* ReceiptStoreTests.swift in Sources */,
 				D8C11A5A22DFC21600D4A88D /* StatsStoreV4Tests.swift in Sources */,
 				261CF2C7255C445A0090D8D3 /* PaymentGatewayStoreTests.swift in Sources */,
+				DE2E8EAF29541C32002E4B14 /* WordPressSiteStore.swift in Sources */,
 				2685C121263E064200D9EE97 /* AddOnGroupStoreTests.swift in Sources */,
 				B9AECD482851F28E00E78584 /* Order+CardPresentPaymentTests.swift in Sources */,
 				02124DB02431C18700980D74 /* Media+ProductImageTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/WordPressSiteAction.swift
+++ b/Yosemite/Yosemite/Actions/WordPressSiteAction.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// WordPressSiteAction: Defines all of the Actions supported by the WordPressSiteStore.
+///
+public enum WordPressSiteAction: Action {
+    /// Fetches information for a given WordPress site URL.
+    case fetchSiteInfo(siteURL: String, completion: (Result<Site, Error>) -> Void)
+}

--- a/Yosemite/Yosemite/Base/SessionManagerProtocol.swift
+++ b/Yosemite/Yosemite/Base/SessionManagerProtocol.swift
@@ -23,6 +23,10 @@ public protocol SessionManagerProtocol {
     ///
     var defaultStoreID: Int64? { get set }
 
+    /// URL of default store
+    ///
+    var defaultStoreURL: String? { get }
+
     /// Roles for the default Store Site.
     ///
     var defaultRoles: [User.Role] { get set }

--- a/Yosemite/Yosemite/Model/Mocks/MockSessionManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockSessionManager.swift
@@ -10,6 +10,7 @@ public struct MockSessionManager: SessionManagerProtocol {
         defaultAccount = objectGraph.defaultAccount
         defaultSite = objectGraph.defaultSite
         defaultStoreID = objectGraph.defaultSite.siteID
+        defaultStoreURL = objectGraph.defaultSite.url
         defaultStoreIDPublisher = Just(objectGraph.defaultSite.siteID).eraseToAnyPublisher()
         defaultCredentials = objectGraph.userCredentials
     }
@@ -25,6 +26,8 @@ public struct MockSessionManager: SessionManagerProtocol {
     }
 
     public var defaultStoreID: Int64?
+
+    public var defaultStoreURL: String?
 
     public var defaultRoles: [User.Role] = []
 

--- a/Yosemite/Yosemite/Stores/WordPressSiteStore.swift
+++ b/Yosemite/Yosemite/Stores/WordPressSiteStore.swift
@@ -40,7 +40,7 @@ private extension WordPressSiteStore {
         Task {
             do {
                 let wpSite = try await remote.fetchSiteInfo(for: siteURL)
-                let site = wpSite.asSite()
+                let site = wpSite.asSite
                 await MainActor.run {
                     completion(.success(site))
                 }

--- a/Yosemite/Yosemite/Stores/WordPressSiteStore.swift
+++ b/Yosemite/Yosemite/Stores/WordPressSiteStore.swift
@@ -18,7 +18,7 @@ public final class WordPressSiteStore: DeauthenticatedStore {
     }
 
     public override func registerSupportedActions(in dispatcher: Dispatcher) {
-        dispatcher.register(processor: self, for: AccountCreationAction.self)
+        dispatcher.register(processor: self, for: WordPressSiteAction.self)
     }
 
     /// Called whenever a given Action is dispatched.

--- a/Yosemite/Yosemite/Stores/WordPressSiteStore.swift
+++ b/Yosemite/Yosemite/Stores/WordPressSiteStore.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Networking
+
+/// Handles `WordPressSiteAction`
+///
+public final class WordPressSiteStore: DeauthenticatedStore {
+    // Keeps a strong reference to remote to keep requests alive.
+    private let remote: WordPressSiteRemote
+
+    public init(remote: WordPressSiteRemote, dispatcher: Dispatcher) {
+        self.remote = remote
+        super.init(dispatcher: dispatcher)
+    }
+
+    public convenience init(network: Network, dispatcher: Dispatcher) {
+        let remote = WordPressSiteRemote(network: network)
+        self.init(remote: remote, dispatcher: dispatcher)
+    }
+
+    public override func registerSupportedActions(in dispatcher: Dispatcher) {
+        dispatcher.register(processor: self, for: AccountCreationAction.self)
+    }
+
+    /// Called whenever a given Action is dispatched.
+    ///
+    public override func onAction(_ action: Action) {
+        guard let action = action as? WordPressSiteAction else {
+            assertionFailure("WordPressSiteStore received an unsupported action: \(action)")
+            return
+        }
+        switch action {
+        case let .fetchSiteInfo(siteURL, completion):
+            fetchSiteInfo(for: siteURL, completion: completion)
+        }
+    }
+}
+
+private extension WordPressSiteStore {
+    func fetchSiteInfo(for siteURL: String, completion: @escaping (Result<Site, Error>) -> Void) {
+        Task {
+            do {
+                let wpSite = try await remote.fetchSiteInfo(for: siteURL)
+                let site = wpSite.asSite()
+                await MainActor.run {
+                    completion(.success(site))
+                }
+            } catch {
+                await MainActor.run {
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/WordPressSiteStore.swift
+++ b/Yosemite/YosemiteTests/Stores/WordPressSiteStore.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import Yosemite
+@testable import Networking
+
+final class WordPressSiteStoreTests: XCTestCase {
+    /// Mock Network: Allows us to inject predefined responses!
+    ///
+    private var network: MockNetwork!
+
+    /// Mock Dispatcher
+    ///
+    private var dispatcher: Dispatcher!
+
+    private let sampleSiteURL = "https://test.com"
+
+    override func setUp() {
+        super.setUp()
+        dispatcher = Dispatcher()
+        network = MockNetwork()
+    }
+
+    func test_fetchSiteInfo_returns_correct_site() throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "wp-json", filename: "wordpress-site-info")
+        let store = WordPressSiteStore(network: network, dispatcher: dispatcher)
+
+        // When
+        let result: Result<Site, Error> = waitFor { promise in
+            let action = WordPressSiteAction.fetchSiteInfo(siteURL: self.sampleSiteURL) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let site = try result.get()
+        XCTAssertEqual(site.name, "My WordPress Site")
+        XCTAssertEqual(site.description, "Just another WordPress site")
+        XCTAssertEqual(site.url, "https://test.com")
+        XCTAssertEqual(site.timezone, "")
+        XCTAssertEqual(site.siteID, -1)
+        XCTAssertEqual(site.gmtOffset, 0)
+        XCTAssertEqual(site.adminURL, "https://test.com/wp-admin")
+        XCTAssertEqual(site.loginURL, "https://test.com/wp-login.php")
+        XCTAssertTrue(site.isWooCommerceActive)
+        XCTAssertFalse(site.isJetpackConnected)
+        XCTAssertFalse(site.isJetpackThePluginInstalled)
+    }
+
+    func test_fetchSiteInfo_relays_error_properly() throws {
+        // Given
+        network.simulateError(requestUrlSuffix: "wp-json", error: NetworkError.notFound)
+        let store = WordPressSiteStore(network: network, dispatcher: dispatcher)
+
+        // When
+        let result: Result<Site, Error> = waitFor { promise in
+            let action = WordPressSiteAction.fetchSiteInfo(siteURL: self.sampleSiteURL) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertTrue(result.failure is NetworkError)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8453 
<!-- Id number of the GitHub issue this PR addresses. --> 

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR integrates the root endpoint to get site info and updates the default site in `DefaultStoresManager` accordingly. Changes include:
- Networking: 
  - Added a new model `WordPressSite` to hold information fetched from `<WP site URL>/wp-json`. This model can be converted to `Site` for use in `DefaultStoresManager`.
  - Add a new remote and mapper to fetch the WP site info.
- Yosemite:
  - Added a new action and store to fetch site WordPress site info given a URL.
  - Updated `AuthenticatedStore` with the new `WordPressStore`.
- UI:
  - Updated `DefaultStoresManager` to load site info with site URL if a placeholder site ID is detected.
 
## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app if needed.
- On the prologue screen, select "Enter your site address". If this option is not available, [disable simplified login](https://github.com/woocommerce/woocommerce-ios/blob/8d471f969911067311412d72f58de6ae2c966c6a/WooCommerce/Classes/Authentication/AuthenticationManager.swift#L61) and build the app again.
- Enter your test store address and select "Sign in with site credentials".
- Enter correct credentials and select "Continue". Notice that you are then navigated to the home screen.
- Notice on the home screen that the correct site address and title are displayed.
- Navigate to Menu tab - notice that the correct site title and URL are displayed.

Please feel free to test again with WPCom login to make sure that everything still works as before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/209063765-6241cab7-6fd3-4a4a-b1fc-0045df85fdb1.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
