### PR TITLE
[REST API] Update Coupon mappers to handle json from REST API

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -738,6 +738,8 @@
 		EE54C8A729486B6800A9BF61 /* ApplicationPasswordMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE54C8A629486B6800A9BF61 /* ApplicationPasswordMapper.swift */; };
 		EE71CC3D2951A8EA0074D908 /* ApplicationPasswordStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE71CC3C2951A8EA0074D908 /* ApplicationPasswordStorage.swift */; };
 		EE71CC412951CE700074D908 /* generate-application-password-using-wporg-creds-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE71CC402951CE700074D908 /* generate-application-password-using-wporg-creds-success.json */; };
+		EE80A24729547F8B003591E4 /* coupons-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE80A24529547F8B003591E4 /* coupons-all-without-data.json */; };
+		EE80A24829547F8B003591E4 /* coupon-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE80A24629547F8B003591E4 /* coupon-without-data.json */; };
 		EE8A86F1286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json in Resources */ = {isa = PBXBuildFile; fileRef = EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */; };
 		EE8DE432294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DE431294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift */; };
 		EECB7EE8286555180028C888 /* media-update-product-id.json in Resources */ = {isa = PBXBuildFile; fileRef = EECB7EE7286555180028C888 /* media-update-product-id.json */; };
@@ -1509,6 +1511,8 @@
 		EE54C8A629486B6800A9BF61 /* ApplicationPasswordMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordMapper.swift; sourceTree = "<group>"; };
 		EE71CC3C2951A8EA0074D908 /* ApplicationPasswordStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordStorage.swift; sourceTree = "<group>"; };
 		EE71CC402951CE700074D908 /* generate-application-password-using-wporg-creds-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "generate-application-password-using-wporg-creds-success.json"; sourceTree = "<group>"; };
+		EE80A24529547F8B003591E4 /* coupons-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupons-all-without-data.json"; sourceTree = "<group>"; };
+		EE80A24629547F8B003591E4 /* coupon-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-without-data.json"; sourceTree = "<group>"; };
 		EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-update-product-id-in-wordpress-site.json"; sourceTree = "<group>"; };
 		EE8DE431294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultApplicationPasswordUseCaseTests.swift; sourceTree = "<group>"; };
 		EECB7EE7286555180028C888 /* media-update-product-id.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-update-product-id.json"; sourceTree = "<group>"; };
@@ -2042,6 +2046,8 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				EE80A24629547F8B003591E4 /* coupon-without-data.json */,
+				EE80A24529547F8B003591E4 /* coupons-all-without-data.json */,
 				EE338A0A294AF92A00183934 /* AppliicationPassword */,
 				DE9DEEF4291CF1B40070AD7C /* site-plugin-without-envelope.json */,
 				028CB714290223CB00331C09 /* account-username-suggestions.json */,
@@ -2755,6 +2761,7 @@
 				31A451D927863A2E00FE81AA /* stripe-account-live-test.json in Resources */,
 				DE9DEEF5291CF1B40070AD7C /* site-plugin-without-envelope.json in Resources */,
 				0261F5A928D4641500B7AC72 /* products-sku-search.json in Resources */,
+				EE80A24829547F8B003591E4 /* coupon-without-data.json in Resources */,
 				09885C8027C3FFD200910A62 /* product-variations-bulk-update.json in Resources */,
 				31054734262E36AB00C5C02B /* wcpay-payment-intent-error.json in Resources */,
 				02AF07EE27493AE700B2D81E /* media-upload-to-wordpress-site.json in Resources */,
@@ -2872,6 +2879,7 @@
 				4515281F257A89B90076B03C /* product-attribute-create.json in Resources */,
 				CEF88DAF233E9F7E00BED485 /* order-details-partially-refunded.json in Resources */,
 				D823D9032237450A00C90817 /* shipment_tracking_new.json in Resources */,
+				EE80A24729547F8B003591E4 /* coupons-all-without-data.json in Resources */,
 				7412A8F021B6E416005D182A /* report-orders.json in Resources */,
 				CCF4346A2906C9C300B4475A /* products-ids-only-empty.json in Resources */,
 				4515282B257A8C010076B03C /* product-attribute-delete.json in Resources */,

