### PR TITLE
Reset Auto Layout constraint that pins to a view that is being removed to fix a crash

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -543,6 +543,12 @@ private extension DashboardViewController {
             return
         }
 
+        // Resets the Auto Layout constraint that pins the previous content view to the bottom of the header view.
+        // Otherwise, if `contentTopToHeaderConstraint?.isActive = true` is called after the previous content view is removed
+        // in the next line `remove(previousDashboardUI)`, the app crashes because the content view is no longer in the
+        // view hierarchy.
+        contentTopToHeaderConstraint = nil
+
         // Tears down the previous child view controller.
         if let previousDashboardUI = dashboardUI {
             remove(previousDashboardUI)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8539 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Note: I'm tagging reviewers based on the author/reviewer of the [related changes](https://github.com/woocommerce/woocommerce-ios/pull/8293) while the author isn't on the team anymore.

### The crash

This PR aims to fix a [recent crash](https://sentry.io/organizations/a8c/issues/3840558984/?project=1458804&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d) in release 11.6 that I got to reproduce. The crash happens when the dashboard is showing the Add Product header, then the header is hidden like in landscape mode (the navigation bar is collapsed). Then, the dashboard content view gets replaced (e.g. when analytics is re-enabled) while the Auto Layout constraint that connects the header and the previous content view is being activated separately (`DashboardViewController.observeNavigationBarHeightForHeaderVisibility`).

### The fix

To prevent the Auto Layout constraint from being activated when it includes a view that is being removed from the view hierarchy, the constraint is reset to `nil` before the content view is removed next. The constraint will be re-established in `onDashboardUIUpdate`'s call to `addViewBelowHeaderStackView` for the new content view.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the Add Product banner is shown for the store
- Launch the app and log in to a store where the Add Product banner is shown --> the banner should be shown on the My store tab
- On web, go to the store's `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` to disable analytics (uncheck `Enables WooCommerce Analytics`)
- In the app, pull to refresh the My store tab
- Rotate the screen to landscape mode and back to portrait mode --> the Add Product banner is not shown anymore
- On web, go to the store's `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` to re-enable analytics (chcek `Enables WooCommerce Analytics`)
- In the app, pull to refresh the My store tab --> the app should not crash, and the Add Product banner is shown again above the analytics



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
