### PR TITLE
Store creation: add support CTA to applicable screens

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryButton.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryButton.swift
@@ -30,9 +30,13 @@ struct StoreCreationCountryButton_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
             StoreCreationCountryButton(countryCode: .US,
-                                       viewModel: .init(storeName: "", onContinue: { _ in }))
+                                       viewModel: .init(storeName: "",
+                                                        onContinue: { _ in },
+                                                        onSupport: {}))
             StoreCreationCountryButton(countryCode: .UM,
-                                       viewModel: .init(storeName: "", onContinue: { _ in }))
+                                       viewModel: .init(storeName: "",
+                                                        onContinue: { _ in },
+                                                        onSupport: {}))
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
@@ -58,7 +58,8 @@ struct StoreCreationCountryQuestionView_Previews: PreviewProvider {
         NavigationView {
             StoreCreationCountryQuestionView(viewModel: .init(storeName: "only in 2023",
                                                               currentLocale: Locale.init(identifier: "en_US"),
-                                                              onContinue: { _ in }))
+                                                              onContinue: { _ in },
+                                                              onSupport: {}))
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionViewModel.swift
@@ -26,12 +26,15 @@ final class StoreCreationCountryQuestionViewModel: StoreCreationProfilerQuestion
     @Published private var isContinueButtonEnabledValue: Bool = false
 
     private let onContinue: (CountryCode) -> Void
+    private let onSupport: () -> Void
 
     init(storeName: String,
          currentLocale: Locale = .current,
-         onContinue: @escaping (CountryCode) -> Void) {
+         onContinue: @escaping (CountryCode) -> Void,
+         onSupport: @escaping () -> Void) {
         self.topHeader = storeName
         self.onContinue = onContinue
+        self.onSupport = onSupport
 
         currentCountryCode = currentLocale.regionCode.map { CountryCode(rawValue: $0) } ?? nil
         selectedCountryCode = currentCountryCode
@@ -64,6 +67,10 @@ extension StoreCreationCountryQuestionViewModel: RequiredStoreCreationProfilerQu
             return
         }
         onContinue(selectedCountryCode)
