### PR TITLE
REST API: Migrate site plugin fetching endpoint

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -728,6 +728,7 @@
 		DE66C5632977CBC700DAA978 /* shipping-label-eligibility-failure-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE66C5622977CBC700DAA978 /* shipping-label-eligibility-failure-without-data.json */; };
 		DE66C5652977CC4300DAA978 /* shipping-label-purchase-success-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE66C5642977CC4300DAA978 /* shipping-label-purchase-success-without-data.json */; };
 		DE66C5672977CEB800DAA978 /* shipping-label-status-success-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE66C5662977CEB800DAA978 /* shipping-label-status-success-without-data.json */; };
+		DE66C5692977D62700DAA978 /* plugins-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DE66C5682977D62700DAA978 /* plugins-without-data.json */; };
 		DE6F308727966FEF004E1C9A /* CouponReportListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */; };
 		DE74F29A27E08F5A0002FE59 /* SiteSettingMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */; };
 		DE74F29C27E0A1D00002FE59 /* setting-coupon.json in Resources */ = {isa = PBXBuildFile; fileRef = DE74F29B27E0A1D00002FE59 /* setting-coupon.json */; };
@@ -1569,6 +1570,7 @@
 		DE66C5622977CBC700DAA978 /* shipping-label-eligibility-failure-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-eligibility-failure-without-data.json"; sourceTree = "<group>"; };
 		DE66C5642977CC4300DAA978 /* shipping-label-purchase-success-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-purchase-success-without-data.json"; sourceTree = "<group>"; };
 		DE66C5662977CEB800DAA978 /* shipping-label-status-success-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-status-success-without-data.json"; sourceTree = "<group>"; };
+		DE66C5682977D62700DAA978 /* plugins-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "plugins-without-data.json"; sourceTree = "<group>"; };
 		DE6F308627966FEF004E1C9A /* CouponReportListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponReportListMapperTests.swift; sourceTree = "<group>"; };
 		DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSettingMapper.swift; sourceTree = "<group>"; };
 		DE74F29B27E0A1D00002FE59 /* setting-coupon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "setting-coupon.json"; sourceTree = "<group>"; };
@@ -2188,6 +2190,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DE66C5682977D62700DAA978 /* plugins-without-data.json */,
 				DE66C5662977CEB800DAA978 /* shipping-label-status-success-without-data.json */,
 				DE66C5642977CC4300DAA978 /* shipping-label-purchase-success-without-data.json */,
 				DE66C5622977CBC700DAA978 /* shipping-label-eligibility-failure-without-data.json */,
@@ -3171,6 +3174,7 @@
 				03E8FEC427B40E3F00F5FC7D /* wcpay-charge-card-present-minimal.json in Resources */,
 				EE6FDCFC2966A70400E1CECF /* product-without-data.json in Resources */,
 				31054724262E2FC600C5C02B /* wcpay-payment-intent-requires-capture.json in Resources */,
+				DE66C5692977D62700DAA978 /* plugins-without-data.json in Resources */,
 				7492FAE3217FBDBC00ED2C69 /* settings-general-alt.json in Resources */,
 				93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */,
 				74C947842193A6C70024CB60 /* comment-moderate-approved.json in Resources */,

--- a/Networking/Networking/Mapper/SitePluginsMapper.swift
+++ b/Networking/Networking/Mapper/SitePluginsMapper.swift
@@ -17,7 +17,11 @@ struct SitePluginsMapper: Mapper {
             .siteID: siteID
         ]
 
