### PR TITLE
Unify font helpers

### DIFF
--- a/WooCommerce/Classes/Extensions/UIFont+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIFont+Helpers.swift
@@ -84,12 +84,19 @@ extension UIFont {
         return UIFontMetrics(forTextStyle: style).scaledFont(for: noticonFont)
     }
 
-    /// Returns a UIFont instance for the specified Style + Weight.
+    /// Returns a UIFont instance for the specified Style + Weight + Max Size.
     ///
-    class func font(forStyle style: UIFont.TextStyle, weight: UIFont.Weight) -> UIFont {
+    class func font(forStyle style: UIFont.TextStyle, weight: UIFont.Weight, maxFontSize: CGFloat? = nil) -> UIFont {
         let descriptor = UIFontDescriptor
             .preferredFontDescriptor(withTextStyle: style)
             .addingAttributes([.traits: [UIFontDescriptor.TraitKey.weight: weight]])
+
+        // Limit the font size if needed
+        if let maxFontSize, descriptor.pointSize > maxFontSize {
+            return UIFont(descriptor: descriptor, size: maxFontSize)
+        }
+
+        // Return font without a predefined size.
         return UIFont(descriptor: descriptor, size: 0)
     }
 

--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -11,22 +11,20 @@ final class StyleManager {
     }
 
     static var statsFont: UIFont {
-        return self.fontForTextStyle(.title3, weight: .semibold, maximumPointSize: 36.0)
+        return .font(forStyle: .title3, weight: .semibold, maxFontSize: 36.0)
     }
 
     static var statsTitleFont: UIFont {
-        return self.fontForTextStyle(.caption2, weight: .regular, maximumPointSize: maxFontSize)
+        return .font(forStyle: .caption2, weight: .regular, maxFontSize: maxFontSize)
     }
 
     static var chartLabelFont: UIFont {
         // Dashboard chart needs from a slighly smaller maximum font to be able to fit it when using the biggest accessibility font.
-        return self.fontForTextStyle(.caption2, weight: .regular, maximumPointSize: 20.0)
+        return .font(forStyle: .caption2, weight: .regular, maxFontSize: 20.0)
     }
 
     static var headlineSemiBold: UIFont {
-        return self.fontForTextStyle(.headline,
-        weight: .semibold,
-        maximumPointSize: maxFontSize)
+        return .font(forStyle: .headline, weight: .semibold, maxFontSize: maxFontSize)
     }
 
     static var subheadlineFont: UIFont {
@@ -38,21 +36,15 @@ final class StyleManager {
     }
 
     static var subheadlineBoldFont: UIFont {
-        return self.fontForTextStyle(.subheadline,
-        weight: .bold,
-        maximumPointSize: maxFontSize)
+        return .font(forStyle: .subheadline, weight: .bold, maxFontSize: maxFontSize)
     }
 
     static var thinCaptionFont: UIFont {
-        return self.fontForTextStyle(.caption1,
-        weight: .thin,
-        maximumPointSize: maxFontSize)
+        return .font(forStyle: .caption1, weight: .thin, maxFontSize: maxFontSize)
     }
 
     static var footerLabelFont: UIFont {
-        return self.fontForTextStyle(.footnote,
-        weight: .regular,
-        maximumPointSize: maxFontSize)
+        return .font(forStyle: .footnote, weight: .regular, maxFontSize: maxFontSize)
 
     }
 
@@ -64,25 +56,5 @@ final class StyleManager {
     // MARK: - StatusBar
     static var statusBarLight: UIStatusBarStyle {
         return UIStatusBarStyle.lightContent
-    }
-}
-
-
-// MARK: - Private convenience methods
-private extension StyleManager {
-    class func fontForTextStyle(_ style: UIFont.TextStyle, weight: UIFont.Weight, maximumPointSize: CGFloat = maxFontSize) -> UIFont {
-        let traits = [UIFontDescriptor.TraitKey.weight: weight]
-        var fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
-        fontDescriptor = fontDescriptor.addingAttributes([.traits: traits])
-        let fontToGetSize = UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
-        return UIFontMetrics(forTextStyle: style).scaledFont(for: fontToGetSize, maximumPointSize: maximumPointSize)
-    }
-
-
-    private class func fontDescriptor(_ style: UIFont.TextStyle, maximumPointSize: CGFloat = maxFontSize) -> UIFontDescriptor {
-        let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
-        let fontToGetSize = UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
-        let scaledFontSize = CGFloat.minimum(fontToGetSize.pointSize, maximumPointSize)
-        return fontDescriptor.withSize(scaledFontSize)
     }
 }


### PR DESCRIPTION
# Why

While working on my HACK Week project, I noticed that for the dashboard we had some duplication regarding font helpers. 
This PR unifies those methods into a single helper method.

# Screenshots

Before | After
---- | ----
![before-1](https://user-images.githubusercontent.com/562080/209582894-3c65c9d0-3c1a-4e8d-b8e4-24eb75cc8a30.png) | ![after-1](https://user-images.githubusercontent.com/562080/209582896-3953bf68-5afe-4ad7-91e9-fb75a7708cec.png)
![before-2](https://user-images.githubusercontent.com/562080/209582904-93202a47-50f4-40e0-96ac-90386da474dc.png) | ![after-2](https://user-images.githubusercontent.com/562080/209582907-126c7dbb-b89a-4066-bffd-d04d66adb588.png)



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
