### PR TITLE
Variations: Refactor how we access all variations.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -699,7 +699,7 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
         }
     }
 
-    /// Generates all possible variations for the product attibutes.
+    /// Generates all possible variations for the product attributes.
     ///
     private func generateAllVariations() {
         viewModel.generateAllVariations(for: product) { [weak self] result in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
@@ -127,7 +127,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
             case .synchronizeAllProductVariations(_, _, let onCompletion):
-                onCompletion(.success(()))
+                onCompletion(.success([]))
             default:
                 break
             }
@@ -159,7 +159,7 @@ final class ProductVariationsViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
             case .synchronizeAllProductVariations(_, _, let onCompletion):
-                onCompletion(.success(()))
+                onCompletion(.success([]))
             case .createProductVariations(_, _, _, let onCompletion):
                 onCompletion(.success([]))
             default:

--- a/Yosemite/Yosemite/Actions/ProductVariationAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductVariationAction.swift
@@ -8,7 +8,7 @@ public enum ProductVariationAction: Action {
 
     /// Synchronizes all the ProductVariation's available in the store.
     ///
-    case synchronizeAllProductVariations(siteID: Int64, productID: Int64, onCompletion: (Result<Void, Error>) -> Void)
+    case synchronizeAllProductVariations(siteID: Int64, productID: Int64, onCompletion: (Result<[ProductVariation], Error>) -> Void)
 
     /// Synchronizes the ProductVariation's matching the specified criteria.
     /// If successful, the result boolean value, will indicate weather there are more variations to fetch or not.


### PR DESCRIPTION
# Why

This PR does a small pending refactor to not access fetched variations via `ServiceLocator.storageManager` but instead do it via the `synchronizeAllProductVariations` action.

# How

- Update `ProductsVariationAction.synchronizeAllProductVariations` to return the fetched variations on it's completion block

# Testing 

- See that generating variations keeps working as the last PR.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
