### PR TITLE
[Mobile Payments] Add metadata to payment intent for TTPoI

### DIFF
--- a/Hardware/Hardware/CardReader/CardReaderType.swift
+++ b/Hardware/Hardware/CardReader/CardReaderType.swift
@@ -29,7 +29,7 @@ extension CardReaderType {
         case .wisepad3:
             return "WISEPAD_3"
         case .appleBuiltIn:
-            return "BUILT_IN"
+            return "COTS_DEVICE"
         default:
             return "UNKNOWN"
         }

--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -511,6 +511,7 @@ private extension StripeCardReaderService {
             ///
             parameters.metadata?[Constants.readerIDMetadataKey] = self?.readerIDForIntent()
             parameters.metadata?[Constants.readerModelMetadataKey] = self?.readerModelForIntent()
+            parameters.metadata?[Constants.platformMetadataKey] = Constants.platform
 
             Terminal.shared.createPaymentIntent(parameters) { (intent, error) in
                 if let error = error {
@@ -921,6 +922,8 @@ private extension StripeCardReaderService {
         ///
         static let readerIDMetadataKey = "reader_ID"
         static let readerModelMetadataKey = "reader_model"
+        static let platformMetadataKey = "platform"
+        static let platform = "ios"
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8622 
Closes: #8621 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the `platform` metadata key, so we can distinguish transactions made using TTPoI and TTP on Android.

Android uses `reader_model: COTS_DEVICE` for built-in reader payments, so we also update to use that for consistency.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Take a payment using Tap to Pay on iPhone
Log in to the Stripe dashboard and find the transaction
Observe that the metadata includes `reader_model: COTS_DEVICE` and `platform: ios`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="825" alt="CleanShot 2023-01-13 at 12 07 46@2x" src="https://user-images.githubusercontent.com/2472348/212317498-3a5ceade-d2fc-4181-9dc9-b7bf4a712e50.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
