### PR TITLE
[IPPInAppFeedback] Orders screen banner placement

### DIFF
--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -19,5 +19,5 @@ public enum FeedbackType: String, Codable {
 
     /// Identifier for the In-Person Payments feedback survey
     ///
-    case IPPFeedback
+    case IPP
 }

--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -16,4 +16,8 @@ public enum FeedbackType: String, Codable {
     /// Identifier for the orders creation feedback survey
     ///
     case ordersCreation
+
+    /// Identifier for the In-Person Payments feedback survey
+    ///
+    case IPPFeedback
 }

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -155,8 +155,10 @@ extension WooConstants {
         ///
 #if DEBUG
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-test-survey"
+        case IPPFeedback = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
 #else
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
+        case IPPFeedback = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
 #endif
 
         /// URL for the products feedback survey

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -789,17 +789,36 @@ private extension OrderListViewController {
     /// Sets the `topBannerView` property to an IPP feedback banner.
     ///
     func setIPPFeedbackTopBanner() {
-        // TODO: Implement the specific banner similar to OrdersTopBannerFactory
-        topBannerView = OrdersTopBannerFactory.createOrdersBanner(
-            onTopButtonPressed: { [weak self] in
-            self?.tableView.updateHeaderHeight()
-        }, onDismissButtonPressed: { [weak self] in
-            self?.viewModel.dismissOrdersBanner()
-        }, onGiveFeedbackButtonPressed: { [weak self] in
-            let surveyNavigation = SurveyCoordinatingController(survey: .orderCreation)
-            self?.present(surveyNavigation, animated: true, completion: nil)
-        })
+        topBannerView = createIPPFeedbackTopBanner()
         showTopBannerView()
+    }
+
+    private func createIPPFeedbackTopBanner() -> TopBannerView {
+        let giveIPPFeedbackAction = TopBannerViewModel.ActionButton(title: "Share feedback", action: { _ in
+            self.displayIPPFeedbackBannerSurvey()
+        })
+        let dismissIPPFeedbackAction = TopBannerViewModel.ActionButton(title: "X", action: { _ in
+            self.dismissIPPFeedbackBannerSurvey()
+        })
+        let viewModel = TopBannerViewModel(
+            title: "Let us know what you think",
+            infoText: "Rate your in-person payment experience.",
+            icon: UIImage.gridicon(.crossSmall),
+            isExpanded: true,
+            topButton: .chevron(handler: {}),
+            actionButtons: [giveIPPFeedbackAction, dismissIPPFeedbackAction]
+        )
+        let topBannerView = TopBannerView(viewModel: viewModel)
+        topBannerView.translatesAutoresizingMaskIntoConstraints = false
+        return topBannerView
+    }
+
+    private func displayIPPFeedbackBannerSurvey() {
+        print("displayIPPFeedbackBannerSurvey")
+    }
+
+    private func dismissIPPFeedbackBannerSurvey() {
+        print("dismissIPPFeedbackBannerSurvey")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -794,19 +794,19 @@ private extension OrderListViewController {
     }
 
     private func createIPPFeedbackTopBanner() -> TopBannerView {
-        let giveIPPFeedbackAction = TopBannerViewModel.ActionButton(title: "Share feedback", action: { _ in
+        let shareIPPFeedbackAction = TopBannerViewModel.ActionButton(title: Localization.shareFeedbackButton, action: { _ in
             self.displayIPPFeedbackBannerSurvey()
         })
 
         let viewModel = TopBannerViewModel(
-            title: "Let us know what you think",
-            infoText: "Rate your in-person payment experience.",
+            title: Localization.feedbackBannerTitle,
+            infoText: Localization.feedbackBannerContent,
             icon: UIImage.gridicon(.comment),
             isExpanded: true,
             topButton: .dismiss(handler: {
                 self.dismissIPPFeedbackBannerSurvey()
             }),
-            actionButtons: [giveIPPFeedbackAction]
+            actionButtons: [shareIPPFeedbackAction]
         )
         let topBannerView = TopBannerView(viewModel: viewModel)
         topBannerView.translatesAutoresizingMaskIntoConstraints = false
@@ -839,6 +839,18 @@ private extension OrderListViewController {
                                  comment: "Action to remove filters orders on the placeholder overlay when no orders match the filter on the Order List")
 
         static let markCompleted = NSLocalizedString("Mark Completed", comment: "Title for the swipe order action to mark it as completed")
+
+        static let feedbackBannerTitle = NSLocalizedString("Let us know what you think",
+                                                           comment: "Title of the In-Person Payments feedback banner in the Orders tab"
+        )
+
+        static let feedbackBannerContent = NSLocalizedString("Rate your In-Person Payment experience.",
+                                                             comment: "Content of the In-Person Payments feedback banner in the Orders tab"
+        )
+
+        static let shareFeedbackButton = NSLocalizedString("Share feedback",
+                                                           comment: "Title of the feedback action button on the In-Person Payments feedback banner"
+        )
 
         static func markCompletedNoticeTitle(orderID: Int64) -> String {
             let format = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -797,16 +797,16 @@ private extension OrderListViewController {
         let giveIPPFeedbackAction = TopBannerViewModel.ActionButton(title: "Share feedback", action: { _ in
             self.displayIPPFeedbackBannerSurvey()
         })
-        let dismissIPPFeedbackAction = TopBannerViewModel.ActionButton(title: "X", action: { _ in
-            self.dismissIPPFeedbackBannerSurvey()
-        })
+
         let viewModel = TopBannerViewModel(
             title: "Let us know what you think",
             infoText: "Rate your in-person payment experience.",
-            icon: UIImage.gridicon(.crossSmall),
+            icon: UIImage.gridicon(.comment),
             isExpanded: true,
-            topButton: .chevron(handler: {}),
-            actionButtons: [giveIPPFeedbackAction, dismissIPPFeedbackAction]
+            topButton: .dismiss(handler: {
+                self.dismissIPPFeedbackBannerSurvey()
+            }),
+            actionButtons: [giveIPPFeedbackAction]
         )
         let topBannerView = TopBannerView(viewModel: viewModel)
         topBannerView.translatesAutoresizingMaskIntoConstraints = false
@@ -814,11 +814,13 @@ private extension OrderListViewController {
     }
 
     private func displayIPPFeedbackBannerSurvey() {
-        print("displayIPPFeedbackBannerSurvey")
+        // TODO: Survey will change based on conditions
+        print("Sharing feedback")
     }
 
     private func dismissIPPFeedbackBannerSurvey() {
-        print("dismissIPPFeedbackBannerSurvey")
+        // TODO: Dismissal logic to not show the banner again for X days/never
+        print("Dismissing feedback")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -254,6 +254,8 @@ private extension OrderListViewController {
                     self.setErrorTopBanner()
                 case .orderCreation:
                     self.setOrderCreationTopBanner()
+                case .IPPFeedback:
+                    self.setIPPFeedbackTopBanner()
                 }
             }
             .store(in: &cancellables)
@@ -774,6 +776,22 @@ private extension OrderListViewController {
     ///
     func setOrderCreationTopBanner() {
         topBannerView = OrdersTopBannerFactory.createOrdersBanner(onTopButtonPressed: { [weak self] in
+            self?.tableView.updateHeaderHeight()
+        }, onDismissButtonPressed: { [weak self] in
+            self?.viewModel.dismissOrdersBanner()
+        }, onGiveFeedbackButtonPressed: { [weak self] in
+            let surveyNavigation = SurveyCoordinatingController(survey: .orderCreation)
+            self?.present(surveyNavigation, animated: true, completion: nil)
+        })
+        showTopBannerView()
+    }
+
+    /// Sets the `topBannerView` property to an IPP feedback banner.
+    ///
+    func setIPPFeedbackTopBanner() {
+        // TODO: Implement the specific banner similar to OrdersTopBannerFactory
+        topBannerView = OrdersTopBannerFactory.createOrdersBanner(
+            onTopButtonPressed: { [weak self] in
             self?.tableView.updateHeaderHeight()
         }, onDismissButtonPressed: { [weak self] in
             self?.viewModel.dismissOrdersBanner()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -821,7 +821,7 @@ private extension OrderListViewController {
 
     private func dismissIPPFeedbackBannerSurvey() {
         // TODO: Dismissal logic to not show the banner again for X days/never
-        print("Dismissing feedback")
+        viewModel.dismissIPPFeedbackBanner()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -803,9 +803,7 @@ private extension OrderListViewController {
             infoText: Localization.feedbackBannerContent,
             icon: UIImage.gridicon(.comment),
             isExpanded: true,
-            topButton: .dismiss(handler: {
-                self.dismissIPPFeedbackBannerSurvey()
-            }),
+            topButton: .dismiss(handler: {  }),
             actionButtons: [shareIPPFeedbackAction]
         )
         let topBannerView = TopBannerView(viewModel: viewModel)
@@ -817,11 +815,6 @@ private extension OrderListViewController {
         // TODO: Survey will change based on conditions
         let surveyNavigation = SurveyCoordinatingController(survey: .IPPFeedback)
         self.present(surveyNavigation, animated: true, completion: nil)
-    }
-
-    private func dismissIPPFeedbackBannerSurvey() {
-        // TODO: Dismissal logic to not show the banner again for X days/never
-        viewModel.dismissIPPFeedbackBanner()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -815,7 +815,8 @@ private extension OrderListViewController {
 
     private func displayIPPFeedbackBannerSurvey() {
         // TODO: Survey will change based on conditions
-        print("Sharing feedback")
+        let surveyNavigation = SurveyCoordinatingController(survey: .IPPFeedback)
+        self.present(surveyNavigation, animated: true, completion: nil)
     }
 
     private func dismissIPPFeedbackBannerSurvey() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -134,7 +134,7 @@ final class OrderListViewModel {
     /// If true, no IPP feedback banner will be shown as the user has told us that they are not interested in this information.
     /// It is persisted through app sessions.
     /// 
-    @Published var hideIPPFeedbackBanner: Bool = false
+    @Published var hideIPPFeedbackBanner: Bool = true
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
@@ -176,8 +176,8 @@ final class OrderListViewModel {
         bindTopBannerState()
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
-            loadIPPFeedbackBannerVisibility()
             loadOrdersBannerVisibility()
+            loadIPPFeedbackBannerVisibility()
             fetchIPPTransactions()
         } else {
             loadOrdersBannerVisibility()
@@ -224,7 +224,7 @@ final class OrderListViewModel {
         let action = AppSettingsAction.loadFeedbackVisibility(type: .IPP) { [weak self] result in
             switch result {
             case .success(let visible):
-                self?.hideIPPFeedbackBanner = !visible
+                self?.hideIPPFeedbackBanner = visible
             case .failure(let error):
                 self?.hideIPPFeedbackBanner = true
                 ServiceLocator.crashLogging.logError(error)
@@ -390,8 +390,8 @@ extension OrderListViewModel {
     private func bindTopBannerState() {
         let errorState = $hasErrorLoadingData.removeDuplicates()
 
-        Publishers.CombineLatest3(errorState, $hideOrdersBanners, $hideIPPFeedbackBanner)
-            .map { hasError, hasDismissedOrdersBanners, hasDismissedIPPFeedbackBanner  -> TopBanner in
+        Publishers.CombineLatest3(errorState, $hideIPPFeedbackBanner, $hideOrdersBanners)
+            .map { hasError, hasDismissedIPPFeedbackBanner, hasDismissedOrdersBanners -> TopBanner in
 
                 guard !hasError else {
                     return .error

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -200,7 +200,7 @@ final class OrderListViewModel {
 
     func dismissIPPFeedbackBanner() {
         print("dismiss tapped")
-        let action = AppSettingsAction.updateFeedbackStatus(type: .IPPFeedback, status: .dismissed, onCompletion: { _ in
+        let action = AppSettingsAction.updateFeedbackStatus(type: .IPP, status: .dismissed, onCompletion: { _ in
             self.hideIPPFeedbackBanner = true
             print("hideIPPFeedbackBanner? \(self.hideIPPFeedbackBanner)")
         })
@@ -231,7 +231,7 @@ final class OrderListViewModel {
     }
 
     private func loadIPPFeedbackBannerVisibility() {
-        let action = AppSettingsAction.loadFeedbackVisibility(type: .IPPFeedback) { [weak self] result in
+        let action = AppSettingsAction.loadFeedbackVisibility(type: .IPP) { [weak self] result in
             switch result {
             case .success(let visible):
                 self?.hideIPPFeedbackBanner = !visible

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -200,13 +200,6 @@ final class OrderListViewModel {
         stores.dispatch(action)
     }
 
-    func dismissIPPFeedbackBanner() {
-        let action = AppSettingsAction.updateFeedbackStatus(type: .IPP, status: .dismissed, onCompletion: { _ in
-            self.hideIPPFeedbackBanner = true
-        })
-        stores.dispatch(action)
-    }
-
     /// Starts the snapshotsProvider, logging any errors.
     private func startReceivingSnapshots() {
         do {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -199,10 +199,8 @@ final class OrderListViewModel {
     }
 
     func dismissIPPFeedbackBanner() {
-        print("dismiss tapped")
         let action = AppSettingsAction.updateFeedbackStatus(type: .IPP, status: .dismissed, onCompletion: { _ in
             self.hideIPPFeedbackBanner = true
-            print("hideIPPFeedbackBanner? \(self.hideIPPFeedbackBanner)")
         })
         stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -150,10 +150,7 @@ final class OrderListViewModel {
         self.filters = filters
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) && !hideIPPFeedbackBanner {
-            hideOrdersBanners = false
             topBanner = .IPPFeedback
-        } else {
-            hideOrdersBanners = true
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -131,6 +131,11 @@ final class OrderListViewModel {
     ///
     @Published var hideOrdersBanners: Bool = false // TODO: Switch back to true
 
+    /// If true, no IPP feedback banner will be shown as the user has told us that they are not interested in this information.
+    /// It is persisted through app sessions.
+    /// 
+    @Published var hideIPPFeedbackBanner: Bool = false
+
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -191,6 +196,15 @@ final class OrderListViewModel {
         stores.dispatch(action)
     }
 
+    func dismissIPPFeedbackBanner() {
+        print("dismiss tapped")
+        let action = AppSettingsAction.updateFeedbackStatus(type: .IPPFeedback, status: .dismissed, onCompletion: { _ in
+            self.hideIPPFeedbackBanner = true
+            print("hideIPPFeedbackBanner? \(self.hideIPPFeedbackBanner)")
+        })
+        stores.dispatch(action)
+    }
+
     /// Starts the snapshotsProvider, logging any errors.
     private func startReceivingSnapshots() {
         do {
@@ -212,10 +226,6 @@ final class OrderListViewModel {
         }
 
         stores.dispatch(action)
-    }
-
-    private func loadIPPFeedbackBannerVisibility() {
-        // TODO: Implement SettingsAction to remember the merchant selection
     }
 
     @objc private func handleAppDeactivation() {

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -68,6 +68,7 @@ extension SurveyViewController {
         case addOnsI1
         case orderCreation
         case couponManagement
+        case IPPFeedback
 
         fileprivate var url: URL {
             switch self {
@@ -102,6 +103,11 @@ extension SurveyViewController {
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
+            case .IPPFeedback:
+                return WooConstants.URLs.IPPFeedback
+                    .asURL()
+                    .tagPlatform("ios")
+                    .tagAppVersion(Bundle.main.bundleVersion())
             }
         }
 
@@ -109,7 +115,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return Localization.title
-            case .productsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement:
+            case .productsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement, .IPPFeedback:
                 return Localization.giveFeedback
             }
         }
@@ -117,7 +123,7 @@ extension SurveyViewController {
         /// The corresponding `FeedbackContext` for event tracking purposes.
         var feedbackContextForEvents: WooAnalyticsEvent.FeedbackContext {
             switch self {
-            case .inAppFeedback:
+            case .inAppFeedback, .IPPFeedback:
                 return .general
             case .productsFeedback:
                 return .productsGeneral

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -275,6 +275,7 @@ final class OrderListViewModelTests: XCTestCase {
 
         // When
         viewModel.activate()
+        viewModel.hideIPPFeedbackBanner = false
 
         // Then
         waitUntil {
@@ -323,6 +324,7 @@ final class OrderListViewModelTests: XCTestCase {
 
         // Then
         if isIPPFeatureFlagEnabled {
+            viewModel.hideIPPFeedbackBanner = false
             waitUntil {
                 viewModel.topBanner == .IPPFeedback
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -239,7 +239,7 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertFalse(resynchronizeRequested)
     }
 
-    func test_when_having_no_error__and_orders_banner_should_not_be_shown_shows_nothing() {
+    func test_when_having_no_error_and_orders_banner_should_not_be_shown_shows_nothing() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
@@ -255,8 +255,14 @@ final class OrderListViewModelTests: XCTestCase {
         viewModel.activate()
 
         // Then
-        waitUntil {
-            viewModel.topBanner == .none
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
+            waitUntil {
+                viewModel.topBanner == .IPPFeedback
+            }
+        } else {
+            waitUntil {
+                viewModel.topBanner == .none
+            }
         }
     }
 
@@ -298,8 +304,14 @@ final class OrderListViewModelTests: XCTestCase {
         viewModel.activate()
 
         // Then
-        waitUntil {
-            viewModel.topBanner == .none
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
+            waitUntil {
+                viewModel.topBanner == .IPPFeedback
+            }
+        } else {
+            waitUntil {
+                viewModel.topBanner == .none
+            }
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -239,6 +239,28 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertFalse(resynchronizeRequested)
     }
 
+    func test_when_having_no_error_and_orders_banner_should_not_be_shown_shows_nothing() {
+        // Given
+        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .loadFeedbackVisibility(_, onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+
+        // When
+        viewModel.activate()
+        viewModel.hideIPPFeedbackBanner = true
+
+        // Then
+        waitUntil {
+            viewModel.topBanner == .none
+        }
+    }
+
     func test_when_having_no_error_and_IPP_banner_should_be_shown_shows_IPP_banner() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
@@ -260,34 +282,13 @@ final class OrderListViewModelTests: XCTestCase {
         }
     }
 
-    func test_when_having_no_error_and_IPP_banner_should_not_be_shown_and_orders_banner_should_be_shown_shows_orders_banner() {
-        // Given
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .loadFeedbackVisibility(.IPP, onCompletion):
-                onCompletion(.success(false))
-            default:
-                break
-            }
-        }
-
-        // When
-        viewModel.activate()
-
-        // Then
-        waitUntil {
-            viewModel.topBanner == .orderCreation
-        }
-    }
-
-    func test_when_having_no_error_and_orders_banner_should_not_be_shown_shows_nothing() {
+    func test_when_having_no_error_and_orders_banner_should_be_shown_shows_orders_banner() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case let .loadFeedbackVisibility(_, onCompletion):
-                onCompletion(.success(false))
+                onCompletion(.success(true))
             default:
                 break
             }
@@ -295,10 +296,11 @@ final class OrderListViewModelTests: XCTestCase {
 
         // When
         viewModel.activate()
+        viewModel.hideIPPFeedbackBanner = true
 
         // Then
         waitUntil {
-            viewModel.topBanner == .none
+            viewModel.topBanner == .orderCreation
         }
     }
 
@@ -367,24 +369,18 @@ final class OrderListViewModelTests: XCTestCase {
         }
     }
 
-    func test_dismissing_orders_banners_does_not_show_banners() {
+    func test_dismissing_banners_does_not_show_banners() {
         // Given
-        let isIPPFeatureFlagEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner)
         let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
 
         // When
         viewModel.activate()
+        viewModel.hideIPPFeedbackBanner = true
         viewModel.hideOrdersBanners = true
 
         // Then
-        if isIPPFeatureFlagEnabled {
-            waitUntil {
-                viewModel.topBanner == .IPPFeedback
-            }
-        } else {
-            waitUntil {
-                viewModel.topBanner == .none
-            }
+        waitUntil {
+            viewModel.topBanner == .none
         }
     }
 

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -37,7 +37,7 @@ struct InAppFeedbackCardVisibilityUseCase {
         switch feedbackType {
         case .general:
             return try shouldGeneralFeedbackBeVisible(currentDate: currentDate)
-        case .shippingLabelsRelease3, .couponManagement, .ordersCreation, .IPPFeedback:
+        case .shippingLabelsRelease3, .couponManagement, .ordersCreation, .IPP:
             return settings.feedbackStatus(of: feedbackType) == .pending
         }
     }

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -37,7 +37,7 @@ struct InAppFeedbackCardVisibilityUseCase {
         switch feedbackType {
         case .general:
             return try shouldGeneralFeedbackBeVisible(currentDate: currentDate)
-        case .shippingLabelsRelease3, .couponManagement, .ordersCreation:
+        case .shippingLabelsRelease3, .couponManagement, .ordersCreation, .IPPFeedback:
             return settings.feedbackStatus(of: feedbackType) == .pending
         }
     }


### PR DESCRIPTION
Closes: #8636 
Part of: https://github.com/woocommerce/woocommerce-ios/issues/8530

## Description

This PR adds the in-app feedback banner to the Order view, as well as the buttons to launch a survey and dismiss the banner.

At the moment the banner is not dismissible. Dismiss will be part of a [different PR](https://github.com/woocommerce/woocommerce-ios/issues/8589).

## Changes
- Adds a `.IPP` case as new `FeedbackType`
- Upon configuring `OrderListViewController`, we set the existing top banner view (generally used to display the Order Creation banner, or an error) to a new IPP banner survey. This uses the existing `TopBannerView` and `TopBannerViewModel` components.
- We have a new Publisher `hideIPPFeedbackBanner`, so we can listen to changes and set priorities on the different banners that should display in the view.
- The banner has an `ActionButton` that will launch the feedback survey via the existing `SurveyCoordinatingController` component.

## Testing instructions

1. Go to Menu > Orders > See the banner at the top of the screen
2. Tap "Share Feedback", a WebView showing a survey form will shop up. Scroll down and tap "Finish Survey", a "Feedback Sent" view will be shown and you'll be redirected to the Orders page.

## Screenshots
![Simulator Screen Recording - iPhone 11 Pro - 2023-01-16 at 12 40 23](https://user-images.githubusercontent.com/3812076/212600007-00e6d0de-bff9-4cf7-8b0e-2a52aa45ed1d.gif)


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
