### PR TITLE
Widgets: Show dynamic store list in settings

### DIFF
--- a/WooCommerce/StoreWidgets/StatsTimeRange.swift
+++ b/WooCommerce/StoreWidgets/StatsTimeRange.swift
@@ -69,24 +69,6 @@ extension StatsTimeRange {
         }
     }
 
-    /// The number of intervals for site visit stats to fetch given a time range.
-    /// The interval unit is in `siteVisitStatsGranularity`.
-    func siteVisitStatsQuantity(date: Date, siteTimezone: TimeZone) -> Int {
-        switch self {
-        case .today:
-            return 1
-        case .thisWeek:
-            return 7
-        case .thisMonth:
-            var calendar = Calendar.current
-            calendar.timeZone = siteTimezone
-            let daysThisMonth = calendar.range(of: .day, in: .month, for: date)
-            return daysThisMonth?.count ?? 0
-        case .thisYear:
-            return 12
-        }
-    }
-
     /// Returns the latest date to be shown for the time range, given the current date and site time zone
     ///
     /// - Parameters:

--- a/WooCommerce/StoreWidgets/StoreWidgets.intentdefinition
+++ b/WooCommerce/StoreWidgets/StoreWidgets.intentdefinition
@@ -184,26 +184,6 @@
 							<key>INIntentParameterPromptDialogType</key>
 							<string>Primary</string>
 						</dict>
-						<dict>
-							<key>INIntentParameterPromptDialogCustom</key>
-							<true/>
-							<key>INIntentParameterPromptDialogFormatString</key>
-							<string>There are ${count} options matching ‘${store}’.</string>
-							<key>INIntentParameterPromptDialogFormatStringID</key>
-							<string>wQnm1C</string>
-							<key>INIntentParameterPromptDialogType</key>
-							<string>DisambiguationIntroduction</string>
-						</dict>
-						<dict>
-							<key>INIntentParameterPromptDialogCustom</key>
-							<true/>
-							<key>INIntentParameterPromptDialogFormatString</key>
-							<string>Just to confirm, you wanted ‘${store}’?</string>
-							<key>INIntentParameterPromptDialogFormatStringID</key>
-							<string>VwQU8v</string>
-							<key>INIntentParameterPromptDialogType</key>
-							<string>Confirmation</string>
-						</dict>
 					</array>
 					<key>INIntentParameterSupportsDynamicEnumeration</key>
 					<true/>

--- a/WooCommerce/StoreWidgets/StoreWidgets.intentdefinition
+++ b/WooCommerce/StoreWidgets/StoreWidgets.intentdefinition
@@ -73,11 +73,11 @@
 	<key>INIntentDefinitionNamespace</key>
 	<string>88xZPY</string>
 	<key>INIntentDefinitionSystemVersion</key>
-	<string>21G115</string>
+	<string>22C65</string>
 	<key>INIntentDefinitionToolsBuildVersion</key>
-	<string>14A309</string>
+	<string>14B47b</string>
 	<key>INIntentDefinitionToolsVersion</key>
-	<string>14.0</string>
+	<string>14.1</string>
 	<key>INIntents</key>
 	<array>
 		<dict>
@@ -90,7 +90,7 @@
 			<key>INIntentIneligibleForSuggestions</key>
 			<true/>
 			<key>INIntentLastParameterTag</key>
-			<integer>2</integer>
+			<integer>4</integer>
 			<key>INIntentName</key>
 			<string>StoreWidgetsConfig</string>
 			<key>INIntentParameters</key>
@@ -155,6 +155,65 @@
 					<key>INIntentParameterType</key>
 					<string>Integer</string>
 				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>Store</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>gEwXth</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>2</integer>
