### PR TITLE
Variations: Create all variations from no variations empty state screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateAllVariationsPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateAllVariationsPresenter.swift
@@ -1,8 +1,0 @@
-import Foundation
-
-/// Type to abstract view controller presentation tasks while all variations are being generated
-///
-final class GenerateVariationsPresenter {
-
-    
-}

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateAllVariationsPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateAllVariationsPresenter.swift
@@ -1,0 +1,153 @@
+import Foundation
+import UIKit
+
+/// Type to encapsulate view controllers and notices shown while generating all variations.
+///
+final class GenerateAllVariationsPresenter {
+
+    /// Base view controller where the loading indicators and notices will be presented.
+    ///
+    private let baseViewController: UIViewController
+
+    /// Default notices presenter.
+    ///
+    private let noticePresenter: NoticePresenter
+
+    init(baseViewController: UIViewController, noticePresenter: NoticePresenter = ServiceLocator.noticePresenter) {
+        self.baseViewController = baseViewController
+        self.noticePresenter = noticePresenter
+    }
+
+    /// Respond to necessary presentation changes.
+    ///
+    func handleStateChanges(state: ProductVariationsViewModel.GenerationState) {
+        switch state {
+        case .fetching:
+            presentFetchingIndicator()
+        case .confirmation(let variationCount, let onCompletion):
+            presentGenerationConfirmation(numberOfVariations: variationCount, onCompletion: onCompletion)
+        case .creating:
+            presentCreatingIndicator()
+        case .canceled:
+            dismissBlockingIndicator()
+        case .finished(let variationsCreated):
+            dismissBlockingIndicator()
+            if variationsCreated {
+                presentVariationsCreatedNotice()
+            } else {
+                presentNoGenerationNotice()
+            }
+            break
+        case .error(let error):
+            dismissBlockingIndicator()
+            presentGenerationError(error)
+        }
+    }
+}
+
+// MARK: Helper Methods
+//
+private extension GenerateAllVariationsPresenter {
+    /// Informs the merchant about errors that happen during the variation generation
+    ///
+    private func presentGenerationError(_ error: ProductVariationsViewModel.GenerationError) {
+        let notice = Notice(title: error.errorTitle, message: error.errorDescription)
+        noticePresenter.enqueue(notice: notice)
+    }
+
+    /// Asks the merchant for confirmation before generating all variations.
+    ///
+    private func presentGenerationConfirmation(numberOfVariations: Int, onCompletion: @escaping (_ confirmed: Bool) -> Void) {
+        let controller = UIAlertController(title: Localization.confirmationTitle,
+                                           message: Localization.confirmationDescription(variationCount: numberOfVariations),
+                                           preferredStyle: .alert)
+        controller.addDefaultActionWithTitle(Localization.ok) { _ in
+            onCompletion(true)
+        }
+        controller.addCancelActionWithTitle(Localization.cancel) { _ in
+            onCompletion(false)
+        }
+
+        // There should be an `inProgressViewController` being presented. Fallback to `self` in case there isn't one.
+        let baseViewController = baseViewController.presentedViewController ?? baseViewController
+        baseViewController.present(controller, animated: true)
+    }
+
+    /// Presents a blocking view controller while variations are being fetched.
+    ///
+    private func presentFetchingIndicator() {
+        let inProgressViewController = InProgressViewController(viewProperties: .init(title: Localization.fetchingVariations, message: ""))
+        baseViewController.present(inProgressViewController, animated: true)
+    }
+
+    /// Presents a blocking view controller while variations are being created.
+    ///
+    private func presentCreatingIndicator() {
+        let newViewProperties = InProgressViewProperties(title: Localization.creatingVariations, message: "")
+
+        // There should be already a presented `InProgressViewController`. But we present one in case there isn;t.
+        guard let inProgressViewController = baseViewController.presentedViewController as? InProgressViewController else {
+            let inProgressViewController = InProgressViewController(viewProperties: newViewProperties)
+            return baseViewController.present(inProgressViewController, animated: true)
+        }
+
+        // Update the already presented view controller with the "Creating..." copy.
+        inProgressViewController.updateViewProperties(newViewProperties)
+    }
+
+    /// Dismiss any `InProgressViewController` being presented.
+    /// By default retires the dismissal one time to overcome UIKit presentation delays.
+    ///
+    private func dismissBlockingIndicator(retry: Bool = true) {
+        if let inProgressViewController = baseViewController.presentedViewController as? InProgressViewController {
+            inProgressViewController.dismiss(animated: true)
+        } else {
+            // When this method is invoked right after `InProgressViewController` is presented, chances are that it won't exists in the view controller
+            // hierarchy yet.
+            // Here we are retrying it with a small delay to give UIKit APIs time to finish its presentation.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                self.dismissBlockingIndicator(retry: false)
+            }
+        }
+    }
+
+    /// Informs the merchant that no variations were created.
+    ///
+    private func presentNoGenerationNotice() {
+        let notice = Notice(title: Localization.noVariationsCreatedTitle, message: Localization.noVariationsCreatedDescription)
+        noticePresenter.enqueue(notice: notice)
+    }
+
+    /// Informs the merchant that some variations were created.
+    ///
+    private func presentVariationsCreatedNotice() {
+        let notice = Notice(title: Localization.variationsCreatedTitle)
+        noticePresenter.enqueue(notice: notice)
+    }
+}
+
+// MARK: Localization
+//
+private extension GenerateAllVariationsPresenter {
+    enum Localization {
+        static let confirmationTitle = NSLocalizedString("Generate all variations?",
+                                                         comment: "Alert title to allow the user confirm if they want to generate all variations")
+        static func confirmationDescription(variationCount: Int) -> String {
+            let format = NSLocalizedString("This will create a variation for each and every possible combination of variation attributes (%d variations).",
+                                           comment: "Alert description to allow the user confirm if they want to generate all variations")
+            return String.localizedStringWithFormat(format, variationCount)
+        }
+        static let ok = NSLocalizedString("OK", comment: "Button text to confirm that we want to generate all variations")
+        static let cancel = NSLocalizedString("Cancel", comment: "Button text to confirm that we don't want to generate all variations")
+        static let fetchingVariations = NSLocalizedString("Fetching Variations...",
+                                                          comment: "Blocking indicator text when fetching existing variations prior generating them.")
+        static let creatingVariations = NSLocalizedString("Creating Variations...",
+                                                          comment: "Blocking indicator text when creating multiple variations remotely.")
+        static let noVariationsCreatedTitle = NSLocalizedString("No variations to generate",
+                                                                comment: "Title for the notice when there were no variations to generate")
+        static let noVariationsCreatedDescription = NSLocalizedString("All variations are already generated.",
+                                                                      comment: "Message for the notice when there were no variations to generate")
+        static let variationsCreatedTitle = NSLocalizedString("Variations created successfully",
+                                                              comment: "Title for the notice when after variations were created")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateAllVariationsPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateAllVariationsPresenter.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Type to abstract view controller presentation tasks while all variations are being generated
+///
+final class GenerateVariationsPresenter {
+
+    
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsOptionPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsOptionPresenter.swift
@@ -28,9 +28,8 @@ final class GenerateVariationsOptionsPresenter {
         }
 
         let viewProperties = BottomSheetListSelectorViewProperties(title: Localization.addVariationAction)
-        let command = GenerateVariationsSelectorCommand(selected: nil) { [weak self] option in
-            guard let self else { return }
-            self.baseViewController.dismiss(animated: true)
+        let command = GenerateVariationsSelectorCommand(selected: nil) { [baseViewController] option in
+            baseViewController.dismiss(animated: true)
             switch option {
             case .single:
                 onCompletion(.single)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsOptionPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsOptionPresenter.swift
@@ -47,6 +47,6 @@ final class GenerateVariationsOptionsPresenter {
 private extension GenerateVariationsOptionsPresenter {
     enum Localization {
         static let addVariationAction = NSLocalizedString("Add Variation",
-                                                          comment: "Title on empty state button when the product has attributes but no variations")
+                                                          comment: "Title on the bottom sheet to choose what variation process to start")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsOptionPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsOptionPresenter.swift
@@ -1,0 +1,53 @@
+import Foundation
+import UIKit
+import Yosemite
+
+/// Type to encapsulate the options presented when generating variations.
+///
+final class GenerateVariationsOptionsPresenter {
+    /// Options available when generating variations
+    ///
+    enum Option {
+        case single
+        case all
+    }
+
+    /// Base view controller where the loading indicators and notices will be presented.
+    ///
+    private let baseViewController: UIViewController
+
+    init(baseViewController: UIViewController) {
+        self.baseViewController = baseViewController
+    }
+
+    /// Displays a bottom sheet allowing the merchant to choose whether to generate one variation or to generate all variations.
+    ///
+    func presentGenerationOptions(sourceView: UIView, onCompletion: @escaping (_ selectedOption: Option) -> Void) {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.generateAllVariations) else {
+            return onCompletion(.single)
+        }
+
+        let viewProperties = BottomSheetListSelectorViewProperties(title: Localization.addVariationAction)
+        let command = GenerateVariationsSelectorCommand(selected: nil) { [weak self] option in
+            guard let self else { return }
+            self.baseViewController.dismiss(animated: true)
+            switch option {
+            case .single:
+                onCompletion(.single)
+            case .all:
+                onCompletion(.all)
+            }
+        }
+        let bottomSheetPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
+        bottomSheetPresenter.show(from: baseViewController, sourceView: sourceView)
+    }
+}
+
+// MARK: Localization
+//
+private extension GenerateVariationsOptionsPresenter {
+    enum Localization {
+        static let addVariationAction = NSLocalizedString("Add Variation",
+                                                          comment: "Title on empty state button when the product has attributes but no variations")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -445,7 +445,11 @@ extension ProductVariationsViewController: UITableViewDelegate {
 private extension ProductVariationsViewController {
     func createVariationFromEmptyState() {
         if product.attributesForVariations.isNotEmpty {
-            createVariation()
+            if featureFlagService.isFeatureFlagEnabled(.generateAllVariations) {
+                presentGenerateVariationOptions()
+            } else {
+                createVariation()
+            }
         } else {
             navigateToAddAttributeViewController()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -445,11 +445,7 @@ extension ProductVariationsViewController: UITableViewDelegate {
 private extension ProductVariationsViewController {
     func createVariationFromEmptyState() {
         if product.attributesForVariations.isNotEmpty {
-            if featureFlagService.isFeatureFlagEnabled(.generateAllVariations) {
-                presentGenerateVariationOptions()
-            } else {
-                createVariation()
-            }
+            presentGenerateVariationOptions()
         } else {
             navigateToAddAttributeViewController()
         }
@@ -609,20 +605,15 @@ private extension ProductVariationsViewController {
     /// Displays a bottom sheet allowing the merchant to choose whether to generate one variation or to generate all variations.
     ///
     private func presentGenerateVariationOptions() {
-        let viewProperties = BottomSheetListSelectorViewProperties(title: Localization.addVariationAction)
-        let command = GenerateVariationsSelectorCommand(selected: nil) { [weak self] option in
-            guard let self else { return }
-            self.dismiss(animated: true)
-            switch option {
+        let presenter = GenerateVariationsOptionsPresenter(baseViewController: self)
+        presenter.presentGenerationOptions(sourceView: topStackView) { [weak self] selectedOption in
+            switch selectedOption {
             case .single:
-                self.createVariation()
+                self?.createVariation()
             case .all:
-                self.generateAllVariations()
+                self?.generateAllVariations()
             }
-
         }
-        let bottomSheetPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
-        bottomSheetPresenter.show(from: self, sourceView: topStackView)
     }
 
     /// Informs the merchant about errors that happen during the variation generation

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -565,12 +565,7 @@ private extension ProductVariationsViewController {
 
     @objc func addButtonTapped() {
         analytics.track(event: WooAnalyticsEvent.Variations.addMoreVariationsButtonTapped(productID: product.productID))
-
-        if featureFlagService.isFeatureFlagEnabled(.generateAllVariations) {
-            presentGenerateVariationOptions()
-        } else {
-            createVariation()
-        }
+        presentGenerateVariationOptions()
     }
 
     /// More Options Action Sheet
@@ -614,83 +609,6 @@ private extension ProductVariationsViewController {
                 self?.generateAllVariations()
             }
         }
-    }
-
-    /// Informs the merchant about errors that happen during the variation generation
-    ///
-    private func presentGenerationError(_ error: ProductVariationsViewModel.GenerationError) {
-        let notice = Notice(title: error.errorTitle, message: error.errorDescription)
-        noticePresenter.enqueue(notice: notice)
-    }
-
-    /// Asks the merchant for confirmation before generating all variations.
-    ///
-    private func presentGenerationConfirmation(numberOfVariations: Int, onCompletion: @escaping (_ confirmed: Bool) -> Void) {
-        let controller = UIAlertController(title: Localization.confirmationTitle,
-                                           message: Localization.confirmationDescription(variationCount: numberOfVariations),
-                                           preferredStyle: .alert)
-        controller.addDefaultActionWithTitle(Localization.ok) { _ in
-            onCompletion(true)
-        }
-        controller.addCancelActionWithTitle(Localization.cancel) { _ in
-            onCompletion(false)
-        }
-
-        // There should be an `inProgressViewController` being presented. Fallback to `self` in case there isn't one.
-        let baseViewController = presentedViewController ?? self
-        baseViewController.present(controller, animated: true)
-    }
-
-    /// Presents a blocking view controller while variations are being fetched.
-    ///
-    private func presentFetchingIndicator() {
-        let inProgressViewController = InProgressViewController(viewProperties: .init(title: Localization.fetchingVariations, message: ""))
-        present(inProgressViewController, animated: true)
-    }
-
-    /// Presents a blocking view controller while variations are being created.
-    ///
-    private func presentCreatingIndicator() {
-        let newViewProperties = InProgressViewProperties(title: Localization.creatingVariations, message: "")
-
-        // There should be already a presented `InProgressViewController`. But we present one in case there isn;t.
-        guard let inProgressViewController = self.presentedViewController as? InProgressViewController else {
-            let inProgressViewController = InProgressViewController(viewProperties: newViewProperties)
-            return present(inProgressViewController, animated: true)
-        }
-
-        // Update the already presented view controller with the "Creating..." copy.
-        inProgressViewController.updateViewProperties(newViewProperties)
-    }
-
-    /// Dismiss any `InProgressViewController` being presented.
-    /// By default retires the dismissal one time to overcome UIKit presentation delays.
-    ///
-    private func dismissBlockingIndicator(retry: Bool = true) {
-        if let inProgressViewController = self.presentedViewController as? InProgressViewController {
-            inProgressViewController.dismiss(animated: true)
-        } else {
-            // When this method is invoked right after `InProgressViewController` is presented, chances are that it won't exists in the view controller
-            // hierarchy yet.
-            // Here we are retrying it with a small delay to give UIKit APIs time to finish its presentation.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                self.dismissBlockingIndicator(retry: false)
-            }
-        }
-    }
-
-    /// Informs the merchant that no variations were created.
-    ///
-    private func presentNoGenerationNotice() {
-        let notice = Notice(title: Localization.noVariationsCreatedTitle, message: Localization.noVariationsCreatedDescription)
-        noticePresenter.enqueue(notice: notice)
-    }
-
-    /// Informs the merchant that some variations were created.
-    ///
-    private func presentVariationsCreatedNotice() {
-        let notice = Notice(title: Localization.variationsCreatedTitle)
-        noticePresenter.enqueue(notice: notice)
     }
 
     /// Updates the current product with the up-to-date list of variations IDs.
@@ -775,28 +693,18 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
     /// Generates all possible variations for the product attributes.
     ///
     private func generateAllVariations() {
-        viewModel.generateAllVariations(for: product) { [weak self] currentState in
+        let presenter = GenerateAllVariationsPresenter(baseViewController: self)
+        viewModel.generateAllVariations(for: product) { [weak self, presenter] currentState in
+            // Perform Presentation Actions
+            presenter.handleStateChanges(state: currentState)
+
+            // Perform other side effects
             switch currentState {
-            case .fetching:
-                self?.presentFetchingIndicator()
-            case .confirmation(let variationCount, let onCompletion):
-                self?.presentGenerationConfirmation(numberOfVariations: variationCount, onCompletion: onCompletion)
-            case .creating:
-                self?.presentCreatingIndicator()
-            case .canceled:
-                self?.dismissBlockingIndicator()
             case .finished(let variationsCreated):
-                self?.dismissBlockingIndicator()
                 if variationsCreated {
                     self?.updateProductVariationCount()
-                    self?.presentVariationsCreatedNotice()
-                } else {
-                    self?.presentNoGenerationNotice()
                 }
-                break
-            case .error(let error):
-                self?.dismissBlockingIndicator()
-                self?.presentGenerationError(error)
+            default: break
             }
         }
     }
@@ -905,27 +813,6 @@ private extension ProductVariationsViewController {
         static let generateVariationError = NSLocalizedString("The variation couldn't be generated.",
                                                               comment: "Error title when failing to generate a variation.")
         static let variationCreated = NSLocalizedString("Variation created", comment: "Text for the notice after creating the first variation.")
-
-        static let confirmationTitle = NSLocalizedString("Generate all variations?",
-                                                         comment: "Alert title to allow the user confirm if they want to generate all variations")
-        static func confirmationDescription(variationCount: Int) -> String {
-            let format = NSLocalizedString("This will create a variation for each and every possible combination of variation attributes (%d variations).",
-                                           comment: "Alert description to allow the user confirm if they want to generate all variations")
-            return String.localizedStringWithFormat(format, variationCount)
-        }
-        static let ok = NSLocalizedString("OK", comment: "Button text to confirm that we want to generate all variations")
-        static let cancel = NSLocalizedString("Cancel", comment: "Button text to confirm that we don't want to generate all variations")
-        static let fetchingVariations = NSLocalizedString("Fetching Variations...",
-                                                          comment: "Blocking indicator text when fetching existing variations prior generating them.")
-        static let creatingVariations = NSLocalizedString("Creating Variations...",
-                                                          comment: "Blocking indicator text when creating multiple variations remotely.")
-        static let noVariationsCreatedTitle = NSLocalizedString("No variations to generate",
-                                                                comment: "Title for the notice when there were no variations to generate")
-        static let noVariationsCreatedDescription = NSLocalizedString("All variations are already generated.",
-                                                                      comment: "Message for the notice when there were no variations to generate")
-        static let variationsCreatedTitle = NSLocalizedString("Variations created successfully",
-                                                              comment: "Title for the notice when after variations were created")
-
     }
 
     /// Localizated strings for the  action sheet options

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -642,7 +642,7 @@
 		26771A14256FFA8700EE030E /* IssueRefundCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26771A13256FFA8700EE030E /* IssueRefundCoordinatingController.swift */; };
 		2678897C270E6E8B00BD249E /* SimplePaymentsAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2678897B270E6E8B00BD249E /* SimplePaymentsAmount.swift */; };
 		267D6882296485850072ED0C /* ProductVariationGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267D6881296485850072ED0C /* ProductVariationGeneratorTests.swift */; };
-		26838354296F460B00CCF60A /* GenerateAllVariationsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26838353296F460B00CCF60A /* GenerateAllVariationsPresenter.swift */; };
+		26838354296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26838353296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift */; };
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
 		2687165A24D350C20042F6AE /* SurveyCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */; };
@@ -2704,7 +2704,7 @@
 		2678897B270E6E8B00BD249E /* SimplePaymentsAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsAmount.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267D6881296485850072ED0C /* ProductVariationGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationGeneratorTests.swift; sourceTree = "<group>"; };
-		26838353296F460B00CCF60A /* GenerateAllVariationsPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateAllVariationsPresenter.swift; sourceTree = "<group>"; };
+		26838353296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationsOptionPresenter.swift; sourceTree = "<group>"; };
 		2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySubmittedViewController.swift; sourceTree = "<group>"; };
 		2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SurveySubmittedViewController.xib; sourceTree = "<group>"; };
 		2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCoordinatingController.swift; sourceTree = "<group>"; };
@@ -4799,7 +4799,7 @@
 				26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */,
 				269A2F46295CC683000828A8 /* GenerateVariationsSelectorCommand.swift */,
 				263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */,
-				26838353296F460B00CCF60A /* GenerateAllVariationsPresenter.swift */,
+				26838353296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift */,
 				4515262B2577D48D0076B03C /* Add Attributes */,
 				AEDDDA0825CA9C0A0077F9B2 /* Edit Attributes */,
 			);
@@ -10234,7 +10234,7 @@
 				B541B220218A007C008FE7C1 /* NSMutableParagraphStyle+Helpers.swift in Sources */,
 				45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */,
 				6832C7CA26DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift in Sources */,
-				26838354296F460B00CCF60A /* GenerateAllVariationsPresenter.swift in Sources */,
+				26838354296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift in Sources */,
 				31FC8CE727B47591004B9456 /* CardReaderSettingsDataSource.swift in Sources */,
 				02B2829027C352DA004A332A /* RefreshableScrollView.swift in Sources */,
 				DE7842F726F2E9340030C792 /* UIViewController+Connectivity.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -642,6 +642,7 @@
 		26771A14256FFA8700EE030E /* IssueRefundCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26771A13256FFA8700EE030E /* IssueRefundCoordinatingController.swift */; };
 		2678897C270E6E8B00BD249E /* SimplePaymentsAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2678897B270E6E8B00BD249E /* SimplePaymentsAmount.swift */; };
 		267D6882296485850072ED0C /* ProductVariationGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267D6881296485850072ED0C /* ProductVariationGeneratorTests.swift */; };
+		26838354296F460B00CCF60A /* GenerateAllVariationsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26838353296F460B00CCF60A /* GenerateAllVariationsPresenter.swift */; };
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
 		2687165A24D350C20042F6AE /* SurveyCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */; };
@@ -2703,6 +2704,7 @@
 		2678897B270E6E8B00BD249E /* SimplePaymentsAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsAmount.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267D6881296485850072ED0C /* ProductVariationGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationGeneratorTests.swift; sourceTree = "<group>"; };
+		26838353296F460B00CCF60A /* GenerateAllVariationsPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateAllVariationsPresenter.swift; sourceTree = "<group>"; };
 		2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySubmittedViewController.swift; sourceTree = "<group>"; };
 		2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SurveySubmittedViewController.xib; sourceTree = "<group>"; };
 		2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCoordinatingController.swift; sourceTree = "<group>"; };
@@ -4797,6 +4799,7 @@
 				26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */,
 				269A2F46295CC683000828A8 /* GenerateVariationsSelectorCommand.swift */,
 				263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */,
+				26838353296F460B00CCF60A /* GenerateAllVariationsPresenter.swift */,
 				4515262B2577D48D0076B03C /* Add Attributes */,
 				AEDDDA0825CA9C0A0077F9B2 /* Edit Attributes */,
 			);
@@ -10231,6 +10234,7 @@
 				B541B220218A007C008FE7C1 /* NSMutableParagraphStyle+Helpers.swift in Sources */,
 				45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */,
 				6832C7CA26DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift in Sources */,
+				26838354296F460B00CCF60A /* GenerateAllVariationsPresenter.swift in Sources */,
 				31FC8CE727B47591004B9456 /* CardReaderSettingsDataSource.swift in Sources */,
 				02B2829027C352DA004A332A /* RefreshableScrollView.swift in Sources */,
 				DE7842F726F2E9340030C792 /* UIViewController+Connectivity.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -643,6 +643,7 @@
 		2678897C270E6E8B00BD249E /* SimplePaymentsAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2678897B270E6E8B00BD249E /* SimplePaymentsAmount.swift */; };
 		267D6882296485850072ED0C /* ProductVariationGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267D6881296485850072ED0C /* ProductVariationGeneratorTests.swift */; };
 		26838354296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26838353296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift */; };
+		26838356296F702B00CCF60A /* GenerateAllVariationsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26838355296F702B00CCF60A /* GenerateAllVariationsPresenter.swift */; };
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
 		2687165A24D350C20042F6AE /* SurveyCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */; };
