### PR TITLE
REST API: Hide password protected option on product visibility screen for users authenticated without WPCom

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -102,13 +102,18 @@ enum ProductSettingsRows {
         }
 
         func handleTap(sourceViewController: UIViewController, onCompletion: @escaping (ProductSettings) -> Void) {
-            // If the password was not fetched, the cell is not selectable
-            guard settings.password != nil else {
+            let passwordProtectedAvailable = ServiceLocator.stores.isAuthenticatedWithoutWPCom == false
+            /// If the password was not fetched for user authenticated with WPCom,
+            /// the cell is not selectable
+            if settings.password == nil && passwordProtectedAvailable {
                 return
             }
 
             ServiceLocator.analytics.track(.productSettingsVisibilityTapped)
-            let viewController = ProductVisibilityViewController(settings: settings) { (productSettings) in
+            let viewController = ProductVisibilityViewController(
+                settings: settings,
+                showsPasswordProtectedVisibility: passwordProtectedAvailable
+            ) { (productSettings) in
                 self.settings.password = productSettings.password
                 self.settings.status = productSettings.status
                 onCompletion(self.settings)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
@@ -44,7 +44,8 @@ final class ProductSettingsViewModel {
             sections = Self.configureSections(productSettings,
                                               productType: product.productType)
             /// If nil, we fetch the password from site post API because it was never fetched
-            if password == nil {
+            /// Skip this if the user is not authenticated with WPCom.
+            if password == nil && ServiceLocator.stores.isAuthenticatedWithoutWPCom == false {
                 retrieveProductPassword(siteID: product.siteID, productID: product.productID) { [weak self] (password, error) in
                     guard let self = self else {
                         return

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
@@ -65,9 +65,10 @@ final class ProductVisibilityViewController: UIViewController {
     private func reloadSections() {
         if visibility == .passwordProtected {
             sections = [Section(rows: [.publicVisibility, .passwordVisibility, .passwordField, .privateVisibility])]
-        }
-        else {
+        } else if productSettings.password != nil {
             sections = [Section(rows: [.publicVisibility, .passwordVisibility, .privateVisibility])]
+        } else {
+            sections = [Section(rows: [.publicVisibility, .privateVisibility])]
         }
         tableView.reloadData()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
@@ -13,6 +13,7 @@ final class ProductVisibilityViewController: UIViewController {
     private let onCompletion: Completion
 
     private let productSettings: ProductSettings
+    private let showsPasswordProtectedVisibility: Bool
 
     private var visibility: ProductVisibility = .public
 
@@ -25,9 +26,10 @@ final class ProductVisibilityViewController: UIViewController {
 
     /// Init
     ///
-    init(settings: ProductSettings, completion: @escaping Completion) {
+    init(settings: ProductSettings, showsPasswordProtectedVisibility: Bool, completion: @escaping Completion) {
         productSettings = settings
         onCompletion = completion
+        self.showsPasswordProtectedVisibility = showsPasswordProtectedVisibility
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -65,7 +67,7 @@ final class ProductVisibilityViewController: UIViewController {
     private func reloadSections() {
         if visibility == .passwordProtected {
             sections = [Section(rows: [.publicVisibility, .passwordVisibility, .passwordField, .privateVisibility])]
-        } else if productSettings.password != nil {
+        } else if showsPasswordProtectedVisibility {
             sections = [Section(rows: [.publicVisibility, .passwordVisibility, .privateVisibility])]
         } else {
             sections = [Section(rows: [.publicVisibility, .privateVisibility])]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -240,8 +240,9 @@ private extension ProductFormRemoteActionUseCase {
     func updatePasswordRemotely(product: EditableProductModel,
                                 password: String?,
                                 onCompletion: @escaping (Result<String?, Error>) -> Void) {
-        // Only update product password if available.
-        guard let updatedPassword = password else {
+        // Only update product password if available and user is authenticated with WPCom.
+        guard let updatedPassword = password,
+              stores.isAuthenticatedWithoutWPCom == false else {
             onCompletion(.success(password))
             return
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8453 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Since fetching/updating passwords for product visibility requires Dotcom endpoints that cannot be handled with application password, we need to hide the option from product settings. This PR adds a few changes:
- Skip fetching and updating password if the user is not authenticated with WPCom.
- Hide the password protected option from the product visibility screen.

To avoid introducing any new issues for the existing feature, we are still disabling the Visibility row if the user is authenticated with WPCom and the setting password cannot be fetched.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Testing user authenticated with site credentials only:
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address and proceed with the address of a self-hosted store.
- Log in with your site credentials. After the login succeeds, you should be navigated to the home screen.
- Navigate to Products tab and select an existing product or tap "+" to create a new one.
- Tap the ellipsis button "..." and select Product Settings.
- Tap Visibility row - notice that a new screen should be displayed with only 2 options: public and private.
- Select any of the options and save the change. The product should be saved successfully without any error.

Testing user authenticated with WPCom:
- Enable or disable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address and proceed with the address of a WPCom store.
- Log in with your WPCom credentials. After the login succeeds, you should be navigated to the home screen.
- Navigate to Products tab and select an existing product or tap "+" to create a new one.
- Tap the ellipsis button "..." and select Product Settings.
- Tap Visibility row - notice that a new screen should be displayed with only 3 options: public, password protected and private.
- Select any of the options and save the change. The product should be saved successfully without any error.
- Turn off the network connection and relaunch the app.
- Select an existing product, notice that the product visibility screen should not be opened when tapping the Visiblity row on the Product Settings screen.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/213435165-517e34a4-bbea-4547-af51-069fb8d07bf5.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
