### PR TITLE
Make `RESTRequest` work with both WooCommerce and WordPress API.

### DIFF
--- a/Networking/NetworkingTests/Requests/JetpackRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/JetpackRequestTests.swift
@@ -140,7 +140,7 @@ final class JetpackRequestTests: XCTestCase {
         let output = try XCTUnwrap(request.asRESTRequest(with: sampleSiteAddress))
 
         // Then
-        XCTAssertEqual(output.wooApiVersion, .mark3)
+        XCTAssertEqual(output.apiVersionPath, WooAPIVersion.mark3.path)
         XCTAssertEqual(output.method, .post)
         XCTAssertEqual(output.path, sampleRPC)
         let params = try XCTUnwrap(output.parameters as? [String: String])

--- a/Networking/NetworkingTests/Requests/RESTRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/RESTRequestTests.swift
@@ -60,6 +60,18 @@ final class RESTRequestTests: XCTestCase {
         assertEqual(url.absoluteString, expectedURL)
     }
 
+    func test_request_wordPressApiVersion_is_correct() throws {
+        // Given
+        let request = RESTRequest(siteURL: sampleSiteAddress, wordpressApiVersion: .wpMark2, method: .get, path: sampleRPC)
+
+        // When
+        let url = try XCTUnwrap(request.asURLRequest().url)
+
+        // Then
+        let expectedURL = "https://wordpress.com/wp-json/wp/v2/sample"
+        assertEqual(url.absoluteString, expectedURL)
+    }
+
     func test_it_uses_JSON_encoding_for_post_method() throws {
         // Given
         let request = RESTRequest(siteURL: sampleSiteAddress, wooApiVersion: sampleWooApiVersion, method: .post, path: sampleRPC, parameters: sampleParameters)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8566 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, `RESTRequest` only had the option to receive `WooAPIVersion` as API version. 

In future, we need to send `RESTRequest`s from `MediaRemote` using WordPress API to perform media-related actions. 

To prepare `RESTRequest` to handle WordPress API, this PR adds `WordPressAPIVersion` handling ability to `RESTRequest`

## Testing instructions
- CI passing should be enough. (`WordPressAPIVersion` on `RESTRequest` will be used in a future PR which will `MediaRemote` endpoints.)

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
