### PR TITLE
REST API: Skip setting up push notification if authenticated without WPCom

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -303,7 +303,10 @@ private extension AppDelegate {
     /// Push Notifications: Authorization + Registration!
     ///
     func setupPushNotificationsManagerIfPossible() {
-        guard ServiceLocator.stores.isAuthenticated, ServiceLocator.stores.needsDefaultStore == false else {
+        let stores = ServiceLocator.stores
+        guard stores.isAuthenticated,
+              stores.needsDefaultStore == false,
+              stores.isAuthenticatedWithoutWPCom == false else {
             if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginErrorNotifications) {
                 ServiceLocator.pushNotesManager.ensureAuthorizationIsRequested(includesProvisionalAuth: true, onCompletion: nil)
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8453 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the push notification setup logic by skipping the setup if the user is authenticated without WPCom.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Delete the app on your physical device if it's already installed.
- Turn on the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app to the device.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address and proceed with the address of your self-hosted site.
- Log in with your site credentials.
- After the login succeeds, you should be navigated to the home screen. There should be no alert for push notification permission. Neither of the methods `didRegisterForRemoteNotificationsWithDeviceToken` and `didFailToRegisterForRemoteNotificationsWithError` on `AppDelegate` should be triggered.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
