### PR TITLE
[Mobile Payments] Update card reader manual URLs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 11.9
 -----
-
+- [*] Mobile payments: fixed card reader manuals links. [https://github.com/woocommerce/woocommerce-ios/pull/8628]
 
 11.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderType+Manual.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardReaderType+Manual.swift
@@ -9,21 +9,21 @@ extension CardReaderType {
                 id: 0,
                 image: .cardReaderImageBBPOSChipper,
                 name: "BBPOS Chipper 2X BT",
-                urlString: "https://stripe.com/files/docs/terminal/c2xbt_product_sheet.pdf"
+                urlString: "https://woocommerce.com/wp-content/uploads/2022/12/c2xbt_product_sheet.pdf"
             )
         case .stripeM2:
             return Manual(
                 id: 1,
                 image: .cardReaderImageM2,
                 name: "Stripe Reader M2",
-                urlString: "https://stripe.com/files/docs/terminal/m2_product_sheet.pdf"
+                urlString: "https://woocommerce.com/wp-content/uploads/2022/12/m2_product_sheet.pdf"
             )
         case .wisepad3:
             return Manual(
                 id: 2,
                 image: .cardReaderImageWisepad3,
                 name: "Wisepad 3",
-                urlString: "https://stripe.com/files/docs/terminal/wp3_product_sheet.pdf"
+                urlString: "https://woocommerce.com/wp-content/uploads/2022/12/wp3_product_sheet.pdf"
             )
         case .other, .appleBuiltIn:
             return nil


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8627
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We use Stripe URLs to load the card reader manuals. Currently, these links are broken. This PR updates the app to use links that we host these ourselves, so that we can fix issues when required.

The links are:
- M2: `https://woocommerce.com/wp-content/uploads/2022/12/m2_product_sheet.pdf`
- Chipper: `https://woocommerce.com/wp-content/uploads/2022/12/c2xbt_product_sheet.pdf`
- WisePad 3: `https://woocommerce.com/wp-content/uploads/2022/12/wp3_product_sheet.pdf`

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a US store

1. Go to the Menu, then Payments
2. Open `Card Reader Manuals`
3. Open the Chipper manual, and observe that it is the correct manual not a 404
4. Go back, and open the M2 manual. Again observe it's the correct manual and not a 404

Using a CA store

Repeat, but open and check the WisePad 3 manual.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/212321419-b1773aba-9956-43cc-b914-9550f945722f.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
