### PR TITLE
Domain settings: show domain credit banner

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -238,6 +238,12 @@ extension UIImage {
         return UIImage.gridicon(.cross, size: CGSize(width: 22, height: 22))
     }
 
+    /// Domain credit image.
+    ///
+    static var domainCreditImage: UIImage {
+        return UIImage(named: "domain-credit")!
+    }
+
     /// Domain search placeholder image.
     ///
     static var domainSearchPlaceholderImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsDomainCreditView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsDomainCreditView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// Shows a banner that explains what domain credit is and a CTA to redeem it.
+struct DomainSettingsDomainCreditView: View {
+    let redeemDomainCreditTapped: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Divider()
+                .dividerStyle()
+
+            HStack(alignment: .bottom) {
+                VStack(alignment: .leading) {
+                    Text(Localization.title)
+                        .bold()
+                    Spacer()
+                        .frame(height: Layout.spacingBetweenTitleAndSubtitle)
+                    Text(Localization.subtitle)
+                        .bodyStyle()
+                    Spacer()
+                        .frame(height: Layout.spacingBetweenSubtitleAndButton)
+                    Button(Localization.buttonTitle) {
+                        redeemDomainCreditTapped()
+                    }
+                    .buttonStyle(TextButtonStyle())
+                }
+                .padding(Layout.textContainerInsets)
+
+                Spacer()
+
+                Image(uiImage: .domainCreditImage)
+            }
+
+            Divider()
+                .dividerStyle()
+
+            Text(Localization.footnote)
+                .footnoteStyle()
+                .padding(Layout.footnoteInsets)
+        }
+    }
+}
+
+private extension DomainSettingsDomainCreditView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Claim your free domain",
+            comment: "Title of the domain credit banner in domain settings."
+        )
+        static let subtitle = NSLocalizedString(
+            "You have a free one-year domain registration included with your plan.",
+            comment: "Subtitle of the domain credit banner in domain settings."
+        )
+        static let buttonTitle = NSLocalizedString(
+            "Claim Domain",
+            comment: "Title of button to redeem domain credit in the domain credit banner in domain settings."
+        )
+        static let footnote = NSLocalizedString(
+            "The domain purchased will redirect users to your primary address.",
+            comment: "Footnote about the domain credit banner in domain settings."
+        )
+    }
+
+    enum Layout {
+        static let textContainerInsets: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+        static let footnoteInsets: EdgeInsets = .init(top: 8, leading: 16, bottom: 8, trailing: 16)
+        static let spacingBetweenTitleAndSubtitle: CGFloat = 8
+        static let spacingBetweenSubtitleAndButton: CGFloat = 16
+    }
+}
+
+struct DomainSettingsDomainCreditView_Previews: PreviewProvider {
+    static var previews: some View {
+        DomainSettingsDomainCreditView {}
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
@@ -40,7 +40,9 @@ struct DomainSettingsView: View {
                 }
 
                 if viewModel.hasDomainCredit {
-                    // TODO: 8558 - domain credit UI with redemption action
+                    DomainSettingsDomainCreditView() {
+                        addDomain()
+                    }
                 }
 
                 if viewModel.domains.isNotEmpty {

--- a/WooCommerce/Resources/Images.xcassets/domain-credit.imageset/Contents.json
+++ b/WooCommerce/Resources/Images.xcassets/domain-credit.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "domain-credit.pdf",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		022BF7FD23B9D708000A1DFB /* InProgressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022BF7FB23B9D708000A1DFB /* InProgressViewController.swift */; };
 		022BF7FE23B9D708000A1DFB /* InProgressViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 022BF7FC23B9D708000A1DFB /* InProgressViewController.xib */; };
 		022C658C2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022C658B2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift */; };
+		022C7D792979778E0036568D /* DomainSettingsDomainCreditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022C7D782979778E0036568D /* DomainSettingsDomainCreditView.swift */; };
 		022F2FA6295E77F4003A0A46 /* StoreCreationCountrySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F2FA5295E77F4003A0A46 /* StoreCreationCountrySectionView.swift */; };
 		022F2FA8295E7A14003A0A46 /* StoreCreationCountryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F2FA7295E7A14003A0A46 /* StoreCreationCountryButton.swift */; };
 		022F2FAA295E8241003A0A46 /* StoreCreationCountryQuestionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F2FA9295E8241003A0A46 /* StoreCreationCountryQuestionViewModelTests.swift */; };
