### PR TITLE
Variations: Adds feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -58,6 +58,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .applicationPasswordAuthenticationForSiteCredentialLogin:
             // Enable this to test application password authentication (WIP)
             return false
+        case .generateAllVariations:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -137,4 +137,8 @@ public enum FeatureFlag: Int {
     /// Whether application password authentication should be used when a user logs in with site credentials.
     ///
     case applicationPasswordAuthenticationForSiteCredentialLogin
+
+    /// Allows merchants to create all variations from a single button
+    ///
+    case generateAllVariations
 }


### PR DESCRIPTION
Closes: #8485

# Why

This PR just adds the `generateAllVariations` feature flag in order to begin development for it.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
