### PR TITLE
Bulk Editing: Update Networking/Yosemite

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -466,6 +466,7 @@
 		A69FE19D2588D70E0059A96B /* order-with-deleted-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */; };
 		AE1950F3296DB2C2004D37D2 /* ProductsBulkUpdateMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1950F2296DB2C2004D37D2 /* ProductsBulkUpdateMapper.swift */; };
 		AE2D6623272A8F6E004A2C3A /* TelemetryRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2D6622272A8F6E004A2C3A /* TelemetryRemoteTests.swift */; };
+		AEA056E4296DBA6E00948D52 /* products-batch-update.json in Resources */ = {isa = PBXBuildFile; fileRef = AEA056E3296DBA6E00948D52 /* products-batch-update.json */; };
 		AED8AEBA272A97B400663FCC /* null-data.json in Resources */ = {isa = PBXBuildFile; fileRef = AE2D6624272A941C004A2C3A /* null-data.json */; };
 		AED8AEBC272A997500663FCC /* IgnoringResponseMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED8AEBB272A997500663FCC /* IgnoringResponseMapperTests.swift */; };
 		AEF94585272974F2001DCCFB /* TelemetryRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF94584272974F2001DCCFB /* TelemetryRemote.swift */; };
@@ -1282,6 +1283,7 @@
 		AE1950F2296DB2C2004D37D2 /* ProductsBulkUpdateMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsBulkUpdateMapper.swift; sourceTree = "<group>"; };
 		AE2D6622272A8F6E004A2C3A /* TelemetryRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryRemoteTests.swift; sourceTree = "<group>"; };
 		AE2D6624272A941C004A2C3A /* null-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "null-data.json"; sourceTree = "<group>"; };
+		AEA056E3296DBA6E00948D52 /* products-batch-update.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "products-batch-update.json"; sourceTree = "<group>"; };
 		AED8AEBB272A997500663FCC /* IgnoringResponseMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoringResponseMapperTests.swift; sourceTree = "<group>"; };
 		AEF94584272974F2001DCCFB /* TelemetryRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryRemote.swift; sourceTree = "<group>"; };
 		AEF9458A27297FF6001DCCFB /* IgnoringResponseMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoringResponseMapper.swift; sourceTree = "<group>"; };
@@ -2285,6 +2287,7 @@
 				025CA2C7238F4FF400B05C81 /* product-shipping-classes-load-all.json */,
 				020220E123966CD900290165 /* product-shipping-classes-load-one.json */,
 				457FC68B2382B2FD00B41B02 /* product-update.json */,
+				AEA056E3296DBA6E00948D52 /* products-batch-update.json */,
 				45152818257A84A60076B03C /* product-attributes-all.json */,
 				4515281E257A89B90076B03C /* product-attribute-create.json */,
 				45152824257A8B740076B03C /* product-attribute-update.json */,
@@ -2973,6 +2976,7 @@
 				02EF1672292F0D1900D90AD6 /* load-plan-success.json in Resources */,
 				DEA6B1C6296C13FB005AA5E9 /* payment-gateway-list-without-data.json in Resources */,
 				2685C0DE263B5A4200D9EE97 /* add-on-groups.json in Resources */,
+				AEA056E4296DBA6E00948D52 /* products-batch-update.json in Resources */,
 				DEC51A9B274E3206009F3DF4 /* plugin-inactive.json in Resources */,
 				CCF48B382628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json in Resources */,
 				31A451D327863A2E00FE81AA /* stripe-account-complete.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -464,6 +464,7 @@
 		93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = 93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */; };
 		93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */; };
 		A69FE19D2588D70E0059A96B /* order-with-deleted-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */; };
+		AE1950F3296DB2C2004D37D2 /* ProductsBulkUpdateMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1950F2296DB2C2004D37D2 /* ProductsBulkUpdateMapper.swift */; };
 		AE2D6623272A8F6E004A2C3A /* TelemetryRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2D6622272A8F6E004A2C3A /* TelemetryRemoteTests.swift */; };
 		AED8AEBA272A97B400663FCC /* null-data.json in Resources */ = {isa = PBXBuildFile; fileRef = AE2D6624272A941C004A2C3A /* null-data.json */; };
 		AED8AEBC272A997500663FCC /* IgnoringResponseMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED8AEBB272A997500663FCC /* IgnoringResponseMapperTests.swift */; };
