### PR TITLE
[IPPInAppFeedback] Make banner content and surveys change dynamically

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -75,6 +75,10 @@ extension WooAnalyticsEvent {
         case orderCreation = "order_creation"
         /// Shown in beta feature banner for coupon management.
         case couponManagement = "coupon_management"
+        // WIP: Shown in IPP banner for different number of IPP transactions. Needed so it can compile.
+        case IPP_COD
+        case IPP_firstTransaction
+        case IPP_powerUsers
     }
 
     /// The action performed on the survey screen.

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -75,9 +75,11 @@ extension WooAnalyticsEvent {
         case orderCreation = "order_creation"
         /// Shown in beta feature banner for coupon management.
         case couponManagement = "coupon_management"
-        // WIP: Shown in IPP banner for different number of IPP transactions. Needed so it can compile.
+        /// Shown in IPP banner for eligible merchants with no IPP transactions.
         case IPP_COD
+        /// Shown in IPP banner for eligible merchants with a few IPP transactions.
         case IPP_firstTransaction
+        /// Shown in IPP banner for eligible merchants with a significant number of IPP transactions.
         case IPP_powerUsers
     }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -76,11 +76,11 @@ extension WooAnalyticsEvent {
         /// Shown in beta feature banner for coupon management.
         case couponManagement = "coupon_management"
         /// Shown in IPP banner for eligible merchants with no IPP transactions.
-        case IPP_COD
+        case inPersonPaymentsCashOnDeliveryBanner
         /// Shown in IPP banner for eligible merchants with a few IPP transactions.
-        case IPP_firstTransaction
+        case inPersonPaymentsFirstTransactionBanner
         /// Shown in IPP banner for eligible merchants with a significant number of IPP transactions.
-        case IPP_powerUsers
+        case inPersonPaymentsPowerUsersBanner
     }
 
     /// The action performed on the survey screen.

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -159,20 +159,20 @@ extension WooConstants {
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
 #endif
 
-        /// URL for IPP feedback testing survey
+        /// URL for the IPP feedback survey for testing purposes
         ///
 #if DEBUG
         case IPP_COD, IPP_firstTransaction, IPP_powerUsers = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
 #else
-        /// URL for IPPfeedback survey, case COD
+        /// URL for the IPP feedback survey (COD case). Used when merchants have COD enabled, but no IPP transactions.
         ///
         case IPP_COD = "https://automattic.survey.fm/woo-app-–-cod-survey"
 
-        /// URL for IPP feedback survey, case first transaction
+        /// URL for IPP feedback survey (First Transaction case). Used when merchants have only a few IPP transactions.
         ///
         case IPP_firstTransaction = "https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey"
 
-        /// URL for IPP feedback survey, case power users
+        /// URL for IPP feedback survey (Power Users case).  Used when merchants have a significant number of IPP transactions.
         ///
         case IPP_powerUsers = "https://automattic.survey.fm/woo-app-–-ipp-survey-for-power-users"
 #endif

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -162,19 +162,21 @@ extension WooConstants {
         /// URL for the IPP feedback survey for testing purposes
         ///
 #if DEBUG
-        case IPP_COD, IPP_firstTransaction, IPP_powerUsers = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
+        case inPersonPaymentsCashOnDeliveryFeedback,
+             inPersonPaymentsFirstTransactionFeedback,
+             inPersonPaymentsPowerUsersFeedback = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
 #else
         /// URL for the IPP feedback survey (COD case). Used when merchants have COD enabled, but no IPP transactions.
         ///
-        case IPP_COD = "https://automattic.survey.fm/woo-app-–-cod-survey"
+        case inPersonPaymentsCashOnDeliveryFeedback = "https://automattic.survey.fm/woo-app-–-cod-survey"
 
         /// URL for IPP feedback survey (First Transaction case). Used when merchants have only a few IPP transactions.
         ///
-        case IPP_firstTransaction = "https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey"
+        case inPersonPaymentsFirstTransactionFeedback = "https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey"
 
         /// URL for IPP feedback survey (Power Users case).  Used when merchants have a significant number of IPP transactions.
         ///
-        case IPP_powerUsers = "https://automattic.survey.fm/woo-app-–-ipp-survey-for-power-users"
+        case inPersonPaymentsPowerUsersFeedback = "https://automattic.survey.fm/woo-app-–-ipp-survey-for-power-users"
 #endif
 
         /// URL for the products feedback survey

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -155,10 +155,26 @@ extension WooConstants {
         ///
 #if DEBUG
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-test-survey"
-        case IPPFeedback = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
 #else
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
-        case IPPFeedback = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
+#endif
+
+        /// URL for IPP feedback testing survey
+        ///
+#if DEBUG
+        case IPP_COD, IPP_firstTransaction, IPP_powerUsers = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
+#else
+        /// URL for IPPfeedback survey, case COD
+        ///
+        case IPP_COD = "https://automattic.survey.fm/woo-app-–-cod-survey"
+
+        /// URL for IPP feedback survey, case first transaction
+        ///
+        case IPP_firstTransaction = "https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey"
+
+        /// URL for IPP feedback survey, case power users
+        ///
+        case IPP_powerUsers = "https://automattic.survey.fm/woo-app-–-ipp-survey-for-power-users"
 #endif
 
         /// URL for the products feedback survey

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -162,7 +162,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
         configureSyncingCoordinator()
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
-            guard let survey = viewModel.displayIPPFeedbackBannerIfEligible() else {
+            guard let survey = viewModel.feedbackBannerSurveySource() else {
                 return
             }
             inPersonPaymentsSurveyVariation = survey

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -162,10 +162,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
         configureSyncingCoordinator()
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
-            guard let survey = viewModel.feedbackBannerSurveySource() else {
-                return
-            }
-            inPersonPaymentsSurveyVariation = survey
+            inPersonPaymentsSurveyVariation = viewModel.feedbackBannerSurveySource()
         }
     }
 
@@ -800,9 +797,6 @@ private extension OrderListViewController {
     /// Sets the `topBannerView` property to an IPP feedback banner.
     ///
     func setIPPFeedbackTopBanner(survey: SurveyViewController.Source) {
-        guard let survey = inPersonPaymentsSurveyVariation else {
-            return
-        }
         topBannerView = createIPPFeedbackTopBanner(survey: survey)
         showTopBannerView()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -262,7 +262,10 @@ private extension OrderListViewController {
                 case .orderCreation:
                     self.setOrderCreationTopBanner()
                 case .IPPFeedback:
-                    self.setIPPFeedbackTopBanner(survey: .IPP_COD)
+                    guard let survey = self.IPPsurveyVariation else {
+                        return
+                    }
+                    self.setIPPFeedbackTopBanner(survey: survey)
                 }
             }
             .store(in: &cancellables)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -120,9 +120,9 @@ final class OrderListViewController: UIViewController, GhostableViewController {
     ///
     private var swipeActionsGlanced = false
 
-    /// Banner variation that will be shown as IPP Feedback Banner. If any.
+    /// Banner variation that will be shown as In-Person Payments feedback banner. If any.
     ///
-    private var IPPsurveyVariation: SurveyViewController.Source?
+    private var inPersonPaymentsSurveyVariation: SurveyViewController.Source?
 
 
     // MARK: - View Lifecycle
@@ -165,7 +165,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
             guard let survey = viewModel.displayIPPFeedbackBannerIfEligible() else {
                 return
             }
-            IPPsurveyVariation = survey
+            inPersonPaymentsSurveyVariation = survey
         }
     }
 
@@ -262,7 +262,7 @@ private extension OrderListViewController {
                 case .orderCreation:
                     self.setOrderCreationTopBanner()
                 case .IPPFeedback:
-                    guard let survey = self.IPPsurveyVariation else {
+                    guard let survey = self.inPersonPaymentsSurveyVariation else {
                         return
                     }
                     self.setIPPFeedbackTopBanner(survey: survey)
@@ -800,7 +800,7 @@ private extension OrderListViewController {
     /// Sets the `topBannerView` property to an IPP feedback banner.
     ///
     func setIPPFeedbackTopBanner(survey: SurveyViewController.Source) {
-        guard let survey = IPPsurveyVariation else {
+        guard let survey = inPersonPaymentsSurveyVariation else {
             return
         }
         topBannerView = createIPPFeedbackTopBanner(survey: survey)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -817,14 +817,14 @@ private extension OrderListViewController {
 
         switch survey {
         case .IPP_COD :
-            bannerTitle = Localization.feedbackBannerTitle
-            bannerText = Localization.feedbackBannerContent
+            bannerTitle = Localization.inPersonPaymentsCashOnDeliveryBannerTitle
+            bannerText = Localization.inPersonPaymentsCashOnDeliveryBannerContent
         case .IPP_firstTransaction:
-            bannerTitle = Localization.feedbackBannerTitle2
-            bannerTitle = Localization.feedbackBannerContent2
+            bannerTitle = Localization.inPersonPaymentsFirstTransactionBannerTitle
+            bannerTitle = Localization.inPersonPaymentsFirstTransactionBannerContent
         case .IPP_powerUsers:
-            bannerTitle = Localization.feedbackBannerTitle3
-            bannerTitle = Localization.feedbackBannerContent3
+            bannerTitle = Localization.inPersonPaymentsPowerUsersBannerTitle
+            bannerTitle = Localization.inPersonPaymentsPowerUsersBannerContent
         default:
             break
         }
@@ -864,27 +864,27 @@ private extension OrderListViewController {
 
         static let markCompleted = NSLocalizedString("Mark Completed", comment: "Title for the swipe order action to mark it as completed")
 
-        static let feedbackBannerTitle = NSLocalizedString("Let us know what you think",
+        static let inPersonPaymentsCashOnDeliveryBannerTitle = NSLocalizedString("Let us know what you think",
                                                            comment: "Title of the In-Person Payments feedback banner in the Orders tab"
         )
 
-        static let feedbackBannerTitle2 = NSLocalizedString("Title 2. TBD.",
+        static let inPersonPaymentsFirstTransactionBannerTitle = NSLocalizedString("Title 2. TBD.",
                                                             comment: "Title of the In-Person Payments feedback banner in the Orders tab"
         )
 
-        static let feedbackBannerTitle3 = NSLocalizedString("Title 3. TBD.",
+        static let inPersonPaymentsPowerUsersBannerTitle = NSLocalizedString("Title 3. TBD.",
                                                             comment: "Title of the In-Person Payments feedback banner in the Orders tab"
         )
 
-        static let feedbackBannerContent = NSLocalizedString("Rate your In-Person Payment experience.",
+        static let inPersonPaymentsCashOnDeliveryBannerContent = NSLocalizedString("Rate your In-Person Payment experience.",
                                                              comment: "Content of the In-Person Payments feedback banner in the Orders tab"
         )
 
-        static let feedbackBannerContent2 = NSLocalizedString("Content 2. TBD.",
+        static let inPersonPaymentsFirstTransactionBannerContent = NSLocalizedString("Content 2. TBD.",
                                                               comment: "Content of the In-Person Payments feedback banner in the Orders tab"
         )
 
-        static let feedbackBannerContent3 = NSLocalizedString("Content 3. TBD.",
+        static let inPersonPaymentsPowerUsersBannerContent = NSLocalizedString("Content 3. TBD.",
                                                               comment: "Content of the In-Person Payments feedback banner in the Orders tab"
         )
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -790,7 +790,7 @@ private extension OrderListViewController {
     /// Sets the `topBannerView` property to an IPP feedback banner.
     ///
     func setIPPFeedbackTopBanner() {
-        let survey: SurveyViewController.Source = .IPPFeedback // TODO: This needs to come from the ViewModel
+        let survey: SurveyViewController.Source = .IPP_powerUsers // TODO: Temporary. This needs to come from the ViewModel
         topBannerView = createIPPFeedbackTopBanner(survey: survey)
         showTopBannerView()
     }
@@ -804,12 +804,17 @@ private extension OrderListViewController {
         var bannerText = "" // Dynamic
 
         switch survey {
-        case .IPPFeedback :
+        case .IPP_COD :
             bannerTitle = Localization.feedbackBannerTitle
             bannerText = Localization.feedbackBannerContent
-            // TODO: Add extra SurveyViewController cases.
-            // TODO: Non-IPP-feedback cases, do nothing.
+        case .IPP_firstTransaction:
+            bannerTitle = Localization.feedbackBannerTitle2
+            bannerTitle = Localization.feedbackBannerContent2
+        case .IPP_powerUsers:
+            bannerTitle = Localization.feedbackBannerTitle3
+            bannerTitle = Localization.feedbackBannerContent3
         default:
+            // Non-IPP-feedback cases, do nothing.
             break
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -158,15 +158,15 @@ final class OrderListViewController: UIViewController, GhostableViewController {
         registerTableViewHeadersAndCells()
         configureTableView()
 
+        configureViewModel()
+        configureSyncingCoordinator()
+
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
             guard let survey = viewModel.displayIPPFeedbackBannerIfEligible() else {
                 return
             }
             IPPsurveyVariation = survey
         }
-
-        configureViewModel()
-        configureSyncingCoordinator()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -363,6 +363,7 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
 
         transitionToSyncingState()
         viewModel.hasErrorLoadingData = false
+        viewModel.updateBannerVisibility()
 
         let action = viewModel.synchronizationAction(
             siteID: siteID,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -122,7 +122,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
 
     /// Banner variation that will be shown as IPP Feedback Banner. If any.
     ///
-    private var IPPsurveyVariation: SurveyViewController.Source = .IPP_COD // TODO: Make optional
+    private var IPPsurveyVariation: SurveyViewController.Source?
 
 
     // MARK: - View Lifecycle
@@ -159,12 +159,10 @@ final class OrderListViewController: UIViewController, GhostableViewController {
         configureTableView()
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
-            // TODO: Make clearer
-            let isEligible = viewModel.displayIPPFeedbackBannerIfEligible().0
-            let surveyType = viewModel.displayIPPFeedbackBannerIfEligible().1
-            if isEligible {
-                IPPsurveyVariation = surveyType ?? .IPP_COD
+            guard let survey = viewModel.displayIPPFeedbackBannerIfEligible() else {
+                return
             }
+            IPPsurveyVariation = survey
         }
 
         configureViewModel()
@@ -798,7 +796,10 @@ private extension OrderListViewController {
     /// Sets the `topBannerView` property to an IPP feedback banner.
     ///
     func setIPPFeedbackTopBanner(survey: SurveyViewController.Source) {
-        topBannerView = createIPPFeedbackTopBanner(survey: IPPsurveyVariation)
+        guard let survey = IPPsurveyVariation else {
+            return
+        }
+        topBannerView = createIPPFeedbackTopBanner(survey: survey)
         showTopBannerView()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -864,27 +864,27 @@ private extension OrderListViewController {
 
         static let markCompleted = NSLocalizedString("Mark Completed", comment: "Title for the swipe order action to mark it as completed")
 
-        static let inPersonPaymentsCashOnDeliveryBannerTitle = NSLocalizedString("Let us know what you think",
+        static let inPersonPaymentsCashOnDeliveryBannerTitle = NSLocalizedString("Let us know how we can help",
                                                            comment: "Title of the In-Person Payments feedback banner in the Orders tab"
         )
 
-        static let inPersonPaymentsFirstTransactionBannerTitle = NSLocalizedString("Title 2. TBD.",
+        static let inPersonPaymentsFirstTransactionBannerTitle = NSLocalizedString("Enjoyed your in-person payment?",
                                                             comment: "Title of the In-Person Payments feedback banner in the Orders tab"
         )
 
-        static let inPersonPaymentsPowerUsersBannerTitle = NSLocalizedString("Title 3. TBD.",
+        static let inPersonPaymentsPowerUsersBannerTitle = NSLocalizedString("Let us know what you think",
                                                             comment: "Title of the In-Person Payments feedback banner in the Orders tab"
         )
 
-        static let inPersonPaymentsCashOnDeliveryBannerContent = NSLocalizedString("Rate your In-Person Payment experience.",
+        static let inPersonPaymentsCashOnDeliveryBannerContent = NSLocalizedString("Share your own experience or how you collect in-person payments.",
                                                              comment: "Content of the In-Person Payments feedback banner in the Orders tab"
         )
 
-        static let inPersonPaymentsFirstTransactionBannerContent = NSLocalizedString("Content 2. TBD.",
+        static let inPersonPaymentsFirstTransactionBannerContent = NSLocalizedString("Rate your first in-person payment experience.",
                                                               comment: "Content of the In-Person Payments feedback banner in the Orders tab"
         )
 
-        static let inPersonPaymentsPowerUsersBannerContent = NSLocalizedString("Content 3. TBD.",
+        static let inPersonPaymentsPowerUsersBannerContent = NSLocalizedString("Tell us all about your experience with in-person payments.",
                                                               comment: "Content of the In-Person Payments feedback banner in the Orders tab"
         )
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -800,8 +800,8 @@ private extension OrderListViewController {
             self.displayIPPFeedbackBannerSurvey(survey: survey)
         })
 
-        var bannerTitle = "" // Dynamic
-        var bannerText = "" // Dynamic
+        var bannerTitle = ""
+        var bannerText = ""
 
         switch survey {
         case .IPP_COD :
@@ -814,7 +814,6 @@ private extension OrderListViewController {
             bannerTitle = Localization.feedbackBannerTitle3
             bannerTitle = Localization.feedbackBannerContent3
         default:
-            // Non-IPP-feedback cases, do nothing.
             break
         }
 
@@ -832,7 +831,6 @@ private extension OrderListViewController {
     }
 
     private func displayIPPFeedbackBannerSurvey(survey: SurveyViewController.Source) {
-        // TODO: Survey will change based on conditions
         let surveyNavigation = SurveyCoordinatingController(survey: survey)
         self.present(surveyNavigation, animated: true, completion: nil)
     }
@@ -858,17 +856,25 @@ private extension OrderListViewController {
                                                            comment: "Title of the In-Person Payments feedback banner in the Orders tab"
         )
 
-        static let feedbackBannerTitle2 = NSLocalizedString("This is the title 2", comment: "Testing")
+        static let feedbackBannerTitle2 = NSLocalizedString("Title 2. TBD.",
+                                                            comment: "Title of the In-Person Payments feedback banner in the Orders tab"
+        )
 
-        static let feedbackBannerTitle3 = NSLocalizedString("This is the title 3", comment: "Testing")
+        static let feedbackBannerTitle3 = NSLocalizedString("Title 3. TBD.",
+                                                            comment: "Title of the In-Person Payments feedback banner in the Orders tab"
+        )
 
         static let feedbackBannerContent = NSLocalizedString("Rate your In-Person Payment experience.",
                                                              comment: "Content of the In-Person Payments feedback banner in the Orders tab"
         )
 
-        static let feedbackBannerContent2 = NSLocalizedString("This is the content text 2", comment: "Testing")
+        static let feedbackBannerContent2 = NSLocalizedString("Content 2. TBD.",
+                                                              comment: "Content of the In-Person Payments feedback banner in the Orders tab"
+        )
 
-        static let feedbackBannerContent3 = NSLocalizedString("This is the content text 3", comment: "Testing")
+        static let feedbackBannerContent3 = NSLocalizedString("Content 3. TBD.",
+                                                              comment: "Content of the In-Person Payments feedback banner in the Orders tab"
+        )
 
         static let shareFeedbackButton = NSLocalizedString("Share feedback",
                                                            comment: "Title of the feedback action button on the In-Person Payments feedback banner"

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -158,6 +158,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
         configureSyncingCoordinator()
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
+            // TODO: Connect data fetched here with the ViewController
             viewModel.displayIPPFeedbackBannerIfEligible()
         }
     }
@@ -789,18 +790,32 @@ private extension OrderListViewController {
     /// Sets the `topBannerView` property to an IPP feedback banner.
     ///
     func setIPPFeedbackTopBanner() {
-        topBannerView = createIPPFeedbackTopBanner()
+        let survey: SurveyViewController.Source = .IPPFeedback // TODO: This needs to come from the ViewModel
+        topBannerView = createIPPFeedbackTopBanner(survey: survey)
         showTopBannerView()
     }
 
-    private func createIPPFeedbackTopBanner() -> TopBannerView {
+    private func createIPPFeedbackTopBanner(survey: SurveyViewController.Source) -> TopBannerView {
         let shareIPPFeedbackAction = TopBannerViewModel.ActionButton(title: Localization.shareFeedbackButton, action: { _ in
-            self.displayIPPFeedbackBannerSurvey()
+            self.displayIPPFeedbackBannerSurvey(survey: survey)
         })
 
+        var bannerTitle = "" // Dynamic
+        var bannerText = "" // Dynamic
+
+        switch survey {
+        case .IPPFeedback :
+            bannerTitle = Localization.feedbackBannerTitle
+            bannerText = Localization.feedbackBannerContent
+            // TODO: Add extra SurveyViewController cases.
+            // TODO: Non-IPP-feedback cases, do nothing.
+        default:
+            break
+        }
+
         let viewModel = TopBannerViewModel(
-            title: Localization.feedbackBannerTitle,
-            infoText: Localization.feedbackBannerContent,
+            title: bannerTitle,
+            infoText: bannerText,
             icon: UIImage.gridicon(.comment),
             isExpanded: true,
             topButton: .dismiss(handler: {  }),
@@ -811,9 +826,9 @@ private extension OrderListViewController {
         return topBannerView
     }
 
-    private func displayIPPFeedbackBannerSurvey() {
+    private func displayIPPFeedbackBannerSurvey(survey: SurveyViewController.Source) {
         // TODO: Survey will change based on conditions
-        let surveyNavigation = SurveyCoordinatingController(survey: .IPPFeedback)
+        let surveyNavigation = SurveyCoordinatingController(survey: survey)
         self.present(surveyNavigation, animated: true, completion: nil)
     }
 }
@@ -838,9 +853,17 @@ private extension OrderListViewController {
                                                            comment: "Title of the In-Person Payments feedback banner in the Orders tab"
         )
 
+        static let feedbackBannerTitle2 = NSLocalizedString("This is the title 2", comment: "Testing")
+
+        static let feedbackBannerTitle3 = NSLocalizedString("This is the title 3", comment: "Testing")
+
         static let feedbackBannerContent = NSLocalizedString("Rate your In-Person Payment experience.",
                                                              comment: "Content of the In-Person Payments feedback banner in the Orders tab"
         )
+
+        static let feedbackBannerContent2 = NSLocalizedString("This is the content text 2", comment: "Testing")
+
+        static let feedbackBannerContent3 = NSLocalizedString("This is the content text 3", comment: "Testing")
 
         static let shareFeedbackButton = NSLocalizedString("Share feedback",
                                                            comment: "Title of the feedback action button on the In-Person Payments feedback banner"

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -120,6 +120,10 @@ final class OrderListViewController: UIViewController, GhostableViewController {
     ///
     private var swipeActionsGlanced = false
 
+    /// Banner variation that will be shown as IPP Feedback Banner. If any.
+    ///
+    private var IPPsurveyVariation: SurveyViewController.Source = .IPP_COD // TODO: Make optional
+
 
     // MARK: - View Lifecycle
 
@@ -154,13 +158,17 @@ final class OrderListViewController: UIViewController, GhostableViewController {
         registerTableViewHeadersAndCells()
         configureTableView()
 
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
+            // TODO: Make clearer
+            let isEligible = viewModel.displayIPPFeedbackBannerIfEligible().0
+            let surveyType = viewModel.displayIPPFeedbackBannerIfEligible().1
+            if isEligible {
+                IPPsurveyVariation = surveyType ?? .IPP_COD
+            }
+        }
+
         configureViewModel()
         configureSyncingCoordinator()
-
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
-            // TODO: Connect data fetched here with the ViewController
-            viewModel.displayIPPFeedbackBannerIfEligible()
-        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -256,7 +264,7 @@ private extension OrderListViewController {
                 case .orderCreation:
                     self.setOrderCreationTopBanner()
                 case .IPPFeedback:
-                    self.setIPPFeedbackTopBanner()
+                    self.setIPPFeedbackTopBanner(survey: .IPP_COD)
                 }
             }
             .store(in: &cancellables)
@@ -789,9 +797,8 @@ private extension OrderListViewController {
 
     /// Sets the `topBannerView` property to an IPP feedback banner.
     ///
-    func setIPPFeedbackTopBanner() {
-        let survey: SurveyViewController.Source = .IPP_powerUsers // TODO: Temporary. This needs to come from the ViewModel
-        topBannerView = createIPPFeedbackTopBanner(survey: survey)
+    func setIPPFeedbackTopBanner(survey: SurveyViewController.Source) {
+        topBannerView = createIPPFeedbackTopBanner(survey: IPPsurveyVariation)
         showTopBannerView()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -281,7 +281,7 @@ final class OrderListViewModel {
         }
     }
 
-    func displayIPPFeedbackBannerIfEligible() -> (Bool, SurveyViewController.Source?) {
+    func displayIPPFeedbackBannerIfEligible() -> SurveyViewController.Source? {
         if isCODEnabled && isIPPSupportedCountry {
             let hasResults = IPPOrdersResultsController.fetchedObjects.isEmpty ? false : true
 
@@ -304,16 +304,16 @@ final class OrderListViewModel {
 
             if !hasResults {
                 print("0 transactions. Banner 1 shown")
-                return (true, .IPP_COD)
+                return .IPP_COD
             } else if IPPresultsCount < Constants.numberOfTransactions {
                 print("< 10 transactions within 30 days. Banner 2 shown")
-                return (true, .IPP_firstTransaction)
+                return .IPP_firstTransaction
             } else if IPPresultsCount >= Constants.numberOfTransactions {
                 print(">= 10 transactions within 30 days. Banner 3 shown")
-                return (true, .IPP_powerUsers)
+                return .IPP_powerUsers
             }
         }
-        return (false, nil)
+        return nil
     }
 
     private func createQuery() -> FetchResultSnapshotsProvider<StorageOrder>.Query {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -281,7 +281,7 @@ final class OrderListViewModel {
         }
     }
 
-    func displayIPPFeedbackBannerIfEligible() {
+    func displayIPPFeedbackBannerIfEligible() -> (Bool, SurveyViewController.Source?) {
         if isCODEnabled && isIPPSupportedCountry {
             let hasResults = IPPOrdersResultsController.fetchedObjects.isEmpty ? false : true
 
@@ -303,13 +303,17 @@ final class OrderListViewModel {
             })
 
             if !hasResults {
-                 print("0 transactions. Banner 1 shown")
-             } else if IPPresultsCount < Constants.numberOfTransactions {
-                 print("< 10 transactions within 30 days. Banner 2 shown")
-             } else if IPPresultsCount >= Constants.numberOfTransactions {
-                 print(">= 10 transactions within 30 days. Banner 3 shown")
-             }
+                print("0 transactions. Banner 1 shown")
+                return (true, .IPP_COD)
+            } else if IPPresultsCount < Constants.numberOfTransactions {
+                print("< 10 transactions within 30 days. Banner 2 shown")
+                return (true, .IPP_firstTransaction)
+            } else if IPPresultsCount >= Constants.numberOfTransactions {
+                print(">= 10 transactions within 30 days. Banner 3 shown")
+                return (true, .IPP_powerUsers)
+            }
         }
+        return (false, nil)
     }
 
     private func createQuery() -> FetchResultSnapshotsProvider<StorageOrder>.Query {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -283,7 +283,7 @@ final class OrderListViewModel {
         }
     }
 
-    func displayIPPFeedbackBannerIfEligible() -> SurveyViewController.Source? {
+    func feedbackBannerSurveySource() -> SurveyViewController.Source? {
         if isCODEnabled && isIPPSupportedCountry {
             let hasResults = IPPOrdersResultsController.fetchedObjects.isEmpty ? false : true
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -174,13 +174,6 @@ final class OrderListViewModel {
 
         observeForegroundRemoteNotifications()
         bindTopBannerState()
-
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
-            syncIPPBannerVisibility()
-            loadOrdersBannerVisibility()
-        } else {
-            loadOrdersBannerVisibility()
-        }
     }
 
     func dismissOrdersBanner() {
@@ -194,6 +187,15 @@ final class OrderListViewModel {
         }
 
         stores.dispatch(action)
+    }
+
+    func updateBannerVisibility() {
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
+            syncIPPBannerVisibility()
+            loadOrdersBannerVisibility()
+        } else {
+            loadOrdersBannerVisibility()
+        }
     }
 
     /// Starts the snapshotsProvider, logging any errors.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -296,22 +296,11 @@ final class OrderListViewModel {
                 $0.paymentMethodTitle == Constants.paymentMethodTitle})
             let IPPresultsCount = IPPTransactionsFound.count
 
-            // TODO: Debug. Remove before merging
-            print("COD enabled? \(isCODEnabled) - Eligible Country? \(isIPPSupportedCountry)")
-            print("hasResults? \(hasResults)")
-            print("IPP transactions within 30 days: \(IPPresultsCount)")
-            print(recentIPPOrdersResultsController.fetchedObjects.map {
-                ("OrderID: \($0.orderID) - PaymentMethodID: \($0.paymentMethodID) (\($0.paymentMethodTitle) - DatePaid: \(String(describing: $0.datePaid))")
-            })
-
             if !hasResults {
-                print("0 transactions. Banner 1 shown")
                 return .IPP_COD
             } else if IPPresultsCount < Constants.numberOfTransactions {
-                print("< 10 transactions within 30 days. Banner 2 shown")
                 return .IPP_firstTransaction
             } else if IPPresultsCount >= Constants.numberOfTransactions {
-                print(">= 10 transactions within 30 days. Banner 3 shown")
                 return .IPP_powerUsers
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -106,17 +106,17 @@ extension SurveyViewController {
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
             case .IPP_COD:
-                return WooConstants.URLs.IPP_COD
+                return WooConstants.URLs.inPersonPaymentsCashOnDeliveryFeedback
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
             case .IPP_firstTransaction:
-                return WooConstants.URLs.IPP_firstTransaction
+                return WooConstants.URLs.inPersonPaymentsFirstTransactionFeedback
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
             case .IPP_powerUsers:
-                return WooConstants.URLs.IPP_powerUsers
+                return WooConstants.URLs.inPersonPaymentsPowerUsersFeedback
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
@@ -148,11 +148,11 @@ extension SurveyViewController {
             case .couponManagement:
                 return .couponManagement
             case .IPP_COD:
-                return .IPP_COD
+                return .inPersonPaymentsCashOnDeliveryBanner
             case .IPP_firstTransaction:
-                return .IPP_firstTransaction
+                return .inPersonPaymentsFirstTransactionBanner
             case .IPP_powerUsers:
-                return .IPP_powerUsers
+                return .inPersonPaymentsPowerUsersBanner
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -68,7 +68,9 @@ extension SurveyViewController {
         case addOnsI1
         case orderCreation
         case couponManagement
-        case IPPFeedback
+        case IPP_COD
+        case IPP_firstTransaction
+        case IPP_powerUsers
 
         fileprivate var url: URL {
             switch self {
@@ -103,8 +105,18 @@ extension SurveyViewController {
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
-            case .IPPFeedback:
-                return WooConstants.URLs.IPPFeedback
+            case .IPP_COD:
+                return WooConstants.URLs.IPP_COD
+                    .asURL()
+                    .tagPlatform("ios")
+                    .tagAppVersion(Bundle.main.bundleVersion())
+            case .IPP_firstTransaction:
+                return WooConstants.URLs.IPP_firstTransaction
+                    .asURL()
+                    .tagPlatform("ios")
+                    .tagAppVersion(Bundle.main.bundleVersion())
+            case .IPP_powerUsers:
+                return WooConstants.URLs.IPP_powerUsers
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
@@ -113,9 +125,9 @@ extension SurveyViewController {
 
         fileprivate var title: String {
             switch self {
-            case .inAppFeedback:
+            case .inAppFeedback, .IPP_COD, .IPP_firstTransaction, .IPP_powerUsers:
                 return Localization.title
-            case .productsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement, .IPPFeedback:
+            case .productsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement:
                 return Localization.giveFeedback
             }
         }
@@ -123,7 +135,7 @@ extension SurveyViewController {
         /// The corresponding `FeedbackContext` for event tracking purposes.
         var feedbackContextForEvents: WooAnalyticsEvent.FeedbackContext {
             switch self {
-            case .inAppFeedback, .IPPFeedback:
+            case .inAppFeedback:
                 return .general
             case .productsFeedback:
                 return .productsGeneral
@@ -135,6 +147,12 @@ extension SurveyViewController {
                 return .orderCreation
             case .couponManagement:
                 return .couponManagement
+            case .IPP_COD:
+                return .IPP_COD
+            case .IPP_firstTransaction:
+                return .IPP_firstTransaction
+            case .IPP_powerUsers:
+                return .IPP_powerUsers
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -239,6 +239,8 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertFalse(resynchronizeRequested)
     }
 
+    // MARK: - Banner visibility
+
     func test_when_having_no_error_and_orders_banner_should_not_be_shown_shows_nothing() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
@@ -250,9 +252,10 @@ final class OrderListViewModelTests: XCTestCase {
                 break
             }
         }
+        viewModel.activate()
 
         // When
-        viewModel.activate()
+        viewModel.updateBannerVisibility()
         viewModel.hideIPPFeedbackBanner = true
 
         // Then
@@ -272,10 +275,12 @@ final class OrderListViewModelTests: XCTestCase {
                 break
             }
         }
+        viewModel.activate()
 
         // When
-        viewModel.activate()
+        viewModel.updateBannerVisibility()
         viewModel.hideIPPFeedbackBanner = false
+
 
         // Then
         waitUntil {
@@ -294,9 +299,10 @@ final class OrderListViewModelTests: XCTestCase {
                 break
             }
         }
+        viewModel.activate()
 
         // When
-        viewModel.activate()
+        viewModel.updateBannerVisibility()
         viewModel.hideIPPFeedbackBanner = true
 
         // Then
@@ -318,9 +324,10 @@ final class OrderListViewModelTests: XCTestCase {
                 break
             }
         }
+        viewModel.activate()
 
         // When
-        viewModel.activate()
+        viewModel.updateBannerVisibility()
 
         // Then
         if isIPPFeatureFlagEnabled {
@@ -347,9 +354,10 @@ final class OrderListViewModelTests: XCTestCase {
                 break
             }
         }
+        viewModel.activate()
 
         // When
-        viewModel.activate()
+        viewModel.updateBannerVisibility()
 
         // Then
         waitUntil {
@@ -360,9 +368,10 @@ final class OrderListViewModelTests: XCTestCase {
     func test_storing_error_shows_error_banner() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID, filters: nil)
+        viewModel.activate()
 
         // When
-        viewModel.activate()
+        viewModel.updateBannerVisibility()
         viewModel.hasErrorLoadingData = true
 
         // Then
@@ -374,9 +383,10 @@ final class OrderListViewModelTests: XCTestCase {
     func test_dismissing_banners_does_not_show_banners() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
+        viewModel.activate()
 
         // When
-        viewModel.activate()
+        viewModel.updateBannerVisibility()
         viewModel.hideIPPFeedbackBanner = true
         viewModel.hideOrdersBanners = true
 
@@ -389,9 +399,10 @@ final class OrderListViewModelTests: XCTestCase {
     func test_hiding_orders_banners_still_shows_error_banner() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID, filters: nil)
+        viewModel.activate()
 
         // When
-        viewModel.activate()
+        viewModel.updateBannerVisibility()
         viewModel.hasErrorLoadingData = true
         viewModel.hideOrdersBanners = true
 


### PR DESCRIPTION
Closes: #8688 
Part of https://github.com/woocommerce/woocommerce-ios/issues/8530

## Description
This PR connects Model and ViewController in order to display the feedback banner content and survey links dynamically, based on how many IPP transactions a merchant has processed. 

## Changes
- `OrderListViewModel` calculates and returns a `SurveyViewController.Source` that determines which survey we must show: `IPP_COD`, `IPP_firstTransaction`, or `IPP_powerUsers`.
- The survey type is passed through `OrderListViewController` in order to configure the content and survey link, as well as  show the feedback banner.
- Added survey links to `WooConstants`, and possible cases to `SurveyViewController`. These have to be added to `WooAnalyticsEvent` as well so it can compile. Proper Tracks/Events will be done on a different PR.

## Testing instructions
- On a US/CA store, with COD enabled. Go to Orders:
- If there's 0 IPP transactions, the banner with `Let us know what you think` title will show up.
- If there's less than 10 IPP transactions, the banner with `Title 2. TBD.` title will show up.
- If there's more than 10 IPP transactions within 30 days, the banner with `Title 3. TBD.` title will show up.

## Screenshots

<img width=400 src="https://user-images.githubusercontent.com/3812076/213214046-e185368f-dec2-434e-8097-df2d9753249f.png">

