### PR TITLE
[Unit Tests] Set default currency settings in AnalyticsHubViewModelTests test setup

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Yosemite
+import WooFoundation
 @testable import WooCommerce
 
 final class AnalyticsHubViewModelTests: XCTestCase {
@@ -14,6 +15,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         eventEmitter = StoreStatsUsageTracksEventEmitter(analytics: analytics)
+        ServiceLocator.setCurrencySettings(CurrencySettings()) // Default is US
     }
 
     func test_cards_viewmodels_show_correct_data_after_updating_from_network() async {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8561
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

On `AnalyticsHubViewModelTests`, test `test_cards_viewmodels_show_correct_data_after_updating_from_network` we hardcode the dollar currency symbol when checking the leading value of the revenue card:

`XCTAssertEqual(vm.revenueCard.leadingValue, "$62")`

This was failing when the unit tests were run after running the app with a test store using different currency settings. (I could only reproduce it immediately after building and running the app normally, and then running the full test suite. The test always passed for me when running that specific test by itself.)

We could fix this by passing specific currency settings into the view model. However, a more straightforward solution for this test is to set the Service Locator to use the default currency settings during the test setup. This seems like a safe approach given that we are only enforcing the default settings for the tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Set your store to use a currency other than USD.
2. Build and run the app normally.
3. Build and run the full unit test suite, and confirm all tests pass.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
