### PR TITLE
[REST API] Migrate Jetpack requests in `ProductsRemote`

### DIFF
--- a/Networking/Networking/Network/MockNetwork.swift
+++ b/Networking/Networking/Network/MockNetwork.swift
@@ -193,6 +193,8 @@ private extension MockNetwork {
             return request.path
         case let request as DotcomRequest:
             return request.path
+        case let request as RESTRequest:
+            return request.path
         default:
             let targetURL = try! request.asURLRequest().url?.absoluteString
             return targetURL ?? ""

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -73,7 +73,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             let parameters = try product.toDictionary()
             let siteID = product.siteID
             let path = Path.products
-            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
             let mapper = ProductMapper(siteID: siteID)
             enqueue(request, mapper: mapper, completion: completion)
         } catch {
@@ -90,7 +90,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///
     public func deleteProduct(for siteID: Int64, productID: Int64, completion: @escaping (Result<Product, Error>) -> Void) {
         let path = "\(Path.products)/\(productID)"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .delete, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .delete, siteID: siteID, path: path, parameters: nil, availableAsRESTRequest: true)
         let mapper = ProductMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -143,7 +143,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         ].merging(filterParameters, uniquingKeysWith: { (first, _) in first })
 
         let path = Path.products
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = ProductListMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -179,7 +179,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.perPage: String(pageSize),
         ]
         let path = Path.products
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = ProductListMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -195,7 +195,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///
     public func loadProduct(for siteID: Int64, productID: Int64, completion: @escaping (Result<Product, Error>) -> Void) {
         let path = "\(Path.products)/\(productID)"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil, availableAsRESTRequest: true)
         let mapper = ProductMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -240,7 +240,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         ].merging(filterParameters, uniquingKeysWith: { (first, _) in first })
 
         let path = Path.products
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = ProductListMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -265,7 +265,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.perPage: String(pageSize)
         ]
         let path = Path.products
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = ProductListMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -286,7 +286,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         ]
 
         let path = Path.products
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = ProductSkuMapper()
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -304,7 +304,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             let productID = product.productID
             let siteID = product.siteID
             let path = "\(Path.products)/\(productID)"
-            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
             let mapper = ProductMapper(siteID: siteID)
 
             enqueue(request, mapper: mapper, completion: completion)