@@ -1278,6 +1279,7 @@
 		93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsRemoteTests.swift; sourceTree = "<group>"; };
 		9BD9C6C44CAC220B3C3B90B7 /* Pods-Networking.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-with-deleted-refunds.json"; sourceTree = "<group>"; };
+		AE1950F2296DB2C2004D37D2 /* ProductsBulkUpdateMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsBulkUpdateMapper.swift; sourceTree = "<group>"; };
 		AE2D6622272A8F6E004A2C3A /* TelemetryRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryRemoteTests.swift; sourceTree = "<group>"; };
 		AE2D6624272A941C004A2C3A /* null-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "null-data.json"; sourceTree = "<group>"; };
 		AED8AEBB272A997500663FCC /* IgnoringResponseMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoringResponseMapperTests.swift; sourceTree = "<group>"; };
@@ -2463,6 +2465,7 @@
 				26731336255ACA850026F7EF /* PaymentGatewayListMapper.swift */,
 				0313651828AE559D00EEE571 /* PaymentGatewayMapper.swift */,
 				74749B96224134FF005C4CF2 /* ProductMapper.swift */,
+				AE1950F2296DB2C2004D37D2 /* ProductsBulkUpdateMapper.swift */,
 				45152810257A81730076B03C /* ProductAttributeMapper.swift */,
 				4515280C257A7EEC0076B03C /* ProductAttributeListMapper.swift */,
 				26B6453F259BCDFE00EF3FB3 /* ProductAttributeTermMapper.swift */,
@@ -3512,6 +3515,7 @@
 				021EAA5625493B3600AA8CCD /* OrderItemAttribute.swift in Sources */,
 				77CE40602514CB3E003FF69D /* ProductDownloadDragAndDrop.swift in Sources */,
 				2685C0FE263B5D8900D9EE97 /* AddOnGroupRemote.swift in Sources */,
+				AE1950F3296DB2C2004D37D2 /* ProductsBulkUpdateMapper.swift in Sources */,
 				450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */,
 				B963A5CC2853870000EFADA0 /* OrderItemRefundMetaData.swift in Sources */,
 				E18152BE28F85B5B0011A0EC /* InAppPurchasesRemote.swift in Sources */,

--- a/Networking/Networking/Mapper/ProductsBulkUpdateMapper.swift
+++ b/Networking/Networking/Mapper/ProductsBulkUpdateMapper.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Mapper: ProductsBulkUpdateMapper
+///
+struct ProductsBulkUpdateMapper: Mapper {
+    /// Site Identifier associated to the products that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Product Endpoints.
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert a dictionary into Products.
+    ///
+    func map(response: Data) throws -> [Product] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+        return try decoder.decode(ProductsEnvelope.self, from: response).updatedProducts
+    }
+}
+
+/// ProductsEnvelope Disposable Entity
+///
+/// `products/batch` endpoint returns the requested updated products in a `update` key, nested in a `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct ProductsEnvelope: Decodable {
+    let updatedProducts: [Product]
+
+    private enum CodingKeys: String, CodingKey {
+        case update
+        case data
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let nestedContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .data)
+        updatedProducts = try nestedContainer.decode([Product].self, forKey: .update)
+    }
+}

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -41,6 +41,7 @@ public protocol ProductsRemoteProtocol {
                    completion: @escaping (Result<String, Error>) -> Void)
     func updateProduct(product: Product, completion: @escaping (Result<Product, Error>) -> Void)
     func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage], completion: @escaping (Result<Product, Error>) -> Void)
+    func updateProducts(siteID: Int64, products: [Product], completion: @escaping (Result<[Product], Error>) -> Void)
     func loadProductIDs(for siteID: Int64, pageNumber: Int, pageSize: Int, completion: @escaping (Result<[Int64], Error>) -> Void)
     func createTemplateProduct(for siteID: Int64, template: ProductsRemote.TemplateType, completion: @escaping (Result<Int64, Error>) -> Void)
 }
@@ -318,6 +319,26 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             let path = "\(Path.products)/\(productID)"
             let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
             let mapper = ProductMapper(siteID: siteID)