+    }
+
+    func supportButtonTapped() {
+        onSupport()
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountrySectionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountrySectionView.swift
@@ -28,6 +28,6 @@ struct StoreCreationCountrySectionView: View {
 
 struct StoreCreationCountrySectionView_Previews: PreviewProvider {
     static var previews: some View {
-        StoreCreationCountrySectionView(header: "EXAMPLES", countryCodes: [.FJ, .UM, .US], viewModel: .init(storeName: "", onContinue: { _ in }))
+        StoreCreationCountrySectionView(header: "EXAMPLES", countryCodes: [.FJ, .UM, .US], viewModel: .init(storeName: "", onContinue: { _ in }, onSupport: {}))
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/RequiredStoreCreationProfilerQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/RequiredStoreCreationProfilerQuestionView.swift
@@ -51,14 +51,9 @@ struct RequiredStoreCreationProfilerQuestionView<QuestionContent: View>: View {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
+                SupportButton{
                     viewModel.supportButtonTapped()
-                } label: {
-                    Image(uiImage: .helpOutlineImage)
-                        .renderingMode(.template)
-                        .linkStyle()
                 }
-                .accessibilityLabel(Localization.supportButtonAccessibilityLabel)
             }
         }
         // Disables large title to avoid a large gap below the navigation bar.
@@ -76,10 +71,6 @@ private enum Layout {
 
 private enum Localization {
     static let continueButtonTitle = NSLocalizedString("Continue", comment: "Title of the button to continue with a profiler question.")
-    static let supportButtonAccessibilityLabel = NSLocalizedString(
-        "Help & Support",
-        comment: "Accessibility label for the Help & Support image navigation bar button in the store creation flow."
-    )
 }
 
 #if DEBUG

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/RequiredStoreCreationProfilerQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/RequiredStoreCreationProfilerQuestionView.swift
@@ -51,7 +51,7 @@ struct RequiredStoreCreationProfilerQuestionView<QuestionContent: View>: View {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                SupportButton{
+                SupportButton {
                     viewModel.supportButtonTapped()
                 }
             }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/RequiredStoreCreationProfilerQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/RequiredStoreCreationProfilerQuestionView.swift
@@ -7,6 +7,9 @@ protocol RequiredStoreCreationProfilerQuestionViewModel {
     /// Called when the continue button is tapped.
     func continueButtonTapped() async
 
+    /// Called when the Help & Support button is tapped.
+    func supportButtonTapped()
+
     /// Whether the continue button is enabled for the user to continue.
     var isContinueButtonEnabled: AnyPublisher<Bool, Never> { get }
 }
@@ -46,6 +49,18 @@ struct RequiredStoreCreationProfilerQuestionView<QuestionContent: View>: View {
             }
             .background(Color(.systemBackground))
         }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    viewModel.supportButtonTapped()
+                } label: {
+                    Image(uiImage: .helpOutlineImage)
+                        .renderingMode(.template)
+                        .linkStyle()
+                }
+                .accessibilityLabel(Localization.supportButtonAccessibilityLabel)
+            }
+        }
         // Disables large title to avoid a large gap below the navigation bar.
         .navigationBarTitleDisplayMode(.inline)
         .onReceive(viewModel.isContinueButtonEnabled) { isContinueButtonEnabled in
@@ -61,6 +76,10 @@ private enum Layout {
 
 private enum Localization {
     static let continueButtonTitle = NSLocalizedString("Continue", comment: "Title of the button to continue with a profiler question.")
+    static let supportButtonAccessibilityLabel = NSLocalizedString(
+        "Help & Support",
+        comment: "Accessibility label for the Help & Support image navigation bar button in the store creation flow."
+    )
 }
 
 #if DEBUG
@@ -75,6 +94,7 @@ private final class StoreCreationQuestionPreviewViewModel: StoreCreationProfiler
         $isContinueButtonEnabledValue.eraseToAnyPublisher()
     }
     func continueButtonTapped() async {}
+    func supportButtonTapped() {}
 }
 
 struct RequiredStoreCreationProfilerQuestionView_Previews: PreviewProvider {

--- a/WooCommerce/Classes/Authentication/Store Creation/Store name/StoreNameForm.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Store name/StoreNameForm.swift
@@ -83,14 +83,9 @@ struct StoreNameForm: View {
                 .buttonStyle(TextButtonStyle())
             }
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
+                SupportButton {
                     onSupport()
-                } label: {
-                    Image(uiImage: .helpOutlineImage)
-                        .renderingMode(.template)
-                        .linkStyle()
                 }
-                .accessibilityLabel(Localization.supportButtonAccessibilityLabel)
             }
         }
         // Disables large title to avoid a large gap below the navigation bar.
@@ -140,10 +135,6 @@ private extension StoreNameForm {
         static let cancelButtonTitle = NSLocalizedString(
             "Cancel",
             comment: "Navigation bar button on the store name form to leave the store creation flow."
-        )
-        static let supportButtonAccessibilityLabel = NSLocalizedString(
-            "Help & Support",
-            comment: "Accessibility label for the Help & Support image navigation bar button in the store creation flow."
         )
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/Store name/StoreNameForm.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Store name/StoreNameForm.swift
@@ -2,18 +2,12 @@ import SwiftUI
 
 /// Hosting controller that wraps the `StoreNameForm`.
 final class StoreNameFormHostingController: UIHostingController<StoreNameForm> {
-    private let onContinue: (String) -> Void
-    private let onClose: () -> Void
-
     init(onContinue: @escaping (String) -> Void,
-         onClose: @escaping () -> Void) {
-        self.onContinue = onContinue
-        self.onClose = onClose
-        super.init(rootView: StoreNameForm())
-
-        rootView.onContinue = { [weak self] storeName in
-            self?.onContinue(storeName)
-        }
+         onClose: @escaping () -> Void,
+         onSupport: @escaping () -> Void) {
+        super.init(rootView: StoreNameForm(onContinue: onContinue,
+                                           onClose: onClose,
+                                           onSupport: onSupport))
     }
 
     @available(*, unavailable)
@@ -24,38 +18,15 @@ final class StoreNameFormHostingController: UIHostingController<StoreNameForm> {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        configureNavigationBarAppearance()
-    }
-
-    /// Shows a transparent navigation bar without a bottom border and with a close button to dismiss.
-    func configureNavigationBarAppearance() {
-        addCloseNavigationBarButton(title: Localization.cancelButtonTitle,
-                                    target: self,
-                                    action: #selector(closeButtonTapped))
-        let appearance = UINavigationBarAppearance()
-        appearance.configureWithTransparentBackground()
-        appearance.backgroundColor = .systemBackground
-
-        navigationItem.standardAppearance = appearance
-        navigationItem.scrollEdgeAppearance = appearance
-        navigationItem.compactAppearance = appearance
-    }
-
-    @objc private func closeButtonTapped() {
-        onClose()
-    }
-}
-
-private extension StoreNameFormHostingController {
-    enum Localization {
-        static let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Navigation bar button on the store name form to leave the store creation flow.")
+        configureTransparentNavigationBar()
     }
 }
 
 /// Allows the user to enter a store name during the store creation flow.
 struct StoreNameForm: View {
-    /// Set in the hosting controller.
-    var onContinue: (String) -> Void = { _ in }
+    let onContinue: (String) -> Void
+    let onClose: () -> Void
+    let onSupport: () -> Void
 
     @State private var name: String = ""
 
@@ -104,6 +75,24 @@ struct StoreNameForm: View {
             .buttonStyle(PrimaryButtonStyle())
             .disabled(name.isEmpty)
         }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(Localization.cancelButtonTitle) {
+                    onClose()
+                }
+                .buttonStyle(TextButtonStyle())
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    onSupport()
+                } label: {
+                    Image(uiImage: .helpOutlineImage)
+                        .renderingMode(.template)
+                        .linkStyle()
+                }
+                .accessibilityLabel(Localization.supportButtonAccessibilityLabel)
+            }
+        }
         // Disables large title to avoid a large gap below the navigation bar.
         .navigationBarTitleDisplayMode(.inline)
         // Hides the back button and shows a close button in the hosting controller instead.