+					<key>INIntentParameterName</key>
+					<string>store</string>
+					<key>INIntentParameterObjectType</key>
+					<string>IntentStore</string>
+					<key>INIntentParameterObjectTypeNamespace</key>
+					<string>88xZPY</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>There are ${count} options matching ‘${store}’.</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>wQnm1C</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationIntroduction</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Just to confirm, you wanted ‘${store}’?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>VwQU8v</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Confirmation</string>
+						</dict>
+					</array>
+					<key>INIntentParameterSupportsDynamicEnumeration</key>
+					<true/>
+					<key>INIntentParameterSupportsSearch</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>4</integer>
+					<key>INIntentParameterType</key>
+					<string>Object</string>
+				</dict>
 			</array>
 			<key>INIntentResponse</key>
 			<dict>
@@ -183,6 +242,70 @@
 		</dict>
 	</array>
 	<key>INTypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>INTypeDisplayName</key>
+			<string>Store</string>
+			<key>INTypeDisplayNameID</key>
+			<string>JZfDw9</string>
+			<key>INTypeLastPropertyTag</key>
+			<integer>99</integer>
+			<key>INTypeName</key>
+			<string>IntentStore</string>
+			<key>INTypeProperties</key>
+			<array>
+				<dict>
+					<key>INTypePropertyDefault</key>
+					<true/>
+					<key>INTypePropertyDisplayPriority</key>
+					<integer>1</integer>
+					<key>INTypePropertyName</key>
+					<string>identifier</string>
+					<key>INTypePropertyTag</key>
+					<integer>1</integer>
+					<key>INTypePropertyType</key>
+					<string>String</string>
+				</dict>
+				<dict>
+					<key>INTypePropertyDefault</key>
+					<true/>
+					<key>INTypePropertyDisplayPriority</key>
+					<integer>2</integer>
+					<key>INTypePropertyName</key>
+					<string>displayString</string>
+					<key>INTypePropertyTag</key>
+					<integer>2</integer>
+					<key>INTypePropertyType</key>
+					<string>String</string>
+				</dict>
+				<dict>
+					<key>INTypePropertyDefault</key>
+					<true/>
+					<key>INTypePropertyDisplayPriority</key>
+					<integer>3</integer>
+					<key>INTypePropertyName</key>
+					<string>pronunciationHint</string>
+					<key>INTypePropertyTag</key>
+					<integer>3</integer>
+					<key>INTypePropertyType</key>
+					<string>String</string>
+				</dict>
+				<dict>
+					<key>INTypePropertyDefault</key>
+					<true/>
+					<key>INTypePropertyDisplayPriority</key>
+					<integer>4</integer>
+					<key>INTypePropertyName</key>
+					<string>alternativeSpeakableMatches</string>
+					<key>INTypePropertySupportsMultipleValues</key>
+					<true/>
+					<key>INTypePropertyTag</key>
+					<integer>4</integer>
+					<key>INTypePropertyType</key>
+					<string>SpeakableString</string>
+				</dict>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/WooCommerce/StoreWidgetsIntentsExtension/Info.plist
+++ b/WooCommerce/StoreWidgetsIntentsExtension/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>IntentsRestrictedWhileLocked</key>
+			<array/>
+			<key>IntentsSupported</key>
+			<array/>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.intents-service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).IntentHandler</string>
+	</dict>
+</dict>
+</plist>

--- a/WooCommerce/StoreWidgetsIntentsExtension/Info.plist
+++ b/WooCommerce/StoreWidgetsIntentsExtension/Info.plist
@@ -8,8 +8,12 @@
 		<dict>
 			<key>IntentsRestrictedWhileLocked</key>
 			<array/>
-			<key>IntentsSupported</key>
+			<key>IntentsRestrictedWhileProtectedDataUnavailable</key>
 			<array/>
+			<key>IntentsSupported</key>
+			<array>
+				<string>StoreWidgetsConfigIntent</string>
+			</array>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.intents-service</string>

--- a/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
+++ b/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
@@ -1,0 +1,12 @@
+import Intents
+
+class IntentHandler: INExtension {
+    
+    override func handler(for intent: INIntent) -> Any {
+        // This is the default implementation.  If you want different objects to handle different intents,
+        // you can override this and return the handler you want for that particular intent.
+        
+        return self
+    }
+    
+}

