### PR TITLE
Domain settings: Yosemite layer changes for 2 actions

### DIFF
--- a/Yosemite/Yosemite/Stores/DomainStore.swift
+++ b/Yosemite/Yosemite/Stores/DomainStore.swift
@@ -48,7 +48,9 @@ private extension DomainStore {
     }
 
     func loadDomains(siteID: Int64, completion: @escaping (Result<[SiteDomain], Error>) -> Void) {
-        // TODO: 8558 - fetch a site's domains from the remote.
-        completion(.success([.init(name: "gotrees.wpcomstaging.com", isPrimary: true, renewalDate: nil)]))
+        Task { @MainActor in
+            let result = await Result { try await remote.loadDomains(siteID: siteID) }
+            completion(result)
+        }
     }
 }

--- a/Yosemite/Yosemite/Stores/PaymentStore.swift
+++ b/Yosemite/Yosemite/Stores/PaymentStore.swift
@@ -62,9 +62,11 @@ private extension PaymentStore {
     }
 
     func loadSiteCurrentPlan(siteID: Int64,
-                             completion: (Result<WPComSitePlan, Error>) -> Void) {
-        // TODO: 8558 - fetch site's current plan
-        completion(.success(.init(plan: .init(productID: 0, name: "", formattedPrice: ""), hasDomainCredit: true)))
+                             completion: @escaping (Result<WPComSitePlan, Error>) -> Void) {
+        Task { @MainActor in
+            let result = await Result { try await remote.loadSiteCurrentPlan(siteID: siteID) }
+            completion(result)
+        }
     }
 
     func createCart(productID: String,

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDomainRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDomainRemote.swift
@@ -7,9 +7,17 @@ final class MockDomainRemote {
     /// The results to return in `loadDomainSuggestions`.
     private var loadDomainSuggestionsResult: Result<[FreeDomainSuggestion], Error>?
 
+    /// The results to return in `loadDomains`.
+    private var loadDomainsResult: Result<[SiteDomain], Error>?
+
     /// Returns the value when `loadDomainSuggestions` is called.
     func whenLoadingDomainSuggestions(thenReturn result: Result<[FreeDomainSuggestion], Error>) {
         loadDomainSuggestionsResult = result
+    }
+
+    /// Returns the value when `loadDomains` is called.
+    func whenLoadingDomains(thenReturn result: Result<[SiteDomain], Error>) {
+        loadDomainsResult = result
     }
 }
 
@@ -17,6 +25,14 @@ extension MockDomainRemote: DomainRemoteProtocol {
     func loadFreeDomainSuggestions(query: String) async throws -> [FreeDomainSuggestion] {
         guard let result = loadDomainSuggestionsResult else {
             XCTFail("Could not find result for loading domain suggestions.")
+            throw NetworkError.notFound
+        }
+        return try result.get()
+    }
+
+    func loadDomains(siteID: Int64) async throws -> [SiteDomain] {
+        guard let result = loadDomainsResult else {
+            XCTFail("Could not find result for loading domains.")
             throw NetworkError.notFound
         }
         return try result.get()

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockPaymentRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockPaymentRemote.swift
@@ -7,12 +7,20 @@ final class MockPaymentRemote {
     /// The results to return in `loadPlan`.
     private var loadPlanResult: Result<WPComPlan, Error>?
 
+    /// The results to return in `loadSiteCurrentPlan`.
+    private var loadSiteCurrentPlanResult: Result<WPComSitePlan, Error>?
+
     /// The results to return in `createCart`.
     private var createCartResult: Result<Void, Error>?
 
     /// Returns the value when `loadPlan` is called.
     func whenLoadingPlan(thenReturn result: Result<WPComPlan, Error>) {
         loadPlanResult = result
+    }
+
+    /// Returns the value when `loadSiteCurrentPlan` is called.
+    func whenLoadingSiteCurrentPlan(thenReturn result: Result<WPComSitePlan, Error>) {
+        loadSiteCurrentPlanResult = result
     }
 
     /// Returns the value when `createCart` is called.
@@ -22,9 +30,17 @@ final class MockPaymentRemote {
 }
 
 extension MockPaymentRemote: PaymentRemoteProtocol {
-    func loadPlan(thatMatchesID productID: Int64) async throws -> Networking.WPComPlan {
+    func loadPlan(thatMatchesID productID: Int64) async throws -> WPComPlan {
         guard let result = loadPlanResult else {
             XCTFail("Could not find result for loading a plan.")
+            throw NetworkError.notFound
+        }
+        return try result.get()
+    }
+
+    func loadSiteCurrentPlan(siteID: Int64) async throws -> WPComSitePlan {
+        guard let result = loadSiteCurrentPlanResult else {
+            XCTFail("Could not find result for loading a site's current plan.")
             throw NetworkError.notFound
         }
         return try result.get()

--- a/Yosemite/YosemiteTests/Stores/PaymentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/PaymentStoreTests.swift
@@ -70,6 +70,42 @@ final class PaymentStoreTests: XCTestCase {
         XCTAssertEqual(error as? NetworkError, .timeout)
     }
 
+    // MARK: - `loadSiteCurrentPlan`
+
+    func test_loadSiteCurrentPlan_returns_plan_on_success() throws {
+        // Given
+        remote.whenLoadingSiteCurrentPlan(thenReturn: .success(.init(hasDomainCredit: true)))
+
+        // When
+        let result = waitFor { promise in
+            self.store.onAction(PaymentAction.loadSiteCurrentPlan(siteID: 645) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let plan = try XCTUnwrap(result.get())
+        XCTAssertEqual(plan, .init(hasDomainCredit: true))
+    }
+
+    func test_loadSiteCurrentPlan_returns_failure_on_error() throws {
+        // Given
+        remote.whenLoadingSiteCurrentPlan(thenReturn: .failure(NetworkError.timeout))
+
+        // When
+        let result = waitFor { promise in
+            self.store.onAction(PaymentAction.loadSiteCurrentPlan(siteID: 645) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? NetworkError, .timeout)
+    }
+
     // MARK: - `createCart`
 
     func test_createCart_returns_on_success() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8558 
Based on https://github.com/woocommerce/woocommerce-ios/pull/8600
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Why

After the user creates a store, they might want to choose a proper domain for their new store. The domain settings screen shows the domains of a WPCOM site, and allows the merchant to add a domain either using their domain credit or the checkout flow similar to the Jetpack app.

### Networking layer changes

More technical details at the spike: pe5sF9-Ug-p2

This PR just contains the Yosemite layer changes for two actions required to show the domain settings UI:

- `DomainAction.loadDomains`: this loads the site's domains, including the free staging domain
- `PaymentAction.loadSiteCurrentPlan`: this loads the site's WPCOM plans, and returns the current plan to determine if the site has domain credit so that the user can pick a domain for free (available from certain WPCOM plans)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: a WC store with a WPCOM plan is required

- Log in if needed, and continue with a WPCOM store
- Go to the Menu tab
- Tap on the settings CTA --> there should be a `Domain` row under the store settings section
- Tap the `Domain` row --> a modal should be shown with a free staging domain at the top with the actual site domain. most likely the site also has a `*.wordpress.com` domain, so the bottom CTA isn't shown for now

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://user-images.githubusercontent.com/1945542/211450360-dc07ba1f-7418-4c83-8a1f-d025c009d24a.png" width="300" />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
