### PR TITLE
Store creation M3: profiler question - optional selling status

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// Hosting controller that wraps the `StoreCreationSellingStatusQuestionView`.
+final class StoreCreationSellingStatusQuestionHostingController: UIHostingController<StoreCreationSellingStatusQuestionView> {
+    init(viewModel: StoreCreationSellingStatusQuestionViewModel) {
+        super.init(rootView: StoreCreationSellingStatusQuestionView(viewModel: viewModel))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureTransparentNavigationBar()
+    }
+}
+
+/// Shows the store selling status question in the store creation flow.
+struct StoreCreationSellingStatusQuestionView: View {
+    @ObservedObject private var viewModel: StoreCreationSellingStatusQuestionViewModel
+
+    init(viewModel: StoreCreationSellingStatusQuestionViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        OptionalStoreCreationProfilerQuestionView(viewModel: viewModel) {
+            VStack(spacing: 16) {
+                ForEach(viewModel.sellingStatuses, id: \.self) { sellingStatus in
+                    Button(action: {
+                        viewModel.selectStatus(sellingStatus)
+                    }, label: {
+                        HStack {
+                            Text(sellingStatus.description)
+                            Spacer()
+                        }
+                    })
+                    .buttonStyle(SelectableSecondaryButtonStyle(isSelected: viewModel.selectedStatus == sellingStatus))
+                }
+            }
+        }
+    }
+}
+
+struct StoreCreationSellingStatusQuestionView_Previews: PreviewProvider {
+    static var previews: some View {
+        StoreCreationSellingStatusQuestionView(viewModel: .init(storeName: "New Year Store", onContinue: {}, onSkip: {}))
+    }
+}

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 /// Hosting controller that wraps the `StoreCreationSellingStatusQuestionView`.
 final class StoreCreationSellingStatusQuestionHostingController: UIHostingController<StoreCreationSellingStatusQuestionView> {
-    init(viewModel: StoreCreationSellingStatusQuestionViewModel) {
-        super.init(rootView: StoreCreationSellingStatusQuestionView(viewModel: viewModel))
+    init(storeName: String, onContinue: @escaping () -> Void, onSkip: @escaping () -> Void) {
+        super.init(rootView: StoreCreationSellingStatusQuestionView(storeName: storeName, onContinue: onContinue, onSkip: onSkip))
     }
 
     @available(*, unavailable)
@@ -21,9 +21,10 @@ final class StoreCreationSellingStatusQuestionHostingController: UIHostingContro
 /// Shows the store selling status question in the store creation flow.
 struct StoreCreationSellingStatusQuestionView: View {
     @ObservedObject private var viewModel: StoreCreationSellingStatusQuestionViewModel
+    @ObservedObject private var platformsViewModel: StoreCreationSellingPlatformsQuestionViewModel
 
-    init(viewModel: StoreCreationSellingStatusQuestionViewModel) {
-        self.viewModel = viewModel
+    init(storeName: String, onContinue: @escaping () -> Void, onSkip: @escaping () -> Void) {
+        self.viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: storeName, onContinue: onContinue, onSkip: onSkip)
     }
 
     var body: some View {
@@ -47,6 +48,6 @@ struct StoreCreationSellingStatusQuestionView: View {
 
 struct StoreCreationSellingStatusQuestionView_Previews: PreviewProvider {
     static var previews: some View {
-        StoreCreationSellingStatusQuestionView(viewModel: .init(storeName: "New Year Store", onContinue: {}, onSkip: {}))
+        StoreCreationSellingStatusQuestionView(storeName: "New Year Store", onContinue: {}, onSkip: {})
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionView.swift
@@ -21,7 +21,6 @@ final class StoreCreationSellingStatusQuestionHostingController: UIHostingContro
 /// Shows the store selling status question in the store creation flow.
 struct StoreCreationSellingStatusQuestionView: View {
     @ObservedObject private var viewModel: StoreCreationSellingStatusQuestionViewModel
-    @ObservedObject private var platformsViewModel: StoreCreationSellingPlatformsQuestionViewModel
 
     init(storeName: String, onContinue: @escaping () -> Void, onSkip: @escaping () -> Void) {
         self.viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: storeName, onContinue: onContinue, onSkip: onSkip)

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionViewModel.swift
@@ -27,9 +27,6 @@ final class StoreCreationSellingStatusQuestionViewModel: StoreCreationProfilerQu
 
     @Published private(set) var selectedStatus: SellingStatus?
 
-    /// Set to `true` when the user selects the selling status as "I am already selling online".
-    @Published private(set) var isAlreadySellingOnline: Bool = false
-
     private let onContinue: () -> Void
     private let onSkip: () -> Void
 
@@ -39,10 +36,6 @@ final class StoreCreationSellingStatusQuestionViewModel: StoreCreationProfilerQu
         self.topHeader = storeName
         self.onContinue = onContinue
         self.onSkip = onSkip
-
-        $selectedStatus
-            .map { $0 == .alreadySellingOnline }
-            .assign(to: &$isAlreadySellingOnline)
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionViewModel.swift
@@ -91,11 +91,11 @@ extension StoreCreationSellingStatusQuestionViewModel.SellingStatus {
 private extension StoreCreationSellingStatusQuestionViewModel {
     enum Localization {
         static let title = NSLocalizedString(
-            "Which of these best describes you?",
+            "Where are you on your commerce journey?",
             comment: "Title of the store creation profiler question about the store selling status."
         )
         static let subtitle = NSLocalizedString(
-            "Let us know where you are in your commerce journey so that we can tailor your Woo experience for you.",
+            "To speed things up, we’ll tailor your WooCommerce experience for you based on your response.",
             comment: "Subtitle of the store creation profiler question about the store selling status."
         )
     }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionViewModel.swift
@@ -1,0 +1,102 @@
+import Combine
+import Foundation
+
+/// View model for `StoreCreationSellingStatusQuestionView`, an optional profiler question about store selling status in the store creation flow.
+@MainActor
+final class StoreCreationSellingStatusQuestionViewModel: StoreCreationProfilerQuestionViewModel, ObservableObject {
+    /// Selling status options.
+    /// https://github.com/Automattic/woocommerce.com/blob/trunk/themes/woo/start/config/options.json
+    enum SellingStatus: Equatable {
+        /// Just starting my business.
+        case justStarting
+        /// Already selling, but not online.
+        case alreadySellingButNotOnline
+        /// Already selling online.
+        case alreadySellingOnline
+    }
+
+    let topHeader: String
+
+    let title: String = Localization.title
+
+    let subtitle: String = Localization.subtitle
+
+    /// Question content.
+    /// TODO: 8376 - update values when API is ready.
+    let sellingStatuses: [SellingStatus] = [.justStarting, .alreadySellingButNotOnline, .alreadySellingOnline]
+
+    @Published private(set) var selectedStatus: SellingStatus?
+
+    /// Set to `true` when the user selects the selling status as "I am already selling online".
+    @Published private(set) var isAlreadySellingOnline: Bool = false
+
+    private let onContinue: () -> Void
+    private let onSkip: () -> Void
+
+    init(storeName: String,
+         onContinue: @escaping () -> Void,
+         onSkip: @escaping () -> Void) {
+        self.topHeader = storeName
+        self.onContinue = onContinue
+        self.onSkip = onSkip
+
+        $selectedStatus
+            .map { $0 == .alreadySellingOnline }
+            .assign(to: &$isAlreadySellingOnline)
+    }
+}
+
+extension StoreCreationSellingStatusQuestionViewModel: OptionalStoreCreationProfilerQuestionViewModel {
+    func continueButtonTapped() async {
+        guard selectedStatus != nil else {
+            return onSkip()
+        }
+        onContinue()
+    }
+
+    func skipButtonTapped() {
+        onSkip()
+    }
+}
+
+extension StoreCreationSellingStatusQuestionViewModel {
+    /// Called when a selling status option is selected.
+    func selectStatus(_ status: SellingStatus) {
+        selectedStatus = status
+    }
+}
+
+extension StoreCreationSellingStatusQuestionViewModel.SellingStatus {
+    var description: String {
+        switch self {
+        case .justStarting:
+            return NSLocalizedString(
+                "I am just starting to sell",
+                comment: "Option in the store creation selling status question."
+            )
+        case .alreadySellingButNotOnline:
+            return NSLocalizedString(
+                "I am selling offline",
+                comment: "Option in the store creation selling status question."
+            )
+        case .alreadySellingOnline:
+            return NSLocalizedString(
+                "I am already selling online",
+                comment: "Option in the store creation selling status question."
+            )
+        }
+    }
+}
+
+private extension StoreCreationSellingStatusQuestionViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Which of these best describes you?",
+            comment: "Title of the store creation profiler question about the store selling status."
+        )
+        static let subtitle = NSLocalizedString(
+            "Let us know where you are in your commerce journey so that we can tailor your Woo experience for you.",
+            comment: "Subtitle of the store creation profiler question about the store selling status."
+        )
+    }
+}

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -312,7 +312,7 @@ private extension StoreCreationCoordinator {
                 } onSkip: { [weak self] in
                     // TODO: analytics
                     guard let self else { return }
-                    self.showDomainSelector(from: navigationController, storeName: storeName, categoryName: nil, planToPurchase: planToPurchase)
+                    self.showSellingStatusQuestion(from: navigationController, storeName: storeName, categoryName: nil, planToPurchase: planToPurchase)
                 })
         navigationController.pushViewController(questionController, animated: true)
         // TODO: analytics

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -308,12 +308,29 @@ private extension StoreCreationCoordinator {
         let questionController = StoreCreationCategoryQuestionHostingController(viewModel:
                 .init(storeName: storeName) { [weak self] categoryName in
                     guard let self else { return }
-                    self.showDomainSelector(from: navigationController, storeName: storeName, categoryName: categoryName, planToPurchase: planToPurchase)
+                    self.showSellingStatusQuestion(from: navigationController, storeName: storeName, categoryName: categoryName, planToPurchase: planToPurchase)
                 } onSkip: { [weak self] in
                     // TODO: analytics
                     guard let self else { return }
                     self.showDomainSelector(from: navigationController, storeName: storeName, categoryName: nil, planToPurchase: planToPurchase)
                 })
+        navigationController.pushViewController(questionController, animated: true)
+        // TODO: analytics
+    }
+
+    @MainActor
+    func showSellingStatusQuestion(from navigationController: UINavigationController,
+                                   storeName: String,
+                                   categoryName: String?,
+                                   planToPurchase: WPComPlanProduct) {
+        let questionController = StoreCreationSellingStatusQuestionHostingController(storeName: storeName) { [weak self] in
+            guard let self else { return }
+            self.showDomainSelector(from: navigationController, storeName: storeName, categoryName: categoryName, planToPurchase: planToPurchase)
+        } onSkip: { [weak self] in
+            // TODO: analytics
+            guard let self else { return }
+            self.showDomainSelector(from: navigationController, storeName: storeName, categoryName: nil, planToPurchase: planToPurchase)
+        }
         navigationController.pushViewController(questionController, animated: true)
         // TODO: analytics
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		020C908424C84652001E2BEB /* ProductListMultiSelectorSearchUICommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020C908324C84652001E2BEB /* ProductListMultiSelectorSearchUICommandTests.swift */; };
 		020D0BFD2914E92800BB3DCE /* StorePickerCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020D0BFC2914E92800BB3DCE /* StorePickerCoordinatorTests.swift */; };
 		020D0BFF2914F6BA00BB3DCE /* LoggedOutStoreCreationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020D0BFE2914F6BA00BB3DCE /* LoggedOutStoreCreationCoordinatorTests.swift */; };
+		020DD0AF294A06C400727BEF /* StoreCreationSellingStatusQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD0AE294A06C400727BEF /* StoreCreationSellingStatusQuestionView.swift */; };
+		020DD0B1294A071600727BEF /* StoreCreationSellingStatusQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD0B0294A071600727BEF /* StoreCreationSellingStatusQuestionViewModel.swift */; };
 		020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */; };
 		020DD48D2322A617005822B1 /* ProductsTabProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */; };
 		020DD48F232392C9005822B1 /* UIViewController+AppReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */; };
