### PR TITLE
[Analytics Hub] Decouple analytics events and views

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCardViewModel.swift
@@ -16,7 +16,11 @@ struct AnalyticsTimeRangeCardViewModel {
     ///
     let previousRangeSubtitle: String
 
-    /// Analytics Usage Tracks Event Emitter
+    /// Closure invoked when the time range card is tapped.
     ///
-    let usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter
+    var onTapped: () -> Void = {}
+
+    /// Closure invoked when a time range is selected.
+    ///
+    var onSelected: (AnalyticsTimeRangeCard.Range) -> Void = { _ in }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -358,7 +358,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
     }
 
     @objc func seeMoreButtonTapped() {
-        ServiceLocator.analytics.track(event: .AnalyticsHub.seeMoreAnalyticsTapped())
+        viewModel.trackSeeMoreButtonTapped()
         let analyticsHubVC = AnalyticsHubHostingViewController(siteID: siteID, timeRange: timeRange, usageTracksEventEmitter: usageTracksEventEmitter)
         show(analyticsHubVC, sender: self)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
@@ -61,6 +61,14 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
         storesManager.dispatch(action)
     }
 
+    /// Tracks when the Analytics "See More" button is tapped
+    ///
+    func trackSeeMoreButtonTapped() {
+        analytics.track(event: .AnalyticsHub.seeMoreAnalyticsTapped())
+    }
+
+    // MARK: Private helpers
+
     /// Calculates and updates the value of `isInAppFeedbackCardVisible`.
     private func refreshIsInAppFeedbackCardVisibleValue() {
         // Abort right away if we don't need to calculate the real value.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -6,11 +6,13 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     private var stores: MockStoresManager!
     private var eventEmitter: StoreStatsUsageTracksEventEmitter!
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: Analytics!
 
     override func setUp() {
         stores = MockStoresManager(sessionManager: .makeForTesting())
-        let analyticsProvider = MockAnalyticsProvider()
-        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         eventEmitter = StoreStatsUsageTracksEventEmitter(analytics: analytics)
     }
 
@@ -166,5 +168,19 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(vm.showSessionsCard)
+    }
+
+    func test_time_range_card_tracks_expected_events() throws {
+        // Given
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, analytics: analytics)
+
+        // When
+        vm.timeRangeCard.onTapped()
+        vm.timeRangeCard.onSelected(.weekToDate)
+
+        // Then
+        assertEqual(["analytics_hub_date_range_button_tapped", "analytics_hub_date_range_option_selected"], analyticsProvider.receivedEvents)
+        let optionSelectedEventProperty = try XCTUnwrap(analyticsProvider.receivedProperties.last?["option"] as? String)
+        assertEqual("Week to Date", optionSelectedEventProperty)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -204,6 +204,17 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual([false, true, false], emittedValues)
     }
+
+    func test_trackSeeMoreButtonTapped_tracks_expected_event() {
+        // Given
+        let viewModel = makeViewModel()
+
+        // When
+        viewModel.trackSeeMoreButtonTapped()
+
+        // Then
+        assertEqual(["dashboard_see_more_analytics_tapped"], analyticsProvider.receivedEvents)
+    }
 }
 
 private extension StoreStatsAndTopPerformersPeriodViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8470
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR decouples the Analytics Hub tracks events from the views where they are used. This makes the views more reusable and allows us to unit test the tracks events.

### Changes

* Moves the event tracking for tapping the "See more" button from the StoreStatsAndTopPerformersPeriod VC to the VM, and adds a corresponding unit test.
* Updates `AnalyticsTimeRangeCard` to invoke closures when the card is tapped and when a time range is selected, to make the view more reusable. These closures are now set when the time range card VM is initialized in `AnalyticsHubViewModel`, with a corresponding unit test.

Note: The unit test does not test that the `StoreStatsUsageTracksEventEmitter` event (`used_analytics`) is triggered, because that also depends on the timing and number of interactions. If we decide that's worth testing, it might be worth having a mock event emitter that is designed for easier use in unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app.
2. Tap the "See More" button on the My Store dashboard and confirm the corresponding event is still triggered.
3. On the Analytics screen, tap the date range card and confirm the corresponding event is still triggered.
4. In the date range list, select a date range option and confirm the corresponding event is still triggered.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
