### PR TITLE
[REST API] Use JSON encoding for `RESTRequest` when needed.

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -760,6 +760,7 @@
 		EEFAA57D295D77F0003583BE /* AuthenticatedRESTRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFAA57C295D77F0003583BE /* AuthenticatedRESTRequest.swift */; };
 		EEFAA57F295D78DF003583BE /* AuthenticatedDotcomRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFAA57E295D78DF003583BE /* AuthenticatedDotcomRequestTests.swift */; };
 		EEFAA581295D78E9003583BE /* AuthenticatedRESTRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFAA580295D78E9003583BE /* AuthenticatedRESTRequestTests.swift */; };
+		EEFAA579295D2FC7003583BE /* RESTRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFAA578295D2FC7003583BE /* RESTRequestTests.swift */; };
 		FE28F6E226840DED004465C7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E126840DED004465C7 /* User.swift */; };
 		FE28F6E426842848004465C7 /* UserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E326842848004465C7 /* UserMapper.swift */; };
 		FE28F6E6268429B6004465C7 /* UserRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE28F6E5268429B6004465C7 /* UserRemote.swift */; };
@@ -1550,6 +1551,7 @@
 		EEFAA57C295D77F0003583BE /* AuthenticatedRESTRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedRESTRequest.swift; sourceTree = "<group>"; };
 		EEFAA57E295D78DF003583BE /* AuthenticatedDotcomRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedDotcomRequestTests.swift; sourceTree = "<group>"; };
 		EEFAA580295D78E9003583BE /* AuthenticatedRESTRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedRESTRequestTests.swift; sourceTree = "<group>"; };
+		EEFAA578295D2FC7003583BE /* RESTRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTRequestTests.swift; sourceTree = "<group>"; };
 		F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6CEE1CA2AD376C0C28AE9F6 /* Pods-NetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
 		FE28F6E126840DED004465C7 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -1837,6 +1839,7 @@
 				020D0C02291504DE00BB3DCE /* UnauthenticatedRequestTests.swift */,
 				EEFAA57E295D78DF003583BE /* AuthenticatedDotcomRequestTests.swift */,
 				EEFAA580295D78E9003583BE /* AuthenticatedRESTRequestTests.swift */,
+				EEFAA578295D2FC7003583BE /* RESTRequestTests.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -3623,6 +3626,7 @@
 				9387A6F0226E3F15001B53D7 /* AccountSettingsMapperTests.swift in Sources */,
 				2685C102263B6A1000D9EE97 /* AddOnGroupRemoteTests.swift in Sources */,
 				02616F8C292132800095BC00 /* SiteRemoteTests.swift in Sources */,
+				EEFAA579295D2FC7003583BE /* RESTRequestTests.swift in Sources */,
 				B57B1E6721C916850046E764 /* NetworkErrorTests.swift in Sources */,
 				D8FBFF0F22D3B25E006E3336 /* WooAPIVersionTests.swift in Sources */,
 				45152831257A8E1A0076B03C /* ProductAttributeMapperTests.swift in Sources */,

--- a/Networking/Networking/Requests/RESTRequest.swift
+++ b/Networking/Networking/Requests/RESTRequest.swift
@@ -50,7 +50,12 @@ struct RESTRequest: URLRequestConvertible {
         let components = [siteURL, Settings.basePath, wooApiVersion.path, path].map { $0.trimSlashes() }
         let url = try components.joined(separator: "/").asURL()
         let request = try URLRequest(url: url, method: method)
-        return try URLEncoding.default.encode(request, with: parameters)
+        switch method {
+        case .post, .put:
+            return try JSONEncoding.default.encode(request, with: parameters)
+        default:
+            return try URLEncoding.default.encode(request, with: parameters)
+        }
     }
 }
 