@@ -2094,6 +2096,8 @@
 		020C908324C84652001E2BEB /* ProductListMultiSelectorSearchUICommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListMultiSelectorSearchUICommandTests.swift; sourceTree = "<group>"; };
 		020D0BFC2914E92800BB3DCE /* StorePickerCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePickerCoordinatorTests.swift; sourceTree = "<group>"; };
 		020D0BFE2914F6BA00BB3DCE /* LoggedOutStoreCreationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedOutStoreCreationCoordinatorTests.swift; sourceTree = "<group>"; };
+		020DD0AE294A06C400727BEF /* StoreCreationSellingStatusQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationSellingStatusQuestionView.swift; sourceTree = "<group>"; };
+		020DD0B0294A071600727BEF /* StoreCreationSellingStatusQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationSellingStatusQuestionViewModel.swift; sourceTree = "<group>"; };
 		020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductTableViewCell.swift; sourceTree = "<group>"; };
 		020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModel.swift; sourceTree = "<group>"; };
 		020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+AppReview.swift"; sourceTree = "<group>"; };
@@ -4116,6 +4120,7 @@
 				0201E4262945B01800C793C7 /* StoreCreationProfilerQuestionView.swift */,
 				0201E42C2946C23600C793C7 /* OptionalStoreCreationProfilerQuestionView.swift */,
 				0201E42E2946F9F400C793C7 /* Category */,