-        return try decoder.decode(SitePluginsEnvelope.self, from: response).plugins
+        do {
+            return try decoder.decode(SitePluginsEnvelope.self, from: response).plugins
+        } catch {
+            return try decoder.decode([SitePlugin].self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Remote/SitePluginsRemote.swift
+++ b/Networking/Networking/Remote/SitePluginsRemote.swift
@@ -13,7 +13,12 @@ public class SitePluginsRemote: Remote {
     public func loadPlugins(for siteID: Int64,
                             completion: @escaping (Result<[SitePlugin], Error>) -> Void) {
         let path = Constants.sitePluginsPath
-        let request = JetpackRequest(wooApiVersion: .none, method: .get, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .none,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true)
         let mapper = SitePluginsMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/NetworkingTests/Mapper/SitePluginsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SitePluginsMapperTests.swift
@@ -39,6 +39,37 @@ class SitePluginsMapperTests: XCTestCase {
         XCTAssertEqual(wooCommerceSubscriptionsPlugin.version, "3.0.13")
         XCTAssertEqual(wooCommerceSubscriptionsPlugin.textDomain, "woocommerce-subscriptions")
     }
+
+    /// Verifies the SitePlugin fields are parsed correctly.
+    ///
+    func test_SitePlugin_fields_are_properly_parsed_when_response_has_no_data_envelope() {
+        let plugins = mapLoadSitePluginsResponseWithoutDataEnvelope()
+        XCTAssertEqual(plugins.count, 3)
+
+        let helloDollyPlugin = plugins[0]
+        XCTAssertNotNil(helloDollyPlugin)
+        XCTAssertEqual(helloDollyPlugin.siteID, dummySiteID)
+        XCTAssertEqual(helloDollyPlugin.status, .inactive)
+        XCTAssertEqual(helloDollyPlugin.name, "Hello Dolly")
+        XCTAssertEqual(helloDollyPlugin.pluginUri, "http://wordpress.org/plugins/hello-dolly/")
+        XCTAssertEqual(helloDollyPlugin.authorUri, "http://ma.tt/")
+        XCTAssertEqual(helloDollyPlugin.descriptionRaw, "This is not just a plugin, it...")
+        XCTAssertEqual(helloDollyPlugin.descriptionRendered, "This is not just a plugin, it symbolizes...")
+        XCTAssertEqual(helloDollyPlugin.version, "1.7.2")
+        XCTAssertEqual(helloDollyPlugin.textDomain, "")
+
+        let wooCommerceSubscriptionsPlugin = plugins[4]
+        XCTAssertNotNil(wooCommerceSubscriptionsPlugin)
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.siteID, dummySiteID)
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.status, .active)
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.name, "WooCommerce Subscriptions")
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.pluginUri, "https://www.woocommerce.com/products/woocommerce-subscriptions/")
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.authorUri, "https://woocommerce.com/")
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.descriptionRaw, "Sell products and services...")
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.descriptionRendered, "Sell products and services with recurring payments...")
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.version, "3.0.13")
+        XCTAssertEqual(wooCommerceSubscriptionsPlugin.textDomain, "woocommerce-subscriptions")
+    }
 }
 
 
