### PR TITLE
[REST API] Handle WPOrg errors in Application Password use case

### DIFF
--- a/Networking/Networking/ApplicationPassword/ApplicationPasswordStorage.swift
+++ b/Networking/Networking/ApplicationPassword/ApplicationPasswordStorage.swift
@@ -26,16 +26,16 @@ struct ApplicationPasswordStorage {
     /// - Parameter password: `ApplicationPasword` to be saved
     ///
     func saveApplicationPassword(_ password: ApplicationPassword) {
-        keychain.password = password.wpOrgUsername
-        keychain.username = password.password.secretValue
+        keychain.username = password.wpOrgUsername
+        keychain.password = password.password.secretValue
     }
 
     /// Removes the currently saved password from storage
     ///
     func removeApplicationPassword() {
         // Delete password from keychain
-        keychain.password = nil
         keychain.username = nil
+        keychain.password = nil
     }
 }
 

--- a/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -141,8 +141,6 @@ private extension DefaultApplicationPasswordUseCase {
                 switch result {
                 case .success(let data):
                     do {
-                        let validator = request.responseDataValidator()
-                        try validator.validate(data: data)
                         let mapper = ApplicationPasswordMapper()
                         let password = try mapper.map(response: data)
                         continuation.resume(returning: password)
@@ -183,14 +181,8 @@ private extension DefaultApplicationPasswordUseCase {
         try await withCheckedThrowingContinuation { continuation in
             network.responseData(for: request) { result in
                 switch result {
-                case .success(let data):
-                    do {
-                        let validator = request.responseDataValidator()
-                        try validator.validate(data: data)
-                        continuation.resume()
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
+                case .success:
+                    continuation.resume()
                 case .failure(let error):
                     continuation.resume(throwing: error)
                 }

--- a/Networking/Networking/Requests/JetpackRequest.swift
+++ b/Networking/Networking/Requests/JetpackRequest.swift
@@ -86,7 +86,7 @@ struct JetpackRequest: Request {
         guard availableAsRESTRequest else {
             return nil
         }
-        return RESTRequest(siteURL: siteURL, method: method, path: path, parameters: parameters)
+        return RESTRequest(siteURL: siteURL, wooApiVersion: wooApiVersion, method: method, path: path, parameters: parameters)
     }
 }
 

--- a/Networking/Networking/Requests/RESTRequest.swift
+++ b/Networking/Networking/Requests/RESTRequest.swift
@@ -8,6 +8,10 @@ struct RESTRequest: URLRequestConvertible {
     ///
     let siteURL: String
 
+    /// WooCommerce API Version
+    ///
+    let wooApiVersion: WooAPIVersion
+
     /// HTTP Request Method
     ///
     let method: HTTPMethod
@@ -32,10 +36,12 @@ struct RESTRequest: URLRequestConvertible {
     ///     - fallbackRequest: A fallback Jetpack request to trigger if the REST request cannot be made.
     ///
     init(siteURL: String,
+         wooApiVersion: WooAPIVersion,
          method: HTTPMethod,
          path: String,
          parameters: [String: Any] = [:]) {
         self.siteURL = siteURL
+        self.wooApiVersion = wooApiVersion
         self.method = method
         self.path = path
         self.parameters = parameters
@@ -44,7 +50,7 @@ struct RESTRequest: URLRequestConvertible {
     /// Returns a URLRequest instance representing the current REST API Request.
     ///
     func asURLRequest() throws -> URLRequest {
-        let url = try (siteURL + path).asURL()
+        let url = try (siteURL.removingSuffix("/") + Settings.basePath + wooApiVersion.path.removingPrefix("/") + path.removingPrefix("/")).asURL()
         let request = try URLRequest(url: url, method: method)
         return try URLEncoding.default.encode(request, with: parameters)
     }
@@ -68,5 +74,11 @@ extension RESTRequest {
 
         request.setValue("Basic \(base64LoginString)", forHTTPHeaderField: "Authorization")
         return request
+    }
+}
+
+private extension RESTRequest {
+    enum Settings {
+        static let basePath = "/wp-json/"
     }
 }

--- a/Networking/Networking/Requests/RESTRequest.swift
+++ b/Networking/Networking/Requests/RESTRequest.swift
@@ -59,7 +59,7 @@ extension RESTRequest {
         request.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
 
         let username = applicationPassword.wpOrgUsername
-        let password = applicationPassword.wpOrgUsername
+        let password = applicationPassword.password.secretValue
         let loginString = "\(username):\(password)"
         guard let loginData = loginString.data(using: .utf8) else {
             return request

--- a/Networking/Networking/Requests/RESTRequest.swift
+++ b/Networking/Networking/Requests/RESTRequest.swift
@@ -50,7 +50,8 @@ struct RESTRequest: URLRequestConvertible {
     /// Returns a URLRequest instance representing the current REST API Request.
     ///
     func asURLRequest() throws -> URLRequest {
-        let url = try (siteURL.removingSuffix("/") + Settings.basePath + wooApiVersion.path.removingPrefix("/") + path.removingPrefix("/")).asURL()
+        let components = [siteURL, Settings.basePath, wooApiVersion.path, path].map { $0.trimSlashes() }
+        let url = try components.joined(separator: "/").asURL()
         let request = try URLRequest(url: url, method: method)
         return try URLEncoding.default.encode(request, with: parameters)
     }
@@ -79,6 +80,16 @@ extension RESTRequest {
 
 private extension RESTRequest {
     enum Settings {
-        static let basePath = "/wp-json/"
+        static let basePath = "wp-json"
+    }
+}
+
+private extension String {
+    /// Trims front slash
+    ///
+    /// - Returns: String after removing prefix and suffix "/"
+    ///
+    func trimSlashes() -> String {
+        removingPrefix("/").removingSuffix("/")
     }
 }

--- a/Networking/NetworkingTests/Network/RequestAuthenticatorTests.swift
+++ b/Networking/NetworkingTests/Network/RequestAuthenticatorTests.swift
@@ -41,7 +41,9 @@ final class RequestAuthenticatorTests: XCTestCase {
         let applicationPassword = ApplicationPassword(wpOrgUsername: credentials.username, password: .init(credentials.secret))
         let useCase = MockApplicationPasswordUseCase(mockApplicationPassword: applicationPassword)
         let authenticator = RequestAuthenticator(credentials: credentials, applicationPasswordUseCase: useCase)
-        let jetpackRequest = JetpackRequest(wooApiVersion: .mark1, method: .get, siteID: 123, path: "test", availableAsRESTRequest: true)
+        let wooAPIVersion = WooAPIVersion.mark1
+        let basePath = "wp-json"
+        let jetpackRequest = JetpackRequest(wooApiVersion: wooAPIVersion, method: .get, siteID: 123, path: "test", availableAsRESTRequest: true)
 
         // When
         var updatedRequest: URLRequestConvertible?
@@ -54,7 +56,7 @@ final class RequestAuthenticatorTests: XCTestCase {
 
         // Then
         let request = try XCTUnwrap(updatedRequest as? URLRequest)
-        let expectedURL = "https://test.com/test"
+        let expectedURL = "https://test.com/\(basePath)\(wooAPIVersion.path)test"
         assertEqual(expectedURL, request.url?.absoluteString)
         let authorizationValue = try XCTUnwrap(request.allHTTPHeaderFields?["Authorization"])
         XCTAssertTrue(authorizationValue.hasPrefix("Basic"))
@@ -66,7 +68,9 @@ final class RequestAuthenticatorTests: XCTestCase {
         let applicationPassword = ApplicationPassword(wpOrgUsername: credentials.username, password: .init(credentials.secret))
         let useCase = MockApplicationPasswordUseCase(mockGeneratedPassword: applicationPassword)
         let authenticator = RequestAuthenticator(credentials: credentials, applicationPasswordUseCase: useCase)
-        let jetpackRequest = JetpackRequest(wooApiVersion: .mark1, method: .get, siteID: 123, path: "test", availableAsRESTRequest: true)
+        let wooAPIVersion = WooAPIVersion.mark1
+        let basePath = "wp-json"
+        let jetpackRequest = JetpackRequest(wooApiVersion: wooAPIVersion, method: .get, siteID: 123, path: "test", availableAsRESTRequest: true)
 
         // When
         var updatedRequest: URLRequestConvertible?
@@ -79,7 +83,7 @@ final class RequestAuthenticatorTests: XCTestCase {
 
         // Then
         let request = try XCTUnwrap(updatedRequest as? URLRequest)
-        let expectedURL = "https://test.com/test"
+        let expectedURL = "https://test.com/\(basePath)\(wooAPIVersion.path)test"
         assertEqual(expectedURL, request.url?.absoluteString)
         let authorizationValue = try XCTUnwrap(request.allHTTPHeaderFields?["Authorization"])
         XCTAssertTrue(authorizationValue.hasPrefix("Basic"))

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -499,7 +499,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         if let wporg = credentials.wporg,
             featureFlagService.isFeatureFlagEnabled(.applicationPasswordAuthenticationForSiteCredentialLogin) {
             ServiceLocator.stores.authenticate(credentials: .wporg(username: wporg.username,
-                                                                   password: wporg.username,
+                                                                   password: wporg.password,
                                                                    siteAddress: wporg.siteURL))
             return onCompletion()
         }

--- a/WooCommerce/WooCommerceTests/ViewModels/Authentication/AccountCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Authentication/AccountCreationFormViewModelTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Yosemite
 @testable import WooCommerce
+import WordPressAuthenticator
 
 final class AccountCreationFormViewModelTests: XCTestCase {
     private var stores: MockStoresManager!
@@ -10,6 +11,9 @@ final class AccountCreationFormViewModelTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+
+        WordPressAuthenticator.initializeAuthenticator()
+
         stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8474 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

We started using WPOrg REST API for fetching application passwords instead of Jetpack tunnel. But we missed to update the error handling to handle errors directly. This PR attempts to fix that.

## Testing instructions
NA

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
