### PR TITLE
Do not force `try` instantiating `TabNavComponent` in UI tests

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/SingleOrderScreen.swift
@@ -3,8 +3,7 @@ import XCTest
 
 public final class SingleOrderScreen: ScreenObject {
 
-    // TODO: Remove force `try` once `ScreenObject` migration is completed
-    let tabBar = try! TabNavComponent()
+    let tabBar: TabNavComponent
 
     private let editOrderButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["order-details-edit-button"]
@@ -23,6 +22,8 @@ public final class SingleOrderScreen: ScreenObject {
     private var collectPaymentButton: XCUIElement { collectPaymentButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
+        tabBar = try TabNavComponent(app: app)
+
         try super.init(
             expectedElementGetters: [ summaryCellGetter, editOrderButtonGetter ],
             app: app

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -3,14 +3,15 @@ import XCTest
 
 public final class ProductsScreen: ScreenObject {
 
-    // TODO: Remove force `try` once `ScreenObject` migration is completed
-    public let tabBar = try! TabNavComponent()
+    public let tabBar: TabNavComponent
 
     static var isVisible: Bool {
         (try? ProductsScreen().isLoaded) ?? false
     }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
+        tabBar = try TabNavComponent(app: app)
+
         try super.init(
             expectedElementGetters: [
                 // swiftlint:disable next opening_brace

--- a/WooCommerce/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
@@ -3,14 +3,15 @@ import XCTest
 
 public final class ReviewsScreen: ScreenObject {
 
-    // TODO: Remove force `try` once `ScreenObject` migration is completed
-    public let tabBar = try! TabNavComponent()
+    public let tabBar: TabNavComponent
 
     static var isVisible: Bool {
         (try? ReviewsScreen().isLoaded) ?? false
     }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
+        tabBar = try TabNavComponent(app: app)
+
         try super.init(
             expectedElementGetters: [ { $0.tables["reviews-table"] } ],
             app: app


### PR DESCRIPTION
## Description

I noticed this code because of the `TODO` flagging it and I was looking through the `TODO`s as part of day 2 task of the Code Quality Challenge "Nuke TODO comments". See https://tuple.app/code-quality-challenge

<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

## Testing instructions
Given this only changes UI tests, if they pass on CI, we should be good.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