--- a/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
+++ b/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
@@ -2,6 +2,8 @@ import Intents
 
 class IntentHandler: INExtension, StoreWidgetsConfigIntentHandling {
 
+    /// Function provides dynamic sites list for widgets configuration UI, filtered by `searchTerm`
+    ///
     func provideStoreOptionsCollection(for intent: StoreWidgetsConfigIntent, searchTerm: String?) async throws -> INObjectCollection<IntentStore> {
         var sitesArray = getAllStores()
         if let searchTerm {
@@ -17,6 +19,9 @@ class IntentHandler: INExtension, StoreWidgetsConfigIntentHandling {
 }
 
 private extension IntentHandler {
+
+    /// Helper to read sites list from shared (group) UserDefaults
+    ///
     func getAllStores() -> [SharedSiteData] {
         guard let sitesData = UserDefaults.group?[.sharedSitesData] as? Data,
               let sitesArray = try? JSONDecoder().decode([SharedSiteData].self, from: sitesData) else {

--- a/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
+++ b/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
@@ -3,7 +3,13 @@ import Intents
 class IntentHandler: INExtension, StoreWidgetsConfigIntentHandling {
 
     func provideStoreOptionsCollection(for intent: StoreWidgetsConfigIntent, searchTerm: String?) async throws -> INObjectCollection<IntentStore> {
-        return INObjectCollection(items: [IntentStore(identifier: "123123", display: "Test Store")])
+        guard let sitesData = UserDefaults.group?[.sharedSitesData] as? Data,
+              let sitesArray = try? JSONDecoder().decode([SharedSiteData].self, from: sitesData) else {
+            return INObjectCollection(items: [])
+        }
+
+        let sites = sitesArray.map { IntentStore(identifier: String($0.siteID), display: $0.siteName) }
+        return INObjectCollection(items: sites)
     }
 
     override func handler(for intent: INIntent) -> Any {

--- a/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
+++ b/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
@@ -3,22 +3,32 @@ import Intents
 class IntentHandler: INExtension, StoreWidgetsConfigIntentHandling {
 
     func provideStoreOptionsCollection(for intent: StoreWidgetsConfigIntent, searchTerm: String?) async throws -> INObjectCollection<IntentStore> {
-        guard let sitesData = UserDefaults.group?[.sharedSitesData] as? Data,
-              let sitesArray = try? JSONDecoder().decode([SharedSiteData].self, from: sitesData) else {
-            // Fallback to single-store implementation
-            if let storeID = UserDefaults.group?[.defaultStoreID] as? Int64,
-               let storeName = UserDefaults.group?[.defaultStoreName] as? String {
-                return INObjectCollection(items: [ IntentStore(identifier: String(storeID), display: storeName) ])
-            } else {
-                return INObjectCollection(items: [])
-            }
+        var sitesArray = getAllStores()
+        if let searchTerm {
+            sitesArray = sitesArray.filter { $0.siteName.contains(searchTerm) }
         }
-
         let sites = sitesArray.map { IntentStore(identifier: String($0.siteID), display: $0.siteName) }
         return INObjectCollection(items: sites)
     }
 
     override func handler(for intent: INIntent) -> Any {
         return self
+    }
+}
+
+private extension IntentHandler {
+    func getAllStores() -> [SharedSiteData] {
+        guard let sitesData = UserDefaults.group?[.sharedSitesData] as? Data,
+              let sitesArray = try? JSONDecoder().decode([SharedSiteData].self, from: sitesData) else {
+            // Fallback to single-store implementation
+            if let storeID = UserDefaults.group?[.defaultStoreID] as? Int64,
+               let storeName = UserDefaults.group?[.defaultStoreName] as? String {
+                return [SharedSiteData(siteID: storeID, siteName: storeName)]
+            } else {
+                return []
+            }
+        }
+
+        return sitesArray
     }
 }

--- a/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
+++ b/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
@@ -1,12 +1,12 @@
 import Intents
 
-class IntentHandler: INExtension {
-    
+class IntentHandler: INExtension, StoreWidgetsConfigIntentHandling {
+
+    func provideStoreOptionsCollection(for intent: StoreWidgetsConfigIntent, searchTerm: String?) async throws -> INObjectCollection<IntentStore> {
+        return INObjectCollection(items: [IntentStore(identifier: "123123", display: "Test Store")])
+    }
+
     override func handler(for intent: INIntent) -> Any {
-        // This is the default implementation.  If you want different objects to handle different intents,
-        // you can override this and return the handler you want for that particular intent.
-        
         return self
     }
-    
 }

--- a/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
+++ b/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
@@ -5,7 +5,7 @@ class IntentHandler: INExtension, StoreWidgetsConfigIntentHandling {
     func provideStoreOptionsCollection(for intent: StoreWidgetsConfigIntent, searchTerm: String?) async throws -> INObjectCollection<IntentStore> {
         var sitesArray = getAllStores()
         if let searchTerm {
-            sitesArray = sitesArray.filter { $0.siteName.contains(searchTerm) }
+            sitesArray = sitesArray.filter { $0.siteName.range(of: searchTerm, options: .caseInsensitive) != nil }
         }
         let sites = sitesArray.map { IntentStore(identifier: String($0.siteID), display: $0.siteName) }
         return INObjectCollection(items: sites)

--- a/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
+++ b/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
@@ -5,7 +5,13 @@ class IntentHandler: INExtension, StoreWidgetsConfigIntentHandling {
     func provideStoreOptionsCollection(for intent: StoreWidgetsConfigIntent, searchTerm: String?) async throws -> INObjectCollection<IntentStore> {
         guard let sitesData = UserDefaults.group?[.sharedSitesData] as? Data,
               let sitesArray = try? JSONDecoder().decode([SharedSiteData].self, from: sitesData) else {
-            return INObjectCollection(items: [])
+            // Fallback to single-store implementation
+            if let storeID = UserDefaults.group?[.defaultStoreID] as? Int64,
+               let storeName = UserDefaults.group?[.defaultStoreName] as? String {
+                return INObjectCollection(items: [ IntentStore(identifier: String(storeID), display: storeName) ])
+            } else {
+                return INObjectCollection(items: [])
+            }
         }
 
         let sites = sitesArray.map { IntentStore(identifier: String($0.siteID), display: $0.siteName) }

--- a/WooCommerce/StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtension.entitlements
+++ b/WooCommerce/StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.automattic.woocommerce.alpha</string>
+	</array>
+</dict>
+</plist>

--- a/WooCommerce/StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtensionDebug.entitlements
+++ b/WooCommerce/StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtensionDebug.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.automattic.woocommerce</string>
+	</array>
+</dict>
+</plist>

--- a/WooCommerce/StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtensionRelease.entitlements
+++ b/WooCommerce/StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtensionRelease.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.automattic.woocommerce</string>
+	</array>
+</dict>
+</plist>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1236,6 +1236,7 @@
 		AECDE19D29561C8400E0CB6E /* Intents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AECDE19C29561C8400E0CB6E /* Intents.framework */; };
 		AECDE1A029561C8400E0CB6E /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECDE19F29561C8400E0CB6E /* IntentHandler.swift */; };
 		AECDE1A429561C8400E0CB6E /* StoreWidgetsIntentsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = AECDE19B29561C8400E0CB6E /* StoreWidgetsIntentsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		AECDE1A929561D2200E0CB6E /* StoreWidgets.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 3F1FA84728B60125009E246C /* StoreWidgets.intentdefinition */; };
 		AED089F227C794BC0020AE10 /* View+CurrencySymbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED089F127C794BC0020AE10 /* View+CurrencySymbol.swift */; };
 		AED9012D28E5F517002B4572 /* AppLinkWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED9012C28E5F517002B4572 /* AppLinkWidget.swift */; };
 		AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */; };
@@ -10078,6 +10079,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AECDE1A929561D2200E0CB6E /* StoreWidgets.intentdefinition in Sources */,
 				AECDE1A029561C8400E0CB6E /* IntentHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1233,6 +1233,9 @@
 		AEC95D412774C5AE001571F5 /* AddressFormViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC95D402774C5AE001571F5 /* AddressFormViewModelProtocol.swift */; };
 		AEC95D432774D07B001571F5 /* CreateOrderAddressFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC95D422774D07B001571F5 /* CreateOrderAddressFormViewModel.swift */; };
 		AECD57D226DFDF7500A3B580 /* EditOrderAddressForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */; };
+		AECDE19D29561C8400E0CB6E /* Intents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AECDE19C29561C8400E0CB6E /* Intents.framework */; };
+		AECDE1A029561C8400E0CB6E /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECDE19F29561C8400E0CB6E /* IntentHandler.swift */; };
+		AECDE1A429561C8400E0CB6E /* StoreWidgetsIntentsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = AECDE19B29561C8400E0CB6E /* StoreWidgetsIntentsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		AED089F227C794BC0020AE10 /* View+CurrencySymbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED089F127C794BC0020AE10 /* View+CurrencySymbol.swift */; };
 		AED9012D28E5F517002B4572 /* AppLinkWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED9012C28E5F517002B4572 /* AppLinkWidget.swift */; };
 		AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */; };
