### PR TITLE
[Mobile Payments] Built-in reader disconnection during payment error message

### DIFF
--- a/Hardware/Hardware/CardReader/UnderlyingError.swift
+++ b/Hardware/Hardware/CardReader/UnderlyingError.swift
@@ -450,7 +450,7 @@ extension UnderlyingError: LocalizedError {
                                      "the device does not meet minimum requirements.")
         case .commandNotAllowedDuringCall:
             return NSLocalizedString("The built-in reader cannot be used during a phone call. Please try again after " +
-                                     "you finish your call",
+                                     "you finish your call.",
                                      comment: "Error message shown when the built-in reader cannot be used because " +
                                      "there is a call in progress")
         case .invalidAmount:

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
@@ -6,9 +6,6 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
     /// Amount charged
     private let amount: String
 
-    /// The error returned by the stack
-    private let error: Error
-
     /// Called when the view is dismissed
     private let onDismiss: () -> Void
 
@@ -29,9 +26,7 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
 
     let auxiliaryButtonTitle: String? = nil
 
-    var bottomTitle: String? {
-        error.localizedDescription
-    }
+    let bottomTitle: String?
 
     let bottomSubtitle: String? = nil
 
@@ -43,10 +38,14 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
         return topTitle + bottomTitle
     }
 
-    init(amount: String, error: Error, onDismiss: @escaping () -> Void) {
+    init(amount: String, errorDescription: String?, onDismiss: @escaping () -> Void) {
         self.amount = amount
-        self.error = error
+        self.bottomTitle = errorDescription
         self.onDismiss = onDismiss
+    }
+
+    convenience init(amount: String, error: Error, onDismiss: @escaping () -> Void) {
+        self.init(amount: amount, errorDescription: error.localizedDescription, onDismiss: onDismiss)
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
@@ -5,10 +5,24 @@ import MessageUI
 import WooFoundation
 import protocol Storage.StorageManagerType
 
+
+/// Protocol to abstract the `LegacyCollectOrderPaymentUseCase`.
+/// Currently only used to facilitate unit tests.
+///
+protocol LegacyCollectOrderPaymentProtocol {
+    /// Starts the collect payment flow.
+    ///
+    ///
+    /// - Parameter onCollect: Closure Invoked after the collect process has finished.
+    /// - Parameter onCompleted: Closure Invoked after the flow has been totally completed.
+    /// - Parameter onCancel: Closure invoked after the flow is cancelled
+    func collectPayment(onCollect: @escaping (Result<Void, Error>) -> (), onCancel: @escaping () -> (), onCompleted: @escaping () -> ())
+}
+
 /// Use case to collect payments from an order.
 /// Orchestrates reader connection, payment, UI alerts, receipt handling and analytics.
 ///
-final class LegacyCollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
+final class LegacyCollectOrderPaymentUseCase: NSObject, LegacyCollectOrderPaymentProtocol {
     /// Currency Formatter
     ///
     private let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -60,7 +60,7 @@ struct PaymentMethodsView: View {
                             Divider()
 
                             MethodRow(icon: .creditCardImage, title: Localization.card, accessibilityID: Accessibility.cardMethod) {
-                                viewModel.collectPayment(on: rootViewController, onSuccess: dismiss)
+                                viewModel.collectPayment(on: rootViewController, onSuccess: dismiss, onFailure: dismiss)
                             }
                         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -29,6 +29,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         let dependencies = Dependencies(stores: stores)
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
@@ -54,6 +55,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         let dependencies = Dependencies(stores: stores)
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
@@ -90,6 +92,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                                         storage: storage)
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
@@ -118,6 +121,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         let dependencies = Dependencies(stores: stores)
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
@@ -148,6 +152,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         let dependencies = Dependencies(presentNoticeSubject: noticeSubject, stores: stores)
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
@@ -185,6 +190,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         let dependencies = Dependencies(presentNoticeSubject: noticeSubject, stores: stores)
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
@@ -232,6 +238,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                                         analytics: WooAnalytics(analyticsProvider: analytics))
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
@@ -265,10 +272,11 @@ final class PaymentMethodsViewModelTests: XCTestCase {
             analytics: WooAnalytics(analyticsProvider: analytics))
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
-        viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
+        viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {}, onFailure: {})
 
         // Then
         assertEqual(analytics.receivedEvents.last, WooAnalyticsStat.paymentsFlowCompleted.rawValue)
@@ -283,6 +291,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         let dependencies = Dependencies(analytics: WooAnalytics(analyticsProvider: analytics))
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
@@ -314,6 +323,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                                         analytics: WooAnalytics(analyticsProvider: analytics))
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
@@ -346,10 +356,11 @@ final class PaymentMethodsViewModelTests: XCTestCase {
             analytics: WooAnalytics(analyticsProvider: analytics))
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
-        viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
+        viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {}, onFailure: {})
 
         // Then
         assertEqual(analytics.receivedEvents.last, WooAnalyticsStat.paymentsFlowFailed.rawValue)
