### PR TITLE
Store creation M3: store country profiler question - integration to the flow

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationSummaryView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationSummaryView.swift
@@ -45,6 +45,9 @@ struct StoreCreationSummaryViewModel {
     let storeSlug: String
     /// Optional category name from the previous profiler question.
     let categoryName: String?
+    /// Country code for the store location.
+    /// `nil` only when the `storeCreationM3Profiler` feature flag is disabled.
+    let countryCode: SiteAddress.CountryCode?
 }
 
 /// Displays a summary of the store creation flow with the store information (e.g. store name, store slug).
@@ -77,7 +80,7 @@ struct StoreCreationSummaryView: View {
                         }
                         .background(Color(.systemColor(.systemGray6)))
 
-                        VStack {
+                        VStack(alignment: .leading, spacing: 16) {
                             VStack(alignment: .leading, spacing: Layout.spacingBetweenStoreNameAndDomain) {
                                 // Store name.
                                 Text(viewModel.storeName)
@@ -86,12 +89,18 @@ struct StoreCreationSummaryView: View {
                                 Text(viewModel.storeSlug)
                                     .foregroundColor(Color(.secondaryLabel))
                                     .bodyStyle()
-                                // Store category (optional).
-                                if let categoryName = viewModel.categoryName {
-                                    Text(categoryName)
-                                        .foregroundColor(Color(.label))
-                                        .bodyStyle()
-                                }
+                            }
+                            // Store country.
+                            if let country = viewModel.country {
+                                Text(country)
+                                    .foregroundColor(Color(.label))
+                                    .bodyStyle()
+                            }
+                            // Store category (optional).
+                            if let categoryName = viewModel.categoryName {
+                                Text(categoryName)
+                                    .foregroundColor(Color(.label))
+                                    .bodyStyle()
                             }
                         }
                         .padding(Layout.storeInfoPadding)
@@ -146,12 +155,25 @@ private extension StoreCreationSummaryView {
     }
 }
 
+private extension StoreCreationSummaryViewModel {
+    /// Text for the store country label.
+    var country: String? {
+        countryCode.map { [$0.readableCountry, $0.flagEmoji].compactMap { $0 }.joined(separator: " ") }
+    }
+}
+
 struct StoreCreationSummaryView_Previews: PreviewProvider {
     static var previews: some View {
         StoreCreationSummaryView(viewModel:
-                .init(storeName: "Fruity shop", storeSlug: "fruityshop.com", categoryName: "Arts and Crafts"))
+                .init(storeName: "Fruity shop",
+                      storeSlug: "fruityshop.com",
+                      categoryName: "Arts and Crafts",
+                      countryCode: .UG))
         StoreCreationSummaryView(viewModel:
-                .init(storeName: "Fruity shop", storeSlug: "fruityshop.com", categoryName: "Arts and Crafts"))
+                .init(storeName: "Fruity shop",
+                      storeSlug: "fruityshop.com",
+                      categoryName: "Arts and Crafts",
+                      countryCode: nil))
         .preferredColorScheme(.dark)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8378 
Based on https://github.com/woocommerce/woocommerce-ios/pull/8509

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After the SwiftUI views in https://github.com/woocommerce/woocommerce-ios/pull/8509, this PR showed the store country question after the previous selling status question. After a country is selected, the country code is passed down to the store summary screen. It's currently optional since the profiler questions are shown behind a feature flag `storeCreationM3Profiler`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in if needed
- Go to the Menu tab, and tap `Switch store`
- On the store picker, tap `+ Add a store`
- Tap `Create a new store` --> the store name form should be shown
- Enter a store name and continue
- On the store category screen, choose an option and continue or skip --> the selling status question should be shown
- Tap `Skip` on the selling status question screen --> the store country question should be shown without a skip CTA. a current country should be shown based on the device region, and pre-selected. If a current country is available, the continue CTA should be enabled
- Optionally select another country, and tap `Continue` --> the domain selector should be shown
- Continue to select a domain --> the store summary screen should be shown with the selected country

---
- [x] @jaclync tests that when the `storeCreationM3Profiler` feature flag is disabled, the profiler question isn't shown and there's no country text on the store summary screen

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

question | country list | store summary
-- | -- | --
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-30 at 14 36 03](https://user-images.githubusercontent.com/1945542/210043122-8604fae2-6d1a-42b0-a0f8-7e991ec461af.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-30 at 14 37 42](https://user-images.githubusercontent.com/1945542/210043127-be727bb0-53ea-4bfe-8945-345c592ccc94.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-30 at 14 49 52](https://user-images.githubusercontent.com/1945542/210044036-853513c6-4b94-4040-b05a-49dea05e41c8.png)
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-30 at 14 37 52](https://user-images.githubusercontent.com/1945542/210043129-af59eae7-81bf-4af9-988d-4851e3b8cb10.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-30 at 14 37 48](https://user-images.githubusercontent.com/1945542/210043128-280c842d-8832-4881-9703-8a58002f99a2.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-30 at 14 49 32](https://user-images.githubusercontent.com/1945542/210044030-1fd97ef3-76e2-41c8-9c03-336acb9ce2ee.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
