### PR TITLE
Store creation M3: store country profiler question UI (not integrated to the flow)

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryButton.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryButton.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// A button for a country that the user can select for their store during the store creation profiler flow.
+struct StoreCreationCountryButton: View {
+    private let countryCode: SiteAddress.CountryCode
+    @ObservedObject private var viewModel: StoreCreationCountryQuestionViewModel
+
+    init(countryCode: SiteAddress.CountryCode, viewModel: StoreCreationCountryQuestionViewModel) {
+        self.countryCode = countryCode
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        Button(action: {
+            viewModel.selectCountry(countryCode)
+        }, label: {
+            HStack(spacing: 24) {
+                if let flagEmoji = countryCode.flagEmoji {
+                    Text(flagEmoji)
+                }
+                Text(countryCode.readableCountry)
+                Spacer()
+            }
+        })
+        .buttonStyle(SelectableSecondaryButtonStyle(isSelected: viewModel.selectedCountryCode == countryCode))
+    }
+}
+
+struct StoreCreationCountryButton_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            StoreCreationCountryButton(countryCode: .US,
+                                       viewModel: .init(storeName: "", onContinue: { _ in }))
+            StoreCreationCountryButton(countryCode: .UM,
+                                       viewModel: .init(storeName: "", onContinue: { _ in }))
+        }
+    }
+}

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+/// Hosting controller that wraps the `StoreCreationCountryQuestionView`.
+final class StoreCreationCountryQuestionHostingController: UIHostingController<StoreCreationCountryQuestionView> {
+    init(viewModel: StoreCreationCountryQuestionViewModel) {
+        super.init(rootView: StoreCreationCountryQuestionView(viewModel: viewModel))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureTransparentNavigationBar()
+    }
+}
+
+/// Shows the store country question in the store creation flow.
+struct StoreCreationCountryQuestionView: View {
+    @ObservedObject private var viewModel: StoreCreationCountryQuestionViewModel
+
+    init(viewModel: StoreCreationCountryQuestionViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        RequiredStoreCreationProfilerQuestionView(viewModel: viewModel) {
+            VStack(spacing: 16) {
+                ForEach(viewModel.countryCodes, id: \.self) { countryCode in
+                    Button(action: {
+                        viewModel.selectCountry(countryCode)
+                    }, label: {
+                        HStack(spacing: 24) {
+                            if let flagEmoji = countryCode.flagEmoji {
+                                Text(flagEmoji)
+                            }
+                            Text(countryCode.readableCountry)
+                            Spacer()
+                        }
+                    })
+                    .buttonStyle(SelectableSecondaryButtonStyle(isSelected: viewModel.selectedCountryCode == countryCode))
+                }
+            }
+        }
+    }
+}
+
+struct StoreCreationCountryQuestionView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            StoreCreationCountryQuestionView(viewModel: .init(storeName: "only in 2023", onContinue: { _ in }, onSkip: {}))
+        }
+    }
+}

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
@@ -20,38 +20,45 @@ final class StoreCreationCountryQuestionHostingController: UIHostingController<S
 
 /// Shows the store country question in the store creation flow.
 struct StoreCreationCountryQuestionView: View {
-    @ObservedObject private var viewModel: StoreCreationCountryQuestionViewModel
+    @StateObject private var viewModel: StoreCreationCountryQuestionViewModel
 
     init(viewModel: StoreCreationCountryQuestionViewModel) {
-        self.viewModel = viewModel
+        self._viewModel = StateObject(wrappedValue: viewModel)
     }
 
     var body: some View {
         RequiredStoreCreationProfilerQuestionView(viewModel: viewModel) {
-            VStack(spacing: 16) {
-                ForEach(viewModel.countryCodes, id: \.self) { countryCode in
-                    Button(action: {
-                        viewModel.selectCountry(countryCode)
-                    }, label: {
-                        HStack(spacing: 24) {
-                            if let flagEmoji = countryCode.flagEmoji {
-                                Text(flagEmoji)
-                            }
-                            Text(countryCode.readableCountry)
-                            Spacer()
-                        }
-                    })
-                    .buttonStyle(SelectableSecondaryButtonStyle(isSelected: viewModel.selectedCountryCode == countryCode))
+            VStack(spacing: 32) {
+                if let currentCountryCode = viewModel.currentCountryCode {
+                    StoreCreationCountrySectionView(header: Localization.currentLocationHeader,
+                                                    countryCodes: [currentCountryCode],
+                                                    viewModel: viewModel)
                 }
+                StoreCreationCountrySectionView(header: Localization.otherCountriesHeader,
+                                                countryCodes: viewModel.countryCodes,
+                                                viewModel: viewModel)
             }
         }
+    }
+}
+
+private extension StoreCreationCountryQuestionView {
+    enum Localization {
+        static let currentLocationHeader = NSLocalizedString(
+            "CURRENT LOCATION",
+            comment: "Header of the current country in the store creation country question.")
+        static let otherCountriesHeader = NSLocalizedString(
+            "COUNTRIES",
+            comment: "Header of a list of other countries in the store creation country question.")
     }
 }
 
 struct StoreCreationCountryQuestionView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            StoreCreationCountryQuestionView(viewModel: .init(storeName: "only in 2023", onContinue: { _ in }, onSkip: {}))
+            StoreCreationCountryQuestionView(viewModel: .init(storeName: "only in 2023",
+                                                              currentLocale: Locale.init(identifier: "en_US"),
+                                                              onContinue: { _ in }))
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionViewModel.swift
@@ -2,6 +2,7 @@ import Combine
 import Foundation
 
 /// View model for `StoreCreationCountryQuestionView`, an optional profiler question about store country in the store creation flow.
+@MainActor
 final class StoreCreationCountryQuestionViewModel: StoreCreationProfilerQuestionViewModel, ObservableObject {
     typealias CountryCode = SiteAddress.CountryCode
 

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionViewModel.swift
@@ -3,14 +3,6 @@ import Foundation
 
 /// View model for `StoreCreationCountryQuestionView`, an optional profiler question about store country in the store creation flow.
 final class StoreCreationCountryQuestionViewModel: StoreCreationProfilerQuestionViewModel, ObservableObject {
-    /// Contains necessary information about a category.
-    struct Category: Equatable {
-        /// Display name for the category.
-        let name: String
-        /// Value that is sent to the API.
-        let value: String
-    }
-
     typealias CountryCode = SiteAddress.CountryCode
 
     let topHeader: String

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionViewModel.swift
@@ -1,0 +1,74 @@
+import Combine
+import Foundation
+
+/// View model for `StoreCreationCountryQuestionView`, an optional profiler question about store country in the store creation flow.
+final class StoreCreationCountryQuestionViewModel: StoreCreationProfilerQuestionViewModel, ObservableObject {
+    /// Contains necessary information about a category.
+    struct Category: Equatable {
+        /// Display name for the category.
+        let name: String
+        /// Value that is sent to the API.
+        let value: String
+    }
+
+    let topHeader: String
+
+    let title: String = Localization.title
+
+    let subtitle: String = Localization.subtitle
+
+    /// Question content.
+    /// TODO: 8378 - update values when API is ready.
+    let countryCodes: [SiteAddress.CountryCode] = SiteAddress.CountryCode.allCases
+
+    @Published private(set) var selectedCountryCode: SiteAddress.CountryCode?
+
+    @Published private var isContinueButtonEnabledValue: Bool = false
+
+    private let onContinue: (SiteAddress.CountryCode) -> Void
+    private let onSkip: () -> Void
+
+    init(storeName: String,
+         onContinue: @escaping (SiteAddress.CountryCode) -> Void,
+         onSkip: @escaping () -> Void) {
+        self.topHeader = storeName
+        self.onContinue = onContinue
+        self.onSkip = onSkip
+
+        $selectedCountryCode
+            .map { $0 != nil }
+            .assign(to: &$isContinueButtonEnabledValue)
+    }
+}
+
+extension StoreCreationCountryQuestionViewModel: RequiredStoreCreationProfilerQuestionViewModel {
+    var isContinueButtonEnabled: AnyPublisher<Bool, Never> {
+        $isContinueButtonEnabledValue.eraseToAnyPublisher()
+    }
+
+    func continueButtonTapped() async {
+        guard let selectedCountryCode else {
+            return onSkip()
+        }
+        onContinue(selectedCountryCode)
+    }
+}
+
+extension StoreCreationCountryQuestionViewModel {
+    func selectCountry(_ countryCode: SiteAddress.CountryCode) {
+        selectedCountryCode = countryCode
+    }
+}
+
+private extension StoreCreationCountryQuestionViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Confirm your location",
+            comment: "Title of the store creation profiler question about the store country."
+        )
+        static let subtitle = NSLocalizedString(
+            "We’ll use this information to get a head start on setting up payments, shipping, and taxes.",
+            comment: "Subtitle of the store creation profiler question about the store country."
+        )
+    }
+}

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountrySectionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountrySectionView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// Shows a header label and a list of countries for selection in the store creation profiler flow.
+struct StoreCreationCountrySectionView: View {
+    private let header: String
+    private let countryCodes: [SiteAddress.CountryCode]
+    @ObservedObject private var viewModel: StoreCreationCountryQuestionViewModel
+
+    init(header: String, countryCodes: [SiteAddress.CountryCode], viewModel: StoreCreationCountryQuestionViewModel) {
+        self.header = header
+        self.countryCodes = countryCodes
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(header)
+                .footnoteStyle()
+            VStack(spacing: 16) {
+                ForEach(countryCodes, id: \.self) { countryCode in
+                    StoreCreationCountryButton(countryCode: countryCode,
+                                               viewModel: viewModel)
+                }
+            }
+        }
+    }
+}
+
+struct StoreCreationCountrySectionView_Previews: PreviewProvider {
+    static var previews: some View {
+        StoreCreationCountrySectionView(header: "EXAMPLES", countryCodes: [.FJ, .UM, .US], viewModel: .init(storeName: "", onContinue: { _ in }))
+    }
+}

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/RequiredStoreCreationProfilerQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/RequiredStoreCreationProfilerQuestionView.swift
@@ -67,8 +67,8 @@ private enum Localization {
 
 private final class StoreCreationQuestionPreviewViewModel: StoreCreationProfilerQuestionViewModel, RequiredStoreCreationProfilerQuestionViewModel {
     let topHeader: String = "Store name"
-    let title: String = "Which of these best describes you?"
-    let subtitle: String = "Choose a category that defines your business the best."
+    let title: String = "This question is required"
+    let subtitle: String = "Choose an option to continue."
     @Published private var isContinueButtonEnabledValue: Bool = false
 
     var isContinueButtonEnabled: AnyPublisher<Bool, Never> {

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/RequiredStoreCreationProfilerQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/RequiredStoreCreationProfilerQuestionView.swift
@@ -1,0 +1,90 @@
+import Combine
+import SwiftUI
+
+/// Handles the navigation action and provides the continue button state in a required profiler question view during store creation.
+/// The question is not skippable.
+protocol RequiredStoreCreationProfilerQuestionViewModel {
+    /// Called when the continue button is tapped.
+    func continueButtonTapped() async
+
+    /// Whether the continue button is enabled for the user to continue.
+    var isContinueButtonEnabled: AnyPublisher<Bool, Never> { get }
+}
+
+/// Shows a mandatory profiler question during the store creation flow with a generic content.
+struct RequiredStoreCreationProfilerQuestionView<QuestionContent: View>: View {
+    private let viewModel: StoreCreationProfilerQuestionViewModel & RequiredStoreCreationProfilerQuestionViewModel
+    @ViewBuilder private let questionContent: () -> QuestionContent
+    @State private var isWaitingForCompletion: Bool = false
+    @State private var isContinueButtonEnabled: Bool = false
+
+    init(viewModel: StoreCreationProfilerQuestionViewModel & RequiredStoreCreationProfilerQuestionViewModel,
+         @ViewBuilder questionContent: @escaping () -> QuestionContent) {
+        self.viewModel = viewModel
+        self.questionContent = questionContent
+    }
+
+    var body: some View {
+        ScrollView {
+            StoreCreationProfilerQuestionView<QuestionContent>(viewModel: viewModel, questionContent: questionContent)
+        }
+        .safeAreaInset(edge: .bottom) {
+            VStack {
+                Divider()
+                    .frame(height: Layout.dividerHeight)
+                    .foregroundColor(Color(.separator))
+                Button(Localization.continueButtonTitle) {
+                    Task { @MainActor in
+                        isWaitingForCompletion = true
+                        await viewModel.continueButtonTapped()
+                        isWaitingForCompletion = false
+                    }
+                }
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isWaitingForCompletion))
+                .disabled(!isContinueButtonEnabled)
+                .padding(Layout.defaultPadding)
+            }
+            .background(Color(.systemBackground))
+        }
+        // Disables large title to avoid a large gap below the navigation bar.
+        .navigationBarTitleDisplayMode(.inline)
+        .onReceive(viewModel.isContinueButtonEnabled) { isContinueButtonEnabled in
+            self.isContinueButtonEnabled = isContinueButtonEnabled
+        }
+    }
+}
+
+private enum Layout {
+    static let dividerHeight: CGFloat = 1
+    static let defaultPadding: EdgeInsets = .init(top: 10, leading: 16, bottom: 10, trailing: 16)
+}
+
+private enum Localization {
+    static let continueButtonTitle = NSLocalizedString("Continue", comment: "Title of the button to continue with a profiler question.")
+}
+
+#if DEBUG
+
+private final class StoreCreationQuestionPreviewViewModel: StoreCreationProfilerQuestionViewModel, RequiredStoreCreationProfilerQuestionViewModel {
+    let topHeader: String = "Store name"
+    let title: String = "Which of these best describes you?"
+    let subtitle: String = "Choose a category that defines your business the best."
+    @Published private var isContinueButtonEnabledValue: Bool = false
+
+    var isContinueButtonEnabled: AnyPublisher<Bool, Never> {
+        $isContinueButtonEnabledValue.eraseToAnyPublisher()
+    }
+    func continueButtonTapped() async {}
+}
+
+struct RequiredStoreCreationProfilerQuestionView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            RequiredStoreCreationProfilerQuestionView(viewModel: StoreCreationQuestionPreviewViewModel()) {
+                Text("question content")
+            }
+        }
+    }
+}
+
+#endif

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		022C658C2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022C658B2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift */; };
 		022F2FA6295E77F4003A0A46 /* StoreCreationCountrySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F2FA5295E77F4003A0A46 /* StoreCreationCountrySectionView.swift */; };
 		022F2FA8295E7A14003A0A46 /* StoreCreationCountryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F2FA7295E7A14003A0A46 /* StoreCreationCountryButton.swift */; };
