### PR TITLE
Configure code signing for Widgets Intents target

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -12122,8 +12122,10 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtensionDebug.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = PZYM8XX95Q;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StoreWidgetsIntentsExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgetsIntentsExtension;
@@ -12138,6 +12140,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.storewidgetsintents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.automattic.woocommerce.storewidgetsintents";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -12154,6 +12157,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = PZYM8XX95Q;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StoreWidgetsIntentsExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgetsIntentsExtension;
@@ -12167,6 +12171,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.storewidgetsintents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.automattic.woocommerce.storewidgetsintents";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -12183,6 +12188,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 99KV9Z6BKV;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StoreWidgetsIntentsExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgetsIntentsExtension;
@@ -12196,6 +12202,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.alpha.woocommerce.storewidgetsintents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match InHouse com.automattic.alpha.woocommerce.storewidgetsintents";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -12140,7 +12140,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.storewidgetsintents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.automattic.woocommerce.storewidgetsintents";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "WooCommerce Widgets Intents Development";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -12122,10 +12122,8 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtensionDebug.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = PZYM8XX95Q;
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StoreWidgetsIntentsExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgetsIntentsExtension;
@@ -12139,8 +12137,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.storewidgetsintents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "WooCommerce Widgets Intents Development";
+				PROVISIONING_PROFILE_SPECIFIER = "WooCommerce Widgets Intents Development";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -12156,8 +12153,7 @@
 				CODE_SIGN_ENTITLEMENTS = StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtensionRelease.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = PZYM8XX95Q;
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StoreWidgetsIntentsExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgetsIntentsExtension;
@@ -12170,8 +12166,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.storewidgetsintents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.automattic.woocommerce.storewidgetsintents";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.automattic.woocommerce.storewidgetsintents";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -12187,8 +12182,7 @@
 				CODE_SIGN_ENTITLEMENTS = StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtension.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 99KV9Z6BKV;
+				DEVELOPMENT_TEAM = 99KV9Z6BKV;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StoreWidgetsIntentsExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgetsIntentsExtension;
@@ -12201,8 +12195,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.alpha.woocommerce.storewidgetsintents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match InHouse com.automattic.alpha.woocommerce.storewidgetsintents";
+				PROVISIONING_PROFILE_SPECIFIER = "match InHouse com.automattic.alpha.woocommerce.storewidgetsintents";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -12135,7 +12135,7 @@
 				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.StoreWidgetsIntentsExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.storewidgetsintents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -12164,7 +12164,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.StoreWidgetsIntentsExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.storewidgetsintents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -12193,7 +12193,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.StoreWidgetsIntentsExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.alpha.woocommerce.storewidgetsintents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -12122,7 +12122,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtensionDebug.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = PZYM8XX95Q;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -12122,8 +12122,8 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtensionDebug.entitlements;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = PZYM8XX95Q;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StoreWidgetsIntentsExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgetsIntentsExtension;
@@ -12137,6 +12137,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.StoreWidgetsIntentsExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -12151,8 +12152,8 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtensionRelease.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = PZYM8XX95Q;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StoreWidgetsIntentsExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgetsIntentsExtension;
@@ -12165,6 +12166,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.StoreWidgetsIntentsExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -12179,8 +12181,8 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = StoreWidgetsIntentsExtension/StoreWidgetsIntentsExtension.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 99KV9Z6BKV;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StoreWidgetsIntentsExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StoreWidgetsIntentsExtension;
@@ -12193,6 +12195,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.StoreWidgetsIntentsExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,14 +31,16 @@ APP_STORE_VERSION_BUNDLE_IDENTIFIER = 'com.automattic.woocommerce'
 # Registered in our main account, for development and App Store
 MAIN_BUNDLE_IDENTIFIERS = [
   APP_STORE_VERSION_BUNDLE_IDENTIFIER,
-  "#{APP_STORE_VERSION_BUNDLE_IDENTIFIER}.storewidgets"
+  "#{APP_STORE_VERSION_BUNDLE_IDENTIFIER}.storewidgets",
+  "#{APP_STORE_VERSION_BUNDLE_IDENTIFIER}.storewidgetsintents"
 ].freeze
 
 ALPHA_VERSION_BUNDLE_IDENTIFIER = 'com.automattic.alpha.woocommerce'
 # Registered in our Enterprise account, for App Center / Installable Builds
 ALPHA_BUNDLE_IDENTIFIERS = [
   ALPHA_VERSION_BUNDLE_IDENTIFIER,
-  "#{ALPHA_VERSION_BUNDLE_IDENTIFIER}.storewidgets"
+  "#{ALPHA_VERSION_BUNDLE_IDENTIFIER}.storewidgets",
+  "#{ALPHA_VERSION_BUNDLE_IDENTIFIER}.storewidgetsintents"
 ].freeze
 
 # Shared options to use when invoking `gym` / `build_app`.


### PR DESCRIPTION
## Description

This PRs configures the Widgets Intents target to use the bundle identifiers and provisioning profiles created for it.

I was pleased to find the `issue/7863-widgets-configuration` branch with the target already created and the progress well documented in #7863. Kudos @ealeksandrov 👍 

## Testing instructions

To test this, I verified that the "Signing & Capabilities" tab for the target had no warnings or errors in all build configurations:

**Debug**:

<img width="1269" alt="Screenshot 2023-01-17 at 11 49 28 am" src="https://user-images.githubusercontent.com/1218433/212786499-a5da31a2-cf2a-4987-92de-d231cbba8ae2.png">

**Release**:

![image](https://user-images.githubusercontent.com/1218433/212786482-9cd13b84-5adb-4618-940b-2e60c0b5258a.png)

**Release-Alpha**:
![image](https://user-images.githubusercontent.com/1218433/212786491-c61b8e73-caf3-4dda-8bf0-42763c69915f.png)

I also run the app on my phone to verify the Development provisioning worked. 

Finally, Installable Builds shows that Enterprise code signing works:

<img width="1160" alt="image" src="https://user-images.githubusercontent.com/1218433/212807967-413e16e2-1ed6-4fd9-899f-fc9636043e32.png">

Unfortunately, we don't have a neat way to test the Company account distribution, but I think we have enough inputs to be confident it will work.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – N.A.
