### PR TITLE
REST API: Migrate site settings endpoints

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -699,6 +699,7 @@
 		DE42F96B296BC23800D514C2 /* customer-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F96A296BC23800D514C2 /* customer-without-data.json */; };
 		DE42F96D296BC67E00D514C2 /* wc-analytics-customers-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F96C296BC67E00D514C2 /* wc-analytics-customers-without-data.json */; };
 		DE42F96F296BC9A700D514C2 /* countries-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE42F96E296BC9A700D514C2 /* countries-without-data.json */; };
+		DE4F2A4229751EAE00B0701C /* setting-coupon-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE4F2A4129751EAE00B0701C /* setting-coupon-without-data.json */; };
 		DE50295928C5BD0200551736 /* JetpackUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295828C5BD0200551736 /* JetpackUser.swift */; };
 		DE50295B28C5F99700551736 /* DotcomUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295A28C5F99700551736 /* DotcomUser.swift */; };
 		DE50295D28C6068B00551736 /* JetpackUserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295C28C6068B00551736 /* JetpackUserMapper.swift */; };
@@ -1518,6 +1519,7 @@
 		DE42F96A296BC23800D514C2 /* customer-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "customer-without-data.json"; sourceTree = "<group>"; };
 		DE42F96C296BC67E00D514C2 /* wc-analytics-customers-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wc-analytics-customers-without-data.json"; sourceTree = "<group>"; };
 		DE42F96E296BC9A700D514C2 /* countries-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "countries-without-data.json"; sourceTree = "<group>"; };
+		DE4F2A4129751EAE00B0701C /* setting-coupon-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-coupon-without-data.json"; sourceTree = "<group>"; };
 		DE50295828C5BD0200551736 /* JetpackUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackUser.swift; sourceTree = "<group>"; };
 		DE50295A28C5F99700551736 /* DotcomUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotcomUser.swift; sourceTree = "<group>"; };
 		DE50295C28C6068B00551736 /* JetpackUserMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackUserMapper.swift; sourceTree = "<group>"; };
@@ -2143,6 +2145,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DE4F2A4129751EAE00B0701C /* setting-coupon-without-data.json */,
 				DEEDA4432975003800F845AB /* settings-general-without-data.json */,
 				DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */,
 				DEA6B1C7296D0E8A005AA5E9 /* systemStatusWithPluginsOnly-without-data.json */,
@@ -3157,6 +3160,7 @@
 				68CB801628D8A39700E169F8 /* customer.json in Resources */,
 				EEA658402966C05D00112DF0 /* product-search-sku-without-data.json in Resources */,
 				DE42F96D296BC67E00D514C2 /* wc-analytics-customers-without-data.json in Resources */,
+				DE4F2A4229751EAE00B0701C /* setting-coupon-without-data.json in Resources */,
 				03EB99982907F4AA00F06A39 /* just-in-time-message-list-multiple.json in Resources */,
 				EE80A25029556FBD003591E4 /* coupon-reports-without-data.json in Resources */,
 				451A97DE260B59870059D135 /* shipping-label-packages-success.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -734,6 +734,7 @@
 		DEC51AF92769A212009F3DF4 /* SystemStatus+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AF82769A212009F3DF4 /* SystemStatus+Settings.swift */; };
 		DEC51AFB2769C66B009F3DF4 /* SystemStatusMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AFA2769C66B009F3DF4 /* SystemStatusMapperTests.swift */; };
 		DEC51B02276AFB35009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */; };
+		DEEDA4442975003800F845AB /* settings-general-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEDA4432975003800F845AB /* settings-general-without-data.json */; };
 		DEF13C5029629EEA0024A02B /* user-complete-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEF13C4F29629EEA0024A02B /* user-complete-without-data.json */; };
 		DEF13C562965689F0024A02B /* LeaderboardListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF13C552965689F0024A02B /* LeaderboardListMapperTests.swift */; };
 		DEF13C5A296571150024A02B /* leaderboards-year-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEF13C59296571150024A02B /* leaderboards-year-without-data.json */; };