+
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
+    /// Updates provided `Products`.
+    ///
+    /// - Parameters:
+    ///     - siteID: site which hosts the Products. 
+    ///     - products: the Products to update remotely.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func updateProducts(siteID: Int64, products: [Product], completion: @escaping (Result<[Product], Error>) -> Void) {
+        do {
+            let parameters = try products.map { try $0.toDictionary() }
+            let path = "\(Path.products)/batch"
+            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: ["update": parameters])
+            let mapper = ProductsBulkUpdateMapper(siteID: siteID)
 
             enqueue(request, mapper: mapper, completion: completion)
         } catch {

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -594,16 +594,14 @@ final class ProductsRemoteTests: XCTestCase {
 
         // When
         let sampleProducts = [sampleProduct()]
-        var updatedProducts: [Product]?
-        waitForExpectation { expectation in
+        let updatedProducts = waitFor { promise in
             remote.updateProducts(siteID: self.sampleSiteID, products: sampleProducts) { result in
                 // Then
                 guard case let .success(products) = result else {
                     XCTFail("Unexpected result: \(result)")
                     return
                 }
-                updatedProducts = products
-                expectation.fulfill()
+                promise(products)
             }
         }
 

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -583,6 +583,34 @@ final class ProductsRemoteTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
     }
 
+    // MARK: - Products batch update
+
+    /// Verifies that updateProducts properly parses the `products-batch-update` sample response.
+    ///
+    func test_bulk_update_products_properly_returns_parsed_products() {
+        // Given
+        let remote = ProductsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "products/batch", filename: "products-batch-update")
+
+        // When
+        let sampleProducts = [sampleProduct()]
+        var updatedProducts: [Product]?
+        waitForExpectation { expectation in
+            remote.updateProducts(siteID: self.sampleSiteID, products: sampleProducts) { result in
+                // Then
+                guard case let .success(products) = result else {
+                    XCTFail("Unexpected result: \(result)")
+                    return
+                }
+                updatedProducts = products
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        assertEqual(updatedProducts, sampleProducts)
+    }
+
     // MARK: - Product IDs
 
     /// Verifies that loadProductIDs properly parses the `products-ids-only` sample response.

--- a/Networking/NetworkingTests/Responses/products-batch-update.json
+++ b/Networking/NetworkingTests/Responses/products-batch-update.json
@@ -1,0 +1,231 @@
+{
+    "data": {
+        "update": [
+            {
+                        "id": 282,
+                        "name": "Book the Green Room",
+                        "slug": "book-the-green-room",
+                        "permalink": "https://example.com/product/book-the-green-room/",
+                        "date_created": "2019-02-19T17:33:31",
+                        "date_created_gmt": "2019-02-19T17:33:31",
+                        "date_modified": "2019-02-19T17:48:01",
+                        "date_modified_gmt": "2019-02-19T17:48:01",
+                        "type": "booking",
+                        "status": "publish",
+                        "featured": false,
+                        "catalog_visibility": "visible",
+                        "description": "<p>This is the party room!</p>\n",
+                        "short_description": "[contact-form]\n<p>The green room&#8217;s max capacity is 30 people. Reserving the date / time of your event is free. We can also accommodate large groups, with seating for 85 board game players at a time. If you have a large group, let us know and we&#8217;ll send you our large group rate.</p>\n<p>GROUP RATES</p>\n<p>Reserve your event for up to 30 guests for $100.</p>\n",
+                        "sku": "",
+                        "price": "0",
+                        "regular_price": "",
+                        "sale_price": "",
+                        "date_on_sale_from": null,
+                        "date_on_sale_from_gmt": "2019-10-15T21:30:00",
+                        "date_on_sale_to": null,
+                        "date_on_sale_to_gmt": "2019-10-27T21:29:59",
+                        "price_html": "Free",
+                        "on_sale": false,
+                        "purchasable": true,
+                        "total_sales": 0,
+                        "virtual": true,
+                        "downloadable": false,
+                        "downloads": [],
+                        "download_limit": -1,
+                        "download_expiry": -1,
+                        "external_url": "http://somewhere.com",
+                        "button_text": "",
+                        "tax_status": "taxable",
+                        "tax_class": "",
+                        "manage_stock": false,
+                        "stock_quantity": null,
+                        "stock_status": "instock",
+                        "backorders": "no",
+                        "backorders_allowed": false,
+                        "backordered": false,
+                        "sold_individually": true,
+                        "weight": "213",
+                        "dimensions": {
+                            "length": "12",
+                            "width": "33",
+                            "height": "54"
+                        },
+                        "shipping_required": false,
+                        "shipping_taxable": false,
+                        "shipping_class": "",
+                        "shipping_class_id": 0,
+                        "reviews_allowed": true,
+                        "average_rating": "4.30",
+                        "rating_count": 23,
+                        "related_ids": [
+                            31,
+                            22,
+                            369,
+                            414,
+                            56
+                        ],
+                        "upsell_ids":  [
+                            99,
+                            1234566
+                        ],
+                        "cross_sell_ids":  [
+                            1234,
+                            234234,
+                            3
+                        ],
+                        "parent_id": 0,
+                        "purchase_note": "Thank you!",
+                        "categories": [
+                            {
+                                "id": 36,
+                                "name": "Events",
+                                "slug": "events"
+                            }
+                        ],
+                        "tags": [
+                            {
+                                "id": 37,
+                                "name": "room",
+                                "slug": "room"
+                            },
+                            {
+                                "id": 38,
+                                "name": "party room",
+                                "slug": "party-room"
+                            },
+                            {
+                                "id": 39,
+                                "name": "30",
+                                "slug": "30"
+                            },
+                            {
+                                "id": 40,
+                                "name": "20+",
+                                "slug": "20"
+                            },
+                            {
+                                "id": 41,
+                                "name": "meeting room",
+                                "slug": "meeting-room"
+                            },
+                            {
+                                "id": 42,
+                                "name": "meetings",
+                                "slug": "meetings"
+                            },
+                            {
+                                "id": 43,
+                                "name": "parties",
+                                "slug": "parties"
+                            },
+                            {
+                                "id": 44,
+                                "name": "graduation",
+                                "slug": "graduation"
+                            },
+                            {
+                                "id": 45,
+                                "name": "birthday party",
+                                "slug": "birthday-party"
+                            }
+                        ],
+                        "images": [
+                            {
+                                "id": 19,
+                                "date_created": "2018-01-26T21:49:45",
+                                "date_created_gmt": "2018-01-26T21:49:45",
+                                "date_modified": "2018-01-26T21:50:11",
+                                "date_modified_gmt": "2018-01-26T21:50:11",
+                                "src": "https://somewebsite.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/vneck-tee.jpg.png",
+                                "name": "Vneck Tshirt",
+                                "alt": ""
+                            }
+                        ],
+                        "attributes": [
+                            {
+                                "id": 0,
+                                "name": "Color",
+                                "position": 1,
+                                "visible": true,
+                                "variation": true,
+                                "options": [
+                                    "Purple",
+                                    "Yellow",
+                                    "Hot Pink",
+                                    "Lime Green",
+                                    "Teal"
+                                ]
+                            },
+                            {
+                                "id": 0,
+                                "name": "Size",
+                                "position": 0,
+                                "visible": true,
+                                "variation": true,
+                                "options": [
+                                    "Small",
+                                    "Medium",
+                                    "Large"
+                                ]
+                            }
+                        ],
+                        "default_attributes": [
+                            {
+                                "id": 0,
+                                "name": "Color",
+                                "option": "Purple"
+                            },
+                            {
+                                "id": 0,
+                                "name": "Size",
+                                "option": "Medium"
+                            }
+                        ],
+                        "variations": [
+                            192,
+                            194,
+                            193
+                        ],
+                        "grouped_products": [],
+                        "menu_order": 0,
+                        "meta_data": [
+                            {
+                                "id": 6779,
+                                "key": "_wpas_done_all",
+                                "value": "1"
+                            },
+                            {
+                                "id": 6780,
+                                "key": "_g_feedback_shortcode_5368fb4ef32094b7055b8732bb77a337bdd9331d",
+                                "value": "[contact-field label=\"Name\" type=\"name\" required=\"1\"][contact-field label=\"Email\" type=\"email\" required=\"1\"][contact-field label=\"Phone Number\" type=\"text\" required=\"1\"][contact-field label=\"Group or Organization Name (if any)\" type=\"text\"][contact-field label=\"Special Requests / Event Notes\" type=\"textarea\"]"
+                            },
+                            {
+                                "id": 6781,
+                                "key": "_g_feedback_shortcode_atts_5368fb4ef32094b7055b8732bb77a337bdd9331d",
+                                "value": {
+                                    "to": "thuy.copeland@automattic.com",
+                                    "subject": "Booking Event",
+                                    "show_subject": "no",
+                                    "widget": 0,
+                                    "id": 282,
+                                    "submit_button_text": "Submit"
+                                }
+                            },
+                        ],
+                        "jetpack_publicize_connections": [],
+                        "_links": {
+                            "self": [
+                                {
+                                    "href": "https://example.com/wp-json/wc/v3/products/282"
+                                }
+                            ],
+                            "collection": [
+                                {
+                                    "href": "https://example.com/wp-json/wc/v3/products"
+                                }
+                            ]
+                        }
+                }
+        ]
+    }
+}

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -75,6 +75,10 @@ public enum ProductAction: Action {
     ///
     case updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage], onCompletion: (Result<Product, ProductUpdateError>) -> Void)
 
+    /// Updates specified Products.
+    ///
+    case updateProducts(siteID: Int64, products: [Product], onCompletion: (Result<[Product], ProductUpdateError>) -> Void)
+
     /// Checks whether a Product SKU is valid against other Products in the store.
     ///
     case validateProductSKU(_ sku: String?, siteID: Int64, onCompletion: (Bool) -> Void)

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -376,7 +376,7 @@ private extension ProductStore {
             case .success(let returnedProducts):
                 self?.upsertStoredProductsInBackground(readOnlyProducts: returnedProducts, siteID: siteID) { [weak self] in
                     guard let storageProducts = self?.storageManager.viewStorage.loadProducts(siteID: siteID,
-                                                                                             productsIDs: returnedProducts.map { $0.productID }) else {
+                                                                                              productsIDs: returnedProducts.map { $0.productID }) else {
                         onCompletion(.failure(.notFoundInStorage))
                         return
                     }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -96,6 +96,8 @@ public class ProductStore: Store {
             updateProduct(product: product, onCompletion: onCompletion)
         case .updateProductImages(let siteID, let productID, let images, let onCompletion):
             updateProductImages(siteID: siteID, productID: productID, images: images, onCompletion: onCompletion)
+        case .updateProducts(let siteID, let products, let onCompletion):
+            updateProducts(siteID: siteID, products: products, onCompletion: onCompletion)
         case .validateProductSKU(let sku, let siteID, let onCompletion):
             validateProductSKU(sku, siteID: siteID, onCompletion: onCompletion)
         case let .replaceProductLocally(product, onCompletion):
@@ -361,6 +363,24 @@ private extension ProductStore {
                         return onCompletion(.failure(.notFoundInStorage))
                     }
                     onCompletion(.success(storageProduct.toReadOnly()))
+                }
+            }
+        }
+    }
+
+    func updateProducts(siteID: Int64, products: [Product], onCompletion: @escaping (Result<[Product], ProductUpdateError>) -> Void) {
+        remote.updateProducts(siteID: siteID, products: products) { [weak self] result in
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(ProductUpdateError(error: error)))
+            case .success(let returnedProducts):
+                self?.upsertStoredProductsInBackground(readOnlyProducts: returnedProducts, siteID: siteID) { [weak self] in
+                    guard let storageProducts = self?.storageManager.viewStorage.loadProducts(siteID: siteID,
+                                                                                             productsIDs: returnedProducts.map { $0.productID }) else {
+                        onCompletion(.failure(.notFoundInStorage))
+                        return
+                    }
+                    onCompletion(.success(storageProducts.map { $0.toReadOnly() }))
                 }
             }
         }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -196,6 +196,10 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         }
     }
 
