### PR TITLE
REST API: Migrate Stripe and WCPay endpoints

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -715,6 +715,7 @@
 		DE50296328C609DE00551736 /* jetpack-user-not-connected.json in Resources */ = {isa = PBXBuildFile; fileRef = DE50296228C609DE00551736 /* jetpack-user-not-connected.json */; };
 		DE50296528C60A8000551736 /* JetpackUserMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50296428C60A8000551736 /* JetpackUserMapperTests.swift */; };
 		DE5CA111288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = DE5CA110288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json */; };
+		DE66C5572976913C00DAA978 /* wcpay-charge-card-present-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE66C5562976913C00DAA978 /* wcpay-charge-card-present-without-data.json */; };
 		DE6F308727966FEF004E1C9A /* CouponReportListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */; };
 		DE74F29A27E08F5A0002FE59 /* SiteSettingMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */; };
 		DE74F29C27E0A1D00002FE59 /* setting-coupon.json in Resources */ = {isa = PBXBuildFile; fileRef = DE74F29B27E0A1D00002FE59 /* setting-coupon.json */; };
@@ -1543,6 +1544,7 @@
 		DE50296228C609DE00551736 /* jetpack-user-not-connected.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "jetpack-user-not-connected.json"; sourceTree = "<group>"; };
 		DE50296428C60A8000551736 /* JetpackUserMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackUserMapperTests.swift; sourceTree = "<group>"; };
 		DE5CA110288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-malformed-variations-and-image-alt.json"; sourceTree = "<group>"; };
+		DE66C5562976913C00DAA978 /* wcpay-charge-card-present-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wcpay-charge-card-present-without-data.json"; sourceTree = "<group>"; };
 		DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapperTests.swift; sourceTree = "<group>"; };
 		DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSettingMapper.swift; sourceTree = "<group>"; };
 		DE74F29B27E0A1D00002FE59 /* setting-coupon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-coupon.json"; sourceTree = "<group>"; };
@@ -2161,6 +2163,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DE66C5562976913C00DAA978 /* wcpay-charge-card-present-without-data.json */,
 				DE4F2A432975684900B0701C /* site-api-without-data.json */,
 				DE4F2A3D29750EF400B0701C /* inbox-note-list-without-data.json */,
 				DE4F2A3E29750EF400B0701C /* inbox-note-without-data.json */,
@@ -3025,6 +3028,7 @@
 				31A451CC27863A2E00FE81AA /* stripe-account-rejected-fraud.json in Resources */,
 				31A451D827863A2E00FE81AA /* stripe-account-restricted-overdue.json in Resources */,
 				D865CE69278CA245002C8520 /* stripe-payment-intent-unknown-status.json in Resources */,
+				DE66C5572976913C00DAA978 /* wcpay-charge-card-present-without-data.json in Resources */,
 				DE42F9652967F34400D514C2 /* refund-single-without-data.json in Resources */,
 				0205021C27C86B9700FB1C6B /* inbox-note-without-isRead.json in Resources */,
 				24F98C622502EFF600F49B68 /* feature-flags-load-all.json in Resources */,