+		022F2FAA295E8241003A0A46 /* StoreCreationCountryQuestionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F2FA9295E8241003A0A46 /* StoreCreationCountryQuestionViewModelTests.swift */; };
 		022F7A0324A05F6400012601 /* LinkedProductsListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F7A0124A05F6400012601 /* LinkedProductsListSelectorViewController.swift */; };
 		022F7A0424A05F6400012601 /* LinkedProductsListSelectorViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 022F7A0224A05F6400012601 /* LinkedProductsListSelectorViewController.xib */; };
 		022F941E257F8E820011CD94 /* BoldableTextParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F941D257F8E820011CD94 /* BoldableTextParser.swift */; };
@@ -2176,6 +2177,7 @@
 		022C658B2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewController+ProductImageUploaderTests.swift"; sourceTree = "<group>"; };
 		022F2FA5295E77F4003A0A46 /* StoreCreationCountrySectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCountrySectionView.swift; sourceTree = "<group>"; };
 		022F2FA7295E7A14003A0A46 /* StoreCreationCountryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCountryButton.swift; sourceTree = "<group>"; };
+		022F2FA9295E8241003A0A46 /* StoreCreationCountryQuestionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCountryQuestionViewModelTests.swift; sourceTree = "<group>"; };
 		022F7A0124A05F6400012601 /* LinkedProductsListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedProductsListSelectorViewController.swift; sourceTree = "<group>"; };
 		022F7A0224A05F6400012601 /* LinkedProductsListSelectorViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LinkedProductsListSelectorViewController.xib; sourceTree = "<group>"; };
 		022F941D257F8E820011CD94 /* BoldableTextParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoldableTextParser.swift; sourceTree = "<group>"; };
@@ -4168,6 +4170,7 @@
 				0201E4302946FFDB00C793C7 /* StoreCreationCategoryQuestionViewModelTests.swift */,
 				028A4654295AD2DA001CF6CE /* StoreCreationSellingStatusQuestionViewModelTests.swift */,
 				026D464F295C08CA0037F59A /* StoreCreationSellingPlatformsQuestionViewModelTests.swift */,
