### PR TITLE
IPP Menu: Handle not supported country case properly

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -8,7 +8,6 @@ final class InPersonPaymentsMenuViewController: UIViewController {
     private let stores: StoresManager
     private var pluginState: CardPresentPaymentsPluginState?
     private var sections = [Section]()
-    private let configurationLoader: CardPresentConfigurationLoader
     private let featureFlagService: FeatureFlagService
     private let cardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCase
     private var cancellables: Set<AnyCancellable> = []
@@ -18,19 +17,12 @@ final class InPersonPaymentsMenuViewController: UIViewController {
                            formatText: Localization.toggleEnableCashOnDeliveryLearnMoreFormat,
                            tappedAnalyticEvent: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingLearnMoreTapped(
                             reason: "reason",
-                            countryCode: configurationLoader.configuration.countryCode))
+                            countryCode: viewModel.cardPresentPaymentsConfiguration.countryCode))
     }()
 
     private let viewModel: InPersonPaymentsMenuViewModel = InPersonPaymentsMenuViewModel()
 
     private let cashOnDeliveryToggleRowViewModel: InPersonPaymentsCashOnDeliveryToggleRowViewModel
-
-    /// No Manuals to be shown in a country where IPP is not supported
-    /// 
-    private var enableCardReaderManualsCell: Bool {
-        !(cardPresentPaymentsOnboardingUseCase.state == .loading ||
-        cardPresentPaymentsOnboardingUseCase.state.isCountryNotSupported)
-    }
 
     private var enableManageCardReaderCell: Bool {
         cardPresentPaymentsOnboardingUseCase.state.isCompleted
@@ -55,7 +47,6 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         self.stores = stores
         self.featureFlagService = featureFlagService
         self.cardPresentPaymentsOnboardingUseCase = CardPresentPaymentsOnboardingUseCase()
-        configurationLoader = CardPresentConfigurationLoader()
         self.cashOnDeliveryToggleRowViewModel = InPersonPaymentsCashOnDeliveryToggleRowViewModel()
 
         super.init(nibName: nil, bundle: nil)
@@ -73,7 +64,7 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         configureTableView()
         registerTableViewCells()
         configureTableReload()
-        runCardPresentPaymentsOnboarding()
+        runCardPresentPaymentsOnboardingIfPossible()
         configureWebViewPresentation()
         viewModel.viewDidLoad()
     }
@@ -82,7 +73,11 @@ final class InPersonPaymentsMenuViewController: UIViewController {
 // MARK: - Card Present Payments Readiness
 
 private extension InPersonPaymentsMenuViewController {
-    func runCardPresentPaymentsOnboarding() {
+    func runCardPresentPaymentsOnboardingIfPossible() {
+        guard viewModel.isEligibleForCardPresentPayments else {
+            return
+        }
+
         cardPresentPaymentsOnboardingUseCase.refresh()
 
         cardPresentPaymentsOnboardingUseCase.$state
@@ -174,11 +169,13 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func configureSections() {
-        sections = [
-            actionsSection,
-            cardReadersSection,
-            paymentOptionsSection
-        ].compactMap { $0 }
+        var composingSections: [Section?] = [actionsSection]
+
+        if viewModel.isEligibleForCardPresentPayments {
+            composingSections.append(contentsOf: [cardReadersSection, paymentOptionsSection])
+        }
+
+        sections = composingSections.compactMap { $0 }
     }
 
     var actionsSection: Section? {
@@ -282,11 +279,9 @@ private extension InPersonPaymentsMenuViewController {
 
     func configureCardReaderManuals(cell: LeftImageTableViewCell) {
         cell.imageView?.tintColor = .text
-        cell.accessoryType = enableCardReaderManualsCell ? .disclosureIndicator : .none
-        cell.selectionStyle = enableCardReaderManualsCell ? .default : .none
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
         cell.configure(image: .cardReaderManualIcon, text: Localization.cardReaderManuals.localizedCapitalized)
-
-        updateEnabledState(in: cell, shouldBeEnabled: enableCardReaderManualsCell)
     }
 
     func configureCollectPayment(cell: LeftImageTableViewCell) {
@@ -361,16 +356,12 @@ extension InPersonPaymentsMenuViewController {
             fatalError("Cannot instantiate `CardReaderSettingsPresentingViewController` from Dashboard storyboard")
         }
 
-        let viewModelsAndViews = CardReaderSettingsViewModelsOrderedList(configuration: configurationLoader.configuration)
+        let viewModelsAndViews = CardReaderSettingsViewModelsOrderedList(configuration: viewModel.cardPresentPaymentsConfiguration)
         viewController.configure(viewModelsAndViews: viewModelsAndViews)
         show(viewController, sender: self)
     }
 
     func cardReaderManualsWasPressed() {
-        guard enableCardReaderManualsCell else {
-            return
-        }
-
         ServiceLocator.analytics.track(.paymentsMenuCardReadersManualsTapped)
         let view = UIHostingController(rootView: CardReaderManualsView())
         navigationController?.pushViewController(view, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModel.swift
@@ -33,7 +33,11 @@ final class InPersonPaymentsMenuViewModel {
         return stores.sessionManager.defaultStoreID
     }
 
-    private let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
+    var isEligibleForCardPresentPayments: Bool {
+        cardPresentPaymentsConfiguration.isSupportedCountry
+    }
+
+    let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
 
     init(dependencies: Dependencies = Dependencies(),
          cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7771 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Before, we used to show the onboarding setup permanent notice when the store's country is not supported for IPP. This is frustrating for our users, given that when tapping on "Setup" we just show an error message about it.
With this PR we prevent running the IPP onboarding when the country is not supported and hide the IPP-related rows to avoid more confusion for the users.
Furthermore, as we used to disable the card reader manuals cell only when the country was not supported but now we just hide it, I removed the enabling/disabling logic for that cell.

Apart from that, I took the chance to remove the `CardPresentConfigurationLoader` property from `InPersonPaymentsMenuViewController` and use the one we had in the view model, which feels more natural.

Read more about the solution decision process here: pdfdoF-25x-p2

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Go to the IPP Menu with these three different store configurations and check that they match the screenshots here:

### With a store based in a country where we don't support IPP

<img src="https://user-images.githubusercontent.com/1864060/210810628-7067bc7c-a556-4f17-93f2-f90ecd185a47.png" width="375">

### With a store in a country where IPP is supported, but whose IPP onboarding is not yet finished

<img src="https://user-images.githubusercontent.com/1864060/210808170-ac9ac56b-4aa2-49d4-aa7d-450e2c6123c9.png" width="375">

## With a store in a country where IPP is supported and the IPP onboarding completed

<img src="https://user-images.githubusercontent.com/1864060/210810431-cf33c9ed-2991-4cb8-b6b2-034224ce0bb7.png" width="375">

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
See above


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.