### PR TITLE
Bulk Editing: Add price picker

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/PriceInputViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/PriceInputViewController.swift
@@ -15,9 +15,13 @@ final class PriceInputViewController: UIViewController {
         return noticePresenter
     }()
 
-    init(viewModel: PriceInputViewModel) {
+    init(viewModel: PriceInputViewModel, noticePresenter: NoticePresenter? = nil) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
+
+        if let noticePresenter {
+            self.noticePresenter = noticePresenter
+        }
     }
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/WooCommerce/Classes/ViewRelated/Products/PriceInputViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/PriceInputViewController.swift
@@ -1,0 +1,120 @@
+import UIKit
+import Yosemite
+import Combine
+
+final class PriceInputViewController: UIViewController {
+
+    let tableView: UITableView = UITableView(frame: .zero, style: .grouped)
+
+    private var viewModel: PriceInputViewModel
+    private var subscriptions = Set<AnyCancellable>()
+
+    init(viewModel: PriceInputViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureTitleAndBackground()
+        configureTableView()
+        configureViewModel()
+    }
+}
+
+private extension PriceInputViewController {
+    func configureTitleAndBackground() {
+        title = viewModel.screenTitle()
+        view.backgroundColor = .listBackground
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel,
+                                                           target: self,
+                                                           action: #selector(cancelButtonTapped))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.bulkEditingApply,
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(applyButtonTapped))
+    }
+
+    func configureViewModel() {
+        viewModel.$applyButtonEnabled
+            .sink { [weak self] enabled in
+                self?.navigationItem.rightBarButtonItem?.isEnabled = enabled
+            }.store(in: &subscriptions)
+    }
+
+    func configureTableView() {
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(tableView)
+        view.pinSubviewToAllEdges(tableView)
+
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.backgroundColor = .listBackground
+
+        tableView.registerNib(for: UnitInputTableViewCell.self)
+
+        tableView.dataSource = self
+    }
+
+    /// Called when the cancel button is tapped
+    ///
+    @objc func cancelButtonTapped() {
+        viewModel.cancelButtonTapped()
+    }
+
+    /// Called when the save button is tapped to update the price for all products
+    ///
+    @objc func applyButtonTapped() {
+        // Dismiss the keyboard before triggering the update
+        view.endEditing(true)
+        viewModel.applyButtonTapped()
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension PriceInputViewController: UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: UnitInputTableViewCell.self.reuseIdentifier, for: indexPath)
+        configure(cell, at: indexPath)
+
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return viewModel.footerText
+    }
+
+    private func configure(_ cell: UITableViewCell, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as UnitInputTableViewCell:
+            let cellViewModel = UnitInputViewModel.createBulkPriceViewModel(using: ServiceLocator.currencySettings) { [weak self] value in
+                self?.viewModel.handlePriceChange(value)
+            }
+            cell.selectionStyle = .none
+            cell.configure(viewModel: cellViewModel)
+        default:
+            fatalError("Unidentified bulk update row type")
+            break
+        }
+    }
+}
+
+private extension PriceInputViewController {
+    enum Localization {
+        static let bulkEditingApply = NSLocalizedString("Apply", comment: "Title for the button to apply bulk editing changes to selected products.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
@@ -20,19 +20,15 @@ final class PriceInputViewModel {
     private let currencySettings: CurrencySettings
     private let currencyFormatter: CurrencyFormatter
 
-    private let cancelClosure: () -> Void
-    private let applyClosure: (String) -> Void
+    var cancelClosure: () -> Void = {}
+    var applyClosure: (String) -> Void = { _ in }
 
     init(productListViewModel: ProductListViewModel,
-         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
-         cancelClosure: @escaping () -> Void,
-         applyClosure: @escaping (String) -> Void) {
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.productListViewModel = productListViewModel
         self.priceSettingsValidator = ProductPriceSettingsValidator(currencySettings: currencySettings)
         self.currencySettings = currencySettings
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
-        self.cancelClosure = cancelClosure
-        self.applyClosure = applyClosure
     }
 
     /// Called when the cancel button is tapped

--- a/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Yosemite
+import WooFoundation
+
+/// View Model logic for the bulk price setting screen
+///
+final class PriceInputViewModel {
+
+    @Published private(set) var applyButtonEnabled: Bool = false
+
+    /// This holds the latest entered price. It is used to perform validations when the user taps the apply button
+    /// and for creating a products array with the new price for the bulk update Action
+    private(set) var currentPrice: String = ""
+
+    private let productListViewModel: ProductListViewModel
+
+    private let currencySettings: CurrencySettings
+    private let currencyFormatter: CurrencyFormatter
+
+    private let cancelClosure: () -> Void
+    private let applyClosure: (String) -> Void
+
+    init(productListViewModel: ProductListViewModel,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         cancelClosure: @escaping () -> Void,
+         applyClosure: @escaping (String) -> Void) {
+        self.productListViewModel = productListViewModel
+        self.currencySettings = currencySettings
+        self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        self.cancelClosure = cancelClosure
+        self.applyClosure = applyClosure
+    }
+
+    /// Called when the cancel button is tapped
+    ///
+    func cancelButtonTapped() {
+        cancelClosure()
+    }
+
+    /// Called when the save button is tapped
+    ///
+    func applyButtonTapped() {
+        applyClosure(currentPrice)
+    }
+
+    /// Called when price changes
+    ///
+    func handlePriceChange(_ price: String?) {
+        currentPrice = price ?? ""
+        updateButtonStateBasedOnCurrentPrice()
+    }
+
+    /// Update the button state to enable/disable based on price value
+    ///
+    private func updateButtonStateBasedOnCurrentPrice() {
+        if currentPrice.isNotEmpty {
+            applyButtonEnabled = true
+        } else {
+            applyButtonEnabled = false
+        }
+    }
+
+    /// Returns the footer text to be displayed with information about the current bulk price and how many products will be updated.
+    ///
+    var footerText: String {
+        let numberOfProducts = productListViewModel.selectedProductsCount
+        let numberOfProductsText = String.pluralize(numberOfProducts,
+                                                      singular: Localization.productsNumberSingularFooter,
+                                                      plural: Localization.productsNumberPluralFooter)
+
+        switch productListViewModel.commonPriceForSelectedProducts {
+        case .none:
+            return [Localization.currentPriceNoneFooter, numberOfProductsText].joined(separator: " ")
+        case .mixed:
+            return [Localization.currentPriceMixedFooter, numberOfProductsText].joined(separator: " ")
+        case let .value(price):
+            let currentPriceText = String.localizedStringWithFormat(Localization.currentPriceFooter, formatPriceString(price))
+            return [currentPriceText, numberOfProductsText].joined(separator: " ")
+        }
+    }
+
+    /// It formats a price `String` according to the current price settings.
+    ///
+    private func formatPriceString(_ price: String) -> String {
+        let currencyCode = currencySettings.currencyCode
+        let currency = currencySettings.symbol(from: currencyCode)
+
+        return currencyFormatter.formatAmount(price, with: currency) ?? ""
+    }
+
+    /// Returns the title to be displayed in the top of bulk update screen
+    ///
+    func screenTitle() -> String {
+        return Localization.screenTitle
+    }
+}
+
+private extension PriceInputViewModel {
+    enum Localization {
+        static let screenTitle = NSLocalizedString("Update Regular Price", comment: "Title that appears on top of the of bulk price setting screen")
+        static let productsNumberSingularFooter = NSLocalizedString("The price will be updated for %d product.",
+                                                                    comment: "Message in the footer of bulk price setting screen (singular).")
+        static let productsNumberPluralFooter = NSLocalizedString("The price will be updated for %d products.",
+                                                                  comment: "Message in the footer of bulk price setting screen (plurar).")
+        static let currentPriceFooter = NSLocalizedString("Current price is %@.",
+                                                          comment: "Message in the footer of bulk price setting screen"
+                                                          + " with the current price, when it is the same for all products")
+        static let currentPriceMixedFooter = NSLocalizedString("Current prices are mixed.",
+                                                               comment: "Message in the footer of bulk price setting screen, when products have"
+                                                               + " different price values.")
+        static let currentPriceNoneFooter = NSLocalizedString("Current price is not set.",
+                                                              comment: "Message in the footer of bulk price setting screen, when none of the"
+                                                              + " products have price value.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
@@ -12,7 +12,7 @@ final class PriceInputViewModel {
 
     /// This holds the latest entered price. It is used to perform validations when the user taps the apply button
     /// and for creating a products array with the new price for the bulk update Action
-    private(set) var currentPrice: String = ""
+    private var currentPrice: String = ""
 
     private let productListViewModel: ProductListViewModel
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -12,7 +12,7 @@ class ProductListViewModel {
     let siteID: Int64
     private let stores: StoresManager
 
-    private var selectedProducts: Set<Product> = .init()
+    private(set) var selectedProducts: Set<Product> = .init()
 
     init(siteID: Int64, stores: StoresManager) {
         self.siteID = siteID
@@ -43,6 +43,17 @@ class ProductListViewModel {
         selectedProducts.removeAll()
     }
 
+    /// Represents if a property in a collection of `Product`  has the same value or different values or is missing.
+    ///
+    enum BulkValue: Equatable {
+        /// All variations have the same value
+        case value(String)
+        /// When variations have mixed values.
+        case mixed
+        /// None of the variation has a value
+        case none
+    }
+
     /// Check if selected products share the same common ProductStatus. Returns `nil` otherwise.
     ///
     var commonStatusForSelectedProducts: ProductStatus? {
@@ -51,6 +62,18 @@ class ProductListViewModel {
             return status
         } else {
             return nil
+        }
+    }
+
+    /// Check if selected products share the same common ProductStatus. Returns `nil` otherwise.
+    ///
+    var commonPriceForSelectedProducts: BulkValue {
+        if selectedProducts.allSatisfy({ $0.regularPrice?.isEmpty != false }) {
+            return .none
+        } else if let price = selectedProducts.first?.regularPrice, selectedProducts.allSatisfy({ $0.regularPrice == price }) {
+            return .value(price)
+        } else {
+            return .mixed
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -96,4 +96,24 @@ class ProductListViewModel {
         }
         stores.dispatch(batchAction)
     }
+
+    /// Update selected products with new price and trigger Network action to save the change remotely.
+    ///
+    func updateSelectedProducts(with newPrice: String, completion: @escaping (Result<Void, Error>) -> Void ) {
+        guard selectedProductsCount > 0 else {
+            completion(.failure(BulkEditError.noProductsSelected))
+            return
+        }
+
+        let updatedProducts = selectedProducts.map({ $0.copy(regularPrice: newPrice) })
+        let batchAction = ProductAction.updateProducts(siteID: siteID, products: updatedProducts) { result in
+            switch result {
+            case .success:
+                completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+        stores.dispatch(batchAction)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -339,8 +339,8 @@ private extension ProductsViewController {
         let updateStatus = UIAlertAction(title: Localization.bulkEditingStatusOption, style: .default) { [weak self] _ in
             self?.showStatusBulkEditingModal()
         }
-        let updatePrice = UIAlertAction(title: Localization.bulkEditingPriceOption, style: .default) { _ in
-            // TODO-8520: show UI for price update
+        let updatePrice = UIAlertAction(title: Localization.bulkEditingPriceOption, style: .default) { [weak self] _ in
+            self?.showPriceBulkEditingModal()
         }
         let cancelAction = UIAlertAction(title: Localization.cancel, style: .cancel)
 
@@ -379,7 +379,7 @@ private extension ProductsViewController {
         }.store(in: &subscriptions)
         listSelectorViewController.navigationItem.rightBarButtonItem = applyButton
 
-        self.present(WooNavigationController(rootViewController: listSelectorViewController), animated: true)
+        present(WooNavigationController(rootViewController: listSelectorViewController), animated: true)
     }
 
     @objc func dismissModal() {
@@ -402,6 +402,16 @@ private extension ProductsViewController {
                 self.presentNotice(title: Localization.updateErrorNotice)
             }
         }
+    }
+
+    func showPriceBulkEditingModal() {
+        let priceInputViewModel = PriceInputViewModel(productListViewModel: viewModel) { [weak self] in
+            self?.dismissModal()
+        } applyClosure: { newPrice in
+            //
+        }
+        let priceInputViewController = PriceInputViewController(viewModel: priceInputViewModel)
+        present(WooNavigationController(rootViewController: priceInputViewController), animated: true)
     }
 
     func displayProductsSavingInProgressView(on vc: UIViewController) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1277,6 +1277,7 @@
 		AEE9A880293A3E5500227C92 /* RefreshablePlainList.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE9A87F293A3E5500227C92 /* RefreshablePlainList.swift */; };
 		AEFF77A42978389400667F7A /* PriceInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFF77A32978389400667F7A /* PriceInputViewController.swift */; };
 		AEFF77A629783CA600667F7A /* PriceInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFF77A529783CA600667F7A /* PriceInputViewModel.swift */; };
+		AEFF77A829786A2900667F7A /* PriceInputViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFF77A729786A2900667F7A /* PriceInputViewControllerTests.swift */; };
 		B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509112D2049E27A007D25DC /* DashboardViewController.swift */; };
 		B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED021C041DF000076A9 /* Locale+Woo.swift */; };
 		B509FED321C05121000076A9 /* SupportManagerAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED221C05121000076A9 /* SupportManagerAdapter.swift */; };
@@ -3333,6 +3334,7 @@
 		AEE9A87F293A3E5500227C92 /* RefreshablePlainList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshablePlainList.swift; sourceTree = "<group>"; };
 		AEFF77A32978389400667F7A /* PriceInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceInputViewController.swift; sourceTree = "<group>"; };
 		AEFF77A529783CA600667F7A /* PriceInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceInputViewModel.swift; sourceTree = "<group>"; };
+		AEFF77A729786A2900667F7A /* PriceInputViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceInputViewControllerTests.swift; sourceTree = "<group>"; };
 		B509112D2049E27A007D25DC /* DashboardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardViewController.swift; sourceTree = "<group>"; };
 		B509FED021C041DF000076A9 /* Locale+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+Woo.swift"; sourceTree = "<group>"; };
 		B509FED221C05121000076A9 /* SupportManagerAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportManagerAdapter.swift; sourceTree = "<group>"; };
@@ -5433,6 +5435,7 @@
 			children = (
 				093B265827DF15100026F92D /* BulkUpdatePriceViewControllerTests.swift */,
 				09BE3A9027C921A70070B69D /* BulkUpdatePriceSettingsViewModelTests.swift */,
+				AEFF77A729786A2900667F7A /* PriceInputViewControllerTests.swift */,
 			);
 			path = "Bulk Edit Price";
 			sourceTree = "<group>";
@@ -11642,6 +11645,7 @@
 				57A5D8D92534FEBB00AA54D6 /* TotalRefundedCalculationUseCaseTests.swift in Sources */,
 				B5718D6521B56B400026C9F0 /* PushNotificationsManagerTests.swift in Sources */,
 				D8A8C4F32268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift in Sources */,
+				AEFF77A829786A2900667F7A /* PriceInputViewControllerTests.swift in Sources */,
 				02C2756F24F5F5EE00286C04 /* ProductShippingSettingsViewModel+ProductVariationTests.swift in Sources */,
 				571FDDAE24C768DC00D486A5 /* MockZendeskManager.swift in Sources */,
 				45FBDF3C238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1275,6 +1275,8 @@
 		AEE2610F26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE2610E26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift */; };
 		AEE2611126E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE2611026E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift */; };
 		AEE9A880293A3E5500227C92 /* RefreshablePlainList.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE9A87F293A3E5500227C92 /* RefreshablePlainList.swift */; };
+		AEFF77A42978389400667F7A /* PriceInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFF77A32978389400667F7A /* PriceInputViewController.swift */; };
+		AEFF77A629783CA600667F7A /* PriceInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFF77A529783CA600667F7A /* PriceInputViewModel.swift */; };
 		B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509112D2049E27A007D25DC /* DashboardViewController.swift */; };
 		B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED021C041DF000076A9 /* Locale+Woo.swift */; };
 		B509FED321C05121000076A9 /* SupportManagerAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED221C05121000076A9 /* SupportManagerAdapter.swift */; };
