### PR TITLE
Store creation: release profiler questions

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -40,7 +40,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .storeCreationM2WithInAppPurchasesEnabled:
             return false
         case .storeCreationM3Profiler:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .justInTimeMessagesOnDashboard:
             return true
         case .systemStatusReportInSupportRequest:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 12.0
 -----
-
+- [internal] Store creation flow now includes 3 profiler questions: store category, selling status, and store country. [https://github.com/woocommerce/woocommerce-ios/pull/8667]
 
 11.9
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -133,6 +133,9 @@ extension WooAnalyticsEvent.StoreCreation {
     /// Steps of the native store creation flow.
     enum Step: String {
         case storeName = "store_name"
+        case profilerCategoryQuestion = "store_profiler_industries"
+        case profilerSellingStatusQuestion = "store_profiler_commerce_journey"
+        case profilerCountryQuestion = "store_profiler_country"
         case domainPicker = "domain_picker"
         case storeSummary = "store_summary"
         case planPurchase = "plan_purchase"

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -323,7 +323,7 @@ private extension StoreCreationCoordinator {
                     self.showSellingStatusQuestion(from: navigationController, storeName: storeName, category: nil, planToPurchase: planToPurchase)
                 })
         navigationController.pushViewController(questionController, animated: true)
-        // TODO: analytics
+        analytics.track(event: .StoreCreation.siteCreationStep(step: .profilerCategoryQuestion))
     }
 
     @MainActor
@@ -348,7 +348,7 @@ private extension StoreCreationCoordinator {
                                           planToPurchase: planToPurchase)
         }
         navigationController.pushViewController(questionController, animated: true)
-        // TODO: analytics
+        analytics.track(event: .StoreCreation.siteCreationStep(step: .profilerSellingStatusQuestion))
     }
 
     @MainActor
@@ -370,7 +370,7 @@ private extension StoreCreationCoordinator {
                     self?.showSupport(from: navigationController)
                 })
         navigationController.pushViewController(questionController, animated: true)
-        // TODO: analytics
+        analytics.track(event: .StoreCreation.siteCreationStep(step: .profilerCountryQuestion))
     }
 
     @MainActor


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8644 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The profiler answer submission API is not ready yet, but we're tracking the answers in a Tracks event for now https://github.com/woocommerce/woocommerce-ios/pull/8656. This PR enabled the profiler questions for the upcoming release, and added Tracks events `site_creation_step` with new step enum cases when each of the 3 profiler questions is shown.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in if needed
- Go to the Menu tab, and tap `Switch store`
- On the store picker, tap `+ Add a store`
- Tap `Create a new store` --> the domain selector should be shown with a placeholder image
- Enter some store name and tap `Continue` --> in the console, a log should be shown `🔵 Tracked site_creation_step, properties: [AnyHashable("step"): "store_profiler_industries"]` when the store category question is shown
- Select a category and tap `Continue`  --> in the console, a log should be shown `🔵 Tracked site_creation_step, properties: [AnyHashable("step"): "store_profiler_commerce_journey"]` when the store selling status question is shown
- Tap `Skip` --> in the console, a log should be shown `🔵 Tracked site_creation_step, properties: [AnyHashable("step"): "store_profiler_country"]` when the store country question is shown
- Select a country and tap `Continue`
- Select or search for a domain, then tap `Continue` --> the store name, category, and country from the previous questions should be shown on the store summary screen. Also, a Tracks event should be tracked like: `🔵 Tracked site_creation_profiler_data, properties: [AnyHashable("country_code"): "**", AnyHashable("industry"): "**", AnyHashable("industry_group"): "**"]`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
