### PR TITLE
Temporarily disable two flaky `InAppPurchaseStoreTests` test cases

### DIFF
--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -30,6 +30,8 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "InAppPurchaseStoreTests\/test_user_is_entitled_to_product_returns_false_when_not_entitled()",
+        "InAppPurchaseStoreTests\/test_user_is_entitled_to_product_returns_true_when_entitled()",
         "StripeCardReaderIntegrationTests"
       ],
       "target" : {

--- a/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/InAppPurchaseStoreTests.swift
@@ -175,6 +175,8 @@ final class InAppPurchaseStoreTests: XCTestCase {
         XCTAssert(error is WordPressApiError)
     }
 
+    // TODO: re-enable the test case when it can pass consistently. More details:
+    // https://github.com/woocommerce/woocommerce-ios/pull/8256#pullrequestreview-1199236279
     func test_user_is_entitled_to_product_returns_false_when_not_entitled() throws {
         // Given
 
@@ -191,6 +193,8 @@ final class InAppPurchaseStoreTests: XCTestCase {
         XCTAssertFalse(isEntitled)
     }
 
+    // TODO: re-enable the test case when it can pass consistently. More details:
+    // https://github.com/woocommerce/woocommerce-ios/pull/8256#pullrequestreview-1199236279
     func test_user_is_entitled_to_product_returns_true_when_entitled() throws {
         // Given
         try storeKitSession.buyProduct(productIdentifier: sampleProductID)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Temporarily for #8221
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We've tried a few ways to fix two flaky tests that call `InAppPurchaseAction.userIsEntitledToProduct`, but haven't found a fix yet that can pass consistently when running the same test cases several times https://github.com/woocommerce/woocommerce-ios/pull/8256#pullrequestreview-1199236279. Let's disable them for now and come up with a way to make them pass consistently, possibly when we're going to launch IAP. This helps us unblock PR merging and save CI resources.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just CI.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
