### PR TITLE
REST API: Show alert for inaccessible login or admin URL

### DIFF
--- a/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -7,6 +7,7 @@ public enum ApplicationPasswordUseCaseError: Error {
     case duplicateName
     case applicationPasswordsDisabled
     case failedToConstructLoginOrAdminURLUsingSiteAddress
+    case unauthorizedRequest
 }
 
 public struct ApplicationPassword {
@@ -160,6 +161,8 @@ private extension DefaultApplicationPasswordUseCase {
                         continuation.resume(throwing: ApplicationPasswordUseCaseError.applicationPasswordsDisabled)
                     case .responseValidationFailed(reason: .unacceptableStatusCode(code: ErrorCode.duplicateNameErrorCode)):
                         continuation.resume(throwing: ApplicationPasswordUseCaseError.duplicateName)
+                    case .responseValidationFailed(reason: .unacceptableStatusCode(code: ErrorCode.unauthorized)):
+                        continuation.resume(throwing: ApplicationPasswordUseCaseError.unauthorizedRequest)
                     default:
                         continuation.resume(throwing: error)
                     }
@@ -206,6 +209,7 @@ private extension DefaultApplicationPasswordUseCase {
         static let notFound = 404
         static let applicationPasswordsDisabledErrorCode = 501
         static let duplicateNameErrorCode = 409
+        static let unauthorized = 401
     }
 
     enum Constants {

--- a/Networking/NetworkingTests/ApplicationPassword/DefaultApplicationPasswordUseCaseTests.swift
+++ b/Networking/NetworkingTests/ApplicationPassword/DefaultApplicationPasswordUseCaseTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import Networking
-
+import Alamofire
 
 /// DefaultApplicationPasswordUseCase Unit Tests
 ///
@@ -42,5 +42,51 @@ final class DefaultApplicationPasswordUseCaseTests: XCTestCase {
         // Then
         XCTAssertEqual(password.password.secretValue, "passwordvalue")
         XCTAssertEqual(password.wpOrgUsername, username)
+    }
+
+    func test_applicationPasswordsDisabled_error_is_thrown_if_generating_password_fails_with_501_error() async throws {
+        // Given
+        let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 501))
+        network.simulateError(requestUrlSuffix: URLSuffix.generateApplicationPassword, error: error)
+        let username = "demo"
+        let siteAddress = "https://test.com"
+        let sut = try DefaultApplicationPasswordUseCase(username: username,
+                                                        password: "qeWOhQ5RUV8W",
+                                                        siteAddress: siteAddress,
+                                                        network: network)
+
+        // When
+        var failure: ApplicationPasswordUseCaseError?
+        do {
+            let _ = try await sut.generateNewPassword()
+        } catch {
+            failure = error as? ApplicationPasswordUseCaseError
+        }
+
+        // Then
+        XCTAssertTrue(failure == .applicationPasswordsDisabled)
+    }
+
+    func test_unauthorizedRequest_error_is_thrown_if_generating_password_fails_with_401_error() async throws {
+        // Given
+        let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 401))
+        network.simulateError(requestUrlSuffix: URLSuffix.generateApplicationPassword, error: error)
+        let username = "demo"
+        let siteAddress = "https://test.com"
+        let sut = try DefaultApplicationPasswordUseCase(username: username,
+                                                        password: "qeWOhQ5RUV8W",
+                                                        siteAddress: siteAddress,
+                                                        network: network)
+
+        // When
+        var failure: ApplicationPasswordUseCaseError?
+        do {
+            let _ = try await sut.generateNewPassword()
+        } catch {
+            failure = error as? ApplicationPasswordUseCaseError
+        }
+
+        // Then
+        XCTAssertTrue(failure == .unauthorizedRequest)
     }
 }

--- a/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
+++ b/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
@@ -198,7 +198,7 @@ private extension PostSiteCredentialLoginChecker {
             comment: "Error message displayed when the WooCommerce plugin detail cannot be fetched after authentication"
         )
         static let invalidLoginOrAdminURL = NSLocalizedString(
-            "Application password cannot be generated due to custom login or admin URL on your site.",
+            "Application password cannot be generated due to a custom login or admin URL on your site.",
             comment: "Message to display when the constructed admin or login URL for the logged-in site is not accessible"
         )
         static let contactSupport = NSLocalizedString("Contact Support", comment: "Button to contact support for login")