@@ -2705,6 +2706,7 @@
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267D6881296485850072ED0C /* ProductVariationGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationGeneratorTests.swift; sourceTree = "<group>"; };
 		26838353296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationsOptionPresenter.swift; sourceTree = "<group>"; };
+		26838355296F702B00CCF60A /* GenerateAllVariationsPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateAllVariationsPresenter.swift; sourceTree = "<group>"; };
 		2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySubmittedViewController.swift; sourceTree = "<group>"; };
 		2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SurveySubmittedViewController.xib; sourceTree = "<group>"; };
 		2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCoordinatingController.swift; sourceTree = "<group>"; };
@@ -4800,6 +4802,7 @@
 				269A2F46295CC683000828A8 /* GenerateVariationsSelectorCommand.swift */,
 				263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */,
 				26838353296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift */,
+				26838355296F702B00CCF60A /* GenerateAllVariationsPresenter.swift */,
 				4515262B2577D48D0076B03C /* Add Attributes */,
 				AEDDDA0825CA9C0A0077F9B2 /* Edit Attributes */,
 			);
@@ -10698,6 +10701,7 @@
 				D8C2A291231BD0FD00F503E9 /* ReviewsDataSource.swift in Sources */,
 				CE855366209BA6A700938BDC /* CustomerInfoTableViewCell.swift in Sources */,
 				02DAE7FC291B7B8B009342B7 /* DomainSelectorViewModel.swift in Sources */,