@@ -3329,6 +3331,8 @@
 		AEE2610E26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditOrderAddressFormViewModel.swift; sourceTree = "<group>"; };
 		AEE2611026E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditOrderAddressFormViewModelTests.swift; sourceTree = "<group>"; };
 		AEE9A87F293A3E5500227C92 /* RefreshablePlainList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshablePlainList.swift; sourceTree = "<group>"; };
+		AEFF77A32978389400667F7A /* PriceInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceInputViewController.swift; sourceTree = "<group>"; };
+		AEFF77A529783CA600667F7A /* PriceInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceInputViewModel.swift; sourceTree = "<group>"; };
 		B509112D2049E27A007D25DC /* DashboardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardViewController.swift; sourceTree = "<group>"; };
 		B509FED021C041DF000076A9 /* Locale+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+Woo.swift"; sourceTree = "<group>"; };
 		B509FED221C05121000076A9 /* SupportManagerAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportManagerAdapter.swift; sourceTree = "<group>"; };
@@ -6822,6 +6826,8 @@
 				020DD49023239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift */,
 				02564A89246CDF6100D6DB2A /* ProductsTopBannerFactory.swift */,
 				0279F0D9252DB4BE0098D7DE /* ProductVariationDetailsFactory.swift */,
