### PR TITLE
[Mobile Payments] Additional analytics events for Tap to Pay on iPhone

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -905,6 +905,54 @@ extension WooAnalyticsEvent {
             gatewayID ?? unknownGatewayID
         }
 
+        /// Tracked when we ask the user to choose between Built In and Bluetooth readers
+        /// at the start of the connection flow
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - countryCode: the country code of the store.
+        ///
+        static func cardReaderSelectTypeShown(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .cardReaderSelectTypeShown,
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
+                              ]
+            )
+        }
+
+        /// Tracked when the user to chooses the Built In reader
+        /// at the start of the connection flow
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - countryCode: the country code of the store.
+        ///
+        static func cardReaderSelectTypeBuiltInTapped(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .cardReaderSelectTypeBuiltInTapped,
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
+                              ]
+            )
+        }
+
+        /// Tracked when the user to chooses the Bluetooth reader
+        /// at the start of the connection flow
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - countryCode: the country code of the store.
+        ///
+        static func cardReaderSelectTypeBluetoothTapped(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .cardReaderSelectTypeBluetoothTapped,
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
+                              ]
+            )
+        }
+
         /// Tracked when we automatically disconnect a Built In reader, when Manage Card Reader is opened
         ///
         /// - Parameters:

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -905,6 +905,21 @@ extension WooAnalyticsEvent {
             gatewayID ?? unknownGatewayID
         }
 
+        /// Tracked when we automatically disconnect a Built In reader, when Manage Card Reader is opened
+        ///
+        /// - Parameters:
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - countryCode: the country code of the store.
+        ///
+        static func manageCardReadersBuiltInReaderAutoDisconnect(forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .manageCardReadersBuiltInReaderAutoDisconnect,
+                              properties: [
+                                Keys.countryCode: countryCode,
+                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
+                              ]
+            )
+        }
+
         /// Tracked when card reader discovery fails
         ///
         /// - Parameters:

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -242,6 +242,7 @@ public enum WooAnalyticsStat: String {
     case cardReaderConnectionFailed = "card_reader_connection_failed"
     case cardReaderConnectionSuccess = "card_reader_connection_success"
     case cardReaderDisconnectTapped = "card_reader_disconnect_tapped"
+    case manageCardReadersBuiltInReaderAutoDisconnect = "manage_card_readers_automatic_disconnect_built_in_reader"
 
     // MARK: Card Reader Software Update Events
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -235,6 +235,9 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Card Reader Connection Events
     //
+    case cardReaderSelectTypeShown = "card_present_select_reader_type_shown"
+    case cardReaderSelectTypeBuiltInTapped = "card_present_select_reader_type_built_in_tapped"
+    case cardReaderSelectTypeBluetoothTapped = "card_present_select_reader_type_bluetooth_tapped"
     case cardReaderDiscoveryTapped = "card_reader_discovery_tapped"
     case cardReaderDiscoveryFailed = "card_reader_discovery_failed"
     case cardReaderDiscoveredReader = "card_reader_discovery_reader_discovered"

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -103,14 +103,22 @@ final class CardPresentPaymentPreflightController {
             return
         }
 
+        analytics.track(event: .InPersonPayments.cardReaderSelectTypeShown(forGatewayID: paymentGatewayAccount.gatewayID,
+                                                                           countryCode: configuration.countryCode))
         alertsPresenter.present(viewModel: CardPresentModalSelectSearchType(
             tapOnIPhoneAction: { [weak self] in
                 guard let self = self else { return }
+                self.analytics.track(event: .InPersonPayments.cardReaderSelectTypeBuiltInTapped(
+                    forGatewayID: self.paymentGatewayAccount.gatewayID,
+                    countryCode: self.configuration.countryCode))
                 self.builtInConnectionController.searchAndConnect(
                     onCompletion: self.handleConnectionResult)
             },
             bluetoothAction: { [weak self] in
                 guard let self = self else { return }
+                self.analytics.track(event: .InPersonPayments.cardReaderSelectTypeBluetoothTapped(
+                    forGatewayID: self.paymentGatewayAccount.gatewayID,
+                    countryCode: self.configuration.countryCode))
                 self.connectionController.searchAndConnect(
                     onCompletion: self.handleConnectionResult)
             },

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
@@ -93,6 +93,12 @@ final class CardReaderConnectionAnalyticsTracker {
                                         countryCode: configuration.countryCode,
                                         cardReaderModel: cardReaderModel))
     }
+
+    func automaticallyDisconnectedFromBuiltInReader() {
+        analytics.track(event: WooAnalyticsEvent.InPersonPayments
+            .manageCardReadersBuiltInReaderAutoDisconnect(forGatewayID: gatewayID,
+                                                          countryCode: configuration.countryCode))
+    }
 }
 
 private extension CardReaderConnectionAnalyticsTracker {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderSettingsConnectedViewModel.swift
@@ -153,6 +153,7 @@ final class BluetoothCardReaderSettingsConnectedViewModel: CardReaderSettingsPre
     private func disconnectFromBuiltInReader(in readers: [CardReader]) {
         if readers.includesBuiltInReader() {
             self.disconnect()
+            self.analyticsTracker.automaticallyDisconnectedFromBuiltInReader()
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8702
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Add the following Tracks events:

- [x] When the reader is presented with a choice between connecting to the built-in reader or a Bluetooth reader. `card_present_select_reader_type_shown`
- [x] What choice they make: `card_present_select_reader_type_built_in_tapped` or `card_present_select_reader_type_bluetooth_tapped`
- [x] When a built-in reader is automatically disconnected on entering the Manage card readers screen `manage_card_readers_automatic_disconnect_built_in_reader`

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Automatic built-in reader disconnection

#### Using a US-based WCPay or Stripe store:

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. When asked for a reader type, tap `Tap to Pay on iPhone` and connect to the reader
6. Take a payment. 
7. Go to `Menu > Payments > Manage Card Reader`
8. Observe that the expected event is tracked

### Select reader type

Navigate to `Menu > Payments > Collect payment`
Go through the payment flow, and select `Card` on the payment method screen
Observe that `card_present_select_reader_type_shown` is tracked
When asked for a reader type, tap `Bluetooth reader`
Observe that `card_present_select_reader_type_bluetooth_tapped ` is tracked
Tap `Cancel`, then tap `Card` again on the Payment method screen
When asked for a reader type, tap `Tap to Pay on iPhone`
Observe that `card_present_select_reader_type_built_in_tapped ` is tracked


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### manage_card_readers_automatic_disconnect_built_in_reader

<img width="584" alt="Analytics console log for automatically disconnecting the built in reader" src="https://user-images.githubusercontent.com/2472348/213447094-bdb79abc-f974-43f1-8016-d1f1b835130c.png">

### card_present_select_reader_type_shown

<img width="669" alt="Analytics console log for showing the card reader type choice" src="https://user-images.githubusercontent.com/2472348/213447134-e975a7e6-fac5-46ee-a9eb-83ce06cfb945.png">

### card_present_select_reader_type_built_in_tapped

<img width="656" alt="Analytics console log for choosing the built in reader" src="https://user-images.githubusercontent.com/2472348/213447110-63ef9606-b851-4be4-9000-939ec58ebdfa.png">

### card_present_select_reader_type_bluetooth_tapped

<img width="675" alt="Analytics console log for choosing the Bluetooth reader" src="https://user-images.githubusercontent.com/2472348/213448015-394a964f-f0f8-42e1-9f53-607005de778a.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