+				26838356296F702B00CCF60A /* GenerateAllVariationsPresenter.swift in Sources */,
 				4521396E27FEE55200964ED3 /* FullScreenTextView.swift in Sources */,
 				DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */,
 				E1E649E92846188C0070B194 /* BetaFeature.swift in Sources */,


### PR DESCRIPTION
Part of #8534 

# Why

We need to be able to generate all variations from 3 states.
- Existing variations State - Already done ✅ 
- No variations state - This PR 👨‍💻 
- No variations & no attributes state - Next PR 🚧 

This PR does two things:
1. Handles the second scenario mentioned above.
2. Abstract view controller & notices presentation needed for the flow in two new classes. `GenerateVariationsOptionsPresenter ` and `GenerateAllVariationsPresenter`. These new classes are just copy-pasting from the code that was already on the `ProductVariationsViewController`. The reason for its extraction is to be able to reuse that presentation & localization on `EditAttributeViewController` to properly handle the third scenario. Which will come in a next PR.

# Demo

https://user-images.githubusercontent.com/562080/211953998-3ba05c98-598d-47be-be5e-c320775ed543.mov

# Testing Steps

- Navigate to a product with attributes but with no variations.
- Tap the "Add Variation" CTA  from the empty state screen.
- Generate All Variations
- See that everything works correctly.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