@@ -317,7 +317,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         do {
             let parameters = try ([ParameterKey.images: images]).toDictionary()
             let path = "\(Path.products)/\(productID)"
-            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
             let mapper = ProductMapper(siteID: siteID)
 
             enqueue(request, mapper: mapper, completion: completion)
@@ -365,7 +365,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         ]
 
         let path = Path.products
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = ProductIDMapper()
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -378,7 +378,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     public func createTemplateProduct(for siteID: Int64, template: ProductsRemote.TemplateType, completion: @escaping (Result<Int64, Error>) -> Void) {
         let parameters = [ParameterKey.templateName: template.rawValue]
         let path = Path.templateProducts
-        let request = JetpackRequest(wooApiVersion: .wcAdmin, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .wcAdmin, method: .post, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
         let mapper = EntityIDMapper()
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/Networking/Requests/RESTRequest.swift
+++ b/Networking/Networking/Requests/RESTRequest.swift
@@ -97,7 +97,7 @@ struct RESTRequest: Request {
     }
 
     func responseDataValidator() -> ResponseDataValidator {
-        PlaceholderDataValidator()
+        WordPressApiValidator()
     }
 }
 

--- a/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
@@ -10,6 +10,10 @@ final class MediaRemoteTests: XCTestCase {
     ///
     private let sampleSiteID: Int64 = 1234
 
+    /// Dummy Site URL
+    ///
+    private let sampleSiteURL = "http://test.com"
+
     /// Dummy Product ID
     ///
     private let sampleProductID: Int64 = 586
@@ -117,6 +121,60 @@ final class MediaRemoteTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
     }
 
+    // MARK: - Load Media From Media Library `loadMediaLibraryUsingRestApi`
+
+    /// Verifies that `loadMediaLibraryUsingRestApi` properly parses the `media-library-from-wordpress-site` sample response.
+    ///
+    func test_loadMediaLibraryUsingRestApi_properly_returns_parsed_media_list() throws {
+        // Given
+        let remote = MediaRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "media", filename: "media-library-from-wordpress-site")
+
+        // When
+        let result = waitFor { promise in
+            remote.loadMediaLibraryUsingRestApi(siteURL: self.sampleSiteURL) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let mediaItems = try XCTUnwrap(result.get())
+        XCTAssertEqual(mediaItems.count, 2)
+        let uploadedMedia = try XCTUnwrap(mediaItems.first)
+        XCTAssertEqual(uploadedMedia.mediaID, 22)
+        XCTAssertEqual(uploadedMedia.date, Date(timeIntervalSince1970: 1637546157))
+        XCTAssertEqual(uploadedMedia.slug, "img_0111-2")
+        XCTAssertEqual(uploadedMedia.mimeType, "image/jpeg")
+        XCTAssertEqual(uploadedMedia.src, "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-scaled.jpeg")
+        XCTAssertEqual(uploadedMedia.alt, "Floral")
+        XCTAssertEqual(uploadedMedia.details?.width, 2560)
+        XCTAssertEqual(uploadedMedia.details?.height, 1920)
+        XCTAssertEqual(uploadedMedia.details?.fileName, "2021/11/img_0111-2-scaled.jpeg")
+        XCTAssertEqual(uploadedMedia.title, .init(rendered: "img_0111-2"))
+        XCTAssertEqual(uploadedMedia.details?.sizes["thumbnail"],
+                       .init(fileName: "img_0111-2-150x150.jpeg",
+                             src: "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-150x150.jpeg",
+                             width: 150,
+                             height: 150))
+    }
+
+    /// Verifies that `loadMediaLibraryUsingRestApi` properly relays Networking Layer errors.
+    ///
+    func test_loadMediaLibraryUsingRestApi_properly_relays_networking_errors() throws {
+        // Given
+        let remote = MediaRemote(network: network)
+
+        // When
+        let result = waitFor { promise in
+            remote.loadMediaLibraryUsingRestApi(siteURL: self.sampleSiteURL) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
     // MARK: - uploadMedia
 
     /// Verifies that `uploadMedia` properly parses the `media-upload` sample response.
@@ -215,6 +273,61 @@ final class MediaRemoteTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
     }
 
+    /// Verifies that `uploadMediaUsingRestApi` properly parses the `media-upload-to-wordpress-site` sample response.
+    ///
+    func test_uploadMediaUsingRestApi_properly_returns_parsed_media() throws {
+        // Given
+        let remote = MediaRemote(network: network)
+        let path = "media"
+        network.simulateResponse(requestUrlSuffix: path, filename: "media-upload-to-wordpress-site")
+
+        // When
+        let result = waitFor { promise in
+            remote.uploadMediaUsingRestApi(siteURL: self.sampleSiteURL,
+                                           productID: self.sampleProductID,
+                                           mediaItems: []) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let uploadedMedia = try XCTUnwrap(result.get())
+        XCTAssertEqual(uploadedMedia.mediaID, 23)
+        XCTAssertEqual(uploadedMedia.date, Date(timeIntervalSince1970: 1637477423))
+        XCTAssertEqual(uploadedMedia.slug, "img_0005-1")
+        XCTAssertEqual(uploadedMedia.mimeType, "image/jpeg")
+        XCTAssertEqual(uploadedMedia.src, "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-scaled.jpeg")
+        XCTAssertEqual(uploadedMedia.alt, "Floral")
+        XCTAssertEqual(uploadedMedia.details?.width, 2560)
+        XCTAssertEqual(uploadedMedia.details?.height, 1708)
+        XCTAssertEqual(uploadedMedia.details?.fileName, "2021/11/img_0005-1-scaled.jpeg")
+        XCTAssertEqual(uploadedMedia.title, .init(rendered: "img_0005-1"))
+        XCTAssertEqual(uploadedMedia.details?.sizes["thumbnail"],
+                       .init(fileName: "img_0005-1-150x150.jpeg",
+                             src: "https://ninja.media/wp-content/uploads/2021/11/img_0005-1-150x150.jpeg",
+                             width: 150,
+                             height: 150))
+    }
+
+    /// Verifies that `uploadMediaUsingRestApi` properly relays Networking Layer errors.
+    ///
+    func test_uploadMediaUsingRestApi_properly_relays_networking_errors() {
+        // Given
+        let remote = MediaRemote(network: network)
+
+        // When
+        let result = waitFor { promise in
+            remote.uploadMediaUsingRestApi(siteURL: self.sampleSiteURL,
+                                           productID: self.sampleProductID,
+                                           mediaItems: []) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
     // MARK: - updateProductID
 
     /// Verifies that `updateProductID` properly parses the `media-update-product-id` sample response.
@@ -293,6 +406,49 @@ final class MediaRemoteTests: XCTestCase {
             remote.updateProductIDToWordPressSite(siteID: self.sampleSiteID,
                                    productID: self.sampleProductID,
                                    mediaID: self.sampleMediaID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+
+    // MARK: - updateProductIDUsingRestApi
+
+    /// Verifies that `updateProductIDUsingRestApi` properly parses the `media-update-product-id-in-wordpress-site` sample response.
+    ///
+    func test_updateProductIDUsingRestApi_properly_returns_parsed_media() throws {
+        // Given
+        let remote = MediaRemote(network: network)
+        let path = "media/\(sampleMediaID)"
+        network.simulateResponse(requestUrlSuffix: path, filename: "media-update-product-id-in-wordpress-site")
+
+        // When
+        let result = waitFor { promise in
+            remote.updateProductIDUsingRestApi(siteURL: self.sampleSiteURL,
+                                               productID: self.sampleProductID,
+                                               mediaID: self.sampleMediaID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let media = try XCTUnwrap(result.get())
+        XCTAssertEqual(media.mediaID, sampleMediaID)
+    }
+
+    /// Verifies that `updateProductIDUsingRestApi` properly relays Networking Layer errors.
+    ///
+    func test_updateProductIDUsingRestApi_properly_relays_networking_errors() {
+        // Given
+        let remote = MediaRemote(network: network)
+
+        // When
+        let result = waitFor { promise in
+            remote.updateProductIDUsingRestApi(siteURL: self.sampleSiteURL,
+                                               productID: self.sampleProductID,
+                                               mediaID: self.sampleMediaID) { result in
                 promise(result)
             }
         }

--- a/Networking/NetworkingTests/Responses/AppliicationPassword/rest_incorrect_application_password_error.json
+++ b/Networking/NetworkingTests/Responses/AppliicationPassword/rest_incorrect_application_password_error.json
@@ -1,0 +1,7 @@
+{
+  "code": "incorrect_password",
+  "message": "The provided password is an invalid application password.",
+  "data": {
+    "status": 401
+  }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -212,7 +212,17 @@ final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
     private func uploadMediaAssetToSiteMediaLibrary(asset: PHAsset, onCompletion: @escaping (Result<Media, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            let action = MediaAction.uploadMedia(siteID: self.siteID, productID: self.productOrVariationID.id, mediaAsset: asset, onCompletion: onCompletion)
+            let siteInfo: MediaAction.SiteInfo = {
+                if case let .wporg(_, _, siteAddress) = ServiceLocator.stores.sessionManager.defaultCredentials {
+                    return .wporg(siteAddress)
+                } else {
+                    return .wpcom(self.siteID)
+                }
+            }()
+            let action = MediaAction.uploadMedia(connectUsing: siteInfo,
+                                                 productID: self.productOrVariationID.id,
+                                                 mediaAsset: asset,
+                                                 onCompletion: onCompletion)
             self.stores.dispatch(action)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesProductIDUpdater.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesProductIDUpdater.swift
@@ -37,7 +37,16 @@ private extension ProductImagesProductIDUpdater {
                             siteID: Int64,
                             productID: Int64) async throws -> Media {
         try await withCheckedThrowingContinuation { continuation in
-            let action = MediaAction.updateProductID(siteID: siteID, productID: productID, mediaID: productImageID) { result in
+            let siteInfo: MediaAction.SiteInfo = {
+                if case let .wporg(_, _, siteAddress) = ServiceLocator.stores.sessionManager.defaultCredentials {
+                    return .wporg(siteAddress)
+                } else {
+                    return .wpcom(siteID)
+                }
+            }()
+            let action = MediaAction.updateProductID(connectUsing: siteInfo,
+                                                     productID: productID,
+                                                     mediaID: productImageID) { result in
                 switch result {
                 case .failure(let error):
                     DDLogError("⛔️ Error updating `parent_id` of media with \(productImageID): \(error)")

--- a/WooCommerce/Classes/ViewRelated/Products/Media/WordPressMediaLibraryPickerDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/WordPressMediaLibraryPickerDataSource.swift
@@ -162,7 +162,14 @@ extension WordPressMediaLibraryPickerDataSource: SyncingCoordinatorDelegate {
 
 private extension WordPressMediaLibraryPickerDataSource {
     func retrieveMedia(pageNumber: Int, pageSize: Int, completion: @escaping (_ mediaItems: [Media], _ error: Error?) -> Void) {
-        let action = MediaAction.retrieveMediaLibrary(siteID: siteID,
+        let siteInfo: MediaAction.SiteInfo = {
+            if case let .wporg(_, _, siteAddress) = ServiceLocator.stores.sessionManager.defaultCredentials {
+                return .wporg(siteAddress)
+            } else {
+                return .wpcom(siteID)
+            }
+        }()
+        let action = MediaAction.retrieveMediaLibrary(connectUsing: siteInfo,
                                                       pageNumber: pageNumber,
                                                       pageSize: pageSize) { result in
             switch result {

--- a/Yosemite/Yosemite/Actions/MediaAction.swift
+++ b/Yosemite/Yosemite/Actions/MediaAction.swift
@@ -19,26 +19,26 @@ public enum MediaAction: Action {
     /// Retrieves media from the site's WP Media Library.
     ///
     /// - Parameters:
-    ///   - siteID: Site for which we'll load the media from.
+    ///   - connectUsing: Provides Site ID or Site URL based on the current login method
     ///   - pageNumber: The index of the page of media data to load from, starting from 1.
     ///   - pageSize: The maximum number of media items to return per page.
     ///   - onCompletion: Closure to be executed upon completion.
     ///
-    case retrieveMediaLibrary(siteID: Int64,
+    case retrieveMediaLibrary(connectUsing: SiteInfo,
                               pageNumber: Int,
                               pageSize: Int,
                               onCompletion: (Result<[Media], Error>) -> Void)
 
     /// Uploads an exportable media asset to the site's WP Media Library.
     ///
-    case uploadMedia(siteID: Int64,
+    case uploadMedia(connectUsing: SiteInfo,
                      productID: Int64,
                      mediaAsset: ExportableAsset,
                      onCompletion: (Result<Media, Error>) -> Void)
 
     /// Updates the `parent_id` of the media using the provided `productID`.
     ///
-    case updateProductID(siteID: Int64,
+    case updateProductID(connectUsing: SiteInfo,
                          productID: Int64,
                          mediaID: Int64,
                          onCompletion: (Result<Media, Error>) -> Void)

--- a/Yosemite/Yosemite/Actions/MediaAction.swift
+++ b/Yosemite/Yosemite/Actions/MediaAction.swift
@@ -3,6 +3,19 @@ import Foundation
 // MARK: - MediaAction: Defines media operations (supported by the MediaStore).
 //
 public enum MediaAction: Action {
+
+    /// Site information using which `MediaAction` will be performed
+    ///
+    public enum SiteInfo {
+        // Connects to WordPress.com servers using provided `siteID`
+        //
+        case wpcom(_ siteID: Int64)
+
+        // Connects to the site URL
+        //
+        case wporg(_ siteURL: String)
+    }
+
     /// Retrieves media from the site's WP Media Library.
     ///
     /// - Parameters:

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMediaRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockMediaRemote.swift
@@ -15,17 +15,26 @@ final class MockMediaRemote {
     /// The results to return based on the given site ID in `loadMediaLibraryFromWordPressSite`
     private var loadMediaLibraryFromWordPressSiteResultsBySiteID = [Int64: Result<[WordPressMedia], Error>]()
 
+    /// The results to return based on the given site ID in `loadMediaLibraryUsingRestApi`
+    private var loadMediaLibraryUsingRestApiResultsBySiteURL = [String: Result<[WordPressMedia], Error>]()
+
     /// The results to return based on the given site ID in `uploadMedia`
     private var uploadMediaResultsBySiteID = [Int64: Result<[Media], Error>]()
 
     /// The results to return based on the given site ID in `uploadMediaToWordPressSite`
     private var uploadMediaToWordPressSiteResultsBySiteID = [Int64: Result<WordPressMedia, Error>]()
 
+    /// The results to return based on the given site ID in `uploadMediaUsingRestApi`
+    private var uploadMediaUsingRestApiResultsBySiteURL = [String: Result<WordPressMedia, Error>]()
+
     /// The results to return based on the given site ID in `updateProductID`
     private var updateProductIDResultsBySiteID = [Int64: Result<Media, Error>]()
 
     /// The results to return based on the given site ID in `updateProductIDToWordPressSite`
     private var updateProductIDToWordPressSiteResultsBySiteID = [Int64: Result<WordPressMedia, Error>]()
+
+    /// The results to return based on the given site ID in `updateProductIDUsingRestApi`
+    private var updateProductIDUsingRestApiResultsBySiteURL = [String: Result<WordPressMedia, Error>]()
 
     /// Returns the value as a publisher when `loadMediaLibrary` is called.
     func whenLoadingMediaLibrary(siteID: Int64, thenReturn result: Result<[Media], Error>) {
@@ -35,6 +44,11 @@ final class MockMediaRemote {
     /// Returns the value as a publisher when `loadMediaLibraryFromWordPressSite` is called.
     func whenLoadingMediaLibraryFromWordPressSite(siteID: Int64, thenReturn result: Result<[WordPressMedia], Error>) {
         loadMediaLibraryFromWordPressSiteResultsBySiteID[siteID] = result
+    }
+
+    /// Returns the value as a publisher when `loadMediaLibraryFromWordPressSite` is called.
+    func whenLoadingMediaLibraryUsingRestApi(siteURL: String, thenReturn result: Result<[WordPressMedia], Error>) {
+        loadMediaLibraryUsingRestApiResultsBySiteURL[siteURL] = result
     }
 
     /// Returns the value as a publisher when `uploadMedia` is called.
@@ -47,6 +61,11 @@ final class MockMediaRemote {
         uploadMediaToWordPressSiteResultsBySiteID[siteID] = result
     }
 
+    /// Returns the value as a publisher when `uploadMediaUsingRestApi` is called.
+    func whenUploadingMediaUsingRestApi(siteURL: String, thenReturn result: Result<WordPressMedia, Error>) {
+        uploadMediaUsingRestApiResultsBySiteURL[siteURL] = result
+    }
+
     /// Returns the value as a publisher when `updateProductID` is called.
     func whenUpdatingProductID(siteID: Int64, thenReturn result: Result<Media, Error>) {
         updateProductIDResultsBySiteID[siteID] = result
@@ -56,16 +75,24 @@ final class MockMediaRemote {
     func whenUpdatingProductIDToWordPressSite(siteID: Int64, thenReturn result: Result<WordPressMedia, Error>) {
         updateProductIDToWordPressSiteResultsBySiteID[siteID] = result
     }
+
+    /// Returns the value as a publisher when `updateProductIDUsingRestApi` is called.
+    func whenUpdatingProductIDUsingRestApi(siteURL: String, thenReturn result: Result<WordPressMedia, Error>) {
+        updateProductIDUsingRestApiResultsBySiteURL[siteURL] = result
+    }
 }
 
 extension MockMediaRemote {
     enum Invocation: Equatable {
         case loadMediaLibrary(siteID: Int64)
         case loadMediaLibraryFromWordPressSite(siteID: Int64)
+        case loadMediaLibraryUsingRestApi(siteURL: String)
         case uploadMedia(siteID: Int64)
         case uploadMediaToWordPressSite(siteID: Int64)
+        case uploadMediaUsingRestApi(siteURL: String)
         case updateProductID(siteID: Int64)
         case updateProductIDToWordPressSite(siteID: Int64)
+        case updateProductIDUsingRestApi(siteURL: String)
     }
 }
 
@@ -85,6 +112,18 @@ extension MockMediaRemote: MediaRemoteProtocol {
         invocations.append(.loadMediaLibraryFromWordPressSite(siteID: siteID))
         guard let result = loadMediaLibraryFromWordPressSiteResultsBySiteID[siteID] else {
             XCTFail("\(String(describing: self)) Could not find result for site ID: \(siteID)")
+            return
+        }
+        completion(result)
+    }
+
+    func loadMediaLibraryUsingRestApi(siteURL: String,
+                                      pageNumber: Int,
+                                      pageSize: Int,
+                                      completion: @escaping (Result<[Networking.WordPressMedia], Error>) -> Void) {
+        invocations.append(.loadMediaLibraryUsingRestApi(siteURL: siteURL))
+        guard let result = loadMediaLibraryUsingRestApiResultsBySiteURL[siteURL] else {
+            XCTFail("\(String(describing: self)) Could not find result for site URL: \(siteURL)")
             return
         }
         completion(result)
@@ -115,6 +154,18 @@ extension MockMediaRemote: MediaRemoteProtocol {
         completion(result)
     }
 
+    func uploadMediaUsingRestApi(siteURL: String,
+                                 productID: Int64,
+                                 mediaItems: [Networking.UploadableMedia],
+                                 completion: @escaping (Result<Networking.WordPressMedia, Error>) -> Void) {
+        invocations.append(.uploadMediaUsingRestApi(siteURL: siteURL))
+        guard let result = uploadMediaUsingRestApiResultsBySiteURL[siteURL] else {
+            XCTFail("\(String(describing: self)) Could not find result for site URL: \(siteURL)")
+            return
+        }
+        completion(result)
+    }
+
     func updateProductID(siteID: Int64,
                          productID: Int64,
                          mediaID: Int64,
@@ -134,6 +185,18 @@ extension MockMediaRemote: MediaRemoteProtocol {
         invocations.append(.updateProductIDToWordPressSite(siteID: siteID))
         guard let result = updateProductIDToWordPressSiteResultsBySiteID[siteID] else {
             XCTFail("\(String(describing: self)) Could not find result for site ID: \(siteID)")
+            return
+        }
+        completion(result)
+    }
+
+    func updateProductIDUsingRestApi(siteURL: String,
+                                     productID: Int64,
+                                     mediaID: Int64,
+                                     completion: @escaping (Result<Networking.WordPressMedia, Error>) -> Void) {
+        invocations.append(.updateProductIDUsingRestApi(siteURL: siteURL))
+        guard let result = updateProductIDUsingRestApiResultsBySiteURL[siteURL] else {
+            XCTFail("\(String(describing: self)) Could not find result for site URL: \(siteURL)")
             return
         }
         completion(result)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8555
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

To make the Products endpoints accessible when authenticating using the application password, this PR makes the Jetpack tunnel requests from `ProductsRemote` available as REST API requests. 

## Testing instructions

- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select "Enter your site address" and enter the address of your self-hosted store.
- Proceed to log in with site credentials.
- Select the Products tab and validate the all the products are loaded. 

**Add product**
- Select the Products tab and tap "+" to add a new Product.
- Tap on the add image icon -> "Add Photos" and upload images. Also, try selecting images from the "WordPress media gallery".
- Add more details to the product, like price, description and etc.
- Save the product and ensure that the product can be saved properly.

**Edit product**
-  Edit the values of an existing product and save. Ensure that it is updated as expected
- Try deleting images from a product.

**Delete product**
- Open a product and tap on `...` button
- Tap on the `Delete` button to delete the product
- Validate that the product is deleted.

**Search product**
- From the Products tab tap on lens button on the top to open search screen
- Search for a product and validate that it works as expected.

Feel free to repeat the steps by turning off `applicationPasswordAuthenticationForSiteCredentialLogin` and logging into the app using WPCOM creds instead of `wp-admin` creds. 

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
