### PR TITLE
[Settings] Use a default app icon image as fallback on About screen

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -37,6 +37,12 @@ extension UIImage {
         return UIImage(named: "icon-analytics")!
     }
 
+    /// App icon (iPhone size)
+    ///
+    static var appIconDefault: UIImage {
+        return UIImage(named: "AppIcon60x60")!
+    }
+
     /// Currency Image
     ///
     static var currencyImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/WooAboutScreenConfiguration.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/WooAboutScreenConfiguration.swift
@@ -69,7 +69,7 @@ final class WooAboutScreenConfiguration: AboutScreenConfiguration {
     static var appInfo: AboutScreenAppInfo {
         return AboutScreenAppInfo(name: WooConstants.appDisplayName,
                                   version: Bundle.main.detailedVersionNumber(),
-                                  icon: UIImage(named: iconNameFromBundle())!)
+                                  icon: UIImage(named: iconNameFromBundle()) ?? .appIconDefault)
     }
 
     /// Provides font definitions for use in the header of the about screen.

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -720,4 +720,8 @@ final class IconsTests: XCTestCase {
     func test_calendar_icon_is_not_nil() {
         XCTAssertNotNil(UIImage.calendar)
     }
+
+    func test_app_icon_is_not_nil() {
+        XCTAssertNotNil(UIImage.appIconDefault)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8467
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a crash when the app icon name can't be retrieved for the About screen. Previously in that case we were force unwrapping an image with an empty name (`UIImage(named: "")`), causing a fatal error. This PR adds a default app icon image to use as a fallback, instead.

## Testing instructions

I couldn't reproduce the crash, but the unit tests should pass and you should be able to open the about screen as usual:

1. Launch the app.
2. Select the Menu tab.
3. Tap the settings icon in the top right.
4. Under "About the app" tap "WooCommerce." Confirm the About screen opens with the WooCommerce app icon at the top.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