@@ -1977,6 +1980,13 @@
 			remoteGlobalIDString = 3FF314DD26FC74450012E68E;
 			remoteInfo = UITestsFoundation;
 		};
+		AECDE1A229561C8400E0CB6E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B56DB3BE2049BFAA00D4AA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AECDE19A29561C8400E0CB6E;
+			remoteInfo = StoreWidgetsIntentsExtension;
+		};
 		B55D4C1420B6131400D7A50F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B56DB3BE2049BFAA00D4AA8E /* Project object */;
@@ -2035,6 +2045,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
+				AECDE1A429561C8400E0CB6E /* StoreWidgetsIntentsExtension.appex in Embed Foundation Extensions */,
 				3F1FA84F28B60126009E246C /* StoreWidgetsExtension.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
@@ -3254,6 +3265,10 @@
 		AEC95D402774C5AE001571F5 /* AddressFormViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressFormViewModelProtocol.swift; sourceTree = "<group>"; };
 		AEC95D422774D07B001571F5 /* CreateOrderAddressFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateOrderAddressFormViewModel.swift; sourceTree = "<group>"; };
 		AECD57D126DFDF7500A3B580 /* EditOrderAddressForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditOrderAddressForm.swift; sourceTree = "<group>"; };
+		AECDE19B29561C8400E0CB6E /* StoreWidgetsIntentsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = StoreWidgetsIntentsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		AECDE19C29561C8400E0CB6E /* Intents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Intents.framework; path = System/Library/Frameworks/Intents.framework; sourceTree = SDKROOT; };
+		AECDE19F29561C8400E0CB6E /* IntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };
+		AECDE1A129561C8400E0CB6E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AED089F127C794BC0020AE10 /* View+CurrencySymbol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+CurrencySymbol.swift"; sourceTree = "<group>"; };
 		AED9012C28E5F517002B4572 /* AppLinkWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLinkWidget.swift; sourceTree = "<group>"; };
 		AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewController.swift; sourceTree = "<group>"; };
@@ -4052,6 +4067,14 @@
 				3FF314E726FC74560012E68E /* ScreenObject in Frameworks */,
 				3FF314F126FC785C0012E68E /* XCTest.framework in Frameworks */,
 				3FF314E926FC74600012E68E /* XCUITestHelpers in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AECDE19829561C8400E0CB6E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AECDE19D29561C8400E0CB6E /* Intents.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6867,6 +6890,7 @@
 				6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */,
 				3F1FA84128B60125009E246C /* WidgetKit.framework */,
 				2886DE5218EEA78ABAF0BE67 /* Pods_StoreWidgetsExtension.framework */,
