### PR TITLE
[IPPInAppFeedback] UI: Payments banner placement

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -45,6 +45,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .systemStatusReportInSupportRequest:
             return true
+        case .IPPInAppFeedbackBanner:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .performanceMonitoring,
                 .performanceMonitoringCoreData,
                 .performanceMonitoringFileIO,

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -99,6 +99,10 @@ public enum FeatureFlag: Int {
     ///
     case systemStatusReportInSupportRequest
 
+    /// IPP in-app feedback banner
+    ///
+    case IPPInAppFeedbackBanner
+
     // MARK: - Performance Monitoring
     //
     // These flags are not transient. That is, they are not here to help us rollout a feature,

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -155,8 +155,11 @@ extension WooConstants {
         ///
 #if DEBUG
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-test-survey"
+        case IPPinAppFeedback = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
 #else
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
+        // TODO: Create the production survey
+        case IPPinAppFeedback = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
 #endif
 
         /// URL for the products feedback survey

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -155,11 +155,11 @@ extension WooConstants {
         ///
 #if DEBUG
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-test-survey"
-        case IPPinAppFeedback = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
+        case IPPFeedback = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
 #else
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
         // TODO: Create the production survey
-        case IPPinAppFeedback = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
+        case IPPFeedback = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
 #endif
 
         /// URL for the products feedback survey

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -154,10 +154,10 @@ extension WooConstants {
         /// URL for in-app feedback survey
         ///
 #if DEBUG
-        case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-test-survey"
+        case generalFeedback = "https://automattic.survey.fm/woo-app-general-feedback-test-survey"
         case IPPFeedback = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
 #else
-        case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
+        case generalFeedback = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
         // TODO: Create the production survey
         case IPPFeedback = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
 #endif

--- a/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
@@ -30,6 +30,10 @@ class DefaultNoticePresenter: NoticePresenter {
     ///
     private var keyboardFrameObserver: KeyboardFrameObserver?
 
+    /// Notices are dismissed automatically by default, unless set otherwise
+    ///
+    var shouldDismissAutomatically: Bool? = true
+
     /// Enqueues the specified Notice for display.
     ///
     @discardableResult
@@ -171,7 +175,12 @@ private extension DefaultNoticePresenter {
         }
 
         animatePresentation(fromState: offScreenState, toState: onScreenState, completion: {
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Animations.dismissDelay, execute: dismiss)
+            guard let shouldDismissAutomatically = self.shouldDismissAutomatically else {
+                return
+            }
+            if shouldDismissAutomatically {
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Animations.dismissDelay, execute: dismiss)
+            }
         })
     }
 

--- a/WooCommerce/Classes/Tools/Notices/Notice.swift
+++ b/WooCommerce/Classes/Tools/Notices/Notice.swift
@@ -31,10 +31,13 @@ struct Notice {
     ///
     let actionTitle: String?
 
+    /// An optional handler closure that will be called when the notice is tapped
+    ///
+    var noticeTappedHandler: (() -> Void)?
+
     /// An optional handler closure that will be called when the action button is tapped, if you've provided an action title
     ///
     let actionHandler: (() -> Void)?
-
 
     /// Designated Initializer
     ///
@@ -44,6 +47,7 @@ struct Notice {
          feedbackType: UINotificationFeedbackGenerator.FeedbackType? = nil,
          notificationInfo: NoticeNotificationInfo? = nil,
          actionTitle: String? = nil,
+         noticeTappedHandler: ((() -> Void))? = nil,
          actionHandler: ((() -> Void))? = nil) {
         self.title = title
         self.subtitle = subtitle
@@ -51,6 +55,7 @@ struct Notice {
         self.feedbackType = feedbackType
         self.notificationInfo = notificationInfo
         self.actionTitle = actionTitle
+        self.noticeTappedHandler = noticeTappedHandler
         self.actionHandler = actionHandler
     }
 }

--- a/WooCommerce/Classes/Tools/Notices/NoticeView.swift
+++ b/WooCommerce/Classes/Tools/Notices/NoticeView.swift
@@ -167,6 +167,8 @@ private extension NoticeView {
         if let subtitle = notice.subtitle {
             subtitleLabel.isHidden = false
             subtitleLabel.text = subtitle
+            // TODO: Remove color, just for testing:
+            subtitleLabel.textColor = .red
         } else {
             subtitleLabel.isHidden = true
         }
@@ -193,6 +195,7 @@ private extension NoticeView {
 private extension NoticeView {
 
     @objc private func viewTapped() {
+        notice.noticeTappedHandler?()
         dismissHandler?()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -356,7 +356,7 @@ private extension InPersonPaymentsMenuViewController {
 
     private func displayFeedbackSurvey() {
         // TODO: Different surveys will be shown:
-        let surveyNavigation = SurveyCoordinatingController(survey: .IPPinAppFeedback)
+        let surveyNavigation = SurveyCoordinatingController(survey: .IPPFeedback)
         self.present(surveyNavigation, animated: true, completion: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -379,7 +379,7 @@ private extension InPersonPaymentsMenuViewController {
         // Configures header container view:
         // TODO: Find the correct width and height
         let width = Int(tableView.frame.width)
-        let height = 150
+        let height = 100
         let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: width, height: height))
 
         headerContainer.addSubview(topBannerView)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -357,7 +357,9 @@ private extension InPersonPaymentsMenuViewController {
             icon: .speakerIcon.withRenderingMode(.alwaysTemplate),
             iconTintColor: .wooCommercePurple(.shade50),
             isExpanded: false,
-            topButton: .chevron(handler: {}),
+            topButton: .chevron(handler: {
+                self.tableView.updateHeaderHeight()
+            }),
             actionButtons: [giveFeedbackAction, dismissFeedbackAction]
         )
         let topBannerView = TopBannerView(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -389,7 +389,7 @@ private extension InPersonPaymentsMenuViewController {
 
     private func displayFeedbackBannerSurvey() {
         // TODO: Different surveys will be shown:
-        let surveyNavigation = SurveyCoordinatingController(survey: .inAppFeedback)
+        let surveyNavigation = SurveyCoordinatingController(survey: .IPPinAppFeedback)
         self.present(surveyNavigation, animated: true, completion: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -339,16 +339,19 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     private func createIPPFeedbackNoticeBanner() {
-        // TODO: Problem - Disappears after x seconds by default
-        // TODO: Style is different than design requirements
         let notice = Notice(
             title: Localization.feedbackNoticeBannerTitle,
-            actionTitle: Localization.shareFeedbackNoticeBannerButton,
-            actionHandler: {
-                print("Button tapped")
+            subtitle: Localization.shareFeedbackNoticeBannerButton,
+            actionTitle: "x", // Experimenting with dismiss.
+            noticeTappedHandler: {
+                print("Notice tapped")
                 self.displayFeedbackSurvey()
+            },
+            actionHandler: {
+                print("Dismiss tapped")
             }
         )
+
         let noticePresenter = DefaultNoticePresenter()
         noticePresenter.presentingViewController = self
         noticePresenter.shouldDismissAutomatically = false

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -351,6 +351,7 @@ private extension InPersonPaymentsMenuViewController {
         )
         let noticePresenter = DefaultNoticePresenter()
         noticePresenter.presentingViewController = self
+        noticePresenter.shouldDismissAutomatically = false
         noticePresenter.enqueue(notice: notice)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -346,11 +346,18 @@ private extension InPersonPaymentsMenuViewController {
             actionTitle: Localization.shareFeedbackNoticeBannerButton,
             actionHandler: {
                 print("Button tapped")
+                self.displayFeedbackSurvey()
             }
         )
         let noticePresenter = DefaultNoticePresenter()
         noticePresenter.presentingViewController = self
         noticePresenter.enqueue(notice: notice)
+    }
+
+    private func displayFeedbackSurvey() {
+        // TODO: Different surveys will be shown:
+        let surveyNavigation = SurveyCoordinatingController(survey: .IPPinAppFeedback)
+        self.present(surveyNavigation, animated: true, completion: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -49,6 +49,8 @@ final class InPersonPaymentsMenuViewController: UIViewController {
 
     private var activityIndicator: UIActivityIndicatorView?
 
+    private var topBannerView: UIView?
+
     init(stores: StoresManager = ServiceLocator.stores,
         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService
     ) {
@@ -75,6 +77,9 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         configureTableReload()
         runCardPresentPaymentsOnboarding()
         configureWebViewPresentation()
+        if featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
+            configureIPPInAppFeedbackBanner()
+        }
         viewModel.viewDidLoad()
     }
 }
@@ -333,6 +338,41 @@ private extension InPersonPaymentsMenuViewController {
             let connectionController = AuthenticatedWebViewController(viewModel: viewModel)
             self.navigationController?.show(connectionController, sender: nil)
         }.store(in: &cancellables)
+    }
+
+    private func configureIPPInAppFeedbackBanner() {
+        // TODO: Create a new one rather than reusing OrdersTopBannerFactory. Uses TopBannerView.
+        topBannerView = OrdersTopBannerFactory.createOrdersBanner(
+            onTopButtonPressed: {
+                print("onTopButtonPressed")
+            },
+            onDismissButtonPressed: {
+                self.hideIPPInAppFeedbackBanner()
+                print("onDismissButtonPressed")
+            },
+            onGiveFeedbackButtonPressed: {
+                // TODO: Open webview with the survey form
+                print("onGiveFeedbackButtonPressed")
+            })
+        showIPPInAppFeedbackBanner()
+    }
+
+    private func showIPPInAppFeedbackBanner() {
+        guard let topBannerView = topBannerView else { return }
+
+        // Configures header container view:
+        // TODO: Find the correct width and height
+        let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        headerContainer.addSubview(topBannerView)
+        headerContainer.pinSubviewToAllEdges(topBannerView)
+
+        tableView.tableHeaderView = headerContainer
+        tableView.updateFooterHeight()
+    }
+
+    private func hideIPPInAppFeedbackBanner() {
+        // TODO: Hide on dismiss
+        print("hideIPPInAppFeedbackBanner called")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -592,19 +592,26 @@ private extension InPersonPaymentsMenuViewController {
             comment: "Call to Action to finish the setup of In-Person Payments in the Menu"
         )
 
-        static let feedbackBannerTitle = NSLocalizedString("How can we improve in-person payments?",
-                                                           comment: "Title of the feedback banner in the Payments tab")
+        static let feedbackBannerTitle = NSLocalizedString(
+            "How can we improve in-person payments?",
+            comment: "Title of the feedback banner in the Payments tab"
+        )
 
-        static let feedbackBannerContent = NSLocalizedString("You enabled an option to collect payments in person." +
-                                                             "Please help us better understand your needs and tell us how we can improve the payments experience.",
-                                                             comment: "Content of the feedback banner in the Payments tab")
+        static let feedbackBannerContent = NSLocalizedString(
+            "You enabled an option to collect payments in person." +
+            "Please help us better understand your needs and tell us how we can improve the payments experience.",
+            comment: "Content of the feedback banner in the Payments tab"
+        )
 
-        static let giveFeedbackButton = NSLocalizedString("Give Feedback",
-                                                                comment: "Title of the feedback action button on the in-app feedback banner")
+        static let giveFeedbackButton = NSLocalizedString(
+            "Give Feedback",
+            comment: "Title of the feedback action button on the in-app feedback banner"
+        )
 
-        static let dismissFeedbackButton = NSLocalizedString("Dismiss",
-                                                                   comment: "Title of the dismiss action button on the in-app feedback banner")
-
+        static let dismissFeedbackButton = NSLocalizedString(
+            "Dismiss",
+            comment: "Title of the dismiss action button on the in-app feedback banner"
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -376,7 +376,7 @@ private extension SettingsViewController {
     }
 
     func presentSurveyForFeedback() {
-        let surveyNavigation = SurveyCoordinatingController(survey: .inAppFeedback)
+        let surveyNavigation = SurveyCoordinatingController(survey: .generalFeedback)
         present(surveyNavigation, animated: true, completion: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -77,7 +77,7 @@ private extension InAppFeedbackCardViewController {
                 return
             }
 
-            let surveyNavigation = SurveyCoordinatingController(survey: .inAppFeedback)
+            let surveyNavigation = SurveyCoordinatingController(survey: .generalFeedback)
             self.present(surveyNavigation, animated: true, completion: nil)
             self.onFeedbackGiven?()
             self.analytics.track(event: .appFeedbackPrompt(action: .didntLike))

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -68,7 +68,7 @@ extension SurveyViewController {
         case addOnsI1
         case orderCreation
         case couponManagement
-        case IPPinAppFeedback
+        case IPPFeedback
 
         fileprivate var url: URL {
             switch self {
@@ -103,8 +103,8 @@ extension SurveyViewController {
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
-            case .IPPinAppFeedback:
-                return WooConstants.URLs.IPPinAppFeedback
+            case .IPPFeedback:
+                return WooConstants.URLs.IPPFeedback
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
@@ -115,7 +115,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return Localization.title
-            case .productsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement, .IPPinAppFeedback:
+            case .productsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement, .IPPFeedback:
                 return Localization.giveFeedback
             }
         }
@@ -123,7 +123,7 @@ extension SurveyViewController {
         /// The corresponding `FeedbackContext` for event tracking purposes.
         var feedbackContextForEvents: WooAnalyticsEvent.FeedbackContext {
             switch self {
-            case .inAppFeedback, .IPPinAppFeedback:
+            case .inAppFeedback, .IPPFeedback:
                 return .general
             case .productsFeedback:
                 return .productsGeneral

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -68,6 +68,7 @@ extension SurveyViewController {
         case addOnsI1
         case orderCreation
         case couponManagement
+        case IPPinAppFeedback
 
         fileprivate var url: URL {
             switch self {
@@ -102,6 +103,11 @@ extension SurveyViewController {
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
+            case .IPPinAppFeedback:
+                return WooConstants.URLs.IPPinAppFeedback
+                    .asURL()
+                    .tagPlatform("ios")
+                    .tagAppVersion(Bundle.main.bundleVersion())
             }
         }
 
@@ -109,7 +115,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return Localization.title
-            case .productsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement:
+            case .productsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement, .IPPinAppFeedback:
                 return Localization.giveFeedback
             }
         }
@@ -117,7 +123,7 @@ extension SurveyViewController {
         /// The corresponding `FeedbackContext` for event tracking purposes.
         var feedbackContextForEvents: WooAnalyticsEvent.FeedbackContext {
             switch self {
-            case .inAppFeedback:
+            case .inAppFeedback, .IPPinAppFeedback:
                 return .general
             case .productsFeedback:
                 return .productsGeneral

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -62,7 +62,7 @@ final class SurveyViewController: UIViewController, SurveyViewControllerOutputs 
 //
 extension SurveyViewController {
     enum Source {
-        case inAppFeedback
+        case generalFeedback
         case productsFeedback
         case shippingLabelsRelease3Feedback
         case addOnsI1
@@ -72,8 +72,8 @@ extension SurveyViewController {
 
         fileprivate var url: URL {
             switch self {
-            case .inAppFeedback:
-                return WooConstants.URLs.inAppFeedback
+            case .generalFeedback:
+                return WooConstants.URLs.generalFeedback
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
@@ -113,7 +113,7 @@ extension SurveyViewController {
 
         fileprivate var title: String {
             switch self {
-            case .inAppFeedback:
+            case .generalFeedback:
                 return Localization.title
             case .productsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement, .IPPFeedback:
                 return Localization.giveFeedback
@@ -123,7 +123,7 @@ extension SurveyViewController {
         /// The corresponding `FeedbackContext` for event tracking purposes.
         var feedbackContextForEvents: WooAnalyticsEvent.FeedbackContext {
             switch self {
-            case .inAppFeedback, .IPPFeedback:
+            case .generalFeedback, .IPPFeedback:
                 return .general
             case .productsFeedback:
                 return .productsGeneral

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyCoordinatorControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyCoordinatorControllerTests.swift
@@ -28,7 +28,7 @@ final class SurveyCoordinatingControllerTests: XCTestCase {
         let factory = MockSurveyViewControllersFactory()
 
         // When
-        let coordinator = SurveyCoordinatingController(survey: .inAppFeedback, viewControllersFactory: factory)
+        let coordinator = SurveyCoordinatingController(survey: .generalFeedback, viewControllersFactory: factory)
 
         // Then
         XCTAssertTrue(coordinator.topViewController is SurveyViewControllerOutputs)
@@ -37,7 +37,7 @@ final class SurveyCoordinatingControllerTests: XCTestCase {
     func test_it_navigates_to_SurveySubmittedViewController_when_survey_is_submitted() throws {
         // Given
         let factory = MockSurveyViewControllersFactory()
-        let coordinator = SurveyCoordinatingController(survey: .inAppFeedback, viewControllersFactory: factory)
+        let coordinator = SurveyCoordinatingController(survey: .generalFeedback, viewControllersFactory: factory)
 
         // When
         factory.surveyViewController.onCompletion()
@@ -51,7 +51,7 @@ final class SurveyCoordinatingControllerTests: XCTestCase {
     func test_it_gets_dismissed_on_backToStore_action() throws {
         // Given
         let factory = MockSurveyViewControllersFactory()
-        let coordinator = SurveyCoordinatingController(survey: .inAppFeedback, viewControllersFactory: factory)
+        let coordinator = SurveyCoordinatingController(survey: .generalFeedback, viewControllersFactory: factory)
 
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()
@@ -72,7 +72,7 @@ final class SurveyCoordinatingControllerTests: XCTestCase {
         // Given
         let zendeskManager = MockZendeskManager()
         let factory = MockSurveyViewControllersFactory()
-        let coordinator = SurveyCoordinatingController(survey: .inAppFeedback, zendeskManager: zendeskManager, viewControllersFactory: factory)
+        let coordinator = SurveyCoordinatingController(survey: .generalFeedback, zendeskManager: zendeskManager, viewControllersFactory: factory)
         assertEmpty(zendeskManager.newRequestIfPossibleInvocations)
 
         // When
@@ -90,7 +90,7 @@ final class SurveyCoordinatingControllerTests: XCTestCase {
     func test_it_tracks_a_surveyScreen_completed_event_when_the_survey_is_submitted() throws {
         // Given
         let factory = MockSurveyViewControllersFactory()
-        _ = SurveyCoordinatingController(survey: .inAppFeedback,
+        _ = SurveyCoordinatingController(survey: .generalFeedback,
                                          viewControllersFactory: factory,
                                          analytics: analytics)
 
@@ -113,7 +113,7 @@ final class SurveyCoordinatingControllerTests: XCTestCase {
         let factory = MockSurveyViewControllersFactory()
 
         // When
-        _ = SurveyCoordinatingController(survey: .inAppFeedback,
+        _ = SurveyCoordinatingController(survey: .generalFeedback,
                                          viewControllersFactory: factory,
                                          analytics: analytics)
 
@@ -138,7 +138,7 @@ final class SurveyCoordinatingControllerTests: XCTestCase {
         window.rootViewController = rootViewController
         window.isHidden = false
 
-        let coordinator = SurveyCoordinatingController(survey: .inAppFeedback,
+        let coordinator = SurveyCoordinatingController(survey: .generalFeedback,
                                                        viewControllersFactory: factory,
                                                        analytics: analytics)
         waitForExpectation { exp in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -11,7 +11,7 @@ final class SurveyViewControllerTests: XCTestCase {
 
     func test_it_loads_the_correct_inApp_feedback_survey() throws {
         // Given
-        let viewController = SurveyViewController(survey: .inAppFeedback, onCompletion: {})
+        let viewController = SurveyViewController(survey: .generalFeedback, onCompletion: {})
 
         // When
         _ = try XCTUnwrap(viewController.view)
@@ -56,7 +56,7 @@ final class SurveyViewControllerTests: XCTestCase {
     func test_it_completes_after_receiving_a_form_submitted_completed_callback_request() throws {
         // Given
         var surveyCompleted = false
-        let viewController = SurveyViewController(survey: .inAppFeedback, onCompletion: {
+        let viewController = SurveyViewController(survey: .generalFeedback, onCompletion: {
             surveyCompleted = true
         })
 
@@ -77,7 +77,7 @@ final class SurveyViewControllerTests: XCTestCase {
     func test_it_does_not_complete_after_receiving_a_form_submitted_non_completed_callback_request() throws {
         // Given
         var surveyCompleted = false
-        let viewController = SurveyViewController(survey: .inAppFeedback, onCompletion: {
+        let viewController = SurveyViewController(survey: .generalFeedback, onCompletion: {
             surveyCompleted = true
         })
 
@@ -100,7 +100,7 @@ final class SurveyViewControllerTests: XCTestCase {
     func test_it_does_not_complete_after_receiving_a_form_submitted_empty_callback_request() throws {
         // Given
         var surveyCompleted = false
-        let viewController = SurveyViewController(survey: .inAppFeedback, onCompletion: {
+        let viewController = SurveyViewController(survey: .generalFeedback, onCompletion: {
             surveyCompleted = true
         })
 
@@ -122,7 +122,7 @@ final class SurveyViewControllerTests: XCTestCase {
 
     func test_it_shows_the_loading_view_when_loading_a_survey() throws {
         // Given
-        let viewController = SurveyViewController(survey: .inAppFeedback, onCompletion: {})
+        let viewController = SurveyViewController(survey: .generalFeedback, onCompletion: {})
 
         // When
         _ = try XCTUnwrap(viewController.view)
@@ -134,7 +134,7 @@ final class SurveyViewControllerTests: XCTestCase {
 
     func test_it_hides_the_loading_view_after_loading_a_survey() throws {
         // Given
-        let viewController = SurveyViewController(survey: .inAppFeedback, onCompletion: {})
+        let viewController = SurveyViewController(survey: .generalFeedback, onCompletion: {})
 
         // When
         _ = try XCTUnwrap(viewController.view)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of https://github.com/woocommerce/woocommerce-ios/issues/8530

## Description

This PR adds the in-app feedback banner in the Payments view, as well as the buttons to launch a survey and dismiss the banner. 

At the moment the survey is only dismissible when tapping on "dismiss" (not upon survey completion), and will show up again each time we navigate to the Payments view.

## TODO:
- [ ] Design has changed. Needs to be re-implemented.
- [ ] Dismissal and show me later/don't show again UI will be added on a different PR. Most probably using `FeatureAnnouncementCardView`

## Changes
- We reuse the existing `Notice` component to create a feedback notice banner in the Payments View.
- Extended Notice to accept a new `noticeTappedHandler` handler noticeTappedHandler, so we can use 2 different behaviours: When the notice is tapped (show survey), and when the action button is tapped (dismiss notice).
- Added a new `IPPFeedback` case to `SurveyViewController` which will launch and manage the Survey launched via the tapping the notice
- Added a temporary testing survey link ( `https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing` ), this will dynamically change in future PRs based on certain conditions.


## Testing instructions
1. Go to Menu > Payments > See the notice on the bottom of the screen
2. Tap the notice, a WebView showing a survey form will shop up. Scroll down and tap "Finish Survey", a "Feedback Sent" view will be shown and you'll be redirected to the Payments page.
3. Navigate to a different View, then navigate to Menu > Payments again. 
4. Tap on "X" and see the banner disappear.

## Screenshots

| Feedback Banner | Give Feedback  | Feedback Sent  | 
|---|---|---|
| <img width=400 src="https://user-images.githubusercontent.com/3812076/211466952-7152a1b2-0caa-4e5e-8ed1-099e98d2d8e7.png"> | <img width=400 src="https://user-images.githubusercontent.com/3812076/210490819-afeb11b2-95f2-4e93-b018-0f4468d971d1.png"> | <img width=400 src="https://user-images.githubusercontent.com/3812076/210490830-4cf628a7-78ef-4e70-b8d5-73cd553a9e69.png"> |