@@ -60,5 +91,11 @@ private extension SitePluginsMapperTests {
     ///
     func mapLoadSitePluginsResponse() -> [SitePlugin] {
         return mapPlugins(from: "plugins")
+    }
+
+    /// Returns the SitePluginsMapper output upon receiving `plugins-without-data`
+    ///
+    func mapLoadSitePluginsResponseWithoutDataEnvelope() -> [SitePlugin] {
+        return mapPlugins(from: "plugins-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/SitePluginsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SitePluginsMapperTests.swift
@@ -57,18 +57,6 @@ class SitePluginsMapperTests: XCTestCase {
         XCTAssertEqual(helloDollyPlugin.descriptionRendered, "This is not just a plugin, it symbolizes...")
         XCTAssertEqual(helloDollyPlugin.version, "1.7.2")
         XCTAssertEqual(helloDollyPlugin.textDomain, "")
-
-        let wooCommerceSubscriptionsPlugin = plugins[4]
-        XCTAssertNotNil(wooCommerceSubscriptionsPlugin)
-        XCTAssertEqual(wooCommerceSubscriptionsPlugin.siteID, dummySiteID)
-        XCTAssertEqual(wooCommerceSubscriptionsPlugin.status, .active)
-        XCTAssertEqual(wooCommerceSubscriptionsPlugin.name, "WooCommerce Subscriptions")
-        XCTAssertEqual(wooCommerceSubscriptionsPlugin.pluginUri, "https://www.woocommerce.com/products/woocommerce-subscriptions/")
-        XCTAssertEqual(wooCommerceSubscriptionsPlugin.authorUri, "https://woocommerce.com/")
-        XCTAssertEqual(wooCommerceSubscriptionsPlugin.descriptionRaw, "Sell products and services...")
-        XCTAssertEqual(wooCommerceSubscriptionsPlugin.descriptionRendered, "Sell products and services with recurring payments...")
-        XCTAssertEqual(wooCommerceSubscriptionsPlugin.version, "3.0.13")
-        XCTAssertEqual(wooCommerceSubscriptionsPlugin.textDomain, "woocommerce-subscriptions")
     }
 }
 

--- a/Networking/NetworkingTests/Responses/plugins-without-data.json
+++ b/Networking/NetworkingTests/Responses/plugins-without-data.json
@@ -1,0 +1,74 @@
+[
+    {
+        "plugin": "hello",
+        "status": "inactive",
+        "name": "Hello Dolly",
+        "plugin_uri": "http://wordpress.org/plugins/hello-dolly/",
+        "author": "Matt Mullenweg",
+        "author_uri": "http://ma.tt/",
+        "description": {
+            "raw": "This is not just a plugin, it...",
+            "rendered": "This is not just a plugin, it symbolizes..."
+        },
+        "version": "1.7.2",
+        "network_only": false,
+        "requires_wp": "",
+        "requires_php": "",
+        "textdomain": "",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wp/v2/plugins/hello"
+                }
+            ]
+        }
+    },
+    {
+        "plugin": "jetpack/jetpack",
+        "status": "active",
+        "name": "Jetpack by WordPress.com",
+        "plugin_uri": "https://jetpack.com",
+        "author": "Automattic",
+        "author_uri": "https://jetpack.com",
+        "description": {
+            "raw": "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.",
+            "rendered": "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users. <cite>By <a href=\"https://jetpack.com\">Automattic</a>.</cite>"
+        },
+        "version": "9.5",
+        "network_only": false,
+        "requires_wp": "5.6",
+        "requires_php": "5.6",
+        "textdomain": "jetpack",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wp/v2/plugins/jetpack/jetpack"
+                }
+            ]
+        }
+    },
+    {
+        "plugin": "woocommerce/woocommerce",
+        "status": "active",
+        "name": "WooCommerce",
+        "plugin_uri": "https://woocommerce.com/",
+        "author": "Automattic",
+        "author_uri": "https://woocommerce.com",
+        "description": {
+            "raw": "An eCommerce toolkit that helps you sell anything. Beautifully.",
+            "rendered": "An eCommerce toolkit that helps you sell anything. Beautifully. <cite>By <a href=\"https://woocommerce.com\">Automattic</a>.</cite>"
+        },
+        "version": "5.1.0",
+        "network_only": false,
+        "requires_wp": "5.4",
+        "requires_php": "7.0",
+        "textdomain": "woocommerce",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com//wp-json/wp/v2/plugins/woocommerce/woocommerce"
+                }
+            ]
+        }
+    }
+]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8677 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR enables REST API on the site plugin fetching endpoint and updates the related mapper to parse contents without the data envelope. I'm not updating the other endpoints for site plugins since we are not handling Jetpack installation for JCP sites when logging in with WPOrg credentials.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- On the prologue screen, select Enter your site address and proceed with the address of your test store.
- Log in with your site credentials. After the login succeeds, you should be navigated to the home screen.
- Navigate to Menu tab and select Settings.
- Select Plugins - all the site's plugin should be listed if your account is a shop administrator. Otherwise, the list will not be displayed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/213110637-4e784526-d1e7-474d-afa2-9bb5335a18ea.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
