### PR TITLE
REST API: Migrate JITM endpoints

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -715,6 +715,7 @@
 		DE50296328C609DE00551736 /* jetpack-user-not-connected.json in Resources */ = {isa = PBXBuildFile; fileRef = DE50296228C609DE00551736 /* jetpack-user-not-connected.json */; };
 		DE50296528C60A8000551736 /* JetpackUserMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50296428C60A8000551736 /* JetpackUserMapperTests.swift */; };
 		DE5CA111288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = DE5CA110288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json */; };
+		DE66C5552976662700DAA978 /* just-in-time-message-list-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE66C5542976662700DAA978 /* just-in-time-message-list-without-data.json */; };
 		DE6F308727966FEF004E1C9A /* CouponReportListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */; };
 		DE74F29A27E08F5A0002FE59 /* SiteSettingMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */; };
 		DE74F29C27E0A1D00002FE59 /* setting-coupon.json in Resources */ = {isa = PBXBuildFile; fileRef = DE74F29B27E0A1D00002FE59 /* setting-coupon.json */; };
@@ -1543,6 +1544,7 @@
 		DE50296228C609DE00551736 /* jetpack-user-not-connected.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "jetpack-user-not-connected.json"; sourceTree = "<group>"; };
 		DE50296428C60A8000551736 /* JetpackUserMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackUserMapperTests.swift; sourceTree = "<group>"; };
 		DE5CA110288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-malformed-variations-and-image-alt.json"; sourceTree = "<group>"; };
+		DE66C5542976662700DAA978 /* just-in-time-message-list-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "just-in-time-message-list-without-data.json"; sourceTree = "<group>"; };
 		DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapperTests.swift; sourceTree = "<group>"; };
 		DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSettingMapper.swift; sourceTree = "<group>"; };
 		DE74F29B27E0A1D00002FE59 /* setting-coupon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-coupon.json"; sourceTree = "<group>"; };
@@ -2161,6 +2163,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DE66C5542976662700DAA978 /* just-in-time-message-list-without-data.json */,
 				DE4F2A432975684900B0701C /* site-api-without-data.json */,
 				DE4F2A3D29750EF400B0701C /* inbox-note-list-without-data.json */,
 				DE4F2A3E29750EF400B0701C /* inbox-note-without-data.json */,
@@ -3121,6 +3124,7 @@
 				93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */,
 				74C947842193A6C70024CB60 /* comment-moderate-approved.json in Resources */,
 				DEC51AED2768A0AD009F3DF4 /* systemStatusWithPluginsOnly.json in Resources */,
+				DE66C5552976662700DAA978 /* just-in-time-message-list-without-data.json in Resources */,
 				D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */,
 				3158FE6426129B1300E566B9 /* wcpay-account-complete.json in Resources */,
 				B56C1EBA20EA7D2C00D749F9 /* sites.json in Resources */,

--- a/Networking/Networking/Mapper/DataBoolMapper.swift
+++ b/Networking/Networking/Mapper/DataBoolMapper.swift
@@ -1,13 +1,17 @@
 import Foundation
 