@@ -148,11 +137,23 @@ private extension StoreNameForm {
             "Continue",
             comment: "Title of the button on the store creation store name form to continue."
         )
+        static let cancelButtonTitle = NSLocalizedString(
+            "Cancel",
+            comment: "Navigation bar button on the store name form to leave the store creation flow."
+        )
+        static let supportButtonAccessibilityLabel = NSLocalizedString(
+            "Help & Support",
+            comment: "Accessibility label for the Help & Support image navigation bar button in the store creation flow."
+        )
     }
 }
 
 struct StoreNameForm_Previews: PreviewProvider {
     static var previews: some View {
-        StoreNameForm()
+        NavigationView {
+            StoreNameForm(onContinue: { _ in },
+                          onClose: {},
+                          onSupport: {})
+        }
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -383,6 +383,8 @@ private extension StoreCreationCoordinator {
                                                             countryCode: countryCode,
                                                             domain: domain,
                                                             planToPurchase: planToPurchase)
+        }, onSupport: { [weak self] in
+            self?.showSupport(from: navigationController)
         })
         navigationController.pushViewController(domainSelector, animated: true)
         analytics.track(event: .StoreCreation.siteCreationStep(step: .domainPicker))

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -355,13 +355,15 @@ private extension StoreCreationCoordinator {
                                   planToPurchase: WPComPlanProduct) {
         let questionController = StoreCreationCountryQuestionHostingController(viewModel:
                 .init(storeName: storeName) { [weak self] countryCode in
-            guard let self else { return }
-            self.showDomainSelector(from: navigationController,
-                                    storeName: storeName,
-                                    categoryName: categoryName,
-                                    countryCode: countryCode,
-                                    planToPurchase: planToPurchase)
-        })
+                    guard let self else { return }
+                    self.showDomainSelector(from: navigationController,
+                                            storeName: storeName,
+                                            categoryName: categoryName,
+                                            countryCode: countryCode,
+                                            planToPurchase: planToPurchase)
+                } onSupport: { [weak self] in
+                    self?.showSupport(from: navigationController)
+                })
         navigationController.pushViewController(questionController, animated: true)
         // TODO: analytics
     }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -148,6 +148,8 @@ private extension StoreCreationCoordinator {
             }
         } onClose: { [weak self] in
             self?.showDiscardChangesAlert(flow: .native)
+        } onSupport: { [weak self] in
+            self?.showSupport(from: navigationController)
         }
         navigationController.pushViewController(storeNameForm, animated: true)
         analytics.track(event: .StoreCreation.siteCreationStep(step: .storeName))
