### PR TITLE
Variations: Fetch all variations before generating variations

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -182,20 +182,21 @@ extension ProductVariationSelectorViewModel: SyncingCoordinatorDelegate {
         let action = ProductVariationAction.synchronizeProductVariations(siteID: siteID,
                                                                          productID: productID,
                                                                          pageNumber: pageNumber,
-                                                                         pageSize: pageSize) { [weak self] error in
+                                                                         pageSize: pageSize) { [weak self] result in
             guard let self = self else { return }
 
-            if let error = error {
+            switch result {
+            case .success:
+                self.updateProductVariationsResultsController()
+            case .failure(let error):
                 self.notice = NoticeFactory.productVariationSyncNotice() { [weak self] in
                     self?.sync(pageNumber: pageNumber, pageSize: pageSize, onCompletion: nil)
                 }
                 DDLogError("⛔️ Error synchronizing product variations during order creation: \(error)")
-            } else {
-                self.updateProductVariationsResultsController()
             }
 
             self.transitionToResultsUpdatedState()
-            onCompletion?(error == nil)
+            onCompletion?(result.isSuccess)
         }
         stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
@@ -85,23 +85,22 @@ final class BulkUpdateViewModel {
         // There is a limitof 100 objects for bulk update API
         let pageNumber = Constants.pageNumber
         let action = ProductVariationAction
-            .synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: numberOfObjects) { [weak self] error in
+            .synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: numberOfObjects) { [weak self] result in
                 guard let self = self else { return }
 
-                if let error = error {
-                    self.syncState = .error
-
-                    DDLogError("⛔️ Error synchronizing product variations: \(error)")
-                } else {
+                switch result {
+                case .success:
                     self.configureResultsControllerAndFetchData { [weak self] error in
                         guard let self = self else { return }
-
                         if error != nil {
                             self.syncState = .error
                         } else {
                             self.syncState = .synced(self.sections)
                         }
                     }
+                case .failure(let error):
+                    self.syncState = .error
+                    DDLogError("⛔️ Error synchronizing product variations: \(error)")
                 }
             }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -612,8 +612,7 @@ private extension ProductVariationsViewController {
             case .single:
                 self.createVariation()
             case .all:
-                // TODO: Start generate all variations flow
-                break
+                self.generateAllVariations()
             }
 
         }
@@ -691,6 +690,16 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
                 DDLogError("⛔️ Error generating variation: \(error)")
             }
         }
+    }
+
+    /// Generates all possible variations for the product attibutes.
+    ///
+    private func generateAllVariations() {
+        viewModel.generateAllVariations(for: product)
+        // TODO:
+        // - Show Loading Indicator
+        // - Alert if there are more than 100 variations to create
+        // - Hide Loading Indicator
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -649,22 +649,23 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
         transitionToSyncingState(pageNumber: pageNumber)
 
         let action = ProductVariationAction
-            .synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] error in
+            .synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] result in
                 guard let self = self else {
                     return
                 }
 
-                if let error = error {
+                switch result {
+                case .success:
+                    ServiceLocator.analytics.track(.productVariationListLoaded)
+                case .failure(let error):
                     ServiceLocator.analytics.track(.productVariationListLoadError, withError: error)
 
                     DDLogError("⛔️ Error synchronizing product variations: \(error)")
                     self.displaySyncingErrorNotice(pageNumber: pageNumber, pageSize: pageSize)
-                } else {
-                    ServiceLocator.analytics.track(.productVariationListLoaded)
                 }
 
                 self.transitionToResultsUpdatedState()
-                onCompletion?(error == nil)
+                onCompletion?(result.isSuccess)
         }
 
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -25,6 +25,23 @@ final class ProductVariationsViewModel {
         useCase.generateVariation(onCompletion: onCompletion)
     }
 
