### PR TITLE
Variations: Add track events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -223,6 +223,7 @@ extension WooAnalyticsEvent {
             static let serverTime = "time"
             static let errorDescription = "error_description"
             static let field = "field"
+            static let variationsCount = "variations_count"
         }
 
         enum BulkUpdateField: String {
@@ -309,6 +310,26 @@ extension WooAnalyticsEvent {
 
         static func bulkUpdateFieldFailed(field: BulkUpdateField, error: Error) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productVariationBulkUpdateFieldFail, properties: [Keys.field: field.rawValue], error: error)
+        }
+
+        static func productVariationGenerationRequested() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productVariationGenerationRequested, properties: [:])
+        }
+
+        static func productVariationGenerationConfirmed(count: Int64) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productVariationGenerationConfirmed, properties: [Keys.variationsCount: count])
+        }
+
+        static func productVariationGenerationLimitReached(count: Int64) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productVariationGenerationLimitReached, properties: [Keys.variationsCount: count])
+        }
+
+        static func productVariationGenerationSuccess() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productVariationGenerationSuccess, properties: [:])
+        }
+
+        static func productVariationGenerationFailure() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productVariationGenerationFailure, properties: [:])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -672,6 +672,12 @@ public enum WooAnalyticsStat: String {
     case editProductVariationAttributeOptionsRowTapped = "edit_product_variation_attribute_options_row_tapped"
     case editProductVariationAttributeOptionsDoneButtonTapped = "edit_product_variation_attribute_options_done_button_tapped"
 
+    case productVariationGenerationRequested = "product_variation_generation_requested"
+    case productVariationGenerationLimitReached = "product_variation_generation_limit_reached"
+    case productVariationGenerationConfirmed = "product_variation_generation_confirmed"
+    case productVariationGenerationSuccess = "product_variation_generation_success"
+    case productVariationGenerationFailure = "product_variation_generation_failure"
+
     // MARK: What's New Component events
     //
     case featureAnnouncementShown = "feature_announcement_shown"

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateAllVariationsUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateAllVariationsUseCase.swift
@@ -73,7 +73,8 @@ final class GenerateAllVariationsUseCase {
 
             case .failure(let error):
                 onStateChanged(.error(.unableToFetchVariations))
-                DDLogError("⛔️ Failed to create variations: \(error)")
+                DDLogError("⛔️ Failed to fetch variations: \(error)")
+                analytics.track(event: .Variations.productVariationGenerationFailure())
             }
         }
     }
@@ -96,13 +97,16 @@ private extension GenerateAllVariationsUseCase {
                                           onCompletion: @escaping (Result<[ProductVariation], GenerationError>) -> Void) {
         let action = ProductVariationAction.createProductVariations(siteID: product.siteID,
                                                                     productID: product.productID,
-                                                                    productVariations: variations, onCompletion: { result in
+                                                                    productVariations: variations, onCompletion: { [analytics] result in
             switch result {
             case .success(let variations):
                 onCompletion(.success(variations))
+                analytics.track(event: .Variations.productVariationGenerationSuccess())
+
             case .failure(let error):
                 onCompletion(.failure(.unableToCreateVariations))
                 DDLogError("⛔️ Failed to create variations: \(error)")
+                analytics.track(event: .Variations.productVariationGenerationFailure())
             }
         })
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsOptionPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateVariationsOptionPresenter.swift
@@ -16,8 +16,13 @@ final class GenerateVariationsOptionsPresenter {
     ///
     private let baseViewController: UIViewController
 
-    init(baseViewController: UIViewController) {
+    /// Analytics tracker.
+    ///
+    private let analytics: Analytics
+
+    init(baseViewController: UIViewController, analytics: Analytics = ServiceLocator.analytics) {
         self.baseViewController = baseViewController
+        self.analytics = analytics
     }
 
     /// Displays a bottom sheet allowing the merchant to choose whether to generate one variation or to generate all variations.
@@ -28,13 +33,14 @@ final class GenerateVariationsOptionsPresenter {
         }
 
         let viewProperties = BottomSheetListSelectorViewProperties(title: Localization.addVariationAction)
-        let command = GenerateVariationsSelectorCommand(selected: nil) { [baseViewController] option in
+        let command = GenerateVariationsSelectorCommand(selected: nil) { [analytics, baseViewController] option in
             baseViewController.dismiss(animated: true)
             switch option {
             case .single:
                 onCompletion(.single)
             case .all:
                 onCompletion(.all)
+                analytics.track(event: .Variations.productVariationGenerationRequested())
             }
         }
         let bottomSheetPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)


### PR DESCRIPTION
Closes #8493 

# Why

This PR adds tracks for the generate all variations process. In particular, we are tracking:


Name | Parameter | Description
-- | -- | --
*_product_variation_generation_requested |   | when a user requests to generate all variations
*_product_variation_generation_limit_reached | variations_count: Int | when a user requested to generate more than 100 variationsThis will help us to understand the importance of supporting generating more than 100 variations, as discussed here.
*_product_variation_generation_confirmed | variations_count: Int | when the user confirms the generation
*_product_variation_generation_success |   | when generated variations are successfully created
*_product_variation_generation_failure |   | when generated variations are not created or existing variations are not fetched


# Registration

- https://github.com/Automattic/tracks-events-registration/pull/1321
- https://github.com/Automattic/tracks-events-registration/pull/1322
- https://github.com/Automattic/tracks-events-registration/pull/1323
- https://github.com/Automattic/tracks-events-registration/pull/1324
- https://github.com/Automattic/tracks-events-registration/pull/1325



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
