### PR TITLE
REST API: Revert naming to `RequestProcessor` and `RequestAuthenticator`

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -754,7 +754,7 @@
 		DEF13C5E296686AB0024A02B /* orders-load-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEF13C5D296686AB0024A02B /* orders-load-all-without-data.json */; };
 		DEF13C6029668C420024A02B /* order-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEF13C5F29668C420024A02B /* order-without-data.json */; };
 		DEFBA74E29485A7600C35BA9 /* RESTRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFBA74D29485A7600C35BA9 /* RESTRequest.swift */; };
-		DEFBA7542949CE6600C35BA9 /* ApplicationPasswordRequestProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFBA7532949CE6600C35BA9 /* ApplicationPasswordRequestProcessor.swift */; };
+		DEFBA7542949CE6600C35BA9 /* RequestProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFBA7532949CE6600C35BA9 /* RequestProcessor.swift */; };
 		DEFBA7562949D17400C35BA9 /* DefaultRequestAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFBA7552949D17300C35BA9 /* DefaultRequestAuthenticatorTests.swift */; };
 		E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */; };
 		E137619929151C7400FD098F /* error-wp-rest-forbidden.json in Resources */ = {isa = PBXBuildFile; fileRef = E137619829151C7400FD098F /* error-wp-rest-forbidden.json */; };
@@ -787,7 +787,7 @@
 		EE80A25029556FBD003591E4 /* coupon-reports-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE80A24F29556FBD003591E4 /* coupon-reports-without-data.json */; };
 		EE8A86F1286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json in Resources */ = {isa = PBXBuildFile; fileRef = EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */; };
 		EE8DE432294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DE431294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift */; };
-		EE99814E295AA7430074AE68 /* ApplicationPasswordAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE99814D295AA7430074AE68 /* ApplicationPasswordAuthenticator.swift */; };
+		EE99814E295AA7430074AE68 /* RequestAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE99814D295AA7430074AE68 /* RequestAuthenticator.swift */; };
 		EE998150295AACE10074AE68 /* RequestConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE99814F295AACE10074AE68 /* RequestConverter.swift */; };
 		EEA6583E2966B41E00112DF0 /* products-load-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EEA6583D2966B41E00112DF0 /* products-load-all-without-data.json */; };
 		EEA658402966C05D00112DF0 /* product-search-sku-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EEA6583F2966C05D00112DF0 /* product-search-sku-without-data.json */; };
