### PR TITLE
REST API: Update login flow for AB testing the REST API project

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -87,7 +87,7 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
 #  pod 'WordPressAuthenticator', '~> 5.1.0-beta.1'
-   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'e9d86a5f1542fe470ffffa4a63318508e41aeb6d'
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '443842881b2ae0d971304b619bc6df956f1ccb27'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -86,8 +86,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-#  pod 'WordPressAuthenticator', '~> 5.1.0-beta.1'
-   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '443842881b2ae0d971304b619bc6df956f1ccb27'
+  pod 'WordPressAuthenticator', '~> 5.1.0-beta.2'
+#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -86,8 +86,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 5.1.0-beta.1'
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+#  pod 'WordPressAuthenticator', '~> 5.1.0-beta.1'
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'e9d86a5f1542fe470ffffa4a63318508e41aeb6d'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -39,7 +39,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (5.1.0-beta.1):
+  - WordPressAuthenticator (5.1.0-beta.2):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -84,7 +84,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.14)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 5.1.0-beta.1)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `e9d86a5f1542fe470ffffa4a63318508e41aeb6d`)
   - WordPressKit (~> 5.0.0)
   - WordPressShared (~> 2.0)
   - WordPressUI (~> 1.12.5)
@@ -94,8 +94,6 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -132,6 +130,16 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :commit: e9d86a5f1542fe470ffffa4a63318508e41aeb6d
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: e9d86a5f1542fe470ffffa4a63318508e41aeb6d
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 8fca6b5563a5baef2c04bee27538025e4ceb2add
@@ -153,7 +161,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: b4df3148e7a7c1ad739bcbe6cc7b5ce728a1b15d
+  WordPressAuthenticator: aac1a2435f3bb1435e0b8726debf38fcd440fd6b
   WordPressKit: 202f529323b079a344f7bc1493b7ebebfd9ed4b5
   WordPressShared: 35d41bdf0927e714af1fc85fa9cb692f934473be
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -169,6 +177,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: d9ae1586866c135c8c538e08c02a66f17b63c344
+PODFILE CHECKSUM: fb3f3a64c847f3fe7c182da7a4b3a49ff01f2c9b
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -84,7 +84,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.14)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `443842881b2ae0d971304b619bc6df956f1ccb27`)
+  - WordPressAuthenticator (~> 5.1.0-beta.2)
   - WordPressKit (~> 5.0.0)
   - WordPressShared (~> 2.0)
   - WordPressUI (~> 1.12.5)
@@ -94,6 +94,8 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 5.0)
 
 SPEC REPOS:
+  https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AppAuth
@@ -130,16 +132,6 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :commit: 443842881b2ae0d971304b619bc6df956f1ccb27
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: 443842881b2ae0d971304b619bc6df956f1ccb27
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 8fca6b5563a5baef2c04bee27538025e4ceb2add
@@ -161,7 +153,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: aac1a2435f3bb1435e0b8726debf38fcd440fd6b
+  WordPressAuthenticator: 23dbdf6bb6c6a805d27959599160de9eea69944b
   WordPressKit: 202f529323b079a344f7bc1493b7ebebfd9ed4b5
   WordPressShared: 35d41bdf0927e714af1fc85fa9cb692f934473be
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -177,6 +169,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 03ed5339e5cdcf69a4c02e3234bd53d7c510412d
+PODFILE CHECKSUM: bd6b2d45ca56a9511a41e94144d888f18715de90
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -84,7 +84,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.14)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `e9d86a5f1542fe470ffffa4a63318508e41aeb6d`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `443842881b2ae0d971304b619bc6df956f1ccb27`)
   - WordPressKit (~> 5.0.0)
   - WordPressShared (~> 2.0)
   - WordPressUI (~> 1.12.5)
@@ -132,12 +132,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: e9d86a5f1542fe470ffffa4a63318508e41aeb6d
+    :commit: 443842881b2ae0d971304b619bc6df956f1ccb27
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: e9d86a5f1542fe470ffffa4a63318508e41aeb6d
+    :commit: 443842881b2ae0d971304b619bc6df956f1ccb27
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -177,6 +177,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: fb3f3a64c847f3fe7c182da7a4b3a49ff01f2c9b
+PODFILE CHECKSUM: 03ed5339e5cdcf69a4c02e3234bd53d7c510412d
 
 COCOAPODS: 1.11.3

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -62,7 +62,7 @@ class AuthenticationManager: Authentication {
         let isWPComMagicLinkPreferredToPassword = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasis)
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasisM2)
         let isStoreCreationMVPEnabled = featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
