### PR TITLE
[Mobile Payments] Fix connection loop when Tap To Pay terms acceptance is cancelled

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -470,6 +470,10 @@ extension StripeCardReaderService: CardReaderService {
                         .softwareUpdate(underlyingError: underlyingError, batteryLevel: nil) :
                         .connection(underlyingError: underlyingError)
                     promise(.failure(serviceError))
+
+                    if case .appleBuiltInReaderTOSAcceptanceCanceled = underlyingError {
+                        self.discoveryCancellable?.cancel({ _ in })
+                    }
                 }
 
                 if let reader = reader {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -875,6 +875,7 @@ extension WooAnalyticsEvent {
             static let softwareUpdateType = "software_update_type"
             static let source = "source"
             static let enabled = "enabled"
+            static let cancellationSource = "cancellation_source"
         }
 
         static let unknownGatewayID = "unknown"
@@ -1150,14 +1151,32 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func collectPaymentCanceled(forGatewayID: String?, countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
+        static func collectPaymentCanceled(forGatewayID: String?,
+                                           countryCode: String,
+                                           cardReaderModel: String,
+                                           cancellationSource: CancellationSource) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentCanceled,
                               properties: [
                                 Keys.cardReaderModel: cardReaderModel,
                                 Keys.countryCode: countryCode,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
+                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                                Keys.cancellationSource: cancellationSource.rawValue
                               ]
             )
+        }
+
+        enum CancellationSource: String {
+            case appleTOSAcceptance = "apple_tap_to_pay_terms_acceptance"
+            case reader = "card_reader"
+            case selectReaderType = "preflight_select_reader_type"
+            case searchingForReader = "searching_for_reader"
+            case foundReader = "found_reader"
+            case foundSeveralReaders = "found_several_readers"
+            case paymentPreparingReader = "payment_preparing_reader"
+            case paymentWaitingForInput = "payment_waiting_for_input"
+            case connectionError = "connection_error"
+            case readerSoftwareUpdate = "reader_software_update"
+            case other = "unknown"
         }
 
         /// Tracked when payment collection succeeds

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -52,7 +52,7 @@ final class BuiltInCardReaderConnectionController {
         /// will be called with a `success` `Bool` `False` result. The view controller passed to `searchAndConnect` will be
         /// dereferenced and the state set to `idle`
         ///
-        case cancel
+        case cancel(WooAnalyticsEvent.InPersonPayments.CancellationSource)
 
         /// A failure occurred. The completion passed to `searchAndConnect`
         /// will be called with a `failure` result. The view controller passed to `searchAndConnect` will be
@@ -163,8 +163,8 @@ private extension BuiltInCardReaderConnectionController {
             onSearching()
         case .retry:
             onRetry()
-        case .cancel:
-            onCancel()
+        case .cancel(let cancellationSource):
+            onCancel(from: cancellationSource)
         case .connectToReader:
             onConnectToReader()
         case .connectingFailed(let error):
@@ -269,7 +269,7 @@ private extension BuiltInCardReaderConnectionController {
         /// stay in this state
         ///
         alertsPresenter.present(viewModel: alertsProvider.scanningForReader(cancel: {
-            self.state = .cancel
+            self.state = .cancel(.searchingForReader)
         }))
     }
 
@@ -279,7 +279,7 @@ private extension BuiltInCardReaderConnectionController {
         let cancel = softwareUpdateCancelable.map { cancelable in
             return { [weak self] in
                 guard let self = self else { return }
-                self.state = .cancel
+                self.state = .cancel(.searchingForReader)
                 self.analyticsTracker.cardReaderSoftwareUpdateCancelTapped()
                 cancelable.cancel { [weak self] result in
                     if case .failure(let error) = result {
@@ -309,9 +309,9 @@ private extension BuiltInCardReaderConnectionController {
 
     /// End the search for a card reader
     ///
-    func onCancel() {
+    func onCancel(from cancellationSource: WooAnalyticsEvent.InPersonPayments.CancellationSource) {
         let action = CardPresentPaymentAction.cancelCardReaderDiscovery() { [weak self] _ in
-            self?.returnSuccess(result: .canceled)
+            self?.returnSuccess(result: .canceled(cancellationSource))
         }
         stores.dispatch(action)
     }
@@ -378,7 +378,7 @@ private extension BuiltInCardReaderConnectionController {
                 // The TOS acceptance flow happens during connection, not discovery, and cancelations from Apple's
                 // screen are returned as failures here.
                 if case .connection(.appleBuiltInReaderTOSAcceptanceCanceled) = error as? CardReaderServiceError {
-                    return self.state = .cancel
+                    return self.state = .cancel(.appleTOSAcceptance)
                 } else {
                     ServiceLocator.analytics.track(
                         event: WooAnalyticsEvent.InPersonPayments.cardReaderConnectionFailed(forGatewayID: self.gatewayID,
@@ -447,7 +447,7 @@ private extension BuiltInCardReaderConnectionController {
         }
 
         let cancelSearch = {
-            self.state = .cancel
+            self.state = .cancel(.connectionError)
         }
 
         guard case CardReaderServiceError.connection(let underlyingError) = error else {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -7,7 +7,7 @@ import ProximityReader
 
 enum CardReaderConnectionResult {
     case connected(CardReader)
-    case canceled
+    case canceled(WooAnalyticsEvent.InPersonPayments.CancellationSource)
 }
 
 final class CardPresentPaymentPreflightController {
@@ -117,7 +117,7 @@ final class CardPresentPaymentPreflightController {
             cancelAction: { [weak self] in
                 guard let self = self else { return }
                 self.alertsPresenter.dismiss()
-                self.handleConnectionResult(.success(.canceled))
+                self.handleConnectionResult(.success(.canceled(.selectReaderType)))
             }))
     }
 
@@ -135,13 +135,10 @@ final class CardPresentPaymentPreflightController {
 
     private func handleConnectionResult(_ result: Result<CardReaderConnectionResult, Error>) {
         let connectionResult = result.map { connection in
-            switch connection {
-            case .connected(let reader):
+            if case .connected(let reader) = connection {
                 self.connectedReader = reader
-                return CardReaderConnectionResult.connected(reader)
-            case .canceled:
-                return CardReaderConnectionResult.canceled
             }
+            return connection
         }
 
         switch connectionResult {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
@@ -389,7 +389,8 @@ private extension LegacyCollectOrderPaymentUseCase {
     func trackPaymentCancelation() {
         analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentCanceled(forGatewayID: paymentGatewayAccount.gatewayID,
                                                                                          countryCode: configuration.countryCode,
-                                                                                         cardReaderModel: connectedReader?.readerType.model ?? ""))
+                                                                                         cardReaderModel: connectedReader?.readerType.model ?? "",
+                                                                                         cancellationSource: .other))
     }
 
     /// Allow merchants to print or email the payment receipt.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8290
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When using TTP with a site for the first time, the merchant must accept Apple's terms and conditions before they can take a payment. This is done during the reader connection process, and if they cancel on the Apple screen, the `appleBuiltInReaderTOSAcceptanceCanceled` error is passed through our code.

"Errors" during connection don't stop the discovery process, so prior to this fix, the reader would immediately be discovered again and connection would start again, leaving the user in a loop.

This PR cancels discovery when a user cancels ToS acceptance on the Apple screen.

Additionally, we add analytic properties for when in a flow the user cancels a payment.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Using a US-based WCPay store which has not had the Apple ToS accepted

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. When asked for a reader type, tap `Tap to Pay on iPhone` and wait until the Terms of Service Apple ID linking is shown.
6. Tap `Cancel`
7. Observe that you are taken back to the payment method screen, and connection doesn't start again
8. Observe that the cancellation analytic event is logged, with the property `cancellation_source: apple_tap_to_pay_terms_acceptance`

### Other cancellation sources

Cancel from the following places:

- Selecting between TTPoI and Bluetooth connections: `preflight_select_reader_type`
- Searching for a reader: `searching_for_reader`
- Preparing reader (with a spinner, you need to be quick): `payment_preparing_reader`
- The "Tap or insert card" screen shown for Bluetooth readers when they're waiting for payment: `payment_waiting_for_input`
- Any retriable error generated from the collection process: `connection_error`
- Cancelling on the reader itself, i.e. the red button on WisePad 3, or the `x` on Apple's Tap To Pay card read screen: `card_reader`
- The alert asking whether the merchant would like to connect: `foundReader`
- The list of readers alert: `foundSeveralReaders
- Card reader software update, the progress screen: `reader_software_update`

N.B. If you have already accepted the ToS, you can unlink your Apple ID by logging in at `https://register.apple.com/tap-to-pay-on-iphone/`, or following the instructions in the email from Apple


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Cancellation loop

#### Before: repro for connection loop

https://user-images.githubusercontent.com/2472348/212736183-0d3a7a5d-6009-4080-a104-bd247c1ba16c.mp4

#### After: fixed so it doesn't loop

https://user-images.githubusercontent.com/2472348/212735564-d14ddc5d-4539-4fa6-93a1-7e93c7b57de9.mp4

### Cancellation analytics

#### Selecting between TTPoI and Bluetooth connections: `preflight_select_reader_type`

![Select reader type in analytics console log](https://user-images.githubusercontent.com/2472348/212728437-ca0e0155-8683-4b5e-91bf-57cfca59aebe.png)

#### Searching for a reader: `searching_for_reader` (easier on Bluetooth)

![Searching for a reader in analytics console log](https://user-images.githubusercontent.com/2472348/212728604-8b98cf14-8f44-455d-adae-8ddfde3f3fe5.png)

#### The alert asking whether the merchant would like to connect: `foundReader`

![Found reader in analytics console log](https://user-images.githubusercontent.com/2472348/212733447-8f81bfff-d34c-474c-b579-fa67583624fb.png)

#### The list of readers alert: `foundSeveralReaders`

![Found several readers in analytics console log](https://user-images.githubusercontent.com/2472348/212733629-2cac4561-4054-4199-9c48-36eb1143ae36.png)

#### Preparing reader (with a spinner, you need to be quick): `payment_preparing_reader`

![Preparing reader in analytics console log](https://user-images.githubusercontent.com/2472348/212728821-83fdcabc-5eb8-4d13-8ab3-73abe3b36baa.png)

#### The "Tap or insert card" screen shown for Bluetooth readers when they're waiting for payment: `payment_waiting_for_input`

![Waiting for input in analytics console log](https://user-images.githubusercontent.com/2472348/212729128-e66d4ac5-65a9-4665-8e05-1b005c959379.png)

#### Any retriable error generated from the collection process: `connection_error`

![Connection error in analytics console log](https://user-images.githubusercontent.com/2472348/212733322-9c8b7c70-0dcc-4580-b70b-aa5fade0e396.png)

#### Cancelling on the reader itself, i.e. the red button on WisePad 3, or the `x` on Apple's Tap To Pay card read screen: `card_reader`

![Cancelling on reader screen in analytics console log](https://user-images.githubusercontent.com/2472348/212729037-1f1bff49-0b03-4b16-8d67-f4becbc59b5f.png)

#### Card reader software update, the progress screen: `reader_software_update`

![Card reader software update in analytics console log](https://user-images.githubusercontent.com/2472348/212733905-61539998-6a4b-4255-97c4-da52ae5d6890.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
