### PR TITLE
[Widgets] Share all stores list with extensions

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -33,6 +33,13 @@ public extension StorageType {
         allObjects(ofType: Site.self, matching: nil, sortedBy: nil)
     }
 
+    /// Retrieves all stored sites with active WooCommerce.
+    ///
+    func loadAllWooCommerceSites() -> [Site] {
+        let predicate = \Site.isWooCommerceActive == true
+        return allObjects(ofType: Site.self, matching: predicate, sortedBy: nil)
+    }
+
     // MARK: - Orders
 
     /// Retrieves the Stored Order.

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -6,6 +6,7 @@ import Foundation
 //
 extension UserDefaults {
     enum Key: String {
+        case sharedSitesData
         case defaultAccountID
         case defaultUsername
         case defaultSiteAddress

--- a/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
+++ b/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
@@ -63,7 +63,7 @@ extension SelectedSiteSettings {
             ServiceLocator.currencySettings.updateCurrencyOptions(with: $0)
         }
 
-        // Needed to correcly format the widget data.
+        // Needed to correctly format the widget data.
         UserDefaults.group?[.defaultStoreCurrencySettings] = try? JSONEncoder().encode(ServiceLocator.currencySettings)
     }
 }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -501,12 +501,24 @@ private extension DefaultStoresManager {
         dispatch(action)
     }
 
