### PR TITLE
[REST API] Delete application password on switch store

### DIFF
--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -157,6 +157,7 @@ class DefaultStoresManager: StoresManager {
     /// Prepares for changing the selected store and remains Authenticated.
     ///
     func removeDefaultStore() {
+        sessionManager.deleteApplicationPassword()
         ServiceLocator.analytics.refreshUserData()
         ZendeskProvider.shared.reset()
         ServiceLocator.pushNotesManager.unregisterForRemoteNotifications()

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -62,6 +62,29 @@ class SessionManagerTests: XCTestCase {
         XCTAssertEqual(retrieved, Settings.wporgCredentials)
     }
 
+    /// Verifies that application password is deleted upon calling `deleteApplicationPassword`
+    ///
+    func test_deleteApplicationPassword_deletes_password_from_keychain() {
+        // Given
+        manager.defaultCredentials = Settings.wporgCredentials
+        let storage = ApplicationPasswordStorage(keychain: Keychain(service: Settings.keychainServiceName))
+        let password = ApplicationPassword(wpOrgUsername: "username", password: Secret("pass"))
+
+        // When
+        storage.saveApplicationPassword(password)
+
+        // Then
+        XCTAssertNotNil(storage.applicationPassword)
+
+        // When
+        manager.deleteApplicationPassword()
+
+        // Then
+        waitUntil {
+            storage.applicationPassword == nil
+        }
+    }
+
     /// Verifies that application password is deleted upon reset
     ///
     func test_application_password_is_deleted_upon_reset() {

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -3,7 +3,7 @@ import Combine
 import XCTest
 import Networking
 @testable import WooCommerce
-
+import Yosemite
 
 /// StoresManager Unit Tests
 ///
@@ -252,6 +252,18 @@ final class StoresManagerTests: XCTestCase {
         // Then
         XCTAssertTrue(mockProductImageUploader.resetWasCalled)
     }
+
+    func test_removing_default_store_invokes_delete_application_password() {
+        // Given
+        let mockSessionManager = MockSessionManager()
+        let sut = DefaultStoresManager(sessionManager: mockSessionManager)
+
+        // When
+        sut.removeDefaultStore()
+
+        // Then
+        XCTAssertTrue(mockSessionManager.deleteApplicationPasswordInvoked)
+    }
 }
 
 
@@ -272,5 +284,45 @@ final class MockAuthenticationManager: AuthenticationManager {
     override func authenticationUI() -> UIViewController {
         authenticationUIInvoked = true
         return UIViewController()
+    }
+}
+
+final class MockSessionManager: SessionManagerProtocol {
+    private(set) var deleteApplicationPasswordInvoked: Bool = false
+
+    var defaultAccount: Yosemite.Account? = nil
+
+    var defaultAccountID: Int64? = nil
+
+    var defaultSite: Yosemite.Site? = nil
+
+    let site = PassthroughSubject<Yosemite.Site?, Never>()
+
+    var defaultSitePublisher: AnyPublisher<Yosemite.Site?, Never> {
+        site.eraseToAnyPublisher()
+    }
+
+    var defaultStoreID: Int64? = nil
+
+    var defaultStoreURL: String? = nil
+
+    var defaultRoles: [Yosemite.User.Role] = []
+
+    let storeID = PassthroughSubject<Int64?, Never>()
+
+    var defaultStoreIDPublisher: AnyPublisher<Int64?, Never> {
+        storeID.eraseToAnyPublisher()
+    }
+
+    var anonymousUserID: String? = nil
+
+    var defaultCredentials: Yosemite.Credentials? = nil
+
+    func reset() {
+        // Do nothing
+    }
+
+    func deleteApplicationPassword() {
+        deleteApplicationPasswordInvoked = true
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8496

## Description
- Deletes the application password upon switching store. 
- Adds unit tests to verify that the delete application password process is invoked properly.


## Testing instructions
- We currently don't have a way to switch stores when authenticated using an application password.
- CI passing should be enough.

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
