### PR TITLE
REST API: Track login events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1852,3 +1852,26 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - REST API Login
+//
+extension WooAnalyticsEvent {
+    enum RESTAPILogin {
+        enum Key: String {
+            case step
+        }
+
+        enum LoginSiteCredentialStep: String {
+            case authentication
+            case applicationPasswordGeneration = "application_password_generation"
+            case wooStatus = "woo_status"
+            case userRole = "user_role"
+        }
+
+        /// Tracks when the login with site credentials failed.
+        ///
+        static func loginSiteCredentialFailed(step: LoginSiteCredentialStep, error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginSiteCredentialsFailed, properties: [Key.step.rawValue: step.rawValue], error: error)
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1856,6 +1856,18 @@ extension WooAnalyticsEvent {
 // MARK: - REST API Login
 //
 extension WooAnalyticsEvent {
+    enum LoginUserRole {
+        enum Key: String {
+            case currentRoles = "current_roles"
+        }
+
+        static func loginWithInsufficientRole(currentRoles: [String]) -> WooAnalyticsEvent {
+            let roles = String(currentRoles.sorted().joined(by: ","))
+            return WooAnalyticsEvent(statName: .loginInsufficientRole,
+                                     properties: [Key.currentRoles.rawValue: roles])
+        }
+    }
+
     enum RESTAPILogin {
         enum Key: String {
             case step
@@ -1871,7 +1883,9 @@ extension WooAnalyticsEvent {
         /// Tracks when the login with site credentials failed.
         ///
         static func loginSiteCredentialFailed(step: LoginSiteCredentialStep, error: Error?) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .loginSiteCredentialsFailed, properties: [Key.step.rawValue: step.rawValue], error: error)
+            WooAnalyticsEvent(statName: .loginSiteCredentialsFailed,
+                              properties: [Key.step.rawValue: step.rawValue],
+                              error: error)
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1856,21 +1856,17 @@ extension WooAnalyticsEvent {
 // MARK: - REST API Login
 //
 extension WooAnalyticsEvent {
-    enum LoginUserRole {
-        enum Key: String {
-            case currentRoles = "current_roles"
-        }
-
-        static func loginWithInsufficientRole(currentRoles: [String]) -> WooAnalyticsEvent {
-            let roles = String(currentRoles.sorted().joined(by: ","))
-            return WooAnalyticsEvent(statName: .loginInsufficientRole,
-                                     properties: [Key.currentRoles.rawValue: roles])
-        }
-    }
-
-    enum RESTAPILogin {
+    enum Login {
         enum Key: String {
             case step
+            case currentRoles = "current_roles"
+            case exists
+            case hasWordPress = "is_wordpress"
+            case isWPCom = "is_wp_com"
+            case isJetpackInstalled = "has_jetpack"
+            case isJetpackActive = "is_jetpack_active"
+            case isJetpackConnected = "is_jetpack_connected"
+            case urlAfterRedirects = "url_after_redirects"
         }
 
         enum LoginSiteCredentialStep: String {
@@ -1880,12 +1876,40 @@ extension WooAnalyticsEvent {
             case userRole = "user_role"
         }
 
+        /// Tracks when the user attempts to log in with insufficient roles.
+        ///
+        static func insufficientRole(currentRoles: [String]) -> WooAnalyticsEvent {
+            let roles = String(currentRoles.sorted().joined(by: ","))
+            return WooAnalyticsEvent(statName: .loginInsufficientRole,
+                                     properties: [Key.currentRoles.rawValue: roles])
+        }
+
         /// Tracks when the login with site credentials failed.
         ///
-        static func loginSiteCredentialFailed(step: LoginSiteCredentialStep, error: Error?) -> WooAnalyticsEvent {
+        static func siteCredentialFailed(step: LoginSiteCredentialStep, error: Error?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .loginSiteCredentialsFailed,
                               properties: [Key.step.rawValue: step.rawValue],
                               error: error)
+        }
+
+        /// Tracks when site info is fetched during site address login.
+        ///
+        static func siteInfoFetched(exists: Bool,
+                                    hasWordPress: Bool,
+                                    isWPCom: Bool,
+                                    isJetpackInstalled: Bool,
+                                    isJetpackActive: Bool,
+                                    isJetpackConnected: Bool,
+                                    urlAfterRedirects: String) -> WooAnalyticsEvent {
+            .init(statName: .loginSiteAddressSiteInfoFetched, properties: [
+                Key.exists.rawValue: exists,
+                Key.hasWordPress.rawValue: hasWordPress,
+                Key.isWPCom.rawValue: isWPCom,
+                Key.isJetpackInstalled.rawValue: isJetpackInstalled,
+                Key.isJetpackActive.rawValue: isJetpackActive,
+                Key.isJetpackConnected.rawValue: isJetpackConnected,
+                Key.urlAfterRedirects.rawValue: urlAfterRedirects
+            ])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1870,7 +1870,7 @@ extension WooAnalyticsEvent {
 
         /// Tracks when the login with site credentials failed.
         ///
-        static func loginSiteCredentialFailed(step: LoginSiteCredentialStep, error: Error) -> WooAnalyticsEvent {
+        static func loginSiteCredentialFailed(step: LoginSiteCredentialStep, error: Error?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .loginSiteCredentialsFailed, properties: [Key.step.rawValue: step.rawValue], error: error)
         }
     }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -82,7 +82,7 @@ public enum WooAnalyticsStat: String {
     case loginInvalidEmailScreenViewed = "login_invalid_email_screen_viewed"
     case whatIsWPComOnInvalidEmailScreenTapped = "what_is_wordpress_com_on_invalid_email_screen"
     case createAccountOnInvalidEmailScreenTapped = "create_account_on_invalid_email_screen"
-    case loginInsufficientRole = "login_insufficent_role"
+    case loginInsufficientRole = "login_insufficient_role"
 
     // MARK: REST API login
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -82,6 +82,12 @@ public enum WooAnalyticsStat: String {
     case loginInvalidEmailScreenViewed = "login_invalid_email_screen_viewed"
     case whatIsWPComOnInvalidEmailScreenTapped = "what_is_wordpress_com_on_invalid_email_screen"
     case createAccountOnInvalidEmailScreenTapped = "create_account_on_invalid_email_screen"
+    case loginInsufficientRole = "login_insufficent_role"
+
+    // MARK: REST API login
+    //
+    case loginSiteAddressSiteInfoFetched = "login_site_address_site_info_fetched"
+    case loginSiteCredentialsFailed = "login_site_credentials_login_failed"
 
     // MARK: Site credentials
     //

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -319,7 +319,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
     ///
     func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (WordPressAuthenticatorResult) -> Void) {
         if let site = siteInfo {
-            ServiceLocator.analytics.track(event: .Login.siteInfoFetched(
+            analytics.track(event: .Login.siteInfoFetched(
                 exists: site.exists,
                 hasWordPress: site.isWP,
                 isWPCom: site.isWPCom,

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -318,6 +318,17 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
     /// and can proceed to the self-hosted username and password view controller.
     ///
     func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (WordPressAuthenticatorResult) -> Void) {
+        if let site = siteInfo {
+            ServiceLocator.analytics.track(event: .Login.siteInfoFetched(
+                exists: site.exists,
+                hasWordPress: site.isWP,
+                isWPCom: site.isWPCom,
+                isJetpackInstalled: site.hasJetpack,
+                isJetpackActive: site.isJetpackActive,
+                isJetpackConnected: site.isJetpackConnected,
+                urlAfterRedirects: site.url
+            ))
+        }
 
         /// WordPress must be present.
         guard let site = siteInfo, site.isWP else {

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -846,6 +846,7 @@ private extension StorePickerViewController {
                 }
             case .failure(let error):
                 if case let RoleEligibilityError.insufficientRole(errorInfo) = error {
+                    ServiceLocator.analytics.track(event: .LoginUserRole.loginWithInsufficientRole(currentRoles: errorInfo.roles))
                     delegate.showRoleErrorScreen(for: site.siteID, errorInfo: errorInfo) { [weak self] in
                         self?.dismiss()
                     }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -846,7 +846,7 @@ private extension StorePickerViewController {
                 }
             case .failure(let error):
                 if case let RoleEligibilityError.insufficientRole(errorInfo) = error {
-                    ServiceLocator.analytics.track(event: .LoginUserRole.loginWithInsufficientRole(currentRoles: errorInfo.roles))
+                    ServiceLocator.analytics.track(event: .Login.insufficientRole(currentRoles: errorInfo.roles))
                     delegate.showRoleErrorScreen(for: site.siteID, errorInfo: errorInfo) { [weak self] in
                         self?.dismiss()
                     }

--- a/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
+++ b/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
@@ -81,6 +81,7 @@ private extension PostSiteCredentialLoginChecker {
             case .failure(let error):
                 self?.analytics.track(event: .RESTAPILogin.loginSiteCredentialFailed(step: .userRole, error: error))
                 if case let RoleEligibilityError.insufficientRole(errorInfo) = error {
+                    self?.analytics.track(event: .LoginUserRole.loginWithInsufficientRole(currentRoles: errorInfo.roles))
                     self?.showRoleErrorScreen(for: WooConstants.placeholderStoreID,
                                              errorInfo: errorInfo,
                                              in: navigationController,

--- a/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
+++ b/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
@@ -79,6 +79,7 @@ private extension PostSiteCredentialLoginChecker {
             case .success:
                 onSuccess()
             case .failure(let error):
+                self?.analytics.track(event: .RESTAPILogin.loginSiteCredentialFailed(step: .userRole, error: error))
                 if case let RoleEligibilityError.insufficientRole(errorInfo) = error {
                     self?.showRoleErrorScreen(for: WooConstants.placeholderStoreID,
                                              errorInfo: errorInfo,
@@ -126,9 +127,11 @@ private extension PostSiteCredentialLoginChecker {
                 if site.isWooCommerceActive {
                     onSuccess()
                 } else {
+                    self?.analytics.track(event: .RESTAPILogin.loginSiteCredentialFailed(step: .wooStatus, error: nil))
                     self?.showAlert(message: Localization.noWooError, in: navigationController)
                 }
             case .failure(let error):
+                self?.analytics.track(event: .RESTAPILogin.loginSiteCredentialFailed(step: .wooStatus, error: error))
                 DDLogError("⛔️ Error checking Woo: \(error)")
                 // show generic error
                 self?.showAlert(message: Localization.wooCheckError, in: navigationController, onRetry: {

--- a/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
+++ b/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
@@ -48,7 +48,7 @@ private extension PostSiteCredentialLoginChecker {
                 let _ = try await useCase.generateNewPassword()
                 onSuccess()
             } catch {
-                analytics.track(event: .RESTAPILogin.loginSiteCredentialFailed(step: .applicationPasswordGeneration, error: error))
+                analytics.track(event: .Login.siteCredentialFailed(step: .applicationPasswordGeneration, error: error))
                 switch error {
                 case ApplicationPasswordUseCaseError.applicationPasswordsDisabled:
                     // show application password disabled error
@@ -79,9 +79,9 @@ private extension PostSiteCredentialLoginChecker {
             case .success:
                 onSuccess()
             case .failure(let error):
-                self?.analytics.track(event: .RESTAPILogin.loginSiteCredentialFailed(step: .userRole, error: error))
+                self?.analytics.track(event: .Login.siteCredentialFailed(step: .userRole, error: error))
                 if case let RoleEligibilityError.insufficientRole(errorInfo) = error {
-                    self?.analytics.track(event: .LoginUserRole.loginWithInsufficientRole(currentRoles: errorInfo.roles))
+                    self?.analytics.track(event: .Login.insufficientRole(currentRoles: errorInfo.roles))
                     self?.showRoleErrorScreen(for: WooConstants.placeholderStoreID,
                                              errorInfo: errorInfo,
                                              in: navigationController,
@@ -128,11 +128,11 @@ private extension PostSiteCredentialLoginChecker {
                 if site.isWooCommerceActive {
                     onSuccess()
                 } else {
-                    self?.analytics.track(event: .RESTAPILogin.loginSiteCredentialFailed(step: .wooStatus, error: nil))
+                    self?.analytics.track(event: .Login.siteCredentialFailed(step: .wooStatus, error: nil))
                     self?.showAlert(message: Localization.noWooError, in: navigationController)
                 }
             case .failure(let error):
-                self?.analytics.track(event: .RESTAPILogin.loginSiteCredentialFailed(step: .wooStatus, error: error))
+                self?.analytics.track(event: .Login.siteCredentialFailed(step: .wooStatus, error: error))
                 DDLogError("⛔️ Error checking Woo: \(error)")
                 // show generic error
                 self?.showAlert(message: Localization.wooCheckError, in: navigationController, onRetry: {

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -295,6 +295,7 @@ private extension AppCoordinator {
 
             // if the previous role check indicates that the user is ineligible, let's show the error message.
             if let errorInfo = try? result.get() {
+                ServiceLocator.analytics.track(event: .Login.insufficientRole(currentRoles: errorInfo.roles))
                 self.displayRoleErrorUI(for: storeID, errorInfo: errorInfo)
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -276,6 +276,7 @@ private extension AppCoordinator {
 
         // this needs to be wrapped within a navigation controller to properly show the right bar button for Help.
         setWindowRootViewControllerAndAnimateIfNeeded(WooNavigationController(rootViewController: errorViewController))
+        ServiceLocator.analytics.track(event: .Login.insufficientRole(currentRoles: errorInfo.roles))
     }
 
     /// Synchronously check if there's any `EligibilityErrorInfo` stored locally. If there is, then let's show the role error UI instead.
@@ -295,7 +296,6 @@ private extension AppCoordinator {
 
             // if the previous role check indicates that the user is ineligible, let's show the error message.
             if let errorInfo = try? result.get() {
-                ServiceLocator.analytics.track(event: .Login.insufficientRole(currentRoles: errorInfo.roles))
                 self.displayRoleErrorUI(for: storeID, errorInfo: errorInfo)
                 return
             }

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -456,10 +456,33 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(analyticsProvider.receivedProperties.first?["is_jetpack_active"] as? Bool))
         XCTAssertTrue(try XCTUnwrap(analyticsProvider.receivedProperties.first?["is_jetpack_connected"] as? Bool))
     }
+
+    func test_shouldPresentUsernamePasswordController_tracks_fetched_site_info() throws {
+        // Given
+        let navigationController = UINavigationController()
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+
+        let siteInfo = siteInfo(exists: true, hasWordPress: true, isWordPressCom: true, hasJetpack: true, isJetpackActive: true, isJetpackConnected: true)
+        let storage = MockStorageManager()
+        let manager = AuthenticationManager(storageManager: storage, analytics: analytics)
+
+        // When
+        manager.shouldPresentUsernamePasswordController(for: siteInfo) { _ in }
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents, [WooAnalyticsStat.loginSiteAddressSiteInfoFetched.rawValue])
+        XCTAssertTrue(try XCTUnwrap(analyticsProvider.receivedProperties.first?["is_wordpress"] as? Bool))
+        XCTAssertTrue(try XCTUnwrap(analyticsProvider.receivedProperties.first?["is_wp_com"] as? Bool))
+        XCTAssertTrue(try XCTUnwrap(analyticsProvider.receivedProperties.first?["has_jetpack"] as? Bool))
+        XCTAssertTrue(try XCTUnwrap(analyticsProvider.receivedProperties.first?["is_jetpack_active"] as? Bool))
+        XCTAssertTrue(try XCTUnwrap(analyticsProvider.receivedProperties.first?["is_jetpack_connected"] as? Bool))
+        XCTAssertEqual(analyticsProvider.receivedProperties.first?["url_after_redirects"] as? String, siteInfo.url)
+    }
 }
 
 private extension AuthenticationManagerTests {
-    func siteInfo(url: String = "",
+    func siteInfo(url: String = "https://test.com",
                   exists: Bool = false,
                   hasWordPress: Bool = false,
                   isWordPressCom: Bool = false,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8453 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds new Tracks events for the login flow to support the REST API project (based on tracking plan pe5sF9-13h-p2):
- `login_insufficent_role` for when the user attempts to log in with insufficient roles - both for site credentials and WPCom login.
- `login_site_credentials_login_failed` for when the user fails to log in with site credentials.
- `login_site_address_site_info_fetched` for when site info is fetched after the user enters site address in the login flow.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Site info fetched
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address.
- Enter the address of your test store and tap Continue.
- Notice in Xcode console: `🔵 Tracked login_site_address_site_info_fetched` with properties: `is_jetpack_connected`, `url_after_redirects`, `exists`, `has_jetpack`, `is_wp_com`, `is_wordpress`, `is_jetpack_active`.

2. Insufficient roles
a. With REST API login
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address.
- Enter the address of a self-hosted store and tap Continue.
- Enter the credentials of a non-admin/store manager user. The insufficient role screen should be displayed.
- In Xcode console, notice: `🔵 Tracked login_insufficent_role, properties: [AnyHashable("current_roles"): <roles>]`

b. With WPCom login
- Disable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address.
- Enter the address of a self-hosted store and tap Continue.
- Log in with the WPCom credentials associated with a user that is not an admin/shop manager.
- In Xcode console, notice: `🔵 Tracked login_insufficent_role, properties: [AnyHashable("current_roles"): <roles>]`

3. Failure to log in with site credentials.
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address.
- Enter the address of a self-hosted site that has application passwords disabled (e.g., has WordFence plugin installed and activated) and tap Continue.
- In Xcode console, notice: `🔵 Tracked login_site_credentials_login_failed, properties: [AnyHashable("error_code"): "1", AnyHashable("error_description"): "Networking.ApplicationPasswordUseCaseError.applicationPasswordsDisabled", AnyHashable("error_domain"): "Networking.ApplicationPasswordUseCaseError", AnyHashable("step"): "application_password_generation"]`

- Try again with a self-hosted site that has application password enabled. 
- Enter the credentials of a non-admin/store manager user. In Xcode console, notice: `🔵 Tracked login_site_credentials_login_failed, properties: [AnyHashable("error_description"): "WooCommerce.RoleEligibilityError.insufficientRole(info: ...))", AnyHashable("error_code"): "0", AnyHashable("step"): "user_role", AnyHashable("error_domain"): "WooCommerce.RoleEligibilityError"]`

- Try again with a self-hosted site that doesn't have Woo.
- Enter the credentials of a user. In Xcode console, notice: `🔵 Tracked login_site_credentials_login_failed, properties: [AnyHashable("step"): "woo_status"]`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.