+				022F2FA9295E8241003A0A46 /* StoreCreationCountryQuestionViewModelTests.swift */,
 			);
 			path = Profiler;
 			sourceTree = "<group>";
@@ -11265,6 +11268,7 @@
 				020BE76723B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift in Sources */,
 				57C9A8FE24C23335001E1C2F /* MockNoticePresenter.swift in Sources */,
 				02BAB01F24D0232800F8B06E /* MockProductVariation.swift in Sources */,
+				022F2FAA295E8241003A0A46 /* StoreCreationCountryQuestionViewModelTests.swift in Sources */,
 				DE279BAF26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				DE61979528A25842005E4362 /* StorePickerViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -123,6 +123,8 @@
 		022BF7FD23B9D708000A1DFB /* InProgressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022BF7FB23B9D708000A1DFB /* InProgressViewController.swift */; };
 		022BF7FE23B9D708000A1DFB /* InProgressViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 022BF7FC23B9D708000A1DFB /* InProgressViewController.xib */; };
 		022C658C2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022C658B2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift */; };
+		022F2FA6295E77F4003A0A46 /* StoreCreationCountrySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F2FA5295E77F4003A0A46 /* StoreCreationCountrySectionView.swift */; };
+		022F2FA8295E7A14003A0A46 /* StoreCreationCountryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F2FA7295E7A14003A0A46 /* StoreCreationCountryButton.swift */; };
 		022F7A0324A05F6400012601 /* LinkedProductsListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F7A0124A05F6400012601 /* LinkedProductsListSelectorViewController.swift */; };
 		022F7A0424A05F6400012601 /* LinkedProductsListSelectorViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 022F7A0224A05F6400012601 /* LinkedProductsListSelectorViewController.xib */; };
 		022F941E257F8E820011CD94 /* BoldableTextParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F941D257F8E820011CD94 /* BoldableTextParser.swift */; };
