### PR TITLE
Variations: Update product variation count after generating variations

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -697,6 +697,13 @@ private extension ProductVariationsViewController {
         let notice = Notice(title: Localization.variationsCreatedTitle)
         noticePresenter.enqueue(notice: notice)
     }
+
+    /// Updates the current product with the up-to-date list of variations IDs.
+    /// This is needed in order to reflect variations count changes back to this and to other screens.
+    ///
+    private func updateProductVariationCount() {
+        self.product = product.copy(variations: resultsController.fetchedObjects.map { $0.productVariationID })
+    }
 }
 
 // MARK: - Placeholders
@@ -786,6 +793,7 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
             case .finished(let variationsCreated):
                 self?.dismissBlockingIndicator()
                 if variationsCreated {
+                    self?.updateProductVariationCount()
                     self?.presentVariationsCreatedNotice()
                 } else {
                     self?.presentNoGenerationNotice()


### PR DESCRIPTION
Closes: #8551 

# Why

This PR takes care of updating the variation count of the main product after generating variations. This is needed to properly reflect changes on the main product screen and on the product list.

# Demo

https://user-images.githubusercontent.com/562080/211855337-8027bb56-fc84-4490-a3aa-390aba1ac943.mov

# Testing Steps

- Start the generate all variation process
- After generating the variations go back to the main product screen
- See that the variation count matches the previous variation count + the new generated variations count.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