+    func updateProducts(siteID: Int64, products: [Product], completion: @escaping (Result<[Product], Error>) -> Void) {
+        // no-op
+    }
+
     func loadProductIDs(for siteID: Int64, pageNumber: Int, pageSize: Int, completion: @escaping (Result<[Int64], Error>) -> Void) {
         // no-op
     }

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1373,17 +1373,15 @@ final class ProductStoreTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         // When
-        var savedResult: Result<[Yosemite.Product], ProductUpdateError>?
-        waitForExpectation { expectation in
-            let action = ProductAction.updateProducts(siteID: sampleSiteID, products: [product]) { result in
-                savedResult = result
-                expectation.fulfill()
+        let result = waitFor { promise in
+            let action = ProductAction.updateProducts(siteID: self.sampleSiteID, products: [product]) { result in
+                promise(result)
             }
             store.onAction(action)
         }
 
         // Then
-        let updatedProducts = try? savedResult?.get()
+        let updatedProducts = try result.get()
         assertEqual(updatedProducts, [product])
     }
 

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1361,6 +1361,32 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
     }
 
+    // MARK: ProductAction.updateProducts
+
+    /// Verifies that `ProductAction.updateProducts` returns the expected `Products`.
+    ///
+    func test_updateProducts_is_correctly_updating_products() throws {
+        // Given
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "products/batch", filename: "products-batch-update")
+        let product = sampleProduct(addOns: [])
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+
+        // When
+        var savedResult: Result<[Yosemite.Product], ProductUpdateError>?
+        waitForExpectation { expectation in
+            let action = ProductAction.updateProducts(siteID: sampleSiteID, products: [product]) { result in
+                savedResult = result
+                expectation.fulfill()
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let updatedProducts = try? savedResult?.get()
+        assertEqual(updatedProducts, [product])
+    }
+
     // MARK: - ProductAction.retrieveProducts
 
     /// Verifies that ProductAction.retrieveProducts effectively persists any retrieved products.


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8521.

## Description

This PR adds Networking and Yosemite action for products batch update endpoint.
Data manipulation (changing status/price) will happen with `Product` objects on viewmodel level.

## Testing

No functionality is enabled in app, check code and CI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
