### PR TITLE
[REST API] Migrate Coupons Jetpack tunnel endpoints to REST API

### DIFF
--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -65,7 +65,8 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
                                      method: .get,
                                      siteID: siteID,
                                      path: Path.coupons,
-                                     parameters: parameters)
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
 
         let mapper = CouponListMapper(siteID: siteID)
 
@@ -87,7 +88,8 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
                                      method: .get,
                                      siteID: siteID,
                                      path: Path.coupons,
-                                     parameters: parameters)
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
 
         let mapper = CouponListMapper(siteID: siteID)
 
@@ -159,7 +161,12 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
             let couponID = coupon.couponID
             let siteID = coupon.siteID
             let path = Path.coupons + "/\(couponID)"
-            let request = JetpackRequest(wooApiVersion: .mark3, method: .put, siteID: siteID, path: path, parameters: parameters)
+            let request = JetpackRequest(wooApiVersion: .mark3,
+                                         method: .put,
+                                         siteID: siteID,
+                                         path: path,
+                                         parameters: parameters,
+                                         availableAsRESTRequest: true)
             let mapper = CouponMapper(siteID: siteID)
 
             enqueue(request, mapper: mapper, completion: completion)
@@ -189,7 +196,12 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
             let parameters = try coupon.toDictionary(keyEncodingStrategy: .convertToSnakeCase, dateFormatter: dateFormatter)
             let siteID = coupon.siteID
             let path = Path.coupons
-            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+            let request = JetpackRequest(wooApiVersion: .mark3,
+                                         method: .post,
+                                         siteID: siteID,
+                                         path: path,
+                                         parameters: parameters,
+                                         availableAsRESTRequest: true)
             let mapper = CouponMapper(siteID: siteID)
 
             enqueue(request, mapper: mapper, completion: completion)
@@ -223,7 +235,8 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
                                      method: .get,
                                      siteID: siteID,
                                      path: Path.couponReports,
-                                     parameters: parameters)
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
 
         let mapper = CouponReportListMapper()
 

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -109,7 +109,8 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
         let request = JetpackRequest(wooApiVersion: .mark3,
                                      method: .get,
                                      siteID: siteID,
-                                     path: Path.coupons + "/\(couponID)")
+                                     path: Path.coupons + "/\(couponID)",
+                                     availableAsRESTRequest: true)
 
         let mapper = CouponMapper(siteID: siteID)
 
@@ -132,7 +133,8 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
                                      method: .delete,
                                      siteID: siteID,
                                      path: Path.coupons + "/\(couponID)",
-                                     parameters: [ParameterKey.force: true])
+                                     parameters: [ParameterKey.force: true],
+                                     availableAsRESTRequest: true)
 
         let mapper = CouponMapper(siteID: siteID)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8390
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR makes the Jetpack tunnel requests from Coupons to be available as REST API requests. 
## Testing instructions
1. Turn on the `applicationPasswordAuthenticationForSiteCredentialLogin` feature flag.
1. Login into the app using .org site credentials.
1. Navigate to the coupons tab.
1. Try creating, editing and deleting coupons.
1. All features in the coupons screen should work as before.

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
