### PR TITLE
Simplified login: Remove A/B test

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -15,11 +15,6 @@ public enum ABTest: String, CaseIterable {
     /// Experiment ref: pbxNRc-1S0-p2
     case aaTestLoggedOut = "woocommerceios_explat_aa_test_logged_out_202212_v2"
 
-    /// A/B test to measure the sign-in success rate when only WPCom login is enabled.
-    /// Experiment ref: pbxNRc-27s-p2
-    ///
-    case abTestLoginWithWPComOnly = "woocommerceios_login_wpcom_only"
-
     /// A/B test to measure the sign-in success rate when native Jetpack installation experience is enabled
     /// Experiment ref: pbxNRc-29W-p2
     ///
@@ -37,7 +32,7 @@ public enum ABTest: String, CaseIterable {
         switch self {
         case .aaTestLoggedIn, .nativeJetpackSetupFlow:
             return .loggedIn
-        case .aaTestLoggedOut, .abTestLoginWithWPComOnly:
+        case .aaTestLoggedOut:
             return .loggedOut
         case .null:
             return .none

--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -25,13 +25,6 @@ struct AuthenticationConstants {
         comment: "Sign in instructions on the 'log in using WordPress.com account' screen."
     )
 
-    /// Get started instructions when simplified login is enabled.
-    /// 
-    static let getStartedInstructionsForSimplifiedLogin = NSLocalizedString(
-        "Enter your email address to get started.",
-        comment: "Sign in instructions on the 'log in using WordPress.com account' screen."
-    )
-
     /// What is WordPress.com? link (Continue with WordPress.com)
     ///
     static let whatIsWPComLinkTitle = NSLocalizedString(
@@ -63,13 +56,6 @@ struct AuthenticationConstants {
     static let applePasswordInstructions = NSLocalizedString(
         "To proceed with this account, please first log in with your WordPress.com password. This will only be asked once.",
         comment: "Sign in instructions asking user to enter WordPress.com password to proceed with sign in using Apple process"
-    )
-
-    /// Simplified Log In button
-    ///
-    static let loginButtonTitle = NSLocalizedString(
-        "Log In",
-        comment: "Button title in the simplified login prologue screen. Takes the user to the login flow."
     )
 
     /// Title of "Continue With WordPress.com" button in Login Prologue

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -64,7 +64,6 @@ class AuthenticationManager: Authentication {
     func initialize(loggedOutAppSettings: LoggedOutAppSettingsProtocol) {
         let isWPComMagicLinkPreferredToPassword = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasis)
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasisM2)
-        let isSimplifiedLoginI1Enabled = ABTest.abTestLoginWithWPComOnly.variation != .control
         let isStoreCreationMVPEnabled = featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
         let isNativeJetpackSetupEnabled = ABTest.nativeJetpackSetupFlow.variation != .control
         let isWPComLoginRequiredForSiteCredentialsLogin = !featureFlagService.isFeatureFlagEnabled(.applicationPasswordAuthenticationForSiteCredentialLogin)
@@ -73,7 +72,7 @@ class AuthenticationManager: Authentication {
                                                                 wpcomScheme: ApiCredentials.dotcomAuthScheme,
                                                                 wpcomTermsOfServiceURL: WooConstants.URLs.termsOfService.rawValue,
                                                                 wpcomAPIBaseURL: Settings.wordpressApiBaseURL,
-                                                                whatIsWPComURL: isSimplifiedLoginI1Enabled ? nil : WooConstants.URLs.whatIsWPCom.rawValue,
+                                                                whatIsWPComURL: WooConstants.URLs.whatIsWPCom.rawValue,
                                                                 googleLoginClientId: ApiCredentials.googleClientId,
                                                                 googleLoginServerClientId: ApiCredentials.googleServerId,
                                                                 googleLoginScheme: ApiCredentials.googleAuthScheme,
@@ -89,9 +88,9 @@ class AuthenticationManager: Authentication {
                                                                 isWPComMagicLinkPreferredToPassword: isWPComMagicLinkPreferredToPassword,
                                                                 isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen:
                                                                     isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen,
-                                                                enableWPComLoginOnlyInPrologue: isSimplifiedLoginI1Enabled,
+                                                                enableWPComLoginOnlyInPrologue: false,
                                                                 enableSiteCreation: isStoreCreationMVPEnabled,
-                                                                enableSocialLogin: !isSimplifiedLoginI1Enabled,
+                                                                enableSocialLogin: true,
                                                                 emphasizeEmailForWPComPassword: true,
                                                                 wpcomPasswordInstructions:
                                                                 AuthenticationConstants.wpcomPasswordInstructions,
@@ -129,13 +128,9 @@ class AuthenticationManager: Authentication {
                                                     LoginPrologueViewController(isFeatureCarouselShown: false),
                                                 statusBarStyle: .default)
 
-        let getStartedInstructions = isSimplifiedLoginI1Enabled ?
-        AuthenticationConstants.getStartedInstructionsForSimplifiedLogin :
-        AuthenticationConstants.getStartedInstructions
+        let getStartedInstructions = AuthenticationConstants.getStartedInstructions
 
-        let continueWithWPButtonTitle = isSimplifiedLoginI1Enabled ?
-        AuthenticationConstants.loginButtonTitle :
-        AuthenticationConstants.continueWithWPButtonTitle
+        let continueWithWPButtonTitle = AuthenticationConstants.continueWithWPButtonTitle
 
         let emailAddressPlaceholder = isSimplifiedLoginI1Enabled ?
         "name@example.com" :

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -132,9 +132,7 @@ class AuthenticationManager: Authentication {
 
         let continueWithWPButtonTitle = AuthenticationConstants.continueWithWPButtonTitle
 
-        let emailAddressPlaceholder = isSimplifiedLoginI1Enabled ?
-        "name@example.com" :
-        WordPressAuthenticatorDisplayStrings.defaultStrings.emailAddressPlaceholder
+        let emailAddressPlaceholder = WordPressAuthenticatorDisplayStrings.defaultStrings.emailAddressPlaceholder
 
         let displayStrings = WordPressAuthenticatorDisplayStrings(emailLoginInstructions: AuthenticationConstants.emailInstructions,
                                                                   getStartedInstructions: getStartedInstructions,

--- a/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
@@ -10,7 +10,6 @@ enum LoginProloguePageType: CaseIterable {
     case products
     case reviews
     case getStarted
-    case simplifiedLoginI1Intro
 
     var title: String {
         switch self {
@@ -26,7 +25,7 @@ enum LoginProloguePageType: CaseIterable {
         case .reviews:
             return NSLocalizedString("Monitor and approve your product reviews",
                                      comment: "Caption displayed in promotional screens shown during the login flow.")
-        case .getStarted, .simplifiedLoginI1Intro:
+        case .getStarted:
             return NSLocalizedString("WooCommerce is a customizable, open-source eCommerce platform built on WordPress.",
                                      comment: "Caption displayed in the simplified prologue screen")
         }
@@ -58,7 +57,7 @@ enum LoginProloguePageType: CaseIterable {
             return UIImage.prologueProductsImage
         case .reviews:
             return UIImage.prologueReviewsImage
-        case .getStarted, .simplifiedLoginI1Intro:
+        case .getStarted:
             return UIImage.prologueWooMobileImage
         }
     }
@@ -144,7 +143,7 @@ private extension LoginProloguePageTypeViewController {
 
         // Label style & layout
         titleLabel.font = {
-            if pageType == .simplifiedLoginI1Intro || pageType == .getStarted {
+            if pageType == .getStarted {
                 return .headline
             } else if showsSubtitle {
                 return .font(forStyle: .title2, weight: .semibold)

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -12,7 +12,6 @@ final class LoginPrologueViewController: UIViewController {
     private let isFeatureCarouselShown: Bool
     private let analytics: Analytics
     private let featureFlagService: FeatureFlagService
-    private let isSimplifiedLogin: Bool
 
     /// Background View, to be placed surrounding the bottom area.
     ///
@@ -45,7 +44,6 @@ final class LoginPrologueViewController: UIViewController {
         self.isFeatureCarouselShown = isFeatureCarouselShown
         self.analytics = analytics
         self.featureFlagService = featureFlagService
-        self.isSimplifiedLogin = ABTest.abTestLoginWithWPComOnly.variation != .control
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -99,8 +97,6 @@ private extension LoginPrologueViewController {
         let pageTypes: [LoginProloguePageType] = {
             if isFeatureCarouselShown {
                 return [.stats, .orderManagement, .products, .reviews]
-            } else if isSimplifiedLogin {
-                return [.simplifiedLoginI1Intro]
             } else {
                 return [.getStarted]
             }
@@ -127,7 +123,7 @@ private extension LoginPrologueViewController {
         guard isNewToWooCommerceButtonShown else {
             return newToWooCommerceButton.isHidden = true
         }
-        let title = isSimplifiedLogin ? Localization.learnMoreAboutWoo : Localization.newToWooCommerce
+        let title = Localization.newToWooCommerce
         newToWooCommerceButton.setTitle(title, for: .normal)
         newToWooCommerceButton.applyLinkButtonStyle()
         newToWooCommerceButton.titleLabel?.numberOfLines = 0
@@ -155,8 +151,5 @@ private extension LoginPrologueViewController {
     enum Localization {
         static let newToWooCommerce = NSLocalizedString("New to WooCommerce?",
                                                         comment: "Title of button in the login prologue screen for users who are new to WooCommerce.")
-        static let learnMoreAboutWoo = NSLocalizedString("Learn more about WooCommerce",
-                                                         comment: "Title of button in the simplified login prologue screen " +
-                                                         "for learning more about WooCommerce.")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8528
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As the title suggests, this PR removes the A/B test for the WPCom-only login screen and deploys the control variant for all users. The result of the experiment [20889-explat-experiment] is inconclusive, and since we want to proceed with the REST API project, we need to keep the entry point to the site credential login flow.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Reinstall the app - make sure that you always see the old version of the login flow.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/210347541-48f5980d-95e3-4f8c-b9a7-e3537667723c.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.