@@ -296,6 +298,10 @@ private extension StoreCreationCoordinator {
 
         // Presents the alert with the presented webview.
         navigationController.presentedViewController?.present(alert, animated: true)
+    }
+
+    func showSupport(from navigationController: UINavigationController) {
+        ZendeskProvider.shared.showNewRequestIfPossible(from: navigationController, with: "origin:store-creation")
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -436,6 +436,8 @@ private extension StoreCreationCoordinator {
                                planToPurchase: planToPurchase,
                                siteID: result.siteID,
                                siteSlug: result.siteSlug)
+        } onSupport: { [weak self] in
+            self?.showSupport(from: navigationController)
         }
         navigationController.pushViewController(storeSummary, animated: true)
         analytics.track(event: .StoreCreation.siteCreationStep(step: .storeSummary))

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationSummaryView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationSummaryView.swift
@@ -2,16 +2,12 @@ import SwiftUI
 
 /// Hosting controller that wraps the `StoreCreationSummaryView`.
 final class StoreCreationSummaryHostingController: UIHostingController<StoreCreationSummaryView> {
-    private let onContinueToPayment: () -> Void
-
     init(viewModel: StoreCreationSummaryViewModel,
-         onContinueToPayment: @escaping () -> Void) {
-        self.onContinueToPayment = onContinueToPayment
-        super.init(rootView: StoreCreationSummaryView(viewModel: viewModel))
-
-        rootView.onContinueToPayment = { [weak self] in
-            self?.onContinueToPayment()
-        }
+         onContinueToPayment: @escaping () -> Void,
+         onSupport: @escaping () -> Void) {
+        super.init(rootView: StoreCreationSummaryView(viewModel: viewModel,
+                                                      onContinueToPayment: onContinueToPayment,
+                                                      onSupport: onSupport))
     }
 
     @available(*, unavailable)
@@ -52,13 +48,17 @@ struct StoreCreationSummaryViewModel {
 
 /// Displays a summary of the store creation flow with the store information (e.g. store name, store slug).
 struct StoreCreationSummaryView: View {
-    /// Set in the hosting controller.
-    var onContinueToPayment: (() -> Void) = {}
+    private let onContinueToPayment: () -> Void
+    private let onSupport: () -> Void
 
     private let viewModel: StoreCreationSummaryViewModel
 
-    init(viewModel: StoreCreationSummaryViewModel) {
+    init(viewModel: StoreCreationSummaryViewModel,
+         onContinueToPayment: @escaping () -> Void,
+         onSupport: @escaping () -> Void) {
         self.viewModel = viewModel
+        self.onContinueToPayment = onContinueToPayment
+        self.onSupport = onSupport
     }
 
     var body: some View {
@@ -126,6 +126,18 @@ struct StoreCreationSummaryView: View {
                 .padding(Layout.defaultButtonPadding)
             }
         }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    onSupport()
+                } label: {
+                    Image(uiImage: .helpOutlineImage)
+                        .renderingMode(.template)
+                        .linkStyle()
+                }
+                .accessibilityLabel(Localization.supportButtonAccessibilityLabel)
+            }
+        }
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.large)
     }
@@ -152,6 +164,10 @@ private extension StoreCreationSummaryView {
             "Continue to Payment",
             comment: "Title of the button on the store creation summary view to continue to payment."
         )
+        static let supportButtonAccessibilityLabel = NSLocalizedString(
+            "Help & Support",
+            comment: "Accessibility label for the Help & Support image navigation bar button in the store creation flow."
+        )
     }
 }
 
@@ -168,12 +184,16 @@ struct StoreCreationSummaryView_Previews: PreviewProvider {
                 .init(storeName: "Fruity shop",
                       storeSlug: "fruityshop.com",
                       categoryName: "Arts and Crafts",
-                      countryCode: .UG))
+                      countryCode: .UG),
+                                 onContinueToPayment: {},
+                                 onSupport: {})
         StoreCreationSummaryView(viewModel:
                 .init(storeName: "Fruity shop",
                       storeSlug: "fruityshop.com",
                       categoryName: "Arts and Crafts",
-                      countryCode: nil))
+                      countryCode: nil),
+                                 onContinueToPayment: {},
+                                 onSupport: {})
         .preferredColorScheme(.dark)
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationSummaryView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationSummaryView.swift
@@ -128,14 +128,9 @@ struct StoreCreationSummaryView: View {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
+                SupportButton {
                     onSupport()
-                } label: {
-                    Image(uiImage: .helpOutlineImage)
-                        .renderingMode(.template)
-                        .linkStyle()
                 }
-                .accessibilityLabel(Localization.supportButtonAccessibilityLabel)
             }
         }
         .navigationTitle(Localization.title)
