### PR TITLE
Bulk Editing: Add status picker

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -465,6 +465,8 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
+        try container.encode(productID, forKey: .productID)
+
         try container.encode(images, forKey: .images)
 
         try container.encode(name, forKey: .name)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/List Selector Data Source/ProductStatusSettingListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/List Selector Data Source/ProductStatusSettingListSelectorCommand.swift
@@ -15,7 +15,7 @@ final class ProductStatusSettingListSelectorCommand: ListSelectorCommand {
         .pending
     ]
 
-    private(set) var selected: ProductStatus?
+    @Published private(set) var selected: ProductStatus?
 
     init(selected: ProductStatus?) {
         self.selected = selected

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -43,6 +43,8 @@ class ProductListViewModel {
         selectedProducts.removeAll()
     }
 
+    /// Check if selected products share the same common ProductStatus. Returns `nil` otherwise.
+    ///
     var commonStatusForSelectedProducts: ProductStatus? {
         let status = selectedProducts.first?.productStatus
         if selectedProducts.allSatisfy({ $0.productStatus == status }) {
@@ -52,6 +54,8 @@ class ProductListViewModel {
         }
     }
 
+    /// Update selected products with new ProductStatus and trigger Network action to save the change remotely.
+    ///
     func updateSelectedProducts(with newStatus: ProductStatus, completion: @escaping (Result<Void, Error>) -> Void ) {
         guard selectedProductsCount > 0 else {
             completion(.failure(BulkEditError.noProductsSelected))

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -4,7 +4,20 @@ import Yosemite
 /// View model for `ProductsViewController`. Only stores logic related to Bulk Editing.
 ///
 class ProductListViewModel {
+
+    enum BulkEditError: Error {
+        case noProductsSelected
+    }
+
+    let siteID: Int64
+    private let stores: StoresManager
+
     private var selectedProducts: Set<Product> = .init()
+
+    init(siteID: Int64, stores: StoresManager) {
+        self.siteID = siteID
+        self.stores = stores
+    }
 
     var selectedProductsCount: Int {
         selectedProducts.count
@@ -37,5 +50,23 @@ class ProductListViewModel {
         } else {
             return nil
         }
+    }
+
+    func updateSelectedProducts(with newStatus: ProductStatus, completion: @escaping (Result<Void, Error>) -> Void ) {
+        guard selectedProductsCount > 0 else {
+            completion(.failure(BulkEditError.noProductsSelected))
+            return
+        }
+
+        let updatedProducts = selectedProducts.map({ $0.copy(statusKey: newStatus.rawValue) })
+        let batchAction = ProductAction.updateProducts(siteID: siteID, products: updatedProducts) { result in
+            switch result {
+            case .success:
+                completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+        stores.dispatch(batchAction)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -29,4 +29,13 @@ class ProductListViewModel {
     func deselectAll() {
         selectedProducts.removeAll()
     }
+
+    var commonStatusForSelectedProducts: ProductStatus? {
+        let status = selectedProducts.first?.productStatus
+        if selectedProducts.allSatisfy({ $0.productStatus == status }) {
+            return status
+        } else {
+            return nil
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -415,7 +415,7 @@ private extension ProductsViewController {
     func presentNotice(title: String) {
         let contextNoticePresenter: NoticePresenter = {
             let noticePresenter = DefaultNoticePresenter()
-            noticePresenter.presentingViewController = self
+            noticePresenter.presentingViewController = tabBarController
             return noticePresenter
         }()
         contextNoticePresenter.enqueue(notice: .init(title: title))

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -328,8 +328,8 @@ private extension ProductsViewController {
     @objc func openBulkEditingOptions(sender: UIButton) {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
-        let updateStatus = UIAlertAction(title: Localization.bulkEditingStatusOption, style: .default) { _ in
-            // TODO-8519: show UI for status update
+        let updateStatus = UIAlertAction(title: Localization.bulkEditingStatusOption, style: .default) { [weak self] _ in
+            self?.showStatusBulkEditingModal()
         }
         let updatePrice = UIAlertAction(title: Localization.bulkEditingPriceOption, style: .default) { _ in
             // TODO-8520: show UI for price update
@@ -346,6 +346,29 @@ private extension ProductsViewController {
         }
 
         present(actionSheet, animated: true)
+    }
+
+    func showStatusBulkEditingModal() {
+        let command = ProductStatusSettingListSelectorCommand(selected: viewModel.commonStatusForSelectedProducts)
+        let listSelectorViewController = ListSelectorViewController(command: command) { _ in
+            // view dismiss callback - no-op
+        }
+        listSelectorViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel,
+                                                                                      target: self,
+                                                                                      action: #selector(dismissModal))
+        listSelectorViewController.navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.bulkEditingApply,
+                                                                                       style: .plain,
+                                                                                       target: self,
+                                                                                       action: #selector(applyBulkEditingStatus))
+        self.present(WooNavigationController(rootViewController: listSelectorViewController), animated: true)
+    }
+
+    @objc func dismissModal() {
+        dismiss(animated: true)
+    }
+
+    @objc func applyBulkEditingStatus() {
+        dismiss(animated: true)
     }
 }
 
@@ -1218,5 +1241,7 @@ private extension ProductsViewController {
             "%1$@ selected",
             comment: "Title that appears on top of the Product List screen during bulk editing. Reads like: 2 selected"
         )
+
+        static let bulkEditingApply = NSLocalizedString("Apply", comment: "Title for the button to apply bulk editing changes to selected products.")
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1253,6 +1253,7 @@
 		AEA3F91527BEC96B00B9F555 /* PriceFieldFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA3F91427BEC96B00B9F555 /* PriceFieldFormatterTests.swift */; };
 		AEACCB6D2785FF4A000D01F0 /* NavigationRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEACCB6C2785FF4A000D01F0 /* NavigationRow.swift */; };
 		AEB4DB99290AE8F300AE4340 /* MockCookieJar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB4DB98290AE8F300AE4340 /* MockCookieJar.swift */; };
+		AEB6903729770B1D00872FE0 /* ProductListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB6903629770B1D00872FE0 /* ProductListViewModelTests.swift */; };
 		AEB73C0C25CD734200A8454A /* AttributePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB73C0B25CD734200A8454A /* AttributePickerViewModel.swift */; };
 		AEB73C1725CD8E5800A8454A /* AttributePickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB73C1625CD8E5800A8454A /* AttributePickerViewModelTests.swift */; };
 		AEBFD13F28E7655F00F598C6 /* StoreInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBFD13E28E7655F00F598C6 /* StoreInfoView.swift */; };
@@ -3303,6 +3304,7 @@
 		AEA3F91427BEC96B00B9F555 /* PriceFieldFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFieldFormatterTests.swift; sourceTree = "<group>"; };
 		AEACCB6C2785FF4A000D01F0 /* NavigationRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRow.swift; sourceTree = "<group>"; };
 		AEB4DB98290AE8F300AE4340 /* MockCookieJar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCookieJar.swift; sourceTree = "<group>"; };
+		AEB6903629770B1D00872FE0 /* ProductListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListViewModelTests.swift; sourceTree = "<group>"; };
 		AEB73C0B25CD734200A8454A /* AttributePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewModel.swift; sourceTree = "<group>"; };
 		AEB73C1625CD8E5800A8454A /* AttributePickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributePickerViewModelTests.swift; sourceTree = "<group>"; };
 		AEBFD13E28E7655F00F598C6 /* StoreInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreInfoView.swift; sourceTree = "<group>"; };
@@ -4766,6 +4768,7 @@
 				0271139924DD15D800574A07 /* ProductsTabProductViewModel+VariationTests.swift */,
 				573A960224F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift */,
 				0279F0DB252DBF1F0098D7DE /* ProductVariationDetailsFactoryTests.swift */,
+				AEB6903629770B1D00872FE0 /* ProductListViewModelTests.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -11566,6 +11569,7 @@
 				02A9A496244D84AB00757B99 /* ProductsSortOrderBottomSheetListSelectorCommandTests.swift in Sources */,
 				B9B6DEF1283F8EB100901FB7 /* SitePluginsURLTests.swift in Sources */,
 				D83F5935225B3CDD00626E75 /* DatePickerTableViewCellTests.swift in Sources */,
+				AEB6903729770B1D00872FE0 /* ProductListViewModelTests.swift in Sources */,
 				314DC4C1268D28B100444C9E /* CardReaderSettingsKnownReadersStorageTests.swift in Sources */,
 				262AF38A2713B67600E39AFF /* SimplePaymentsAmountViewModelTests.swift in Sources */,
 				93FA787221CD2A1A00B663E5 /* CurrencySettingsTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+import Yosemite
+import Fakes
+@testable import WooCommerce
+
+final class ProductListViewModelTests: XCTestCase {
+    private let sampleSiteID: Int64 = 123
+    private var storesManager: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        storesManager = MockStoresManager(sessionManager: .makeForTesting())
+    }
+
+    override func tearDown() {
+        storesManager = nil
+        super.tearDown()
+    }
+
+    func test_selecting_and_deselecting_product_and_checking_its_state_works() {
+        // Given
+        let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1)
+        XCTAssertFalse(viewModel.productIsSelected(sampleProduct1))
+
+        // When
+        viewModel.selectProduct(sampleProduct1)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedProductsCount, 1)
+        XCTAssertTrue(viewModel.productIsSelected(sampleProduct1))
+
+        // When
+        viewModel.deselectProduct(sampleProduct1)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedProductsCount, 0)
+        XCTAssertFalse(viewModel.productIsSelected(sampleProduct1))
+    }
+
+    func test_deselecting_not_selected_product_does_nothing() {
+        // Given
+        let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1)
+        let sampleProduct2 = Product.fake().copy(productID: 2)
+        XCTAssertEqual(viewModel.selectedProductsCount, 0)
+
+        // When
+        viewModel.deselectProduct(sampleProduct1)
+        viewModel.selectProduct(sampleProduct2)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedProductsCount, 1)
+        XCTAssertFalse(viewModel.productIsSelected(sampleProduct1))
+        XCTAssertTrue(viewModel.productIsSelected(sampleProduct2))
+    }
+
+    func test_selecting_and_deselecting_product_twice_is_ignored() {
+        // Given
+        let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1)
+        XCTAssertEqual(viewModel.selectedProductsCount, 0)
+
+        // When
+        viewModel.selectProduct(sampleProduct1)
+        viewModel.selectProduct(sampleProduct1)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedProductsCount, 1)
+        XCTAssertTrue(viewModel.productIsSelected(sampleProduct1))
+
+        // When
+        viewModel.deselectProduct(sampleProduct1)
+        viewModel.deselectProduct(sampleProduct1)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedProductsCount, 0)
+        XCTAssertFalse(viewModel.productIsSelected(sampleProduct1))
+    }
+
+    func test_bulk_edit_bool_is_set_correctly() {
+        // Given
+        let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1)
+        XCTAssertFalse(viewModel.bulkEditActionIsEnabled)
+
+        // When
+        viewModel.selectProduct(sampleProduct1)
+
+        // Then
+        XCTAssertTrue(viewModel.bulkEditActionIsEnabled)
+
+        // When
+        viewModel.deselectProduct(sampleProduct1)
+
+        // Then
+        XCTAssertFalse(viewModel.bulkEditActionIsEnabled)
+    }
+
+    func test_deselect_all_works_correctly() {
+        // Given
+        let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1)
+        let sampleProduct2 = Product.fake().copy(productID: 2)
+
+        viewModel.selectProduct(sampleProduct1)
+        viewModel.selectProduct(sampleProduct2)
+        XCTAssertEqual(viewModel.selectedProductsCount, 2)
+
+        // When
+        viewModel.deselectAll()
+
+        // Then
+        XCTAssertEqual(viewModel.selectedProductsCount, 0)
+
+        // When - Duplicated call
+        viewModel.deselectAll()
+
+        // Then
+        XCTAssertEqual(viewModel.selectedProductsCount, 0)
+    }
+
+    func test_common_status_works_correctly() {
+        // Given
+        let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1, statusKey: "draft")
+        let sampleProduct2 = Product.fake().copy(productID: 2, statusKey: "draft")
+        let sampleProduct3 = Product.fake().copy(productID: 3, statusKey: "publish")
+        XCTAssertNil(viewModel.commonStatusForSelectedProducts)
+
+        // When
+        viewModel.selectProduct(sampleProduct1)
+        viewModel.selectProduct(sampleProduct2)
+
+        // Then
+        XCTAssertEqual(viewModel.commonStatusForSelectedProducts, .draft)
+
+        // When
+        viewModel.selectProduct(sampleProduct3)
+
+        // Then
+        XCTAssertNil(viewModel.commonStatusForSelectedProducts)
+    }
+
+    func test_updating_products_with_status_sets_correct_status() throws {
+        // Given
+        let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1, statusKey: "draft")
+        let sampleProduct2 = Product.fake().copy(productID: 2, statusKey: "draft")
+        let sampleProduct3 = Product.fake().copy(productID: 3, statusKey: "publish")
+
+        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .updateProducts(_, products, completion):
+                XCTAssertTrue(products.allSatisfy { $0.statusKey == "publish" })
+                completion(.success(products))
+            default:
+                break
+            }
+        }
+
+        // When
+        viewModel.selectProduct(sampleProduct1)
+        viewModel.selectProduct(sampleProduct2)
+        viewModel.selectProduct(sampleProduct3)
+        let result = waitFor { promise in
+            viewModel.updateSelectedProducts(with: .published) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8519

## Description

This PR adds status selector for bulk editing on Products List. Networking action is connected, loading, success and error states implemented.

## Testing

1. Build and run the app in debug/alpha mode.
2. On the products list tap the "multi-select" icon in the navbar.
3. Select a few products from the list.
4. Tap "Bulk update" in the bottom toolbar.
5. Tap "Update status".
6. Confirm that correct status is preselected only if all selected products have the same status.
7. Confirm that "Apply" button is disabled for current or missing status.
8. Confirm that "Apply" button is enabled when different status is picked.
9. Tap "Apply". Observe loading state and success message.
10. Confirm product is updated in the list.

_Bonus:_ update single product manually using the old flow to make sure serialization is not broken (since we added "id" to product encoder).

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
