### PR TITLE
[Mobile Payments] Check built in card reader requirements

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderService.swift
+++ b/Hardware/Hardware/CardReader/CardReaderService.swift
@@ -18,6 +18,12 @@ public protocol CardReaderService {
 
     // MARK: - Commands
 
+    /// Checks for support of a given reader type and discovery method combination. Does not start discovery.
+    ///
+    func checkSupport(for cardReaderType: CardReaderType,
+                      configProvider: CardReaderConfigProvider,
+                      discoveryMethod: CardReaderDiscoveryMethod) -> Bool
+
     /// Starts the service.
     /// That could imply, for example, that the reader discovery process starts
     func start(_ configProvider: CardReaderConfigProvider, discoveryMethod: CardReaderDiscoveryMethod) throws

--- a/Hardware/Hardware/CardReader/StripeCardReader/CardReaderType+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/CardReaderType+Stripe.swift
@@ -19,5 +19,20 @@ extension CardReaderType {
             return .other
         }
     }
+
+    func toStripe() -> DeviceType? {
+        switch self {
+        case .chipper:
+            return .chipper2X
+        case .stripeM2:
+            return .stripeM2
+        case .wisepad3:
+            return .wisePad3
+        case .appleBuiltIn:
+            return .appleBuiltIn
+        case .other:
+            return nil
+        }
+    }
 }
 #endif

--- a/Hardware/Hardware/CardReader/StripeCardReader/NoOpCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/NoOpCardReaderService.swift
@@ -1,5 +1,5 @@
 import Combine
-/// The adapter wrapping the Stripe Terminal SDK
+/// A no-op replacement for the adapter wrapping the Stripe Terminal SDK
 public struct NoOpCardReaderService: CardReaderService {
     // MARK: - Queries
     /// The publisher that emits the list of discovered readers whenever the service discovers a new reader.
@@ -17,6 +17,12 @@ public struct NoOpCardReaderService: CardReaderService {
 
     public init() {}
     // MARK: - Commands
+
+    public func checkSupport(for cardReaderType: CardReaderType,
+                             configProvider: CardReaderConfigProvider,
+                             discoveryMethod: CardReaderDiscoveryMethod) -> Bool {
+        return false
+    }
 
     /// Starts the service.
     /// That could imply, for example, that the reader discovery process starts

--- a/WooCommerce/Classes/Model/BetaFeature.swift
+++ b/WooCommerce/Classes/Model/BetaFeature.swift
@@ -155,7 +155,7 @@ private extension BetaFeature {
             "phone's built in reader")
         static let tapToPayOnIPhoneDescription = NSLocalizedString(
             "Test out In-Person Payments using your phone's built-in card reader, as we get ready to launch. " +
-            "Supported on iPhone XS and newer phones, running iOS 15.5 or above.",
+            "Supported on iPhone XS and newer phones, running iOS 16 or above, for US-based stores.",
             comment: "Cell description on beta features screen to enable in-app purchases")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -82,7 +82,8 @@ final class CardPresentPaymentPreflightController {
             analyticsTracker: analyticsTracker)
     }
 
-    func start() {
+    @MainActor
+    func start() async {
         configureBackend()
         observeConnectedReaders()
         // If we're already connected to a reader, return it
@@ -94,7 +95,7 @@ final class CardPresentPaymentPreflightController {
         // TODO: Run onboarding if needed
 
         // Ask for a Reader type if supported by device/in country
-        guard localMobileReaderSupported(),
+        guard await localMobileReaderSupported(),
               configuration.supportedReaders.contains(.appleBuiltIn)
         else {
             // Attempt to find a bluetooth reader and connect
@@ -120,16 +121,16 @@ final class CardPresentPaymentPreflightController {
             }))
     }
 
-    private func localMobileReaderSupported() -> Bool {
-        #if targetEnvironment(simulator)
-        return true
-        #else
-        if #available(iOS 15.4, *) {
-            return PaymentCardReader.isSupported
-        } else {
-            return false
+    @MainActor
+    private func localMobileReaderSupported() async -> Bool {
+        await withCheckedContinuation { continuation in
+            let action = CardPresentPaymentAction.checkDeviceSupport(siteID: siteID,
+                                                                     cardReaderType: .appleBuiltIn,
+                                                                     discoveryMethod: .localMobile) { result in
+                continuation.resume(returning: result)
+            }
+            stores.dispatch(action)
         }
-        #endif
     }
 
     private func handleConnectionResult(_ result: Result<CardReaderConnectionResult, Error>) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -178,7 +178,9 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
         }
         .store(in: &cancellables)
 
-        preflightController?.start()
+        Task {
+            await preflightController?.start()
+        }
     }
 }
 

