### PR TITLE
REST API: Update title and URL and hide Switch store button on Hub menu

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -34,7 +34,7 @@ struct HubMenu: View {
         VStack {
             TopBar(avatarURL: viewModel.avatarURL,
                    storeTitle: viewModel.storeTitle,
-                   storeURL: viewModel.storeURL.absoluteString) {
+                   storeURL: viewModel.storeURL?.absoluteString) {
                 viewModel.presentSwitchStore()
             }
                    .padding([.leading, .trailing], Constants.padding)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -34,7 +34,8 @@ struct HubMenu: View {
         VStack {
             TopBar(avatarURL: viewModel.avatarURL,
                    storeTitle: viewModel.storeTitle,
-                   storeURL: viewModel.storeURL?.absoluteString) {
+                   storeURL: viewModel.storeURL?.absoluteString,
+                   switchStoreEnabled: viewModel.switchStoreEnabled) {
                 viewModel.presentSwitchStore()
             }
                    .padding([.leading, .trailing], Constants.padding)
@@ -141,6 +142,7 @@ struct HubMenu: View {
         let avatarURL: URL?
         let storeTitle: String
         let storeURL: String?
+        let switchStoreEnabled: Bool
         var switchStoreHandler: (() -> Void)?
 
         @State private var showSettings = false
@@ -177,6 +179,7 @@ struct HubMenu: View {
                     }
                     .linkStyle()
                     .accessibilityIdentifier("switch-store-button")
+                    .renderedIf(switchStoreEnabled)
                 }
                 Spacer()
                 VStack {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -34,7 +34,7 @@ struct HubMenu: View {
         VStack {
             TopBar(avatarURL: viewModel.avatarURL,
                    storeTitle: viewModel.storeTitle,
-                   storeURL: viewModel.storeURL?.absoluteString,
+                   storeURL: viewModel.storeURL.absoluteString,
                    switchStoreEnabled: viewModel.switchStoreEnabled) {
                 viewModel.presentSwitchStore()
             }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -31,9 +31,9 @@ final class HubMenuViewModel: ObservableObject {
 
     @Published private(set) var storeTitle = Localization.myStore
 
-    @Published private(set) var storeURL: URL?
+    @Published private(set) var storeURL = WooConstants.URLs.blog.asURL()
 
-    @Published private(set) var woocommerceAdminURL: URL?
+    @Published private(set) var woocommerceAdminURL = WooConstants.URLs.blog.asURL()
 
     /// Child items
     ///

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -29,23 +29,11 @@ final class HubMenuViewModel: ObservableObject {
         return url
     }
 
-    var storeTitle: String {
-        stores.sessionManager.defaultSite?.name ?? Localization.myStore
-    }
+    @Published private(set) var storeTitle = Localization.myStore
 
-    var storeURL: URL {
-        guard let urlString = stores.sessionManager.defaultSite?.url, let url = URL(string: urlString) else {
-            return WooConstants.URLs.blog.asURL()
-        }
-        return url
-    }
-    var woocommerceAdminURL: URL {
-        guard let urlString = stores.sessionManager.defaultSite?.adminURL, let url = URL(string: urlString) else {
-            return stores.sessionManager.defaultSite?.adminURLWithFallback() ??
-            WooConstants.URLs.blog.asURL()
-        }
-        return url
-    }
+    @Published private(set) var storeURL: URL?
+
+    @Published private(set) var woocommerceAdminURL: URL?
 
     /// Child items
     ///
@@ -60,8 +48,6 @@ final class HubMenuViewModel: ObservableObject {
     private var productReviewFromNoteParcel: ProductReviewFromNoteParcel?
 
     private var storePickerCoordinator: StorePickerCoordinator?
-
-    private var cancellables = Set<AnyCancellable>()
 
     init(siteID: Int64,
          navigationController: UINavigationController? = nil,
@@ -139,9 +125,27 @@ final class HubMenuViewModel: ObservableObject {
     }
 
     private func observeSiteForUIUpdates() {
-        stores.site.sink { site in
-            // This will be useful in the future for updating some info of the screen depending on the store site info
-        }.store(in: &cancellables)
+        stores.site
+            .compactMap { site -> URL? in
+                guard let urlString = site?.url, let url = URL(string: urlString) else {
+                    return nil
+                }
+                return url
+            }
+            .assign(to: &$storeURL)
+
+        stores.site
+            .compactMap { $0?.name }
+            .assign(to: &$storeTitle)
+
+        stores.site
+            .compactMap { site -> URL? in
+                guard let urlString = site?.adminURL, let url = URL(string: urlString) else {
+                    return site?.adminURLWithFallback()
+                }
+                return url
+            }
+            .assign(to: &$woocommerceAdminURL)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -39,6 +39,10 @@ final class HubMenuViewModel: ObservableObject {
     ///
     @Published private(set) var menuElements: [HubMenuItem] = []
 
+    /// The switch store button should be hidden when logged in with site credentials only.
+    ///
+    @Published private(set) var switchStoreEnabled = false
+
     @Published var showingReviewDetail = false
 
     private let stores: StoresManager
@@ -59,6 +63,7 @@ final class HubMenuViewModel: ObservableObject {
         self.stores = stores
         self.featureFlagService = featureFlagService
         self.generalAppSettings = generalAppSettings
+        self.switchStoreEnabled = stores.isAuthenticatedWithoutWPCom == false
         observeSiteForUIUpdates()
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -271,6 +271,42 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.woocommerceAdminURL)
         XCTAssertEqual(viewModel.woocommerceAdminURL, try URL(string: expectedAdminURL)?.asURL())
     }
+
+    func test_switchStoreEnabled_returns_true_when_logged_in_with_wpcom() {
+        // Given
+        let sampleStoreURL = "https://testshop.com"
+        let sampleAdminURL = ""
+        let expectedAdminURL = "https://testshop.com/wp-admin"
+        let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: true)
+        let site = Site.fake().copy(url: sampleStoreURL, adminURL: sampleAdminURL)
+        sessionManager.defaultSite = site
+        let stores = MockStoresManager(sessionManager: sessionManager)
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: site.siteID,
+                                         stores: stores)
+
+        // Then
+        XCTAssertTrue(viewModel.switchStoreEnabled)
+    }
+
+    func test_switchStoreEnabled_returns_false_when_logged_in_with_wpcom() {
+        // Given
+        let sampleStoreURL = "https://testshop.com"
+        let sampleAdminURL = ""
+        let expectedAdminURL = "https://testshop.com/wp-admin"
+        let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: false)
+        let site = Site.fake().copy(url: sampleStoreURL, adminURL: sampleAdminURL)
+        sessionManager.defaultSite = site
+        let stores = MockStoresManager(sessionManager: sessionManager)
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: site.siteID,
+                                         stores: stores)
+
+        // Then
+        XCTAssertFalse(viewModel.switchStoreEnabled)
+    }
 }
 
 private extension HubMenuViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8511 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the logic on Hub menu to observe the logged-in site to update its title and URL accordingly.

Also: a new boolean was added to hide the Switch store button when the user is logged in with site credentials only.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Make sure that application password is enabled on your test site.
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app if needed.
- On the prologue screen, select "Enter your site address". If this option is not available, [disable simplified login](https://github.com/woocommerce/woocommerce-ios/blob/8d471f969911067311412d72f58de6ae2c966c6a/WooCommerce/Classes/Authentication/AuthenticationManager.swift#L61) and build the app again.
- Enter your test store address and select "Sign in with site credentials".
- Enter correct credentials and select "Continue". The app should navigate to the home screen after that.
- Navigate to the Menu tab. Notice that the site title and URL are updated correctly. The Switch store button should be hidden.

Please feel free to test again by logging in with a WPCom account. The menu should work as before.
## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/210217622-77acbee9-a202-445d-aa4a-f9847e270499.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