--- a/Networking/Networking/Mapper/ReaderConnectionTokenMapper.swift
+++ b/Networking/Networking/Mapper/ReaderConnectionTokenMapper.swift
@@ -7,7 +7,11 @@ struct ReaderConnectionTokenMapper: Mapper {
     func map(response: Data) throws -> ReaderConnectionToken {
         let decoder = JSONDecoder()
 
-        return try decoder.decode(ReaderConnectionTokenEnvelope.self, from: response).token
+        do {
+            return try decoder.decode(ReaderConnectionTokenEnvelope.self, from: response).token
+        } catch {
+            return try decoder.decode(ReaderConnectionToken.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Mapper/RemotePaymentIntentMapper.swift
+++ b/Networking/Networking/Mapper/RemotePaymentIntentMapper.swift
@@ -9,7 +9,11 @@ struct RemotePaymentIntentMapper: Mapper {
     func map(response: Data) throws -> RemotePaymentIntent {
         let decoder = JSONDecoder()
 
-        return try decoder.decode(WCPayPaymentIntentEnvelope.self, from: response).paymentIntent
+        do {
+            return try decoder.decode(WCPayPaymentIntentEnvelope.self, from: response).paymentIntent
+        } catch {
+            return try decoder.decode(RemotePaymentIntent.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Mapper/RemoteReaderLocationMapper.swift
+++ b/Networking/Networking/Mapper/RemoteReaderLocationMapper.swift
@@ -9,7 +9,11 @@ struct RemoteReaderLocationMapper: Mapper {
     func map(response: Data) throws -> RemoteReaderLocation {
         let decoder = JSONDecoder()
 
-        return try decoder.decode(RemoteReaderLocationEnvelope.self, from: response).location
+        do {
+            return try decoder.decode(RemoteReaderLocationEnvelope.self, from: response).location
+        } catch {
+            return try decoder.decode(RemoteReaderLocation.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Mapper/StripeAccountMapper.swift
+++ b/Networking/Networking/Mapper/StripeAccountMapper.swift
@@ -14,7 +14,11 @@ struct StripeAccountMapper: Mapper {
         /// can cross that bridge when we need those decoded.
         decoder.dateDecodingStrategy = .secondsSince1970
 
-        return try decoder.decode(StripeAccountEnvelope.self, from: response).account
+        do {
+            return try decoder.decode(StripeAccountEnvelope.self, from: response).account
+        } catch {
+            return try decoder.decode(StripeAccount.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Mapper/WCPayAccountMapper.swift
+++ b/Networking/Networking/Mapper/WCPayAccountMapper.swift
@@ -18,9 +18,15 @@ struct WCPayAccountMapper: Mapper {
         /// indicating that the plugin was active but the merchant had not on-boarded (and therefore has no account.)
         if let _ = try? decoder.decode(WCPayNullAccountEnvelope.self, from: response) {
             return WCPayAccount.noAccount
+        } else if let _ = try? decoder.decode([String].self, from: response) {
+            return WCPayAccount.noAccount
         }
 
-        return try decoder.decode(WCPayAccountEnvelope.self, from: response).account
+        do {
+            return try decoder.decode(WCPayAccountEnvelope.self, from: response).account
+        } catch {
+            return try decoder.decode(WCPayAccount.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Mapper/WCPayChargeMapper.swift
+++ b/Networking/Networking/Mapper/WCPayChargeMapper.swift
@@ -16,7 +16,11 @@ struct WCPayChargeMapper: Mapper {
         /// can cross that bridge when we need those decoded.
         decoder.dateDecodingStrategy = .secondsSince1970
 
-        return try decoder.decode(WCPayChargeEnvelope.self, from: response).charge
+        do {
+            return try decoder.decode(WCPayChargeEnvelope.self, from: response).charge
+        } catch {
+            return try decoder.decode(WCPayCharge.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Model/WordPressSite.swift
+++ b/Networking/Networking/Model/WordPressSite.swift
@@ -42,6 +42,32 @@ public struct WordPressSite: Decodable, Equatable {
         self.gmtOffset = gmtOffset
         self.namespaces = namespaces
     }
+
+    /// Decodable Conformance.
+    ///
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let name = try container.decode(String.self, forKey: .name)
+        let description = try container.decode(String.self, forKey: .description)
+        let url = try container.decode(String.self, forKey: .url)
+        let timezone = try container.decode(String.self, forKey: .timezone)
+        let gmtOffset: String = try {
+            do {
+                return try container.decode(String.self, forKey: .gmtOffset)
+            } catch {
+                let double = try container.decode(Double.self, forKey: .gmtOffset)
+                return double.description
+            }
+        }()
+        let namespaces = try container.decode([String].self, forKey: .namespaces)
+
+        self.init(name: name,
+                  description: description,
+                  url: url,
+                  timezone: timezone,
+                  gmtOffset: gmtOffset,
+                  namespaces: namespaces)
+    }
 }
 
 public extension WordPressSite {
@@ -79,7 +105,7 @@ private extension WordPressSite {
     }
 
     enum Constants {
-        static let adminPath = "/wp-admin"
+        static let adminPath = "/wp-admin/"
         static let loginPath = "/wp-login.php"
         static let wooNameSpace = "wc/"
     }

--- a/Networking/Networking/Remote/StripeRemote.swift
+++ b/Networking/Networking/Remote/StripeRemote.swift
@@ -12,7 +12,12 @@ public class StripeRemote: Remote {
                             completion: @escaping (Result<StripeAccount, Error>) -> Void) {
         let parameters = [AccountParameterKeys.fields: AccountParameterValues.fieldValues]
 
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: Path.accounts, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Path.accounts,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
 
         let mapper = StripeAccountMapper()
 
@@ -36,7 +41,12 @@ public class StripeRemote: Remote {
             CaptureOrderPaymentKeys.paymentIntentID: paymentIntentID
         ]
 
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
 
         let mapper = RemotePaymentIntentMapper()
 
@@ -53,7 +63,11 @@ extension StripeRemote {
     ///   - completion: Closure to be executed upon completion.
     public func loadConnectionToken(for siteID: Int64,
                                     completion: @escaping(Result<ReaderConnectionToken, Error>) -> Void) {
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: Path.connectionTokens)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: Path.connectionTokens,
+                                     availableAsRESTRequest: true)
 
         let mapper = ReaderConnectionTokenMapper()
 
@@ -68,7 +82,12 @@ extension StripeRemote {
     ///
     public func loadDefaultReaderLocation(for siteID: Int64,
                                           onCompletion: @escaping (Result<RemoteReaderLocation, Error>) -> Void) {
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: Path.locations, parameters: [:])
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Path.locations,
+                                     parameters: [:],
+                                     availableAsRESTRequest: true)
 
         let mapper = RemoteReaderLocationMapper()
 

--- a/Networking/Networking/Remote/WCPayRemote.swift
+++ b/Networking/Networking/Remote/WCPayRemote.swift
@@ -12,7 +12,12 @@ public class WCPayRemote: Remote {
                             completion: @escaping (Result<WCPayAccount, Error>) -> Void) {
         let parameters = [AccountParameterKeys.fields: AccountParameterValues.fieldValues]
 
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: Path.accounts, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Path.accounts,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
 
         let mapper = WCPayAccountMapper()
 
@@ -34,7 +39,12 @@ public class WCPayRemote: Remote {
             CaptureOrderPaymentKeys.paymentIntentID: paymentIntentID
         ]
 
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
 
         let mapper = RemotePaymentIntentMapper()
 
@@ -52,7 +62,12 @@ public class WCPayRemote: Remote {
                             completion: @escaping (Result<WCPayCharge, Error>) -> Void) {
         let path = "\(Path.charges)/\(chargeID)"
 
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: [:])
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: [:],
+                                     availableAsRESTRequest: true)
 
         let mapper = WCPayChargeMapper(siteID: siteID)
 
@@ -69,7 +84,11 @@ extension WCPayRemote {
     ///   - completion: Closure to be executed upon completion.
     public func loadConnectionToken(for siteID: Int64,
                                     completion: @escaping(Result<ReaderConnectionToken, Error>) -> Void) {
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: Path.connectionTokens)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: Path.connectionTokens,
+                                     availableAsRESTRequest: true)
 
         let mapper = ReaderConnectionTokenMapper()
 
@@ -84,7 +103,12 @@ extension WCPayRemote {
     ///
     public func loadDefaultReaderLocation(for siteID: Int64,
                                           onCompletion: @escaping (Result<RemoteReaderLocation, Error>) -> Void) {
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: Path.locations, parameters: [:])
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Path.locations,
+                                     parameters: [:],
+                                     availableAsRESTRequest: true)
 
         let mapper = RemoteReaderLocationMapper()
 

--- a/Networking/NetworkingTests/Mapper/WCPayChargeMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/WCPayChargeMapperTests.swift
@@ -8,8 +8,15 @@ class WCPayChargeMapperTests: XCTestCase {
 
     /// Verifies that the WCPayCharge is parsed.
     ///
-    func test_WCPayCharge_map_parses_all_coupons_in_response() throws {
+    func test_WCPayCharge_map_parses_data_in_response() throws {
         let wcpayCharge = try mapRetrieveWCPayChargeResponse()
+        XCTAssertNotNil(wcpayCharge)
+    }
+
+    /// Verifies that the WCPayCharge is parsed.
+    ///
+    func test_WCPayCharge_map_parses_data_in_response_without_data_envelope() throws {
+        let wcpayCharge = try mapRetrieveWCPayChargeResponse(responseName: .cardPresentWithoutDataEnvelope)
         XCTAssertNotNil(wcpayCharge)
     }
 
@@ -173,6 +180,7 @@ private extension WCPayChargeMapperTests {
 
     enum ChargeResponse: String {
         case cardPresent = "wcpay-charge-card-present"
+        case cardPresentWithoutDataEnvelope = "wcpay-charge-card-present-without-data"
         case cardPresentMinimal = "wcpay-charge-card-present-minimal"
         case card = "wcpay-charge-card"
         case interacPresent = "wcpay-charge-interac-present"

--- a/Networking/NetworkingTests/Responses/wcpay-charge-card-present-without-data.json
+++ b/Networking/NetworkingTests/Responses/wcpay-charge-card-present-without-data.json
@@ -1,0 +1,155 @@
+{
+    "id": "ch_3KMVap2EdyGr1FMV1uKJEWtg",
+    "object": "charge",
+    "amount": 1800,
+    "amount_captured": 1800,
+    "amount_refunded": 0,
+    "application": "ca_Ex84e31yMTLaNU5ozQvi5woLclpIDVpX",
+    "application_fee": "fee_1KMVaw2EdyGr1FMVkom8DN98",
+    "application_fee_amount": 57,
+    "authorization_code": "123456",
+    "balance_transaction": {
+        "id": "txn_3KMVap2EdyGr1FMV1M2Xw1C4",
+        "object": "balance_transaction",
+        "amount": 1800,
+        "available_on": 1643846400,
+        "created": 1643280770,
+        "currency": "usd",
+        "description": "In-Person Payment for Order #205 for My WordPress Site",
+        "exchange_rate": null,
+        "fee": 57,
+        "fee_details": [
+            {
+                "amount": 57,
+                "application": "ca_Ex84e31yMTLaNU5ozQvi5woLclpIDVpX",
+                "currency": "usd",
+                "description": "WooCommerce Payments application fee",
+                "type": "application_fee"
+            }
+        ],
+        "net": 1743,
+        "reporting_category": "charge",
+        "source": "ch_3KMVap2EdyGr1FMV1uKJEWtg",
+        "status": "pending",
+        "type": "charge"
+    },
+    "billing_details": {
+        "address": {
+            "city": null,
+            "country": null,
+            "line1": null,
+            "line2": null,
+            "postal_code": null,
+            "state": null
+        },
+        "email": null,
+        "name": null,
+        "phone": null,
+        "formatted_address": ""
+    },
+    "calculated_statement_descriptor": "AwesomeStore",
+    "captured": true,
+    "created": 1643280767,
+    "currency": "usd",
+    "customer": "cus_L2amf96J6ksaTQ",
+    "description": "In-Person Payment for Order #205 for My WordPress Site",
+    "destination": null,
+    "dispute": null,
+    "disputed": false,
+    "failure_code": null,
+    "failure_message": null,
+    "fraud_details": [],
+    "invoice": null,
+    "level3": {
+        "customer_reference": "205",
+        "line_items": [
+            {
+                "discount_amount": 0,
+                "product_code": "simple-payme",
+                "product_description": "Simple Payments",
+                "quantity": 1,
+                "tax_amount": 0,
+                "unit_cost": 1800
+            }
+        ],
+        "merchant_reference": "205",
+        "shipping_amount": 0,
+        "shipping_from_zip": "85120"
+    },
+    "livemode": false,
+    "metadata": {
+        "order_id": "205",
+        "payment_type": "single",
+        "paymentintent.storename": "My WordPress Site",
+        "reader_ID": "STRM26138002546",
+        "reader_model": "STRIPE_M2",
+        "site_url": "https:\/\/store.example.com"
+    },
+    "on_behalf_of": null,
+    "order": {
+        "number": "205",
+        "url": "https:\/\/store.example.com\/wp-admin\/post.php?post=205&action=edit",
+        "customer_url": "admin.php?page=wc-admin&path=\/customers&filter=single_customer&customers=0",
+        "subscriptions": []
+    },
+    "outcome": {
+        "network_status": "approved_by_network",
+        "reason": null,
+        "risk_level": "not_assessed",
+        "seller_message": "Payment complete.",
+        "type": "authorized"
+    },
+    "paid": true,
+    "payment_intent": "pi_3KMVap2EdyGr1FMV16atNgK9",
+    "payment_method": "pm_1KMVas2EdyGr1FMVnleuPovE",
+    "payment_method_details": {
+        "card_present": {
+            "amount_authorized": 1800,
+            "brand": "visa",
+            "cardholder_name": "CARDHOLDER\/VISA",
+            "country": "US",
+            "emv_auth_data": "8A023030",
+            "exp_month": 3,
+            "exp_year": 2023,
+            "fingerprint": "gXsIWYqS9BLUBw0c",
+            "funding": "credit",
+            "generated_card": "pm_1KMVas2EdyGr1FMVa2Zzy6lj",
+            "last4": "9969",
+            "network": "visa",
+            "overcapture_supported": false,
+            "read_method": "contactless_emv",
+            "receipt": {
+                "account_type": "credit",
+                "application_cryptogram": "6B75F6DE4A78CD0A",
+                "application_preferred_name": "Stripe Credit",
+                "authorization_code": null,
+                "authorization_response_code": "3030",
+                "cardholder_verification_method": "approval",
+                "dedicated_file_name": "A000000003101001",
+                "terminal_verification_results": "0000000000",
+                "transaction_status_information": "0000"
+            }
+        },
+        "type": "card_present"
+    },
+    "receipt_email": null,
+    "receipt_number": null,
+    "receipt_url": "https:\/\/pay.stripe.com\/receipts\/acct_1Jaefx2EdyGr1FMV\/ch_3KMVap2EdyGr1FMV1uKJEWtg\/rcpt_L2amKKvKwznzyj7VprDFvjt6LVfqpsN",
+    "refunded": false,
+    "refunds": {
+        "object": "list",
+        "data": [],
+        "has_more": false,
+        "total_count": 0,
+        "url": "\/v1\/charges\/ch_3KMVap2EdyGr1FMV1uKJEWtg\/refunds"
+    },
+    "review": null,
+    "shipping": null,
+    "source": null,
+    "source_transfer": null,
+    "statement_descriptor": "AwesomeStore",
+    "statement_descriptor_suffix": null,
+    "status": "succeeded",
+    "transfer_data": null,
+    "transfer_group": null
+}

--- a/Yosemite/YosemiteTests/Stores/WordPressSiteStore.swift
+++ b/Yosemite/YosemiteTests/Stores/WordPressSiteStore.swift
@@ -41,7 +41,7 @@ final class WordPressSiteStoreTests: XCTestCase {
         XCTAssertEqual(site.timezone, "")
         XCTAssertEqual(site.siteID, -1)
         XCTAssertEqual(site.gmtOffset, 0)
-        XCTAssertEqual(site.adminURL, "https://test.com/wp-admin")
+        XCTAssertEqual(site.adminURL, "https://test.com/wp-admin/")
         XCTAssertEqual(site.loginURL, "https://test.com/wp-login.php")
         XCTAssertFalse(site.isWooCommerceActive)
         XCTAssertFalse(site.isJetpackConnected)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8648 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR enables WCPay and Stripe endpoints to use REST API and application password authentication. Related mappers are also updated to parse contents without the data envelope.

Also: `WordPressSite` was updated to parse `gmtOffset` as either a number or a string. The default wp-admin URL was also updated to have a "/" at the end to fix the issue opening the page for finishing payment setup.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Pre-requisite: Make sure that you have a self-hosted store set up for IPP with both WCPay and Stripe. Setup guides can be found in PdfdoF-D-p2 and PdfdoF-oU-p2. You'll need a card reader to test this.
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app to a physical device.
- On the prologue screen, select Enter your site address and proceed with the address of your test store.
- Log in with your site credentials. After the login succeeds, you should be navigated to the home screen.
- Navigate to the Menu tab and select Payments. Select WCPay as the payment option.
- Select Collect Payment and proceed with an IPP. Your device should be able to connect to your card reader and complete the payment.
- On the Payments screen, switch the Payment Provider to WC Stripe Gateway. Repeat the above step to make sure that the payment also succeed.
- Create an order on your test store with cash on delivery.
- Open the order on the app and select Collect Payment to proceed with IPP.
- After the payment succeeds, select Issue Refund on the order detail screen. Select an item and tap Next. In the Refund via row, the correct payment method should be displayed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.