@@ -1552,6 +1553,7 @@
 		DEC51AF82769A212009F3DF4 /* SystemStatus+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemStatus+Settings.swift"; sourceTree = "<group>"; };
 		DEC51AFA2769C66B009F3DF4 /* SystemStatusMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusMapperTests.swift; sourceTree = "<group>"; };
 		DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemStatus+DropinMustUsePlugin.swift"; sourceTree = "<group>"; };
+		DEEDA4432975003800F845AB /* settings-general-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "settings-general-without-data.json"; sourceTree = "<group>"; };
 		DEF13C4F29629EEA0024A02B /* user-complete-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "user-complete-without-data.json"; sourceTree = "<group>"; };
 		DEF13C552965689F0024A02B /* LeaderboardListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardListMapperTests.swift; sourceTree = "<group>"; };
 		DEF13C59296571150024A02B /* leaderboards-year-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "leaderboards-year-without-data.json"; sourceTree = "<group>"; };
@@ -2141,6 +2143,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DEEDA4432975003800F845AB /* settings-general-without-data.json */,
 				DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */,
 				DEA6B1C7296D0E8A005AA5E9 /* systemStatusWithPluginsOnly-without-data.json */,
 				DEA6B1C5296C13FB005AA5E9 /* payment-gateway-list-without-data.json */,
@@ -3148,6 +3151,7 @@
 				02616F902921336C0095BC00 /* site-creation-success.json in Resources */,
 				CC0786632678F79500BA9AC1 /* shipping-label-purchase-success.json in Resources */,
 				7497376A2141F2BE0008C490 /* top-performers-week-alt.json in Resources */,
+				DEEDA4442975003800F845AB /* settings-general-without-data.json in Resources */,
 				D865CE61278CA1AE002C8520 /* stripe-payment-intent-processing.json in Resources */,
 				743E84F222172D0A00FAC9D7 /* shipment_tracking_plugin_not_active.json in Resources */,
 				68CB801628D8A39700E169F8 /* customer.json in Resources */,

--- a/Networking/Networking/Mapper/SiteSettingMapper.swift
+++ b/Networking/Networking/Mapper/SiteSettingMapper.swift
@@ -25,7 +25,11 @@ struct SiteSettingMapper: Mapper {
             .settingGroupKey: settingsGroup.rawValue
         ]
 
