### PR TITLE
REST API: Migrate customer endpoints

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -697,6 +697,7 @@
 		DE42F9652967F34400D514C2 /* refund-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F9642967F34400D514C2 /* refund-single-without-data.json */; };
 		DE42F9672967F61D00D514C2 /* refunds-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F9662967F61D00D514C2 /* refunds-all-without-data.json */; };
 		DE42F96F296BC9A700D514C2 /* countries-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F96E296BC9A700D514C2 /* countries-without-data.json */; };
+		DE42F96B296BC23800D514C2 /* customer-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F96A296BC23800D514C2 /* customer-without-data.json */; };
 		DE50295928C5BD0200551736 /* JetpackUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295828C5BD0200551736 /* JetpackUser.swift */; };
 		DE50295B28C5F99700551736 /* DotcomUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295A28C5F99700551736 /* DotcomUser.swift */; };
 		DE50295D28C6068B00551736 /* JetpackUserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295C28C6068B00551736 /* JetpackUserMapper.swift */; };
@@ -1509,6 +1510,7 @@
 		DE42F9642967F34400D514C2 /* refund-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "refund-single-without-data.json"; sourceTree = "<group>"; };
 		DE42F9662967F61D00D514C2 /* refunds-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "refunds-all-without-data.json"; sourceTree = "<group>"; };
 		DE42F96E296BC9A700D514C2 /* countries-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "countries-without-data.json"; sourceTree = "<group>"; };
+		DE42F96A296BC23800D514C2 /* customer-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "customer-without-data.json"; sourceTree = "<group>"; };
 		DE50295828C5BD0200551736 /* JetpackUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackUser.swift; sourceTree = "<group>"; };
 		DE50295A28C5F99700551736 /* DotcomUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotcomUser.swift; sourceTree = "<group>"; };
 		DE50295C28C6068B00551736 /* JetpackUserMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackUserMapper.swift; sourceTree = "<group>"; };
@@ -2130,6 +2132,7 @@
 			isa = PBXGroup;
 			children = (
 				DE42F96E296BC9A700D514C2 /* countries-without-data.json */,
+				DE42F96A296BC23800D514C2 /* customer-without-data.json */,
 				DE42F9662967F61D00D514C2 /* refunds-all-without-data.json */,
 				DE42F9642967F34400D514C2 /* refund-single-without-data.json */,
 				EE80A24B29556F1D003591E4 /* Coupon */,
@@ -3035,6 +3038,7 @@
 				4515281F257A89B90076B03C /* product-attribute-create.json in Resources */,
 				CEF88DAF233E9F7E00BED485 /* order-details-partially-refunded.json in Resources */,
 				D823D9032237450A00C90817 /* shipment_tracking_new.json in Resources */,
+				DE42F96B296BC23800D514C2 /* customer-without-data.json in Resources */,
 				EE80A24729547F8B003591E4 /* coupons-all-without-data.json in Resources */,
 				7412A8F021B6E416005D182A /* report-orders.json in Resources */,
 				CCF4346A2906C9C300B4475A /* products-ids-only-empty.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -698,6 +698,7 @@
 		DE42F9672967F61D00D514C2 /* refunds-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F9662967F61D00D514C2 /* refunds-all-without-data.json */; };
 		DE42F96F296BC9A700D514C2 /* countries-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F96E296BC9A700D514C2 /* countries-without-data.json */; };
 		DE42F96B296BC23800D514C2 /* customer-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F96A296BC23800D514C2 /* customer-without-data.json */; };
+		DE42F96D296BC67E00D514C2 /* wc-analytics-customers-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F96C296BC67E00D514C2 /* wc-analytics-customers-without-data.json */; };
 		DE50295928C5BD0200551736 /* JetpackUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295828C5BD0200551736 /* JetpackUser.swift */; };
 		DE50295B28C5F99700551736 /* DotcomUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295A28C5F99700551736 /* DotcomUser.swift */; };
 		DE50295D28C6068B00551736 /* JetpackUserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295C28C6068B00551736 /* JetpackUserMapper.swift */; };
