### PR TITLE
REST API: Update WordPress site info fetching task to run on main thread

### DIFF
--- a/Yosemite/Yosemite/Stores/WordPressSiteStore.swift
+++ b/Yosemite/Yosemite/Stores/WordPressSiteStore.swift
@@ -37,17 +37,13 @@ public final class WordPressSiteStore: DeauthenticatedStore {
 
 private extension WordPressSiteStore {
     func fetchSiteInfo(for siteURL: String, completion: @escaping (Result<Site, Error>) -> Void) {
-        Task {
+        Task { @MainActor in
             do {
                 let wpSite = try await remote.fetchSiteInfo(for: siteURL)
                 let site = wpSite.asSite
-                await MainActor.run {
-                    completion(.success(site))
-                }
+                completion(.success(site))
             } catch {
-                await MainActor.run {
-                    completion(.failure(error))
-                }
+                completion(.failure(error))
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8511
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After attempting to fix #8511 with #8518, I could sometimes still be able to reproduce the issue that site address info not being loaded properly. I looked at Xcode console today and found an error:

> ⛔️ Cannot fetch WordPress site info: Error Domain=NSURLErrorDomain Code=-999 "cancelled" UserInfo={...}

It seems that the request was cancelled for some reason, and this issue doesn't happen consistently. It didn't seem to be an issue with `DefaultStoresManager` - but I checked Yosemite and found the part where site info is fetched suspicious. I switched to setting the whole `Task` to run from the main thread instead of using `MainActor.run` for the callback closure, which seems to stop the request from being cancelled.

I found an [article](https://www.hackingwithswift.com/quick-start/concurrency/how-to-use-mainactor-to-run-code-on-the-main-queue) where Paul Hudson shared an interesting point:

> If your function is already running on the main actor, using `await MainActor.run()` will run your code immediately without waiting for the next run loop, but using Task as shown above (with `@MainActor in`) will wait for the next run loop. 

I wonder if this has anything to do with the issue - I can't really find a proper explanation for this. My observation is that using `MainActor.run`, the fetch request fails in every 3 tries, while I can't seem to reproduce the issue with the other approach.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Turn on the feature flag for `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address and enter the address of your self-hosted site.
- Proceed to log in with your site credentials.
- When the login succeed, you should be navigated to the home screen. Notice that the site name on the home screen and the menu tab are both correct.
- Kill and relaunch the app as many time as you want. The site name should still be correct on both those screens.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