-    /// Updates the necesary dependencies for the widget to function correctly.
+    /// Updates the necessary dependencies for the widget to function correctly.
     /// Reloads widgets timelines.
     ///
     func updateAndReloadWidgetInformation(with siteID: Int64?) {
         // Token to fire network requests
         keychain.currentAuthToken = sessionManager.defaultCredentials?.authToken
+
+        // Share all stores list to extensions
+        let action = AccountAction.fetchStores { sites in
+            let sharedSitesData = sites.map { SharedSiteData(siteID: $0.siteID, siteName: $0.name) }
+            do {
+                let encodedSitesData = try JSONEncoder().encode(sharedSitesData)
+                UserDefaults.group?[.sharedSitesData] = encodedSitesData
+            } catch {
+                DDLogWarn("⚠️ Unable to serialise shared sites data: \(error)")
+            }
+        }
+        dispatch(action)
 
         // Non-critical store info
         UserDefaults.group?[.defaultStoreID] = siteID

--- a/WooCommerce/StoreWidgets/SharedSiteData.swift
+++ b/WooCommerce/StoreWidgets/SharedSiteData.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct SharedSiteData: Codable {
+    let siteID: Int64
+    let siteName: String
+}

--- a/WooCommerce/StoreWidgets/StatsTimeRange.swift
+++ b/WooCommerce/StoreWidgets/StatsTimeRange.swift
@@ -92,7 +92,7 @@ extension StatsTimeRange {
     /// - Parameters:
     ///   - currentDate: the date which the latest date is based on
     ///   - siteTimezone: site time zone, which the stats data are based on
-    func latestDate(currentDate: Date, siteTimezone: TimeZone) -> Date {
+    func latestDate(currentDate: Date, siteTimezone: TimeZone) -> Date? {
         switch self {
         case .today:
             return currentDate.endOfDay(timezone: siteTimezone)
@@ -110,7 +110,7 @@ extension StatsTimeRange {
     /// - Parameters:
     ///   - latestDate: the date which the earliest date is based on
     ///   - siteTimezone: site time zone, which the stats data are based on
-    func earliestDate(latestDate: Date, siteTimezone: TimeZone) -> Date {
+    func earliestDate(latestDate: Date, siteTimezone: TimeZone) -> Date? {
         switch self {
         case .today:
             return latestDate.startOfDay(timezone: siteTimezone)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1235,6 +1235,7 @@
 		AED9012D28E5F517002B4572 /* AppLinkWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED9012C28E5F517002B4572 /* AppLinkWidget.swift */; };
 		AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */; };
 		AEDDDA1A25CAB2170077F9B2 /* AttributePickerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */; };
+		AEDE42E62954597800AED652 /* StatsTimeRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDE42E52954597800AED652 /* StatsTimeRange.swift */; };
 		AEE085B52897C871007ACE20 /* LinkedProductsPromoCampaign.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE085B42897C871007ACE20 /* LinkedProductsPromoCampaign.swift */; };
 		AEE1D4F525D14F88006A490B /* AttributeOptionListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE1D4F425D14F88006A490B /* AttributeOptionListSelectorCommand.swift */; };
 		AEE1D4FF25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE1D4FE25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift */; };
@@ -3254,6 +3255,7 @@
 		AED9012C28E5F517002B4572 /* AppLinkWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLinkWidget.swift; sourceTree = "<group>"; };
 		AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewController.swift; sourceTree = "<group>"; };
 		AEDDDA1925CAB2170077F9B2 /* AttributePickerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AttributePickerViewController.xib; sourceTree = "<group>"; };
+		AEDE42E52954597800AED652 /* StatsTimeRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsTimeRange.swift; sourceTree = "<group>"; };
 		AEE085B42897C871007ACE20 /* LinkedProductsPromoCampaign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedProductsPromoCampaign.swift; sourceTree = "<group>"; };
 		AEE1D4F425D14F88006A490B /* AttributeOptionListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeOptionListSelectorCommand.swift; sourceTree = "<group>"; };
 		AEE1D4FE25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeOptionListSelectorCommandTests.swift; sourceTree = "<group>"; };
@@ -5780,8 +5782,8 @@
 				3F1FA84528B60125009E246C /* StoreWidgets.swift */,
 				265C99E028B9BA43005E6117 /* StoreInfoWidget.swift */,
 				265C99E328B9C834005E6117 /* StoreInfoProvider.swift */,
+				AEDE42E52954597800AED652 /* StatsTimeRange.swift */,
 				260DE20828CA7CE2009ECD7C /* StoreInfoDataService.swift */,
-				AEA7840328FEE82A000485FC /* StatsTimeRange.swift */,
 				265C99E528B9CB8E005E6117 /* StoreInfoViewModifiers.swift */,
 				3F1FA84728B60125009E246C /* StoreWidgets.intentdefinition */,
 				3F1FA84828B60126009E246C /* Assets.xcassets */,
@@ -9941,7 +9943,6 @@
 				AED9012D28E5F517002B4572 /* AppLinkWidget.swift in Sources */,
 				2608C50728C941D600C9DFC0 /* UserDefaults+Woo.swift in Sources */,
 				265C99E628B9CB8E005E6117 /* StoreInfoViewModifiers.swift in Sources */,
-				AEA7840428FEE82A000485FC /* StatsTimeRange.swift in Sources */,
 				2608C50628C93AB700C9DFC0 /* WooConstants.swift in Sources */,
 				260DE20A28CA7CFE009ECD7C /* StoreInfoDataService.swift in Sources */,
 				AE56E73428E76CDB00A1292B /* StoreInfoInlineWidget.swift in Sources */,
@@ -9949,6 +9950,7 @@
 				AEBFD13F28E7655F00F598C6 /* StoreInfoView.swift in Sources */,
 				AE56E73628E7787700A1292B /* StoreInfoCircularWidget.swift in Sources */,
 				265C99E228B9BCD0005E6117 /* StoreInfoWidget.swift in Sources */,
+				AEDE42E62954597800AED652 /* StatsTimeRange.swift in Sources */,
 				AE56E73828E7869800A1292B /* StoreInfoRectangularWidget.swift in Sources */,
 				265C99E428B9C834005E6117 /* StoreInfoProvider.swift in Sources */,
 				3F1FA84628B60125009E246C /* StoreWidgets.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1197,6 +1197,8 @@
 		ABC3521A374A2355001E3CD6 /* CardReaderSettingsSearchingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC353433EABC5F0EC796222 /* CardReaderSettingsSearchingViewController.swift */; };
 		ABC35528D2D6BE6F516E5CEF /* InPersonPaymentsOnboardingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC35A4B736A0B2D8348DD08 /* InPersonPaymentsOnboardingError.swift */; };
 		ABC35F18E744C5576B986CB3 /* InPersonPaymentsUnavailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC35055F8AC8C8EB649F421 /* InPersonPaymentsUnavailableView.swift */; };
+		AE0AB0FE2956072A0050FC47 /* SharedSiteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0AB0FD2956072A0050FC47 /* SharedSiteData.swift */; };
+		AE0AB0FF2956072A0050FC47 /* SharedSiteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0AB0FD2956072A0050FC47 /* SharedSiteData.swift */; };
 		AE1CC33829129A010021C8EF /* LinkBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1CC33729129A010021C8EF /* LinkBehavior.swift */; };
 		AE3AA889290C303B00BE422D /* WebKitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3AA888290C303B00BE422D /* WebKitViewController.swift */; };
 		AE3AA88B290C30B900BE422D /* WebViewControllerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3AA88A290C30B900BE422D /* WebViewControllerConfiguration.swift */; };
