### PR TITLE
Bulk Editing: Add select all action

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -31,12 +31,16 @@ class ProductListViewModel {
         return selectedProducts.contains(productToCheck)
     }
 
-    func selectProduct(_ selectedProduct: Product) {
-        selectedProducts.insert(selectedProduct)
+    func selectProduct(_ product: Product) {
+        selectedProducts.insert(product)
     }
 
-    func deselectProduct(_ selectedProduct: Product) {
-        selectedProducts.remove(selectedProduct)
+    func selectProducts(_ products: [Product]) {
+        selectedProducts.formUnion(products)
+    }
+
+    func deselectProduct(_ product: Product) {
+        selectedProducts.remove(product)
     }
 
     func deselectAll() {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -73,7 +73,7 @@ final class ProductsViewController: UIViewController, GhostableViewController {
         didSet {
             bottomToolbar.isHidden = true
             bottomToolbar.backgroundColor = .systemColor(.secondarySystemGroupedBackground)
-            bottomToolbar.setSubviews(leftViews: [], rightViews: [bulkEditButton])
+            bottomToolbar.setSubviews(leftViews: [selectAllButton], rightViews: [bulkEditButton])
             bottomToolbar.addDividerOnTop()
         }
     }
@@ -102,6 +102,18 @@ final class ProductsViewController: UIViewController, GhostableViewController {
         configuration.contentInsets = Constants.toolbarButtonInsets
         button.configuration = configuration
         button.isEnabled = false
+        return button
+    }()
+
+    /// The select all CTA in the bottom toolbar.
+    private lazy var selectAllButton: UIButton = {
+        let button = UIButton(frame: .zero)
+        button.setTitle(Localization.selectAllToolbarButtonTitle, for: .normal)
+        button.addTarget(self, action: #selector(selectAllProducts), for: .touchUpInside)
+        button.applyLinkButtonStyle()
+        var configuration = UIButton.Configuration.plain()
+        configuration.contentInsets = Constants.toolbarButtonInsets
+        button.configuration = configuration
         return button
     }()
 
@@ -331,6 +343,9 @@ private extension ProductsViewController {
     func updatedSelectedItems() {
         updateNavigationBarTitleForEditing()
         bulkEditButton.isEnabled = viewModel.bulkEditActionIsEnabled
+    }
+
+    @objc func selectAllProducts() {
     }
 
     @objc func openBulkEditingOptions(sender: UIButton) {
@@ -1305,6 +1320,10 @@ private extension ProductsViewController {
             comment: "VoiceOver accessibility hint, informing the user the button can be used to bulk edit products"
         )
 
+        static let selectAllToolbarButtonTitle = NSLocalizedString(
+            "Select all",
+            comment: "Title of a button that selects all products for bulk update"
+        )
         static let bulkEditingToolbarButtonTitle = NSLocalizedString(
             "Bulk update",
             comment: "Title of a button that presents a menu with possible products bulk update options"

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -346,6 +346,9 @@ private extension ProductsViewController {
     }
 
     @objc func selectAllProducts() {
+        viewModel.selectProducts(resultsController.fetchedObjects)
+        updatedSelectedItems()
+        tableView.reloadRows(at: tableView.indexPathsForVisibleRows ?? [], with: .none)
     }
 
     @objc func openBulkEditingOptions(sender: UIButton) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
@@ -38,6 +38,25 @@ final class ProductListViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.productIsSelected(sampleProduct1))
     }
 
+    func test_selecting_multiple_products_works() {
+        // Given
+        let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1)
+        let sampleProduct2 = Product.fake().copy(productID: 2)
+        let sampleProduct3 = Product.fake().copy(productID: 3)
+        XCTAssertEqual(viewModel.selectedProductsCount, 0)
+
+        // When
+        viewModel.selectProduct(sampleProduct1)
+        viewModel.selectProducts([sampleProduct2, sampleProduct3])
+
+        // Then
+        XCTAssertEqual(viewModel.selectedProductsCount, 3)
+        XCTAssertTrue(viewModel.productIsSelected(sampleProduct1))
+        XCTAssertTrue(viewModel.productIsSelected(sampleProduct2))
+        XCTAssertTrue(viewModel.productIsSelected(sampleProduct3))
+    }
+
     func test_deselecting_not_selected_product_does_nothing() {
         // Given
         let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8524

## Description

This PR adds "select all" button in bottom toolbar for bulk editing state on Products List.

_Note:_ it will not select product from pages that are not loaded yet. I confirmed the same behavior on WC-Android. Header will immediately show the number of selected products, so merchant should have right expectation.

## Testing

1. Build and run the app in debug/alpha mode.
2. On the products list tap the "multi-select" icon in the navbar.
3. Tap "Select all" in the bottom toolbar.
4. Confirm all products in the list switched to selected state.
5. Tap some products to confirm deselect action works.
6. Tap "Bulk update" in the bottom toolbar and pick "Update price".
7. Confirm description in footer shows correct number of selected products.

## Screenshots

<img width=350 src="https://user-images.githubusercontent.com/3132438/213405538-e1dff280-d8ea-4173-bf67-76cc4121712b.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