@@ -2172,6 +2174,8 @@
 		022BF7FB23B9D708000A1DFB /* InProgressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressViewController.swift; sourceTree = "<group>"; };
 		022BF7FC23B9D708000A1DFB /* InProgressViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InProgressViewController.xib; sourceTree = "<group>"; };
 		022C658B2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewController+ProductImageUploaderTests.swift"; sourceTree = "<group>"; };
+		022F2FA5295E77F4003A0A46 /* StoreCreationCountrySectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCountrySectionView.swift; sourceTree = "<group>"; };
+		022F2FA7295E7A14003A0A46 /* StoreCreationCountryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCountryButton.swift; sourceTree = "<group>"; };
 		022F7A0124A05F6400012601 /* LinkedProductsListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedProductsListSelectorViewController.swift; sourceTree = "<group>"; };
 		022F7A0224A05F6400012601 /* LinkedProductsListSelectorViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LinkedProductsListSelectorViewController.xib; sourceTree = "<group>"; };
 		022F941D257F8E820011CD94 /* BoldableTextParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoldableTextParser.swift; sourceTree = "<group>"; };
@@ -4770,6 +4774,8 @@
 			children = (
 				027CB042295D7B6B00F98F7C /* StoreCreationCountryQuestionView.swift */,
 				027CB044295D7B8B00F98F7C /* StoreCreationCountryQuestionViewModel.swift */,
