### PR TITLE
Variations: Generate All Variations Remotely

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -197,6 +197,8 @@
 		26B2F74924C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74824C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift */; };
 		26B2F74B24C696C00065CCC8 /* LeaderboardRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74A24C696C00065CCC8 /* LeaderboardRow.swift */; };
 		26B2F74D24C696E70065CCC8 /* LeaderboardRowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B2F74C24C696E70065CCC8 /* LeaderboardRowContent.swift */; };
+		26BD9FCD2965EC3C004E0D15 /* product-variations-bulk-create.json in Resources */ = {isa = PBXBuildFile; fileRef = 26BD9FCC2965EC3C004E0D15 /* product-variations-bulk-create.json */; };
+		26BD9FCF2965EE71004E0D15 /* ProductVariationsBulkCreateMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BD9FCE2965EE71004E0D15 /* ProductVariationsBulkCreateMapper.swift */; };
 		26FB056C25F6CB9100A40B26 /* Fakes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26FB056B25F6CB9100A40B26 /* Fakes.framework */; };
 		31054702262E04F700C5C02B /* RemotePaymentIntentMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31054701262E04F700C5C02B /* RemotePaymentIntentMapper.swift */; };
 		31054706262E278100C5C02B /* RemotePaymentIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31054705262E278100C5C02B /* RemotePaymentIntent.swift */; };
@@ -982,6 +984,8 @@
 		26B6453F259BCDFE00EF3FB3 /* ProductAttributeTermMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermMapper.swift; sourceTree = "<group>"; };
 		26B64543259BCE0F00EF3FB3 /* ProductAttributeTermListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermListMapper.swift; sourceTree = "<group>"; };
 		26B6454D259BF81400EF3FB3 /* product-attribute-terms.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-attribute-terms.json"; sourceTree = "<group>"; };
+		26BD9FCC2965EC3C004E0D15 /* product-variations-bulk-create.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variations-bulk-create.json"; sourceTree = "<group>"; };
+		26BD9FCE2965EE71004E0D15 /* ProductVariationsBulkCreateMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductVariationsBulkCreateMapper.swift; sourceTree = "<group>"; };
 		26E5A08725A66AFC000DF8F6 /* ProductAttributeTermRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermRemote.swift; sourceTree = "<group>"; };
 		26E5A08B25A66FD3000DF8F6 /* ProductAttributeTermRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttributeTermRemoteTests.swift; sourceTree = "<group>"; };
 		26FB056B25F6CB9100A40B26 /* Fakes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Fakes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2225,6 +2229,7 @@
 				02C54CC524D3E937007D658F /* product-variations-load-all-manage-stock-two-states.json */,
 				020C907A24C6E108001E2BEB /* product-variation-update.json */,
 				09885C7F27C3FFD200910A62 /* product-variations-bulk-update.json */,
+				26BD9FCC2965EC3C004E0D15 /* product-variations-bulk-create.json */,
 				451274A525276C82009911FF /* product-variation.json */,
 				CE0A0F1E223998A00075ED8D /* products-load-all.json */,
 				2676F4CF290B0EC700C7A15B /* product-id-only.json */,
@@ -2426,6 +2431,7 @@
 				026CF61D237D6985009563D4 /* ProductVariationListMapper.swift */,
 				02C1CEF324C6A02B00703EBA /* ProductVariationMapper.swift */,
 				09EA564A27C75FCE00407D40 /* ProductVariationsBulkUpdateMapper.swift */,
+				26BD9FCE2965EE71004E0D15 /* ProductVariationsBulkCreateMapper.swift */,
 				451A9831260B9D2D0059D135 /* ShippingLabelPackagesMapper.swift */,
 				029BA53A255DFABD006171FD /* ShippingLabelPrintDataMapper.swift */,
 				021A84D9257DF92800BC71D1 /* ShippingLabelRefundMapper.swift */,
@@ -2878,6 +2884,7 @@
 				028CB71F2902589E00331C09 /* create-account-error-invalid-email.json in Resources */,
 				E137619929151C7400FD098F /* error-wp-rest-forbidden.json in Resources */,
 				31A451CE27863A2E00FE81AA /* stripe-account-wrong-json.json in Resources */,
+				26BD9FCD2965EC3C004E0D15 /* product-variations-bulk-create.json in Resources */,
 				028CB718290223CB00331C09 /* account-username-suggestions.json in Resources */,
 				0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */,
 				45152825257A8B740076B03C /* product-attribute-update.json in Resources */,