@@ -163,10 +158,6 @@ private extension StoreCreationSummaryView {
         static let continueButtonTitle = NSLocalizedString(
             "Continue to Payment",
             comment: "Title of the button on the store creation summary view to continue to payment."
-        )
-        static let supportButtonAccessibilityLabel = NSLocalizedString(
-            "Help & Support",
-            comment: "Accessibility label for the Help & Support image navigation bar button in the store creation flow."
         )
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/SupportButton.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/SupportButton.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// A support button with a help icon that is currently shown in the navigation bar.
+struct SupportButton: View {
+    let onTapped: () -> Void
+
+    var body: some View {
+        Button {
+            onTapped()
+        } label: {
+            Image(uiImage: .helpOutlineImage)
+                .renderingMode(.template)
+                .linkStyle()
+        }
+        .accessibilityLabel(Localization.accessibilityLabel)
+    }
+}
+
+private extension SupportButton {
+    enum Localization {
+        static let accessibilityLabel = NSLocalizedString(
+            "Help & Support",
+            comment: "Accessibility label for the Help & Support image navigation bar button in the store creation flow."
+        )
+    }
+}
+
+struct SupportButton_Previews: PreviewProvider {
+    static var previews: some View {
+        SupportButton(onTapped: {})
+    }
+}

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -361,6 +361,12 @@ extension UIImage {
         return UIImage.gridicon(.heartOutline)
     }
 
+    /// Help Outline
+    ///
+    static var helpOutlineImage: UIImage {
+        return UIImage.gridicon(.helpOutline)
+    }
+
     /// House Image
     ///
     static var houseImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorView.swift
@@ -7,14 +7,14 @@ final class DomainSelectorHostingController: UIHostingController<DomainSelectorV
     /// - Parameters:
     ///   - viewModel: View model for the domain selector.
     ///   - onDomainSelection: Called when the user continues with a selected domain name.
+    ///   - onSupport: Called when the user taps to contact support.
     init(viewModel: DomainSelectorViewModel,
-         onDomainSelection: @escaping (String) async -> Void) {
+         onDomainSelection: @escaping (String) async -> Void,
+         onSupport: @escaping () -> Void) {
         self.viewModel = viewModel
-        super.init(rootView: DomainSelectorView(viewModel: viewModel))
-
-        rootView.onDomainSelection = { domain in
-            await onDomainSelection(domain)
-        }
+        super.init(rootView: DomainSelectorView(viewModel: viewModel,
+                                                onDomainSelection: onDomainSelection,
+                                                onSupport: onSupport))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -55,8 +55,8 @@ struct DomainSelectorView: View {
         case results(domains: [String])
     }
 
-    /// Set in the hosting controller.
-    var onDomainSelection: ((String) async -> Void) = { _ in }
+    private let onDomainSelection: (String) async -> Void
+    private let onSupport: () -> Void
 
     /// View model to drive the view.
     @ObservedObject private var viewModel: DomainSelectorViewModel
@@ -70,8 +70,12 @@ struct DomainSelectorView: View {
 
     @FocusState private var textFieldIsFocused: Bool
 
-    init(viewModel: DomainSelectorViewModel) {
+    init(viewModel: DomainSelectorViewModel,
+         onDomainSelection: @escaping (String) async -> Void,
+         onSupport: @escaping () -> Void) {
         self.viewModel = viewModel
+        self.onDomainSelection = onDomainSelection
+        self.onSupport = onSupport
     }
 
     var body: some View {
@@ -177,6 +181,18 @@ struct DomainSelectorView: View {
                 .background(Color(.systemBackground))
             }
         }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    onSupport()
+                } label: {
+                    Image(uiImage: .helpOutlineImage)
+                        .renderingMode(.template)
+                        .linkStyle()
+                }
+                .accessibilityLabel(Localization.supportButtonAccessibilityLabel)
+            }
+        }
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.large)
         .onChange(of: viewModel.isLoadingDomainSuggestions) { isLoadingDomainSuggestions in
@@ -203,6 +219,10 @@ private extension DomainSelectorView {
         static let searchPlaceholder = NSLocalizedString("Type a name for your store", comment: "Placeholder of the search text field on the domain selector.")
         static let suggestionsHeader = NSLocalizedString("SUGGESTIONS", comment: "Header label of the domain suggestions on the domain selector.")
         static let continueButtonTitle = NSLocalizedString("Continue", comment: "Title of the button to continue with a selected domain.")
+        static let supportButtonAccessibilityLabel = NSLocalizedString(
+            "Help & Support",
+            comment: "Accessibility label for the Help & Support image navigation bar button in the store creation flow."
+        )
     }
 }
 
