### PR TITLE
Conclude native Jetpack install experiment

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -15,11 +15,6 @@ public enum ABTest: String, CaseIterable {
     /// Experiment ref: pbxNRc-1S0-p2
     case aaTestLoggedOut = "woocommerceios_explat_aa_test_logged_out_202212_v2"
 
-    /// A/B test to measure the sign-in success rate when native Jetpack installation experience is enabled
-    /// Experiment ref: pbxNRc-29W-p2
-    ///
-    case nativeJetpackSetupFlow = "woocommerceios_login_jetpack_setup_flow_v2"
-
     /// Returns a variation for the given experiment
     public var variation: Variation {
         ExPlat.shared?.experiment(rawValue) ?? .control
@@ -30,7 +25,7 @@ public enum ABTest: String, CaseIterable {
     /// When adding a new experiment, add it to the appropriate case depending on its context (logged-in or logged-out experience).
     public var context: ExperimentContext {
         switch self {
-        case .aaTestLoggedIn, .nativeJetpackSetupFlow:
+        case .aaTestLoggedIn:
             return .loggedIn
         case .aaTestLoggedOut:
             return .loggedOut

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Design refresh: Buttons, links, and other calls to action are now purple instead of pink. [https://github.com/woocommerce/woocommerce-ios/pull/8451]
 - [internal] Design: Updated capitalization for various pages, links, and buttons to match new design guidelines. [https://github.com/woocommerce/woocommerce-ios/pull/8455]
+- [internal] Remove A/B testing and release native Jetpack installation flow for all users. [https://github.com/woocommerce/woocommerce-ios/pull/8533]
 
 11.7
 -----

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -70,7 +70,6 @@ class AuthenticationManager: Authentication {
         let isWPComMagicLinkPreferredToPassword = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasis)
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasisM2)
         let isStoreCreationMVPEnabled = featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
-        let isNativeJetpackSetupEnabled = true
         let isWPComLoginRequiredForSiteCredentialsLogin = !featureFlagService.isFeatureFlagEnabled(.applicationPasswordAuthenticationForSiteCredentialLogin)
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
@@ -99,7 +98,7 @@ class AuthenticationManager: Authentication {
                                                                 emphasizeEmailForWPComPassword: true,
                                                                 wpcomPasswordInstructions:
                                                                 AuthenticationConstants.wpcomPasswordInstructions,
-                                                                skipXMLRPCCheckForSiteDiscovery: isNativeJetpackSetupEnabled)
+                                                                skipXMLRPCCheckForSiteDiscovery: true)
 
         let systemGray3LightModeColor = UIColor(red: 199/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1)
         let systemLabelLightModeColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -673,39 +673,6 @@ private extension AuthenticationManager {
         }
     }
 
-    /// The error screen to be displayed when the user enters a site
-    /// without Jetpack in the site discovery flow.
-    /// More about this flow: pe5sF9-mz-p2.
-    ///
-    func jetpackErrorUI(for siteURL: String, with matcher: ULAccountMatcher, in navigationController: UINavigationController) -> UIViewController {
-        let viewModel = JetpackErrorViewModel(siteURL: siteURL,
-                                              siteCredentials: nil,
-                                              onJetpackSetupCompletion: { [weak self] authorizedEmailAddress in
-            guard let self = self else { return }
-
-            // Tries re-syncing to get an updated store list
-            ServiceLocator.stores.synchronizeEntities { [weak self] in
-                guard let self = self else { return }
-                matcher.refreshStoredSites()
-                guard let matchedSite = matcher.matchedSite(originalURL: siteURL) else {
-                    DDLogWarn("⚠️ Could not find \(siteURL) connected to the account")
-                    return
-                }
-                // checks if the site has woo
-                if matchedSite.isWooCommerceActive == false {
-                    let noWooUI = self.noWooUI(for: matchedSite,
-                                               with: matcher,
-                                               navigationController: navigationController,
-                                               onStorePickerDismiss: {})
-                    navigationController.show(noWooUI, sender: nil)
-                } else {
-                    self.startStorePicker(with: matchedSite.siteID, in: navigationController, onDismiss: {})
-                }
-            }
-        })
-        return ULErrorViewController(viewModel: viewModel)
-    }
-
     /// The error screen to be displayed when the user tries to enter a site
     /// whose Jetpack is not associated with their account.
     /// - Parameters:

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -70,7 +70,7 @@ class AuthenticationManager: Authentication {
         let isWPComMagicLinkPreferredToPassword = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasis)
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasisM2)
         let isStoreCreationMVPEnabled = featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
-        let isNativeJetpackSetupEnabled = ABTest.nativeJetpackSetupFlow.variation != .control
+        let isNativeJetpackSetupEnabled = true
         let isWPComLoginRequiredForSiteCredentialsLogin = !featureFlagService.isFeatureFlagEnabled(.applicationPasswordAuthenticationForSiteCredentialLogin)
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -786,18 +786,9 @@ private extension AuthenticationManager {
         }
 
         // Shows the native Jetpack flow during the site discovery flow.
-        if ABTest.nativeJetpackSetupFlow.variation != .control {
-            return jetpackSetupUI(for: site.url,
-                                  connectionMissingOnly: site.hasJetpack && site.isJetpackActive,
-                                  in: navigationController)
-        }
-
-        /// Jetpack is required. Present an error if we don't detect a valid installation.
-        guard site.hasJetpack && site.isJetpackActive else {
-            return jetpackErrorUI(for: site.url, with: matcher, in: navigationController)
-        }
-
-        return accountMismatchUI(for: site.url, siteCredentials: nil, with: matcher, in: navigationController)
+        return jetpackSetupUI(for: site.url,
+                              connectionMissingOnly: site.hasJetpack && site.isJetpackActive,
+                              in: navigationController)
     }
 
     /// The error screen to be displayed when the user tries to log in with site credentials


### PR DESCRIPTION
Part of: #8514
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR removes the A/B testing experiment code and enables the native Jetpack installation process for all users. 

Changes
- Remove A/B test case `nativeJetpackSetupFlow`
- Enable native Jetpack setup flow for all users.

### Testing instructions
- Log out of the app or skip login onboarding if needed.
- On the prologue screen, select "Log In" or "Continue with WordPress.com" based on the A/B test variant you get.
- Log in with your WordPress.com account.
- If your account doesn't have any associated site, notice that the empty store picker is displayed with the matching design as on Figma.
- Select Add a Store > Connect an existing site.
- Enter the address of your test store and tap Continue.
- You should see a Jetpack error screen from where you can Install Jetpack or Connect Jetpack natively.

### Screenshots
<img src="https://user-images.githubusercontent.com/524475/210358629-978909ac-3796-429b-9a78-1ef0597255c3.png" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.