-        let isWPComLoginRequiredForSiteCredentialsLogin = !featureFlagService.isFeatureFlagEnabled(.applicationPasswordAuthenticationForSiteCredentialLogin)
+        let enableSiteAddressLoginOnly = featureFlagService.isFeatureFlagEnabled(.applicationPasswordAuthenticationForSiteCredentialLogin)
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
                                                                 wpcomScheme: ApiCredentials.dotcomAuthScheme,
@@ -80,7 +80,7 @@ class AuthenticationManager: Authentication {
                                                                 enableUnifiedAuth: true,
                                                                 continueWithSiteAddressFirst: false,
                                                                 enableSiteCredentialsLoginForSelfHostedSites: true,
-                                                                isWPComLoginRequiredForSiteCredentialsLogin: isWPComLoginRequiredForSiteCredentialsLogin,
+                                                                isWPComLoginRequiredForSiteCredentialsLogin: !enableSiteAddressLoginOnly,
                                                                 isWPComMagicLinkPreferredToPassword: isWPComMagicLinkPreferredToPassword,
                                                                 isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen:
                                                                     isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen,
@@ -91,7 +91,8 @@ class AuthenticationManager: Authentication {
                                                                 wpcomPasswordInstructions:
                                                                 AuthenticationConstants.wpcomPasswordInstructions,
                                                                 skipXMLRPCCheckForSiteDiscovery: true,
-                                                                useEnterEmailAddressAsStepValueForGetStartedVC: true)
+                                                                useEnterEmailAddressAsStepValueForGetStartedVC: true,
+                                                                enableSiteAddressLoginOnlyInPrologue: enableSiteAddressLoginOnly)
 
         let systemGray3LightModeColor = UIColor(red: 199/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1)
         let systemLabelLightModeColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -62,6 +62,7 @@ class AuthenticationManager: Authentication {
         let isWPComMagicLinkPreferredToPassword = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasis)
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasisM2)
         let isStoreCreationMVPEnabled = featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
+        // TODO: Replace with A/B experiment
         let enableSiteAddressLoginOnly = featureFlagService.isFeatureFlagEnabled(.applicationPasswordAuthenticationForSiteCredentialLogin)
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
@@ -330,21 +331,17 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         /// save the site to memory to check for jetpack requirement in epilogue
         currentSelfHostedSite = site
 
-        /// For self-hosted sites, navigate to enter the email address associated to the wp.com account:
-        /// https://github.com/woocommerce/woocommerce-ios/issues/3426
-        guard site.isWPCom else {
+        // TODO: Replace with A/B experiment
+        let enableWPComOnlyForWPComSites = featureFlagService.isFeatureFlagEnabled(.applicationPasswordAuthenticationForSiteCredentialLogin)
+
+        switch (enableWPComOnlyForWPComSites, site.isWPCom) {
+        case (true, true), (false, _):
             let authenticationResult: WordPressAuthenticatorResult = .presentEmailController
-
             onCompletion(authenticationResult)
-
-            return
+        case (true, false):
+            let authenticationResult: WordPressAuthenticatorResult = .presentPasswordController(value: false)
+            onCompletion(authenticationResult)
         }
-
-        /// We should never reach this point, as WPAuthenticator won't call its delegate for this case.
-        ///
-        DDLogWarn("⚠️ Present password controller for site: \(site.url)")
-        let authenticationResult: WordPressAuthenticatorResult = .presentPasswordController(value: false)
-        onCompletion(authenticationResult)
     }
 
     /// Displays appropriate error based on the input `siteInfo`.

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -339,7 +339,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             let authenticationResult: WordPressAuthenticatorResult = .presentEmailController
             onCompletion(authenticationResult)
         case (true, false):
-            let authenticationResult: WordPressAuthenticatorResult = .presentPasswordController(value: false)
+            let authenticationResult: WordPressAuthenticatorResult = .presentPasswordController(value: true)
             onCompletion(authenticationResult)
         }
     }

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ApplicationPasswordDisabledViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ApplicationPasswordDisabledViewModel.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressAuthenticator
 
 /// Configuration and actions for an ULErrorViewController,
 /// modeling an error when application password is disabled.
