### PR TITLE
Fixes gaps on the Dashboard header

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -52,6 +52,8 @@ final class DashboardViewController: UIViewController {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = .listForeground(modal: false)
         view.axis = .vertical
+        view.directionalLayoutMargins = .init(top: 0, leading: 0, bottom: Constants.tabStripSpacing, trailing: 0)
+        view.spacing = Constants.headerStackViewSpacing
         return view
     }()
 
@@ -291,7 +293,7 @@ private extension DashboardViewController {
 
         // This constraint will pin the bottom of the header to the top of the content
         // We want this to be active when the header is visible
-        contentTopToHeaderConstraint = contentView.topAnchor.constraint(equalTo: headerStackView.bottomAnchor, constant: Constants.tabStripSpacing)
+        contentTopToHeaderConstraint = contentView.topAnchor.constraint(equalTo: headerStackView.bottomAnchor)
         contentTopToHeaderConstraint?.isActive = true
 
         // This constraint has a lower priority and will pin the top of the content view to its superview
@@ -720,5 +722,6 @@ private extension DashboardViewController {
         static let iPhoneCollapsedNavigationBarHeight = CGFloat(44)
         static let iPadCollapsedNavigationBarHeight = CGFloat(50)
         static let tabStripSpacing = CGFloat(12)
+        static let headerStackViewSpacing = CGFloat(4)
     }
 }


### PR DESCRIPTION
closes #8399 

# Why

This PR fixes some odd gaps in the dashboard header that were visible mostly in dark mode.

# How

- Move the spacing from the tab-header constraint to the header view stack view margins.
- Add a 4pt spacing between members of the header stack view.

# Screenshots

Dark | Dark + No Connection View | Dark + No Products View
--- | --- | ---
![vanilla](https://user-images.githubusercontent.com/562080/209964791-2f55ca7e-3611-47ac-952d-8900d85c67bd.png) | ![offline](https://user-images.githubusercontent.com/562080/209964814-8fd03469-2585-4e45-adfc-a124431c0013.png) | ![banner](https://user-images.githubusercontent.com/562080/209964815-15237aa2-a5d5-465c-a426-cb66dadfd272.png)

# Testing Steps

- Switch the device/simulator to dark mode if needed
- Login if needed --> in the My store tab, check that there is no weird gap between the title, store name and tab.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