-/// Mapper: Bool Result Wrapped in `data` Key
+/// Mapper: Bool Result, Wrapped in `data` Key or not
 ///
 struct DataBoolMapper: Mapper {
 
     /// (Attempts) to extract the boolean flag from a given JSON Encoded response.
     ///
     func map(response: Data) throws -> Bool {
-        try JSONDecoder().decode(DataBool.self, from: response).data
+        do {
+            return try JSONDecoder().decode(DataBool.self, from: response).data
+        } catch {
+            return try JSONDecoder().decode(Bool.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Mapper/JustInTimeMessageListMapper.swift
+++ b/Networking/Networking/Mapper/JustInTimeMessageListMapper.swift
@@ -16,7 +16,11 @@ struct JustInTimeMessageListMapper: Mapper {
         decoder.userInfo = [
             .siteID: siteID
         ]
-        return try decoder.decode(JustInTimeMessageListEnvelope.self, from: response).data
+        do {
+            return try decoder.decode(JustInTimeMessageListEnvelope.self, from: response).data
+        } catch {
+            return try decoder.decode([JustInTimeMessage].self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Remote/JustInTimeMessagesRemote.swift
+++ b/Networking/Networking/Remote/JustInTimeMessagesRemote.swift
@@ -35,7 +35,8 @@ public final class JustInTimeMessagesRemote: Remote, JustInTimeMessagesRemotePro
                                      locale: locale,
                                      path: Path.jitm,
                                      parameters: getParameters(messagePath: messagePath,
-                                                               query: query))
+                                                               query: query),
+                                     availableAsRESTRequest: true)
 
         let mapper = JustInTimeMessageListMapper(siteID: siteID)
 
@@ -97,7 +98,8 @@ public final class JustInTimeMessagesRemote: Remote, JustInTimeMessagesRemotePro
                                      method: .post,
                                      siteID: siteID,
                                      path: Path.jitm,
-                                     parameters: parameters)
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
 
         return try await enqueue(request, mapper: DataBoolMapper())
     }

--- a/Networking/NetworkingTests/Mapper/JustInTimeMessageListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/JustInTimeMessageListMapperTests.swift
@@ -15,6 +15,14 @@ final class JustInTimeMessageListMapperTests: XCTestCase {
         assertEqual(1, justInTimeMessages?.count)
     }
 
+    /// Verifies that the message is parsed.
+    ///
+    func test_JustInTimeMessageListMapper_parses_the_JustInTimeMessage_in_response_without_data_envelope() throws {
+        let justInTimeMessages = try mapLoadJustInTimeMessageListResponseWithoutDataEnvelope()
+        XCTAssertNotNil(justInTimeMessages)
+        assertEqual(1, justInTimeMessages?.count)
+    }
+
     /// Verifies that the fields are all parsed correctly.
     ///
     func test_JustInTimeMessageListMapper_parses_all_fields_in_result() throws {
@@ -54,5 +62,11 @@ private extension JustInTimeMessageListMapperTests {
     ///
     func mapLoadJustInTimeMessageListResponse() throws -> [JustInTimeMessage]? {
         return try mapJustInTimeMessageList(from: "just-in-time-message-list")
+    }
+
+    /// Returns the JustInTimeMessageListMapper output from `just-in-time-message-list-without-data.json`
+    ///
+    func mapLoadJustInTimeMessageListResponseWithoutDataEnvelope() throws -> [JustInTimeMessage]? {
+        return try mapJustInTimeMessageList(from: "just-in-time-message-list-without-data")
     }
 }

--- a/Networking/NetworkingTests/Responses/just-in-time-message-list-without-data.json
+++ b/Networking/NetworkingTests/Responses/just-in-time-message-list-without-data.json
@@ -1,0 +1,33 @@
+[
+  {
+    "content": {
+      "message": "In-person card payments",
+      "icon": "",
+      "iconPath": null,
+      "list": [],
+      "description": "Sell anywhere, and take card payments using a mobile card reader.",
+      "classes": "",
+      "title": "",
+      "disclaimer": []
+    },
+    "CTA": {
+      "message": "Purchase Card Reader",
+      "hook": "",
+      "newWindow": true,
+      "primary": true,
+      "link": "https:\/\/woocommerce.com\/products\/hardware\/US"
+    },
+    "template": "default",
+    "ttl": 300,
+    "id": "woomobile_ipp_barcode_users",
+    "feature_class": "woomobile_ipp",
+    "expires": 3628800,
+    "max_dismissal": 2,
+    "activate_module": null,
+    "is_dismissible": true,
+    "is_user_created_by_partner": null,
+    "message_expiration": null,
+    "url": "https:\/\/jetpack.com\/redirect\/?source=jitm-woomobile_ipp_barcode_users&#038;site=store.example.com&#038;u=1",
+    "jitm_stats_url": "https:\/\/pixel.wp.com\/b.gif?v=wpcom2&rand=b8ec47eefac4b8f64b70cd379dc573dd&x_jetpack-jitm=woomobile_ipp_barcode_users"
+  }
+]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8661 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR continues the work for the REST API migration by enabling REST API for JITM endpoints.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Pre-requisite: Make sure to have a self-hosted store and follow pdfdoF-1uc-p2#comment-2581 for details of setting up your store to be eligible for the test JITM.
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- On the prologue screen, select Enter your site address and proceed with the address of your test store.
- Log in with your site credentials. After the login succeeds, you should be navigated to the home screen.
- On the home screen, notice the JITM banner is displayed. Xcode console should log `🔵 Tracked jitm_fetch_success` and `🔵 Tracked jitm_displayed`.
- Tap the dismiss button on the banner, the banner should disappear. Xcode console should log `🔵 Tracked jitm_dismissed` and `🔵 Tracked jitm_dismiss_success`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/212818640-1d4144e6-6186-4a67-a109-48383391cb9f.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