@@ -1585,7 +1585,7 @@
 		DEF13C5D296686AB0024A02B /* orders-load-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "orders-load-all-without-data.json"; sourceTree = "<group>"; };
 		DEF13C5F29668C420024A02B /* order-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-without-data.json"; sourceTree = "<group>"; };
 		DEFBA74D29485A7600C35BA9 /* RESTRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTRequest.swift; sourceTree = "<group>"; };
-		DEFBA7532949CE6600C35BA9 /* ApplicationPasswordRequestProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordRequestProcessor.swift; sourceTree = "<group>"; };
+		DEFBA7532949CE6600C35BA9 /* RequestProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestProcessor.swift; sourceTree = "<group>"; };
 		DEFBA7552949D17300C35BA9 /* DefaultRequestAuthenticatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRequestAuthenticatorTests.swift; sourceTree = "<group>"; };
 		E12552C426385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressValidationSuccess.swift; sourceTree = "<group>"; };
 		E137619829151C7400FD098F /* error-wp-rest-forbidden.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "error-wp-rest-forbidden.json"; sourceTree = "<group>"; };
@@ -1618,7 +1618,7 @@
 		EE80A24F29556FBD003591E4 /* coupon-reports-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-reports-without-data.json"; sourceTree = "<group>"; };
 		EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-update-product-id-in-wordpress-site.json"; sourceTree = "<group>"; };
 		EE8DE431294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultApplicationPasswordUseCaseTests.swift; sourceTree = "<group>"; };
-		EE99814D295AA7430074AE68 /* ApplicationPasswordAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordAuthenticator.swift; sourceTree = "<group>"; };
+		EE99814D295AA7430074AE68 /* RequestAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestAuthenticator.swift; sourceTree = "<group>"; };
 		EE99814F295AACE10074AE68 /* RequestConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestConverter.swift; sourceTree = "<group>"; };
 		EEA6583D2966B41E00112DF0 /* products-load-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-load-all-without-data.json"; sourceTree = "<group>"; };
 		EEA6583F2966C05D00112DF0 /* product-search-sku-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-search-sku-without-data.json"; sourceTree = "<group>"; };
@@ -2794,10 +2794,10 @@
 		EE54C899294777D000A9BF61 /* ApplicationPassword */ = {
 			isa = PBXGroup;
 			children = (
-				DEFBA7532949CE6600C35BA9 /* ApplicationPasswordRequestProcessor.swift */,
+				DEFBA7532949CE6600C35BA9 /* RequestProcessor.swift */,
 				EE54C89E2947782E00A9BF61 /* ApplicationPasswordUseCase.swift */,
 				EE71CC3C2951A8EA0074D908 /* ApplicationPasswordStorage.swift */,
-				EE99814D295AA7430074AE68 /* ApplicationPasswordAuthenticator.swift */,
+				EE99814D295AA7430074AE68 /* RequestAuthenticator.swift */,
 				EE99814F295AACE10074AE68 /* RequestConverter.swift */,
 			);
 			path = ApplicationPassword;
@@ -3345,7 +3345,7 @@
 				457A574025D1817E000797AD /* ShippingLabelAddressVerification.swift in Sources */,
 				74ABA1D1213F22CA00FFAD30 /* TopEarnersStatsRemote.swift in Sources */,
 				DEC51AF127699E7A009F3DF4 /* SystemStatus+Page.swift in Sources */,
-				EE99814E295AA7430074AE68 /* ApplicationPasswordAuthenticator.swift in Sources */,
+				EE99814E295AA7430074AE68 /* RequestAuthenticator.swift in Sources */,
 				025CA2C0238EB8CB00B05C81 /* ProductShippingClass.swift in Sources */,
 				02C1CEF424C6A02B00703EBA /* ProductVariationMapper.swift in Sources */,
 				3105470C262E27F000C5C02B /* WCPayPaymentIntentStatusEnum.swift in Sources */,
@@ -3377,7 +3377,7 @@
 				020D07B823D852BB00FD9580 /* Media.swift in Sources */,
 				B5BB1D0C20A2050300112D92 /* DateFormatter+Woo.swift in Sources */,
 				743E84EE2217244C00FAC9D7 /* ShipmentTrackingListMapper.swift in Sources */,
-				DEFBA7542949CE6600C35BA9 /* ApplicationPasswordRequestProcessor.swift in Sources */,
+				DEFBA7542949CE6600C35BA9 /* RequestProcessor.swift in Sources */,
 				451A97E5260B631E0059D135 /* ShippingLabelPredefinedPackage.swift in Sources */,
 				BAB373722795A1FB00837B4A /* OrderTaxLine.swift in Sources */,
 				EE54C89F2947782E00A9BF61 /* ApplicationPasswordUseCase.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -781,7 +781,7 @@
 		EE6FDCFC2966A70400E1CECF /* product-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE6FDCFB2966A70400E1CECF /* product-without-data.json */; };
 		EE71CC3D2951A8EA0074D908 /* ApplicationPasswordStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE71CC3C2951A8EA0074D908 /* ApplicationPasswordStorage.swift */; };
 		EE71CC412951CE700074D908 /* generate-application-password-using-wporg-creds-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE71CC402951CE700074D908 /* generate-application-password-using-wporg-creds-success.json */; };
-		EE76762F2962B85E000066FA /* ApplicationPasswordRequestProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE76762E2962B85E000066FA /* ApplicationPasswordRequestProcessorTests.swift */; };
+		EE76762F2962B85E000066FA /* RequestProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE76762E2962B85E000066FA /* RequestProcessorTests.swift */; };
 		EE80A24729547F8B003591E4 /* coupons-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE80A24529547F8B003591E4 /* coupons-all-without-data.json */; };
 		EE80A24829547F8B003591E4 /* coupon-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE80A24629547F8B003591E4 /* coupon-without-data.json */; };
 		EE80A25029556FBD003591E4 /* coupon-reports-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE80A24F29556FBD003591E4 /* coupon-reports-without-data.json */; };
