### PR TITLE
Dashboard: Add spacing to tab strip bar

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -291,7 +291,7 @@ private extension DashboardViewController {
 
         // This constraint will pin the bottom of the header to the top of the content
         // We want this to be active when the header is visible
-        contentTopToHeaderConstraint = contentView.topAnchor.constraint(equalTo: headerStackView.bottomAnchor)
+        contentTopToHeaderConstraint = contentView.topAnchor.constraint(equalTo: headerStackView.bottomAnchor, constant: Constants.tabStripSpacing)
         contentTopToHeaderConstraint?.isActive = true
 
         // This constraint has a lower priority and will pin the top of the content view to its superview
@@ -719,5 +719,6 @@ private extension DashboardViewController {
         static let backgroundColor: UIColor = .systemBackground
         static let iPhoneCollapsedNavigationBarHeight = CGFloat(44)
         static let iPadCollapsedNavigationBarHeight = CGFloat(50)
+        static let tabStripSpacing = CGFloat(12)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -477,7 +477,6 @@ private extension StoreStatsAndTopPerformersViewController {
         settings.style.buttonBarItemTitleColor = .textSubtle
         settings.style.buttonBarItemsShouldFillAvailableWidth = false
         settings.style.buttonBarItemLeftRightMargin = TabStrip.buttonLeftRightMargin
-        settings.style.buttonBarHeight = UIFontMetrics.default.scaledValue(for: TabStrip.tabHeight)
 
         changeCurrentIndexProgressive = {
             (oldCell: ButtonBarViewCell?,
@@ -547,7 +546,6 @@ private extension StoreStatsAndTopPerformersViewController {
     enum TabStrip {
         static let buttonLeftRightMargin: CGFloat   = 16.0
         static let selectedBarHeight: CGFloat       = 3.0
-        static let tabHeight: CGFloat               = 36.0
     }
 
     enum Constants {


### PR DESCRIPTION
# Why

In [this comment](https://github.com/woocommerce/woocommerce-ios/pull/8463#issuecomment-1363541394) it was requested to add a 12pts spacing between the store name & the tab, as well as make the tab strip to have 44pts of height.

# Screenshots

Request | Before | After
--- | --- | ---
<img width="388" alt="request" src="https://user-images.githubusercontent.com/562080/209580211-e4aaaf60-c162-4b0d-b828-f3d8cc100e46.png"> | <img width="426" alt="before" src="https://user-images.githubusercontent.com/562080/209580212-57b88b3d-7848-4e83-b9bf-7af216d5a435.png"> | <img width="438" alt="spacing" src="https://user-images.githubusercontent.com/562080/209580213-acf2ffdf-b55e-43cf-a778-24f460f44daa.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