@@ -237,7 +257,9 @@ struct DomainSelectorView_Previews: PreviewProvider {
             // Empty query state.
             DomainSelectorView(viewModel:
                     .init(initialSearchTerm: "",
-                          stores: DomainSelectorViewStores(result: nil)))
+                          stores: DomainSelectorViewStores(result: nil)),
+                               onDomainSelection: { _ in },
+                               onSupport: {})
             // Results state.
             DomainSelectorView(viewModel:
                     .init(initialSearchTerm: "Fruit smoothie",
@@ -248,18 +270,24 @@ struct DomainSelectorView_Previews: PreviewProvider {
                             .init(name: "freesmoothieeee.com", isFree: true),
                             .init(name: "greatfruitsmoothie1.com", isFree: true),
                             .init(name: "tropicalsmoothie.com", isFree: true)
-                          ]))))
+                          ]))),
+                               onDomainSelection: { _ in },
+                               onSupport: {})
             // Error state.
             DomainSelectorView(viewModel:
                     .init(initialSearchTerm: "test",
                           stores: DomainSelectorViewStores(result: .failure(
                             DotcomError.unknown(code: "invalid_query",
                                                 message: "Domain searches must contain a word with the following characters.")
-                          ))))
+                          ))),
+                               onDomainSelection: { _ in },
+                               onSupport: {})
             // Loading state.
             DomainSelectorView(viewModel:
                     .init(initialSearchTerm: "test",
-                          stores: DomainSelectorViewStores(result: nil)))
+                          stores: DomainSelectorViewStores(result: nil)),
+                               onDomainSelection: { _ in },
+                               onSupport: {})
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorView.swift
@@ -183,14 +183,9 @@ struct DomainSelectorView: View {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
+                SupportButton {
                     onSupport()
-                } label: {
-                    Image(uiImage: .helpOutlineImage)
-                        .renderingMode(.template)
-                        .linkStyle()
                 }
-                .accessibilityLabel(Localization.supportButtonAccessibilityLabel)
             }
         }
         .navigationTitle(Localization.title)
@@ -219,10 +214,6 @@ private extension DomainSelectorView {
         static let searchPlaceholder = NSLocalizedString("Type a name for your store", comment: "Placeholder of the search text field on the domain selector.")
         static let suggestionsHeader = NSLocalizedString("SUGGESTIONS", comment: "Header label of the domain suggestions on the domain selector.")
         static let continueButtonTitle = NSLocalizedString("Continue", comment: "Title of the button to continue with a selected domain.")
-        static let supportButtonAccessibilityLabel = NSLocalizedString(
-            "Help & Support",
-            comment: "Accessibility label for the Help & Support image navigation bar button in the store creation flow."
-        )
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -413,6 +413,7 @@
 		02CEBB8024C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */; };
 		02CEBB8224C98861002EDF35 /* ProductFormDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */; };
 		02CEBB8424C99A10002EDF35 /* Product+ShippingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */; };
+		02D3B68529657061009BF0BC /* SupportButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D3B68429657061009BF0BC /* SupportButton.swift */; };
 		02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */; };
 		02DAE7FC291B7B8B009342B7 /* DomainSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DAE7FB291B7B8B009342B7 /* DomainSelectorViewModel.swift */; };
 		02DAE7FF291B8C8A009342B7 /* DomainSelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DAE7FE291B8C8A009342B7 /* DomainSelectorViewModelTests.swift */; };
@@ -2468,6 +2469,7 @@
 		02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryProtocol.swift; sourceTree = "<group>"; };
 		02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormDataModel.swift; sourceTree = "<group>"; };
 		02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ShippingTests.swift"; sourceTree = "<group>"; };
