### PR TITLE
Variations: Error handling

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -64,6 +64,7 @@ final class ProductVariationsViewController: UIViewController, GhostableViewCont
     ///
     private let syncingCoordinator = SyncingCoordinator()
 
+
     private lazy var stateCoordinator: PaginatedListViewControllerStateCoordinator = {
         let stateCoordinator = PaginatedListViewControllerStateCoordinator(onLeavingState: { [weak self] state in
             self?.didLeave(state: state)
@@ -668,10 +669,18 @@ private extension ProductVariationsViewController {
     }
 
     /// Dismiss any `InProgressViewController` being presented.
+    /// By default retires the dismissal one time to overcome UIKit presentation delays.
     ///
-    private func dismissBlockingIndicator() {
+    private func dismissBlockingIndicator(retry: Bool = true) {
         if let inProgressViewController = self.presentedViewController as? InProgressViewController {
             inProgressViewController.dismiss(animated: true)
+        } else {
+            // When this method is invoked right after `InProgressViewController` is presented, chances are that it won't exists in the view controller
+            // hierarchy yet.
+            // Here we are retrying it with a small delay to give UIKit APIs time to finish its presentation.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                self.dismissBlockingIndicator(retry: false)
+            }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -70,9 +70,9 @@ final class ProductVariationsViewModel {
                     }
                 }))
 
-            case .failure:
-                // TODO: Log and inform error
-                break
+            case .failure(let error):
+                onStateChanged(.error(.unableToFetchVariations))
+                DDLogError("⛔️ Failed to create variations: \(error)")
             }
         }
     }
@@ -104,9 +104,9 @@ final class ProductVariationsViewModel {
             switch result {
             case .success:
                 onCompletion(.success(()))
-            case .failure:
-                // TODO: Log Error
-                break
+            case .failure(let error):
+                onCompletion(.failure(.unableToCreateVariations))
+                DDLogError("⛔️ Failed to create variations: \(error)")
             }
         })
         stores.dispatch(action)
@@ -161,17 +161,27 @@ extension ProductVariationsViewModel {
     /// Type to represent known generation errors
     ///
     enum GenerationError: LocalizedError, Equatable {
+        case unableToFetchVariations
+        case unableToCreateVariations
         case tooManyVariations(variationCount: Int)
 
         var errorTitle: String {
             switch self {
+            case .unableToFetchVariations:
+                return NSLocalizedString("Unable to fetch variations", comment: "Error title for when we can't fetch existing variations.")
+            case .unableToCreateVariations:
+                return NSLocalizedString("Unable to create variations", comment: "Error title for when we can't create variations remotely.")
             case .tooManyVariations:
-                return NSLocalizedString("Generation limit exceeded", comment: "Error title for for when there are too many variations to generate.")
+                return NSLocalizedString("Generation limit exceeded", comment: "Error title for when there are too many variations to generate.")
             }
         }
 
         var errorDescription: String? {
             switch self {
+            case .unableToFetchVariations:
+                return NSLocalizedString("Something went wrong, please try again later.", comment: "Error message for when we can't fetch existing variations.")
+            case .unableToCreateVariations:
+                return NSLocalizedString("Something went wrong, please try again later.", comment: "Error message for when we can't create variations remotely")
             case .tooManyVariations(let variationCount):
                 let format = NSLocalizedString(
                     "Currently creation is supported for 100 variations maximum. Generating variations for this product would create %d variations.",


### PR DESCRIPTION
Closes: #8536

# Why

This PR adds error handling for the cases where there is a problem fetching variations or there is a problem creating variations remotely.

# How

- Define and send the corresponding error states.
- One workaround to properly dismiss the blocking loading indicator right after its presentation has been issued.

Fetching Error | Creating Error
--- | ---
![fetch](https://user-images.githubusercontent.com/562080/211686469-a0251c9d-0971-4ee2-9acb-9b87bedf2c3b.png) | ![create](https://user-images.githubusercontent.com/562080/211686471-02d26b5a-f2f1-4c20-80dc-0ec05dd01bfb.png)


# Testing Step

- Go to a variable product that is missing variations.
- Turn off wifi and start the generate variations process.
- See that the error notice is presented.

- Turn on wifi and start the generate variations process.
- Before confirming the variations to generate, turn off wifi and then tap "OK" on the alert.
- See that the error notice is presented.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