--- a/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
+++ b/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
@@ -52,6 +52,10 @@ private extension PostSiteCredentialLoginChecker {
                     let errorUI = applicationPasswordDisabledUI(for: siteURL)
                     navigationController.show(errorUI, sender: nil)
                 }
+            } catch ApplicationPasswordUseCaseError.unauthorizedRequest {
+                await MainActor.run {
+                    self.showAlert(message: Localization.invalidLoginOrAdminURL, in: navigationController)
+                }
             } catch {
                 // show generic error
                 await MainActor.run {
@@ -150,6 +154,13 @@ private extension PostSiteCredentialLoginChecker {
                 onRetry()
             }
             alert.addAction(retryAction)
+        } else {
+            let supportAction = UIAlertAction(title: Localization.contactSupport, style: .default) { [weak self] _ in
+                navigationController.popViewController(animated: true)
+                self?.stores.deauthenticate()
+                ServiceLocator.authenticationManager.presentSupport(from: navigationController, sourceTag: .loginSiteAddress)
+            }
+            alert.addAction(supportAction)
         }
         let restartAction = UIAlertAction(title: Localization.restartLoginButton, style: .cancel) { [weak self] _ in
             self?.stores.deauthenticate()
@@ -186,6 +197,11 @@ private extension PostSiteCredentialLoginChecker {
             "Error checking for the WooCommerce plugin.",
             comment: "Error message displayed when the WooCommerce plugin detail cannot be fetched after authentication"
         )
+        static let invalidLoginOrAdminURL = NSLocalizedString(
+            "Application password cannot be generated due to custom login or admin URL on your site.",
+            comment: "Message to display when the constructed admin or login URL for the logged-in site is not accessible"
+        )
+        static let contactSupport = NSLocalizedString("Contact Support", comment: "Button to contact support for login")
         static let retryButton = NSLocalizedString("Try Again", comment: "Button to refetch application password for the current site")
         static let restartLoginButton = NSLocalizedString("Log In With Another Account", comment: "Button to restart the login flow.")
     }

--- a/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
+++ b/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
@@ -155,9 +155,8 @@ private extension PostSiteCredentialLoginChecker {
             }
             alert.addAction(retryAction)
         } else {
-            let supportAction = UIAlertAction(title: Localization.contactSupport, style: .default) { [weak self] _ in
+            let supportAction = UIAlertAction(title: Localization.contactSupport, style: .default) { _ in
                 navigationController.popViewController(animated: true)
-                self?.stores.deauthenticate()
                 ServiceLocator.authenticationManager.presentSupport(from: navigationController, sourceTag: .loginSiteAddress)
             }
             alert.addAction(supportAction)

--- a/WooCommerce/WooCommerceTests/Authentication/PostSiteCredentialLoginCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/PostSiteCredentialLoginCheckerTests.swift
@@ -183,7 +183,6 @@ final class PostSiteCredentialLoginCheckerTests: XCTestCase {
         stores.whenReceivingAction(ofType: WordPressSiteAction.self) { action in
             switch action {
             case .fetchSiteInfo(_, let completion):
-                let site = Site.fake().copy(isWooCommerceActive: false)
                 completion(.failure(NetworkError.timeout))
             }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8453 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the `DefaultApplicationPasswordUseCase` to check for the unauthorized error when generating application passwords (error code 401). This error can occur if the login or admin URL is not accessible, so we can listen to this error and show an alert about it on the UI.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Update your site login URL by installing the [Change wp-admin login URL](https://wordpress.org/plugins/change-wp-admin-login/) plugin and following its instructions.
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app if needed.
- On the prologue screen, select "Enter your site address".
- Enter your test store address and select "Sign in with site credentials".
- Enter the correct credentials for a user account with an eligible role and select "Continue". 
- Notice that an alert will then be displayed mentioning a custom login or admin URL causing application password generation to fail.
- Select the Contact Support button, you should be navigated back to the site address login screen and the support flow should start.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/210493732-282c82cf-47e6-4f6a-bd8d-fb76c307ff4c.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