@@ -365,6 +376,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                                         analytics: WooAnalytics(analyticsProvider: analytics))
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
@@ -382,6 +394,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         let dependencies = Dependencies(analytics: WooAnalytics(analyticsProvider: analytics))
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
@@ -405,10 +418,11 @@ final class PaymentMethodsViewModelTests: XCTestCase {
             analytics: WooAnalytics(analyticsProvider: analytics))
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
-        viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
+        viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {}, onFailure: {})
 
         // Then
         assertEqual(analytics.receivedEvents.last, WooAnalyticsStat.paymentsFlowCollect.rawValue)
@@ -433,6 +447,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                                                 orderID: 111,
                                                 formattedTotal: "$5.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // Then
@@ -456,6 +471,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                                                 orderID: 111,
                                                 formattedTotal: "$5.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // Then
@@ -479,6 +495,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                                                 orderID: 111,
                                                 formattedTotal: "$5.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // Then
@@ -502,6 +519,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                                                 orderID: 111,
                                                 formattedTotal: "$5.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // Then
@@ -539,6 +557,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                                                 orderID: 111,
                                                 formattedTotal: "$5.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // Then
@@ -576,6 +595,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                                                 orderID: 111,
                                                 formattedTotal: "$5.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // Then
@@ -584,7 +604,10 @@ final class PaymentMethodsViewModelTests: XCTestCase {
 
     func test_paymentLinkRow_is_hidden_if_payment_link_is_not_available() {
         // Given
-        let viewModel = PaymentMethodsViewModel(paymentLink: nil, formattedTotal: "$12.00", flow: .simplePayment)
+        let viewModel = PaymentMethodsViewModel(paymentLink: nil,
+                                                formattedTotal: "$12.00",
+                                                flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false)
 
         // Then
         XCTAssertFalse(viewModel.showPaymentLinkRow)
@@ -594,7 +617,10 @@ final class PaymentMethodsViewModelTests: XCTestCase {
     func test_paymentLinkRow_is_shown_if_payment_link_is_available() {
         // Given
         let paymentURL = URL(string: "http://www.automattic.com")
-        let viewModel = PaymentMethodsViewModel(paymentLink: paymentURL, formattedTotal: "$12.00", flow: .simplePayment)
+        let viewModel = PaymentMethodsViewModel(paymentLink: paymentURL,
+                                                formattedTotal: "$12.00",
+                                                flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false)
 
         // Then
         XCTAssertTrue(viewModel.showPaymentLinkRow)
@@ -607,6 +633,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         let dependencies = Dependencies(presentNoticeSubject: noticeSubject)
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
@@ -651,6 +678,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                                         storage: storage)
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
@@ -665,7 +693,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
             }
             .store(in: &self.subscriptions)
 
-            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
+            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {}, onFailure: {})
         }
 
         // Then
@@ -690,13 +718,17 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                                         storage: storage)
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
         let calledOnSuccess: Bool = waitFor { promise in
-            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {
+            viewModel.collectPayment(on: UIViewController(),
+                                     useCase: useCase,
+                                     onSuccess: {
                 promise(true)
-            })
+            },
+                                     onFailure: {})
         }
 
         // Then
@@ -723,6 +755,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                                         storage: storage)
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
+                                                isTapToPayOnIPhoneEnabled: false,
                                                 dependencies: dependencies)
 
         // When
@@ -735,7 +768,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
                     XCTFail("Unexpected action: \(action)")
                 }
             }
-            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {})
+            viewModel.collectPayment(on: UIViewController(), useCase: useCase, onSuccess: {}, onFailure: {})
         }
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/MockCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/MockCollectOrderPaymentUseCase.swift
@@ -1,9 +1,9 @@
 import Foundation
 @testable import WooCommerce
 
-/// Mock type for `CollectOrderPaymentProtocol`
+/// Mock type for `LegacyCollectOrderPaymentProtocol`
 ///
-struct MockCollectOrderPaymentUseCase: CollectOrderPaymentProtocol {
+struct MockCollectOrderPaymentUseCase: LegacyCollectOrderPaymentProtocol {
 
     /// Assign to be returned on `onCollect` closure.
     ///


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8089
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The built-in card reader used with Tap to Pay on iPhone can disconnect for a number of reasons, in general, when the app goes in to the background.

In future, we may automatically reconnect in this scenario, but I've found that there's significant risk in that approach, as we can't always tell whether the payment was taken or not. See pdfdoF-2aX-p2 for more context.

When this happens during a payment, we need to inform the user about the payment failure and how to continue

### Changes in this PR
When we get an error collecting the payment, caused by the reader disconnecting, any retry attempt will fail.

By showing a non-retriable error which dismisses the payment flow, the merchant will be taken back to the order and can see clearly whether the payment has gone through or not, before attempting the payment again.

The error message specifically tells the user about this interruption without using the word “disconnected”, which is strange in the context of the built in reader, and informs them about how to continue with the payment.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Using an iPhone XS or newer on iOS 16.0 or newer on a US store

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. When asked for a reader type, tap `Tap to Pay on iPhone` and go through the Terms of Service Apple ID linking (if you've not done so before)
6. As soon as the `Getting ready to collect payment` screen is shown, background the app
7. Observe that the apple card reader screen shows with the title `Canceled`
8. Open the app
9. Observe that you see a non retriable error telling you about the interrupted payment, and to retry from the order screen.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/212146580-4fbe62ae-e597-4636-aa56-c13d1abef472.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