-        return try decoder.decode(SiteSettingEnvelope.self, from: response).setting
+        do {
+            return try decoder.decode(SiteSettingEnvelope.self, from: response).setting
+        } catch {
+            return try decoder.decode(SiteSetting.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Mapper/SiteSettingsMapper.swift
+++ b/Networking/Networking/Mapper/SiteSettingsMapper.swift
@@ -26,7 +26,11 @@ struct SiteSettingsMapper: Mapper {
             .settingGroupKey: settingsGroup.rawValue
         ]
 
-        return try decoder.decode(SiteSettingsEnvelope.self, from: response).settings
+        do {
+            return try decoder.decode(SiteSettingsEnvelope.self, from: response).settings
+        } catch {
+            return try decoder.decode([SiteSetting].self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Remote/SiteSettingsRemote.swift
+++ b/Networking/Networking/Remote/SiteSettingsRemote.swift
@@ -13,7 +13,12 @@ public class SiteSettingsRemote: Remote {
     ///
     public func loadGeneralSettings(for siteID: Int64, completion: @escaping ([SiteSetting]?, Error?) -> Void) {
         let path = Constants.siteSettingsPath + Constants.generalSettingsGroup
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true)
         let mapper = SiteSettingsMapper(siteID: siteID, settingsGroup: SiteSettingGroup.general)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -27,7 +32,12 @@ public class SiteSettingsRemote: Remote {
     ///
     public func loadProductSettings(for siteID: Int64, completion: @escaping ([SiteSetting]?, Error?) -> Void) {
         let path = Constants.siteSettingsPath + Constants.productSettingsGroup
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true)
         let mapper = SiteSettingsMapper(siteID: siteID, settingsGroup: SiteSettingGroup.product)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -43,7 +53,12 @@ public class SiteSettingsRemote: Remote {
     ///
     public func loadSetting(for siteID: Int64, settingGroup: SiteSettingGroup, settingID: String, completion: @escaping (Result<SiteSetting, Error>) -> Void) {
         let path = Constants.siteSettingsPath + settingGroup.rawValue + "/" + settingID
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true)
         let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: SiteSettingGroup.general)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -65,7 +80,12 @@ public class SiteSettingsRemote: Remote {
                               completion: @escaping (Result<SiteSetting, Error>) -> Void) {
         let parameters: [String: Any] = [Constants.valueParameter: value]
         let path = Constants.siteSettingsPath + settingGroup.rawValue + "/" + settingID
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .put, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .put,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
         let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: SiteSettingGroup.general)
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/NetworkingTests/Mapper/SiteSettingMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteSettingMapperTests.swift
@@ -17,6 +17,18 @@ final class SiteSettingMapperTests: XCTestCase {
         XCTAssertEqual(setting.label, "Enable coupons")
         XCTAssertEqual(setting.value, "yes")
     }
+
+    /// Verifies the SiteSetting fields are parsed correctly when response has no data envelope.
+    ///
+    func test_SiteSetting_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
+        let setting = try XCTUnwrap(mapLoadCouponSettingResponseWithoutDataEnvelope())
+        XCTAssertEqual(setting.siteID, dummySiteID)
+        XCTAssertEqual(setting.settingID, "woocommerce_enable_coupons")
+        XCTAssertEqual(setting.settingDescription, "Enable the use of coupon codes")
+        XCTAssertEqual(setting.label, "Enable coupons")
+        XCTAssertEqual(setting.value, "yes")
+    }
+
     func test_SiteSetting_value_field_is_properly_parsed_when_value_field_is_not_string() throws {
         let setting = try XCTUnwrap(loadMultiselectValueSettingResponse())
         XCTAssertEqual(setting.settingID, "woocommerce_all_except_countries")
@@ -41,6 +53,13 @@ private extension SiteSettingMapperTests {
     func mapLoadCouponSettingResponse() -> SiteSetting? {
         return mapSetting(from: "setting-coupon")
     }
+
+    /// Returns the SiteSettingMapper output upon receiving `setting-coupon-without-data`
+    ///
+    func mapLoadCouponSettingResponseWithoutDataEnvelope() -> SiteSetting? {
+        return mapSetting(from: "setting-coupon-without-data")
+    }
+
     /// Returns the SiteSettingMapper output upon receiving `setting-all-except-countries`
     ///
     func loadMultiselectValueSettingResponse() -> SiteSetting? {

--- a/Networking/NetworkingTests/Mapper/SiteSettingsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteSettingsMapperTests.swift
@@ -45,7 +45,7 @@ class SiteSettingsMapperTests: XCTestCase {
     /// Verifies the SiteSetting fields are parsed correctly when response has no data envelope.
     ///
     func test_SiteSetting_fields_are_properly_parsed_when_response_has_no_data_envelope() {
-        let settings = mapLoadGeneralSiteSettingsResponseWithoutData()
+        let settings = mapLoadGeneralSiteSettingsResponseWithoutDataEnvelope()
         XCTAssertEqual(settings.count, 20)
 
         let firstSetting = settings[0]

--- a/Networking/NetworkingTests/Mapper/SiteSettingsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteSettingsMapperTests.swift
@@ -42,6 +42,38 @@ class SiteSettingsMapperTests: XCTestCase {
         XCTAssertEqual(decimalSetting.value, "2")
     }
 
+    /// Verifies the SiteSetting fields are parsed correctly when response has no data envelope.
+    ///
+    func test_SiteSetting_fields_are_properly_parsed_when_response_has_no_data_envelope() {
+        let settings = mapLoadGeneralSiteSettingsResponseWithoutData()
+        XCTAssertEqual(settings.count, 20)
+
+        let firstSetting = settings[0]
+        XCTAssertNotNil(firstSetting)
+        XCTAssertEqual(firstSetting.siteID, dummySiteID)
+        XCTAssertEqual(firstSetting.settingID, "woocommerce_store_address")
+        XCTAssertEqual(firstSetting.settingDescription, "The street address for your business location.")
+        XCTAssertEqual(firstSetting.label, "Address line 1")
+        XCTAssertEqual(firstSetting.value, "60 29th Street #343")
+
+        let currencySetting = settings[14]
+        XCTAssertNotNil(currencySetting)
+        XCTAssertEqual(currencySetting.siteID, dummySiteID)
+        XCTAssertEqual(currencySetting.settingID, "woocommerce_currency")
+        XCTAssertEqual(currencySetting.settingDescription,
+                       "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.")
+        XCTAssertEqual(currencySetting.label, "Currency")
+        XCTAssertEqual(currencySetting.value, "USD")
+
+        let decimalSetting = settings[18]
+        XCTAssertNotNil(decimalSetting)
+        XCTAssertEqual(decimalSetting.siteID, dummySiteID)
+        XCTAssertEqual(decimalSetting.settingID, "woocommerce_price_num_decimals")
+        XCTAssertEqual(decimalSetting.settingDescription, "This sets the number of decimal points shown in displayed prices.")
+        XCTAssertEqual(decimalSetting.label, "Number of decimals")
+        XCTAssertEqual(decimalSetting.value, "2")
+    }
+
     /// Verifies that a SiteSetting in a broken state gets default values
     ///
     func test_SiteSettings_are_properly_parsed_when_nulls_received() {
@@ -63,7 +95,7 @@ class SiteSettingsMapperTests: XCTestCase {
 ///
 private extension SiteSettingsMapperTests {
 
-    /// Returns the OrderNotesMapper output upon receiving `filename` (Data Encoded)
+    /// Returns the [SiteSetting] output upon receiving `filename` (Data Encoded)
     ///
     func mapGeneralSettings(from filename: String) -> [SiteSetting] {
         guard let response = Loader.contentsOf(filename) else {
@@ -73,13 +105,19 @@ private extension SiteSettingsMapperTests {
         return try! SiteSettingsMapper(siteID: dummySiteID, settingsGroup: SiteSettingGroup.general).map(response: response)
     }
 
-    /// Returns the OrderNotesMapper output upon receiving `settings-general`
+    /// Returns the [SiteSetting] output upon receiving `settings-general`
     ///
     func mapLoadGeneralSiteSettingsResponse() -> [SiteSetting] {
         return mapGeneralSettings(from: "settings-general")
     }
 
-    /// Returns the OrderNotesMapper output upon receiving `broken-settings-general`
+    /// Returns the [SiteSetting] output upon receiving `settings-general-without-data`
+    ///
+    func mapLoadGeneralSiteSettingsResponseWithoutDataEnvelope() -> [SiteSetting] {
+        return mapGeneralSettings(from: "settings-general-without-data")
+    }
+
+    /// Returns the [SiteSetting] output upon receiving `broken-settings-general`
     ///
     func mapLoadBrokenGeneralSiteSettingsResponse() -> [SiteSetting] {
         return mapGeneralSettings(from: "broken-settings-general")

--- a/Networking/NetworkingTests/Responses/setting-coupon-without-data.json
+++ b/Networking/NetworkingTests/Responses/setting-coupon-without-data.json
@@ -1,0 +1,21 @@
+{
+    "id": "woocommerce_enable_coupons",
+    "label": "Enable coupons",
+    "description": "Enable the use of coupon codes",
+    "type": "checkbox",
+    "default": "yes",
+    "tip": "Coupons can be applied from the cart and checkout pages.",
+    "value": "yes",
+    "_links": {
+        "self": [
+            {
+                "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_enable_coupons"
+            }
+        ],
+        "collection": [
+            {
+                "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+            }
+        ]
+    }
+}

--- a/Networking/NetworkingTests/Responses/settings-general-without-data.json
+++ b/Networking/NetworkingTests/Responses/settings-general-without-data.json
@@ -1,0 +1,462 @@
+[
+    {
+        "id": "woocommerce_store_address",
+        "label": "Address line 1",
+        "description": "The street address for your business location.",
+        "type": "text",
+        "default": "",
+        "tip": "The street address for your business location.",
+        "value": "60 29th Street #343",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_store_address"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_store_address_2",
+        "label": "Address line 2",
+        "description": "An additional, optional address line for your business location.",
+        "type": "text",
+        "default": "",
+        "tip": "An additional, optional address line for your business location.",
+        "value": "",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_store_address_2"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_store_city",
+        "label": "City",
+        "description": "The city in which your business is located.",
+        "type": "text",
+        "default": "",
+        "tip": "The city in which your business is located.",
+        "value": "Auburn",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_store_city"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_default_country",
+        "label": "Country / State",
+        "description": "The country and state or province, if any, in which your business is located.",
+        "type": "select",
+        "default": "GB",
+        "tip": "The country and state or province, if any, in which your business is located.",
+        "value": "US:NY",
+        "options": {
+            "AX": "&#197;land Islands",
+            "AF": "Afghanistan"
+        },
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_default_country"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_store_postcode",
+        "label": "Postcode / ZIP",
+        "description": "The postal code, if any, in which your business is located.",
+        "type": "text",
+        "default": "",
+        "tip": "The postal code, if any, in which your business is located.",
+        "value": "13021",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_store_postcode"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_allowed_countries",
+        "label": "Selling location(s)",
+        "description": "This option lets you limit which countries you are willing to sell to.",
+        "type": "select",
+        "default": "all",
+        "options": {
+            "all": "Sell to all countries",
+            "all_except": "Sell to all countries, except for&hellip;",
+            "specific": "Sell to specific countries"
+        },
+        "tip": "This option lets you limit which countries you are willing to sell to.",
+        "value": "all",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_allowed_countries"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_all_except_countries",
+        "label": "Sell to all countries, except for&hellip;",
+        "description": "",
+        "type": "multiselect",
+        "default": "",
+        "value": [],
+        "options": {
+            "ZW": "Zimbabwe"
+        },
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_all_except_countries"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_specific_allowed_countries",
+        "label": "Sell to specific countries",
+        "description": "",
+        "type": "multiselect",
+        "default": "",
+        "value": [],
+        "options": {
+            "VN": "Vietnam",
+            "WF": "Wallis and Futuna",
+            "EH": "Western Sahara",
+            "YE": "Yemen"
+        },
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_specific_allowed_countries"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_ship_to_countries",
+        "label": "Shipping location(s)",
+        "description": "Choose which countries you want to ship to, or choose to ship to all locations you sell to.",
+        "type": "select",
+        "default": "",
+        "options": {
+            "all": "Ship to all countries",
+            "specific": "Ship to specific countries only",
+            "disabled": "Disable shipping &amp; shipping calculations"
+        },
+        "tip": "Choose which countries you want to ship to, or choose to ship to all locations you sell to.",
+        "value": "all",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_ship_to_countries"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_specific_ship_to_countries",
+        "label": "Ship to specific countries",
+        "description": "",
+        "type": "multiselect",
+        "default": "",
+        "value": [],
+        "options": {
+            "VN": "Vietnam",
+            "WF": "Wallis and Futuna",
+            "EH": "Western Sahara",
+            "YE": "Yemen"
+        },
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_specific_ship_to_countries"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_default_customer_address",
+        "label": "Default customer location",
+        "description": "",
+        "type": "select",
+        "default": "geolocation",
+        "options": {
+            "base": "Shop base address",
+            "geolocation": "Geolocate",
+            "geolocation_ajax": "Geolocate (with page caching support)"
+        },
+        "tip": "This option determines a customers default location. The MaxMind GeoLite Database will be periodically downloaded to your wp-content directory if using geolocation.",
+        "value": "geolocation",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_default_customer_address"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_calc_taxes",
+        "label": "Enable taxes",
+        "description": "Enable tax rates and calculations",
+        "type": "checkbox",
+        "default": "no",
+        "tip": "Rates will be configurable and taxes will be calculated during checkout.",
+        "value": "yes",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_calc_taxes"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_enable_coupons",
+        "label": "Enable coupons",
+        "description": "Enable the use of coupon codes",
+        "type": "checkbox",
+        "default": "yes",
+        "tip": "Coupons can be applied from the cart and checkout pages.",
+        "value": "yes",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_enable_coupons"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_calc_discounts_sequentially",
+        "label": "",
+        "description": "Calculate coupon discounts sequentially",
+        "type": "checkbox",
+        "default": "no",
+        "tip": "When applying multiple coupons, apply the first coupon to the full price and the second coupon to the discounted price and so on.",
+        "value": "no",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_calc_discounts_sequentially"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_currency",
+        "label": "Currency",
+        "description": "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.",
+        "type": "select",
+        "default": "GBP",
+        "options": {
+            "GBP": "Pound sterling (&pound;)",
+            "USD": "United States (US) dollar (&#36;)"
+        },
+        "tip": "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.",
+        "value": "USD",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_currency"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_currency_pos",
+        "label": "Currency position",
+        "description": "This controls the position of the currency symbol.",
+        "type": "select",
+        "default": "left",
+        "options": {
+            "left": "Left",
+            "right": "Right",
+            "left_space": "Left with space",
+            "right_space": "Right with space"
+        },
+        "tip": "This controls the position of the currency symbol.",
+        "value": "left",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_currency_pos"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_price_thousand_sep",
+        "label": "Thousand separator",
+        "description": "This sets the thousand separator of displayed prices.",
+        "type": "text",
+        "default": ",",
+        "tip": "This sets the thousand separator of displayed prices.",
+        "value": ",",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_price_thousand_sep"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_price_decimal_sep",
+        "label": "Decimal separator",
+        "description": "This sets the decimal separator of displayed prices.",
+        "type": "text",
+        "default": ".",
+        "tip": "This sets the decimal separator of displayed prices.",
+        "value": ".",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_price_decimal_sep"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_price_num_decimals",
+        "label": "Number of decimals",
+        "description": "This sets the number of decimal points shown in displayed prices.",
+        "type": "number",
+        "default": "2",
+        "tip": "This sets the number of decimal points shown in displayed prices.",
+        "value": "2",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_price_num_decimals"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    },
+    {
+        "id": "woocommerce_bookings_tz_calculation",
+        "label": "Enable Bookings Timezone calculation",
+        "description": "Schedule Bookings events, such as reminder emails and auto-completions of bookings, using your site’s configured timezone.",
+        "type": "checkbox",
+        "default": "no",
+        "value": "no",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_bookings_tz_calculation"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
+                }
+            ]
+        }
+    }
+]

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -351,14 +351,17 @@ private extension DefaultStoresManager {
         }
         dispatch(productSettingsAction)
 
-        group.enter()
-        let sitePlanAction = AccountAction.synchronizeSitePlan(siteID: siteID) { result in
-            if case let .failure(error) = result {
-                errors.append(error)
+        /// skips synchronizing site plan if logged in with WPOrg credentials
+        if siteID != WooConstants.placeholderStoreID {
+            group.enter()
+            let sitePlanAction = AccountAction.synchronizeSitePlan(siteID: siteID) { result in
+                if case let .failure(error) = result {
+                    errors.append(error)
+                }
+                group.leave()
             }
-            group.leave()
+            dispatch(sitePlanAction)
         }
-        dispatch(sitePlanAction)
 
         group.notify(queue: .main) {
             if errors.isEmpty {

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -352,7 +352,8 @@ private extension DefaultStoresManager {
         dispatch(productSettingsAction)
 
         /// skips synchronizing site plan if logged in with WPOrg credentials
-        if siteID != WooConstants.placeholderStoreID {
+        /// because this requires a WPCom endpoint.
+        if isAuthenticatedWithoutWPCom {
             group.enter()
             let sitePlanAction = AccountAction.synchronizeSitePlan(siteID: siteID) { result in
                 if case let .failure(error) = result {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8637 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the site settings mapper and enables REST API for site settings endpoints.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Pre-requisite: due to a rate-limit issue with Pressable sites, create a JN site to ensure that testing is smooth for now.
- Enable feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address and enter the address of your self-hosted site.
- Proceed to log in with site credentials.
- When the login succeeds, you should see the home screen.
- You should then see in Xcode console: `🎛 Site settings sync completed for siteID` and not `⛔️ Site settings sync had <count> error(s) for siteID`.

Testing setting loading and updating.
- In WP Admin, select WooCommerce > Settings > General and disable the option "Enable the use of coupon codes ".
- On the app, enable coupons if needed (in Settings > Experimental features > Coupon management).
- Navigate to the Menu app and select Coupons. Notice that the screen shows a message saying coupons are disabled for the store.
- Select Enable coupon. Notice that the list will the be reloaded and show the correct data after that.
- Reload the General WC settings page on WP Admin, the setting for coupons should be enabled again. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/212608051-6e223fb7-0971-4fc1-b124-2e699a25edac.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