+				022F2FA5295E77F4003A0A46 /* StoreCreationCountrySectionView.swift */,
+				022F2FA7295E7A14003A0A46 /* StoreCreationCountryButton.swift */,
 			);
 			path = Country;
 			sourceTree = "<group>";
@@ -10112,6 +10118,7 @@
 				AE9E04752776213E003FA09E /* OrderCustomerSection.swift in Sources */,
 				CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */,
 				DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */,
+				022F2FA8295E7A14003A0A46 /* StoreCreationCountryButton.swift in Sources */,
 				02E8B17A23E2C4BD00A43403 /* CircleSpinnerView.swift in Sources */,
 				CCE4CD282669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift in Sources */,
 				02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */,
@@ -10744,6 +10751,7 @@
 				DE279BA826E9C8E3002BA963 /* ShippingLabelSinglePackage.swift in Sources */,
 				DEC2962726C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift in Sources */,
 				26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */,
+				022F2FA6295E77F4003A0A46 /* StoreCreationCountrySectionView.swift in Sources */,
 				CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */,
 				DE4B3B5826A7041800EEF2D8 /* EdgeInsets+Woo.swift in Sources */,
 				02CE4304276993DA0006EAEF /* CaptureDevicePermissionChecker.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -279,6 +279,9 @@
 		027B8BB823FE0CB30040944E /* DefaultProductUIImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027B8BB723FE0CB30040944E /* DefaultProductUIImageLoader.swift */; };
 		027B8BBD23FE0DE10040944E /* ProductImageActionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027B8BBC23FE0DE10040944E /* ProductImageActionHandlerTests.swift */; };
 		027B8BBF23FE0F850040944E /* MockMediaStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027B8BBE23FE0F850040944E /* MockMediaStoresManager.swift */; };
