### PR TITLE
Variations: Add options bottom sheet

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsSelectorCommand.swift
@@ -63,7 +63,7 @@ private extension GenerateVariationsSelectorCommand {
                                                          comment: "Description for the option to generate just one variation")
         static let allTitle = NSLocalizedString("Generate all variations", comment: "Title for the option to generate all possible variations")
         static let allDescription = NSLocalizedString("Creates variations for all combinations of your attributes.",
-                                                         comment: "Descroption for the option to generate all possible variations")
+                                                      comment: "Description for the option to generate all possible variations")
 
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsSelectorCommand.swift
@@ -60,7 +60,7 @@ private extension GenerateVariationsSelectorCommand {
     enum Localization {
         static let singleTitle = NSLocalizedString("Add new variation", comment: "Title for the option to generate just one variation")
         static let singleDescription = NSLocalizedString("Create one new variation. Manually set which attributes belong to the variable product.",
-                                                         comment: "Descroption for the option to generate just one variation")
+                                                         comment: "Description for the option to generate just one variation")
         static let allTitle = NSLocalizedString("Generate all variations", comment: "Title for the option to generate all possible variations")
         static let allDescription = NSLocalizedString("Creates variations for all combinations of your attributes.",
                                                          comment: "Descroption for the option to generate all possible variations")

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsSelectorCommand.swift
@@ -1,0 +1,69 @@
+import UIKit
+
+/// `GenerateVariationsSelectorCommand` for selecting what create variation strategy to follow
+///
+final class GenerateVariationsSelectorCommand: BottomSheetListSelectorCommand {
+
+    /// Available Generation Options
+    ///
+    enum Options: CaseIterable {
+        case single
+        case all
+
+        var title: String {
+            switch self {
+            case .single:
+                return Localization.singleTitle
+            case .all:
+                return Localization.allTitle
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .single:
+                return Localization.singleDescription
+            case .all:
+                return Localization.allDescription
+            }
+        }
+    }
+
+    let data = Options.allCases
+    var selected: Options? = nil
+    private let onSelection: (Options) -> Void
+
+    init(selected: Options?, onSelection: @escaping (Options) -> Void) {
+        self.onSelection = onSelection
+        self.selected = selected
+    }
+
+    func configureCell(cell: ImageAndTitleAndTextTableViewCell, model: Options) {
+        let viewModel = ImageAndTitleAndTextTableViewCell.ViewModel(title: model.title,
+                                                                    text: model.description,
+                                                                    numberOfLinesForText: 0,
+                                                                    isSelected: isSelected(model: model)
+        )
+        cell.updateUI(viewModel: viewModel)
+    }
+
+    func handleSelectedChange(selected: Options) {
+        onSelection(selected)
+    }
+
+    func isSelected(model: Options) -> Bool {
+        return model == selected
+    }
+}
+
+private extension GenerateVariationsSelectorCommand {
+    enum Localization {
+        static let singleTitle = NSLocalizedString("Add new variation", comment: "Title for the option to generate just one variation")
+        static let singleDescription = NSLocalizedString("Create one new variation. Manually set which attributes belong to the variable product.",
+                                                         comment: "Descroption for the option to generate just one variation")
+        static let allTitle = NSLocalizedString("Generate all variations", comment: "Title for the option to generate all possible variations")
+        static let allDescription = NSLocalizedString("Creates variations for all combinations of your attributes.",
+                                                         comment: "Descroption for the option to generate all possible variations")
+
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -618,7 +618,7 @@ private extension ProductVariationsViewController {
 
         }
         let bottomSheetPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
-        bottomSheetPresenter.show(from: self)
+        bottomSheetPresenter.show(from: self, sourceView: topStackView)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -283,7 +283,8 @@ private extension ProductVariationsViewController {
 //
 private extension ProductVariationsViewController {
     func configureTopStackView() {
-        addTopButton(title: Localization.generateVariationAction,
+        let title = featureFlagService.isFeatureFlagEnabled(.generateAllVariations) ? Localization.addVariationAction : Localization.generateVariationAction
+        addTopButton(title: title,
                      insets: .init(top: 16, left: 16, bottom: 8, right: 16),
                      hasBottomBorder: true,
                      actionSelector: #selector(addButtonTapped),
@@ -563,7 +564,12 @@ private extension ProductVariationsViewController {
 
     @objc func addButtonTapped() {
         analytics.track(event: WooAnalyticsEvent.Variations.addMoreVariationsButtonTapped(productID: product.productID))
-        createVariation()
+
+        if featureFlagService.isFeatureFlagEnabled(.generateAllVariations) {
+            presentGenerateVariationOptions()
+        } else {
+            createVariation()
+        }
     }
 
     /// More Options Action Sheet
@@ -593,6 +599,26 @@ private extension ProductVariationsViewController {
         popoverController?.barButtonItem = sender
 
         present(actionSheet, animated: true)
+    }
+
+    /// Displays a bottom sheet allowing the merchant to choose whether to generate one variation or to generate all variations.
+    ///
+    private func presentGenerateVariationOptions() {
+        let viewProperties = BottomSheetListSelectorViewProperties(title: Localization.addVariationAction)
+        let command = GenerateVariationsSelectorCommand(selected: nil) { [weak self] option in
+            guard let self else { return }
+            self.dismiss(animated: true)
+            switch option {
+            case .single:
+                self.createVariation()
+            case .all:
+                // TODO: Start generate all variations flow
+                break
+            }
+
+        }
+        let bottomSheetPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
+        bottomSheetPresenter.show(from: self)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -635,6 +635,7 @@
 		269098B627D2C09D001FEB07 /* ShippingInputTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269098B527D2C09D001FEB07 /* ShippingInputTransformerTests.swift */; };
 		269098B827D68CCD001FEB07 /* FeesInputTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269098B727D68CCD001FEB07 /* FeesInputTransformer.swift */; };
 		269098BA27D6922E001FEB07 /* FeesInputTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269098B927D6922E001FEB07 /* FeesInputTransformerTests.swift */; };
+		269A2F47295CC683000828A8 /* GenerateVariationsSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269A2F46295CC683000828A8 /* GenerateVariationsSelectorCommand.swift */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
 		26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */; };
 		26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */; };
@@ -2670,6 +2671,7 @@
 		269098B527D2C09D001FEB07 /* ShippingInputTransformerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingInputTransformerTests.swift; sourceTree = "<group>"; };
 		269098B727D68CCD001FEB07 /* FeesInputTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeesInputTransformer.swift; sourceTree = "<group>"; };
 		269098B927D6922E001FEB07 /* FeesInputTransformerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeesInputTransformerTests.swift; sourceTree = "<group>"; };
+		269A2F46295CC683000828A8 /* GenerateVariationsSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationsSelectorCommand.swift; sourceTree = "<group>"; };
 		26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCase.swift; sourceTree = "<group>"; };
 		26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCaseTests.swift; sourceTree = "<group>"; };
 		26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundableOrderItem.swift; sourceTree = "<group>"; };
@@ -4732,6 +4734,7 @@
 				CCD2E67D25DD4DC900BD975D /* ProductVariationsViewModel.swift */,
 				0202B68C23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift */,
 				26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */,
+				269A2F46295CC683000828A8 /* GenerateVariationsSelectorCommand.swift */,
 				4515262B2577D48D0076B03C /* Add Attributes */,
 				AEDDDA0825CA9C0A0077F9B2 /* Edit Attributes */,
 			);
@@ -10213,6 +10216,7 @@
 				02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */,
 				093B265527DE8F020026F92D /* UnitInputViewModel+BulkUpdatePrice.swift in Sources */,
 				0245465F24EE9106004F531C /* ProductVariationFormEventLogger.swift in Sources */,
+				269A2F47295CC683000828A8 /* GenerateVariationsSelectorCommand.swift in Sources */,
 				DE19BB1826C3B5C300AB70D9 /* ShippingLabelCustomsFormItemDetails.swift in Sources */,
 				DE1B0310268EB2FB00804330 /* ReviewOrderViewModel.swift in Sources */,
 				02DC2ED2242061BF002F9676 /* ProductPriceSettingsViewModel.swift in Sources */,


### PR DESCRIPTION
Closes: #8486 

# Why

In order to allow merchants to generate all possible variations in one go, this PR updates the behavior of the "Generate New Variation" button to show a bottom sheet where the user can choose to create one variation(existing behavior) or to generate all variations(behavior to implement).

These changes are under a feature flag.

# Screenshots

<img width="444" alt="bottom sheet" src="https://user-images.githubusercontent.com/562080/209866245-ec9704ca-1808-42d1-b8c6-ff161eafb038.png">


# Testing Scenarios

- Test that the bottom sheet is presented when you tap on the "Add Variation" Button

- Test that you can generate a single variation.

-  Test that the "generate all variations" option does nothing for now.

- Test that when the feature flag is off, no bottom sheet is presented and the  "Create One Variation" flow executes immediately.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