+				AEFF77A32978389400667F7A /* PriceInputViewController.swift */,
+				AEFF77A529783CA600667F7A /* PriceInputViewModel.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -10477,6 +10483,7 @@
 				26AC0DD92941081500859074 /* AnalyticsHubCustomRangeData.swift in Sources */,
 				CECC759723D607C900486676 /* OrderItemRefund+Woo.swift in Sources */,
 				03EF250228C615A5006A033E /* InPersonPaymentsMenuViewModel.swift in Sources */,
+				AEFF77A629783CA600667F7A /* PriceInputViewModel.swift in Sources */,
 				0212275C244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift in Sources */,
 				DEC6C51A2747758D006832D3 /* JetpackInstallView.swift in Sources */,
 				DE37517C28DC5FC6000163CB /* Authenticator.swift in Sources */,
@@ -10750,6 +10757,7 @@
 				024DF31923742C3F006658FE /* AztecFormatBarFactory.swift in Sources */,
 				02291737270BEFF200449FA0 /* ProcessConfiguration.swift in Sources */,
 				45CE2D322625AA9A00E3CA00 /* ShippingLabelPackageList.swift in Sources */,
+				AEFF77A42978389400667F7A /* PriceInputViewController.swift in Sources */,
 				02535CBB25823F7A00E137BB /* ShippingLabelPaperSize+UI.swift in Sources */,
 				CCD2E67E25DD4DC900BD975D /* ProductVariationsViewModel.swift in Sources */,
 				02C2756824F4E77F00286C04 /* ProductShippingSettingsViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1278,6 +1278,7 @@
 		AEFF77A42978389400667F7A /* PriceInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFF77A32978389400667F7A /* PriceInputViewController.swift */; };
 		AEFF77A629783CA600667F7A /* PriceInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFF77A529783CA600667F7A /* PriceInputViewModel.swift */; };
 		AEFF77A829786A2900667F7A /* PriceInputViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFF77A729786A2900667F7A /* PriceInputViewControllerTests.swift */; };
