### PR TITLE
Migrate the telemetry endpoint to use REST API

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -707,6 +707,7 @@
 		DE4F2A3F29750EF400B0701C /* inbox-note-list-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE4F2A3D29750EF400B0701C /* inbox-note-list-without-data.json */; };
 		DE4F2A4029750EF400B0701C /* inbox-note-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE4F2A3E29750EF400B0701C /* inbox-note-without-data.json */; };
 		DE4F2A4229751EAE00B0701C /* setting-coupon-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE4F2A4129751EAE00B0701C /* setting-coupon-without-data.json */; };
+		DE4F2A442975684900B0701C /* site-api-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE4F2A432975684900B0701C /* site-api-without-data.json */; };
 		DE50295928C5BD0200551736 /* JetpackUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295828C5BD0200551736 /* JetpackUser.swift */; };
 		DE50295B28C5F99700551736 /* DotcomUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295A28C5F99700551736 /* DotcomUser.swift */; };
 		DE50295D28C6068B00551736 /* JetpackUserMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295C28C6068B00551736 /* JetpackUserMapper.swift */; };
@@ -1534,6 +1535,7 @@
 		DE4F2A3D29750EF400B0701C /* inbox-note-list-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "inbox-note-list-without-data.json"; sourceTree = "<group>"; };
 		DE4F2A3E29750EF400B0701C /* inbox-note-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "inbox-note-without-data.json"; sourceTree = "<group>"; };
 		DE4F2A4129751EAE00B0701C /* setting-coupon-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-coupon-without-data.json"; sourceTree = "<group>"; };
+		DE4F2A432975684900B0701C /* site-api-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-api-without-data.json"; sourceTree = "<group>"; };
 		DE50295828C5BD0200551736 /* JetpackUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackUser.swift; sourceTree = "<group>"; };
 		DE50295A28C5F99700551736 /* DotcomUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotcomUser.swift; sourceTree = "<group>"; };
 		DE50295C28C6068B00551736 /* JetpackUserMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackUserMapper.swift; sourceTree = "<group>"; };
@@ -2159,6 +2161,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DE4F2A432975684900B0701C /* site-api-without-data.json */,
 				DE4F2A3D29750EF400B0701C /* inbox-note-list-without-data.json */,
 				DE4F2A3E29750EF400B0701C /* inbox-note-without-data.json */,
 				DE4F2A4129751EAE00B0701C /* setting-coupon-without-data.json */,
@@ -3087,6 +3090,7 @@
 				4515281F257A89B90076B03C /* product-attribute-create.json in Resources */,
 				CEF88DAF233E9F7E00BED485 /* order-details-partially-refunded.json in Resources */,
 				D823D9032237450A00C90817 /* shipment_tracking_new.json in Resources */,
+				DE4F2A442975684900B0701C /* site-api-without-data.json in Resources */,
 				DE42F96B296BC23800D514C2 /* customer-without-data.json in Resources */,
 				EE80A24729547F8B003591E4 /* coupons-all-without-data.json in Resources */,
 				7412A8F021B6E416005D182A /* report-orders.json in Resources */,

--- a/Networking/Networking/Mapper/SiteAPIMapper.swift
+++ b/Networking/Networking/Mapper/SiteAPIMapper.swift
@@ -19,7 +19,11 @@ struct SiteAPIMapper: Mapper {
             .siteID: siteID
         ]
 