--- a/Networking/Networking/Mapper/CouponListMapper.swift
+++ b/Networking/Networking/Mapper/CouponListMapper.swift
@@ -11,8 +11,14 @@ struct CouponListMapper: Mapper {
     /// (Attempts) to convert a dictionary into `[Coupon]`.
     ///
     func map(response: Data) throws -> [Coupon] {
-        let coupons = try Coupon.decoder.decode(CouponListEnvelope.self, from: response).coupons
-        return coupons.map { $0.copy(siteID: siteID) }
+        let decoder = Coupon.decoder
+        do {
+            let coupons = try decoder.decode(CouponListEnvelope.self, from: response).coupons
+            return coupons.map { $0.copy(siteID: siteID) }
+        } catch {
+            return try decoder.decode([Coupon].self, from: response)
+                .map { $0.copy(siteID: siteID) }
+        }
     }
 }
 

--- a/Networking/Networking/Mapper/CouponMapper.swift
+++ b/Networking/Networking/Mapper/CouponMapper.swift
@@ -11,8 +11,13 @@ struct CouponMapper: Mapper {
     /// (Attempts) to convert a dictionary into `Coupon`.
     ///
     func map(response: Data) throws -> Coupon {
-        let coupon = try Coupon.decoder.decode(CouponEnvelope.self, from: response).coupon
-        return coupon.copy(siteID: siteID)
+        let decoder = Coupon.decoder
+        do {
+            let coupon = try decoder.decode(CouponEnvelope.self, from: response).coupon
+            return coupon.copy(siteID: siteID)
+        } catch {
+            return try decoder.decode(Coupon.self, from: response).copy(siteID: siteID)
+        }
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/CouponListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CouponListMapperTests.swift
@@ -10,14 +10,21 @@ class CouponListMapperTests: XCTestCase {
     /// Verifies that the whole list is parsed, minus the items with non-default discount type.
     ///
     func test_CouponsList_map_parses_all_coupons_in_response() throws {
-        let coupons = try mapLoadAllCouponsResponse()
+        let coupons = try mapLoadAllCouponsResponseWithDataEnvelope()
+        XCTAssertEqual(coupons.count, 4)
+    }
+
+    /// Verifies that the whole list is parsed, minus the items with non-default discount type.
+    ///
+    func test_CouponsList_map_parses_all_coupons_in_response_without_data_envelope() throws {
+        let coupons = try mapLoadAllCouponsResponseWithoutDataEnvelope()
         XCTAssertEqual(coupons.count, 4)
     }
 
     /// Verifies that the `siteID` is added in the mapper, to all results, because it's not provided by the API endpoint
     ///
     func test_CouponsList_map_includes_siteID_in_parsed_results() throws {
-        let coupons = try mapLoadAllCouponsResponse()
+        let coupons = try mapLoadAllCouponsResponseWithDataEnvelope()
         XCTAssertTrue(coupons.count > 0)
 
         for coupon in coupons {
@@ -28,7 +35,7 @@ class CouponListMapperTests: XCTestCase {
     /// Verifies that the fields are all parsed correctly
     ///
     func test_CouponsList_map_parses_all_fields_in_result() throws {
-        let coupons = try mapLoadAllCouponsResponse()
+        let coupons = try mapLoadAllCouponsResponseWithDataEnvelope()
         let coupon = coupons[0]
 
         let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
@@ -63,7 +70,7 @@ class CouponListMapperTests: XCTestCase {
     /// Verifies that nulls in optional fields are parsed correctly
     ///
     func test_CouponsList_map_accepts_nulls_in_expected_optional_fields() throws {
-        let coupons = try mapLoadAllCouponsResponse()
+        let coupons = try mapLoadAllCouponsResponseWithDataEnvelope()
         let coupon = coupons[2]
 
         let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
@@ -113,7 +120,13 @@ private extension CouponListMapperTests {
 
     /// Returns the CouponsMapper output from `coupons-all.json`
     ///
-    func mapLoadAllCouponsResponse() throws -> [Coupon] {
+    func mapLoadAllCouponsResponseWithDataEnvelope() throws -> [Coupon] {
         return try mapCoupons(from: "coupons-all")
+    }
+
+    /// Returns the CouponsMapper output from `coupons-all-without-data.json`
+    ///
+    func mapLoadAllCouponsResponseWithoutDataEnvelope() throws -> [Coupon] {
+        return try mapCoupons(from: "coupons-all-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/CouponMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CouponMapperTests.swift
@@ -9,21 +9,28 @@ final class CouponMapperTests: XCTestCase {
 
     /// Verifies that the coupon is parsed.
     ///
-    func test_Coupon_map_parses_all_coupons_in_response() throws {
+    func test_Coupon_map_parses_coupon_in_response() throws {
         let coupon = try mapRetrieveCouponResponse()
+        XCTAssertNotNil(coupon)
+    }
+
+    /// Verifies that the coupon is parsed.
+    ///
+    func test_Coupon_map_parses_coupon_in_response_without_data_envelope() throws {
+        let coupon = try mapRetrieveCouponResponseWithoutDataEnvelope()
         XCTAssertNotNil(coupon)
     }
 
     /// Verifies that the `siteID` is added in the mapper, because it's not provided by the API endpoint
     ///
-    func test_CouponsList_map_includes_siteID_in_parsed_results() throws {
+    func test_coupon_map_includes_siteID_in_parsed_results() throws {
         let coupon = try mapRetrieveCouponResponse()
         XCTAssertEqual(coupon.siteID, dummySiteID)
     }
 
     /// Verifies that the fields are all parsed correctly
     ///
-    func test_CouponsList_map_parses_all_fields_in_result() throws {
+    func test_coupon_map_parses_all_fields_in_result() throws {
         let coupon = try mapRetrieveCouponResponse()
 
         let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
@@ -76,6 +83,12 @@ private extension CouponMapperTests {
     ///
     func mapRetrieveCouponResponse() throws -> Coupon {
         return try mapCoupon(from: "coupon")
+    }
+
+    /// Returns the CouponMapper output from `coupon-without-data.json`
+    ///
+    func mapRetrieveCouponResponseWithoutDataEnvelope() throws -> Coupon {
+        return try mapCoupon(from: "coupon-without-data")
     }
 
     struct FileNotFoundError: Error {}

--- a/Networking/NetworkingTests/Responses/coupon-without-data.json
+++ b/Networking/NetworkingTests/Responses/coupon-without-data.json
@@ -1,0 +1,41 @@
+{
+    "id": 720,
+    "code": "free shipping",
+    "amount": "10.00",
+    "date_created": "2017-03-21T15:25:02",
+    "date_created_gmt": "2017-03-21T18:25:02",
+    "date_modified": "2017-03-21T15:25:02",
+    "date_modified_gmt": "2017-03-21T18:25:02",
+    "discount_type": "fixed_cart",
+    "description": "Coupon description",
+    "date_expires": "2017-03-31T15:25:02",
+    "date_expires_gmt": "2017-03-31T18:25:02",
+    "usage_count": 10,
+    "individual_use": true,
+    "product_ids": [12893712, 12389],
+    "excluded_product_ids": [12213],
+    "usage_limit": 1200,
+    "usage_limit_per_user": 3,
+    "limit_usage_to_x_items": 10,
+    "free_shipping": true,
+    "product_categories": [123, 435, 232],
+    "excluded_product_categories": [908],
+    "exclude_sale_items": false,
+    "minimum_amount": "5.00",
+    "maximum_amount": "500.00",
+    "email_restrictions": ["*@a8c.com", "someone.else@example.com"],
+    "used_by": ["someone.else@example.com", "person@a8c.com"],
+    "meta_data": [],
+    "_links": {
+        "self": [
+            {
+                "href": "https://example.com/wp-json/wc/v3/coupons/720"
+            }
+        ],
+        "collection": [
+            {
+                "href": "https://example.com/wp-json/wc/v3/coupons"
+            }
+        ]
+    }
+}

--- a/Networking/NetworkingTests/Responses/coupons-all-without-data.json
+++ b/Networking/NetworkingTests/Responses/coupons-all-without-data.json
@@ -1,0 +1,166 @@
+[
+    {
+        "id": 720,
+        "code": "free shipping",
+        "amount": "10.00",
+        "date_created": "2017-03-21T15:25:02",
+        "date_created_gmt": "2017-03-21T18:25:02",
+        "date_modified": "2017-03-21T15:25:02",
+        "date_modified_gmt": "2017-03-21T18:25:02",
+        "discount_type": "fixed_cart",
+        "description": "Coupon description",
+        "date_expires": "2017-03-31T15:25:02",
+        "date_expires_gmt": "2017-03-31T18:25:02",
+        "usage_count": 10,
+        "individual_use": true,
+        "product_ids": [12893712, 12389],
+        "excluded_product_ids": [12213],
+        "usage_limit": 1200,
+        "usage_limit_per_user": 3,
+        "limit_usage_to_x_items": 10,
+        "free_shipping": true,
+        "product_categories": [123, 435, 232],
+        "excluded_product_categories": [908],
+        "exclude_sale_items": false,
+        "minimum_amount": "5.00",
+        "maximum_amount": "500.00",
+        "email_restrictions": ["*@a8c.com", "someone.else@example.com"],
+        "used_by": ["someone.else@example.com", "person@a8c.com"],
+        "meta_data": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/coupons/720"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/coupons"
+                }
+            ]
+        }
+    },
+    {
+        "id": 719,
+        "code": "10off",
+        "amount": "10.00",
+        "date_created": "2017-03-21T15:23:00",
+        "date_created_gmt": "2017-03-21T18:23:00",
+        "date_modified": "2017-03-21T15:23:00",
+        "date_modified_gmt": "2017-03-21T18:23:00",
+        "discount_type": "fixed_cart",
+        "description": "",
+        "date_expires": null,
+        "date_expires_gmt": null,
+        "usage_count": 0,
+        "individual_use": true,
+        "product_ids": [],
+        "excluded_product_ids": [],
+        "usage_limit": null,
+        "usage_limit_per_user": null,
+        "limit_usage_to_x_items": null,
+        "free_shipping": false,
+        "product_categories": [],
+        "excluded_product_categories": [],
+        "exclude_sale_items": true,
+        "minimum_amount": "100.00",
+        "maximum_amount": "0.00",
+        "email_restrictions": [],
+        "used_by": [],
+        "meta_data": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/coupons/719"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/coupons"
+                }
+            ]
+        }
+    },
+    {
+        "id": 10714,
+        "code": "test",
+        "amount": "0.00",
+        "date_created": "2021-04-13T08:26:25",
+        "date_created_gmt": "2021-04-13T08:26:25",
+        "date_modified": "2021-04-13T08:26:25",
+        "date_modified_gmt": "2021-04-13T08:26:25",
+        "discount_type": "percent",
+        "description": "",
+        "date_expires": null,
+        "date_expires_gmt": null,
+        "usage_count": 0,
+        "individual_use": false,
+        "product_ids": [],
+        "excluded_product_ids": [],
+        "usage_limit": null,
+        "usage_limit_per_user": null,
+        "limit_usage_to_x_items": null,
+        "free_shipping": false,
+        "product_categories": [],
+        "excluded_product_categories": [],
+        "exclude_sale_items": false,
+        "minimum_amount": "0.00",
+        "maximum_amount": "0.00",
+        "email_restrictions": [],
+        "used_by": [],
+        "meta_data": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/coupons/720"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/coupons"
+                }
+            ]
+        }
+    },
+    {
+        "id": 581,
+        "code": "usrufb6q",
+        "amount": "30.00",
+        "date_created": "2022-01-07T10:59:47",
+        "date_created_gmt": "2022-01-07T03:59:47",
+        "date_modified": "2022-01-07T10:59:56",
+        "date_modified_gmt": "2022-01-07T03:59:56",
+        "discount_type": "sign_up_fee_percent",
+        "description": "",
+        "date_expires": null,
+        "date_expires_gmt": null,
+        "usage_count": 0,
+        "individual_use": false,
+        "product_ids": [],
+        "excluded_product_ids": [],
+        "usage_limit": null,
+        "usage_limit_per_user": null,
+        "limit_usage_to_x_items": null,
+        "free_shipping": false,
+        "product_categories": [],
+        "excluded_product_categories": [],
+        "exclude_sale_items": false,
+        "minimum_amount": "0.00",
+        "maximum_amount": "0.00",
+        "email_restrictions": [],
+        "used_by": [],
+        "meta_data": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://huongdotests1.blog/wp-json/wc/v3/coupons/581"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://huongdotests1.blog/wp-json/wc/v3/coupons"
+                }
+            ]
+        }
+    }
+]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8390 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

This PR updates the `CouponMapper` and `CouponListMapper` to handle JSON response with and without data envelope. The mock JSON files and unit tests are also updated as needed. 

We will receive JSON ,
- with data envelope from Jetpack tunnel.
- with no data envelope from REST API.

## Testing instructions
- Login into the app
- Turn on `Coupon Management` from `Experimental Features`.
- Test the Coupons feature and ensure that it works as before.  Try searching, creating, editing and deleting coupons. 

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