@@ -1511,6 +1512,7 @@
 		DE42F9662967F61D00D514C2 /* refunds-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "refunds-all-without-data.json"; sourceTree = "<group>"; };
 		DE42F96E296BC9A700D514C2 /* countries-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "countries-without-data.json"; sourceTree = "<group>"; };
 		DE42F96A296BC23800D514C2 /* customer-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "customer-without-data.json"; sourceTree = "<group>"; };
+		DE42F96C296BC67E00D514C2 /* wc-analytics-customers-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wc-analytics-customers-without-data.json"; sourceTree = "<group>"; };
 		DE50295828C5BD0200551736 /* JetpackUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackUser.swift; sourceTree = "<group>"; };
 		DE50295A28C5F99700551736 /* DotcomUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotcomUser.swift; sourceTree = "<group>"; };
 		DE50295C28C6068B00551736 /* JetpackUserMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackUserMapper.swift; sourceTree = "<group>"; };
@@ -2132,6 +2134,7 @@
 			isa = PBXGroup;
 			children = (
 				DE42F96E296BC9A700D514C2 /* countries-without-data.json */,
+				DE42F96C296BC67E00D514C2 /* wc-analytics-customers-without-data.json */,
 				DE42F96A296BC23800D514C2 /* customer-without-data.json */,
 				DE42F9662967F61D00D514C2 /* refunds-all-without-data.json */,
 				DE42F9642967F34400D514C2 /* refund-single-without-data.json */,
@@ -3133,6 +3136,7 @@
 				743E84F222172D0A00FAC9D7 /* shipment_tracking_plugin_not_active.json in Resources */,
 				68CB801628D8A39700E169F8 /* customer.json in Resources */,
 				EEA658402966C05D00112DF0 /* product-search-sku-without-data.json in Resources */,
+				DE42F96D296BC67E00D514C2 /* wc-analytics-customers-without-data.json in Resources */,
 				03EB99982907F4AA00F06A39 /* just-in-time-message-list-multiple.json in Resources */,
 				EE80A25029556FBD003591E4 /* coupon-reports-without-data.json in Resources */,
 				451A97DE260B59870059D135 /* shipping-label-packages-success.json in Resources */,