@@ -3336,6 +3343,7 @@
 				B554FA912180BCFC00C54DFF /* NoteHash.swift in Sources */,
 				68F48B0D28E3B2E80045C15B /* WCAnalyticsCustomerMapper.swift in Sources */,
 				CE0A0F19223987DF0075ED8D /* ProductListMapper.swift in Sources */,
+				26BD9FCF2965EE71004E0D15 /* ProductVariationsBulkCreateMapper.swift in Sources */,
 				021C7BF723863D1800A3BCBD /* Encodable+Serialization.swift in Sources */,
 				0219B03923964BB3007DCD5E /* ProductShippingClassMapper.swift in Sources */,
 				7452387321124B7700A973CD /* AnyCodable.swift in Sources */,

--- a/Networking/Networking/Mapper/ProductVariationsBulkCreateMapper.swift
+++ b/Networking/Networking/Mapper/ProductVariationsBulkCreateMapper.swift
@@ -48,4 +48,3 @@ private struct ProductVariationsEnvelope: Decodable {
         createdProductVariations = try nestedContainer.decode([ProductVariation].self, forKey: .create)
     }
 }
-

--- a/Networking/Networking/Mapper/ProductVariationsBulkCreateMapper.swift
+++ b/Networking/Networking/Mapper/ProductVariationsBulkCreateMapper.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Mapper: ProductVariationsBulkCreateMapper
+///
+struct ProductVariationsBulkCreateMapper: Mapper {
+    /// Site Identifier associated to the product variation that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Product Variation Endpoints.
+    ///
+    let siteID: Int64
+
+    /// Product Identifier associated to the product variation that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because ProductID is not returned in any of the Product Variation Endpoints.
+    ///
+    let productID: Int64
+
+    /// (Attempts) to convert a dictionary into ProductVariations.
+    ///
+    func map(response: Data) throws -> [ProductVariation] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID,
+            .productID: productID
+        ]
+        return try decoder.decode(ProductVariationsEnvelope.self, from: response).createdProductVariations
+    }
+}
+
+/// ProductVariationsEnvelope Disposable Entity
+///
+/// `Variations/batch` endpoint returns the requested create product variations document in a `create` key, nested in a `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct ProductVariationsEnvelope: Decodable {
+    let createdProductVariations: [ProductVariation]
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+        case create
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let nestedContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .data)
+        createdProductVariations = try nestedContainer.decode([ProductVariation].self, forKey: .create)
+    }
+}
+

--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -102,6 +102,31 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
         }
     }
 
+    /// Creates the provided `ProductVariations`.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site which hosts the ProductVariations.
+    ///     - productID: Identifier of the Product.
+    ///     - productVariations: the ProductVariations to created remotely.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func createProductVariations(siteID: Int64,
+                                        productID: Int64,
+                                        productVariations: [CreateProductVariation],
+                                        completion: @escaping (Result<[ProductVariation], Error>) -> Void) {
+
+        do {
+            let parameters = try productVariations.map { try $0.toDictionary() }
+            let path = "\(Path.products)/\(productID)/variations/batch"
+            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: ["create": parameters])
+            let mapper = ProductVariationsBulkCreateMapper(siteID: siteID, productID: productID)
+
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
     /// Updates a specific `ProductVariation`.
     ///
     /// - Parameters:

--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -16,6 +16,10 @@ public protocol ProductVariationsRemoteProtocol {
                                 productID: Int64,
                                 newVariation: CreateProductVariation,
                                 completion: @escaping (Result<ProductVariation, Error>) -> Void)
+    func createProductVariations(siteID: Int64,
+                                 productID: Int64,
+                                 productVariations: [CreateProductVariation],
+                                 completion: @escaping (Result<[ProductVariation], Error>) -> Void)
     func updateProductVariation(productVariation: ProductVariation, completion: @escaping (Result<ProductVariation, Error>) -> Void)
     func updateProductVariationImage(siteID: Int64,
                                      productID: Int64,

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -208,6 +208,25 @@ final class ProductVariationsRemoteTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(result).isFailure)
     }
 
+    func test_create_product_variations_returns_parsed_variations() throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations/batch", filename: "product-variations-bulk-create")
+
+        // When
+        let result = waitFor { promise in
+            remote.createProductVariations(siteID: self.sampleSiteID, productID: self.sampleProductID, productVariations: []) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let sampleProductVariationID: Int64 = 2783
+        let expectedVariations = [sampleProductVariation(siteID: sampleSiteID, productID: sampleProductID, id: sampleProductVariationID)]
+        let createdVariations = try result.get()
+        XCTAssertEqual(createdVariations, expectedVariations)
+    }
+
     // MARK: - Update ProductVariation
 
     /// Verifies that updateProductVariation properly parses the `product-variation-update` sample response.