+		027CB043295D7B6B00F98F7C /* StoreCreationCountryQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027CB042295D7B6B00F98F7C /* StoreCreationCountryQuestionView.swift */; };
+		027CB045295D7B8B00F98F7C /* StoreCreationCountryQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027CB044295D7B8B00F98F7C /* StoreCreationCountryQuestionViewModel.swift */; };
+		027CB047295D7EF400F98F7C /* RequiredStoreCreationProfilerQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027CB046295D7EF400F98F7C /* RequiredStoreCreationProfilerQuestionView.swift */; };
 		027D4A8D2526FD1800108626 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027D4A8B2526FD1700108626 /* SettingsViewController.swift */; };
 		027D4A8E2526FD1800108626 /* SettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 027D4A8C2526FD1700108626 /* SettingsViewController.xib */; };
 		027D67D1245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027D67D0245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift */; };
@@ -2326,6 +2329,9 @@
 		027B8BB723FE0CB30040944E /* DefaultProductUIImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProductUIImageLoader.swift; sourceTree = "<group>"; };
 		027B8BBC23FE0DE10040944E /* ProductImageActionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageActionHandlerTests.swift; sourceTree = "<group>"; };
 		027B8BBE23FE0F850040944E /* MockMediaStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaStoresManager.swift; sourceTree = "<group>"; };
+		027CB042295D7B6B00F98F7C /* StoreCreationCountryQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCountryQuestionView.swift; sourceTree = "<group>"; };
+		027CB044295D7B8B00F98F7C /* StoreCreationCountryQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCountryQuestionViewModel.swift; sourceTree = "<group>"; };
+		027CB046295D7EF400F98F7C /* RequiredStoreCreationProfilerQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredStoreCreationProfilerQuestionView.swift; sourceTree = "<group>"; };
 		027D4A8B2526FD1700108626 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		027D4A8C2526FD1700108626 /* SettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsViewController.xib; sourceTree = "<group>"; };
 		027D67D0245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterTypeViewModel+Helpers.swift"; sourceTree = "<group>"; };
@@ -4135,8 +4141,10 @@
 			children = (
 				0201E4262945B01800C793C7 /* StoreCreationProfilerQuestionView.swift */,
 				0201E42C2946C23600C793C7 /* OptionalStoreCreationProfilerQuestionView.swift */,
+				027CB046295D7EF400F98F7C /* RequiredStoreCreationProfilerQuestionView.swift */,
 				0201E42E2946F9F400C793C7 /* Category */,
 				020DD0AD294A069500727BEF /* Selling Status */,
+				026D4655295D7A380037F59A /* Country */,
 			);
 			path = Profiler;
 			sourceTree = "<group>";
@@ -4755,6 +4763,15 @@
 				AEDDDA0825CA9C0A0077F9B2 /* Edit Attributes */,
 			);
 			path = Variations;
