### PR TITLE
Configure `WordPressAuthenticator` in `AppCoordinator` initialization to fix crash from deep links before login onboarding is complete

### DIFF
--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -58,6 +58,9 @@ final class AppCoordinator {
         self.featureFlagService = featureFlagService
 
         authenticationManager.setLoggedOutAppSettings(loggedOutAppSettings)
+
+        // Configures authenticator first in case `WordPressAuthenticator` is used in other `AppDelegate` launch events.
+        configureAuthenticator()
     }
 
     func start() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #7890 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I looked more into [a crash](https://sentry.io/organizations/a8c/issues/3571878108/?project=1458804&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d) due to uninitialized `WordPressAuthenticator` from `AuthenticationManager.handleAuthenticationUrl` most likely after opening a login magic link. There were 67 events in the last 30 days, thankfully I was able to reproduce it.

### Root cause

When we implemented login onboarding, `WordPressAuthenticator` is only initialized after the user completes or dismisses the login onboarding screen because the action in the onboarding screen affects the parameters of the `WordPressAuthenticator` initialization. This is fine until there are other triggers of `WordPressAuthenticator`, like when opening the app from a magic link.

### The fix

To prevent any similar crashes in the future, it's best for `WordPressAuthenticator` to be initialized at the beginning from `application(_:didFinishLaunchingWithOptions:)`. The parameters of `WordPressAuthenticator` initialization only affect the UI later on, initializing `WordPressAuthenticator` more than for non-UI operations once doesn't create issues from my testing.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Reinstall the app, if needed. Put the app to the background
- In a separate device (or the same device before reinstallation), log in with a non-A8C WordPress.com email and wait for the email with a login magic link
- In the email, copy the link address of the login magic link and paste to a web browser (e.g. Safari on a simulator) --> the browser should request to open the app after authentication succeeds
- Tap to open the link in the app --> the app shouldn't crash anymore and should show the store picker or enter the logged-in state, while it crashes consistently before this PR
- Log out from the app
- Skip the onboarding
- Log in to the app again --> the app should enter the logged-in state

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
