### PR TITLE
Store creation: send a Tracks event with profiler answers when reaching store summary screen

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -9,6 +9,8 @@ extension WooAnalyticsEvent {
             static let errorType = "error_type"
             static let flow = "flow"
             static let step = "step"
+            static let category = "industry"
+            static let categoryGroup = "industry_group"
         }
 
         /// Tracked when the user taps on the CTA in store picker (logged in to WPCOM) to create a store.
@@ -52,6 +54,15 @@ extension WooAnalyticsEvent {
         /// Tracked when tapping on the “Manage my store” button on the store creation success screen.
         static func siteCreationManageStoreTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .siteCreationManageStoreTapped, properties: [:])
+        }
+
+        /// Tracked when completing the last profiler question during the store creation flow.
+        static func siteCreationProfilerData(category: StoreCreationCategoryAnswer?) -> WooAnalyticsEvent {
+            let properties = [
+                Key.category: category?.value,
+                Key.categoryGroup: category?.groupValue
+            ].compactMapValues({ $0 })
+            return WooAnalyticsEvent(statName: .siteCreationProfilerData, properties: properties)
         }
 
         /// Tracked when the user taps on the CTA in login prologue (logged out) to create a store.

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -13,6 +13,7 @@ extension WooAnalyticsEvent {
             static let categoryGroup = "industry_group"
             static let sellingStatus = "user_commerce_journey"
             static let sellingPlatforms = "ecommerce_platforms"
+            static let countryCode = "country_code"
         }
 
         /// Tracked when the user taps on the CTA in store picker (logged in to WPCOM) to create a store.