--- a/Networking/NetworkingTests/Responses/product-variations-bulk-create.json
+++ b/Networking/NetworkingTests/Responses/product-variations-bulk-create.json
@@ -1,0 +1,84 @@
+{
+    "data": {
+        "create": [{
+            "id": 2783,
+            "date_created": "2020-06-12T22:36:02",
+            "date_created_gmt": "2020-06-12T14:36:02",
+            "date_modified": "2020-07-21T16:35:47",
+            "date_modified_gmt": "2020-07-21T08:35:47",
+            "description": "<p>Nutty chocolate marble, 99% and organic.</p>\n",
+            "permalink": "https://chocolate.com/marble",
+            "sku": "87%-strawberry-marble",
+            "price": "14.99",
+            "regular_price": "14.99",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "on_sale": false,
+            "status": "publish",
+            "purchasable": true,
+            "virtual": false,
+            "downloadable": true,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": 0,
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": "parent",
+            "stock_quantity": 16,
+            "stock_status": "instock",
+            "backorders": "notify",
+            "backorders_allowed": true,
+            "backordered": false,
+            "weight": "2.5",
+            "dimensions": {
+                "length": "10",
+                "width": "2.5",
+                "height": ""
+            },
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "image": {
+                "id": 2432,
+                "date_created": "2020-03-13T19:13:57",
+                "date_created_gmt": "2020-03-13T03:13:57",
+                "date_modified": "2020-07-22T00:29:16",
+                "date_modified_gmt": "2020-07-21T08:29:16",
+                "src": "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1",
+                "name": "DSC_0010",
+                "alt": ""
+            },
+            "attributes": [{
+                    "id": 0,
+                    "name": "Darkness",
+                    "option": "87%"
+                },
+                {
+                    "id": 0,
+                    "name": "Flavor",
+                    "option": "strawberry"
+                },
+                {
+                    "id": 0,
+                    "name": "Shape",
+                    "option": "marble"
+                }
+            ],
+            "menu_order": 1,
+            "meta_data": [],
+            "_links": {
+                "self": [{
+                    "href": "https://example.com/wp-json/wc/v3/products/846/variations/2783"
+                }],
+                "collection": [{
+                    "href": "https://example.com/wp-json/wc/v3/products/846/variations"
+                }],
+                "up": [{
+                    "href": "https://example.com/wp-json/wc/v3/products/846"
+                }]
+            }
+        }]
+    }
+}

--- a/Yosemite/Yosemite/Actions/ProductVariationAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductVariationAction.swift
@@ -26,6 +26,13 @@ public enum ProductVariationAction: Action {
                                  newVariation: CreateProductVariation,
                                  onCompletion: (Result<ProductVariation, Error>) -> Void)
 
+    /// Creates the provided ProductVariations.
+    ///
+    case createProductVariations(siteID: Int64,
+                                 productID: Int64,
+                                 productVariations: [CreateProductVariation],
+                                 onCompletion: (Result<[ProductVariation], Error>) -> Void)
+
     /// Updates a specified ProductVariation.
     ///
     case updateProductVariation(productVariation: ProductVariation, onCompletion: (Result<ProductVariation, ProductUpdateError>) -> Void)

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
@@ -127,6 +127,13 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
         }
     }
 
+    func createProductVariations(siteID: Int64,
+                                 productID: Int64,
+                                 productVariations: [Networking.CreateProductVariation],
+                                 completion: @escaping (Result<[Networking.ProductVariation], Error>) -> Void) {
+        // No op
+    }
+
     func updateProductVariation(productVariation: ProductVariation, completion: @escaping (Result<ProductVariation, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else {


### PR DESCRIPTION
Closes: #8490 

# Why

This PR takes adds the necessary methods to create multiple product variations remotely.

# How

- Add create variations method on `ProductVariationsRemote`
- Add create variations method on `ProductVariationsStore`
- Adds create variations action on `ProductVariationsAction`
- Integrates action on the ViewModel

**Note: Error handling and user messages will be tackled in a different PR**

# Demo

https://user-images.githubusercontent.com/562080/210695043-1037ee2c-f8dc-488c-a2b9-f6dc7687cb4d.mov

# Testing Steps

- Go to a variable product
- Add some attributes and options to the product
- Start the "Generate All Variations" flow
- See that all the variations were created.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