+			sourceTree = "<group>";
+		};
+		026D4655295D7A380037F59A /* Country */ = {
+			isa = PBXGroup;
+			children = (
+				027CB042295D7B6B00F98F7C /* StoreCreationCountryQuestionView.swift */,
+				027CB044295D7B8B00F98F7C /* StoreCreationCountryQuestionViewModel.swift */,
+			);
+			path = Country;
 			sourceTree = "<group>";
 		};
 		027111402913B9D400F5269A /* Authentication */ = {
@@ -10678,6 +10695,7 @@
 				7E6A01972725B811001668D5 /* FilterProductCategoryListViewController.swift in Sources */,
 				E10DFC7A2673595A0083AFF2 /* ShareSheet.swift in Sources */,
 				03EF250628C75838006A033E /* PurchaseCardReaderWebViewViewModel.swift in Sources */,
+				027CB043295D7B6B00F98F7C /* StoreCreationCountryQuestionView.swift in Sources */,
 				AEE085B52897C871007ACE20 /* LinkedProductsPromoCampaign.swift in Sources */,
 				933A27372222354600C2143A /* Logging.swift in Sources */,
 				0290E26F238E3CE400B5C466 /* ListSelectorViewController.swift in Sources */,
@@ -10787,6 +10805,7 @@
 				4520A15E2722BA3E001FA573 /* OrderDateRangeFilter+Utils.swift in Sources */,
 				DEE183F1292E0ED0008818AB /* LoginJetpackSetupInterruptedView.swift in Sources */,
 				028A465329597A91001CF6CE /* StoreCreationSellingPlatformsQuestionViewModel.swift in Sources */,
+				027CB045295D7B8B00F98F7C /* StoreCreationCountryQuestionViewModel.swift in Sources */,
 				2676F4CC2908284800C7A15B /* ProductCreationTypeCommand.swift in Sources */,
 				45A24E5F2451DF1A0050606B /* ProductMenuOrderViewController.swift in Sources */,
 				0201E4272945B01800C793C7 /* StoreCreationProfilerQuestionView.swift in Sources */,
@@ -10877,6 +10896,7 @@
 				021940E8291FDBF90090354E /* StoreCreationSummaryView.swift in Sources */,
 				0201E4292945B8B600C793C7 /* StoreCreationCategoryQuestionView.swift in Sources */,
 				B63D9009293E56E300BB5C9D /* AnalyticsHubQuarterToDateRangeData.swift in Sources */,
+				027CB047295D7EF400F98F7C /* RequiredStoreCreationProfilerQuestionView.swift in Sources */,
 				02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */,
 				45D875D22611EA2100226C3F /* ListHeaderView.swift in Sources */,
 				DE2FE58D292617C30018040A /* SiteCredentialLoginViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCountryQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCountryQuestionViewModelTests.swift
@@ -1,0 +1,126 @@
+import Combine
+import XCTest
+@testable import WooCommerce
+
+final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
+    private var subscriptions: Set<AnyCancellable> = []
+
+    func test_topHeader_is_set_to_store_name() throws {
+        // Given
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store 🌟") { _ in }
+
+        // Then
+        XCTAssertEqual(viewModel.topHeader, "store 🌟")
+    }
+
+    func test_currentCountryCode_and_initial_selectedCountryCode_are_set_by_locale() throws {
+        // Given
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "fr_FR")) { _ in }
+
+        // Then
+        XCTAssertEqual(viewModel.currentCountryCode, .FR)
+        XCTAssertEqual(viewModel.selectedCountryCode, .FR)
+    }
+
+    func test_currentCountryCode_and_initial_selectedCountryCode_are_nil_with_an_invalid_locale() throws {
+        // Given
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "zzzz")) { _ in }
+
+        // Then
+        XCTAssertNil(viewModel.currentCountryCode)
+        XCTAssertNil(viewModel.selectedCountryCode)
+    }
+
+    func test_countryCodes_include_all_countries_with_an_invalid_locale() throws {
+        // Given
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "zzzz")) { _ in }
+
+        // Then
+        XCTAssertEqual(viewModel.countryCodes, SiteAddress.CountryCode.allCases.sorted(by: { $0.readableCountry < $1.readableCountry }))
+    }
+
+    func test_countryCodes_do_not_include_currentCountryCode_from_locale() throws {
+        // Given
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "fr_FR")) { _ in }
+
+        // Then
+        XCTAssertFalse(viewModel.countryCodes.contains(.FR))
+        XCTAssertEqual(viewModel.countryCodes.count, SiteAddress.CountryCode.allCases.count - 1)
+    }
+
+    func test_selecting_a_country_updates_selectedCountryCode() throws {
+        // Given
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store") { _ in }
+
+        // When
+        viewModel.selectCountry(.FJ)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedCountryCode, .FJ)
+    }
+
+    func test_selecting_a_country_sets_isContinueButtonEnabled_to_true_with_an_invalid_locale() throws {
+        // Given
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "zzzz")) { _ in }
+        var isContinueButtonEnabledValues = [Bool]()
+        viewModel.isContinueButtonEnabled.removeDuplicates().sink { isEnabled in
+            isContinueButtonEnabledValues.append(isEnabled)
+        }.store(in: &subscriptions)
+
+        XCTAssertEqual(isContinueButtonEnabledValues, [false])
+
+        // When
+        viewModel.selectCountry(.FJ)
+
+        // Then
+        XCTAssertEqual(isContinueButtonEnabledValues, [false, true])
+    }
+
+    func test_isContinueButtonEnabled_stays_true_with_a_valid_locale() throws {
+        // Given
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "fr_FR")) { _ in }
+        var isContinueButtonEnabledValues = [Bool]()
+        viewModel.isContinueButtonEnabled.removeDuplicates().sink { isEnabled in
+            isContinueButtonEnabledValues.append(isEnabled)
+        }.store(in: &subscriptions)
+
+        XCTAssertEqual(isContinueButtonEnabledValues, [true])
+
+        // When
+        viewModel.selectCountry(.FJ)
+
+        // Then
+        XCTAssertEqual(isContinueButtonEnabledValues, [true])
+    }
+
+    func test_continueButtonTapped_invokes_onContinue_after_selecting_a_country() throws {
+        waitFor { promise in
+            // Given
+            let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store",
+                                                                  currentLocale: .init(identifier: "zzzz")) { countryCode in
+                // Then
+                XCTAssertEqual(countryCode, .JP)
+                promise(())
+            }
+
+            // When
+            viewModel.selectCountry(.JP)
+            Task { @MainActor in
+                await viewModel.continueButtonTapped()
+            }
+        }
+    }
+
+    func test_continueButtonTapped_is_no_op_without_selecting_a_country() throws {
+        // Given
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store",
+                                                              currentLocale: .init(identifier: "zzzz")) { countryCode in
+            // Then
+            XCTFail("Should not be invoked without selecting a country.")
+        }
+        // When
+        Task { @MainActor in
+            await viewModel.continueButtonTapped()
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCountryQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCountryQuestionViewModelTests.swift
@@ -2,6 +2,7 @@ import Combine
 import XCTest
 @testable import WooCommerce
 
+@MainActor
 final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
     private var subscriptions: Set<AnyCancellable> = []
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8378 
Based on https://github.com/woocommerce/woocommerce-ios/pull/8508
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Due to the PR size, I'm leaving the integration with the store creation flow to a future PR. This PR mainly contains the SwiftUI views & view model for the third & last profiler question about the store country. This question is mandatory, and thus I created a `RequiredStoreCreationProfilerQuestionView` with a view model protocol to provide the navigation state & handling similar to `OptionalStoreCreationProfilerQuestionView`.

The main SwiftUI view is `StoreCreationCountryQuestionView`, with a few components `StoreCreationCountryButton` and `StoreCreationCountrySectionView`, a hosting controller, and a view model that conforms to `StoreCreationProfilerQuestionViewModel` and `RequiredStoreCreationProfilerQuestionViewModel`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

The new UI isn't used yet, please feel free to check the SwiftUI previews in Xcode.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

When it's integrated:

dark | light
-- | -- 
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-30 at 14 36 03](https://user-images.githubusercontent.com/1945542/210043122-8604fae2-6d1a-42b0-a0f8-7e991ec461af.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-30 at 14 37 52](https://user-images.githubusercontent.com/1945542/210043129-af59eae7-81bf-4af9-988d-4851e3b8cb10.png)
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-30 at 14 37 42](https://user-images.githubusercontent.com/1945542/210043127-be727bb0-53ea-4bfe-8945-345c592ccc94.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-30 at 14 37 48](https://user-images.githubusercontent.com/1945542/210043128-280c842d-8832-4881-9703-8a58002f99a2.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