--- a/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Yosemite/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -23,6 +23,11 @@ public enum CardPresentPaymentAction: Action {
     ///
     case loadAccounts(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
 
+    case checkDeviceSupport(siteID: Int64,
+                            cardReaderType: CardReaderType,
+                            discoveryMethod: CardReaderDiscoveryMethod,
+                            onCompletion: (Bool) -> Void)
+
     /// Start the Card Reader discovery process.
     ///
     case startCardReaderDiscovery(siteID: Int64,

--- a/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Yosemite/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -50,6 +50,12 @@ final class MockCardReaderService: CardReaderService {
     /// The publisher to return in `capturePayment`.
     private var capturePaymentPublisher: AnyPublisher<PaymentIntent, Error>?
 
+
+    var didCheckSupport = false
+    var spyCheckSupportCardReaderType: CardReaderType? = nil
+    var spyCheckSupportConfigProvider: CardReaderConfigProvider? = nil
+    var spyCheckSupportDiscoveryMethod: CardReaderDiscoveryMethod? = nil
+
     /// The future to return in `waitForInsertedCardToBeRemoved`.
     private var waitForInsertedCardToBeRemovedFuture: Future<Void, Never>?
 
@@ -59,6 +65,17 @@ final class MockCardReaderService: CardReaderService {
 
     init() {
 
+    }
+
+    func checkSupport(for cardReaderType: Hardware.CardReaderType,
+                      configProvider: Hardware.CardReaderConfigProvider,
+                      discoveryMethod: Hardware.CardReaderDiscoveryMethod) -> Bool {
+        didCheckSupport = true
+        spyCheckSupportCardReaderType = cardReaderType
+        spyCheckSupportConfigProvider = configProvider
+        spyCheckSupportDiscoveryMethod = discoveryMethod
+
+        return true
     }
 
     func start(_ configProvider: Hardware.CardReaderConfigProvider, discoveryMethod: Hardware.CardReaderDiscoveryMethod) throws {

--- a/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -775,4 +775,37 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         // Then
         XCTAssertEqual(result, account)
     }
+
+    func test_checkDeviceSupport_action_passes_configuration_provider_to_service() {
+        let cardPresentStore = CardPresentPaymentStore(dispatcher: dispatcher,
+                                                       storageManager: storageManager,
+                                                       network: network,
+                                                       cardReaderService: mockCardReaderService)
+
+        let action = CardPresentPaymentAction.checkDeviceSupport(siteID: sampleSiteID,
+                                                                 cardReaderType: .appleBuiltIn,
+                                                                 discoveryMethod: .localMobile,
+                                                                 onCompletion: { _ in })
+
+        cardPresentStore.onAction(action)
+
+        XCTAssertNotNil(mockCardReaderService.spyCheckSupportConfigProvider)
+    }
+
+    func test_checkDeviceSupport_action_passes_reader_type_and_discovery_method_to_service() {
+        let cardPresentStore = CardPresentPaymentStore(dispatcher: dispatcher,
+                                                       storageManager: storageManager,
+                                                       network: network,
+                                                       cardReaderService: mockCardReaderService)
+
+        let action = CardPresentPaymentAction.checkDeviceSupport(siteID: sampleSiteID,
+                                                                 cardReaderType: .chipper,
+                                                                 discoveryMethod: .bluetoothScan,
+                                                                 onCompletion: { _ in })
+
+        cardPresentStore.onAction(action)
+
+        assertEqual(.bluetoothScan, mockCardReaderService.spyCheckSupportDiscoveryMethod)
+        assertEqual(.chipper, mockCardReaderService.spyCheckSupportCardReaderType)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8314
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In sTAP Away, we're adding support for Tap to Pay on iPhone, using Stripe's Terminal SDK to access the feature.

Apple's requirements for TTP are documented as needing iOS 15.5, on an iPhone XS or newer, and in US-based stores. However, Stripe's SDK is more stringent, and only makes the feature available for iPhones (not iPads) running iOS 16 or newer.

This PR updates the device and OS checks using Stripe's rules.

### Background
When we did the proof of concept, we relied on Apple's `PaymentCardReader.isSupported` property, and didn't see a function in Stripe's SDK for checking support, as it was done intrinsically when we tried to discover a reader. 

Unfortunately, this is not a suitable flow for our app, as we give the user an upfront choice of the reader type they want to use. In the production version of Stripe's SDK, there is a `checkDeviceSupport` function which allows us to find this detail out according to Stripe's rules.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

N.B. To fully test this on device needs a lot of test devices, more than I have available. I have checked scenarios 1 and 5 on device, and all scenarios on the simulator.

Unfortunately, Stripe's terminal simulator is returning `true` for iPhone X and iPhone 8, which doesn't reflect the published device support, so scenario 3 is essentially untested, or failing the test. I've reached out to Stripe about this, but if anyone is able to test that specific scenario on device, I'd appreciate you noting it in the comments 😊

### 1. Using an iPhone XS or newer on iOS 16.0 or newer on a US store

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. Observe that you are asked to choose a reader type: tap `Tap to Pay on iPhone` and go through the Terms of Service Apple ID linking (if you've not done so before)
6. Observe that you can take the payment

### 2. Using an iPad on iOS 16.0 or newer on a US store

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. Observe that you are not asked to choose a reader type, and taken straight to the Bluetooth reader discovery flow

### 3. Using an iPhone X or older on iOS 16.0 or newer on a US store

As for iPad above

### 4. Using an iPhone XS or newer on iOS 15.7.2 or older on a US store

As for iPad above

### 5. Using an iPhone X or older on iOS 15.7.2 or older on a US store

As for iPad above


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/211371971-a04d8a8e-8cad-4ae4-a0c9-2a31b4188cc7.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