@@ -27,8 +28,8 @@ struct ApplicationPasswordDisabledViewModel: ULErrorViewModel {
     let isAuxiliaryButtonHidden = false
     let auxiliaryButtonTitle = Localization.auxiliaryButtonTitle
 
-    let primaryButtonTitle = ""
-    let isPrimaryButtonHidden = true
+    let primaryButtonTitle = Localization.primaryButtonTitle
+    let isPrimaryButtonHidden = false
 
     let secondaryButtonTitle = Localization.secondaryButtonTitle
 
@@ -37,7 +38,10 @@ struct ApplicationPasswordDisabledViewModel: ULErrorViewModel {
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        // no-op
+        guard let viewController else {
+            return
+        }
+        WordPressAuthenticator.showLoginForJustWPCom(from: viewController)
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
@@ -69,6 +73,10 @@ private extension ApplicationPasswordDisabledViewModel {
         static let auxiliaryButtonTitle = NSLocalizedString(
             "What is Application Password?",
             comment: "Button that will navigate to a web page explaining Application Password"
+        )
+        static let primaryButtonTitle = NSLocalizedString(
+            "Log in with WordPress.com",
+            comment: "Button that will navigate to the authentication flow with WP.com"
         )
     }
     enum Constants {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1843,6 +1843,7 @@
 		DE61978F289A5674005E4362 /* NoWooErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61978E289A5674005E4362 /* NoWooErrorViewModelTests.swift */; };
 		DE61979328A20C17005E4362 /* StorePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61979228A20C17005E4362 /* StorePickerViewModel.swift */; };
 		DE61979528A25842005E4362 /* StorePickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61979428A25842005E4362 /* StorePickerViewModelTests.swift */; };
+		DE66C56F2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE66C56E2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift */; };
 		DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */; };
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
 		DE68B81F26F86B1700C86CFB /* OfflineBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */; };
@@ -3929,6 +3930,7 @@
 		DE61978E289A5674005E4362 /* NoWooErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModelTests.swift; sourceTree = "<group>"; };
 		DE61979228A20C17005E4362 /* StorePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePickerViewModel.swift; sourceTree = "<group>"; };
 		DE61979428A25842005E4362 /* StorePickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePickerViewModelTests.swift; sourceTree = "<group>"; };
+		DE66C56E2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordDisabledViewModelTests.swift; sourceTree = "<group>"; };
 		DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFrom.swift"; sourceTree = "<group>"; };
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
 		DE68B81E26F86B1700C86CFB /* OfflineBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBannerView.swift; sourceTree = "<group>"; };
@@ -6566,6 +6568,7 @@
 				DE50295228BF4A8A00551736 /* JetpackConnectionWebViewModelTests.swift */,
 				020D0BFC2914E92800BB3DCE /* StorePickerCoordinatorTests.swift */,
 				DEF13C532963ED4E0024A02B /* PostSiteCredentialLoginCheckerTests.swift */,
+				DE66C56E2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -11295,6 +11298,7 @@
 				09BE3A9127C921A70070B69D /* BulkUpdatePriceSettingsViewModelTests.swift in Sources */,
 				095A077E27CF486C007A61D2 /* ValueOneTableViewCellTests.swift in Sources */,
 				E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */,
