### PR TITLE
[REST API] `MediaRemote` - Add REST API methods

### DIFF
--- a/Networking/Networking/Network/MockNetwork.swift
+++ b/Networking/Networking/Network/MockNetwork.swift
@@ -193,6 +193,8 @@ private extension MockNetwork {
             return request.path
         case let request as DotcomRequest:
             return request.path
+        case let request as RESTRequest:
+            return request.path
         default:
             let targetURL = try! request.asURLRequest().url?.absoluteString
             return targetURL ?? ""

--- a/Networking/Networking/Remote/MediaRemote.swift
+++ b/Networking/Networking/Remote/MediaRemote.swift
@@ -2,6 +2,8 @@ import Foundation
 
 /// Protocol for `MediaRemote` mainly used for mocking.
 public protocol MediaRemoteProtocol {
+    // MARK: Load Media library
+    //
     func loadMediaLibrary(for siteID: Int64,
                           pageNumber: Int,
                           pageSize: Int,
@@ -11,6 +13,13 @@ public protocol MediaRemoteProtocol {
                                            pageNumber: Int,
                                            pageSize: Int,
                                            completion: @escaping (Result<[WordPressMedia], Error>) -> Void)
+    func loadMediaLibraryUsingRestApi(siteURL: String,
+                                      pageNumber: Int,
+                                      pageSize: Int,
+                                      completion: @escaping (Result<[WordPressMedia], Error>) -> Void)
+
+    // MARK: Upload Media
+    //
     func uploadMedia(for siteID: Int64,
                      productID: Int64,
                      context: String?,
@@ -20,6 +29,13 @@ public protocol MediaRemoteProtocol {
                                     productID: Int64,
                                     mediaItems: [UploadableMedia],
                                     completion: @escaping (Result<WordPressMedia, Error>) -> Void)
+    func uploadMediaUsingRestApi(siteURL: String,
+                                 productID: Int64,
+                                 mediaItems: [UploadableMedia],
+                                 completion: @escaping (Result<WordPressMedia, Error>) -> Void)
+
+    // MARK: Update Product ID
+    //
     func updateProductID(siteID: Int64,
                          productID: Int64,
                          mediaID: Int64,
@@ -28,11 +44,18 @@ public protocol MediaRemoteProtocol {
                                         productID: Int64,
                                         mediaID: Int64,
                                         completion: @escaping (Result<WordPressMedia, Error>) -> Void)
+    func updateProductIDUsingRestApi(siteURL: String,
+                                     productID: Int64,
+                                     mediaID: Int64,
+                                     completion: @escaping (Result<WordPressMedia, Error>) -> Void)
 }
 
 /// Media: Remote Endpoints
 ///
 public class MediaRemote: Remote, MediaRemoteProtocol {
+    // MARK: Load Media library
+    //
+
     /// Loads an array of media from the site's WP Media Library.
     /// API reference: https://developer.wordpress.com/docs/api/1.2/get/sites/%24site/media/
     ///
@@ -93,6 +116,35 @@ public class MediaRemote: Remote, MediaRemoteProtocol {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Loads an array of media from the site's WP Media Library via WordPress site API.
+    /// API reference: https://developer.wordpress.org/rest-api/reference/media/#list-media
+    ///
+    /// - Parameters:
+    ///   - siteURL: Site for which we'll load the media from.
+    ///   - pageNumber: The index of the page of media data to load from, starting from 1.
+    ///   - pageSize: The number of media items to return.
+    ///   - completion: Closure to be executed upon completion.
+    public func loadMediaLibraryUsingRestApi(siteURL: String,
+                                             pageNumber: Int = Default.pageNumber,
+                                             pageSize: Int = 25,
+                                             completion: @escaping (Result<[WordPressMedia], Error>) -> Void) {
+        let parameters: [String: Any] = [
+            ParameterKey.pageSize: pageSize,
+            ParameterKey.pageNumber: pageNumber,
+            ParameterKey.fieldsWordPressSite: ParameterValue.wordPressMediaFields,
+            ParameterKey.mimeType: "image"
+        ]
+
+        let path = "media"
+        let request = RESTRequest(siteURL: siteURL, wordpressApiVersion: .wpMark2, method: .get, path: path, parameters: parameters)
+        let mapper = WordPressMediaListMapper()
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
+    // MARK: Upload Media
+    //
 
     /// Uploads an array of media in the local file system.
     /// API reference: https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/media/new/
@@ -173,6 +225,43 @@ public class MediaRemote: Remote, MediaRemoteProtocol {
         }, completion: completion)
     }
 
+    /// Uploads an array of media in the local file system to the WordPress site.via WordPress site API
+    /// API reference: https://developer.wordpress.org/rest-api/reference/media/#create-a-media-item
+    ///
+    /// - Parameters:
+    ///   - siteURL: Site for which we'll upload the media to.
+    ///   - productID: Product for which the media items are first added to.
+    ///   - mediaItems: An array of uploadable media items.
+    ///   - completion: Closure to be executed upon completion.
+    public func uploadMediaUsingRestApi(siteURL: String,
+                                        productID: Int64,
+                                        mediaItems: [UploadableMedia],
+                                        completion: @escaping (Result<WordPressMedia, Error>) -> Void) {
+        let formParameters: [String: String] = [
+            ParameterKey.wordPressMediaPostID: "\(productID)",
+            ParameterKey.fieldsWordPressSite: ParameterValue.wordPressMediaFields,
+        ]
+        let path = "media"
+        let request = RESTRequest(siteURL: siteURL, wordpressApiVersion: .wpMark2, method: .post, path: path)
+        let mapper = WordPressMediaMapper()
+
+        enqueueMultipartFormDataUpload(request, mapper: mapper, multipartFormData: { multipartFormData in
+            formParameters.forEach { (key, value) in
+                multipartFormData.append(Data(value.utf8), withName: key)
+            }
+
+            mediaItems.forEach { mediaItem in
+                multipartFormData.append(mediaItem.localURL,
+                                         withName: ParameterValue.mediaUploadName,
+                                         fileName: mediaItem.filename,
+                                         mimeType: mediaItem.mimeType)
+            }
+        }, completion: completion)
+    }
+
+    // MARK: Update Product ID
+    //
+
     /// Sets the provided `productID` as `parent_id` of the `media`.
     ///
     /// API reference: https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/media/%24media_ID/
@@ -219,6 +308,32 @@ public class MediaRemote: Remote, MediaRemoteProtocol {
         ]
         let path = "sites/\(siteID)/media/\(mediaID)"
         let request = DotcomRequest(wordpressApiVersion: .wpMark2, method: .post, path: path, parameters: parameters)
+        let mapper = WordPressMediaMapper()
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
+    /// Sets the provided `productID` as post ID of the Media in WordPress site using WordPress site API
+    ///
+    /// API reference: to the WordPress site.via WordPress site API
+    /// https://developer.wordpress.org/rest-api/reference/media/#update-a-media-item
+    ///
+    /// - Parameters:
+    ///     - siteURL: Site in which the media was uploaded to.
+    ///     - productID: Product ID to use as post ID of the media.
+    ///     - mediaID: ID of media for which post ID needs to be updated.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func updateProductIDUsingRestApi(siteURL: String,
+                                            productID: Int64,
+                                            mediaID: Int64,
+                                            completion: @escaping (Result<WordPressMedia, Error>) -> Void) {
+        let parameters: [String: String] = [
+            ParameterKey.wordPressMediaPostID: "\(productID)",
+            ParameterKey.fieldsWordPressSite: ParameterValue.wordPressMediaFields,
+        ]
+        let path = "media/\(mediaID)"
+        let request = RESTRequest(siteURL: siteURL, wordpressApiVersion: .wpMark2, method: .post, path: path, parameters: parameters)
         let mapper = WordPressMediaMapper()
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
@@ -10,6 +10,10 @@ final class MediaRemoteTests: XCTestCase {
     ///
     private let sampleSiteID: Int64 = 1234
 
+    /// Dummy Site URL
+    ///
+    private let sampleSiteURL = "http://test.com"
+
     /// Dummy Product ID
     ///
     private let sampleProductID: Int64 = 586
@@ -117,6 +121,60 @@ final class MediaRemoteTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
     }
 
+    // MARK: - Load Media From Media Library `loadMediaLibraryUsingRestApi`
+
+    /// Verifies that `loadMediaLibraryUsingRestApi` properly parses the `media-library-from-wordpress-site` sample response.
+    ///
+    func test_loadMediaLibraryUsingRestApi_properly_returns_parsed_media_list() throws {
+        // Given
+        let remote = MediaRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "media", filename: "media-library-from-wordpress-site")
+
+        // When
+        let result = waitFor { promise in
+            remote.loadMediaLibraryUsingRestApi(siteURL: self.sampleSiteURL) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let mediaItems = try XCTUnwrap(result.get())
+        XCTAssertEqual(mediaItems.count, 2)
+        let uploadedMedia = try XCTUnwrap(mediaItems.first)
+        XCTAssertEqual(uploadedMedia.mediaID, 22)
+        XCTAssertEqual(uploadedMedia.date, Date(timeIntervalSince1970: 1637546157))
+        XCTAssertEqual(uploadedMedia.slug, "img_0111-2")
+        XCTAssertEqual(uploadedMedia.mimeType, "image/jpeg")
+        XCTAssertEqual(uploadedMedia.src, "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-scaled.jpeg")
+        XCTAssertEqual(uploadedMedia.alt, "Floral")
+        XCTAssertEqual(uploadedMedia.details?.width, 2560)
+        XCTAssertEqual(uploadedMedia.details?.height, 1920)
+        XCTAssertEqual(uploadedMedia.details?.fileName, "2021/11/img_0111-2-scaled.jpeg")
+        XCTAssertEqual(uploadedMedia.title, .init(rendered: "img_0111-2"))
+        XCTAssertEqual(uploadedMedia.details?.sizes["thumbnail"],
+                       .init(fileName: "img_0111-2-150x150.jpeg",
+                             src: "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-150x150.jpeg",
+                             width: 150,
+                             height: 150))
+    }
+
+    /// Verifies that `loadMediaLibraryUsingRestApi` properly relays Networking Layer errors.
+    ///
+    func test_loadMediaLibraryUsingRestApi_properly_relays_networking_errors() throws {
+        // Given
+        let remote = MediaRemote(network: network)
+
+        // When
+        let result = waitFor { promise in
+            remote.loadMediaLibraryUsingRestApi(siteURL: self.sampleSiteURL) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
     // MARK: - uploadMedia
 
     /// Verifies that `uploadMedia` properly parses the `media-upload` sample response.
@@ -215,6 +273,61 @@ final class MediaRemoteTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
     }
 
+    /// Verifies that `uploadMediaUsingRestApi` properly parses the `media-upload-to-wordpress-site` sample response.
+    ///
+    func test_uploadMediaUsingRestApi_properly_returns_parsed_media() throws {
+        // Given
+        let remote = MediaRemote(network: network)
+        let path = "media"
+        network.simulateResponse(requestUrlSuffix: path, filename: "media-upload-to-wordpress-site")
+
+        // When
+        let result = waitFor { promise in
+            remote.uploadMediaUsingRestApi(siteURL: self.sampleSiteURL,
+                                           productID: self.sampleProductID,
+                                           mediaItems: []) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let uploadedMedia = try XCTUnwrap(result.get())
+        XCTAssertEqual(uploadedMedia.mediaID, 23)
+        XCTAssertEqual(uploadedMedia.date, Date(timeIntervalSince1970: 1637477423))
+        XCTAssertEqual(uploadedMedia.slug, "img_0005-1")
+        XCTAssertEqual(uploadedMedia.mimeType, "image/jpeg")
+        XCTAssertEqual(uploadedMedia.src, "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-scaled.jpeg")
+        XCTAssertEqual(uploadedMedia.alt, "Floral")
+        XCTAssertEqual(uploadedMedia.details?.width, 2560)
+        XCTAssertEqual(uploadedMedia.details?.height, 1708)
+        XCTAssertEqual(uploadedMedia.details?.fileName, "2021/11/img_0005-1-scaled.jpeg")
+        XCTAssertEqual(uploadedMedia.title, .init(rendered: "img_0005-1"))
+        XCTAssertEqual(uploadedMedia.details?.sizes["thumbnail"],
+                       .init(fileName: "img_0005-1-150x150.jpeg",
+                             src: "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-150x150.jpeg",
+                             width: 150,
+                             height: 150))
+    }
+
+    /// Verifies that `uploadMediaUsingRestApi` properly relays Networking Layer errors.
+    ///
+    func test_uploadMediaUsingRestApi_properly_relays_networking_errors() {
+        // Given
+        let remote = MediaRemote(network: network)
+
+        // When
+        let result = waitFor { promise in
+            remote.uploadMediaUsingRestApi(siteURL: self.sampleSiteURL,
+                                           productID: self.sampleProductID,
+                                           mediaItems: []) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
     // MARK: - updateProductID
 
     /// Verifies that `updateProductID` properly parses the `media-update-product-id` sample response.
@@ -293,6 +406,49 @@ final class MediaRemoteTests: XCTestCase {
             remote.updateProductIDToWordPressSite(siteID: self.sampleSiteID,
                                    productID: self.sampleProductID,
                                    mediaID: self.sampleMediaID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
+    // MARK: - updateProductIDUsingRestApi
+
+    /// Verifies that `updateProductIDUsingRestApi` properly parses the `media-update-product-id-in-wordpress-site` sample response.
+    ///
+    func test_updateProductIDUsingRestApi_properly_returns_parsed_media() throws {
+        // Given
+        let remote = MediaRemote(network: network)
+        let path = "media/\(sampleMediaID)"
+        network.simulateResponse(requestUrlSuffix: path, filename: "media-update-product-id-in-wordpress-site")
+
+        // When
+        let result = waitFor { promise in
+            remote.updateProductIDUsingRestApi(siteURL: self.sampleSiteURL,
+                                               productID: self.sampleProductID,
+                                               mediaID: self.sampleMediaID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let media = try XCTUnwrap(result.get())
+        XCTAssertEqual(media.mediaID, sampleMediaID)
+    }
+
+    /// Verifies that `updateProductIDUsingRestApi` properly relays Networking Layer errors.
+    ///
+    func test_updateProductIDUsingRestApi_properly_relays_networking_errors() {
+        // Given
+        let remote = MediaRemote(network: network)
+
+        // When
+        let result = waitFor { promise in
+            remote.updateProductIDUsingRestApi(siteURL: self.sampleSiteURL,
+                                               productID: self.sampleProductID,
+                                               mediaID: self.sampleMediaID) { result in
                 promise(result)
             }
         }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMediaRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMediaRemote.swift
@@ -15,17 +15,26 @@ final class MockMediaRemote {
     /// The results to return based on the given site ID in `loadMediaLibraryFromWordPressSite`
     private var loadMediaLibraryFromWordPressSiteResultsBySiteID = [Int64: Result<[WordPressMedia], Error>]()
 
+    /// The results to return based on the given site ID in `loadMediaLibraryUsingRestApi`
+    private var loadMediaLibraryUsingRestApiResultsBySiteURL = [String: Result<[WordPressMedia], Error>]()
+
     /// The results to return based on the given site ID in `uploadMedia`
     private var uploadMediaResultsBySiteID = [Int64: Result<[Media], Error>]()
 
     /// The results to return based on the given site ID in `uploadMediaToWordPressSite`
     private var uploadMediaToWordPressSiteResultsBySiteID = [Int64: Result<WordPressMedia, Error>]()
 
+    /// The results to return based on the given site ID in `uploadMediaUsingRestApi`
+    private var uploadMediaUsingRestApiResultsBySiteURL = [String: Result<WordPressMedia, Error>]()
+
     /// The results to return based on the given site ID in `updateProductID`
     private var updateProductIDResultsBySiteID = [Int64: Result<Media, Error>]()
 
     /// The results to return based on the given site ID in `updateProductIDToWordPressSite`
     private var updateProductIDToWordPressSiteResultsBySiteID = [Int64: Result<WordPressMedia, Error>]()
+
+    /// The results to return based on the given site ID in `updateProductIDUsingRestApi`
+    private var updateProductIDUsingRestApiResultsBySiteURL = [String: Result<WordPressMedia, Error>]()
 
     /// Returns the value as a publisher when `loadMediaLibrary` is called.
     func whenLoadingMediaLibrary(siteID: Int64, thenReturn result: Result<[Media], Error>) {
@@ -35,6 +44,11 @@ final class MockMediaRemote {
     /// Returns the value as a publisher when `loadMediaLibraryFromWordPressSite` is called.
     func whenLoadingMediaLibraryFromWordPressSite(siteID: Int64, thenReturn result: Result<[WordPressMedia], Error>) {
         loadMediaLibraryFromWordPressSiteResultsBySiteID[siteID] = result
+    }
+
+    /// Returns the value as a publisher when `loadMediaLibraryFromWordPressSite` is called.
+    func whenLoadingMediaLibraryUsingRestApi(siteURL: String, thenReturn result: Result<[WordPressMedia], Error>) {
+        loadMediaLibraryUsingRestApiResultsBySiteURL[siteURL] = result
     }
 
     /// Returns the value as a publisher when `uploadMedia` is called.
@@ -47,6 +61,11 @@ final class MockMediaRemote {
         uploadMediaToWordPressSiteResultsBySiteID[siteID] = result
     }
 
+    /// Returns the value as a publisher when `uploadMediaUsingRestApi` is called.
+    func whenUploadingMediaUsingRestApi(siteURL: String, thenReturn result: Result<WordPressMedia, Error>) {
+        uploadMediaUsingRestApiResultsBySiteURL[siteURL] = result
+    }
+
     /// Returns the value as a publisher when `updateProductID` is called.
     func whenUpdatingProductID(siteID: Int64, thenReturn result: Result<Media, Error>) {
         updateProductIDResultsBySiteID[siteID] = result
@@ -56,16 +75,24 @@ final class MockMediaRemote {
     func whenUpdatingProductIDToWordPressSite(siteID: Int64, thenReturn result: Result<WordPressMedia, Error>) {
         updateProductIDToWordPressSiteResultsBySiteID[siteID] = result
     }
+
+    /// Returns the value as a publisher when `updateProductIDUsingRestApi` is called.
+    func whenUpdatingProductIDUsingRestApi(siteURL: String, thenReturn result: Result<WordPressMedia, Error>) {
+        updateProductIDUsingRestApiResultsBySiteURL[siteURL] = result
+    }
 }
 
 extension MockMediaRemote {
     enum Invocation: Equatable {
         case loadMediaLibrary(siteID: Int64)
         case loadMediaLibraryFromWordPressSite(siteID: Int64)
+        case loadMediaLibraryUsingRestApi(siteURL: String)
         case uploadMedia(siteID: Int64)
         case uploadMediaToWordPressSite(siteID: Int64)
+        case uploadMediaUsingRestApi(siteURL: String)
         case updateProductID(siteID: Int64)
         case updateProductIDToWordPressSite(siteID: Int64)
+        case updateProductIDUsingRestApi(siteURL: String)
     }
 }
 
@@ -85,6 +112,18 @@ extension MockMediaRemote: MediaRemoteProtocol {
         invocations.append(.loadMediaLibraryFromWordPressSite(siteID: siteID))
         guard let result = loadMediaLibraryFromWordPressSiteResultsBySiteID[siteID] else {
             XCTFail("\(String(describing: self)) Could not find result for site ID: \(siteID)")
+            return
+        }
+        completion(result)
+    }
+
+    func loadMediaLibraryUsingRestApi(siteURL: String,
+                                      pageNumber: Int,
+                                      pageSize: Int,
+                                      completion: @escaping (Result<[Networking.WordPressMedia], Error>) -> Void) {
+        invocations.append(.loadMediaLibraryUsingRestApi(siteURL: siteURL))
+        guard let result = loadMediaLibraryUsingRestApiResultsBySiteURL[siteURL] else {
+            XCTFail("\(String(describing: self)) Could not find result for site URL: \(siteURL)")
             return
         }
         completion(result)
@@ -115,6 +154,18 @@ extension MockMediaRemote: MediaRemoteProtocol {
         completion(result)
     }
 
+    func uploadMediaUsingRestApi(siteURL: String,
+                                 productID: Int64,
+                                 mediaItems: [Networking.UploadableMedia],
+                                 completion: @escaping (Result<Networking.WordPressMedia, Error>) -> Void) {
+        invocations.append(.uploadMediaUsingRestApi(siteURL: siteURL))
+        guard let result = uploadMediaUsingRestApiResultsBySiteURL[siteURL] else {
+            XCTFail("\(String(describing: self)) Could not find result for site URL: \(siteURL)")
+            return
+        }
+        completion(result)
+    }
+
     func updateProductID(siteID: Int64,
                          productID: Int64,
                          mediaID: Int64,
@@ -134,6 +185,18 @@ extension MockMediaRemote: MediaRemoteProtocol {
         invocations.append(.updateProductIDToWordPressSite(siteID: siteID))
         guard let result = updateProductIDToWordPressSiteResultsBySiteID[siteID] else {
             XCTFail("\(String(describing: self)) Could not find result for site ID: \(siteID)")
+            return
+        }
+        completion(result)
+    }
+
+    func updateProductIDUsingRestApi(siteURL: String,
+                                     productID: Int64,
+                                     mediaID: Int64,
+                                     completion: @escaping (Result<Networking.WordPressMedia, Error>) -> Void) {
+        invocations.append(.updateProductIDUsingRestApi(siteURL: siteURL))
+        guard let result = updateProductIDUsingRestApiResultsBySiteURL[siteURL] else {
+            XCTFail("\(String(describing: self)) Could not find result for site URL: \(siteURL)")
             return
         }
         completion(result)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8566
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

`MediaRemote` doesn't use Jetpack tunnel requests. It uses all `DotComRequest`s due to restrictions related to content headers and JCP sites. More details in this thread - p1672921523522859-slack-C046HDZL87J

So, we cannot use the `availableAsRESTRequest` property of `JetpackRequest` to handle the migration of Media related endpoints. We need to have the ability to send `RESTRequest`s directly instead of `DotComRequest`s from `MediaRemote`

This PR adds new methods to `MediaRemoteProtocol` to handle REST API calls. 

## Testing instructions
CI passing should be enough. 

## Screenshots
NA

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.