--- a/Networking/Networking/Mapper/CustomerMapper.swift
+++ b/Networking/Networking/Mapper/CustomerMapper.swift
@@ -12,8 +12,11 @@ struct CustomerMapper: Mapper {
     func map(response: Data) throws -> Customer {
         let decoder = JSONDecoder()
         decoder.userInfo = [.siteID: siteID]
-        let customer = try decoder.decode(CustomerEnvelope.self, from: response).customer
-        return customer
+        do {
+            return try decoder.decode(CustomerEnvelope.self, from: response).customer
+        } catch {
+            return try decoder.decode(Customer.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Mapper/WCAnalyticsCustomerMapper.swift
+++ b/Networking/Networking/Mapper/WCAnalyticsCustomerMapper.swift
@@ -13,8 +13,11 @@ struct WCAnalyticsCustomerMapper: Mapper {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [.siteID: siteID]
-        let customers = try decoder.decode(WCAnalyticsCustomerEnvelope.self, from: response).customer
-        return customers
+        do {
+            return try decoder.decode(WCAnalyticsCustomerEnvelope.self, from: response).customer
+        } catch {
+            return try decoder.decode([WCAnalyticsCustomer].self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Remote/CustomerRemote.swift
+++ b/Networking/Networking/Remote/CustomerRemote.swift
@@ -14,8 +14,8 @@ public class CustomerRemote: Remote {
                                      method: .get,
                                      siteID: siteID,
                                      path: path,
-                                     parameters: nil
-        )
+                                     parameters: nil,
+                                     availableAsRESTRequest: true)
 
         let mapper = CustomerMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/Networking/Remote/WCAnalyticsCustomerRemote.swift
+++ b/Networking/Networking/Remote/WCAnalyticsCustomerRemote.swift
@@ -21,7 +21,8 @@ public class WCAnalyticsCustomerRemote: Remote {
             method: .get,
             siteID: siteID,
             path: path,
-            parameters: ["search": name]
+            parameters: ["search": name],
+            availableAsRESTRequest: true
         )
 
         let mapper = WCAnalyticsCustomerMapper(siteID: siteID)

--- a/Networking/NetworkingTests/Mapper/CustomerMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CustomerMapperTests.swift
@@ -12,6 +12,7 @@ class CustomerMapperTests: XCTestCase {
     /// Local file that holds Customer data representing the API endpoint
     ///
     private let filename: String = "customer"
+    private let fileNameWithoutDataEnvelope = "customer-without-data"
 
     /// Verifies that the Customer object can be mapped fron the Encoded data
     ///
@@ -36,6 +37,38 @@ class CustomerMapperTests: XCTestCase {
     func test_Customer_response_values_are_correctly_parsed() throws {
         // Given
         guard let customer = try mapCustomer(from: filename) else {
+            XCTFail()
+            return
+        }
+
+        // Then
+        XCTAssertNotNil(customer)
+        XCTAssertEqual(customer.customerID, 25)
+        XCTAssertEqual(customer.email, "john.doe@example.com")
+        XCTAssertEqual(customer.firstName, "John")
+        XCTAssertEqual(customer.lastName, "Doe")
+
+        let dummyAddresses = [customer.shipping, customer.billing].compactMap({ $0 })
+        XCTAssertEqual(dummyAddresses.count, 2)
+
+        for address in dummyAddresses {
+            XCTAssertEqual(address.firstName, "John")
+            XCTAssertEqual(address.lastName, "Doe")
+            XCTAssertEqual(address.company, "")
+            XCTAssertEqual(address.address1, "969 Market")
+            XCTAssertEqual(address.address2, "")
+            XCTAssertEqual(address.city, "San Francisco")
+            XCTAssertEqual(address.state, "CA")
+            XCTAssertEqual(address.postcode, "94103")
+            XCTAssertEqual(address.country, "US")
+        }
+    }
+
+    /// Verifies that all of the Customer response values are parsed correctly
+    ///
+    func test_Customer_response_values_are_correctly_parsed_when_response_has_no_data_envelope() throws {
+        // Given
+        guard let customer = try mapCustomer(from: fileNameWithoutDataEnvelope) else {
             XCTFail()
             return
         }

--- a/Networking/NetworkingTests/Mapper/WCAnalyticsCustomerMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WCAnalyticsCustomerMapperTests.swift
@@ -60,7 +60,7 @@ class WCAnalyticsCustomerMapperTests: XCTestCase {
         XCTAssertEqual(customers[3].name, "John Doe")
     }
 
-    func test_WCAnalyticsCustomer_array_maps_all_available_entities_if_response_has_no_data_eenvelope() {
+    func test_WCAnalyticsCustomer_array_maps_all_available_entities_if_response_has_no_data_envelope() {
         // Given
         let mapper = WCAnalyticsCustomerMapper(siteID: dummySiteID)
         var customers: [WCAnalyticsCustomer] = []

--- a/Networking/NetworkingTests/Mapper/WCAnalyticsCustomerMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WCAnalyticsCustomerMapperTests.swift
@@ -59,4 +59,22 @@ class WCAnalyticsCustomerMapperTests: XCTestCase {
         XCTAssertEqual(customers[3].userID, 3)
         XCTAssertEqual(customers[3].name, "John Doe")
     }
+
+    func test_WCAnalyticsCustomer_array_maps_all_available_entities_if_response_has_no_data_eenvelope() {
+        // Given
+        let mapper = WCAnalyticsCustomerMapper(siteID: dummySiteID)
+        var customers: [WCAnalyticsCustomer] = []
+
+        XCTAssertEqual(customers.count, 0)
+
+        // When
+        guard let data = Loader.contentsOf("wc-analytics-customers-without-data") else {
+            XCTFail("Data couldn't be loaded")
+            return
+        }
+        customers = try! mapper.map(response: data)
+
+        // Then
+        XCTAssertEqual(customers.count, 2)
+    }
 }

--- a/Networking/NetworkingTests/Responses/customer-without-data.json
+++ b/Networking/NetworkingTests/Responses/customer-without-data.json
@@ -1,0 +1,51 @@
+{
+    "id": 25,
+    "date_created": "2017-03-21T16:09:28",
+    "date_created_gmt": "2017-03-21T19:09:28",
+    "date_modified": "2017-03-21T16:09:30",
+    "date_modified_gmt": "2017-03-21T19:09:30",
+    "email": "john.doe@example.com",
+    "first_name": "John",
+    "last_name": "Doe",
+    "role": "customer",
+    "username": "john.doe",
+    "billing": {
+      "first_name": "John",
+      "last_name": "Doe",
+      "company": "",
+      "address_1": "969 Market",
+      "address_2": "",
+      "city": "San Francisco",
+      "state": "CA",
+      "postcode": "94103",
+      "country": "US",
+      "email": "john.doe@example.com",
+      "phone": "(555) 555-5555"
+    },
+    "shipping": {
+      "first_name": "John",
+      "last_name": "Doe",
+      "company": "",
+      "address_1": "969 Market",
+      "address_2": "",
+      "city": "San Francisco",
+      "state": "CA",
+      "postcode": "94103",
+      "country": "US"
+    },
+    "is_paying_customer": false,
+    "avatar_url": "https://secure.gravatar.com/avatar/8eb1b522f60d11fa897de1dc6351b7e8?s=96",
+    "meta_data": [],
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/customers/25"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/customers"
+        }
+      ]
+    }
+}

--- a/Networking/NetworkingTests/Responses/wc-analytics-customers-without-data.json
+++ b/Networking/NetworkingTests/Responses/wc-analytics-customers-without-data.json
@@ -1,0 +1,40 @@
+[
+    {
+        "id":0,
+        "user_id":0,
+        "username":"Matt.the.unregistered",
+        "name":"Matt The Unregistered",
+        "email":"matt.t.u@example.com",
+        "country":"US",
+        "city":"San Francisco",
+        "state":"CA",
+        "postcode":"94103",
+        "date_registered":null,
+        "date_last_active":"2022-07-12T08:36:54",
+        "date_last_order":"2022-07-12 08:36:54",
+        "orders_count":1,
+        "total_spend":10,
+        "avg_order_value":10,
+        "date_registered_gmt":null,
+        "date_last_active_gmt":"2022-07-12T08:36:54"
+    },
+    {
+        "id":1,
+        "user_id":1,
+        "username":"John",
+        "name":"John",
+        "email":"john.doe@example.com",
+        "country":"US",
+        "city":"San Francisco",
+        "state":"CA",
+        "postcode":"94103",
+        "date_registered":null,
+        "date_last_active":"2022-07-12T08:36:54",
+        "date_last_order":"2022-07-12 08:36:54",
+        "orders_count":1,
+        "total_spend":10,
+        "avg_order_value":10,
+        "date_registered_gmt":null,
+        "date_last_active_gmt":"2022-07-12T08:36:54"
+    }
+]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8582 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR migrates customer endpoints for the REST API:
- Updated `CustomerMapper` and `WCAnalyticsCustomerMapper` to parse contents without the data envelope.
- Enabled REST API on both customer and wc analytics customer endpoints.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Pre-requisite: place an order on your test store. This will register your test customer with the store - we currently support customer search for registered users only.
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select "Enter your site address" and enter the address of your self-hosted store.
- Proceed to log in with site credentials.
- After the login succeeds, you should be navigated to the home screen.
- Select the Orders tab and tap "+" to add a new order.
- On the order creation form, select "Add Customer Details".
- On the Customer Details screen, tap the search button. 
- On the search screen, enter the name you entered when placing the test order. The correct user should show up in the search result.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/211245456-cd635b73-2a3c-46ce-885e-0a4f22f285aa.png" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
