### PR TITLE
Bulk Editing: Warn about variations in price flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
@@ -88,11 +88,11 @@ final class PriceInputViewModel {
     var footerText: String {
         var footerData: [String] = []
 
-        if productListViewModel.variableProductsCount > 0 {
+        if productListViewModel.selectedVariableProductsCount > 0 {
             footerData.append(Localization.variationsWarning)
         }
 
-        let numberOfProducts = productListViewModel.selectedProductsCount - productListViewModel.variableProductsCount
+        let numberOfProducts = productListViewModel.selectedProductsCount - productListViewModel.selectedVariableProductsCount
         let numberOfProductsText = String.pluralize(numberOfProducts,
                                                     singular: Localization.productsNumberSingularFooter,
                                                     plural: Localization.productsNumberPluralFooter)

--- a/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
@@ -88,6 +88,16 @@ final class PriceInputViewModel {
     var footerText: String {
         var footerData: [String] = []
 
+        switch productListViewModel.commonPriceForSelectedProducts {
+        case .none:
+            footerData.append(Localization.currentPriceNoneFooter)
+        case .mixed:
+            footerData.append(Localization.currentPriceMixedFooter)
+        case let .value(price):
+            let currentPriceText = String.localizedStringWithFormat(Localization.currentPriceFooter, formatPriceString(price))
+            footerData.append(currentPriceText)
+        }
+
         if productListViewModel.selectedVariableProductsCount > 0 {
             footerData.append(Localization.variationsWarning)
         }
@@ -97,16 +107,6 @@ final class PriceInputViewModel {
                                                     singular: Localization.productsNumberSingularFooter,
                                                     plural: Localization.productsNumberPluralFooter)
         footerData.append(numberOfProductsText)
-
-        switch productListViewModel.commonPriceForSelectedProducts {
-        case .none:
-            footerData.insert(Localization.currentPriceNoneFooter, at: 0)
-        case .mixed:
-            footerData.insert(Localization.currentPriceMixedFooter, at: 0)
-        case let .value(price):
-            let currentPriceText = String.localizedStringWithFormat(Localization.currentPriceFooter, formatPriceString(price))
-            footerData.insert(currentPriceText, at: 0)
-        }
 
         return footerData.joined(separator: " ")
     }

--- a/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
@@ -86,20 +86,29 @@ final class PriceInputViewModel {
     /// Returns the footer text to be displayed with information about the current bulk price and how many products will be updated.
     ///
     var footerText: String {
-        let numberOfProducts = productListViewModel.selectedProductsCount
+        var footerData: [String] = []
+
+        if productListViewModel.variableProductsCount > 0 {
+            footerData.append(Localization.variationsWarning)
+        }
+
+        let numberOfProducts = productListViewModel.selectedProductsCount - productListViewModel.variableProductsCount
         let numberOfProductsText = String.pluralize(numberOfProducts,
-                                                      singular: Localization.productsNumberSingularFooter,
-                                                      plural: Localization.productsNumberPluralFooter)
+                                                    singular: Localization.productsNumberSingularFooter,
+                                                    plural: Localization.productsNumberPluralFooter)
+        footerData.append(numberOfProductsText)
 
         switch productListViewModel.commonPriceForSelectedProducts {
         case .none:
-            return [Localization.currentPriceNoneFooter, numberOfProductsText].joined(separator: " ")
+            footerData.insert(Localization.currentPriceNoneFooter, at: 0)
         case .mixed:
-            return [Localization.currentPriceMixedFooter, numberOfProductsText].joined(separator: " ")
+            footerData.insert(Localization.currentPriceMixedFooter, at: 0)
         case let .value(price):
             let currentPriceText = String.localizedStringWithFormat(Localization.currentPriceFooter, formatPriceString(price))
-            return [currentPriceText, numberOfProductsText].joined(separator: " ")
+            footerData.insert(currentPriceText, at: 0)
         }
+
+        return footerData.joined(separator: " ")
     }
 
     /// It formats a price `String` according to the current price settings.
@@ -134,5 +143,7 @@ private extension PriceInputViewModel {
         static let currentPriceNoneFooter = NSLocalizedString("Current price is not set.",
                                                               comment: "Message in the footer of bulk price setting screen, when none of the"
                                                               + " products have price value.")
+        static let variationsWarning = NSLocalizedString("Prices for variations won't be updated.",
+                                                         comment: "Message in the footer of bulk price setting screen, when variable products are selected")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -23,6 +23,14 @@ class ProductListViewModel {
         selectedProducts.count
     }
 
+    var variableProductsCount: Int {
+        selectedProducts.filter({ $0.productType == .variable }).count
+    }
+
+    var onlyVariableProductsSelected: Bool {
+        selectedProducts.filter({ $0.productType != .variable }).isEmpty
+    }
+
     var bulkEditActionIsEnabled: Bool {
         !selectedProducts.isEmpty
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -23,7 +23,7 @@ class ProductListViewModel {
         selectedProducts.count
     }
 
-    var variableProductsCount: Int {
+    var selectedVariableProductsCount: Int {
         selectedProducts.filter({ $0.productType == .variable }).count
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -345,7 +345,9 @@ private extension ProductsViewController {
         let cancelAction = UIAlertAction(title: Localization.cancel, style: .cancel)
 
         actionSheet.addAction(updateStatus)
-        actionSheet.addAction(updatePrice)
+        if !viewModel.onlyVariableProductsSelected {
+            actionSheet.addAction(updatePrice)
+        }
         actionSheet.addAction(cancelAction)
 
         if let popoverController = actionSheet.popoverPresentationController {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
@@ -120,6 +120,30 @@ final class ProductListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedProductsCount, 0)
     }
 
+    func test_variation_helpers_work_correctly() {
+        // Given
+        let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1)
+        let sampleProduct2 = Product.fake().copy(productID: 2, productTypeKey: "variable")
+
+        // When
+        viewModel.selectProduct(sampleProduct1)
+        viewModel.selectProduct(sampleProduct2)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedProductsCount, 2)
+        XCTAssertEqual(viewModel.variableProductsCount, 1)
+        XCTAssertFalse(viewModel.onlyVariableProductsSelected)
+
+        // When
+        viewModel.deselectProduct(sampleProduct1)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedProductsCount, 1)
+        XCTAssertEqual(viewModel.variableProductsCount, 1)
+        XCTAssertTrue(viewModel.onlyVariableProductsSelected)
+    }
+
     func test_common_status_works_correctly() {
         // Given
         let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
@@ -132,7 +132,7 @@ final class ProductListViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.selectedProductsCount, 2)
-        XCTAssertEqual(viewModel.variableProductsCount, 1)
+        XCTAssertEqual(viewModel.selectedVariableProductsCount, 1)
         XCTAssertFalse(viewModel.onlyVariableProductsSelected)
 
         // When
@@ -140,7 +140,7 @@ final class ProductListViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.selectedProductsCount, 1)
-        XCTAssertEqual(viewModel.variableProductsCount, 1)
+        XCTAssertEqual(viewModel.selectedVariableProductsCount, 1)
         XCTAssertTrue(viewModel.onlyVariableProductsSelected)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: https://github.com/woocommerce/woocommerce-ios/issues/8577

## Description

This PR adds a warning about variations in Price Picker footer and disables price flow when only variable products are selected.

## Testing

1. Build and run the app in debug/alpha mode.
2. On the products list tap the "multi-select" icon in the navbar.
3. Select a variable product (or multiple variable products).
4. Tap "Bulk update" in the bottom toolbar.
5. Confirm there is no "Update price" option in the action sheet.
6. Cancel action sheet, select simple product (in addition to selected variable products).
7. Tap "Bulk update" in the bottom toolbar, select "Update price" option.
8. Confirm that footer has a warning about variable products + it shows correct number of items to update (excluding variable ones).
9. Cancel the modal, deselect variable products (leave simple ones selected).
10. Tap "Bulk update" in the bottom toolbar, select "Update price" option.
11. Confirm there is no warning about variable products in the footer.

## Screenshots

<img width=350 src="https://user-images.githubusercontent.com/3132438/213413190-fabdd328-b3f7-4704-93fd-19b72cafee84.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