+				AECDE19C29561C8400E0CB6E /* Intents.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -6944,6 +6968,15 @@
 				26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */,
 			);
 			path = "Address Edit";
+			sourceTree = "<group>";
+		};
+		AECDE19E29561C8400E0CB6E /* StoreWidgetsIntentsExtension */ = {
+			isa = PBXGroup;
+			children = (
+				AECDE19F29561C8400E0CB6E /* IntentHandler.swift */,
+				AECDE1A129561C8400E0CB6E /* Info.plist */,
+			);
+			path = StoreWidgetsIntentsExtension;
 			sourceTree = "<group>";
 		};
 		AED9012B28E5F27B002B4572 /* Lockscreen */ = {
@@ -7148,6 +7181,7 @@
 				CCDC49CB23FFFFF4003166BA /* WooCommerceUITests */,
 				3FF314DF26FC74450012E68E /* UITestsFoundation */,
 				3F1FA84428B60125009E246C /* StoreWidgets */,
+				AECDE19E29561C8400E0CB6E /* StoreWidgetsIntentsExtension */,
 				88A44ABE866401E6DB03AC60 /* Frameworks */,
 				B56DB3C72049BFAA00D4AA8E /* Products */,
 				8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */,
@@ -7167,6 +7201,7 @@
 				CCDC49CA23FFFFF4003166BA /* WooCommerceUITests.xctest */,
 				3FF314DE26FC74450012E68E /* UITestsFoundation.framework */,
 				3F1FA84028B60125009E246C /* StoreWidgetsExtension.appex */,
+				AECDE19B29561C8400E0CB6E /* StoreWidgetsIntentsExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -9284,6 +9319,23 @@
 			productReference = 3FF314DE26FC74450012E68E /* UITestsFoundation.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		AECDE19A29561C8400E0CB6E /* StoreWidgetsIntentsExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AECDE1A829561C8500E0CB6E /* Build configuration list for PBXNativeTarget "StoreWidgetsIntentsExtension" */;
+			buildPhases = (
+				AECDE19729561C8400E0CB6E /* Sources */,
+				AECDE19829561C8400E0CB6E /* Frameworks */,
+				AECDE19929561C8400E0CB6E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StoreWidgetsIntentsExtension;
+			productName = StoreWidgetsIntentsExtension;
+			productReference = AECDE19B29561C8400E0CB6E /* StoreWidgetsIntentsExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		B56DB3C52049BFAA00D4AA8E /* WooCommerce */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B56DB3E62049BFAA00D4AA8E /* Build configuration list for PBXNativeTarget "WooCommerce" */;
@@ -9303,6 +9355,7 @@
 			dependencies = (
 				B55D4C1520B6131400D7A50F /* PBXTargetDependency */,
 				3F1FA84E28B60126009E246C /* PBXTargetDependency */,
+				AECDE1A329561C8400E0CB6E /* PBXTargetDependency */,
 			);
 			name = WooCommerce;
 			packageProductDependencies = (
@@ -9396,7 +9449,7 @@
 		B56DB3BE2049BFAA00D4AA8E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1340;
+				LastSwiftUpdateCheck = 1410;
 				LastUpgradeCheck = 1400;
 				ORGANIZATIONNAME = Automattic;
 				TargetAttributes = {
@@ -9405,6 +9458,9 @@
 					};
 					3FF314DD26FC74450012E68E = {
 						CreatedOnToolsVersion = 13.0;
+					};
+					AECDE19A29561C8400E0CB6E = {
+						CreatedOnToolsVersion = 14.1;
 					};
 					B55D4C0F20B612F300D7A50F = {
 						CreatedOnToolsVersion = 9.3.1;
@@ -9493,6 +9549,7 @@
 				CCDC49C923FFFFF4003166BA /* WooCommerceUITests */,
 				3FF314DD26FC74450012E68E /* UITestsFoundation */,
 				3F1FA83F28B60125009E246C /* StoreWidgetsExtension */,
+				AECDE19A29561C8400E0CB6E /* StoreWidgetsIntentsExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -9508,6 +9565,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		3FF314DC26FC74450012E68E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AECDE19929561C8400E0CB6E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -10007,6 +10071,14 @@
 				3F0CF3102704490A00EF3D71 /* SingleOrderScreen.swift in Sources */,
 				3F0CF3062704490A00EF3D71 /* SingleReviewScreen.swift in Sources */,
 				3F0CF3112704490A00EF3D71 /* ProductsScreen.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AECDE19729561C8400E0CB6E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AECDE1A029561C8400E0CB6E /* IntentHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11623,6 +11695,11 @@
 			target = 3FF314DD26FC74450012E68E /* UITestsFoundation */;
 			targetProxy = 3FF314ED26FC76CB0012E68E /* PBXContainerItemProxy */;
 		};
+		AECDE1A329561C8400E0CB6E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AECDE19A29561C8400E0CB6E /* StoreWidgetsIntentsExtension */;
+			targetProxy = AECDE1A229561C8400E0CB6E /* PBXContainerItemProxy */;
+		};
 		B55D4C1520B6131400D7A50F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B55D4C0F20B612F300D7A50F /* GenerateCredentials */;
@@ -12022,6 +12099,87 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+			};
+			name = "Release-Alpha";
+		};
+		AECDE1A529561C8500E0CB6E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = StoreWidgetsIntentsExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgetsIntentsExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Automattic. All rights reserved.";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.StoreWidgetsIntentsExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		AECDE1A629561C8500E0CB6E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = StoreWidgetsIntentsExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgetsIntentsExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Automattic. All rights reserved.";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.StoreWidgetsIntentsExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		AECDE1A729561C8500E0CB6E /* Release-Alpha */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 99KV9Z6BKV;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = StoreWidgetsIntentsExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgetsIntentsExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Automattic. All rights reserved.";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.StoreWidgetsIntentsExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Release-Alpha";
 		};