+				020DD0AD294A069500727BEF /* Selling Status */,
 			);
 			path = Profiler;
 			sourceTree = "<group>";
@@ -4250,6 +4255,15 @@
 				0261F5A628D454CF00B7AC72 /* ProductSearchUICommandTests.swift */,
 			);
 			path = Product;
+			sourceTree = "<group>";
+		};
+		020DD0AD294A069500727BEF /* Selling Status */ = {
+			isa = PBXGroup;
+			children = (
+				020DD0AE294A06C400727BEF /* StoreCreationSellingStatusQuestionView.swift */,
+				020DD0B0294A071600727BEF /* StoreCreationSellingStatusQuestionViewModel.swift */,
+			);
+			path = "Selling Status";
 			sourceTree = "<group>";
 		};
 		020DD48B2322A5F9005822B1 /* View Models */ = {
@@ -10518,6 +10532,7 @@
 				CC254F3026C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift in Sources */,
 				7441E1D221503F77004E6ECE /* IntrinsicTableView.swift in Sources */,
 				B517EA1D218B41F200730EC4 /* String+Woo.swift in Sources */,
+				020DD0B1294A071600727BEF /* StoreCreationSellingStatusQuestionViewModel.swift in Sources */,
 				26B3D8A0252235C50054C319 /* RefundShippingDetailsViewModel.swift in Sources */,
 				B958A7CD28B3DD9100823EEF /* OrderDetailsRoute.swift in Sources */,
 				45DB7040261209B10064A6CF /* ItemToFulfillRow.swift in Sources */,
@@ -11058,6 +11073,7 @@
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
 				028CB70F290138EF00331C09 /* Publisher+Concurrency.swift in Sources */,
 				311F827426CD897900DF5BAD /* CardReaderSettingsAlertsProvider.swift in Sources */,
+				020DD0AF294A06C400727BEF /* StoreCreationSellingStatusQuestionView.swift in Sources */,
 				CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */,
 				DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */,
 				020A55F127F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -297,6 +297,7 @@
 		0286B27C23C7051F003D784B /* ProductImagesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0286B27823C7051F003D784B /* ProductImagesViewController.xib */; };
 		0286B27D23C7051F003D784B /* ProductImagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0286B27923C7051F003D784B /* ProductImagesViewController.swift */; };
 		0286B27F23C70557003D784B /* ColumnFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0286B27E23C70557003D784B /* ColumnFlowLayout.swift */; };
