### PR TITLE
Variations: Completion notices

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -674,6 +674,20 @@ private extension ProductVariationsViewController {
             inProgressViewController.dismiss(animated: true)
         }
     }
+
+    /// Informs the merchant that no variations were created.
+    ///
+    private func presentNoGenerationNotice() {
+        let notice = Notice(title: Localization.noVariationsCreatedTitle, message: Localization.noVariationsCreatedDescription)
+        noticePresenter.enqueue(notice: notice)
+    }
+
+    /// Informs the merchant that some variations were created.
+    ///
+    private func presentVariationsCreatedNotice() {
+        let notice = Notice(title: Localization.variationsCreatedTitle)
+        noticePresenter.enqueue(notice: notice)
+    }
 }
 
 // MARK: - Placeholders
@@ -762,7 +776,11 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
                 self?.dismissBlockingIndicator()
             case .finished(let variationsCreated):
                 self?.dismissBlockingIndicator()
-                // TODO: Inform about created variations
+                if variationsCreated {
+                    self?.presentVariationsCreatedNotice()
+                } else {
+                    self?.presentNoGenerationNotice()
+                }
                 break
             case .error(let error):
                 self?.dismissBlockingIndicator()
@@ -889,6 +907,12 @@ private extension ProductVariationsViewController {
                                                           comment: "Blocking indicator text when fetching existing variations prior generating them.")
         static let creatingVariations = NSLocalizedString("Creating Variations...",
                                                           comment: "Blocking indicator text when creating multiple variations remotely.")
+        static let noVariationsCreatedTitle = NSLocalizedString("No variations to generate",
+                                                                comment: "Title for the notice when there were no variations to generate")
+        static let noVariationsCreatedDescription = NSLocalizedString("All variations are already generated.",
+                                                                      comment: "Message for the notice when there were no variations to generate")
+        static let variationsCreatedTitle = NSLocalizedString("Variations created successfully",
+                                                              comment: "Title for the notice when after variations were created")
 
     }
 


### PR DESCRIPTION
Closes: #8574

# Why

This PR takes care of showing notices when the generate variation process finishes. 
The variation process can finish with variations generated or without variations generated

# Demo

https://user-images.githubusercontent.com/562080/211104839-6ae8263d-c398-4919-8643-c14bb5fb0f24.mov


https://user-images.githubusercontent.com/562080/211104855-88d68056-4d99-433f-acfa-2d9d1dd1bdc1.mov

# Testing Steps

- Open a product that has variations left to generate
- Start the  "Generate all variations" process
- After generation see that a notice indicating that variations were generated appears.
- Start the  "Generate all variations" process again
- See that a notice indicating that there are no variations to generate appear.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
