### PR TITLE
[REST API] Pass site ID or URL in `MediaAction`

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -696,9 +696,9 @@
 		DE42F9632967C8B900D514C2 /* ReportOrderTotalsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE42F9622967C8B900D514C2 /* ReportOrderTotalsMapperTests.swift */; };
 		DE42F9652967F34400D514C2 /* refund-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F9642967F34400D514C2 /* refund-single-without-data.json */; };
 		DE42F9672967F61D00D514C2 /* refunds-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F9662967F61D00D514C2 /* refunds-all-without-data.json */; };
-		DE42F96F296BC9A700D514C2 /* countries-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F96E296BC9A700D514C2 /* countries-without-data.json */; };
 		DE42F96B296BC23800D514C2 /* customer-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F96A296BC23800D514C2 /* customer-without-data.json */; };
 		DE42F96D296BC67E00D514C2 /* wc-analytics-customers-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F96C296BC67E00D514C2 /* wc-analytics-customers-without-data.json */; };
+		DE42F96F296BC9A700D514C2 /* countries-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F96E296BC9A700D514C2 /* countries-without-data.json */; };
 		DE50295928C5BD0200551736 /* JetpackUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295828C5BD0200551736 /* JetpackUser.swift */; };
 		DE50295B28C5F99700551736 /* DotcomUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295A28C5F99700551736 /* DotcomUser.swift */; };
 		DE50295D28C6068B00551736 /* JetpackUserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295C28C6068B00551736 /* JetpackUserMapper.swift */; };
@@ -756,6 +756,7 @@
 		E1BAB2C52913FB1800C3982B /* WordPressApiValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAB2C42913FB1800C3982B /* WordPressApiValidator.swift */; };
 		E1BAB2C72913FB5800C3982B /* WordPressApiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAB2C62913FB5800C3982B /* WordPressApiError.swift */; };
 		EE338A0E294AF9BD00183934 /* ApplicationPasswordMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE338A0D294AF9BD00183934 /* ApplicationPasswordMapperTests.swift */; };
+		EE422B87296D0AAF00324265 /* rest_incorrect_application_password_error.json in Resources */ = {isa = PBXBuildFile; fileRef = EE422B86296D0AAF00324265 /* rest_incorrect_application_password_error.json */; };
 		EE54C89F2947782E00A9BF61 /* ApplicationPasswordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE54C89E2947782E00A9BF61 /* ApplicationPasswordUseCase.swift */; };
 		EE54C8A729486B6800A9BF61 /* ApplicationPasswordMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE54C8A629486B6800A9BF61 /* ApplicationPasswordMapper.swift */; };
 		EE62EE61295ACF8D009C965B /* RequestConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE60295ACF8D009C965B /* RequestConverterTests.swift */; };