-        return try decoder.decode(SiteAPIEnvelope.self, from: response).siteAPI
+        do {
+            return try decoder.decode(SiteAPIEnvelope.self, from: response).siteAPI
+        } catch {
+            return try decoder.decode(SiteAPI.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Remote/SiteAPIRemote.swift
+++ b/Networking/Networking/Remote/SiteAPIRemote.swift
@@ -15,7 +15,12 @@ public class SiteAPIRemote: Remote {
     public func loadAPIInformation(for siteID: Int64, completion: @escaping (Result<SiteAPI, Error>) -> Void) {
         let path = String()
         let parameters = [ParameterKeys.fields: ParameterValues.fieldValues]
-        let request = JetpackRequest(wooApiVersion: .none, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .none,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
         let mapper = SiteAPIMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/Networking/Remote/TelemetryRemote.swift
+++ b/Networking/Networking/Remote/TelemetryRemote.swift
@@ -16,7 +16,12 @@ public class TelemetryRemote: Remote {
     public func sendTelemetry(for siteID: Int64, versionString: String, completion: @escaping (Result<Void, Error>) -> Void) {
         let path = "tracker"
         let parameters = ["platform": "ios", "version": versionString]
-        let request = JetpackRequest(wooApiVersion: .wcTelemetry, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .wcTelemetry,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
         let mapper = IgnoringResponseMapper()
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/NetworkingTests/Mapper/SiteAPIMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteAPIMapperTests.swift
@@ -32,6 +32,18 @@ class SiteAPIMapperTests: XCTestCase {
 
     /// Verifies the SiteSetting fields are parsed correctly.
     ///
+    func test_SiteSetting_fields_are_properly_parsed_when_response_has_no_data_envelope() {
+        let apiSettings = mapLoadSiteAPIResponseWithoutDataEnvelope()
+
+        XCTAssertNotNil(apiSettings)
+        XCTAssertEqual(apiSettings?.siteID, dummySiteID)
+        XCTAssertNotNil(apiSettings?.namespaces)
+        XCTAssertEqual(apiSettings?.namespaces, dummyNamespaces)
+        XCTAssertEqual(apiSettings?.highestWooVersion, WooAPIVersion.mark3)
+    }
+
+    /// Verifies the SiteSetting fields are parsed correctly.
+    ///
     func test_broken_SiteSetting_fields_are_properly_parsed() {
         let apiSettings = mapLoadBrokenSiteAPIResponse()
 
@@ -62,6 +74,12 @@ private extension SiteAPIMapperTests {
     ///
     func mapLoadSiteAPIResponse() -> SiteAPI? {
         return mapSiteAPIData(from: "site-api")
+    }
+
+    /// Returns the SiteAPIMapper output upon receiving `site-api-without-data`
+    ///
+    func mapLoadSiteAPIResponseWithoutDataEnvelope() -> SiteAPI? {
+        return mapSiteAPIData(from: "site-api-without-data")
     }
 
     /// Returns the SiteAPIMapper output upon receiving `site-api`

--- a/Networking/NetworkingTests/Remote/TelemetryRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/TelemetryRemoteTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 /// TelemetryRemote Unit Tests
 ///
-class TelemetryRemoteTests: XCTestCase {
+final class TelemetryRemoteTests: XCTestCase {
 
     /// Dummy Network Wrapper
     ///
@@ -44,6 +44,24 @@ class TelemetryRemoteTests: XCTestCase {
         // Given
         let remote = TelemetryRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "tracker", filename: "generic_success_data")
+
+        // When
+        let result: Result<Void, Error> = waitFor { promise in
+            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2") { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+    }
+
+    /// Verifies that sendTelemetry properly accepts non-null response without data envelope.
+    ///
+    func test_sendTelemetry_properly_accepts_non_null_response_without_data_envelope() throws {
+        // Given
+        let remote = TelemetryRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "tracker", filename: "generic_success")
 
         // When
         let result: Result<Void, Error> = waitFor { promise in

--- a/Networking/NetworkingTests/Responses/site-api-without-data.json
+++ b/Networking/NetworkingTests/Responses/site-api-without-data.json
@@ -1,0 +1,21 @@
+{
+    "namespaces": [
+        "oembed\/1.0",
+        "akismet\/v1",
+        "jetpack\/v4",
+        "wpcom\/v2",
+        "wc\/v1",
+        "wc\/v2",
+        "wc\/v3",
+        "wc-pb\/v3",
+        "wp\/v2"
+    ],
+    "authentication": [],
+    "_links": {
+        "help": [
+            {
+                "href": "http:\/\/v2.wp-api.org\/"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8646
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR continues the REST API migration work by enabling the send telemetry endpoint to use the REST API.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Pre-requisite: due to a rate-limit issue with Pressable sites, create a JN site to ensure that testing is smooth for now.
- Enable feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address and enter the address of your self-hosted site.
- Proceed to log in with site credentials.
- When the login succeeds, you should see the home screen.
- Suppose your test store has Woo version >= 5.9.0, you should be able to see a log in the Xcode console: `Successfully sent telemetry for siteID` (unless throttled).
- Please feel free to install Woo version < 5.9.0 and repeat the steps above. Telemetry API is not available for these versions so the request should not be made.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
