### PR TITLE
Improve provisioning profiles update workflow from Fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -924,34 +924,23 @@ platform :ios do
   ########################################################################
   # Configure Lanes
   ########################################################################
-  #####################################################################################
-  # update_certs_and_profiles
-  # -----------------------------------------------------------------------------------
-  # This lane downloads all the required certs and profiles and,
-  # if not run on CI it creates the missing ones.
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  # bundle exec fastlane update_certs_and_profiles
+
+  # Downloads all the required certificates and profiles for both production and internal distribution builds.
+  # Optionally, it can create any new necessary certificate or profile.
   #
-  # Example:
-  # bundle exec fastlane update_certs_and_profiles
-  #####################################################################################
-  lane :update_certs_and_profiles do
-    alpha_code_signing
-    appstore_code_signing
+  # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
+  lane :update_certs_and_profiles do |options|
+    alpha_code_signing(options)
+    appstore_code_signing(options)
   end
 
-  ########################################################################
-  # Fastlane match code signing
-  ########################################################################
-  private_lane :alpha_code_signing do
+  # Downloads all the required certificates and profiles the enterprise build.
+  # Optionally, it can create any new necessary certificate or profile.
+  #
+  # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
+  private_lane :alpha_code_signing do |options|
     api_key_path = ASC_KEY_PATH
-
-    # We could implement a more refined ENV to boolean conversion to support
-    # 1, yes, etc. but for the moment and given the limited scope of this tool
-    # and feature, we can implicitly expect CODE_SIGNING_READONLY to be a
-    # 'true' or 'false' string.
-    readonly = ENV.fetch('CODE_SIGNING_READONLY', 'true').to_s.downcase == 'true'
+    readonly = options.fetch(:readonly, true)
 
     unless readonly
       # The Enterprise account APIs do not support authentication via API key.
@@ -972,12 +961,16 @@ platform :ios do
     )
   end
 