+				DE66C56F2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift in Sources */,
 				269098B627D2C09D001FEB07 /* ShippingInputTransformerTests.swift in Sources */,
 				02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */,
 				DE2BF4FD2846192B00FBE68A /* CouponAllowedEmailsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/ApplicationPasswordDisabledViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/ApplicationPasswordDisabledViewModelTests.swift
@@ -1,9 +1,30 @@
 import XCTest
+import SafariServices
+import WordPressAuthenticator
 @testable import WooCommerce
 
 final class ApplicationPasswordDisabledViewModelTests: XCTestCase {
 
     private let testURL = "https://test.com"
+    private var navigationController: UINavigationController!
+    private let window = UIWindow(frame: UIScreen.main.bounds)
+
+    override func setUp() {
+        super.setUp()
+
+        window.makeKeyAndVisible()
+        navigationController = .init()
+        window.rootViewController = navigationController
+        WordPressAuthenticator.initializeAuthenticator()
+    }
+
+    override func tearDown() {
+        navigationController = nil
+        window.resignKey()
+        window.rootViewController = nil
+
+        super.tearDown()
+    }
 
     func test_viewmodel_provides_expected_image() {
         // Given
@@ -92,6 +113,34 @@ final class ApplicationPasswordDisabledViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(secondaryButtonTitle, Expectations.secondaryButtonTitle)
+    }
+
+    func test_didTapAuxiliaryButton_presents_a_web_view() {
+        // Given
+        let viewModel = ApplicationPasswordDisabledViewModel(siteURL: testURL)
+
+        // When
+        viewModel.didTapAuxiliaryButton(in: navigationController)
+
+        // Then
+        waitUntil {
+            self.navigationController.presentedViewController != nil
+        }
+        XCTAssertTrue(navigationController.presentedViewController is SFSafariViewController)
+    }
+
+    func test_didTapPrimaryButton_presents_LoginNavigationController() {
+        // Given
+        let viewModel = ApplicationPasswordDisabledViewModel(siteURL: testURL)
+
+        // When
+        viewModel.didTapPrimaryButton(in: navigationController)
+
+        // Then
+        waitUntil {
+            self.navigationController.presentedViewController != nil
+        }
+        XCTAssertTrue(navigationController.presentedViewController is LoginNavigationController)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Authentication/ApplicationPasswordDisabledViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/ApplicationPasswordDisabledViewModelTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import WooCommerce
+
+final class ApplicationPasswordDisabledViewModelTests: XCTestCase {
+
+    private let testURL = "https://test.com"
+
+    func test_viewmodel_provides_expected_image() {
+        // Given
+        let viewModel = ApplicationPasswordDisabledViewModel(siteURL: testURL)
+
+        // When
+        let image = viewModel.image
+
+        // Then
+        XCTAssertEqual(image, Expectations.image)
+    }
+
+    func test_viewmodel_provides_expected_error_message() {
+        // Given
+        let viewModel = ApplicationPasswordDisabledViewModel(siteURL: testURL)
+        let expectation = Expectations.errorMessage.replacingOccurrences(of: "%@", with: "test.com")
+
+        // When
+        let errorMessage = viewModel.text.string
+
+        // Then
+        XCTAssertEqual(errorMessage, expectation)
+    }
+
+    func test_viewmodel_provides_expected_visibility_for_auxiliary_button() {
+        // Given
+        let viewModel = ApplicationPasswordDisabledViewModel(siteURL: testURL)
+
+        // When
+        let isHidden = viewModel.isAuxiliaryButtonHidden
+
+        // Then
+        XCTAssertFalse(isHidden)
+    }
+
+    func test_viewmodel_provides_expected_title_for_auxiliary_button() {
+        // Given
+        let viewModel = ApplicationPasswordDisabledViewModel(siteURL: testURL)
+
+        // When
+        let auxiliaryButtonTitle = viewModel.auxiliaryButtonTitle
+
+        // Then
+        XCTAssertEqual(auxiliaryButtonTitle, Expectations.auxiliaryButtonTitle)
+    }
+
+    func test_viewmodel_provides_expected_visibility_for_primary_button() {
+        // Given
+        let viewModel = ApplicationPasswordDisabledViewModel(siteURL: testURL)
+
+        // When
+        let isHidden = viewModel.isPrimaryButtonHidden
+
+        // Then
+        XCTAssertFalse(isHidden)
+    }
+
+    func test_viewmodel_provides_expected_title_for_primary_button() {
+        // Given
+        let viewModel = ApplicationPasswordDisabledViewModel(siteURL: testURL)
+
+        // When
+        let primaryButtonTitle = viewModel.primaryButtonTitle
+
+        // Then
+        XCTAssertEqual(primaryButtonTitle, Expectations.primaryButtonTitle)
+    }
+
+    func test_viewmodel_provides_expected_visibility_for_secondary_button() {
+        // Given
+        let viewModel = ApplicationPasswordDisabledViewModel(siteURL: testURL)
+
+        // When
+        let isHidden = viewModel.isSecondaryButtonHidden
+
+        // Then
+        XCTAssertFalse(isHidden)
+    }
+
+    func test_viewmodel_provides_expected_title_for_secondary_button() {
+        // Given
+        let viewModel = ApplicationPasswordDisabledViewModel(siteURL: testURL)
+
+        // When
+        let secondaryButtonTitle = viewModel.secondaryButtonTitle
+
+        // Then
+        XCTAssertEqual(secondaryButtonTitle, Expectations.secondaryButtonTitle)
+    }
+}
+
+private extension ApplicationPasswordDisabledViewModelTests {
+    enum Expectations {
+        static let image = UIImage.errorImage
+
+        static let errorMessage = NSLocalizedString(
+            "It seems that your site %@ has Application Password disabled. Please enable it to use the WooCommerce app.",
+            comment: "An error message displayed when the user tries to log in to the app with site credentials but has application password disabled. " +
+            "Reads like: It seems that your site google.com has Application Password disabled. " +
+            "Please enable it to use the WooCommerce app."
+        )
+        static let secondaryButtonTitle = NSLocalizedString(
+            "Log In With Another Account",
+            comment: "Action button that will restart the login flow."
+            + "Presented when the user tries to log in to the app with site credentials but has application password disabled."
+        )
+        static let auxiliaryButtonTitle = NSLocalizedString(
+            "What is Application Password?",
+            comment: "Button that will navigate to a web page explaining Application Password"
+        )
+        static let primaryButtonTitle = NSLocalizedString(
+            "Log in with WordPress.com",
+            comment: "Button that will navigate to the authentication flow with WP.com"
+        )
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -276,7 +276,6 @@ final class HubMenuViewModelTests: XCTestCase {
         // Given
         let sampleStoreURL = "https://testshop.com"
         let sampleAdminURL = ""
-        let expectedAdminURL = "https://testshop.com/wp-admin"
         let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: true)
         let site = Site.fake().copy(url: sampleStoreURL, adminURL: sampleAdminURL)
         sessionManager.defaultSite = site
@@ -294,7 +293,6 @@ final class HubMenuViewModelTests: XCTestCase {
         // Given
         let sampleStoreURL = "https://testshop.com"
         let sampleAdminURL = ""
-        let expectedAdminURL = "https://testshop.com/wp-admin"
         let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: false)
         let site = Site.fake().copy(url: sampleStoreURL, adminURL: sampleAdminURL)
         sessionManager.defaultSite = site


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8679 
Please also review https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/725.

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR update the login flow to apply AB testing for the REST API project. Changes include:
- Add a new config for `WordPressAuthenticator` to display only site address login on the prologue screen.
- Update the logic to show site credential login when detecting a self-hosted site. Otherwise, WPCom login is still presented for WPCom sites.
- Add a primary button on the application password disabled screen. This button should navigate to the WPCom login flow to avoid blocking users from using the app when they have application password disabled.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Prologue screen and site address login flow.
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- Notice that the prologue screen has only CTAs to log in with site address and create a new store.
- Select Enter your site address and proceed with the address of a self-hosted site. Notice that the app will then navigate to the site credential login screen immediately.
- Try again with the address of a WPCom site. Tapping Continue should navigate to WPCom login flow.

Please feel free to test again with `applicationPasswordAuthenticationForSiteCredentialLogin` disabled. The prologue screen should show the CTA to the WPCom login flow, and entering site address should navigate to the WPCom login flow with a CTA to site credential login at the bottom.

2. Application password disabled screen
Pre-requisite: Disable application password on your self-hosted site (e.g. by installing WordFence plugin).
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- Notice that the prologue screen has only CTAs to log in with site address and create a new store.
- Select Enter your site address and proceed with the address of a self-hosted site.
- Enter your site credentials. You should should then be navigated to the application password disabled screen.
- Notice that there's a primary button on the screen to log in with WPCom. Tap that button.
- Continue with the WPCom login flow. After the login succeeds, you should be able to navigate to the My Store screen.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| | Feature flag off | Feature flag on |
| -----| ----- | ----- |
| Prologue screen | <image src="https://user-images.githubusercontent.com/5533851/213160111-3f6c0fec-2dc8-402e-8b8a-5dd5bda07ebc.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/213160207-d5fa8774-7407-4e36-a9dd-30438c9e1d59.png" width=320 /> |
| After enter site address | <img src="https://user-images.githubusercontent.com/5533851/213160340-357743a9-48a0-42b5-b368-9ec7f10cdc85.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/213160419-0759768d-f09c-441d-ada5-519fb789ed61.png" width=320 /> |

Application password disabled:
<img src="https://user-images.githubusercontent.com/5533851/213163507-196a86df-5985-4a5b-8d4e-2d41a27d1266.png" width=320 />




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
