### PR TITLE
Variations: Show loading indicators

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Progress/InProgressViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Progress/InProgressViewController.swift
@@ -16,7 +16,7 @@ final class InProgressViewController: UIViewController {
     @IBOutlet private weak var activityIndicatorView: UIActivityIndicatorView!
     @IBOutlet private weak var messageLabel: UILabel!
 
-    private let viewProperties: InProgressViewProperties
+    private var viewProperties: InProgressViewProperties
     private let hidesNavigationBar: Bool
 
     /// - Parameters:
@@ -43,6 +43,7 @@ final class InProgressViewController: UIViewController {
         configureTitle()
         configureActivityIndicator()
         configureMessage()
+        configureViewsValues()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -61,6 +62,13 @@ final class InProgressViewController: UIViewController {
         }
 
         super.viewWillDisappear(animated)
+    }
+
+    /// Assign new values for the view to render.
+    ///
+    func updateViewProperties(_ viewProperties: InProgressViewProperties) {
+        self.viewProperties = viewProperties
+        configureViewsValues()
     }
 }
 
@@ -82,8 +90,6 @@ private extension InProgressViewController {
         titleLabel.textColor = .white
         titleLabel.textAlignment = .center
         titleLabel.numberOfLines = 0
-
-        titleLabel.text = viewProperties.title
     }
 
     func configureActivityIndicator() {
@@ -96,7 +102,10 @@ private extension InProgressViewController {
         messageLabel.textColor = .gray(.shade10)
         messageLabel.textAlignment = .center
         messageLabel.numberOfLines = 0
+    }
 
+    func configureViewsValues() {
+        titleLabel.text = viewProperties.title
         messageLabel.text = viewProperties.message
     }
 }


### PR DESCRIPTION
Closes: #8491 

# Why 

This PRs shows a blocking loading indicator while variations are being fetched and created so the merchant is informed about what is going on.

# How

- Update `InProgressViewController` to allow for a runtime update.
- Update `ProductVariationsViewController` to show and hide the "Fetching..." and "Creating..." blocking indicators.

# Demo

https://user-images.githubusercontent.com/562080/211050999-90f5d38e-2623-4869-9165-d7dfcfe22b77.mov

# Testing Steps

- Navigate to a variable product
- Make sure there are some variations to be created
- Start the "Generate All Variations" process
- See that proper loading indicators are being shown.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
