### PR TITLE
Properly render Dashboard with big fonts.

### DIFF
--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -11,7 +11,8 @@ final class StyleManager {
     }
 
     static var chartLabelFont: UIFont {
-        return .font(forStyle: .caption2, weight: .regular)
+        // Dashboard chart needs from a slighly smaller maximum font to be able to fit it when using the biggest accessibility font.
+        return self.fontForTextStyle(.caption2, weight: .regular, maximumPointSize: 20.0)
     }
 
     static var headlineSemiBold: UIFont {

--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -10,6 +10,14 @@ final class StyleManager {
         return .font(forStyle: .headline, weight: .semibold)
     }
 
+    static var statsFont: UIFont {
+        return self.fontForTextStyle(.title3, weight: .semibold, maximumPointSize: 36.0)
+    }
+
+    static var statsTitleFont: UIFont {
+        return self.fontForTextStyle(.caption2, weight: .regular, maximumPointSize: maxFontSize)
+    }
+
     static var chartLabelFont: UIFont {
         // Dashboard chart needs from a slighly smaller maximum font to be able to fit it when using the biggest accessibility font.
         return self.fontForTextStyle(.caption2, weight: .regular, maximumPointSize: 20.0)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -12,6 +12,7 @@ final class ProductTableViewCell: UITableViewCell {
     @IBOutlet private var nameLabel: UILabel!
     @IBOutlet private var detailLabel: UILabel!
     @IBOutlet private var accessoryLabel: UILabel!
+    @IBOutlet private var dataStackView: UIStackView!
 
     /// We use a custom view instead of the default separator as it's width varies depending on the image size, which varies depending on the screen size.
     @IBOutlet private var bottomBorderView: UIView!
@@ -62,6 +63,7 @@ final class ProductTableViewCell: UITableViewCell {
         backgroundColor = Constants.backgroundColor
         bottomBorderView.backgroundColor = .systemColor(.separator)
         selectionStyle = .default
+        adjustStackViewAxis()
     }
 
     private func applyProductImageStyle() {
@@ -70,6 +72,17 @@ final class ProductTableViewCell: UITableViewCell {
         productImage.layer.borderWidth = ProductImage.borderWidth
         productImage.layer.borderColor = ProductImage.borderColor.cgColor
         productImage.clipsToBounds = true
+    }
+
+    /// Adjusts the data stack view axis depending on the current trait collection content size category.
+    ///
+    private func adjustStackViewAxis() {
+        dataStackView.axis = traitCollection.preferredContentSizeCategory > .accessibilityMedium ? .vertical : .horizontal
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        adjustStackViewAxis()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -28,16 +28,16 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="wbD-Qx-IG5">
-                                <rect key="frame" x="45" y="0.0" width="145" height="54.5"/>
+                                <rect key="frame" x="45" y="0.0" width="145" height="62.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B98-58-fIv">
-                                        <rect key="frame" x="0.0" y="0.0" width="145" height="36"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="145" height="42.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="     " textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hrx-8V-5Ga">
-                                        <rect key="frame" x="0.0" y="40" width="145" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="46.5" width="145" height="16"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -45,16 +45,16 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="yc7-gf-KCU">
-                                <rect key="frame" x="206" y="0.0" width="50" height="67"/>
+                                <rect key="frame" x="206" y="0.0" width="50" height="70.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" text="    " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2yh-4i-vuE" userLabel="Accessory Label">
-                                        <rect key="frame" x="0.0" y="0.0" width="50" height="17"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="50" height="20.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YoE-TO-fIp">
-                                        <rect key="frame" x="0.0" y="17" width="50" height="50"/>
+                                        <rect key="frame" x="0.0" y="20.5" width="50" height="50"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     </view>
                                 </subviews>
@@ -87,6 +87,7 @@
             <connections>
                 <outlet property="accessoryLabel" destination="2yh-4i-vuE" id="Pe0-nm-XVK"/>
                 <outlet property="bottomBorderView" destination="lOL-Ke-vhW" id="k0w-aD-sTk"/>
+                <outlet property="dataStackView" destination="VJh-YT-pnW" id="Jl7-eI-QN5"/>
                 <outlet property="detailLabel" destination="hrx-8V-5Ga" id="tzf-vx-Bs7"/>
                 <outlet property="nameLabel" destination="B98-58-fIv" id="Hh5-mS-u6w"/>
                 <outlet property="productImage" destination="yk6-X3-NSJ" id="Kva-Sx-kub"/>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarView.swift
@@ -33,6 +33,7 @@ private extension StatsTimeRangeBarView {
         label.font = Constants.labelFont
         label.textColor = Constants.labelColor
         label.textAlignment = Constants.labelTextAlignment
+        label.adjustsFontSizeToFitWidth = true
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -291,7 +291,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
         let storeStatsPeriodView = storeStatsPeriodViewController.view!
         stackView.addArrangedSubview(storeStatsPeriodView)
         NSLayoutConstraint.activate([
-            storeStatsPeriodView.heightAnchor.constraint(equalToConstant: Constants.storeStatsPeriodViewHeight),
+            storeStatsPeriodView.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.storeStatsPeriodViewHeight),
             ])
 
         // Analytics Hub ("See more") button

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -477,7 +477,7 @@ private extension StoreStatsAndTopPerformersViewController {
         settings.style.buttonBarItemTitleColor = .textSubtle
         settings.style.buttonBarItemsShouldFillAvailableWidth = false
         settings.style.buttonBarItemLeftRightMargin = TabStrip.buttonLeftRightMargin
-        settings.style.buttonBarHeight = TabStrip.tabHeight
+        settings.style.buttonBarHeight = UIFontMetrics.default.scaledValue(for: TabStrip.tabHeight)
 
         changeCurrentIndexProgressive = {
             (oldCell: ButtonBarViewCell?,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsDataOrRedactedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsDataOrRedactedView.swift
@@ -92,7 +92,7 @@ private extension StoreStatsDataOrRedactedView {
     enum Constants {
         static let statsTextColor: UIColor = .text
         static let statsHighlightTextColor: UIColor = .accent
-        static let statsFont: UIFont = .font(forStyle: .title3, weight: .semibold)
+        static let statsFont = StyleManager.statsFont
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsDataOrRedactedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsDataOrRedactedView.swift
@@ -52,6 +52,7 @@ private extension StoreStatsDataOrRedactedView {
     func configureDataLabel() {
         dataLabel.font = Constants.statsFont
         dataLabel.textColor = Constants.statsTextColor
+        dataLabel.adjustsFontSizeToFitWidth = true
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -705,9 +705,8 @@ private extension StoreStatsV4PeriodViewController {
     enum Constants {
         static let statsTextColor: UIColor = .text
         static let statsHighlightTextColor: UIColor = .accent
-        static let statsFont: UIFont = .font(forStyle: .title3, weight: .semibold)
         static let revenueFont: UIFont = .font(forStyle: .largeTitle, weight: .semibold)
-        static let statsTitleFont: UIFont = .caption2
+        static let statsTitleFont: UIFont = StyleManager.statsTitleFont
 
         static let chartAnimationDuration: TimeInterval = 0.75
         static let chartExtraRightOffset: CGFloat       = 25.0

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -394,7 +394,7 @@ private extension StoreStatsV4PeriodViewController {
         let xAxis = lineChartView.xAxis
         xAxis.labelPosition = .bottom
         xAxis.yOffset = 8
-        xAxis.labelFont = .caption2
+        xAxis.labelFont = StyleManager.chartLabelFont
         xAxis.labelTextColor = .textSubtle
         xAxis.axisLineColor = .systemColor(.separator)
         xAxis.gridColor = .systemColor(.separator)
@@ -407,7 +407,7 @@ private extension StoreStatsV4PeriodViewController {
         updateChartXAxisLabelCount(xAxis: xAxis, timeRange: timeRange)
 
         let yAxis = lineChartView.leftAxis
-        yAxis.labelFont = .caption2
+        yAxis.labelFont = StyleManager.chartLabelFont
         yAxis.labelTextColor = .textSubtle
         yAxis.axisLineColor = .systemColor(.separator)
         yAxis.gridColor = .systemColor(.separator)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -693,6 +693,7 @@ private extension StoreStatsV4PeriodViewController {
     func updateStatsDataToDefaultStyles() {
         revenueData.font = Constants.revenueFont
         revenueData.textColor = Constants.statsTextColor
+        revenueData.adjustsFontSizeToFitWidth = true
         revenueData.accessibilityIdentifier = "revenue-value"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -394,7 +394,7 @@ private extension StoreStatsV4PeriodViewController {
         let xAxis = lineChartView.xAxis
         xAxis.labelPosition = .bottom
         xAxis.yOffset = 8
-        xAxis.labelFont = StyleManager.chartLabelFont
+        xAxis.labelFont = .caption2
         xAxis.labelTextColor = .textSubtle
         xAxis.axisLineColor = .systemColor(.separator)
         xAxis.gridColor = .systemColor(.separator)
@@ -407,7 +407,7 @@ private extension StoreStatsV4PeriodViewController {
         updateChartXAxisLabelCount(xAxis: xAxis, timeRange: timeRange)
 
         let yAxis = lineChartView.leftAxis
-        yAxis.labelFont = StyleManager.chartLabelFont
+        yAxis.labelFont = .caption2
         yAxis.labelTextColor = .textSubtle
         yAxis.axisLineColor = .systemColor(.separator)
         yAxis.gridColor = .systemColor(.separator)


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8383

# Why 

This PR makes sure that all the content on the dashboard is visible when using the biggest accessibility font.

# How

- Update some font styles to have a maximum size, in order to not break the layout and follow how android shows the dashboard.

- Update top performers cell stack view to render content vertically when needed, previously the item count was missing

- Allow the dashboard stats +chart view to grow more than the minimum defined size.

- Adjust some labels so their font shrinks when the content is bigger than their available width.

# Screenshot

Before | After
---- | ----
![before-1](https://user-images.githubusercontent.com/562080/209140099-aa48b539-953f-4ba0-ac12-aa4cdb6d3733.png) | ![after-1](https://user-images.githubusercontent.com/562080/209140108-460598fb-36b9-4024-8c56-485e681f5bd1.png)
![before-2](https://user-images.githubusercontent.com/562080/209140182-74763be8-a94c-4c1d-a8ba-a99219bc5435.png) | ![after-2](https://user-images.githubusercontent.com/562080/209140186-b686f830-cc48-486a-870a-0b2a3d7aa9df.png)

# Testing 

- Before launching the app go to the phone settings and set the device font to the biggest size available.
- Launch the app
- See that all of the dashboard content is visible.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