+		AEFF77AA29786DAA00667F7A /* PriceInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFF77A929786DAA00667F7A /* PriceInputViewModelTests.swift */; };
 		B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509112D2049E27A007D25DC /* DashboardViewController.swift */; };
 		B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED021C041DF000076A9 /* Locale+Woo.swift */; };
 		B509FED321C05121000076A9 /* SupportManagerAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED221C05121000076A9 /* SupportManagerAdapter.swift */; };
@@ -3335,6 +3336,7 @@
 		AEFF77A32978389400667F7A /* PriceInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceInputViewController.swift; sourceTree = "<group>"; };
 		AEFF77A529783CA600667F7A /* PriceInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceInputViewModel.swift; sourceTree = "<group>"; };
 		AEFF77A729786A2900667F7A /* PriceInputViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceInputViewControllerTests.swift; sourceTree = "<group>"; };
+		AEFF77A929786DAA00667F7A /* PriceInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceInputViewModelTests.swift; sourceTree = "<group>"; };
 		B509112D2049E27A007D25DC /* DashboardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardViewController.swift; sourceTree = "<group>"; };
 		B509FED021C041DF000076A9 /* Locale+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+Woo.swift"; sourceTree = "<group>"; };
 		B509FED221C05121000076A9 /* SupportManagerAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportManagerAdapter.swift; sourceTree = "<group>"; };
@@ -5436,6 +5438,7 @@
 				093B265827DF15100026F92D /* BulkUpdatePriceViewControllerTests.swift */,
 				09BE3A9027C921A70070B69D /* BulkUpdatePriceSettingsViewModelTests.swift */,
 				AEFF77A729786A2900667F7A /* PriceInputViewControllerTests.swift */,