@@ -2202,6 +2203,7 @@
 		022BF7FB23B9D708000A1DFB /* InProgressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressViewController.swift; sourceTree = "<group>"; };
 		022BF7FC23B9D708000A1DFB /* InProgressViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InProgressViewController.xib; sourceTree = "<group>"; };
 		022C658B2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewController+ProductImageUploaderTests.swift"; sourceTree = "<group>"; };
+		022C7D782979778E0036568D /* DomainSettingsDomainCreditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSettingsDomainCreditView.swift; sourceTree = "<group>"; };
 		022F2FA5295E77F4003A0A46 /* StoreCreationCountrySectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCountrySectionView.swift; sourceTree = "<group>"; };
 		022F2FA7295E7A14003A0A46 /* StoreCreationCountryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCountryButton.swift; sourceTree = "<group>"; };
 		022F2FA9295E8241003A0A46 /* StoreCreationCountryQuestionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCountryQuestionViewModelTests.swift; sourceTree = "<group>"; };
@@ -4572,6 +4574,7 @@
 				02562AD1296D293D00980404 /* DomainSettingsCoordinator.swift */,
 				028203CE297662A200217369 /* DomainSelectorDataProvider.swift */,
 				02F36F462978349500D97EA0 /* DomainPurchaseSuccessView.swift */,
+				022C7D782979778E0036568D /* DomainSettingsDomainCreditView.swift */,
 			);
 			path = Domains;
 			sourceTree = "<group>";
@@ -10173,6 +10176,7 @@
 				31B05523264B3C8900134D87 /* CardPresentModalConnectingToReader.swift in Sources */,
 				025FA38B2522CB4D0054CA57 /* AppCoordinator.swift in Sources */,
 				02CEBB8024C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift in Sources */,
+				022C7D792979778E0036568D /* DomainSettingsDomainCreditView.swift in Sources */,
 				CE21B3E020FFC59700A259D5 /* ProductDetailsTableViewCell.swift in Sources */,
 				B6F3796A29378B3900718561 /* AnalyticsHubMonthToDateRangeData.swift in Sources */,
 				B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -132,6 +132,10 @@ final class IconsTests: XCTestCase {
         XCTAssertEqual(deleteCellImage.size, CGSize(width: 22, height: 22))
     }
 
+    func test_domainCreditImage_is_not_nil() {
+        XCTAssertNotNil(UIImage.domainCreditImage)
+    }
+
     func test_domainSearchPlaceholderImage_is_not_nil() {
         XCTAssertNotNil(UIImage.domainSearchPlaceholderImage)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8558 
Based off of https://github.com/woocommerce/woocommerce-ios/pull/8696 to avoid merge conflicts on the project file
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In this PR, a domain credit banner is shown on the domain settings with a CTA to redeem the domain credit if it's available for the site. The new view is `DomainSettingsDomainCreditView`, and the action goes to the domain selector without domain credit handling (WIP, will be in a future PR).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: a WC store with a WPCOM plan that has a domain credit is required. The easiest way to generate one is to create a site in Calypso (WPCOM web) and add an annual eCommerce plan, as the monthly plan does not include a domain credit

- Log in if needed, and continue with a WPCOM store with a domain credit
- Go to the Menu tab
- Tap on the settings CTA
- Tap the `Domain` row --> there should be a domain credit banner below the staging domain like in the design VyLr7LvKodHE4kINfBE7Lw-fi-682%3A40227&t=SH7sZF4DTOOL8qjm-0
- Tap `Claim Domain` in the domain credit banner --> domain selector with paid domains should be shown, and each domain should have price info (with the barebone UI)

---
- [x] @jaclync tests that a store without a domain credit doesn't have this banner

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light
-- | --
![Simulator Screen Shot - iPhone 14 - 2023-01-20 at 09 25 53](https://user-images.githubusercontent.com/1945542/213598848-72c4e812-fc22-4630-916d-6d2ffc1658e3.png) | ![Simulator Screen Shot - iPhone 14 - 2023-01-20 at 09 26 04](https://user-images.githubusercontent.com/1945542/213598853-eace4dbc-4cfb-4cb1-b59e-a39864faedeb.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.