@@ -12447,6 +12605,16 @@
 				3FF314E226FC74450012E68E /* Debug */,
 				3FF314E326FC74450012E68E /* Release */,
 				3FF314E426FC74450012E68E /* Release-Alpha */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AECDE1A829561C8500E0CB6E /* Build configuration list for PBXNativeTarget "StoreWidgetsIntentsExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AECDE1A529561C8500E0CB6E /* Debug */,
+				AECDE1A629561C8500E0CB6E /* Release */,
+				AECDE1A729561C8500E0CB6E /* Release-Alpha */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -3270,6 +3270,9 @@
 		AECDE19C29561C8400E0CB6E /* Intents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Intents.framework; path = System/Library/Frameworks/Intents.framework; sourceTree = SDKROOT; };
 		AECDE19F29561C8400E0CB6E /* IntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };
 		AECDE1A129561C8400E0CB6E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AECDE1AA29561DAA00E0CB6E /* StoreWidgetsIntentsExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StoreWidgetsIntentsExtension.entitlements; sourceTree = "<group>"; };
+		AECDE1AB29561DC100E0CB6E /* StoreWidgetsIntentsExtensionDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StoreWidgetsIntentsExtensionDebug.entitlements; sourceTree = "<group>"; };
+		AECDE1AC29561DCE00E0CB6E /* StoreWidgetsIntentsExtensionRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StoreWidgetsIntentsExtensionRelease.entitlements; sourceTree = "<group>"; };
 		AED089F127C794BC0020AE10 /* View+CurrencySymbol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+CurrencySymbol.swift"; sourceTree = "<group>"; };
 		AED9012C28E5F517002B4572 /* AppLinkWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLinkWidget.swift; sourceTree = "<group>"; };
 		AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewController.swift; sourceTree = "<group>"; };
@@ -6974,6 +6977,9 @@
 		AECDE19E29561C8400E0CB6E /* StoreWidgetsIntentsExtension */ = {
 			isa = PBXGroup;
 			children = (
+				AECDE1AC29561DCE00E0CB6E /* StoreWidgetsIntentsExtensionRelease.entitlements */,
+				AECDE1AB29561DC100E0CB6E /* StoreWidgetsIntentsExtensionDebug.entitlements */,
+				AECDE1AA29561DAA00E0CB6E /* StoreWidgetsIntentsExtension.entitlements */,
 				AECDE19F29561C8400E0CB6E /* IntentHandler.swift */,
 				AECDE1A129561C8400E0CB6E /* Info.plist */,
 			);
@@ -12109,6 +12115,7 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_ENTITLEMENTS = StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtensionDebug.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -12136,6 +12143,7 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_ENTITLEMENTS = StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtensionRelease.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
@@ -12163,6 +12171,7 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_ENTITLEMENTS = StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtension.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 99KV9Z6BKV;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1237,6 +1237,9 @@
 		AECDE1A029561C8400E0CB6E /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECDE19F29561C8400E0CB6E /* IntentHandler.swift */; };
 		AECDE1A429561C8400E0CB6E /* StoreWidgetsIntentsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = AECDE19B29561C8400E0CB6E /* StoreWidgetsIntentsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		AECDE1A929561D2200E0CB6E /* StoreWidgets.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 3F1FA84728B60125009E246C /* StoreWidgets.intentdefinition */; };