+		028A4655295AD2DA001CF6CE /* StoreCreationSellingStatusQuestionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028A4654295AD2DA001CF6CE /* StoreCreationSellingStatusQuestionViewModelTests.swift */; };
 		028AFFB32484ED2800693C09 /* Dictionary+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028AFFB22484ED2800693C09 /* Dictionary+Logging.swift */; };
 		028AFFB62484EDA000693C09 /* Dictionary+LoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028AFFB52484EDA000693C09 /* Dictionary+LoggingTests.swift */; };
 		028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */; };
@@ -2336,6 +2337,7 @@
 		0286B27823C7051F003D784B /* ProductImagesViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductImagesViewController.xib; sourceTree = "<group>"; };
 		0286B27923C7051F003D784B /* ProductImagesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductImagesViewController.swift; sourceTree = "<group>"; };
 		0286B27E23C70557003D784B /* ColumnFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnFlowLayout.swift; sourceTree = "<group>"; };
+		028A4654295AD2DA001CF6CE /* StoreCreationSellingStatusQuestionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationSellingStatusQuestionViewModelTests.swift; sourceTree = "<group>"; };
 		028AFFB22484ED2800693C09 /* Dictionary+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Logging.swift"; sourceTree = "<group>"; };
 		028AFFB52484EDA000693C09 /* Dictionary+LoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+LoggingTests.swift"; sourceTree = "<group>"; };
 		028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersViewController.swift; sourceTree = "<group>"; };
@@ -4138,6 +4140,7 @@
 			isa = PBXGroup;
 			children = (
 				0201E4302946FFDB00C793C7 /* StoreCreationCategoryQuestionViewModelTests.swift */,