+		02D3B68429657061009BF0BC /* SupportButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportButton.swift; sourceTree = "<group>"; };
 		02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Dot.swift"; sourceTree = "<group>"; };
 		02DAE7FB291B7B8B009342B7 /* DomainSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSelectorViewModel.swift; sourceTree = "<group>"; };
 		02DAE7FE291B8C8A009342B7 /* DomainSelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSelectorViewModelTests.swift; sourceTree = "<group>"; };
@@ -4808,6 +4810,7 @@
 				02E3B63029066858007E0F13 /* StoreCreationCoordinator.swift */,
 				02EAA4C7290F992B00918DAB /* LoggedOutStoreCreationCoordinator.swift */,
 				021940E7291FDBF90090354E /* StoreCreationSummaryView.swift */,
+				02D3B68429657061009BF0BC /* SupportButton.swift */,
 			);
 			path = "Store Creation";
 			sourceTree = "<group>";
@@ -10337,6 +10340,7 @@
 				451A04EC2386D2B300E368C9 /* ProductImagesCollectionViewDataSource.swift in Sources */,
 				02DD81F9242CAA400060E50B /* WordPressMediaLibraryImagePickerViewController.swift in Sources */,
 				D8C2A28823190B2300F503E9 /* StorageProductReview+Woo.swift in Sources */,