@@ -1510,9 +1511,9 @@
 		DE42F9622967C8B900D514C2 /* ReportOrderTotalsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportOrderTotalsMapperTests.swift; sourceTree = "<group>"; };
 		DE42F9642967F34400D514C2 /* refund-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "refund-single-without-data.json"; sourceTree = "<group>"; };
 		DE42F9662967F61D00D514C2 /* refunds-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "refunds-all-without-data.json"; sourceTree = "<group>"; };
-		DE42F96E296BC9A700D514C2 /* countries-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "countries-without-data.json"; sourceTree = "<group>"; };
 		DE42F96A296BC23800D514C2 /* customer-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "customer-without-data.json"; sourceTree = "<group>"; };
 		DE42F96C296BC67E00D514C2 /* wc-analytics-customers-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wc-analytics-customers-without-data.json"; sourceTree = "<group>"; };
+		DE42F96E296BC9A700D514C2 /* countries-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "countries-without-data.json"; sourceTree = "<group>"; };
 		DE50295828C5BD0200551736 /* JetpackUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackUser.swift; sourceTree = "<group>"; };
 		DE50295A28C5F99700551736 /* DotcomUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotcomUser.swift; sourceTree = "<group>"; };
 		DE50295C28C6068B00551736 /* JetpackUserMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackUserMapper.swift; sourceTree = "<group>"; };
@@ -1570,6 +1571,7 @@
 		E1BAB2C42913FB1800C3982B /* WordPressApiValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressApiValidator.swift; sourceTree = "<group>"; };
 		E1BAB2C62913FB5800C3982B /* WordPressApiError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressApiError.swift; sourceTree = "<group>"; };
 		EE338A0D294AF9BD00183934 /* ApplicationPasswordMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordMapperTests.swift; sourceTree = "<group>"; };
+		EE422B86296D0AAF00324265 /* rest_incorrect_application_password_error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rest_incorrect_application_password_error.json; sourceTree = "<group>"; };
 		EE54C89E2947782E00A9BF61 /* ApplicationPasswordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordUseCase.swift; sourceTree = "<group>"; };
 		EE54C8A629486B6800A9BF61 /* ApplicationPasswordMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordMapper.swift; sourceTree = "<group>"; };
 		EE62EE60295ACF8D009C965B /* RequestConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestConverterTests.swift; sourceTree = "<group>"; };
@@ -2727,6 +2729,7 @@
 		EE338A0A294AF92A00183934 /* AppliicationPassword */ = {
 			isa = PBXGroup;
 			children = (
+				EE422B86296D0AAF00324265 /* rest_incorrect_application_password_error.json */,
 				EE71CC402951CE700074D908 /* generate-application-password-using-wporg-creds-success.json */,
 			);
 			path = AppliicationPassword;
@@ -3168,6 +3171,7 @@
 				0359EA2127AAE58C0048DE2D /* wcpay-charge-card-present.json in Resources */,
 				451274A625276C82009911FF /* product-variation.json in Resources */,
 				CC80E3F92948C8BC00D5FF45 /* site-visits-quarter.json in Resources */,
+				EE422B87296D0AAF00324265 /* rest_incorrect_application_password_error.json in Resources */,
 				020D07C223D858BB00FD9580 /* media-upload.json in Resources */,
 				31A451D127863A2E00FE81AA /* stripe-account-rejected-other.json in Resources */,
 				DEF13C5029629EEA0024A02B /* user-complete-without-data.json in Resources */,

--- a/Networking/Networking/Requests/RESTRequest.swift
+++ b/Networking/Networking/Requests/RESTRequest.swift
@@ -97,7 +97,7 @@ struct RESTRequest: Request {
     }
 
     func responseDataValidator() -> ResponseDataValidator {
-        PlaceholderDataValidator()
+        WordPressApiValidator()
     }
 }
 