+				AEFF77A929786DAA00667F7A /* PriceInputViewModelTests.swift */,
 			);
 			path = "Bulk Edit Price";
 			sourceTree = "<group>";
@@ -11517,6 +11520,7 @@
 				0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */,
 				FEED57FA2686544D00E47FD9 /* RoleErrorViewModelTests.swift in Sources */,
 				03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */,
+				AEFF77AA29786DAA00667F7A /* PriceInputViewModelTests.swift in Sources */,
 				EEC2D27F292CF60E0072132E /* LoginJetpackSetupHostingControllerTests.swift in Sources */,
 				4535EE82281BE726004212B4 /* CouponCodeInputFormatterTests.swift in Sources */,
 				DEF36DEC2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/PriceInputViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/PriceInputViewControllerTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import XCTest
+import Yosemite
+
+@testable import WooCommerce
+
+/// Tests for `PriceInputViewController`.
+///
+final class PriceInputViewControllerTests: XCTestCase {
+    private let sampleSiteID: Int64 = 123
+    private var storesManager: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        storesManager = MockStoresManager(sessionManager: .makeForTesting())
+    }
+
+    override func tearDown() {
+        storesManager = nil
+        super.tearDown()
+    }
+
+    func test_view_controller_displays_notice_on_selected_regular_price_is_less_than_sale_price_validation_error() throws {
+        // Given
+        let noticePresenter = MockNoticePresenter()
+        let listViewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1, dateOnSaleStart: Date(), dateOnSaleEnd: Date(), regularPrice: "100", salePrice: "42")
+        listViewModel.selectProduct(sampleProduct1)
+
+        let viewModel = PriceInputViewModel(productListViewModel: listViewModel)
+        let viewController = PriceInputViewController(viewModel: viewModel, noticePresenter: noticePresenter)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        viewModel.handlePriceChange("24")
+        viewModel.applyButtonTapped()
+
+        waitUntil {
+            noticePresenter.queuedNotices.count == 1
+        }
+
+        // Then
+        let notice = try XCTUnwrap(noticePresenter.queuedNotices.first)
+        XCTAssertEqual(notice.feedbackType, .error)
+    }
+
+    func test_view_controller_displays_notice_on_no_regular_price_validation_error() throws {
+        // Given
+        let noticePresenter = MockNoticePresenter()
+        let listViewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1, dateOnSaleStart: Date(), dateOnSaleEnd: Date(), regularPrice: "100", salePrice: "42")
+        listViewModel.selectProduct(sampleProduct1)
+
+        let viewModel = PriceInputViewModel(productListViewModel: listViewModel)
+        let viewController = PriceInputViewController(viewModel: viewModel, noticePresenter: noticePresenter)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        viewModel.handlePriceChange("")
+        viewModel.applyButtonTapped()
+
+        waitUntil {
+            noticePresenter.queuedNotices.count == 1
+        }
+
+        // Then
+        let notice = try XCTUnwrap(noticePresenter.queuedNotices.first)
+        XCTAssertEqual(notice.feedbackType, .error)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/PriceInputViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/PriceInputViewModelTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+/// Tests for `PriceInputViewModel`
+///
+final class PriceInputViewModelTests: XCTestCase {
+    private let sampleSiteID: Int64 = 123
+    private var storesManager: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        storesManager = MockStoresManager(sessionManager: .makeForTesting())
+    }
+
+    override func tearDown() {
+        storesManager = nil
+        super.tearDown()
+    }
+
+    func test_initial_viewModel_state() throws {
+        // Given
+        let listViewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1, regularPrice: "100")
+        listViewModel.selectProduct(sampleProduct1)
+
+        let viewModel = PriceInputViewModel(productListViewModel: listViewModel)
+
+        // Then
+        XCTAssertEqual(viewModel.applyButtonEnabled, false)
+        XCTAssertNil(viewModel.inputValidationError)
+        XCTAssertTrue(viewModel.footerText.isNotEmpty)
+    }
+
+    func test_state_when_price_is_changed_from_empty_to_a_value() {
+        // Given
+        let listViewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1, regularPrice: "100")
+        listViewModel.selectProduct(sampleProduct1)
+
+        let viewModel = PriceInputViewModel(productListViewModel: listViewModel)
+
+        // When
+        viewModel.handlePriceChange("42")
+
+        // Then
+        XCTAssertEqual(viewModel.applyButtonEnabled, true)
+        XCTAssertNil(viewModel.inputValidationError)
+    }
+
+    func test_state_when_price_is_changed_from_a_value_to_empty() {
+        // Given
+        let listViewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1, regularPrice: "100")
+        listViewModel.selectProduct(sampleProduct1)
+
+        let viewModel = PriceInputViewModel(productListViewModel: listViewModel)
+
+        // When
+        viewModel.handlePriceChange("")
+
+        // Then
+        XCTAssertEqual(viewModel.applyButtonEnabled, false)
+        XCTAssertNil(viewModel.inputValidationError)
+    }
+
+    func test_state_when_selected_regular_price_is_less_than_sale_price() {
+        // Given
+        let listViewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1, dateOnSaleStart: Date(), dateOnSaleEnd: Date(), regularPrice: "100", salePrice: "42")
+        listViewModel.selectProduct(sampleProduct1)
+
+        let viewModel = PriceInputViewModel(productListViewModel: listViewModel)
+
+        // When
+        viewModel.handlePriceChange("24")
+        viewModel.applyButtonTapped()
+
+        // Then
+        XCTAssertEqual(viewModel.applyButtonEnabled, true)
+        XCTAssertEqual(viewModel.inputValidationError, .salePriceHigherThanRegularPrice)
+    }
+
+    func test_state_when_selected_valid_price_is_valid_and_action_is_dispatched() {
+        // Given
+        var callbackValue: String?
+        let listViewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1, regularPrice: "100")
+        listViewModel.selectProduct(sampleProduct1)
+
+        let viewModel = PriceInputViewModel(productListViewModel: listViewModel)
+        viewModel.applyClosure = { result in
+            callbackValue = result
+        }
+
+        // When
+        viewModel.handlePriceChange("42")
+        viewModel.applyButtonTapped()
+
+        // Then
+        XCTAssertEqual(viewModel.applyButtonEnabled, true)
+        XCTAssertNil(viewModel.inputValidationError)
+        XCTAssertEqual(callbackValue, "42")
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8520

## Description

This PR adds status selector for bulk editing on Products List. Networking action is connected, loading, success and error states implemented.

### How

UI is based on `BulkUpdatePriceViewController` that is used for bulk variations update. `PriceInputViewController` is mostly the same, but stripped of networking actions and variation logic. In future we can unify them by adding some coordinator/subclass for variations.

## Testing

1. Build and run the app in debug/alpha mode.
2. On the products list tap the "multi-select" icon in the navbar.
3. Select a few products from the list.
4. Tap "Bulk update" in the bottom toolbar.
5. Tap "Update price".
6. Confirm that correct price is described in footer only if all selected products have the same status.
7. Confirm that "Apply" button is disabled for empty price.
8. Confirm that "Apply" button is enabled when price is entered.
9. Enter a price that is less than sale price of one of the selected products.
10. Tap "Apply". Observe immediate validation error notice.
11. Enter a valid price (greater than any of sale prices).
12. Tap "Apply". Observe loading state and success message.
13. Confirm products are updated in the list.


## Video

https://user-images.githubusercontent.com/3132438/213264489-fb8447f8-f55d-43c1-9c8d-923be44129bb.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
