### PR TITLE
REST API: Migrate system status endpoints

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -716,6 +716,8 @@
 		DE9DEEF5291CF1B40070AD7C /* site-plugin-without-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9DEEF4291CF1B40070AD7C /* site-plugin-without-envelope.json */; };
 		DEA6B1C4296C0F45005AA5E9 /* payment-gateway-cod-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEA6B1C3296C0F45005AA5E9 /* payment-gateway-cod-without-data.json */; };
 		DEA6B1C6296C13FB005AA5E9 /* payment-gateway-list-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEA6B1C5296C13FB005AA5E9 /* payment-gateway-list-without-data.json */; };
+		DEA6B1C9296D0E8B005AA5E9 /* systemStatusWithPluginsOnly-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEA6B1C7296D0E8A005AA5E9 /* systemStatusWithPluginsOnly-without-data.json */; };
+		DEA6B1CA296D0E8B005AA5E9 /* systemStatus-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
 		DEC51A97274DD962009F3DF4 /* plugin.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51A96274DD962009F3DF4 /* plugin.json */; };
@@ -1532,6 +1534,8 @@
 		DE9DEEF4291CF1B40070AD7C /* site-plugin-without-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-plugin-without-envelope.json"; sourceTree = "<group>"; };
 		DEA6B1C3296C0F45005AA5E9 /* payment-gateway-cod-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "payment-gateway-cod-without-data.json"; sourceTree = "<group>"; };
 		DEA6B1C5296C13FB005AA5E9 /* payment-gateway-list-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "payment-gateway-list-without-data.json"; sourceTree = "<group>"; };
+		DEA6B1C7296D0E8A005AA5E9 /* systemStatusWithPluginsOnly-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "systemStatusWithPluginsOnly-without-data.json"; sourceTree = "<group>"; };
+		DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "systemStatus-without-data.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
 		DEC51A96274DD962009F3DF4 /* plugin.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = plugin.json; sourceTree = "<group>"; };
@@ -2137,6 +2141,8 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */,
+				DEA6B1C7296D0E8A005AA5E9 /* systemStatusWithPluginsOnly-without-data.json */,
 				DEA6B1C5296C13FB005AA5E9 /* payment-gateway-list-without-data.json */,
 				DEA6B1C3296C0F45005AA5E9 /* payment-gateway-cod-without-data.json */,
 				DE42F96E296BC9A700D514C2 /* countries-without-data.json */,
@@ -2944,6 +2950,7 @@
 				02AF07EC27492FDD00B2D81E /* media-library-from-wordpress-site.json in Resources */,
 				CC9A253C26442C71005DE56E /* shipping-label-eligibility-success.json in Resources */,
 				B5A24179217F98F600595DEF /* notifications-load-all.json in Resources */,
+				DEA6B1C9296D0E8B005AA5E9 /* systemStatusWithPluginsOnly-without-data.json in Resources */,
 				314EDF2927C02CC100A56B6F /* stripe-account-complete-empty-descriptor.json in Resources */,
 				028CB71F2902589E00331C09 /* create-account-error-invalid-email.json in Resources */,
 				E137619929151C7400FD098F /* error-wp-rest-forbidden.json in Resources */,
@@ -3003,6 +3010,7 @@
 				02BA23C922EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json in Resources */,
 				CCB2CAA226209A1200285CA0 /* generic_success_data.json in Resources */,
 				45150AA2268373F8006922EA /* countries.json in Resources */,
+				DEA6B1CA296D0E8B005AA5E9 /* systemStatus-without-data.json in Resources */,
 				743E84F422172D0A00FAC9D7 /* shipment_tracking_multiple.json in Resources */,
 				02698CF624C17FC1005337C4 /* product-alternative-types.json in Resources */,
 				03EB99962907F03000F06A39 /* empty-data-array.json in Resources */,

--- a/Networking/Networking/Mapper/SystemPluginMapper.swift
+++ b/Networking/Networking/Mapper/SystemPluginMapper.swift
@@ -17,7 +17,13 @@ struct SystemPluginMapper: Mapper {
             .siteID: siteID
         ]
 
-        let systemStatus = try decoder.decode(SystemStatusEnvelope.self, from: response).systemStatus
+        let systemStatus: SystemStatus = try {
+            do {
+                return try decoder.decode(SystemStatusEnvelope.self, from: response).systemStatus
+            } catch {
+                return try decoder.decode(SystemStatus.self, from: response)
+            }
+        }()
 
         /// Active and in-active plugins share identical structure, but are stored in separate parts of the remote response
         /// (and without an active attribute in the response). So... we use the same decoder for active and in-active plugins

--- a/Networking/Networking/Mapper/SystemStatusMapper.swift
+++ b/Networking/Networking/Mapper/SystemStatusMapper.swift
@@ -17,8 +17,11 @@ struct SystemStatusMapper: Mapper {
             .siteID: siteID
         ]
 