-  private_lane :appstore_code_signing do
+  # Downloads all the required certificates and profiles the production build.
+  # Optionally, it can create any new necessary certificate or profile.
+  #
+  # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
+  private_lane :appstore_code_signing do |options|
     match(
       type: 'appstore',
       team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
       app_identifier: MAIN_BUNDLE_IDENTIFIERS,
-      readonly: false,
+      readonly: options.fetch(:readonly, true),
       api_key_path: ASC_KEY_PATH
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -939,13 +939,14 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   private_lane :alpha_code_signing do |options|
-    api_key_path = ASC_KEY_PATH
     readonly = options.fetch(:readonly, true)
 
-    unless readonly
+    if readonly
+      # In readonly mode, we can use the API key
+      api_key_path = ASC_KEY_PATH
+    else
       # The Enterprise account APIs do not support authentication via API key.
-      # If we want to modify data (readonly = false) we need to authenticate
-      # manually.
+      # If we want to modify data (readonly = false) we need to authenticate manually.
       prompt_user_for_app_store_connect_credentials
       # We also need to pass no API key path, otherwise Fastlane will give
       # precedence to that authentication mode.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -618,13 +618,7 @@ platform :ios do
     # We're about to use `add_development_certificates_to_provisioning_profiles` and `add_all_devices_to_provisioning_profiles`.
     # These actions use Developer Portal APIs that don't yet support authentication via API key (-.-').
     # Let's preemptively ask for and set the email here to avoid being asked twice for it if not set.
-
-    require 'credentials_manager'
-
-    # If Fastlane cannot instantiate a user, it will ask the caller for the email.
-    # Once we have it, we can set it as `FASTLANE_USER` in the environment (which has lifecycle limited to this call) so that the next commands will already have access to it.
-    # Note that if the user is already available to `AccountManager`, setting it in the environment is redundant, but Fastlane doesn't provide a way to check it so we have to do it anyway.
-    ENV['FASTLANE_USER'] = CredentialsManager::AccountManager.new.user
+    prompt_user_for_app_store_connect_credentials
 
     # Add all development certificates to the provisioning profiles (just in case – this is an easy step to miss)
     add_development_certificates_to_provisioning_profiles(
@@ -951,11 +945,30 @@ platform :ios do
   # Fastlane match code signing
   ########################################################################
   private_lane :alpha_code_signing do
+    api_key_path = ASC_KEY_PATH
+
+    # We could implement a more refined ENV to boolean conversion to support
+    # 1, yes, etc. but for the moment and given the limited scope of this tool
+    # and feature, we can implicitly expect CODE_SIGNING_READONLY to be a
+    # 'true' or 'false' string.
+    readonly = ENV.fetch('CODE_SIGNING_READONLY', 'true').to_s.downcase == 'true'
+
+    unless readonly
+      # The Enterprise account APIs do not support authentication via API key.
+      # If we want to modify data (readonly = false) we need to authenticate
+      # manually.
+      prompt_user_for_app_store_connect_credentials
+      # We also need to pass no API key path, otherwise Fastlane will give
+      # precedence to that authentication mode.
+      api_key_path = nil
+    end
+
     match(
       type: 'enterprise',
       team_id: get_required_env('INT_EXPORT_TEAM_ID'),
       app_identifier: ALPHA_BUNDLE_IDENTIFIERS,
-      readonly: true
+      readonly: readonly,
+      api_key_path: api_key_path
     )
   end
 
@@ -964,7 +977,8 @@ platform :ios do
       type: 'appstore',
       team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
       app_identifier: MAIN_BUNDLE_IDENTIFIERS,
-      readonly: true
+      readonly: false,
+      api_key_path: ASC_KEY_PATH
     )
   end
 
@@ -1170,6 +1184,15 @@ end
 
 def buildkite_ci?
   ENV.fetch('BUILDKITE', false)
+end
+
+def prompt_user_for_app_store_connect_credentials
+  require 'credentials_manager'
+
+  # If Fastlane cannot instantiate a user, it will ask the caller for the email.
+  # Once we have it, we can set it as `FASTLANE_USER` in the environment (which has lifecycle limited to this call) so that the next commands will already have access to it.
+  # Note that if the user is already available to `AccountManager`, setting it in the environment is redundant, but Fastlane doesn't provide a way to check it so we have to do it anyway.
+  ENV['FASTLANE_USER'] = CredentialsManager::AccountManager.new.user
 end
 
 # https://buildkite.com/docs/test-analytics/ci-environments

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -7,6 +7,3 @@ storage_mode('google_cloud')
 google_cloud_bucket_name('a8c-fastlane-match')
 secrets_directory = File.join(Dir.home, '.configure', 'woocommerce-ios', 'secrets')
 google_cloud_keys_file(File.join(secrets_directory, 'google_cloud_keys.json'))
-
-# Use the decrypted API Key for authentication
-api_key_path(File.join(secrets_directory, 'app_store_connect_fastlane_api_key.json'))


### PR DESCRIPTION
## Description

As part of https://github.com/woocommerce/woocommerce-ios/pull/8653, I used the `update_certs_and_profiles` lane to create new distribution provisioning profiles for the upcoming Widgets Intents target (see #7863). 

The previous `update_certs_and_profiles` worked great in `readonly = true` mode, but consistently failed with `readonly = false` because Apple's Enterprise portal does not support authentication via API key. For search-ability, the error one gets in that case is `undefined method `in_house?' for nil:NilClass`:

![image](https://user-images.githubusercontent.com/1218433/212809060-3249bfdf-c1f9-4097-8e92-4f920dc6eba1.png)

Before this change, we'd hack our way through it by commenting and editing code to run the public App Store automation as usual, and the Enterprise one with manual authentication.

With this change, we can call
`bundle exec fastlane update_certs_and_profiles readonly:false` and be prompted for credentials when necessary. No more editing `Fastfile` and discarding changes required.

## Testing instructions

You can verify the behavior by running:

`bundle exec fastlane update_certs_and_profiles readonly:false` and verify it shows the login prompt:

![2023-01-17 15-43-07 2023-01-17 15_44_42](https://user-images.githubusercontent.com/1218433/212811916-11c7c8d1-b5f2-4b3b-a204-0d285d0777b4.gif)

`bundle exec fastlane update_certs_and_profiles readonly:true` and verify it does not show the login prompt and runs in `readonly = true` mode:

![2023-01-17 15-45-56 2023-01-17 15_46_56](https://user-images.githubusercontent.com/1218433/212812289-90579199-a94a-45b8-beca-3039755f5c76.gif)


- `bundle exec fastlane update_certs_and_profiles` and verify it does not show the login prompt and runs in `readonly = true` mode:

![2023-01-17 15-41-30 2023-01-17 15_42_38](https://user-images.githubusercontent.com/1218433/212811957-667aa021-a470-48c9-909a-79a24f0528e8.gif)

_It's safe to cancel the lane after verifying the configuration behavior._

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
