### PR TITLE
Update a `var` from `public` to `internal` in `MockStorageManager`

### DIFF
--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager.swift
@@ -28,9 +28,7 @@ public class MockStorageManager: StorageManagerType {
 
     /// Persistent Container: Holds the full CoreData Stack
     ///
-    /// TODO This should be private. It is not part of the `StorageManagerType` spec.
-    ///
-    public lazy var persistentContainer: NSPersistentContainer = {
+    lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: name, managedObjectModel: managedModel)
         container.persistentStoreDescriptions = [storeDescription]
 


### PR DESCRIPTION
## Description

Using the strictest access level possible ensures we as little information as possible, which improves encapsulation and information hiding.

I noticed this code because of the `TODO` flagging it and I was looking through the `TODO`s as part of day 2 task of the Code Quality Challenge "Nuke TODO comments".
See https://tuple.app/code-quality-challenge


## Testing instructions
Given this only updates the access level of a property, compiling the code is all we need to verify the change. Green CI is enough.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