+    /// Generates all missing variations for a product. Up to 100 variations.
+    ///
+    func generateAllVariations(for product: Product) {
+        let action = ProductVariationAction.synchronizeAllProductVariations(siteID: product.siteID, productID: product.productID) { result in
+            // Temp
+            let fetched = ServiceLocator.storageManager.viewStorage.loadProductVariations(siteID: product.siteID, productID: product.productID)
+            print("Synchronized \(fetched?.count ?? 0) variations")
+        }
+        stores.dispatch(action)
+
+        // TODO:
+        // - Generate all variations locally
+        // - Substract already created variations
+        // - Alert if there are more than 100 variations to create
+        // - Create variations remotely
+    }
+
     /// Updates the internal `formType` to `edit` if  the given product exists remotely and previous formType was `.add`
     ///
     func updatedFormTypeIfNeeded(newProduct: Product) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
@@ -70,7 +70,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
                 XCTAssertTrue(viewModel.shouldShowScrollIndicator, "Scroll indicator is not enabled during sync")
-                onCompletion(nil)
+                onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
             }
@@ -91,7 +91,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
                 XCTAssertEqual(viewModel.syncStatus, .firstPageSync)
-                onCompletion(nil)
+                onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
             }
@@ -113,7 +113,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
                 XCTAssertEqual(viewModel.syncStatus, .firstPageSync)
                 self.insert(self.sampleProductVariation)
-                onCompletion(nil)
+                onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
             }
@@ -136,7 +136,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
                 XCTAssertEqual(viewModel.syncStatus, .results)
-                onCompletion(nil)
+                onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
             }
@@ -192,7 +192,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
-                onCompletion(NSError(domain: "Error", code: 0))
+                onCompletion(.failure(NSError(domain: "Error", code: 0)))
             default:
                 XCTFail("Received unsupported action: \(action)")
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewControllerTests.swift
@@ -23,7 +23,7 @@ final class BulkUpdateViewControllerTests: XCTestCase {
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
-                onCompletion(NSError.init(domain: "sample error", code: 0, userInfo: nil))
+                onCompletion(.failure(NSError.init(domain: "sample error", code: 0, userInfo: nil)))
             default:
                 XCTFail("Unsupported Action")
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
@@ -98,7 +98,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
-                onCompletion(NSError.init(domain: "sample error", code: 0, userInfo: nil))
+                onCompletion(.failure(NSError.init(domain: "sample error", code: 0, userInfo: nil)))
             default:
                 XCTFail("Unsupported Action")
             }
@@ -122,7 +122,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
-                onCompletion(nil)
+                onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
             }
@@ -144,7 +144,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
-                onCompletion(nil)
+                onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
             }
@@ -180,7 +180,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
-                onCompletion(nil)
+                onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
             }
@@ -218,7 +218,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
-                onCompletion(nil)
+                onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
             }
@@ -255,7 +255,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
-                onCompletion(nil)
+                onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
             }
@@ -292,7 +292,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action  in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
-                onCompletion(nil)
+                onCompletion(.success(false))
             default:
                 XCTFail("Unsupported Action")
             }