-        let systemStatus = try decoder.decode(SystemStatusEnvelope.self, from: response).systemStatus
-        return systemStatus
+        do {
+            return try decoder.decode(SystemStatusEnvelope.self, from: response).systemStatus
+        } catch {
+            return try decoder.decode(SystemStatus.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Remote/SystemStatusRemote.swift
+++ b/Networking/Networking/Remote/SystemStatusRemote.swift
@@ -16,7 +16,12 @@ public class SystemStatusRemote: Remote {
         let parameters = [
             ParameterKeys.fields: [ParameterValues.activePlugins, ParameterValues.inactivePlugins]
         ]
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
         let mapper = SystemPluginMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -31,7 +36,12 @@ public class SystemStatusRemote: Remote {
     public func fetchSystemStatusReport(for siteID: Int64,
                                         completion: @escaping (Result<SystemStatus, Error>) -> Void) {
         let path = Constants.systemStatusPath
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true)
         let mapper = SystemStatusMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/NetworkingTests/Mapper/SystemPluginMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SystemPluginMapperTests.swift
@@ -78,6 +78,25 @@ final class SystemPluginMapperTests: XCTestCase {
         XCTAssertEqual(systemPlugin.networkActivated, expectedNetworkActivated)
         XCTAssertEqual(systemPlugin.active, expectedActive)
     }
+
+    func test_plugins_are_parsed_successfully_when_response_has_no_data_envelope() throws {
+        // When
+        let plugins = try mapLoadSystemStatusResponseWithoutDataEnvelope()
+
+        // Then
+        XCTAssertEqual(plugins.count, 2)
+        let systemPlugin = plugins[0]
+        XCTAssertEqual(systemPlugin.siteID, 999999)
+        XCTAssertEqual(systemPlugin.plugin, "woocommerce/woocommerce.php")
+        XCTAssertEqual(systemPlugin.name, "WooCommerce")
+        XCTAssertEqual(systemPlugin.url, "https://woocommerce.com/")
+        XCTAssertEqual(systemPlugin.version, "5.8.0")
+        XCTAssertEqual(systemPlugin.versionLatest, "5.8.0")
+        XCTAssertEqual(systemPlugin.authorName, "Automattic")
+        XCTAssertEqual(systemPlugin.authorUrl, "https://woocommerce.com")
+        XCTAssertFalse(systemPlugin.networkActivated)
+        XCTAssertTrue(systemPlugin.active)
+    }
 }
 
 /// Private Methods.
@@ -94,9 +113,16 @@ private extension SystemPluginMapperTests {
         return try SystemPluginMapper(siteID: dummySiteID).map(response: response)
     }
 
-    /// Returns the SystemStatusMapper output upon receiving `systemPlugins`
+    /// Returns the SystemStatusMapper output upon receiving `systemStatusWithPluginsOnly`
     ///
     func mapLoadSystemStatusResponse() throws -> [SystemPlugin] {
         return try mapPlugins(from: "systemStatusWithPluginsOnly")
+    }
+
+    /// Returns the SystemStatusMapper output upon receiving
+    /// `systemStatusWithPluginsOnly-without-data`
+    ///
+    func mapLoadSystemStatusResponseWithoutDataEnvelope() throws -> [SystemPlugin] {
+        return try mapPlugins(from: "systemStatusWithPluginsOnly-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/SystemStatusMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SystemStatusMapperTests.swift
@@ -58,6 +58,56 @@ final class SystemStatusMapperTests: XCTestCase {
         XCTAssertEqual(report.pages.count, 5)
         XCTAssertEqual(report.postTypeCounts.count, 3)
     }
+
+    func test_system_status_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
+        // When
+        let report = try mapLoadSystemStatusResponseWithoutDataEnvelope()
+
+        // Then
+        XCTAssertEqual(report.environment?.homeURL, "https://additional-beetle.jurassic.ninja")
+        XCTAssertEqual(report.environment?.siteURL, "https://additional-beetle.jurassic.ninja")
+        XCTAssertEqual(report.environment?.version, "5.9.0")
+        XCTAssertEqual(report.environment?.wpVersion, "5.8.2")
+        XCTAssertEqual(report.environment?.phpVersion, "7.4.26")
+        XCTAssertEqual(report.environment?.curlVersion, "7.47.0, OpenSSL/1.0.2g")
+        XCTAssertEqual(report.environment?.mysqlVersion, "5.7.33-0ubuntu0.16.04.1-log")
+
+        XCTAssertEqual(report.database?.wcDatabaseVersion, "5.9.0")
+        XCTAssertEqual(report.database?.databasePrefix, "wp_")
+        XCTAssertEqual(report.database?.databaseTables.woocommerce.count, 14)
+        XCTAssertEqual(report.database?.databaseTables.other.count, 29)
+
+        XCTAssertEqual(report.activePlugins.count, 4)
+        XCTAssertEqual(report.activePlugins[0].siteID, dummySiteID)
+        XCTAssertEqual(report.inactivePlugins.count, 2)
+        XCTAssertEqual(report.inactivePlugins[1].siteID, dummySiteID)
+        XCTAssertEqual(report.dropinPlugins.count, 2)
+        XCTAssertEqual(report.dropinPlugins[0].name, "advanced-cache.php")
+        XCTAssertEqual(report.mustUsePlugins.count, 1)
+        XCTAssertEqual(report.mustUsePlugins[0].name, "WP.com Site Helper")
+
+        XCTAssertEqual(report.theme?.name, "Twenty Twenty-One")
+        XCTAssertEqual(report.theme?.version, "1.4")
+        XCTAssertEqual(report.theme?.authorURL, "https://wordpress.org/")
+        XCTAssertEqual(report.theme?.hasWoocommerceSupport, true)
+        XCTAssertEqual(report.theme?.overrides.count, 0)
+
+        XCTAssertEqual(report.settings?.apiEnabled, false)
+        XCTAssertEqual(report.settings?.currency, "USD")
+        XCTAssertEqual(report.settings?.currencySymbol, "&#36;")
+        XCTAssertEqual(report.settings?.currencyPosition, "left")
+        XCTAssertEqual(report.settings?.numberOfDecimals, 2)
+        XCTAssertEqual(report.settings?.thousandSeparator, ",")
+        XCTAssertEqual(report.settings?.decimalSeparator, ".")
+        XCTAssertEqual(report.settings?.taxonomies["external"], "external")
+        XCTAssertEqual(report.settings?.productVisibilityTerms["exclude-from-catalog"], "exclude-from-catalog")
+
+        XCTAssertEqual(report.security?.secureConnection, true)
+        XCTAssertEqual(report.security?.hideErrors, false)
+
+        XCTAssertEqual(report.pages.count, 5)
+        XCTAssertEqual(report.postTypeCounts.count, 3)
+    }
 }
 
 private extension SystemStatusMapperTests {
@@ -72,9 +122,15 @@ private extension SystemStatusMapperTests {
         return try SystemStatusMapper(siteID: dummySiteID).map(response: response)
     }
 
-    /// Returns the SystemStatusMapper output upon receiving `systemStatus.json`
+    /// Returns the SystemStatus output upon receiving `systemStatus.json`
     ///
     func mapLoadSystemStatusResponse() throws -> SystemStatus {
         return try mapReport(from: "systemStatus")
+    }
+
+    /// Returns the SystemStatus output upon receiving `systemStatus-without-data.json`
+    ///
+    func mapLoadSystemStatusResponseWithoutDataEnvelope() throws -> SystemStatus {
+        return try mapReport(from: "systemStatus-without-data")
     }
 }

--- a/Networking/NetworkingTests/Responses/systemStatus-without-data.json
+++ b/Networking/NetworkingTests/Responses/systemStatus-without-data.json
@@ -1,0 +1,485 @@
+{
+    "data": {
+        "environment": {
+            "home_url": "https://additional-beetle.jurassic.ninja",
+            "site_url": "https://additional-beetle.jurassic.ninja",
+            "version": "5.9.0",
+            "log_directory": "/srv/users/user9fe179e8/apps/user9fe179e8/public/wp-content/uploads/wc-logs/",
+            "log_directory_writable": true,
+            "wp_version": "5.8.2",
+            "wp_multisite": false,
+            "wp_memory_limit": 268435456,
+            "wp_debug_mode": true,
+            "wp_cron": true,
+            "language": "en_US",
+            "external_object_cache": null,
+            "server_info": "Apache/2.4.51 (Unix) OpenSSL/1.0.2g",
+            "php_version": "7.4.26",
+            "php_post_max_size": 1073741824,
+            "php_max_execution_time": 30,
+            "php_max_input_vars": 5000,
+            "curl_version": "7.47.0, OpenSSL/1.0.2g",
+            "suhosin_installed": false,
+            "max_upload_size": 536870912,
+            "mysql_version": "5.7.33",
+            "mysql_version_string": "5.7.33-0ubuntu0.16.04.1-log",
+            "default_timezone": "UTC",
+            "fsockopen_or_curl_enabled": true,
+            "soapclient_enabled": true,
+            "domdocument_enabled": true,
+            "gzip_enabled": true,
+            "mbstring_enabled": true,
+            "remote_post_successful": true,
+            "remote_post_response": 200,
+            "remote_get_successful": true,
+            "remote_get_response": 200
+        },
+        "database": {
+            "wc_database_version": "5.9.0",
+            "database_prefix": "wp_",
+            "maxmind_geoip_database": "",
+            "database_tables": {
+                "woocommerce": {
+                    "wp_woocommerce_sessions": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_api_keys": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_attribute_taxonomies": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_downloadable_product_permissions": {
+                        "data": "0.02",
+                        "index": "0.06",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_order_items": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_order_itemmeta": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_tax_rates": {
+                        "data": "0.02",
+                        "index": "0.06",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_tax_rate_locations": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_shipping_zones": {
+                        "data": "0.02",
+                        "index": "0.00",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_shipping_zone_locations": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_shipping_zone_methods": {
+                        "data": "0.02",
+                        "index": "0.00",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_payment_tokens": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_payment_tokenmeta": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_woocommerce_log": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    }
+                },
+                "other": {
+                    "wp_actionscheduler_actions": {
+                        "data": "0.02",
+                        "index": "0.13",
+                        "engine": "InnoDB"
+                    },
+                    "wp_actionscheduler_claims": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_actionscheduler_groups": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_actionscheduler_logs": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_commentmeta": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_comments": {
+                        "data": "0.02",
+                        "index": "0.09",
+                        "engine": "InnoDB"
+                    },
+                    "wp_links": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_options": {
+                        "data": "3.48",
+                        "index": "0.06",
+                        "engine": "InnoDB"
+                    },
+                    "wp_postmeta": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_posts": {
+                        "data": "0.02",
+                        "index": "0.06",
+                        "engine": "InnoDB"
+                    },
+                    "wp_termmeta": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_terms": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_term_relationships": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_term_taxonomy": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_usermeta": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_users": {
+                        "data": "0.02",
+                        "index": "0.05",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_admin_notes": {
+                        "data": "0.05",
+                        "index": "0.00",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_admin_note_actions": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_category_lookup": {
+                        "data": "0.02",
+                        "index": "0.00",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_customer_lookup": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_download_log": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_order_coupon_lookup": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_order_product_lookup": {
+                        "data": "0.02",
+                        "index": "0.06",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_order_stats": {
+                        "data": "0.02",
+                        "index": "0.05",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_order_tax_lookup": {
+                        "data": "0.02",
+                        "index": "0.03",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_product_meta_lookup": {
+                        "data": "0.02",
+                        "index": "0.09",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_reserved_stock": {
+                        "data": "0.02",
+                        "index": "0.00",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_tax_rate_classes": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    },
+                    "wp_wc_webhooks": {
+                        "data": "0.02",
+                        "index": "0.02",
+                        "engine": "InnoDB"
+                    }
+                }
+            },
+            "database_size": {
+                "data": 4.3499999999999925,
+                "index": 1.4300000000000006
+            }
+        },
+        "active_plugins":[
+            {
+                "plugin":"woocommerce\/woocommerce.php",
+                "name":"WooCommerce",
+                "version":"5.8.0",
+                "version_latest":"5.8.0",
+                "url":"https:\/\/woocommerce.com\/",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/woocommerce.com",
+                "network_activated":false
+            },
+            {
+                "plugin":"woocommerce-payments\/woocommerce-payments.php",
+                "name":"WooCommerce Payments",
+                "version":"3.1.0",
+                "version_latest":"3.1.0",
+                "url":"https:\/\/woocommerce.com\/payments\/",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/woocommerce.com\/",
+                "network_activated":false
+            },
+            {
+                "plugin":"woocommerce-subscriptions\/woocommerce-subscriptions",
+                "name":"WooCommerce Subscriptions",
+                "version":"3.1.6",
+                "version_latest":"3.1.6",
+                "url":"https:\/\/www.woocommerce.com\/products\/woocommerce-subscriptions\/",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/woocommerce.com\/",
+                "network_activated":false
+            },
+            {
+                "plugin":"jetpack\/jetpack.php",
+                "name":"Jetpack",
+                "version":"10.2",
+                "version_latest":"10.2.1",
+                "url":"https:\/\/jetpack.com",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/jetpack.com",
+                "network_activated":false
+            }
+        ],
+        "inactive_plugins":[
+            {
+                "plugin":"akismet\/akismet.php",
+                "name":"Akismet Anti-Spam",
+                "version":"4.2.1",
+                "version_latest":"4.2.1",
+                "url":"https:\/\/akismet.com\/",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/automattic.com\/wordpress-plugins\/",
+                "network_activated":false
+            },
+            {
+                "plugin":"hello.php",
+                "name":"Hello Dolly",
+                "version":"1.7.2",
+                "version_latest":"1.7.2",
+                "url":"http:\/\/wordpress.org\/plugins\/hello-dolly\/",
+                "author_name":"Matt Mullenweg",
+                "author_url":"http:\/\/ma.tt\/",
+                "network_activated":false
+            }
+        ],
+        "dropins_mu_plugins": {
+            "dropins": [
+                {
+                    "plugin": "advanced-cache.php",
+                    "name": "advanced-cache.php"
+                },
+                {
+                    "plugin": "object-cache.php",
+                    "name": "Memcached"
+                }
+            ],
+            "mu_plugins": [
+                {
+                    "plugin": "wpcomsh-loader.php",
+                    "name": "WP.com Site Helper",
+                    "version": "",
+                    "url": "",
+                    "author_name": "",
+                    "author_url": ""
+                }
+            ]
+        },
+        "theme": {
+            "name": "Twenty Twenty-One",
+            "version": "1.4",
+            "version_latest": "1.4",
+            "author_url": "https://wordpress.org/",
+            "is_child_theme": false,
+            "has_woocommerce_support": true,
+            "has_woocommerce_file": false,
+            "has_outdated_templates": false,
+            "overrides": [],
+            "parent_name": "",
+            "parent_version": "",
+            "parent_version_latest": "",
+            "parent_author_url": ""
+        },
+        "settings": {
+            "api_enabled": false,
+            "force_ssl": false,
+            "currency": "USD",
+            "currency_symbol": "&#36;",
+            "currency_position": "left",
+            "thousand_separator": ",",
+            "decimal_separator": ".",
+            "number_of_decimals": 2,
+            "geolocation_enabled": false,
+            "taxonomies": {
+                "external": "external",
+                "grouped": "grouped",
+                "simple": "simple",
+                "subscription": "subscription",
+                "variable": "variable",
+                "variable-subscription": "variable subscription"
+            },
+            "product_visibility_terms": {
+                "exclude-from-catalog": "exclude-from-catalog",
+                "exclude-from-search": "exclude-from-search",
+                "featured": "featured",
+                "outofstock": "outofstock",
+                "rated-1": "rated-1",
+                "rated-2": "rated-2",
+                "rated-3": "rated-3",
+                "rated-4": "rated-4",
+                "rated-5": "rated-5"
+            },
+            "woocommerce_com_connected": "no"
+        },
+        "security": {
+            "secure_connection": true,
+            "hide_errors": false
+        },
+        "pages": [
+            {
+                "page_name": "Shop base",
+                "page_id": "5",
+                "page_set": true,
+                "page_exists": true,
+                "page_visible": true,
+                "shortcode": "",
+                "block": "",
+                "shortcode_required": false,
+                "shortcode_present": false,
+                "block_present": false,
+                "block_required": false
+            },
+            {
+                "page_name": "Cart",
+                "page_id": "6",
+                "page_set": true,
+                "page_exists": true,
+                "page_visible": true,
+                "shortcode": "[woocommerce_cart]",
+                "block": "woocommerce/cart",
+                "shortcode_required": true,
+                "shortcode_present": true,
+                "block_present": false,
+                "block_required": true
+            },
+            {
+                "page_name": "Checkout",
+                "page_id": "7",
+                "page_set": true,
+                "page_exists": true,
+                "page_visible": true,
+                "shortcode": "[woocommerce_checkout]",
+                "block": "woocommerce/checkout",
+                "shortcode_required": true,
+                "shortcode_present": true,
+                "block_present": false,
+                "block_required": true
+            },
+            {
+                "page_name": "My account",
+                "page_id": "8",
+                "page_set": true,
+                "page_exists": true,
+                "page_visible": true,
+                "shortcode": "[woocommerce_my_account]",
+                "block": "",
+                "shortcode_required": true,
+                "shortcode_present": true,
+                "block_present": false,
+                "block_required": false
+            },
+            {
+                "page_name": "Terms and conditions",
+                "page_id": "",
+                "page_set": false,
+                "page_exists": false,
+                "page_visible": false,
+                "shortcode": "",
+                "block": "",
+                "shortcode_required": false,
+                "shortcode_present": false,
+                "block_present": false,
+                "block_required": false
+            }
+        ],
+        "post_type_counts": [
+            {
+                "type": "attachment",
+                "count": "1"
+            },
+            {
+                "type": "page",
+                "count": "7"
+            },
+            {
+                "type": "post",
+                "count": "2"
+            }
+        ]
+    }
+}

--- a/Networking/NetworkingTests/Responses/systemStatus-without-data.json
+++ b/Networking/NetworkingTests/Responses/systemStatus-without-data.json
@@ -1,485 +1,483 @@
 {
-    "data": {
-        "environment": {
-            "home_url": "https://additional-beetle.jurassic.ninja",
-            "site_url": "https://additional-beetle.jurassic.ninja",
-            "version": "5.9.0",
-            "log_directory": "/srv/users/user9fe179e8/apps/user9fe179e8/public/wp-content/uploads/wc-logs/",
-            "log_directory_writable": true,
-            "wp_version": "5.8.2",
-            "wp_multisite": false,
-            "wp_memory_limit": 268435456,
-            "wp_debug_mode": true,
-            "wp_cron": true,
-            "language": "en_US",
-            "external_object_cache": null,
-            "server_info": "Apache/2.4.51 (Unix) OpenSSL/1.0.2g",
-            "php_version": "7.4.26",
-            "php_post_max_size": 1073741824,
-            "php_max_execution_time": 30,
-            "php_max_input_vars": 5000,
-            "curl_version": "7.47.0, OpenSSL/1.0.2g",
-            "suhosin_installed": false,
-            "max_upload_size": 536870912,
-            "mysql_version": "5.7.33",
-            "mysql_version_string": "5.7.33-0ubuntu0.16.04.1-log",
-            "default_timezone": "UTC",
-            "fsockopen_or_curl_enabled": true,
-            "soapclient_enabled": true,
-            "domdocument_enabled": true,
-            "gzip_enabled": true,
-            "mbstring_enabled": true,
-            "remote_post_successful": true,
-            "remote_post_response": 200,
-            "remote_get_successful": true,
-            "remote_get_response": 200
-        },
-        "database": {
-            "wc_database_version": "5.9.0",
-            "database_prefix": "wp_",
-            "maxmind_geoip_database": "",
-            "database_tables": {
-                "woocommerce": {
-                    "wp_woocommerce_sessions": {
-                        "data": "0.02",
-                        "index": "0.02",
-                        "engine": "InnoDB"
-                    },
-                    "wp_woocommerce_api_keys": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_woocommerce_attribute_taxonomies": {
-                        "data": "0.02",
-                        "index": "0.02",
-                        "engine": "InnoDB"
-                    },
-                    "wp_woocommerce_downloadable_product_permissions": {
-                        "data": "0.02",
-                        "index": "0.06",
-                        "engine": "InnoDB"
-                    },
-                    "wp_woocommerce_order_items": {
-                        "data": "0.02",
-                        "index": "0.02",
-                        "engine": "InnoDB"
-                    },
-                    "wp_woocommerce_order_itemmeta": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_woocommerce_tax_rates": {
-                        "data": "0.02",
-                        "index": "0.06",
-                        "engine": "InnoDB"
-                    },
-                    "wp_woocommerce_tax_rate_locations": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_woocommerce_shipping_zones": {
-                        "data": "0.02",
-                        "index": "0.00",
-                        "engine": "InnoDB"
-                    },
-                    "wp_woocommerce_shipping_zone_locations": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_woocommerce_shipping_zone_methods": {
-                        "data": "0.02",
-                        "index": "0.00",
-                        "engine": "InnoDB"
-                    },
-                    "wp_woocommerce_payment_tokens": {
-                        "data": "0.02",
-                        "index": "0.02",
-                        "engine": "InnoDB"
-                    },
-                    "wp_woocommerce_payment_tokenmeta": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_woocommerce_log": {
-                        "data": "0.02",
-                        "index": "0.02",
-                        "engine": "InnoDB"
-                    }
+    "environment": {
+        "home_url": "https://additional-beetle.jurassic.ninja",
+        "site_url": "https://additional-beetle.jurassic.ninja",
+        "version": "5.9.0",
+        "log_directory": "/srv/users/user9fe179e8/apps/user9fe179e8/public/wp-content/uploads/wc-logs/",
+        "log_directory_writable": true,
+        "wp_version": "5.8.2",
+        "wp_multisite": false,
+        "wp_memory_limit": 268435456,
+        "wp_debug_mode": true,
+        "wp_cron": true,
+        "language": "en_US",
+        "external_object_cache": null,
+        "server_info": "Apache/2.4.51 (Unix) OpenSSL/1.0.2g",
+        "php_version": "7.4.26",
+        "php_post_max_size": 1073741824,
+        "php_max_execution_time": 30,
+        "php_max_input_vars": 5000,
+        "curl_version": "7.47.0, OpenSSL/1.0.2g",
+        "suhosin_installed": false,
+        "max_upload_size": 536870912,
+        "mysql_version": "5.7.33",
+        "mysql_version_string": "5.7.33-0ubuntu0.16.04.1-log",
+        "default_timezone": "UTC",
+        "fsockopen_or_curl_enabled": true,
+        "soapclient_enabled": true,
+        "domdocument_enabled": true,
+        "gzip_enabled": true,
+        "mbstring_enabled": true,
+        "remote_post_successful": true,
+        "remote_post_response": 200,
+        "remote_get_successful": true,
+        "remote_get_response": 200
+    },
+    "database": {
+        "wc_database_version": "5.9.0",
+        "database_prefix": "wp_",
+        "maxmind_geoip_database": "",
+        "database_tables": {
+            "woocommerce": {
+                "wp_woocommerce_sessions": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
                 },
-                "other": {
-                    "wp_actionscheduler_actions": {
-                        "data": "0.02",
-                        "index": "0.13",
-                        "engine": "InnoDB"
-                    },
-                    "wp_actionscheduler_claims": {
-                        "data": "0.02",
-                        "index": "0.02",
-                        "engine": "InnoDB"
-                    },
-                    "wp_actionscheduler_groups": {
-                        "data": "0.02",
-                        "index": "0.02",
-                        "engine": "InnoDB"
-                    },
-                    "wp_actionscheduler_logs": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_commentmeta": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_comments": {
-                        "data": "0.02",
-                        "index": "0.09",
-                        "engine": "InnoDB"
-                    },
-                    "wp_links": {
-                        "data": "0.02",
-                        "index": "0.02",
-                        "engine": "InnoDB"
-                    },
-                    "wp_options": {
-                        "data": "3.48",
-                        "index": "0.06",
-                        "engine": "InnoDB"
-                    },
-                    "wp_postmeta": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_posts": {
-                        "data": "0.02",
-                        "index": "0.06",
-                        "engine": "InnoDB"
-                    },
-                    "wp_termmeta": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_terms": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_term_relationships": {
-                        "data": "0.02",
-                        "index": "0.02",
-                        "engine": "InnoDB"
-                    },
-                    "wp_term_taxonomy": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_usermeta": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_users": {
-                        "data": "0.02",
-                        "index": "0.05",
-                        "engine": "InnoDB"
-                    },
-                    "wp_wc_admin_notes": {
-                        "data": "0.05",
-                        "index": "0.00",
-                        "engine": "InnoDB"
-                    },
-                    "wp_wc_admin_note_actions": {
-                        "data": "0.02",
-                        "index": "0.02",
-                        "engine": "InnoDB"
-                    },
-                    "wp_wc_category_lookup": {
-                        "data": "0.02",
-                        "index": "0.00",
-                        "engine": "InnoDB"
-                    },
-                    "wp_wc_customer_lookup": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_wc_download_log": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_wc_order_coupon_lookup": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_wc_order_product_lookup": {
-                        "data": "0.02",
-                        "index": "0.06",
-                        "engine": "InnoDB"
-                    },
-                    "wp_wc_order_stats": {
-                        "data": "0.02",
-                        "index": "0.05",
-                        "engine": "InnoDB"
-                    },
-                    "wp_wc_order_tax_lookup": {
-                        "data": "0.02",
-                        "index": "0.03",
-                        "engine": "InnoDB"
-                    },
-                    "wp_wc_product_meta_lookup": {
-                        "data": "0.02",
-                        "index": "0.09",
-                        "engine": "InnoDB"
-                    },
-                    "wp_wc_reserved_stock": {
-                        "data": "0.02",
-                        "index": "0.00",
-                        "engine": "InnoDB"
-                    },
-                    "wp_wc_tax_rate_classes": {
-                        "data": "0.02",
-                        "index": "0.02",
-                        "engine": "InnoDB"
-                    },
-                    "wp_wc_webhooks": {
-                        "data": "0.02",
-                        "index": "0.02",
-                        "engine": "InnoDB"
-                    }
-                }
-            },
-            "database_size": {
-                "data": 4.3499999999999925,
-                "index": 1.4300000000000006
-            }
-        },
-        "active_plugins":[
-            {
-                "plugin":"woocommerce\/woocommerce.php",
-                "name":"WooCommerce",
-                "version":"5.8.0",
-                "version_latest":"5.8.0",
-                "url":"https:\/\/woocommerce.com\/",
-                "author_name":"Automattic",
-                "author_url":"https:\/\/woocommerce.com",
-                "network_activated":false
-            },
-            {
-                "plugin":"woocommerce-payments\/woocommerce-payments.php",
-                "name":"WooCommerce Payments",
-                "version":"3.1.0",
-                "version_latest":"3.1.0",
-                "url":"https:\/\/woocommerce.com\/payments\/",
-                "author_name":"Automattic",
-                "author_url":"https:\/\/woocommerce.com\/",
-                "network_activated":false
-            },
-            {
-                "plugin":"woocommerce-subscriptions\/woocommerce-subscriptions",
-                "name":"WooCommerce Subscriptions",
-                "version":"3.1.6",
-                "version_latest":"3.1.6",
-                "url":"https:\/\/www.woocommerce.com\/products\/woocommerce-subscriptions\/",
-                "author_name":"Automattic",
-                "author_url":"https:\/\/woocommerce.com\/",
-                "network_activated":false
-            },
-            {
-                "plugin":"jetpack\/jetpack.php",
-                "name":"Jetpack",
-                "version":"10.2",
-                "version_latest":"10.2.1",
-                "url":"https:\/\/jetpack.com",
-                "author_name":"Automattic",
-                "author_url":"https:\/\/jetpack.com",
-                "network_activated":false
-            }
-        ],
-        "inactive_plugins":[
-            {
-                "plugin":"akismet\/akismet.php",
-                "name":"Akismet Anti-Spam",
-                "version":"4.2.1",
-                "version_latest":"4.2.1",
-                "url":"https:\/\/akismet.com\/",
-                "author_name":"Automattic",
-                "author_url":"https:\/\/automattic.com\/wordpress-plugins\/",
-                "network_activated":false
-            },
-            {
-                "plugin":"hello.php",
-                "name":"Hello Dolly",
-                "version":"1.7.2",
-                "version_latest":"1.7.2",
-                "url":"http:\/\/wordpress.org\/plugins\/hello-dolly\/",
-                "author_name":"Matt Mullenweg",
-                "author_url":"http:\/\/ma.tt\/",
-                "network_activated":false
-            }
-        ],
-        "dropins_mu_plugins": {
-            "dropins": [
-                {
-                    "plugin": "advanced-cache.php",
-                    "name": "advanced-cache.php"
+                "wp_woocommerce_api_keys": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
                 },
-                {
-                    "plugin": "object-cache.php",
-                    "name": "Memcached"
+                "wp_woocommerce_attribute_taxonomies": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_downloadable_product_permissions": {
+                    "data": "0.02",
+                    "index": "0.06",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_order_items": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_order_itemmeta": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_tax_rates": {
+                    "data": "0.02",
+                    "index": "0.06",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_tax_rate_locations": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_shipping_zones": {
+                    "data": "0.02",
+                    "index": "0.00",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_shipping_zone_locations": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_shipping_zone_methods": {
+                    "data": "0.02",
+                    "index": "0.00",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_payment_tokens": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_payment_tokenmeta": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_log": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
                 }
-            ],
-            "mu_plugins": [
-                {
-                    "plugin": "wpcomsh-loader.php",
-                    "name": "WP.com Site Helper",
-                    "version": "",
-                    "url": "",
-                    "author_name": "",
-                    "author_url": ""
+            },
+            "other": {
+                "wp_actionscheduler_actions": {
+                    "data": "0.02",
+                    "index": "0.13",
+                    "engine": "InnoDB"
+                },
+                "wp_actionscheduler_claims": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_actionscheduler_groups": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_actionscheduler_logs": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_commentmeta": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_comments": {
+                    "data": "0.02",
+                    "index": "0.09",
+                    "engine": "InnoDB"
+                },
+                "wp_links": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_options": {
+                    "data": "3.48",
+                    "index": "0.06",
+                    "engine": "InnoDB"
+                },
+                "wp_postmeta": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_posts": {
+                    "data": "0.02",
+                    "index": "0.06",
+                    "engine": "InnoDB"
+                },
+                "wp_termmeta": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_terms": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_term_relationships": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_term_taxonomy": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_usermeta": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_users": {
+                    "data": "0.02",
+                    "index": "0.05",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_admin_notes": {
+                    "data": "0.05",
+                    "index": "0.00",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_admin_note_actions": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_category_lookup": {
+                    "data": "0.02",
+                    "index": "0.00",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_customer_lookup": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_download_log": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_order_coupon_lookup": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_order_product_lookup": {
+                    "data": "0.02",
+                    "index": "0.06",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_order_stats": {
+                    "data": "0.02",
+                    "index": "0.05",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_order_tax_lookup": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_product_meta_lookup": {
+                    "data": "0.02",
+                    "index": "0.09",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_reserved_stock": {
+                    "data": "0.02",
+                    "index": "0.00",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_tax_rate_classes": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_webhooks": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
                 }
-            ]
+            }
         },
-        "theme": {
-            "name": "Twenty Twenty-One",
-            "version": "1.4",
-            "version_latest": "1.4",
-            "author_url": "https://wordpress.org/",
-            "is_child_theme": false,
-            "has_woocommerce_support": true,
-            "has_woocommerce_file": false,
-            "has_outdated_templates": false,
-            "overrides": [],
-            "parent_name": "",
-            "parent_version": "",
-            "parent_version_latest": "",
-            "parent_author_url": ""
+        "database_size": {
+            "data": 4.3499999999999925,
+            "index": 1.4300000000000006
+        }
+    },
+    "active_plugins":[
+        {
+            "plugin":"woocommerce\/woocommerce.php",
+            "name":"WooCommerce",
+            "version":"5.8.0",
+            "version_latest":"5.8.0",
+            "url":"https:\/\/woocommerce.com\/",
+            "author_name":"Automattic",
+            "author_url":"https:\/\/woocommerce.com",
+            "network_activated":false
         },
-        "settings": {
-            "api_enabled": false,
-            "force_ssl": false,
-            "currency": "USD",
-            "currency_symbol": "&#36;",
-            "currency_position": "left",
-            "thousand_separator": ",",
-            "decimal_separator": ".",
-            "number_of_decimals": 2,
-            "geolocation_enabled": false,
-            "taxonomies": {
-                "external": "external",
-                "grouped": "grouped",
-                "simple": "simple",
-                "subscription": "subscription",
-                "variable": "variable",
-                "variable-subscription": "variable subscription"
-            },
-            "product_visibility_terms": {
-                "exclude-from-catalog": "exclude-from-catalog",
-                "exclude-from-search": "exclude-from-search",
-                "featured": "featured",
-                "outofstock": "outofstock",
-                "rated-1": "rated-1",
-                "rated-2": "rated-2",
-                "rated-3": "rated-3",
-                "rated-4": "rated-4",
-                "rated-5": "rated-5"
-            },
-            "woocommerce_com_connected": "no"
+        {
+            "plugin":"woocommerce-payments\/woocommerce-payments.php",
+            "name":"WooCommerce Payments",
+            "version":"3.1.0",
+            "version_latest":"3.1.0",
+            "url":"https:\/\/woocommerce.com\/payments\/",
+            "author_name":"Automattic",
+            "author_url":"https:\/\/woocommerce.com\/",
+            "network_activated":false
         },
-        "security": {
-            "secure_connection": true,
-            "hide_errors": false
+        {
+            "plugin":"woocommerce-subscriptions\/woocommerce-subscriptions",
+            "name":"WooCommerce Subscriptions",
+            "version":"3.1.6",
+            "version_latest":"3.1.6",
+            "url":"https:\/\/www.woocommerce.com\/products\/woocommerce-subscriptions\/",
+            "author_name":"Automattic",
+            "author_url":"https:\/\/woocommerce.com\/",
+            "network_activated":false
         },
-        "pages": [
+        {
+            "plugin":"jetpack\/jetpack.php",
+            "name":"Jetpack",
+            "version":"10.2",
+            "version_latest":"10.2.1",
+            "url":"https:\/\/jetpack.com",
+            "author_name":"Automattic",
+            "author_url":"https:\/\/jetpack.com",
+            "network_activated":false
+        }
+    ],
+    "inactive_plugins":[
+        {
+            "plugin":"akismet\/akismet.php",
+            "name":"Akismet Anti-Spam",
+            "version":"4.2.1",
+            "version_latest":"4.2.1",
+            "url":"https:\/\/akismet.com\/",
+            "author_name":"Automattic",
+            "author_url":"https:\/\/automattic.com\/wordpress-plugins\/",
+            "network_activated":false
+        },
+        {
+            "plugin":"hello.php",
+            "name":"Hello Dolly",
+            "version":"1.7.2",
+            "version_latest":"1.7.2",
+            "url":"http:\/\/wordpress.org\/plugins\/hello-dolly\/",
+            "author_name":"Matt Mullenweg",
+            "author_url":"http:\/\/ma.tt\/",
+            "network_activated":false
+        }
+    ],
+    "dropins_mu_plugins": {
+        "dropins": [
             {
-                "page_name": "Shop base",
-                "page_id": "5",
-                "page_set": true,
-                "page_exists": true,
-                "page_visible": true,
-                "shortcode": "",
-                "block": "",
-                "shortcode_required": false,
-                "shortcode_present": false,
-                "block_present": false,
-                "block_required": false
+                "plugin": "advanced-cache.php",
+                "name": "advanced-cache.php"
             },
             {
-                "page_name": "Cart",
-                "page_id": "6",
-                "page_set": true,
-                "page_exists": true,
-                "page_visible": true,
-                "shortcode": "[woocommerce_cart]",
-                "block": "woocommerce/cart",
-                "shortcode_required": true,
-                "shortcode_present": true,
-                "block_present": false,
-                "block_required": true
-            },
-            {
-                "page_name": "Checkout",
-                "page_id": "7",
-                "page_set": true,
-                "page_exists": true,
-                "page_visible": true,
-                "shortcode": "[woocommerce_checkout]",
-                "block": "woocommerce/checkout",
-                "shortcode_required": true,
-                "shortcode_present": true,
-                "block_present": false,
-                "block_required": true
-            },
-            {
-                "page_name": "My account",
-                "page_id": "8",
-                "page_set": true,
-                "page_exists": true,
-                "page_visible": true,
-                "shortcode": "[woocommerce_my_account]",
-                "block": "",
-                "shortcode_required": true,
-                "shortcode_present": true,
-                "block_present": false,
-                "block_required": false
-            },
-            {
-                "page_name": "Terms and conditions",
-                "page_id": "",
-                "page_set": false,
-                "page_exists": false,
-                "page_visible": false,
-                "shortcode": "",
-                "block": "",
-                "shortcode_required": false,
-                "shortcode_present": false,
-                "block_present": false,
-                "block_required": false
+                "plugin": "object-cache.php",
+                "name": "Memcached"
             }
         ],
-        "post_type_counts": [
+        "mu_plugins": [
             {
-                "type": "attachment",
-                "count": "1"
-            },
-            {
-                "type": "page",
-                "count": "7"
-            },
-            {
-                "type": "post",
-                "count": "2"
+                "plugin": "wpcomsh-loader.php",
+                "name": "WP.com Site Helper",
+                "version": "",
+                "url": "",
+                "author_name": "",
+                "author_url": ""
             }
         ]
-    }
+    },
+    "theme": {
+        "name": "Twenty Twenty-One",
+        "version": "1.4",
+        "version_latest": "1.4",
+        "author_url": "https://wordpress.org/",
+        "is_child_theme": false,
+        "has_woocommerce_support": true,
+        "has_woocommerce_file": false,
+        "has_outdated_templates": false,
+        "overrides": [],
+        "parent_name": "",
+        "parent_version": "",
+        "parent_version_latest": "",
+        "parent_author_url": ""
+    },
+    "settings": {
+        "api_enabled": false,
+        "force_ssl": false,
+        "currency": "USD",
+        "currency_symbol": "&#36;",
+        "currency_position": "left",
+        "thousand_separator": ",",
+        "decimal_separator": ".",
+        "number_of_decimals": 2,
+        "geolocation_enabled": false,
+        "taxonomies": {
+            "external": "external",
+            "grouped": "grouped",
+            "simple": "simple",
+            "subscription": "subscription",
+            "variable": "variable",
+            "variable-subscription": "variable subscription"
+        },
+        "product_visibility_terms": {
+            "exclude-from-catalog": "exclude-from-catalog",
+            "exclude-from-search": "exclude-from-search",
+            "featured": "featured",
+            "outofstock": "outofstock",
+            "rated-1": "rated-1",
+            "rated-2": "rated-2",
+            "rated-3": "rated-3",
+            "rated-4": "rated-4",
+            "rated-5": "rated-5"
+        },
+        "woocommerce_com_connected": "no"
+    },
+    "security": {
+        "secure_connection": true,
+        "hide_errors": false
+    },
+    "pages": [
+        {
+            "page_name": "Shop base",
+            "page_id": "5",
+            "page_set": true,
+            "page_exists": true,
+            "page_visible": true,
+            "shortcode": "",
+            "block": "",
+            "shortcode_required": false,
+            "shortcode_present": false,
+            "block_present": false,
+            "block_required": false
+        },
+        {
+            "page_name": "Cart",
+            "page_id": "6",
+            "page_set": true,
+            "page_exists": true,
+            "page_visible": true,
+            "shortcode": "[woocommerce_cart]",
+            "block": "woocommerce/cart",
+            "shortcode_required": true,
+            "shortcode_present": true,
+            "block_present": false,
+            "block_required": true
+        },
+        {
+            "page_name": "Checkout",
+            "page_id": "7",
+            "page_set": true,
+            "page_exists": true,
+            "page_visible": true,
+            "shortcode": "[woocommerce_checkout]",
+            "block": "woocommerce/checkout",
+            "shortcode_required": true,
+            "shortcode_present": true,
+            "block_present": false,
+            "block_required": true
+        },
+        {
+            "page_name": "My account",
+            "page_id": "8",
+            "page_set": true,
+            "page_exists": true,
+            "page_visible": true,
+            "shortcode": "[woocommerce_my_account]",
+            "block": "",
+            "shortcode_required": true,
+            "shortcode_present": true,
+            "block_present": false,
+            "block_required": false
+        },
+        {
+            "page_name": "Terms and conditions",
+            "page_id": "",
+            "page_set": false,
+            "page_exists": false,
+            "page_visible": false,
+            "shortcode": "",
+            "block": "",
+            "shortcode_required": false,
+            "shortcode_present": false,
+            "block_present": false,
+            "block_required": false
+        }
+    ],
+    "post_type_counts": [
+        {
+            "type": "attachment",
+            "count": "1"
+        },
+        {
+            "type": "page",
+            "count": "7"
+        },
+        {
+            "type": "post",
+            "count": "2"
+        }
+    ]
 }

--- a/Networking/NetworkingTests/Responses/systemStatusWithPluginsOnly-without-data.json
+++ b/Networking/NetworkingTests/Responses/systemStatusWithPluginsOnly-without-data.json
@@ -1,0 +1,68 @@
+{
+    "data": {
+        "active_plugins":[
+            {
+                "plugin":"woocommerce\/woocommerce.php",
+                "name":"WooCommerce",
+                "version":"5.8.0",
+                "version_latest":"5.8.0",
+                "url":"https:\/\/woocommerce.com\/",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/woocommerce.com",
+                "network_activated":false
+            },
+            {
+                "plugin":"woocommerce-payments\/woocommerce-payments.php",
+                "name":"WooCommerce Payments",
+                "version":"3.1.0",
+                "version_latest":"3.1.0",
+                "url":"https:\/\/woocommerce.com\/payments\/",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/woocommerce.com\/",
+                "network_activated":false
+            },
+            {
+                "plugin":"woocommerce-subscriptions\/woocommerce-subscriptions",
+                "name":"WooCommerce Subscriptions",
+                "version":"3.1.6",
+                "version_latest":"3.1.6",
+                "url":"https:\/\/www.woocommerce.com\/products\/woocommerce-subscriptions\/",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/woocommerce.com\/",
+                "network_activated":false
+            },
+            {
+                "plugin":"jetpack\/jetpack.php",
+                "name":"Jetpack",
+                "version":"10.2",
+                "version_latest":"10.2.1",
+                "url":"https:\/\/jetpack.com",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/jetpack.com",
+                "network_activated":false
+            }
+        ],
+        "inactive_plugins":[
+            {
+                "plugin":"akismet\/akismet.php",
+                "name":"Akismet Anti-Spam",
+                "version":"4.2.1",
+                "version_latest":"4.2.1",
+                "url":"https:\/\/akismet.com\/",
+                "author_name":"Automattic",
+                "author_url":"https:\/\/automattic.com\/wordpress-plugins\/",
+                "network_activated":false
+            },
+            {
+                "plugin":"hello.php",
+                "name":"Hello Dolly",
+                "version":"1.7.2",
+                "version_latest":"1.7.2",
+                "url":"http:\/\/wordpress.org\/plugins\/hello-dolly\/",
+                "author_name":"Matt Mullenweg",
+                "author_url":"http:\/\/ma.tt\/",
+                "network_activated":false
+            }
+        ]
+    }
+}

--- a/Networking/NetworkingTests/Responses/systemStatusWithPluginsOnly-without-data.json
+++ b/Networking/NetworkingTests/Responses/systemStatusWithPluginsOnly-without-data.json
@@ -1,68 +1,26 @@
 {
-    "data": {
-        "active_plugins":[
-            {
-                "plugin":"woocommerce\/woocommerce.php",
-                "name":"WooCommerce",
-                "version":"5.8.0",
-                "version_latest":"5.8.0",
-                "url":"https:\/\/woocommerce.com\/",
-                "author_name":"Automattic",
-                "author_url":"https:\/\/woocommerce.com",
-                "network_activated":false
-            },
-            {
-                "plugin":"woocommerce-payments\/woocommerce-payments.php",
-                "name":"WooCommerce Payments",
-                "version":"3.1.0",
-                "version_latest":"3.1.0",
-                "url":"https:\/\/woocommerce.com\/payments\/",
-                "author_name":"Automattic",
-                "author_url":"https:\/\/woocommerce.com\/",
-                "network_activated":false
-            },
-            {
-                "plugin":"woocommerce-subscriptions\/woocommerce-subscriptions",
-                "name":"WooCommerce Subscriptions",
-                "version":"3.1.6",
-                "version_latest":"3.1.6",
-                "url":"https:\/\/www.woocommerce.com\/products\/woocommerce-subscriptions\/",
-                "author_name":"Automattic",
-                "author_url":"https:\/\/woocommerce.com\/",
-                "network_activated":false
-            },
-            {
-                "plugin":"jetpack\/jetpack.php",
-                "name":"Jetpack",
-                "version":"10.2",
-                "version_latest":"10.2.1",
-                "url":"https:\/\/jetpack.com",
-                "author_name":"Automattic",
-                "author_url":"https:\/\/jetpack.com",
-                "network_activated":false
-            }
-        ],
-        "inactive_plugins":[
-            {
-                "plugin":"akismet\/akismet.php",
-                "name":"Akismet Anti-Spam",
-                "version":"4.2.1",
-                "version_latest":"4.2.1",
-                "url":"https:\/\/akismet.com\/",
-                "author_name":"Automattic",
-                "author_url":"https:\/\/automattic.com\/wordpress-plugins\/",
-                "network_activated":false
-            },
-            {
-                "plugin":"hello.php",
-                "name":"Hello Dolly",
-                "version":"1.7.2",
-                "version_latest":"1.7.2",
-                "url":"http:\/\/wordpress.org\/plugins\/hello-dolly\/",
-                "author_name":"Matt Mullenweg",
-                "author_url":"http:\/\/ma.tt\/",
-                "network_activated":false
-            }
-        ]
-    }
+    "active_plugins":[
+        {
+            "plugin":"woocommerce\/woocommerce.php",
+            "name":"WooCommerce",
+            "version":"5.8.0",
+            "version_latest":"5.8.0",
+            "url":"https:\/\/woocommerce.com\/",
+            "author_name":"Automattic",
+            "author_url":"https:\/\/woocommerce.com",
+            "network_activated":false
+        }
+    ],
+    "inactive_plugins":[
+        {
+            "plugin":"akismet\/akismet.php",
+            "name":"Akismet Anti-Spam",
+            "version":"4.2.1",
+            "version_latest":"4.2.1",
+            "url":"https:\/\/akismet.com\/",
+            "author_name":"Automattic",
+            "author_url":"https:\/\/automattic.com\/wordpress-plugins\/",
+            "network_activated":false
+        }
+    ]
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8602 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR continues the migration for the REST API project, this time is for system status endpoints:
- Updated the mappers for system status and system plugins.
- Enable REST API for system status endpoints.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address and proceed with the address of your self-hosted site.
- Proceed to log in with your site credentials.
- After the login succeeds, you should be navigated to the home screen.
- Navigate to the Menu app and select Settings.
- Notice on the row "WooCommerce Version", the correct version for Woo on your site should be displayed.
- Select "Help & Support" > "System Status Report". The report should be loaded and displayed without error.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