+				028A4654295AD2DA001CF6CE /* StoreCreationSellingStatusQuestionViewModelTests.swift */,
 			);
 			path = Profiler;
 			sourceTree = "<group>";
@@ -11539,6 +11542,7 @@
 				26F94E34267AA42F00DB6CCF /* ProductAddOnViewModelTests.swift in Sources */,
 				AE7C957F27C417FA007E8E12 /* FeeLineDetailsViewModelTests.swift in Sources */,
 				0290E27E238E5B5C00B5C466 /* ProductStockStatusListSelectorCommandTests.swift in Sources */,
+				028A4655295AD2DA001CF6CE /* StoreCreationSellingStatusQuestionViewModelTests.swift in Sources */,
 				EE81B1382865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift in Sources */,
 				7E7C5F8B2719AEDA00315B61 /* EditProductCategoryListViewModelTests.swift in Sources */,
 				0247F510286E7D26009C177E /* ProductVariationFormViewModel+ImageUploaderTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationSellingStatusQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationSellingStatusQuestionViewModelTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import WooCommerce
+
+@MainActor
+final class StoreCreationSellingStatusQuestionViewModelTests: XCTestCase {
+    func test_selectCategory_updates_selectedStatus() throws {
+        // Given
+        let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") {} onSkip: {}
+
+        // When
+        viewModel.selectStatus(.alreadySellingOnline)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedStatus, .alreadySellingOnline)
+    }
+
+    func test_continueButtonTapped_invokes_onContinue_after_selecting_a_status() throws {
+        waitFor { promise in
+            // Given
+            let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") {
+                // Then
+                promise(())
+            } onSkip: {}
+            // When
+            viewModel.selectStatus(.alreadySellingButNotOnline)
+            Task { @MainActor in
+                await viewModel.continueButtonTapped()
+            }
+        }
+    }
+
+    func test_continueButtonTapped_invokes_onSkip_without_selecting_a_category() throws {
+        waitFor { promise in
+            // Given
+            let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") {} onSkip: {
+                // Then
+                promise(())
+            }
+            // When
+            Task { @MainActor in
+                await viewModel.continueButtonTapped()
+            }
+        }
+    }
+
+    func test_skipButtonTapped_invokes_onSkip() throws {
+        waitFor { promise in
+            // Given
+            let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") {} onSkip: {
+                // Then
+                promise(())
+            }
+            // When
+            viewModel.skipButtonTapped()
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8377 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR only includes the UI part, as the API is still WIP (p1670825052838929/1670823717.177509-slack-C01SFMVEYAK). The profiler question is only shown behind a new feature flag `storeCreationM3Profiler`, and the selected option isn't shown in the store summary screen so the value doesn't need to be passed to subsequent view controllers.

For the selling status, there are two subscreens: the first one asks for the selling status, and if the merchant chooses "I'm already selling online" then another screen is shown for the merchant to pick the platform(s) they're already selling on. At any point, the merchant can skip this question. This PR just contains the first subscreen for the PR size.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in if needed
- Go to the Menu tab, and tap `Switch store`
- On the store picker, tap `+ Add a store`
- Tap `Create a new store` --> the store name form should be shown
- Enter a store name and continue
- On the store category screen, choose an option and continue or skip --> the selling status profiler question should be shown
- Tap `Skip` --> the domain selector should be shown
- Go back to the previous screen
- Select an option and tap `Continue` --> the domain selector should be shown

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

light | dark
-- | --
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-27 at 15 58 14](https://user-images.githubusercontent.com/1945542/209632611-87f21d30-2b5b-4fdf-88a7-1a7ba768b86a.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-27 at 15 58 29](https://user-images.githubusercontent.com/1945542/209632619-4329ff68-34f3-4a9b-a544-6d663e62599c.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.