+		AECDE1AD29561E6900E0CB6E /* UserDefaults+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AA7B3E20ED81C2004DA14F /* UserDefaults+Woo.swift */; };
+		AECDE1AE29561E7700E0CB6E /* SharedSiteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0AB0FD2956072A0050FC47 /* SharedSiteData.swift */; };
+		AECDE1AF29561E8900E0CB6E /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */; };
 		AED089F227C794BC0020AE10 /* View+CurrencySymbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED089F127C794BC0020AE10 /* View+CurrencySymbol.swift */; };
 		AED9012D28E5F517002B4572 /* AppLinkWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED9012C28E5F517002B4572 /* AppLinkWidget.swift */; };
 		AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDDDA0925CA9C980077F9B2 /* AttributePickerViewController.swift */; };
@@ -10086,7 +10089,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				AECDE1A929561D2200E0CB6E /* StoreWidgets.intentdefinition in Sources */,
+				AECDE1AE29561E7700E0CB6E /* SharedSiteData.swift in Sources */,
 				AECDE1A029561C8400E0CB6E /* IntentHandler.swift in Sources */,
+				AECDE1AD29561E6900E0CB6E /* UserDefaults+Woo.swift in Sources */,
+				AECDE1AF29561E8900E0CB6E /* WooConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/7863.
Targeting feature branch.

## Description

This PR adds dynamic store picker in widgets settings UI. Selecting a store won't provide correct data yet, networking will be updated in later PR.

_Note:_ since provisioning for new extension is not set up yet, the project won't build for the device.

### How

- Add `store` parameter to the intent
- Add intents extension to provide dynamic list of options
- Load shared sites data in the extension and provide it in the UI
- Handle search functionality

## Testing

1. Add a widget to home screen (long press on home screen > tap + in top left > search for Woo).
2. Configure Widget (long press on widget > tap "Edit Widget").
3. Confirm that "Store" setting is available with all correct options.
4. Try filtering/sorting with a textfield on top the list.

## Screenshots

Widget Settings|Store Picker
--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/209700750-f5f7a8d7-2dad-4da9-baa3-194654f7a33d.png)|![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/209700762-6a390e34-57ea-4008-8219-b65c4529bdd0.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