@@ -3217,6 +3219,7 @@
 		ABC35055F8AC8C8EB649F421 /* InPersonPaymentsUnavailableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsUnavailableView.swift; sourceTree = "<group>"; };
 		ABC353433EABC5F0EC796222 /* CardReaderSettingsSearchingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsSearchingViewController.swift; sourceTree = "<group>"; };
 		ABC35A4B736A0B2D8348DD08 /* InPersonPaymentsOnboardingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsOnboardingError.swift; sourceTree = "<group>"; };
+		AE0AB0FD2956072A0050FC47 /* SharedSiteData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedSiteData.swift; sourceTree = "<group>"; };
 		AE1CC33729129A010021C8EF /* LinkBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkBehavior.swift; sourceTree = "<group>"; };
 		AE3AA888290C303B00BE422D /* WebKitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebKitViewController.swift; sourceTree = "<group>"; };
 		AE3AA88A290C30B900BE422D /* WebViewControllerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewControllerConfiguration.swift; sourceTree = "<group>"; };
@@ -5783,6 +5786,7 @@
 				265C99E028B9BA43005E6117 /* StoreInfoWidget.swift */,
 				265C99E328B9C834005E6117 /* StoreInfoProvider.swift */,
 				AEDE42E52954597800AED652 /* StatsTimeRange.swift */,
+				AE0AB0FD2956072A0050FC47 /* SharedSiteData.swift */,
 				260DE20828CA7CE2009ECD7C /* StoreInfoDataService.swift */,
 				265C99E528B9CB8E005E6117 /* StoreInfoViewModifiers.swift */,
 				3F1FA84728B60125009E246C /* StoreWidgets.intentdefinition */,
@@ -9943,6 +9947,7 @@
 				AED9012D28E5F517002B4572 /* AppLinkWidget.swift in Sources */,
 				2608C50728C941D600C9DFC0 /* UserDefaults+Woo.swift in Sources */,
 				265C99E628B9CB8E005E6117 /* StoreInfoViewModifiers.swift in Sources */,
+				AE0AB0FF2956072A0050FC47 /* SharedSiteData.swift in Sources */,
 				2608C50628C93AB700C9DFC0 /* WooConstants.swift in Sources */,
 				260DE20A28CA7CFE009ECD7C /* StoreInfoDataService.swift in Sources */,
 				AE56E73428E76CDB00A1292B /* StoreInfoInlineWidget.swift in Sources */,
@@ -10730,6 +10735,7 @@
 				DE2FE5812923729A0018040A /* JetpackSetupRequiredViewModel.swift in Sources */,
 				020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */,
 				26E7EE7429365F0700793045 /* TopPerformersView.swift in Sources */,
+				AE0AB0FE2956072A0050FC47 /* SharedSiteData.swift in Sources */,
 				74AAF6A5212A04A900C612B0 /* ChartMarker.swift in Sources */,
 				CE32B11520BF8779006FBCF4 /* ButtonTableViewCell.swift in Sources */,
 				025FDD3223717D2900824006 /* EditorFactory.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -12,6 +12,7 @@ public enum AccountAction: Action {
     case synchronizeAccountSettings(userID: Int64, onCompletion: (Result<AccountSettings, Error>) -> Void)
     /// The boolean in the completion block indicates whether the sites contain any JCP sites (connected to Jetpack without Jetpack-the-plugin).
     case synchronizeSites(selectedSiteID: Int64?, onCompletion: (Result<Bool, Error>) -> Void)
+    case fetchStores(onCompletion: ([Site]) -> Void)
     case synchronizeSitePlan(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
     case updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: (Result<Void, Error>) -> Void)
     case closeAccount(onCompletion: (Result<Void, Error>) -> Void)

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -71,6 +71,8 @@ public class AccountStore: Store {
         case .synchronizeSites(let selectedSiteID, let onCompletion):
             synchronizeSites(selectedSiteID: selectedSiteID,
                              onCompletion: onCompletion)
+        case .fetchStores(onCompletion: let onCompletion):
+            fetchStores(onCompletion: onCompletion)
         case .synchronizeSitePlan(let siteID, let onCompletion):
             synchronizeSitePlan(siteID: siteID, onCompletion: onCompletion)
         case .updateAccountSettings(let userID, let tracksOptOut, let onCompletion):
@@ -183,6 +185,12 @@ private extension AccountStore {
                     onCompletion(.failure(error))
                 }
             }.store(in: &cancellables)
+    }
+
+    /// Loads all stores data from the storage.
+    ///
+    func fetchStores(onCompletion: @escaping ([Site]) -> Void) {
+        onCompletion(storageManager.viewStorage.loadAllWooCommerceSites().map { $0.toReadOnly() })
     }
 
     /// Loads the site plan for the default site.


### PR DESCRIPTION
Part of: https://github.com/woocommerce/woocommerce-ios/issues/7863

## Description

To allow user selecting any connected store in widgets, we need to share full list of stores connected to user's account.
We need `siteID` to query data and `name` to display it in the settings UI (store picker).

This PR doesn't include reading this data on extension side, since it requires setting up additional target. But it's already validated, working well and will come in later PRs.

_Question:_ do we want to share currency settings for each store separately? Should we add it in this dataset? Should we query all sites settings from API, since we only have current site cached in the Storage?

## Testing

The data is not used yet, just check the code.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