@@ -1612,7 +1612,7 @@
 		EE6FDCFB2966A70400E1CECF /* product-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-without-data.json"; sourceTree = "<group>"; };
 		EE71CC3C2951A8EA0074D908 /* ApplicationPasswordStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordStorage.swift; sourceTree = "<group>"; };
 		EE71CC402951CE700074D908 /* generate-application-password-using-wporg-creds-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "generate-application-password-using-wporg-creds-success.json"; sourceTree = "<group>"; };
-		EE76762E2962B85E000066FA /* ApplicationPasswordRequestProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordRequestProcessorTests.swift; sourceTree = "<group>"; };
+		EE76762E2962B85E000066FA /* RequestProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestProcessorTests.swift; sourceTree = "<group>"; };
 		EE80A24529547F8B003591E4 /* coupons-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupons-all-without-data.json"; sourceTree = "<group>"; };
 		EE80A24629547F8B003591E4 /* coupon-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-without-data.json"; sourceTree = "<group>"; };
 		EE80A24F29556FBD003591E4 /* coupon-reports-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-reports-without-data.json"; sourceTree = "<group>"; };
@@ -2844,7 +2844,7 @@
 			isa = PBXGroup;
 			children = (
 				EE8DE431294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift */,
-				EE76762E2962B85E000066FA /* ApplicationPasswordRequestProcessorTests.swift */,
+				EE76762E2962B85E000066FA /* RequestProcessorTests.swift */,
 			);
 			path = ApplicationPassword;
 			sourceTree = "<group>";
@@ -3769,7 +3769,7 @@
 				D800DA0A25EFEB9C001E13CE /* WCPayRemoteTests.swift in Sources */,
 				E13BAD5328F8625600217769 /* InAppPurchasesRemoteTests.swift in Sources */,
 				CC851D1425E52AB500249E9C /* Decimal+ExtensionsTests.swift in Sources */,
-				EE76762F2962B85E000066FA /* ApplicationPasswordRequestProcessorTests.swift in Sources */,
+				EE76762F2962B85E000066FA /* RequestProcessorTests.swift in Sources */,
 				B554FA8B2180B1D500C54DFF /* NotificationsRemoteTests.swift in Sources */,
 				B518662A20A09C6F00037A38 /* OrdersRemoteTests.swift in Sources */,
 				02EF166E292F0C5800D90AD6 /* PaymentRemoteTests.swift in Sources */,