+				02D3B68529657061009BF0BC /* SupportButton.swift in Sources */,
 				2664210126F3E1BB001FC5B4 /* ModalHostingPresentationController.swift in Sources */,
 				D8B4D5F026C2C7EC00F34E94 /* InPersonPaymentsStripeAccountPendingView.swift in Sources */,
 				B92639FF293E2D4C00A257E0 /* JustInTimeMessagesProvider.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCountryQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCountryQuestionViewModelTests.swift
@@ -8,7 +8,7 @@ final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
 
     func test_topHeader_is_set_to_store_name() throws {
         // Given
-        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store 🌟") { _ in }
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store 🌟") { _ in } onSupport: {}
 
         // Then
         XCTAssertEqual(viewModel.topHeader, "store 🌟")
@@ -16,7 +16,7 @@ final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
 
     func test_currentCountryCode_and_initial_selectedCountryCode_are_set_by_locale() throws {
         // Given
-        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "fr_FR")) { _ in }
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "fr_FR")) { _ in } onSupport: {}
 
         // Then
         XCTAssertEqual(viewModel.currentCountryCode, .FR)
@@ -25,7 +25,7 @@ final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
 
     func test_currentCountryCode_and_initial_selectedCountryCode_are_nil_with_an_invalid_locale() throws {
         // Given
-        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "zzzz")) { _ in }
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "zzzz")) { _ in } onSupport: {}
 
         // Then
         XCTAssertNil(viewModel.currentCountryCode)
@@ -34,7 +34,7 @@ final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
 
     func test_countryCodes_include_all_countries_with_an_invalid_locale() throws {
         // Given
-        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "zzzz")) { _ in }
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "zzzz")) { _ in } onSupport: {}
 
         // Then
         XCTAssertEqual(viewModel.countryCodes, SiteAddress.CountryCode.allCases.sorted(by: { $0.readableCountry < $1.readableCountry }))
@@ -42,7 +42,7 @@ final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
 
     func test_countryCodes_do_not_include_currentCountryCode_from_locale() throws {
         // Given
-        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "fr_FR")) { _ in }
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "fr_FR")) { _ in } onSupport: {}
 
         // Then
         XCTAssertFalse(viewModel.countryCodes.contains(.FR))
@@ -51,7 +51,7 @@ final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
 
     func test_selecting_a_country_updates_selectedCountryCode() throws {
         // Given
-        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store") { _ in }
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store") { _ in } onSupport: {}
 
         // When
         viewModel.selectCountry(.FJ)
@@ -62,7 +62,7 @@ final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
 
     func test_selecting_a_country_sets_isContinueButtonEnabled_to_true_with_an_invalid_locale() throws {
         // Given
-        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "zzzz")) { _ in }
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "zzzz")) { _ in } onSupport: {}
         var isContinueButtonEnabledValues = [Bool]()
         viewModel.isContinueButtonEnabled.removeDuplicates().sink { isEnabled in
             isContinueButtonEnabledValues.append(isEnabled)
@@ -79,7 +79,7 @@ final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
 
     func test_isContinueButtonEnabled_stays_true_with_a_valid_locale() throws {
         // Given
-        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "fr_FR")) { _ in }
+        let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store", currentLocale: .init(identifier: "fr_FR")) { _ in } onSupport: {}
         var isContinueButtonEnabledValues = [Bool]()
         viewModel.isContinueButtonEnabled.removeDuplicates().sink { isEnabled in
             isContinueButtonEnabledValues.append(isEnabled)
@@ -102,7 +102,7 @@ final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
                 // Then
                 XCTAssertEqual(countryCode, .JP)
                 promise(())
-            }
+            } onSupport: {}
 
             // When
             viewModel.selectCountry(.JP)
@@ -118,10 +118,24 @@ final class StoreCreationCountryQuestionViewModelTests: XCTestCase {
                                                               currentLocale: .init(identifier: "zzzz")) { countryCode in
             // Then
             XCTFail("Should not be invoked without selecting a country.")
-        }
+        } onSupport: {}
         // When
         Task { @MainActor in
             await viewModel.continueButtonTapped()
+        }
+    }
+
+    func test_supportButtonTapped_invokes_onSupport() throws {
+        waitFor { promise in
+            // Given
+            let viewModel = StoreCreationCountryQuestionViewModel(storeName: "store",
+                                                                  currentLocale: .init(identifier: "")) { _ in } onSupport: {
+                // Then
+                promise(())
+            }
+
+            // When
+            viewModel.supportButtonTapped()
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -204,6 +204,10 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.heartOutlineImage)
     }
 
+    func test_helpOutlineImage_icon_is_not_nil() {
+        XCTAssertNotNil(UIImage.helpOutlineImage)
+    }
+
     func testHouseImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.houseImage)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8538 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

From p1670931902787739/1670929798.889469-slack-C045CUK1Y3U, we want to make it easier for users to contact support during the store creation flow. We're adding a ❓ icon to the navigation bar trailing edge to screens that don't have a trailing bar button - store name, country selector, domain selector, and store summary.

I created a SwiftUI view `SupportButton` to show as a `ToolbarItem` at the trailing edge of the navigation bar in the 4 screens with some refactoring on the related code. A new image `helpOutline` is added following the [Android implementation](https://github.com/woocommerce/woocommerce-android/pull/8054).

Please note that I'm clarifying two points on this UX change p1672818334782819-slack-C045CUK1Y3U, there might be some changes after the decision is made.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in if needed
- Go to the Menu tab, and tap `Switch store`
- On the store picker, tap `+ Add a store`
- Tap `Create a new store` --> the store name form should be shown with a support CTA on the top right of the navigation bar
- Tap on the icon to submit a support ticket --> the Zendesk ticket should have the tag `origin:store-creation` (make sure to note that the ticket is only for testing since we don't have permission to close them in Zendesk)
- Go back and enter a store name, then tap `Continue` --> the category question should be shown without a support CTA
- Tap `Continue` to skip --> the selling status question should be shown without a support CTA
- Tap `Continue` to skip --> the country question should be shown with a support CTA on the top right of the navigation bar
- Tap on the icon to submit a support ticket --> the Zendesk ticket should have the tag `origin:store-creation`
- Go back and select an option, then tap `Continue` --> the domain selector should be shown with a support CTA on the top right of the navigation bar
- Tap on the icon to submit a support ticket --> the Zendesk ticket should have the tag `origin:store-creation`
- Go back and select a domain, then tap `Continue` --> the summary screen should be shown with a support CTA on the top right of the navigation bar
- Tap on the icon to submit a support ticket --> the Zendesk ticket should have the tag `origin:store-creation`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

store name | country selector | domain selector | store summary
-- | -- | -- | --
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-01-04 at 15 33 54](https://user-images.githubusercontent.com/1945542/210522901-698b5114-2bda-4621-afe0-42e02515f9a4.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2023-01-04 at 15 34 00](https://user-images.githubusercontent.com/1945542/210522919-caa73db6-7fc3-46eb-8854-623d60ec3b48.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2023-01-04 at 15 34 05](https://user-images.githubusercontent.com/1945542/210522923-0b5bf141-aa05-4484-8c12-6aed8ab95cbf.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2023-01-04 at 15 34 14](https://user-images.githubusercontent.com/1945542/210522926-64646dc1-8244-4be8-989c-70f9b2c1b22f.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.