### PR TITLE
Widgets: Query data for configured store

### DIFF
--- a/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
+++ b/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
@@ -26,14 +26,24 @@ private extension IntentHandler {
         guard let sitesData = UserDefaults.group?[.sharedSitesData] as? Data,
               let sitesArray = try? JSONDecoder().decode([SharedSiteData].self, from: sitesData) else {
             // Fallback to single-store implementation
-            if let storeID = UserDefaults.group?[.defaultStoreID] as? Int64,
-               let storeName = UserDefaults.group?[.defaultStoreName] as? String {
-                return [SharedSiteData(siteID: storeID, siteName: storeName)]
+            if let selectedStore = getSelectedStore() {
+                return [selectedStore]
             } else {
                 return []
             }
         }
 
         return sitesArray
+    }
+
+    /// Helper to get details for the store selected in the host app
+    ///
+    func getSelectedStore() -> SharedSiteData? {
+        guard let storeID = UserDefaults.group?[.defaultStoreID] as? Int64,
+              let storeName = UserDefaults.group?[.defaultStoreName] as? String else {
+            return nil
+        }
+
+        return SharedSiteData(siteID: storeID, siteName: storeName)
     }
 }

--- a/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
+++ b/WooCommerce/StoreWidgetsIntentsExtension/IntentHandler.swift
@@ -13,6 +13,16 @@ class IntentHandler: INExtension, StoreWidgetsConfigIntentHandling {
         return INObjectCollection(items: sites)
     }
 
+    /// Function provides default value for `store` parameter
+    ///
+    func defaultStore(for intent: StoreWidgetsConfigIntent) -> IntentStore? {
+        guard let selectedStore = getSelectedStore() else {
+            return nil
+        }
+
+        return IntentStore(identifier: String(selectedStore.siteID), display: selectedStore.siteName)
+    }
+
     override func handler(for intent: INIntent) -> Any {
         return self
     }


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/7863.
Targeting feature branch.

## Description

This PR updates widgets networking to query data for the store selected in widgets settings UI.

## Testing

1. Add a widget to home screen (long press on home screen > tap + in top left > search for Woo).
2. Configure Widget (long press on widget > tap "Edit Widget").
3. Confirm that "Store" setting is prefilled with a store currently selected in app.
4. Add another widget, select a different store for its configuration options.
5. Confirm that both widgets show correct data.

## Screenshots

<img width=350 src="https://user-images.githubusercontent.com/3132438/209975041-2c822543-b42c-4863-8cf9-27f6a0700234.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