--- a/Networking/NetworkingTests/Responses/AppliicationPassword/rest_incorrect_application_password_error.json
+++ b/Networking/NetworkingTests/Responses/AppliicationPassword/rest_incorrect_application_password_error.json
@@ -1,0 +1,7 @@
+{
+  "code": "incorrect_password",
+  "message": "The provided password is an invalid application password.",
+  "data": {
+    "status": 401
+  }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -212,7 +212,17 @@ final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
     private func uploadMediaAssetToSiteMediaLibrary(asset: PHAsset, onCompletion: @escaping (Result<Media, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            let action = MediaAction.uploadMedia(siteID: self.siteID, productID: self.productOrVariationID.id, mediaAsset: asset, onCompletion: onCompletion)
+            let siteInfo: MediaAction.SiteInfo = {
+                if case let .wporg(_, _, siteAddress) = ServiceLocator.stores.sessionManager.defaultCredentials {
+                    return .wporg(siteAddress)
+                } else {
+                    return .wpcom(self.siteID)
+                }
+            }()
+            let action = MediaAction.uploadMedia(connectUsing: siteInfo,
+                                                 productID: self.productOrVariationID.id,
+                                                 mediaAsset: asset,
+                                                 onCompletion: onCompletion)
             self.stores.dispatch(action)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesProductIDUpdater.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesProductIDUpdater.swift
@@ -37,7 +37,16 @@ private extension ProductImagesProductIDUpdater {
                             siteID: Int64,
                             productID: Int64) async throws -> Media {
         try await withCheckedThrowingContinuation { continuation in
-            let action = MediaAction.updateProductID(siteID: siteID, productID: productID, mediaID: productImageID) { result in
+            let siteInfo: MediaAction.SiteInfo = {
+                if case let .wporg(_, _, siteAddress) = ServiceLocator.stores.sessionManager.defaultCredentials {
+                    return .wporg(siteAddress)
+                } else {
+                    return .wpcom(siteID)
+                }
+            }()
+            let action = MediaAction.updateProductID(connectUsing: siteInfo,
+                                                     productID: productID,
+                                                     mediaID: productImageID) { result in
                 switch result {
                 case .failure(let error):
                     DDLogError("⛔️ Error updating `parent_id` of media with \(productImageID): \(error)")

--- a/WooCommerce/Classes/ViewRelated/Products/Media/WordPressMediaLibraryPickerDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/WordPressMediaLibraryPickerDataSource.swift
@@ -162,7 +162,14 @@ extension WordPressMediaLibraryPickerDataSource: SyncingCoordinatorDelegate {
 
 private extension WordPressMediaLibraryPickerDataSource {
     func retrieveMedia(pageNumber: Int, pageSize: Int, completion: @escaping (_ mediaItems: [Media], _ error: Error?) -> Void) {
-        let action = MediaAction.retrieveMediaLibrary(siteID: siteID,
+        let siteInfo: MediaAction.SiteInfo = {
+            if case let .wporg(_, _, siteAddress) = ServiceLocator.stores.sessionManager.defaultCredentials {
+                return .wporg(siteAddress)
+            } else {
+                return .wpcom(siteID)
+            }
+        }()
+        let action = MediaAction.retrieveMediaLibrary(connectUsing: siteInfo,
                                                       pageNumber: pageNumber,
                                                       pageSize: pageSize) { result in
             switch result {

--- a/Yosemite/Yosemite/Actions/MediaAction.swift
+++ b/Yosemite/Yosemite/Actions/MediaAction.swift
@@ -19,26 +19,26 @@ public enum MediaAction: Action {
     /// Retrieves media from the site's WP Media Library.
     ///
     /// - Parameters:
-    ///   - siteID: Site for which we'll load the media from.
+    ///   - connectUsing: Provides Site ID or Site URL based on the current login method
     ///   - pageNumber: The index of the page of media data to load from, starting from 1.
     ///   - pageSize: The maximum number of media items to return per page.
     ///   - onCompletion: Closure to be executed upon completion.
     ///
-    case retrieveMediaLibrary(siteID: Int64,
+    case retrieveMediaLibrary(connectUsing: SiteInfo,
                               pageNumber: Int,
                               pageSize: Int,
                               onCompletion: (Result<[Media], Error>) -> Void)
 
     /// Uploads an exportable media asset to the site's WP Media Library.
     ///
-    case uploadMedia(siteID: Int64,
+    case uploadMedia(connectUsing: SiteInfo,
                      productID: Int64,
                      mediaAsset: ExportableAsset,
                      onCompletion: (Result<Media, Error>) -> Void)
 
     /// Updates the `parent_id` of the media using the provided `productID`.
     ///
-    case updateProductID(siteID: Int64,
+    case updateProductID(connectUsing: SiteInfo,
                          productID: Int64,
                          mediaID: Int64,
                          onCompletion: (Result<Media, Error>) -> Void)

--- a/Yosemite/Yosemite/Actions/MediaAction.swift
+++ b/Yosemite/Yosemite/Actions/MediaAction.swift
@@ -3,6 +3,19 @@ import Foundation
 // MARK: - MediaAction: Defines media operations (supported by the MediaStore).
 //
 public enum MediaAction: Action {
+
+    /// Site information using which `MediaAction` will be performed
+    ///
+    public enum SiteInfo {
+        // Connects to WordPress.com servers using provided `siteID`
+        //
+        case wpcom(_ siteID: Int64)
+
+        // Connects to the site URL
+        //
+        case wporg(_ siteURL: String)
+    }
+
     /// Retrieves media from the site's WP Media Library.
     ///
     /// - Parameters:

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -172,6 +172,17 @@ private extension MediaStore {
     }
 }
 
+// MARK: Helpers
+//
+private extension MediaStore {
+    func isSiteJetpackJCPConnected(_ siteID: Int64) -> Bool {
+        guard let site = storageManager.viewStorage.loadSite(siteID: siteID)?.toReadOnly() else {
+            return false
+        }
+        return site.isJetpackCPConnected
+    }
+}
+
 public enum MediaActionError: Error {
     case unexpectedMediaCount(count: Int)
     case unknown

--- a/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
@@ -20,6 +20,10 @@ final class MediaStoreTests: XCTestCase {
     ///
     private let sampleSiteID: Int64 = 123
 
+    /// Testing Site URL
+    ///
+    private let sampleSiteURL = "http://test.com"
+
     /// Testing Product ID
     ///
     private let sampleProductID: Int64 = 586
@@ -39,9 +43,9 @@ final class MediaStoreTests: XCTestCase {
 
     // MARK: test cases for `MediaAction.retrieveMediaLibrary`
 
-    /// Verifies that `MediaAction.retrieveMediaLibrary` returns the expected response.
+    /// Verifies that `MediaAction.retrieveMediaLibrary` returns the expected response when using WPCOM siteID.
     ///
-    func test_retrieveMediaLibrary_returns_media_list() throws {
+    func test_retrieveMediaLibrary_returns_media_list_when_connect_using_siteID() throws {
         // Given
         network.simulateResponse(requestUrlSuffix: "media", filename: "media-library")
         let expectedMedia = Media(mediaID: 2352,
@@ -61,7 +65,7 @@ final class MediaStoreTests: XCTestCase {
 
         // When
         let result: Result<[Media], Error> = waitFor { promise in
-            let action = MediaAction.retrieveMediaLibrary(siteID: self.sampleSiteID,
+            let action = MediaAction.retrieveMediaLibrary(connectUsing: .wpcom(self.sampleSiteID),
                                                           pageNumber: 1,
                                                           pageSize: 20) { result in
                 promise(result)
@@ -73,6 +77,36 @@ final class MediaStoreTests: XCTestCase {
         let mediaItems = try XCTUnwrap(result.get())
         XCTAssertEqual(mediaItems.count, 5)
         XCTAssertEqual(mediaItems.first, expectedMedia)
+    }
+
+    /// Verifies that `MediaAction.retrieveMediaLibrary` returns the expected response when using site URL.
+    ///
+    func test_retrieveMediaLibrary_returns_media_list_when_connect_using_siteURL() throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "media", filename: "media-library-from-wordpress-site")
+        let mediaStore = MediaStore(dispatcher: dispatcher,
+                                    storageManager: storageManager,
+                                    network: network)
+
+        // When
+        let result: Result<[Media], Error> = waitFor { promise in
+            let action = MediaAction.retrieveMediaLibrary(connectUsing: .wporg(self.sampleSiteURL),
+                                                          pageNumber: 1,
+                                                          pageSize: 20) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        let mediaItems = try XCTUnwrap(result.get())
+        XCTAssertEqual(mediaItems.count, 2)
+        let uploadedMedia = try XCTUnwrap(mediaItems.first)
+        XCTAssertEqual(uploadedMedia.mediaID, 22)
+        XCTAssertEqual(uploadedMedia.date, Date(timeIntervalSince1970: 1637546157))
+        XCTAssertEqual(uploadedMedia.mimeType, "image/jpeg")
+        XCTAssertEqual(uploadedMedia.src, "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-scaled.jpeg")
+        XCTAssertEqual(uploadedMedia.alt, "Floral")
     }
 
     /// Verifies that `MediaAction.retrieveMediaLibrary` returns the expected response for cases where URLs contain special chars.
@@ -98,7 +132,7 @@ final class MediaStoreTests: XCTestCase {
 
         // When
         let result: Result<[Media], Error> = waitFor { promise in
-            let action = MediaAction.retrieveMediaLibrary(siteID: self.sampleSiteID,
+            let action = MediaAction.retrieveMediaLibrary(connectUsing: .wpcom(self.sampleSiteID),
                                                           pageNumber: 1,
                                                           pageSize: 20) { result in
                 promise(result)
@@ -114,7 +148,7 @@ final class MediaStoreTests: XCTestCase {
 
     /// Verifies that `MediaAction.retrieveMediaLibrary` returns an error whenever there is an error response from the backend.
     ///
-    func test_retrieveMediaLibrary_returns_error_upon_response_error() throws {
+    func test_retrieveMediaLibrary_returns_error_upon_response_error_when_connect_using_siteID() throws {
         // Given
         network.simulateResponse(requestUrlSuffix: "media", filename: "generic_error")
         let mediaStore = MediaStore(dispatcher: dispatcher,
@@ -123,7 +157,7 @@ final class MediaStoreTests: XCTestCase {
 
         // When
         let result: Result<[Media], Error> = waitFor { promise in
-            let action = MediaAction.retrieveMediaLibrary(siteID: self.sampleSiteID,
+            let action = MediaAction.retrieveMediaLibrary(connectUsing: .wpcom(self.sampleSiteID),
                                                           pageNumber: 1,
                                                           pageSize: 20) { result in
                 promise(result)
@@ -136,16 +170,61 @@ final class MediaStoreTests: XCTestCase {
         XCTAssertEqual(error, .unauthorized)
     }
 
+    /// Verifies that `MediaAction.retrieveMediaLibrary` returns an error whenever there is an error response from the backend.
+    ///
+    func test_retrieveMediaLibrary_returns_error_upon_response_error_when_connect_using_siteURL() throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "media", filename: "rest_incorrect_application_password_error")
+        let mediaStore = MediaStore(dispatcher: dispatcher,
+                                    storageManager: storageManager,
+                                    network: network)
+
+        // When
+        let result: Result<[Media], Error> = waitFor { promise in
+            let action = MediaAction.retrieveMediaLibrary(connectUsing: .wporg(self.sampleSiteURL),
+                                                          pageNumber: 1,
+                                                          pageSize: 20) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure as? WordPressApiError)
+        XCTAssertEqual(error, .unknown(code: "incorrect_password", message: "The provided password is an invalid application password."))
+    }
+
     /// Verifies that `MediaAction.retrieveMediaLibrary` returns an error whenever there is no backend response.
     ///
-    func test_retrieveMediaLibrary_returns_error_upon_empty_response() {
+    func test_retrieveMediaLibrary_returns_error_upon_empty_response_when_connect_using_siteID() {
         // Given
         let mediaStore = MediaStore(dispatcher: dispatcher,
                                     storageManager: storageManager,
                                     network: network)
         // When
         let result: Result<[Media], Error> = waitFor { promise in
-            let action = MediaAction.retrieveMediaLibrary(siteID: self.sampleSiteID,
+            let action = MediaAction.retrieveMediaLibrary(connectUsing: .wpcom(self.sampleSiteID),
+                                                          pageNumber: 1,
+                                                          pageSize: 20) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
+    /// Verifies that `MediaAction.retrieveMediaLibrary` returns an error whenever there is no backend response.
+    ///
+    func test_retrieveMediaLibrary_returns_error_upon_empty_response_when_connect_using_siteURL() {
+        // Given
+        let mediaStore = MediaStore(dispatcher: dispatcher,
+                                    storageManager: storageManager,
+                                    network: network)
+        // When
+        let result: Result<[Media], Error> = waitFor { promise in
+            let action = MediaAction.retrieveMediaLibrary(connectUsing: .wporg(self.sampleSiteURL),
                                                           pageNumber: 1,
                                                           pageSize: 20) { result in
                 promise(result)
@@ -169,7 +248,7 @@ final class MediaStoreTests: XCTestCase {
 
         // When
         let _: Result<[Media], Error> = waitFor { promise in
-            let action = MediaAction.retrieveMediaLibrary(siteID: self.sampleSiteID,
+            let action = MediaAction.retrieveMediaLibrary(connectUsing: .wpcom(self.sampleSiteID),
                                                           pageNumber: 1,
                                                           pageSize: 20) { result in
                 promise(result)
@@ -196,7 +275,7 @@ final class MediaStoreTests: XCTestCase {
 
         // When
         let result: Result<[Media], Error> = waitFor { promise in
-            let action = MediaAction.retrieveMediaLibrary(siteID: self.sampleSiteID,
+            let action = MediaAction.retrieveMediaLibrary(connectUsing: .wpcom(self.sampleSiteID),
                                                           pageNumber: 1,
                                                           pageSize: 20) { result in
                 promise(result)
@@ -225,7 +304,7 @@ final class MediaStoreTests: XCTestCase {
 
         // When
         let result: Result<[Media], Error> = waitFor { promise in
-            let action = MediaAction.retrieveMediaLibrary(siteID: self.sampleSiteID,
+            let action = MediaAction.retrieveMediaLibrary(connectUsing: .wpcom(self.sampleSiteID),
                                                           pageNumber: 1,
                                                           pageSize: 20) { result in
                 promise(result)
@@ -240,9 +319,63 @@ final class MediaStoreTests: XCTestCase {
         XCTAssertEqual(error, .unauthorized)
     }
 
+    /// Verifies that `MediaAction.retrieveMediaLibrary` invokes `MediaRemoteProtocol.loadMediaLibraryUsingRestApi` when connect using site URL.
+    func test_retrieveMediaLibrary_invokes_loadMediaLibraryUsingRestApi_remote_call_when_connect_using_site_URL() throws {
+        // Given
+        let remote = MockMediaRemote()
+        remote.whenLoadingMediaLibraryUsingRestApi(siteURL: sampleSiteURL, thenReturn: .success([]))
+        let mediaStore = MediaStore(dispatcher: dispatcher,
+                                    storageManager: storageManager,
+                                    network: network,
+                                    remote: remote)
+
+        // When
+        let _: Result<[Media], Error> = waitFor { promise in
+            let action = MediaAction.retrieveMediaLibrary(connectUsing: .wporg(self.sampleSiteURL),
+                                                          pageNumber: 1,
+                                                          pageSize: 20) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(remote.invocations, [.loadMediaLibraryUsingRestApi(siteURL: sampleSiteURL)])
+    }
+
+    /// Verifies that `MediaAction.retrieveMediaLibrary` using site URL returns error from remote
+    func test_retrieveMediaLibrary_using_site_URL_returns_error_from_MediaRemote() throws {
+        // Given
+        let expectedError = WordPressApiError.unknown(code: "1", message: "Sample message")
+        let remote = MockMediaRemote()
+        remote.whenLoadingMediaLibraryUsingRestApi(siteURL: sampleSiteURL, thenReturn: .failure(expectedError))
+        let mediaStore = MediaStore(dispatcher: dispatcher,
+                                    storageManager: storageManager,
+                                    network: network,
+                                    remote: remote)
+
+        insertJCPSiteToStorage(siteID: sampleSiteID)
+
+        // When
+        let result: Result<[Media], Error> = waitFor { promise in
+            let action = MediaAction.retrieveMediaLibrary(connectUsing: .wporg(self.sampleSiteURL),
+                                                          pageNumber: 1,
+                                                          pageSize: 20) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(remote.invocations, [.loadMediaLibraryUsingRestApi(siteURL: sampleSiteURL)])
+
+        let error = try XCTUnwrap(result.failure as? WordPressApiError)
+        XCTAssertEqual(error, expectedError)
+    }
+
     // MARK: test cases for `MediaAction.uploadMedia`
 
-    func test_uploadMedia_returns_uploaded_media_and_deletes_input_media_file() throws {
+    func test_uploadMedia_returns_uploaded_media_and_deletes_input_media_file_when_connect_using_siteID() throws {
         // Given
         let fileManager = FileManager.default
 
@@ -261,7 +394,7 @@ final class MediaStoreTests: XCTestCase {
 
         // When
         let result: Result<Media, Error> = waitFor { promise in
-            let action = MediaAction.uploadMedia(siteID: self.sampleSiteID,
+            let action = MediaAction.uploadMedia(connectUsing: .wpcom(self.sampleSiteID),
                                                  productID: self.sampleProductID,
                                                  mediaAsset: asset) { result in
                 promise(result)
@@ -276,7 +409,41 @@ final class MediaStoreTests: XCTestCase {
         XCTAssertFalse(fileManager.fileExists(atPath: targetURL.path))
     }
 
-    func test_uploadMedia_returns_error_upon_response_error() {
+    func test_uploadMedia_returns_uploaded_media_and_deletes_input_media_file_when_connect_using_siteURL() throws {
+        // Given
+        let fileManager = FileManager.default
+
+        // Creates a temporary file to simulate a uploadable media file.
+        let targetURL: URL = {
+            let filename = "test.txt"
+            return fileManager.temporaryDirectory.appendingPathComponent(filename, isDirectory: false)
+        }()
+
+        let mediaStore = createMediaStoreAndExportableMedia(at: targetURL, fileManager: fileManager)
+
+        let path = "media"
+        network.simulateResponse(requestUrlSuffix: path, filename: "media-upload-to-wordpress-site")
+
+        let asset = PHAsset()
+
+        // When
+        let result: Result<Media, Error> = waitFor { promise in
+            let action = MediaAction.uploadMedia(connectUsing: .wporg(self.sampleSiteURL),
+                                                 productID: self.sampleProductID,
+                                                 mediaAsset: asset) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        _ = try XCTUnwrap(result.get())
+
+        // Verifies that the temporary file is removed after the media is uploaded.
+        XCTAssertFalse(fileManager.fileExists(atPath: targetURL.path))
+    }
+
+    func test_uploadMedia_returns_error_upon_response_error_when_connect_using_siteID() {
         // Given
         let fileManager = FileManager.default
 
@@ -296,7 +463,42 @@ final class MediaStoreTests: XCTestCase {
 
         // When
         let result: Result<Media, Error> = waitFor { promise in
-            let action = MediaAction.uploadMedia(siteID: self.sampleSiteID,
+            let action = MediaAction.uploadMedia(connectUsing: .wpcom(self.sampleSiteID),
+                                                 productID: self.sampleProductID,
+                                                 mediaAsset: asset) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+
+        // Verifies that the temporary file is removed after the media is uploaded.
+        XCTAssertFalse(fileManager.fileExists(atPath: targetURL.path))
+    }
+
+    func test_uploadMedia_returns_error_upon_response_error_when_connect_using_siteURL() {
+        // Given
+        let fileManager = FileManager.default
+
+        // Creates a temporary file to simulate a uploadable media file.
+        let targetURL: URL = {
+            let filename = "test.txt"
+            return fileManager.temporaryDirectory.appendingPathComponent(filename, isDirectory: false)
+        }()
+
+        let mediaStore = createMediaStoreAndExportableMedia(at: targetURL, fileManager: fileManager)
+
+        let path = "media"
+
+        network.simulateResponse(requestUrlSuffix: path, filename: "rest_incorrect_application_password_error")
+
+        let asset = PHAsset()
+
+        // When
+        let result: Result<Media, Error> = waitFor { promise in
+            let action = MediaAction.uploadMedia(connectUsing: .wporg(self.sampleSiteURL),
                                                  productID: self.sampleProductID,
                                                  mediaAsset: asset) { result in
                 promise(result)
@@ -331,7 +533,7 @@ final class MediaStoreTests: XCTestCase {
 
         // When
         let _: Result<Media, Error> = waitFor { promise in
-            let action = MediaAction.uploadMedia(siteID: self.sampleSiteID,
+            let action = MediaAction.uploadMedia(connectUsing: .wpcom(self.sampleSiteID),
                                                  productID: self.sampleProductID,
                                                  mediaAsset: asset) { result in
                 promise(result)
@@ -366,7 +568,7 @@ final class MediaStoreTests: XCTestCase {
 
         // When
         let result: Result<Media, Error> = waitFor { promise in
-            let action = MediaAction.uploadMedia(siteID: self.sampleSiteID,
+            let action = MediaAction.uploadMedia(connectUsing: .wpcom(self.sampleSiteID),
                                                  productID: self.sampleProductID,
                                                  mediaAsset: asset) { result in
                 promise(result)
@@ -406,7 +608,7 @@ final class MediaStoreTests: XCTestCase {
 
         // When
         let result: Result<Media, Error> = waitFor { promise in
-            let action = MediaAction.uploadMedia(siteID: self.sampleSiteID,
+            let action = MediaAction.uploadMedia(connectUsing: .wpcom(self.sampleSiteID),
                                                  productID: self.sampleProductID,
                                                  mediaAsset: asset) { result in
                 promise(result)
@@ -436,7 +638,7 @@ final class MediaStoreTests: XCTestCase {
                                     remote: remote)
         // When
         let result: Result<Media, Error> = waitFor { promise in
-            let action = MediaAction.updateProductID(siteID: self.sampleSiteID,
+            let action = MediaAction.updateProductID(connectUsing: .wpcom(self.sampleSiteID),
                                                      productID: self.sampleProductID,
                                                      mediaID: self.sampleMediaID) { result in
                 promise(result)
@@ -462,7 +664,7 @@ final class MediaStoreTests: XCTestCase {
 
         // When
         let result: Result<Media, Error> = waitFor { promise in
-            let action = MediaAction.updateProductID(siteID: self.sampleSiteID,
+            let action = MediaAction.updateProductID(connectUsing: .wpcom(self.sampleSiteID),
                                                      productID: self.sampleProductID,
                                                      mediaID: self.sampleMediaID) { result in
                 promise(result)
@@ -490,7 +692,7 @@ final class MediaStoreTests: XCTestCase {
 
         // When
         let result: Result<Media, Error> = waitFor { promise in
-            let action = MediaAction.updateProductID(siteID: self.sampleSiteID,
+            let action = MediaAction.updateProductID(connectUsing: .wpcom(self.sampleSiteID),
                                                      productID: self.sampleProductID,
                                                      mediaID: self.sampleMediaID) { result in
                 promise(result)
@@ -517,7 +719,7 @@ final class MediaStoreTests: XCTestCase {
 
         // When
         let result: Result<Media, Error> = waitFor { promise in
-            let action = MediaAction.updateProductID(siteID: self.sampleSiteID,
+            let action = MediaAction.updateProductID(connectUsing: .wpcom(self.sampleSiteID),
                                                      productID: self.sampleProductID,
                                                      mediaID: self.sampleMediaID) { result in
                 promise(result)
@@ -528,6 +730,60 @@ final class MediaStoreTests: XCTestCase {
         // Then
         let error = try XCTUnwrap(result.failure as? DotcomError)
         XCTAssertEqual(error, .unauthorized)
+    }
+
+    /// Verifies that `MediaAction.updateProductID` returns the expected response while connecting using Site URL
+    ///
+    func test_updateProductID_returns_media_when_connect_using_siteURL() throws {
+        // Given
+        let remote = MockMediaRemote()
+        let media = WordPressMedia.fake()
+        remote.whenUpdatingProductIDUsingRestApi(siteURL: sampleSiteURL, thenReturn: .success(media))
+        let mediaStore = MediaStore(dispatcher: dispatcher,
+                                    storageManager: storageManager,
+                                    network: network,
+                                    remote: remote)
+
+        // When
+        let result: Result<Media, Error> = waitFor { promise in
+            let action = MediaAction.updateProductID(connectUsing: .wporg(self.sampleSiteURL),
+                                                     productID: self.sampleProductID,
+                                                     mediaID: self.sampleMediaID) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        let mediaFromResult = try XCTUnwrap(result.get())
+        XCTAssertEqual(mediaFromResult, media.toMedia())
+    }
+
+    /// Verifies that `MediaAction.updateProductID`  while connecting using Site URL returns an error whenever there is an error response from the backend.
+    ///
+    func test_updateProductID_returns_error_upon_response_error_when_connect_using_siteURL() throws {
+        // Given
+        let expectedError = WordPressApiError.unknown(code: "1", message: "Sample message")
+        let remote = MockMediaRemote()
+        remote.whenUpdatingProductIDUsingRestApi(siteURL: sampleSiteURL, thenReturn: .failure(expectedError))
+        let mediaStore = MediaStore(dispatcher: dispatcher,
+                                    storageManager: storageManager,
+                                    network: network,
+                                    remote: remote)
+
+        // When
+        let result: Result<Media, Error> = waitFor { promise in
+            let action = MediaAction.updateProductID(connectUsing: .wporg(self.sampleSiteURL),
+                                                     productID: self.sampleProductID,
+                                                     mediaID: self.sampleMediaID) { result in
+                promise(result)
+            }
+            mediaStore.onAction(action)
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure as? WordPressApiError)
+        XCTAssertEqual(error, expectedError)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8566
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
`MediaRemote` doesn't use Jetpack tunnel requests. It uses all `DotComRequest`s due to restrictions related to content headers and JCP sites. More details in this thread - p1672921523522859-slack-C046HDZL87J

So, we cannot use the `availableAsRESTRequest` property of `JetpackRequest` to handle the migration of Media related endpoints. We need to have the ability to send `RESTRequest`s directly instead of `DotComRequest`s from `MediaRemote`

In this PR
- Added a way to pass site information through `MediaAction` as a parameter. Site ID or URL will be passed as needed.
- Invoke REST API calls from `MediaStore` if site URL is provided instead of site ID.
- Use `WordPressApiValidator` to validate `RESTRequest` response. 
- Add unit tests.

## Testing instructions

**WPCOM Creds login**
- Log in into the app using WordPress.com credentials
- Navigate to Products tab.
- Try adding a new product and uploading images to it.
- Try selecting images from the "WordPress media gallery".
- Try deleting images from a product.
- Everything should work as before.

**.org site creds login**
- We need to enable the endpoints in `ProductsRemote` to test media related features. This part will be tested in https://github.com/woocommerce/woocommerce-ios/pull/8605

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