@@ -60,12 +61,14 @@ extension WooAnalyticsEvent {
 
         /// Tracked when completing the last profiler question during the store creation flow.
         static func siteCreationProfilerData(category: StoreCreationCategoryAnswer?,
-                                             sellingStatus: StoreCreationSellingStatusAnswer?) -> WooAnalyticsEvent {
+                                             sellingStatus: StoreCreationSellingStatusAnswer?,
+                                             countryCode: SiteAddress.CountryCode?) -> WooAnalyticsEvent {
             let properties = [
                 Key.category: category?.value,
                 Key.categoryGroup: category?.groupValue,
                 Key.sellingStatus: sellingStatus?.sellingStatus.rawValue,
-                Key.sellingPlatforms: sellingStatus?.sellingPlatforms?.map { $0.rawValue }.sorted().joined(separator: ",")
+                Key.sellingPlatforms: sellingStatus?.sellingPlatforms?.map { $0.rawValue }.sorted().joined(separator: ","),
+                Key.countryCode: countryCode?.rawValue
             ].compactMapValues({ $0 })
             return WooAnalyticsEvent(statName: .siteCreationProfilerData, properties: properties)
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -11,6 +11,8 @@ extension WooAnalyticsEvent {
             static let step = "step"
             static let category = "industry"
             static let categoryGroup = "industry_group"
+            static let sellingStatus = "user_commerce_journey"
+            static let sellingPlatforms = "ecommerce_platforms"
         }
 
         /// Tracked when the user taps on the CTA in store picker (logged in to WPCOM) to create a store.
@@ -57,10 +59,13 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when completing the last profiler question during the store creation flow.
-        static func siteCreationProfilerData(category: StoreCreationCategoryAnswer?) -> WooAnalyticsEvent {
+        static func siteCreationProfilerData(category: StoreCreationCategoryAnswer?,
+                                             sellingStatus: StoreCreationSellingStatusAnswer?) -> WooAnalyticsEvent {
             let properties = [
                 Key.category: category?.value,
-                Key.categoryGroup: category?.groupValue
+                Key.categoryGroup: category?.groupValue,
+                Key.sellingStatus: sellingStatus?.sellingStatus.rawValue,
+                Key.sellingPlatforms: sellingStatus?.sellingPlatforms?.map { $0.rawValue }.sorted().joined(separator: ",")
             ].compactMapValues({ $0 })
             return WooAnalyticsEvent(statName: .siteCreationProfilerData, properties: properties)
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -182,6 +182,7 @@ public enum WooAnalyticsStat: String {
     case siteCreationStep = "site_creation_step"
     case siteCreationSitePreviewed = "site_creation_site_previewed"
     case siteCreationManageStoreTapped = "site_creation_store_management_opened"
+    case siteCreationProfilerData = "site_creation_profiler_site_data"
     case loginPrologueCreateSiteTapped = "login_prologue_create_site_tapped"
     case signupFormLoginTapped = "signup_login_button_tapped"
     case signupSubmitted = "signup_submitted"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -182,7 +182,7 @@ public enum WooAnalyticsStat: String {
     case siteCreationStep = "site_creation_step"
     case siteCreationSitePreviewed = "site_creation_site_previewed"
     case siteCreationManageStoreTapped = "site_creation_store_management_opened"
-    case siteCreationProfilerData = "site_creation_profiler_site_data"
+    case siteCreationProfilerData = "site_creation_profiler_data"
     case loginPrologueCreateSiteTapped = "login_prologue_create_site_tapped"
     case signupFormLoginTapped = "signup_login_button_tapped"
     case signupSubmitted = "signup_submitted"

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionViewModel.swift
@@ -1,9 +1,21 @@
 import Combine
 import Foundation
 
+/// Necessary data from the answer of the store creation category question.
+struct StoreCreationCategoryAnswer {
+    /// Display name of the selected category.
+    let name: String
+    /// Raw value of the category (industry) to be sent to the backend.
+    let value: String
+    /// Raw value of the category group (industry group) to be sent to the backend.
+    let groupValue: String
+}
+
 /// View model for `StoreCreationCategoryQuestionView`, an optional profiler question about store category in the store creation flow.
 @MainActor
 final class StoreCreationCategoryQuestionViewModel: StoreCreationProfilerQuestionViewModel, ObservableObject {
+    typealias Answer = StoreCreationCategoryAnswer
+
     let topHeader: String
 
     let title: String = Localization.title
@@ -14,11 +26,11 @@ final class StoreCreationCategoryQuestionViewModel: StoreCreationProfilerQuestio
     /// TODO: 8376 - update values when API is ready.
     @Published private(set) var selectedCategory: Category?
 
-    private let onContinue: (String) -> Void
+    private let onContinue: (Answer) -> Void
     private let onSkip: () -> Void
 
     init(storeName: String,
-         onContinue: @escaping (String) -> Void,
+         onContinue: @escaping (Answer) -> Void,
          onSkip: @escaping () -> Void) {
         self.topHeader = storeName
         self.onContinue = onContinue
@@ -28,11 +40,12 @@ final class StoreCreationCategoryQuestionViewModel: StoreCreationProfilerQuestio
 
 extension StoreCreationCategoryQuestionViewModel: OptionalStoreCreationProfilerQuestionViewModel {
     func continueButtonTapped() async {
-        guard let selectedCategory else {
+        guard let selectedCategory,
+        let categoryGroup = categorySections.first(where: { $0.categories.contains(selectedCategory) })?.group else {
             return onSkip()
         }
 
-        onContinue(selectedCategory.name)
+        onContinue(.init(name: selectedCategory.name, value: selectedCategory.rawValue, groupValue: categoryGroup.rawValue))
     }
 
     func skipButtonTapped() {

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Category/StoreCreationCategoryQuestionViewModel.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 
 /// Necessary data from the answer of the store creation category question.
-struct StoreCreationCategoryAnswer {
+struct StoreCreationCategoryAnswer: Equatable {
     /// Display name of the selected category.
     let name: String
     /// Raw value of the category (industry) to be sent to the backend.

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingPlatformsQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingPlatformsQuestionView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct StoreCreationSellingPlatformsQuestionView: View {
     @ObservedObject private var viewModel: StoreCreationSellingPlatformsQuestionViewModel
 
-    init(storeName: String, onContinue: @escaping () -> Void, onSkip: @escaping () -> Void) {
+    init(storeName: String, onContinue: @escaping (StoreCreationSellingStatusAnswer?) -> Void, onSkip: @escaping () -> Void) {
         self.viewModel = StoreCreationSellingPlatformsQuestionViewModel(storeName: storeName, onContinue: onContinue, onSkip: onSkip)
     }
 
@@ -31,7 +31,7 @@ struct StoreCreationSellingPlatformsQuestionView: View {
 struct StoreCreationSellingPlatformsQuestionView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            StoreCreationSellingPlatformsQuestionView(storeName: "New Year Store", onContinue: {}, onSkip: {})
+            StoreCreationSellingPlatformsQuestionView(storeName: "New Year Store", onContinue: { _ in }, onSkip: {})
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingPlatformsQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingPlatformsQuestionViewModel.swift
@@ -9,14 +9,14 @@ import Foundation
 final class StoreCreationSellingPlatformsQuestionViewModel: StoreCreationProfilerQuestionViewModel, ObservableObject {
     /// Other online platforms that the user might be selling. Source of truth:
     /// https://github.com/Automattic/woocommerce.com/blob/trunk/themes/woo/start/config/options.json
-    enum Platform: Equatable, CaseIterable {
+    enum Platform: String, CaseIterable {
         case amazon
-        case bigCartel
-        case bigCommerce
-        case eBay
+        case bigCartel = "big-cartel"
+        case bigCommerce = "big-commerce"
+        case eBay = "ebay"
         case etsy
-        case facebookMarketplace
-        case googleShopping
+        case facebookMarketplace = "facebook-marketplace"
+        case googleShopping = "google-shopping"
         case pinterest
         case shopify
         case square
@@ -37,11 +37,11 @@ final class StoreCreationSellingPlatformsQuestionViewModel: StoreCreationProfile
 
     @Published private(set) var selectedPlatforms: Set<Platform> = []
 
-    private let onContinue: () -> Void
+    private let onContinue: (StoreCreationSellingStatusAnswer?) -> Void
     private let onSkip: () -> Void
 
     init(storeName: String,
-         onContinue: @escaping () -> Void,
+         onContinue: @escaping (StoreCreationSellingStatusAnswer?) -> Void,
          onSkip: @escaping () -> Void) {
         self.topHeader = storeName
         self.onContinue = onContinue
@@ -52,7 +52,7 @@ final class StoreCreationSellingPlatformsQuestionViewModel: StoreCreationProfile
 extension StoreCreationSellingPlatformsQuestionViewModel: OptionalStoreCreationProfilerQuestionViewModel {
     func continueButtonTapped() async {
         // TODO: submission API.
-        onContinue()
+        onContinue(.init(sellingStatus: .alreadySellingOnline, sellingPlatforms: selectedPlatforms))
     }
 
     func skipButtonTapped() {

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionContainerView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionContainerView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Necessary data from the answer to the store creation selling status question.
-struct StoreCreationSellingStatusAnswer {
+struct StoreCreationSellingStatusAnswer: Equatable {
     /// The status of the merchant's eCommerce experience.
     let sellingStatus: StoreCreationSellingStatusQuestionViewModel.SellingStatus
     /// The eCommerce platforms that the merchant is already selling on.

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionContainerView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionContainerView.swift
@@ -1,8 +1,17 @@
 import SwiftUI
 
+/// Necessary data from the answer to the store creation selling status question.
+struct StoreCreationSellingStatusAnswer {
+    /// The status of the merchant's eCommerce experience.
+    let sellingStatus: StoreCreationSellingStatusQuestionViewModel.SellingStatus
+    /// The eCommerce platforms that the merchant is already selling on.
+    /// When the merchant isn't already selling online, the value is `nil`.
+    let sellingPlatforms: Set<StoreCreationSellingPlatformsQuestionViewModel.Platform>?
+}
+
 /// Hosting controller that wraps the `StoreCreationSellingStatusQuestionContainerView`.
 final class StoreCreationSellingStatusQuestionHostingController: UIHostingController<StoreCreationSellingStatusQuestionContainerView> {
-    init(storeName: String, onContinue: @escaping () -> Void, onSkip: @escaping () -> Void) {
+    init(storeName: String, onContinue: @escaping (StoreCreationSellingStatusAnswer?) -> Void, onSkip: @escaping () -> Void) {
         super.init(rootView: StoreCreationSellingStatusQuestionContainerView(storeName: storeName, onContinue: onContinue, onSkip: onSkip))
     }
 
@@ -23,10 +32,10 @@ final class StoreCreationSellingStatusQuestionHostingController: UIHostingContro
 struct StoreCreationSellingStatusQuestionContainerView: View {
     @StateObject private var viewModel: StoreCreationSellingStatusQuestionViewModel
     private let storeName: String
-    private let onContinue: () -> Void
+    private let onContinue: (StoreCreationSellingStatusAnswer?) -> Void
     private let onSkip: () -> Void
 
-    init(storeName: String, onContinue: @escaping () -> Void, onSkip: @escaping () -> Void) {
+    init(storeName: String, onContinue: @escaping (StoreCreationSellingStatusAnswer?) -> Void, onSkip: @escaping () -> Void) {
         self._viewModel = StateObject(wrappedValue: StoreCreationSellingStatusQuestionViewModel(storeName: storeName, onContinue: onContinue, onSkip: onSkip))
         self.storeName = storeName
         self.onContinue = onContinue
@@ -45,7 +54,7 @@ struct StoreCreationSellingStatusQuestionContainerView: View {
 struct StoreCreationSellingStatusQuestionContainerView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            StoreCreationSellingStatusQuestionContainerView(storeName: "New Year Store", onContinue: {}, onSkip: {})
+            StoreCreationSellingStatusQuestionContainerView(storeName: "New Year Store", onContinue: { _ in }, onSkip: {})
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionView.swift
@@ -30,7 +30,7 @@ struct StoreCreationSellingStatusQuestionView: View {
 struct StoreCreationSellingStatusQuestionView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            StoreCreationSellingStatusQuestionView(viewModel: .init(storeName: "New Year Store", onContinue: {}, onSkip: {}))
+            StoreCreationSellingStatusQuestionView(viewModel: .init(storeName: "New Year Store", onContinue: { _ in }, onSkip: {}))
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionViewModel.swift
@@ -5,14 +5,15 @@ import Foundation
 @MainActor
 final class StoreCreationSellingStatusQuestionViewModel: StoreCreationProfilerQuestionViewModel, ObservableObject {
     /// Selling status options.
+    /// Its raw value is the value to be sent to the backend.
     /// https://github.com/Automattic/woocommerce.com/blob/trunk/themes/woo/start/config/options.json
-    enum SellingStatus: Equatable {
+    enum SellingStatus: String {
         /// Just starting my business.
-        case justStarting
+        case justStarting = "im_just_starting_my_business"
         /// Already selling, but not online.
-        case alreadySellingButNotOnline
+        case alreadySellingButNotOnline = "im_already_selling_but_not_online"
         /// Already selling online.
-        case alreadySellingOnline
+        case alreadySellingOnline = "im_already_selling_online"
     }
 
     let topHeader: String
@@ -30,11 +31,11 @@ final class StoreCreationSellingStatusQuestionViewModel: StoreCreationProfilerQu
     /// Set to `true` when the user selects the selling status as "I am already selling online".
     @Published private(set) var isAlreadySellingOnline: Bool = false
 
-    private let onContinue: () -> Void
+    private let onContinue: (StoreCreationSellingStatusAnswer?) -> Void
     private let onSkip: () -> Void
 
     init(storeName: String,
-         onContinue: @escaping () -> Void,
+         onContinue: @escaping (StoreCreationSellingStatusAnswer?) -> Void,
          onSkip: @escaping () -> Void) {
         self.topHeader = storeName
         self.onContinue = onContinue
@@ -48,7 +49,7 @@ final class StoreCreationSellingStatusQuestionViewModel: StoreCreationProfilerQu
 
 extension StoreCreationSellingStatusQuestionViewModel: OptionalStoreCreationProfilerQuestionViewModel {
     func continueButtonTapped() async {
-        guard selectedStatus != nil else {
+        guard let selectedStatus else {
             return onSkip()
         }
         guard selectedStatus != .alreadySellingOnline else {
@@ -56,7 +57,7 @@ extension StoreCreationSellingStatusQuestionViewModel: OptionalStoreCreationProf
             return
         }
         // TODO: submission API.
-        onContinue()
+        onContinue(.init(sellingStatus: selectedStatus, sellingPlatforms: nil))
     }
 
     func skipButtonTapped() {

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -143,6 +143,7 @@ private extension StoreCreationCoordinator {
                 self?.showDomainSelector(from: navigationController,
                                          storeName: storeName,
                                          category: nil,
+                                         sellingStatus: nil,
                                          countryCode: nil,
                                          planToPurchase: planToPurchase)
             }
@@ -330,11 +331,12 @@ private extension StoreCreationCoordinator {
                                    storeName: String,
                                    category: StoreCreationCategoryAnswer?,
                                    planToPurchase: WPComPlanProduct) {
-        let questionController = StoreCreationSellingStatusQuestionHostingController(storeName: storeName) { [weak self] in
+        let questionController = StoreCreationSellingStatusQuestionHostingController(storeName: storeName) { [weak self] sellingStatus in
             guard let self else { return }
             self.showStoreCountryQuestion(from: navigationController,
                                           storeName: storeName,
                                           category: category,
+                                          sellingStatus: sellingStatus,
                                           planToPurchase: planToPurchase)
         } onSkip: { [weak self] in
             // TODO: analytics
@@ -342,6 +344,7 @@ private extension StoreCreationCoordinator {
             self.showStoreCountryQuestion(from: navigationController,
                                           storeName: storeName,
                                           category: category,
+                                          sellingStatus: nil,
                                           planToPurchase: planToPurchase)
         }
         navigationController.pushViewController(questionController, animated: true)
@@ -352,6 +355,7 @@ private extension StoreCreationCoordinator {
     func showStoreCountryQuestion(from navigationController: UINavigationController,
                                   storeName: String,
                                   category: StoreCreationCategoryAnswer?,
+                                  sellingStatus: StoreCreationSellingStatusAnswer?,
                                   planToPurchase: WPComPlanProduct) {
         let questionController = StoreCreationCountryQuestionHostingController(viewModel:
                 .init(storeName: storeName) { [weak self] countryCode in
@@ -359,6 +363,7 @@ private extension StoreCreationCoordinator {
                     self.showDomainSelector(from: navigationController,
                                             storeName: storeName,
                                             category: category,
+                                            sellingStatus: sellingStatus,
                                             countryCode: countryCode,
                                             planToPurchase: planToPurchase)
                 } onSupport: { [weak self] in
@@ -372,6 +377,7 @@ private extension StoreCreationCoordinator {
     func showDomainSelector(from navigationController: UINavigationController,
                             storeName: String,
                             category: StoreCreationCategoryAnswer?,
+                            sellingStatus: StoreCreationSellingStatusAnswer?,
                             countryCode: SiteAddress.CountryCode?,
                             planToPurchase: WPComPlanProduct) {
         let domainSelector = DomainSelectorHostingController(viewModel: .init(initialSearchTerm: storeName),
@@ -380,6 +386,7 @@ private extension StoreCreationCoordinator {
             await self.createStoreAndContinueToStoreSummary(from: navigationController,
                                                             name: storeName,
                                                             category: category,
+                                                            sellingStatus: sellingStatus,
                                                             countryCode: countryCode,
                                                             domain: domain,
                                                             planToPurchase: planToPurchase)
@@ -394,11 +401,13 @@ private extension StoreCreationCoordinator {
     func createStoreAndContinueToStoreSummary(from navigationController: UINavigationController,
                                               name: String,
                                               category: StoreCreationCategoryAnswer?,
+                                              sellingStatus: StoreCreationSellingStatusAnswer?,
                                               countryCode: SiteAddress.CountryCode?,
                                               domain: String,
                                               planToPurchase: WPComPlanProduct) async {
         let result = await createStore(name: name, domain: domain)
-        analytics.track(event: .StoreCreation.siteCreationProfilerData(category: category))
+        analytics.track(event: .StoreCreation.siteCreationProfilerData(category: category,
+                                                                      sellingStatus: sellingStatus))
         switch result {
         case .success(let siteResult):
             showStoreSummary(from: navigationController,

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -407,7 +407,8 @@ private extension StoreCreationCoordinator {
                                               planToPurchase: WPComPlanProduct) async {
         let result = await createStore(name: name, domain: domain)
         analytics.track(event: .StoreCreation.siteCreationProfilerData(category: category,
-                                                                      sellingStatus: sellingStatus))
+                                                                       sellingStatus: sellingStatus,
+                                                                       countryCode: countryCode))
         switch result {
         case .success(let siteResult):
             showStoreSummary(from: navigationController,

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCategoryQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationCategoryQuestionViewModelTests.swift
@@ -17,12 +17,11 @@ final class StoreCreationCategoryQuestionViewModelTests: XCTestCase {
     }
 
     func test_continueButtonTapped_invokes_onContinue_after_selecting_a_category() throws {
-        waitFor { promise in
+        let answer = waitFor { promise in
             // Given
             let viewModel = StoreCreationCategoryQuestionViewModel(storeName: "store",
-                                                                   onContinue: { _ in
-                // Then
-                promise(())
+                                                                   onContinue: { answer in
+                promise(answer)
             },
                                                                    onSkip: {})
             // When
@@ -31,6 +30,11 @@ final class StoreCreationCategoryQuestionViewModelTests: XCTestCase {
                 await viewModel.continueButtonTapped()
             }
         }
+
+        // Then
+        XCTAssertEqual(answer, .init(name: StoreCreationCategoryQuestionViewModel.Category.clothingAndAccessories.name,
+                                     value: "clothing_and_accessories",
+                                     groupValue: "retail"))
     }
 
     func test_continueButtonTapped_invokes_onSkip_without_selecting_a_category() throws {

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationSellingPlatformsQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationSellingPlatformsQuestionViewModelTests.swift
@@ -79,7 +79,7 @@ final class StoreCreationSellingPlatformsQuestionViewModelTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(answer, .init(sellingStatus: .alreadySellingOnline, sellingPlatforms: nil))
+        XCTAssertEqual(answer, .init(sellingStatus: .alreadySellingOnline, sellingPlatforms: []))
     }
 
     func test_skipButtonTapped_invokes_onSkip() throws {

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationSellingPlatformsQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationSellingPlatformsQuestionViewModelTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class StoreCreationSellingPlatformsQuestionViewModelTests: XCTestCase {
     func test_topHeader_is_set_to_store_name() throws {
         // Given
-        let viewModel = StoreCreationSellingPlatformsQuestionViewModel(storeName: "store 🌟") {} onSkip: {}
+        let viewModel = StoreCreationSellingPlatformsQuestionViewModel(storeName: "store 🌟") { _ in } onSkip: {}
 
         // Then
         XCTAssertEqual(viewModel.topHeader, "store 🌟")
@@ -13,7 +13,7 @@ final class StoreCreationSellingPlatformsQuestionViewModelTests: XCTestCase {
 
     func test_selecting_a_platform_adds_to_selectedPlatforms() throws {
         // Given
-        let viewModel = StoreCreationSellingPlatformsQuestionViewModel(storeName: "store") {} onSkip: {}
+        let viewModel = StoreCreationSellingPlatformsQuestionViewModel(storeName: "store") { _ in } onSkip: {}
         XCTAssertEqual(viewModel.selectedPlatforms, [])
 
         // When
@@ -31,7 +31,7 @@ final class StoreCreationSellingPlatformsQuestionViewModelTests: XCTestCase {
 
     func test_selecting_a_platform_twice_removes_platform_from_selectedPlatforms() throws {
         // Given
-        let viewModel = StoreCreationSellingPlatformsQuestionViewModel(storeName: "store") {} onSkip: {}
+        let viewModel = StoreCreationSellingPlatformsQuestionViewModel(storeName: "store") { _ in } onSkip: {}
         XCTAssertEqual(viewModel.selectedPlatforms, [])
 
         // When
@@ -47,40 +47,45 @@ final class StoreCreationSellingPlatformsQuestionViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedPlatforms, [])
     }
 
-    func test_continueButtonTapped_invokes_onContinue_after_selecting_a_platform() throws {
-        waitFor { promise in
+    func test_continueButtonTapped_invokes_onContinue_after_selecting_multiple_platforms() throws {
+        let answer = waitFor { promise in
             // Given
-            let viewModel = StoreCreationSellingPlatformsQuestionViewModel(storeName: "store") {
-                // Then
-                promise(())
+            let viewModel = StoreCreationSellingPlatformsQuestionViewModel(storeName: "store") { answer in
+                promise(answer)
             } onSkip: {}
 
             // When
             viewModel.selectPlatform(.wordPress)
+            viewModel.selectPlatform(.amazon)
             Task { @MainActor in
                 await viewModel.continueButtonTapped()
             }
         }
+
+        // Then
+        XCTAssertEqual(answer, .init(sellingStatus: .alreadySellingOnline, sellingPlatforms: [.wordPress, .amazon]))
     }
 
-    func test_continueButtonTapped_invokes_onContinue_without_selecting_a_category() throws {
-        waitFor { promise in
+    func test_continueButtonTapped_invokes_onContinue_without_selecting_a_platform() throws {
+        let answer = waitFor { promise in
             // Given
-            let viewModel = StoreCreationSellingPlatformsQuestionViewModel(storeName: "store") {
-                // Then
-                promise(())
+            let viewModel = StoreCreationSellingPlatformsQuestionViewModel(storeName: "store") { answer in
+                promise(answer)
             } onSkip: {}
             // When
             Task { @MainActor in
                 await viewModel.continueButtonTapped()
             }
         }
+
+        // Then
+        XCTAssertEqual(answer, .init(sellingStatus: .alreadySellingOnline, sellingPlatforms: nil))
     }
 
     func test_skipButtonTapped_invokes_onSkip() throws {
         waitFor { promise in
             // Given
-            let viewModel = StoreCreationSellingPlatformsQuestionViewModel(storeName: "store") {} onSkip: {
+            let viewModel = StoreCreationSellingPlatformsQuestionViewModel(storeName: "store") { _ in } onSkip: {
                 // Then
                 promise(())
             }

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationSellingStatusQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationSellingStatusQuestionViewModelTests.swift
@@ -48,7 +48,7 @@ final class StoreCreationSellingStatusQuestionViewModelTests: XCTestCase {
 
     func test_continueButtonTapped_does_not_invoke_onContinue_after_selecting_alreadySellingOnline_status() throws {
         // Given
-        let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") { answer in
+        let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") { _ in
             XCTFail("onContinue should not be invoked after selecting alreadySellingOnline status.")
         } onSkip: {}
 

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationSellingStatusQuestionViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationSellingStatusQuestionViewModelTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class StoreCreationSellingStatusQuestionViewModelTests: XCTestCase {
     func test_selecting_non_alreadySellingOnline_updates_selectedStatus_and_not_isAlreadySellingOnline() throws {
         // Given
-        let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") {} onSkip: {}
+        let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") { _ in } onSkip: {}
         XCTAssertFalse(viewModel.isAlreadySellingOnline)
 
         // When
@@ -18,7 +18,7 @@ final class StoreCreationSellingStatusQuestionViewModelTests: XCTestCase {
 
     func test_selecting_alreadySellingOnline_updates_selectedStatus_and_isAlreadySellingOnline() throws {
         // Given
-        let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") {} onSkip: {}
+        let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") { _ in } onSkip: {}
         XCTAssertFalse(viewModel.isAlreadySellingOnline)
 
         // When
@@ -30,11 +30,10 @@ final class StoreCreationSellingStatusQuestionViewModelTests: XCTestCase {
     }
 
     func test_continueButtonTapped_invokes_onContinue_after_selecting_a_non_alreadySellingOnline_status() throws {
-        waitFor { promise in
+        let answer = waitFor { promise in
             // Given
-            let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") {
-                // Then
-                promise(())
+            let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") { answer in
+                promise(answer)
             } onSkip: {}
             // When
             viewModel.selectStatus(.alreadySellingButNotOnline)
@@ -42,11 +41,14 @@ final class StoreCreationSellingStatusQuestionViewModelTests: XCTestCase {
                 await viewModel.continueButtonTapped()
             }
         }
+
+        // Then
+        XCTAssertEqual(answer, .init(sellingStatus: .alreadySellingButNotOnline, sellingPlatforms: nil))
     }
 
     func test_continueButtonTapped_does_not_invoke_onContinue_after_selecting_alreadySellingOnline_status() throws {
         // Given
-        let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") {
+        let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") { answer in
             XCTFail("onContinue should not be invoked after selecting alreadySellingOnline status.")
         } onSkip: {}
 
@@ -60,7 +62,7 @@ final class StoreCreationSellingStatusQuestionViewModelTests: XCTestCase {
     func test_continueButtonTapped_invokes_onSkip_without_selecting_a_category() throws {
         waitFor { promise in
             // Given
-            let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") {} onSkip: {
+            let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") { _ in } onSkip: {
                 // Then
                 promise(())
             }
@@ -74,7 +76,7 @@ final class StoreCreationSellingStatusQuestionViewModelTests: XCTestCase {
     func test_skipButtonTapped_invokes_onSkip() throws {
         waitFor { promise in
             // Given
-            let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") {} onSkip: {
+            let viewModel = StoreCreationSellingStatusQuestionViewModel(storeName: "store") { _ in } onSkip: {
                 // Then
                 promise(())
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8644 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Why

Source: p1673363982459279-slack-C045CUK1Y3U
Ref: pe5sF9-I3-p2#milestone-4-onboarding

> Since we have the profiling questions ready, but we are still waiting for the API endpoints, Anitaa get the approval from Samrat to release the profiling questions without the endpoint, collecting the answers somewhere: ideally on Tracks, unless you have a better tool in mind for that.

### Event

Event name: `*site_creation_profiler_data`
Event properties:
```
industry_group : automotive , food_drink , digital_products, etc
industry : fuel_dispensers , books, grocery_stores, long etc
user_commerce_journey : im_just_starting_my_business , im_already_selling_but_not_online, im_already_selling_online
ecommerce_platforms: amazon , big-cartel shopify , big-commerce , etc.
country: country ISO code
```

### Implementation

Since the API request was originally designed to fire after completing each profiler question, some changes were made to pass the answer to the later screens until it reaches the store summary screen where the new Tracks event is sent with all the answers from the 3 profiler questions. 2 new answer structs were created to encapsulate all the data needed to show on the store summary screen and send to the Tracks event (and later the API).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in if needed
- Go to the Menu tab, and tap `Switch store`
- On the store picker, tap `+ Add a store`
- Tap `Create a new store` --> the domain selector should be shown with a placeholder image
- Enter some store name and tap `Continue`
- Select a category and tap `Continue`
- Select `I'm already selling online` and tap `Continue`
- Select multiple platforms and tap `Continue`
- Select a country and tap `Continue`
- Select or search for a domain, then tap `Continue` --> the store name, category, and country from the previous questions should be shown on the store summary screen. Also, a Tracks event should be tracked like: `🔵 Tracked site_creation_profiler_data, properties: [AnyHashable("country_code"): "AQ", AnyHashable("ecommerce_platforms"): "amazon,etsy,facebook-marketplace,google-shopping", AnyHashable("user_commerce_journey"): "im_already_selling_online", AnyHashable("industry"): "shoes", AnyHashable("industry_group"): "retail"]`
- Go back to the category question
- Tap `Skip` to skip the category question
- Tap `Skip` to skip the selling status question
- Tap `Continue` to continue with the default country code
- Select or search for a domain, then tap `Continue` --> the store name, category, and country from the previous questions should be shown on the store summary screen. Also, a Tracks event should be tracked like: `🔵 Tracked site_creation_profiler_data, properties: [AnyHashable("country_code"): "US"]`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://user-images.githubusercontent.com/1945542/212794922-c68fe25b-5b7e-4a78-9786-b0f4e32da8ce.png" width="300" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.