--- a/Yosemite/Yosemite/Actions/ProductVariationAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductVariationAction.swift
@@ -7,8 +7,9 @@ import Networking
 public enum ProductVariationAction: Action {
 
     /// Synchronizes the ProductVariation's matching the specified criteria.
+    /// If successful, the result boolean value, will indicate weather there are more variations to fetch or not.
     ///
-    case synchronizeProductVariations(siteID: Int64, productID: Int64, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
+    case synchronizeProductVariations(siteID: Int64, productID: Int64, pageNumber: Int, pageSize: Int, onCompletion: (Result<Bool, Error>) -> Void)
 
     /// Retrieves the specified ProductVariation.
     ///

--- a/Yosemite/Yosemite/Actions/ProductVariationAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductVariationAction.swift
@@ -6,6 +6,10 @@ import Networking
 //
 public enum ProductVariationAction: Action {
 
+    /// Synchronizes all the ProductVariation's available in the store.
+    ///
+    case synchronizeAllProductVariations(siteID: Int64, productID: Int64, onCompletion: (Result<Void, Error>) -> Void)
+
     /// Synchronizes the ProductVariation's matching the specified criteria.
     /// If successful, the result boolean value, will indicate weather there are more variations to fetch or not.
     ///

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -66,7 +66,7 @@ private extension ProductVariationStore {
     /// Synchronizes all the product reviews associated with a given Site ID (if any!).
     ///
     func synchronizeAllProductVariations(siteID: Int64, productID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        let maxPageSize = 30 // API only allows to fetch a max of 100 variations at a time
+        let maxPageSize = 100 // API only allows to fetch a max of 100 variations at a time
         recursivelySyncAllVariations(siteID: siteID,
                                      productID: productID,
                                      pageNumber: Default.firstPageNumber,

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -36,6 +36,8 @@ public final class ProductVariationStore: Store {
         }
 
         switch action {
+        case .synchronizeAllProductVariations(let siteID, let productID, let onCompletion):
+            synchronizeAllProductVariations(siteID: siteID, productID: productID, onCompletion: onCompletion)
         case .synchronizeProductVariations(let siteID, let productID, let pageNumber, let pageSize, let onCompletion):
             synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         case .retrieveProductVariation(let siteID, let productID, let variationID, let onCompletion):
@@ -60,6 +62,19 @@ public final class ProductVariationStore: Store {
 // MARK: - Services!
 //
 private extension ProductVariationStore {
+
+    /// Synchronizes all the product reviews associated with a given Site ID (if any!).
+    ///
+    func synchronizeAllProductVariations(siteID: Int64, productID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        let maxPageSize = 30 // API only allows to fetch a max of 100 variations at a time
+        recursivelySyncAllVariations(siteID: siteID,
+                                     productID: productID,
+                                     pageNumber: Default.firstPageNumber,
+                                     pageSize: maxPageSize) { result in
+            // Transforms Result<Bool, Error> -> Result<Void, Error> as the bool value is not needed anymore.
+            onCompletion(result.map { _ in () }) //
+        }
+    }
 
     /// Synchronizes the product reviews associated with a given Site ID (if any!).
     /// If successful, the result boolean value, will indicate weather there are more variations to fetch or not.
@@ -407,6 +422,30 @@ private extension ProductVariationStore {
             let newStorageImage = storage.insertNewObject(ofType: Storage.ProductImage.self)
             newStorageImage.update(with: readOnlyImage)
             storageVariation.image = newStorageImage
+        }
+    }
+
+    /// Recursively sync all product variations starting with the given page number and using a maximum page size.
+    ///
+    private func recursivelySyncAllVariations(siteID: Int64,
+                                              productID: Int64,
+                                              pageNumber: Int,
+                                              pageSize: Int,
+                                              onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+        synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] result in
+            switch result {
+            case .success(let hasMoreVariationsToFetch):
+                guard hasMoreVariationsToFetch else {
+                    return onCompletion(.success(false))
+                }
+                self?.recursivelySyncAllVariations(siteID: siteID,
+                                                   productID: productID,
+                                                   pageNumber: pageNumber + 1,
+                                                   pageSize: pageSize,
+                                                   onCompletion: onCompletion)
+            case .failure(let error):
+                onCompletion(.failure(error))
+            }
         }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -60,9 +60,9 @@ final class ProductVariationStoreTests: XCTestCase {
         let action = ProductVariationAction.synchronizeProductVariations(siteID: sampleSiteID,
                                                                          productID: sampleProductID,
                                                                          pageNumber: defaultPageNumber,
-                                                                         pageSize: defaultPageSize) { error in
+                                                                         pageSize: defaultPageSize) { result in
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductVariation.self), 8)
-            XCTAssertNil(error)
+            XCTAssertTrue(result.isSuccess)
 
             let sampleProductVariationID: Int64 = 1275
             let storedProductVariation = self.viewStorage.loadProductVariation(siteID: self.sampleSiteID, productVariationID: sampleProductVariationID)
@@ -90,8 +90,8 @@ final class ProductVariationStoreTests: XCTestCase {
         let action = ProductVariationAction.synchronizeProductVariations(siteID: sampleSiteID,
                                                                          productID: sampleProductID,
                                                                          pageNumber: defaultPageNumber,
-                                                                         pageSize: defaultPageSize) { error in
-            XCTAssertNil(error)
+                                                                         pageSize: defaultPageSize) { result in
+            XCTAssertTrue(result.isSuccess)
 
             let storedProductVariations = self.viewStorage.loadProductVariations(siteID: self.sampleSiteID, productID: self.sampleProductID)
             XCTAssertEqual(storedProductVariations?.count, 8)
@@ -103,8 +103,8 @@ final class ProductVariationStoreTests: XCTestCase {
             let action = ProductVariationAction.synchronizeProductVariations(siteID: self.sampleSiteID,
                                                                              productID: self.sampleProductID,
                                                                              pageNumber: self.defaultPageNumber,
-                                                                             pageSize: self.defaultPageSize) { error in
-                XCTAssertNil(error)
+                                                                             pageSize: self.defaultPageSize) { result in
+                XCTAssertTrue(result.isSuccess)
 
                 let storedProductVariations = self.viewStorage.loadProductVariations(siteID: self.sampleSiteID, productID: self.sampleProductID)
                 XCTAssertEqual(storedProductVariations?.count, 8)
@@ -192,8 +192,8 @@ final class ProductVariationStoreTests: XCTestCase {
         let action = ProductVariationAction.synchronizeProductVariations(siteID: siteID1,
                                                                          productID: productID,
                                                                          pageNumber: Store.Default.firstPageNumber,
-                                                                         pageSize: defaultPageSize) { error in
-            XCTAssertNil(error)
+                                                                         pageSize: defaultPageSize) { result in
+            XCTAssertTrue(result.isSuccess)
 
             // The previously upserted ProductVariation for siteID1 should be deleted.
             let storedVariationForSite1 = self.viewStorage.loadProductVariation(siteID: siteID1, productVariationID: variationID)
@@ -234,8 +234,8 @@ final class ProductVariationStoreTests: XCTestCase {
         let action = ProductVariationAction.synchronizeProductVariations(siteID: siteID,
                                                                          productID: productID,
                                                                          pageNumber: 3,
-                                                                         pageSize: defaultPageSize) { error in
-            XCTAssertNil(error)
+                                                                         pageSize: defaultPageSize) { result in
+            XCTAssertTrue(result.isSuccess)
 
             // The previously upserted ProductVariation's should stay in storage.
             let storedVariation = self.viewStorage.loadProductVariation(siteID: siteID, productVariationID: variationID)
@@ -288,6 +288,24 @@ final class ProductVariationStoreTests: XCTestCase {
 
         store.onAction(action)
         wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_sync_product_variations_indicates_when_there_are_more_variations_to_fetch() {
+        let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+        let pageSize = 8 // "product-variations-load-all" currently has 8 variations
+
+
+        let hasMoreVariationsToFetch: Bool = waitFor { promise in
+            let action = ProductVariationAction.synchronizeProductVariations(siteID: self.sampleSiteID,
+                                                                             productID: self.sampleProductID,
+                                                                             pageNumber: self.defaultPageNumber,
+                                                                             pageSize: pageSize) { result in
+                promise((try? result.get()) ?? false)
+            }
+            store.onAction(action)
+        }
+        XCTAssertTrue(hasMoreVariationsToFetch)
     }
 
     // MARK: - ProductVariationAction.retrieveProductVariation


### PR DESCRIPTION
Closes: #8487

# Why

This PR makes sure that all product variations are fetched before starting the "Generate All Variations" process.
This is needed in order to not create duplicate variations.

# How

- The first [big change](https://github.com/woocommerce/woocommerce-ios/commit/c81c307e475e86bb69edd6e5b830fd61e9b9fee3) is to update the `synchronizeProductVariations` method to return a `Result<Bool, Error` instead of an `Error?`.

The boolean success case indicates if there could be more variations to fetch. We assume there are more variations to fetch if the resulting set has the same count as the page size.

- The second change adds `synchronizeAllProductVariations` function to recursively fetch all product variations.

- The third change integrates `synchronizeAllProductVariations` with the "Generate All Variations" button

# Testing Steps

- Navigate to Products Tab - > Variable Product ->  Variations List
- Tap on the "Add Variation" Button and select the "Generate All Variations Button"
- See in the console a message that says `Number Of Variations: {variation-number}`

**Note: If you don't have a product with more than 100 variations, you can update `line 69` of `ProductVariationStore.swift` to test the recursion easily.**

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