--- a/Networking/NetworkingTests/Requests/RESTRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/RESTRequestTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import Networking
+import Alamofire
+
+/// RESTRequest Unit Tests
+///
+final class RESTRequestTests: XCTestCase {
+    /// Testing API Version
+    ///
+    private let sampleWooApiVersion = WooAPIVersion.mark3
+
+    /// Sample SiteID
+    ///
+    private let sampleSiteID: Int64 = 1234
+
+    /// Sample site address
+    ///
+    private let sampleSiteAddress = "https://wordpress.com"
+
+    /// RPC Sample Method Path
+    ///
+    private let sampleRPC = "sample"
+
+    /// Sample Parameters
+    ///
+    private let sampleParameters = ["some": "thing", "yo": "semite"]
+
+    func test_it_uses_JSON_encoding_for_post_method() throws {
+        // Given
+        let request = RESTRequest(siteURL: sampleSiteAddress, wooApiVersion: sampleWooApiVersion, method: .post, path: sampleRPC)
+
+        // When
+        let urlRequest = try request.asURLRequest()
+
+        // Then
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
+    func test_it_uses_JSON_encoding_for_put_method() throws {
+        // Given
+        let request = RESTRequest(siteURL: sampleSiteAddress, wooApiVersion: sampleWooApiVersion, method: .put, path: sampleRPC)
+
+        // When
+        let urlRequest = try request.asURLRequest()
+
+        // Then
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
+    func test_it_uses_URL_encoding_for_methods_other_than_post_and_put() throws {
+        // Given
+        let method: HTTPMethod = try XCTUnwrap([.options, .get, .head, .patch, .delete, .trace, .connect].randomElement())
+        let request = RESTRequest(siteURL: sampleSiteAddress, wooApiVersion: sampleWooApiVersion, method: method, path: sampleRPC)
+
+        // When
+        let urlRequest = try request.asURLRequest()
+
+        // Then
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded; charset=utf-8")
+    }
+}

--- a/Networking/NetworkingTests/Requests/RESTRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/RESTRequestTests.swift
@@ -27,7 +27,7 @@ final class RESTRequestTests: XCTestCase {
 
     func test_it_uses_JSON_encoding_for_post_method() throws {
         // Given
-        let request = RESTRequest(siteURL: sampleSiteAddress, wooApiVersion: sampleWooApiVersion, method: .post, path: sampleRPC)
+        let request = RESTRequest(siteURL: sampleSiteAddress, wooApiVersion: sampleWooApiVersion, method: .post, path: sampleRPC, parameters: sampleParameters)
 
         // When
         let urlRequest = try request.asURLRequest()
@@ -38,7 +38,7 @@ final class RESTRequestTests: XCTestCase {
 
     func test_it_uses_JSON_encoding_for_put_method() throws {
         // Given
-        let request = RESTRequest(siteURL: sampleSiteAddress, wooApiVersion: sampleWooApiVersion, method: .put, path: sampleRPC)
+        let request = RESTRequest(siteURL: sampleSiteAddress, wooApiVersion: sampleWooApiVersion, method: .put, path: sampleRPC, parameters: sampleParameters)
 
         // When
         let urlRequest = try request.asURLRequest()
@@ -47,17 +47,21 @@ final class RESTRequestTests: XCTestCase {
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
     }
 
-    func test_it_uses_URL_encoding_for_methods_other_than_post_and_put() throws {
+    func test_it_does_not_use_JSON_encoding_for_methods_other_than_post_and_put() throws {
         // Given
         let methods: [HTTPMethod] = [.options, .get, .head, .patch, .delete, .trace, .connect]
         for method in methods {
-            let request = RESTRequest(siteURL: sampleSiteAddress, wooApiVersion: sampleWooApiVersion, method: method, path: sampleRPC)
+            let request = RESTRequest(siteURL: sampleSiteAddress,
+                                      wooApiVersion: sampleWooApiVersion,
+                                      method: method,
+                                      path: sampleRPC,
+                                      parameters: sampleParameters)
 
             // When
             let urlRequest = try request.asURLRequest()
 
             // Then
-            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded; charset=utf-8")
+            XCTAssertNotEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
         }
     }
 }

--- a/Networking/NetworkingTests/Requests/RESTRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/RESTRequestTests.swift
@@ -49,13 +49,15 @@ final class RESTRequestTests: XCTestCase {
 
     func test_it_uses_URL_encoding_for_methods_other_than_post_and_put() throws {
         // Given
-        let method: HTTPMethod = try XCTUnwrap([.options, .get, .head, .patch, .delete, .trace, .connect].randomElement())
-        let request = RESTRequest(siteURL: sampleSiteAddress, wooApiVersion: sampleWooApiVersion, method: method, path: sampleRPC)
+        let methods: [HTTPMethod] = [.options, .get, .head, .patch, .delete, .trace, .connect]
+        for method in methods {
+            let request = RESTRequest(siteURL: sampleSiteAddress, wooApiVersion: sampleWooApiVersion, method: method, path: sampleRPC)
 
-        // When
-        let urlRequest = try request.asURLRequest()
+            // When
+            let urlRequest = try request.asURLRequest()
 
-        // Then
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded; charset=utf-8")
+            // Then
+            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded; charset=utf-8")
+        }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8390 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

For the REST API requests, `put` and `post` method type requests should use JSON encoding. For the rest of methods we should use URLEncoding. 

## Testing instructions
CI should pass.

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