--- a/Networking/Networking/ApplicationPassword/RequestAuthenticator.swift
+++ b/Networking/Networking/ApplicationPassword/RequestAuthenticator.swift
@@ -26,7 +26,7 @@ protocol RequestAuthenticator {
 
 /// Authenticates request
 ///
-public struct DefaultApplicationPasswordAuthenticator: RequestAuthenticator {
+public struct DefaultRequestAuthenticator: RequestAuthenticator {
     /// Credentials to authenticate the URLRequest
     ///
     let credentials: Credentials?
@@ -84,7 +84,7 @@ public struct DefaultApplicationPasswordAuthenticator: RequestAuthenticator {
     }
 }
 
-private extension DefaultApplicationPasswordAuthenticator {
+private extension DefaultRequestAuthenticator {
     /// To check whether the given URLRequest is a REST API request
     /// 
     func isRestAPIRequest(_ urlRequest: URLRequest) -> Bool {

--- a/Networking/Networking/ApplicationPassword/RequestAuthenticator.swift
+++ b/Networking/Networking/ApplicationPassword/RequestAuthenticator.swift
@@ -1,9 +1,9 @@
-enum ApplicationPasswordAuthenticatorError: Error {
+enum RequestAuthenticatorError: Error {
     case applicationPasswordUseCaseNotAvailable
     case applicationPasswordNotAvailable
 }
 
-protocol ApplicationPasswordAuthenticator {
+protocol RequestAuthenticator {
     /// Credentials to authenticate the URLRequest
     ///
     var credentials: Credentials? { get }
@@ -26,7 +26,7 @@ protocol ApplicationPasswordAuthenticator {
 
 /// Authenticates request
 ///
-public struct DefaultApplicationPasswordAuthenticator: ApplicationPasswordAuthenticator {
+public struct DefaultApplicationPasswordAuthenticator: RequestAuthenticator {
     /// Credentials to authenticate the URLRequest
     ///
     let credentials: Credentials?
@@ -71,7 +71,7 @@ public struct DefaultApplicationPasswordAuthenticator: ApplicationPasswordAuthen
     ///
     func generateApplicationPassword() async throws {
         guard let applicationPasswordUseCase else {
-            throw ApplicationPasswordAuthenticatorError.applicationPasswordUseCaseNotAvailable
+            throw RequestAuthenticatorError.applicationPasswordUseCaseNotAvailable
         }
         let _ = try await applicationPasswordUseCase.generateNewPassword()
         return
@@ -110,7 +110,7 @@ private extension DefaultApplicationPasswordAuthenticator {
     ///
     func authenticateUsingApplicationPasswordIfPossible(_ urlRequest: URLRequest) throws -> URLRequest {
         guard let applicationPassword = applicationPasswordUseCase?.applicationPassword else {
-            throw ApplicationPasswordAuthenticatorError.applicationPasswordNotAvailable
+            throw RequestAuthenticatorError.applicationPasswordNotAvailable
         }
 
         return AuthenticatedRESTRequest(applicationPassword: applicationPassword, request: urlRequest).asURLRequest()

--- a/Networking/Networking/ApplicationPassword/RequestProcessor.swift
+++ b/Networking/Networking/ApplicationPassword/RequestProcessor.swift
@@ -3,21 +3,21 @@ import Foundation
 
 /// Authenticates and retries requests
 ///
-final class ApplicationPasswordRequestProcessor {
+final class RequestProcessor {
     private var requestsToRetry = [RequestRetryCompletion]()
 
     private var isAuthenticating = false
 
-    private let requestAuthenticator: ApplicationPasswordAuthenticator
+    private let requestAuthenticator: RequestAuthenticator
 
-    init(requestAuthenticator: ApplicationPasswordAuthenticator) {
+    init(requestAuthenticator: RequestAuthenticator) {
         self.requestAuthenticator = requestAuthenticator
     }
 }
 
 // MARK: Request Authentication
 //
-extension ApplicationPasswordRequestProcessor: RequestAdapter {
+extension RequestProcessor: RequestAdapter {
     func adapt(_ urlRequest: URLRequest) throws -> URLRequest {
         return try requestAuthenticator.authenticate(urlRequest)
     }
@@ -25,7 +25,7 @@ extension ApplicationPasswordRequestProcessor: RequestAdapter {
 
 // MARK: Retrying Request
 //
-extension ApplicationPasswordRequestProcessor: RequestRetrier {
+extension RequestProcessor: RequestRetrier {
     func should(_ manager: Alamofire.SessionManager,
                 retry request: Alamofire.Request,
                 with error: Error,
@@ -48,7 +48,7 @@ extension ApplicationPasswordRequestProcessor: RequestRetrier {
 
 // MARK: Helpers
 //
-private extension ApplicationPasswordRequestProcessor {
+private extension RequestProcessor {
     func generateApplicationPassword() {
         Task(priority: .medium) {
             isAuthenticating = true
@@ -66,7 +66,7 @@ private extension ApplicationPasswordRequestProcessor {
 
     func shouldRetry(_ error: Error) -> Bool {
         // Need to generate application password
-        if .applicationPasswordNotAvailable == error as? ApplicationPasswordAuthenticatorError {
+        if .applicationPasswordNotAvailable == error as? RequestAuthenticatorError {
             return true
         }
 

--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -36,7 +36,7 @@ public class AlamofireNetwork: Network {
     ///
     public required init(credentials: Credentials?) {
         self.requestConverter = RequestConverter(credentials: credentials)
-        self.requestAuthenticator = RequestProcessor(requestAuthenticator: DefaultApplicationPasswordAuthenticator(credentials: credentials))
+        self.requestAuthenticator = RequestProcessor(requestAuthenticator: DefaultRequestAuthenticator(credentials: credentials))
     }
 
     /// Executes the specified Network Request. Upon completion, the payload will be sent back to the caller as a Data instance.

--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -28,7 +28,7 @@ public class AlamofireNetwork: Network {
 
     /// Authenticator to update requests authorization header if possible.
     ///
-    private let requestAuthenticator: ApplicationPasswordRequestProcessor
+    private let requestAuthenticator: RequestProcessor
 
     public var session: URLSession { SessionManager.default.session }
 
@@ -36,7 +36,7 @@ public class AlamofireNetwork: Network {
     ///
     public required init(credentials: Credentials?) {
         self.requestConverter = RequestConverter(credentials: credentials)
-        self.requestAuthenticator = ApplicationPasswordRequestProcessor(requestAuthenticator: DefaultApplicationPasswordAuthenticator(credentials: credentials))
+        self.requestAuthenticator = RequestProcessor(requestAuthenticator: DefaultApplicationPasswordAuthenticator(credentials: credentials))
     }
 
     /// Executes the specified Network Request. Upon completion, the payload will be sent back to the caller as a Data instance.

--- a/Networking/NetworkingTests/ApplicationPassword/ApplicationPasswordRequestProcessorTests.swift
+++ b/Networking/NetworkingTests/ApplicationPassword/ApplicationPasswordRequestProcessorTests.swift
@@ -6,7 +6,7 @@ import XCTest
 ///
 final class ApplicationPasswordRequestProcessorTests: XCTestCase {
     private var mockRequestAuthenticator: MockRequestAuthenticator!
-    private var sut: ApplicationPasswordRequestProcessor!
+    private var sut: RequestProcessor!
     private var sessionManager: Alamofire.SessionManager!
 
     private let url = URL(string: "https://test.com/")!
@@ -16,7 +16,7 @@ final class ApplicationPasswordRequestProcessorTests: XCTestCase {
 
         sessionManager = Alamofire.SessionManager(configuration: URLSessionConfiguration.default)
         mockRequestAuthenticator = MockRequestAuthenticator()
-        sut = ApplicationPasswordRequestProcessor(requestAuthenticator: mockRequestAuthenticator)
+        sut = RequestProcessor(requestAuthenticator: mockRequestAuthenticator)
     }
 
     override func tearDown() {
@@ -50,7 +50,7 @@ final class ApplicationPasswordRequestProcessorTests: XCTestCase {
         // When
         request.retryCount = 0
         let shouldRetry = waitFor { promise in
-            let error = ApplicationPasswordAuthenticatorError.applicationPasswordNotAvailable
+            let error = RequestAuthenticatorError.applicationPasswordNotAvailable
             self.sut.should(sessionManager, retry: request, with: error) { shouldRetry, timeDelay in
                 promise(shouldRetry)
             }
@@ -68,7 +68,7 @@ final class ApplicationPasswordRequestProcessorTests: XCTestCase {
         // When
         request.retryCount = 1
         let shouldRetry = waitFor { promise in
-            let error = ApplicationPasswordAuthenticatorError.applicationPasswordNotAvailable
+            let error = RequestAuthenticatorError.applicationPasswordNotAvailable
             self.sut.should(sessionManager, retry: request, with: error) { shouldRetry, timeDelay in
                 promise(shouldRetry)
             }
@@ -88,7 +88,7 @@ final class ApplicationPasswordRequestProcessorTests: XCTestCase {
         // When
         mockRequestAuthenticator.mockedShouldRetryValue = true
         let shouldRetry = waitFor { promise in
-            let error = ApplicationPasswordAuthenticatorError.applicationPasswordNotAvailable
+            let error = RequestAuthenticatorError.applicationPasswordNotAvailable
             self.sut.should(sessionManager, retry: request, with: error) { shouldRetry, timeDelay in
                 promise(shouldRetry)
             }
@@ -106,7 +106,7 @@ final class ApplicationPasswordRequestProcessorTests: XCTestCase {
         // When
         mockRequestAuthenticator.mockedShouldRetryValue = false
         let shouldRetry = waitFor { promise in
-            let error = ApplicationPasswordAuthenticatorError.applicationPasswordNotAvailable
+            let error = RequestAuthenticatorError.applicationPasswordNotAvailable
             self.sut.should(sessionManager, retry: request, with: error) { shouldRetry, timeDelay in
                 promise(shouldRetry)
             }
@@ -124,7 +124,7 @@ final class ApplicationPasswordRequestProcessorTests: XCTestCase {
         let request = try mockRequest()
 
         // When
-        let error = ApplicationPasswordAuthenticatorError.applicationPasswordNotAvailable
+        let error = RequestAuthenticatorError.applicationPasswordNotAvailable
         let shouldRetry = waitFor { promise in
             self.sut.should(sessionManager, retry: request, with: error) { shouldRetry, timeDelay in
                 promise(shouldRetry)
@@ -177,7 +177,7 @@ final class ApplicationPasswordRequestProcessorTests: XCTestCase {
         let request = try mockRequest()
 
         // When
-        let error = ApplicationPasswordAuthenticatorError.applicationPasswordNotAvailable
+        let error = RequestAuthenticatorError.applicationPasswordNotAvailable
         waitFor { promise in
             self.sut.should(sessionManager, retry: request, with: error) { shouldRetry, timeDelay in
                 promise(())
@@ -196,7 +196,7 @@ final class ApplicationPasswordRequestProcessorTests: XCTestCase {
         // When
         mockRequestAuthenticator.mockedShouldRetryValue = false
         waitFor { promise in
-            let error = ApplicationPasswordAuthenticatorError.applicationPasswordNotAvailable
+            let error = RequestAuthenticatorError.applicationPasswordNotAvailable
             self.sut.should(sessionManager, retry: request, with: error) { shouldRetry, timeDelay in
                 promise(())
             }
@@ -226,7 +226,7 @@ private class MockTaskConvertible: TaskConvertible {
     }
 }
 
-private class MockRequestAuthenticator: ApplicationPasswordAuthenticator {
+private class MockRequestAuthenticator: RequestAuthenticator {
     var mockedShouldRetryValue: Bool?
 
     private(set) var authenticateCalled = false

--- a/Networking/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
+++ b/Networking/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 /// RequestProcessor Unit Tests
 ///
-final class ApplicationPasswordRequestProcessorTests: XCTestCase {
+final class RequestProcessorTests: XCTestCase {
     private var mockRequestAuthenticator: MockRequestAuthenticator!
     private var sut: RequestProcessor!
     private var sessionManager: Alamofire.SessionManager!
@@ -209,7 +209,7 @@ final class ApplicationPasswordRequestProcessorTests: XCTestCase {
 
 // MARK: Helpers
 //
-private extension ApplicationPasswordRequestProcessorTests {
+private extension RequestProcessorTests {
     func mockRequest() throws -> Alamofire.Request {
         let originalTask = MockTaskConvertible()
         let task = try originalTask.task(session: sessionManager.session, adapter: nil, queue: .main)

--- a/Networking/NetworkingTests/Network/DefaultRequestAuthenticatorTests.swift
+++ b/Networking/NetworkingTests/Network/DefaultRequestAuthenticatorTests.swift
@@ -6,7 +6,7 @@ final class DefaultRequestAuthenticatorTests: XCTestCase {
 
     func test_authenticateRequest_returns_unauthenticated_request_for_non_REST_request_without_WPCOM_credentials() throws {
         // Given
-        let authenticator = DefaultApplicationPasswordAuthenticator(credentials: nil)
+        let authenticator = DefaultRequestAuthenticator(credentials: nil)
         let jetpackRequest = JetpackRequest(wooApiVersion: .mark1, method: .get, siteID: 123, path: "test", availableAsRESTRequest: false)
 
         // When
@@ -20,7 +20,7 @@ final class DefaultRequestAuthenticatorTests: XCTestCase {
     func test_authenticatedRequest_returns_authenticated_request_for_non_REST_request_with_WPCOM_credentials() throws {
         // Given
         let credentials = Credentials(authToken: "secret")
-        let authenticator = DefaultApplicationPasswordAuthenticator(credentials: credentials)
+        let authenticator = DefaultRequestAuthenticator(credentials: credentials)
         let jetpackRequest = JetpackRequest(wooApiVersion: .mark1, method: .get, siteID: 123, path: "test", availableAsRESTRequest: false)
 
         // When
@@ -38,7 +38,7 @@ final class DefaultRequestAuthenticatorTests: XCTestCase {
         let credentials: Credentials = .wporg(username: "admin", password: "supersecret", siteAddress: siteURL)
         let applicationPassword = ApplicationPassword(wpOrgUsername: credentials.username, password: .init(credentials.secret))
         let useCase = MockApplicationPasswordUseCase(mockApplicationPassword: applicationPassword)
-        let authenticator = DefaultApplicationPasswordAuthenticator(credentials: credentials, applicationPasswordUseCase: useCase)
+        let authenticator = DefaultRequestAuthenticator(credentials: credentials, applicationPasswordUseCase: useCase)
         let wooAPIVersion = WooAPIVersion.mark1
         let basePath = RESTRequest.Settings.basePath
         let restRequest = RESTRequest(siteURL: siteURL, wooApiVersion: wooAPIVersion, method: .get, path: "test")
@@ -60,7 +60,7 @@ final class DefaultRequestAuthenticatorTests: XCTestCase {
         let credentials: Credentials = .wporg(username: "admin", password: "supersecret", siteAddress: siteURL)
         let applicationPassword = ApplicationPassword(wpOrgUsername: credentials.username, password: .init(credentials.secret))
         let useCase = MockApplicationPasswordUseCase(mockGeneratedPassword: applicationPassword)
-        let authenticator = DefaultApplicationPasswordAuthenticator(credentials: credentials, applicationPasswordUseCase: useCase)
+        let authenticator = DefaultRequestAuthenticator(credentials: credentials, applicationPasswordUseCase: useCase)
         let wooAPIVersion = WooAPIVersion.mark1
         let basePath = RESTRequest.Settings.basePath
         let restRequest = RESTRequest(siteURL: siteURL, wooApiVersion: wooAPIVersion, method: .get, path: "test")
@@ -88,7 +88,7 @@ final class DefaultRequestAuthenticatorTests: XCTestCase {
         let siteURL = "https://test.com/"
         let credentials: Credentials = .wporg(username: "admin", password: "supersecret", siteAddress: siteURL)
         let useCase = MockApplicationPasswordUseCase(mockGenerationError: NetworkError.timeout)
-        let authenticator = DefaultApplicationPasswordAuthenticator(credentials: credentials, applicationPasswordUseCase: useCase)
+        let authenticator = DefaultRequestAuthenticator(credentials: credentials, applicationPasswordUseCase: useCase)
         let wooAPIVersion = WooAPIVersion.mark1
         let restRequest = RESTRequest(siteURL: siteURL, wooApiVersion: wooAPIVersion, method: .get, path: "test")
 
@@ -115,7 +115,7 @@ final class DefaultRequestAuthenticatorTests: XCTestCase {
         let siteURL = "https://test.com/"
         let credentials: Credentials = .wporg(username: "admin", password: "supersecret", siteAddress: siteURL)
         let useCase = MockApplicationPasswordUseCase(mockGenerationError: NetworkError.timeout)
-        let authenticator = DefaultApplicationPasswordAuthenticator(credentials: credentials, applicationPasswordUseCase: useCase)
+        let authenticator = DefaultRequestAuthenticator(credentials: credentials, applicationPasswordUseCase: useCase)
         let wooAPIVersion = WooAPIVersion.mark1
         let restRequest = RESTRequest(siteURL: siteURL, wooApiVersion: wooAPIVersion, method: .get, path: "test")
 
@@ -131,7 +131,7 @@ final class DefaultRequestAuthenticatorTests: XCTestCase {
         let siteURL = "https://test.com/"
         let credentials: Credentials = .wporg(username: "admin", password: "supersecret", siteAddress: siteURL)
         let useCase = MockApplicationPasswordUseCase(mockGenerationError: NetworkError.timeout)
-        let authenticator = DefaultApplicationPasswordAuthenticator(credentials: credentials, applicationPasswordUseCase: useCase)
+        let authenticator = DefaultRequestAuthenticator(credentials: credentials, applicationPasswordUseCase: useCase)
         let jetpackRequest = JetpackRequest(wooApiVersion: .mark1, method: .get, siteID: 123, path: "test", availableAsRESTRequest: false)
 
         // When

--- a/Networking/NetworkingTests/Network/DefaultRequestAuthenticatorTests.swift
+++ b/Networking/NetworkingTests/Network/DefaultRequestAuthenticatorTests.swift
@@ -70,7 +70,7 @@ final class DefaultRequestAuthenticatorTests: XCTestCase {
 
         do {
             let _ = try authenticator.authenticate(request)
-        } catch ApplicationPasswordAuthenticatorError.applicationPasswordNotAvailable {
+        } catch RequestAuthenticatorError.applicationPasswordNotAvailable {
             try await authenticator.generateApplicationPassword()
         }
 
@@ -98,7 +98,7 @@ final class DefaultRequestAuthenticatorTests: XCTestCase {
         let request = try restRequest.asURLRequest()
         do {
             let _ = try authenticator.authenticate(request)
-        } catch ApplicationPasswordAuthenticatorError.applicationPasswordNotAvailable {
+        } catch RequestAuthenticatorError.applicationPasswordNotAvailable {
             // Then
             do {
                 try await authenticator.generateApplicationPassword()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8453 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When working on #8569, I renamed `RequestProcessor` and `RequestAuthenticator` to have the `ApplicationPassword` to be more specific and avoid confusion with `CookieNonceAuthenticator`. 

@selanthiraiyan [clarified](https://github.com/woocommerce/woocommerce-ios/pull/8659/files#r1073281562) that these handle not only application password but also WPCom token. So this PR aims to revert that naming.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Login with site credentials and application password should still work as before.
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address and proceed with the address of your test site.
- Log in with your site credentials. Notice that the login succeeds.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
