### PR TITLE
[REST API] Delete application password upon logout

### DIFF
--- a/Networking/Networking/ApplicationPassword/ApplicationPasswordStorage.swift
+++ b/Networking/Networking/ApplicationPassword/ApplicationPasswordStorage.swift
@@ -7,8 +7,8 @@ struct ApplicationPasswordStorage {
     ///
     private let keychain: Keychain
 
-    init(keychain: Keychain = Keychain(service: KeychainServiceName.name)) {
-        self.keychain = keychain
+    init(keychain: Keychain? = nil) {
+        self.keychain = keychain ?? Keychain(service: KeychainServiceName.name)
     }
 
     /// Returns the saved application password if available

--- a/Networking/Networking/ApplicationPassword/ApplicationPasswordStorage.swift
+++ b/Networking/Networking/ApplicationPassword/ApplicationPasswordStorage.swift
@@ -7,8 +7,8 @@ struct ApplicationPasswordStorage {
     ///
     private let keychain: Keychain
 
-    init(keychain: Keychain? = nil) {
-        self.keychain = keychain ?? Keychain(service: KeychainServiceName.name)
+    init(keychain: Keychain = Keychain(service: WooConstants.keychainServiceName)) {
+        self.keychain = keychain
     }
 
     /// Returns the saved application password if available
@@ -36,16 +36,6 @@ struct ApplicationPasswordStorage {
         // Delete password from keychain
         keychain.username = nil
         keychain.password = nil
-    }
-}
-
-// MARK: - Constants
-//
-private extension ApplicationPasswordStorage {
-    enum KeychainServiceName {
-        /// Matching `WooConstants.keychainServiceName`
-        ///
-        static let name = "com.automattic.woocommerce"
     }
 }
 

--- a/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -2,6 +2,7 @@ import Foundation
 import WordPressShared
 import WordPressKit
 import enum Alamofire.AFError
+import KeychainAccess
 
 public enum ApplicationPasswordUseCaseError: Error {
     case duplicateName
@@ -52,7 +53,7 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
 
     /// To store application password
     ///
-    private let storage = ApplicationPasswordStorage()
+    private let storage: ApplicationPasswordStorage
 
     /// Used to name the password in wpadmin.
     ///
@@ -67,9 +68,11 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
     public init(username: String,
                 password: String,
                 siteAddress: String,
-                network: Network? = nil) throws {
+                network: Network? = nil,
+                keychain: Keychain? = nil) throws {
         self.siteAddress = siteAddress
         self.username = username
+        self.storage = ApplicationPasswordStorage(keychain: keychain)
 
         if let network {
             self.network = network

--- a/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -10,14 +10,14 @@ public enum ApplicationPasswordUseCaseError: Error {
     case failedToConstructLoginOrAdminURLUsingSiteAddress
 }
 
-struct ApplicationPassword {
+public struct ApplicationPassword {
     /// WordPress org username that the application password belongs to
     ///
-    public let wpOrgUsername: String
+    let wpOrgUsername: String
 
     /// Application password
     ///
-    public let password: Secret<String>
+    let password: Secret<String>
 }
 
 public protocol ApplicationPasswordUseCase {
@@ -95,7 +95,7 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
 
     /// Returns the locally saved ApplicationPassword if available
     ///
-    var applicationPassword: ApplicationPassword? {
+    public var applicationPassword: ApplicationPassword? {
         storage.applicationPassword
     }
 
@@ -105,7 +105,7 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
     ///
     /// - Returns: Generated `ApplicationPassword` instance
     ///
-    func generateNewPassword() async throws -> ApplicationPassword {
+    public func generateNewPassword() async throws -> ApplicationPassword {
         async let password = try {
             do {
                 return try await createApplicationPassword()

--- a/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -69,7 +69,7 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
                 password: String,
                 siteAddress: String,
                 network: Network? = nil,
-                keychain: Keychain? = nil) throws {
+                keychain: Keychain = Keychain(service: WooConstants.keychainServiceName)) throws {
         self.siteAddress = siteAddress
         self.username = username
         self.storage = ApplicationPasswordStorage(keychain: keychain)

--- a/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -10,7 +10,7 @@ public enum ApplicationPasswordUseCaseError: Error {
     case failedToConstructLoginOrAdminURLUsingSiteAddress
 }
 
-public struct ApplicationPassword {
+struct ApplicationPassword {
     /// WordPress org username that the application password belongs to
     ///
     public let wpOrgUsername: String
@@ -95,7 +95,7 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
 
     /// Returns the locally saved ApplicationPassword if available
     ///
-    public var applicationPassword: ApplicationPassword? {
+    var applicationPassword: ApplicationPassword? {
         storage.applicationPassword
     }
 
@@ -105,7 +105,7 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
     ///
     /// - Returns: Generated `ApplicationPassword` instance
     ///
-    public func generateNewPassword() async throws -> ApplicationPassword {
+    func generateNewPassword() async throws -> ApplicationPassword {
         async let password = try {
             do {
                 return try await createApplicationPassword()

--- a/Networking/Networking/Settings/WooConstants.swift
+++ b/Networking/Networking/Settings/WooConstants.swift
@@ -2,7 +2,11 @@ import Foundation
 
 /// Constants to be shared in Networking layer.
 ///
-enum WooConstants {
+public enum WooConstants {
     /// Placeholder site ID to be used when the user is logged in without WPCom.
     static let placeholderSiteID: Int64 = -1
+
+    /// Keychain Access's Service Name
+    ///
+    public static let keychainServiceName = "com.automattic.woocommerce"
 }

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -173,7 +173,8 @@ final class SessionManager: SessionManagerProtocol {
         guard case let .wporg(username, password, siteAddress) = loadCredentials(),
               let usecase = try? DefaultApplicationPasswordUseCase(username: username,
                                                                    password: password,
-                                                                   siteAddress: siteAddress) else {
+                                                                   siteAddress: siteAddress,
+                                                                   keychain: keychain) else {
             return
         }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -2,6 +2,7 @@ import Combine
 import Foundation
 import Yosemite
 import KeychainAccess
+import class Networking.DefaultApplicationPasswordUseCase
 
 // MARK: - SessionManager Notifications
 //
@@ -159,10 +160,26 @@ final class SessionManager: SessionManagerProtocol {
     /// Nukes all of the known Session's properties.
     ///
     func reset() {
+        deleteApplicationPassword()
         defaultAccount = nil
         defaultCredentials = nil
         defaultStoreID = nil
         defaultSite = nil
+    }
+
+    /// Deletes application password
+    ///
+    func deleteApplicationPassword() {
+        guard case let .wporg(username, password, siteAddress) = loadCredentials(),
+              let usecase = try? DefaultApplicationPasswordUseCase(username: username,
+                                                                   password: password,
+                                                                   siteAddress: siteAddress) else {
+            return
+        }
+
+        Task {
+            try await usecase.deletePassword()
+        }
     }
 }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -166,6 +166,7 @@ class DefaultStoresManager: StoresManager {
     /// Prepares for changing the selected store and remains Authenticated.
     ///
     func removeDefaultStore() {
+        sessionManager.deleteApplicationPassword()
         ServiceLocator.analytics.refreshUserData()
         ZendeskProvider.shared.reset()
         ServiceLocator.pushNotesManager.unregisterForRemoteNotifications()

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -62,6 +62,29 @@ class SessionManagerTests: XCTestCase {
         XCTAssertEqual(retrieved, Settings.wporgCredentials)
     }
 
+    /// Verifies that application password is deleted upon calling `deleteApplicationPassword`
+    ///
+    func test_deleteApplicationPassword_deletes_password_from_keychain() {
+        // Given
+        manager.defaultCredentials = Settings.wporgCredentials
+        let storage = ApplicationPasswordStorage(keychain: Keychain(service: Settings.keychainServiceName))
+        let password = ApplicationPassword(wpOrgUsername: "username", password: Secret("pass"))
+
+        // When
+        storage.saveApplicationPassword(password)
+
+        // Then
+        XCTAssertNotNil(storage.applicationPassword)
+
+        // When
+        manager.deleteApplicationPassword()
+
+        // Then
+        waitUntil {
+            storage.applicationPassword == nil
+        }
+    }
+
     /// Verifies that application password is deleted upon reset
     ///
     func test_application_password_is_deleted_upon_reset() {

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import WooCommerce
 import Yosemite
 import KeychainAccess
+@testable import Networking
+import WordPressShared
 
 /// SessionManager Unit Tests
 ///
@@ -58,6 +60,29 @@ class SessionManagerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(retrieved, Settings.wporgCredentials)
+    }
+
+    /// Verifies that application password is deleted upon reset
+    ///
+    func test_application_password_is_deleted_upon_reset() {
+        // Given
+        manager.defaultCredentials = Settings.wporgCredentials
+        let storage = ApplicationPasswordStorage(keychain: Keychain(service: Settings.keychainServiceName))
+        let password = ApplicationPassword(wpOrgUsername: "username", password: Secret("pass"))
+
+        // When
+        storage.saveApplicationPassword(password)
+
+        // Then
+        XCTAssertNotNil(storage.applicationPassword)
+
+        // When
+        manager.reset()
+
+        // Then
+        waitUntil {
+            storage.applicationPassword == nil
+        }
     }
 
     /// Verifies that `removeDefaultCredentials` effectively nukes everything from the keychain

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -3,7 +3,7 @@ import Combine
 import XCTest
 import Networking
 @testable import WooCommerce
-
+import Yosemite
 
 /// StoresManager Unit Tests
 ///
@@ -271,6 +271,18 @@ final class StoresManagerTests: XCTestCase {
         // Then
         XCTAssertTrue(mockProductImageUploader.resetWasCalled)
     }
+
+    func test_removing_default_store_invokes_delete_application_password() {
+        // Given
+        let mockSessionManager = MockSessionManager()
+        let sut = DefaultStoresManager(sessionManager: mockSessionManager)
+
+        // When
+        sut.removeDefaultStore()
+
+        // Then
+        XCTAssertTrue(mockSessionManager.deleteApplicationPasswordInvoked)
+    }
 }
 
 
@@ -291,5 +303,45 @@ final class MockAuthenticationManager: AuthenticationManager {
     override func authenticationUI() -> UIViewController {
         authenticationUIInvoked = true
         return UIViewController()
+    }
+}
+
+final class MockSessionManager: SessionManagerProtocol {
+    private(set) var deleteApplicationPasswordInvoked: Bool = false
+
+    var defaultAccount: Yosemite.Account? = nil
+
+    var defaultAccountID: Int64? = nil
+
+    var defaultSite: Yosemite.Site? = nil
+
+    let site = PassthroughSubject<Yosemite.Site?, Never>()
+
+    var defaultSitePublisher: AnyPublisher<Yosemite.Site?, Never> {
+        site.eraseToAnyPublisher()
+    }
+
+    var defaultStoreID: Int64? = nil
+
+    var defaultStoreURL: String? = nil
+
+    var defaultRoles: [Yosemite.User.Role] = []
+
+    let storeID = PassthroughSubject<Int64?, Never>()
+
+    var defaultStoreIDPublisher: AnyPublisher<Int64?, Never> {
+        storeID.eraseToAnyPublisher()
+    }
+
+    var anonymousUserID: String? = nil
+
+    var defaultCredentials: Yosemite.Credentials? = nil
+
+    func reset() {
+        // Do nothing
+    }
+
+    func deleteApplicationPassword() {
+        deleteApplicationPasswordInvoked = true
     }
 }

--- a/Yosemite/Yosemite/Base/SessionManagerProtocol.swift
+++ b/Yosemite/Yosemite/Base/SessionManagerProtocol.swift
@@ -46,4 +46,8 @@ public protocol SessionManagerProtocol {
     /// Nukes all of the known Session's properties.
     ///
     func reset()
+
+    /// Deletes application password
+    ///
+    func deleteApplicationPassword()
 }

--- a/Yosemite/Yosemite/Model/Mocks/MockSessionManager.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockSessionManager.swift
@@ -40,4 +40,8 @@ public struct MockSessionManager: SessionManagerProtocol {
     public func reset() {
         // Do nothing
     }
+
+    public func deleteApplicationPassword() {
+        // Do nothing
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8496
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR deletes the application password from the `wp-admin` portal upon logout. 

## Testing instructions
1. Create a JN site has WooCommerce installed. 
1. Turn on the `applicationPasswordAuthenticationForSiteCredentialLogin` feature flag.
1. Login into the app using .org site credentials.
1. Navigate to the coupons tab.
1. Validate from the `wp-admin` page that an application password is created for the logged-in user. Check [this guide](https://make.wordpress.org/core/2020/11/05/application-passwords-integration-guide/) to know how to check the application password.
1. Log out from the mobile app.  
1. Validate from the `wp-admin` page that the application password is deleted. 

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
