### PR TITLE
REST API: Migrate product review endpoints

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -742,6 +742,7 @@
 		DEA6B1C9296D0E8B005AA5E9 /* systemStatusWithPluginsOnly-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEA6B1C7296D0E8A005AA5E9 /* systemStatusWithPluginsOnly-without-data.json */; };
 		DEA6B1CA296D0E8B005AA5E9 /* systemStatus-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
+		DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08C297AA048003923FB /* reviews-all-without-data.json */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
 		DEC51A97274DD962009F3DF4 /* plugin.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51A96274DD962009F3DF4 /* plugin.json */; };
 		DEC51A99274DDDC9009F3DF4 /* SitePluginMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */; };
@@ -1591,6 +1592,7 @@
 		DEA6B1C7296D0E8A005AA5E9 /* systemStatusWithPluginsOnly-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "systemStatusWithPluginsOnly-without-data.json"; sourceTree = "<group>"; };
 		DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "systemStatus-without-data.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
+		DEC2B08C297AA048003923FB /* reviews-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-all-without-data.json"; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
 		DEC51A96274DD962009F3DF4 /* plugin.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = plugin.json; sourceTree = "<group>"; };
 		DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapperTests.swift; sourceTree = "<group>"; };
@@ -2207,6 +2209,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DEC2B08C297AA048003923FB /* reviews-all-without-data.json */,
 				DE66C5682977D62700DAA978 /* plugins-without-data.json */,
 				DE66C5662977CEB800DAA978 /* shipping-label-status-success-without-data.json */,
 				DE66C5642977CC4300DAA978 /* shipping-label-purchase-success-without-data.json */,
@@ -3254,6 +3257,7 @@
 				0272E3FB254AABB800436277 /* order-with-line-item-attributes-before-API-support.json in Resources */,
 				DE42F95D2966CB6A00D514C2 /* order-notes-without-data.json in Resources */,
 				31723C892787A299007F1405 /* stripe-connection-token.json in Resources */,
+				DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */,
 				74A1D266211898F000931DFA /* site-visits-year.json in Resources */,
 				743BF8BE21191B63008A9D87 /* site-visits.json in Resources */,
 				CE0A0F1F223998A10075ED8D /* products-load-all.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -743,6 +743,7 @@
 		DEA6B1CA296D0E8B005AA5E9 /* systemStatus-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08C297AA048003923FB /* reviews-all-without-data.json */; };
+		DEC2B08F297AA123003923FB /* reviews-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08E297AA123003923FB /* reviews-single-without-data.json */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
 		DEC51A97274DD962009F3DF4 /* plugin.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51A96274DD962009F3DF4 /* plugin.json */; };
 		DEC51A99274DDDC9009F3DF4 /* SitePluginMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */; };
@@ -1593,6 +1594,7 @@
 		DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "systemStatus-without-data.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC2B08C297AA048003923FB /* reviews-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-all-without-data.json"; sourceTree = "<group>"; };
+		DEC2B08E297AA123003923FB /* reviews-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-single-without-data.json"; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
 		DEC51A96274DD962009F3DF4 /* plugin.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = plugin.json; sourceTree = "<group>"; };
 		DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapperTests.swift; sourceTree = "<group>"; };
@@ -2209,6 +2211,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DEC2B08E297AA123003923FB /* reviews-single-without-data.json */,
 				DEC2B08C297AA048003923FB /* reviews-all-without-data.json */,
 				DE66C5682977D62700DAA978 /* plugins-without-data.json */,
 				DE66C5662977CEB800DAA978 /* shipping-label-status-success-without-data.json */,
@@ -3126,6 +3129,7 @@
 				B58D10C82114D21D00107ED4 /* generic_error.json in Resources */,
 				077F39D826A58EB600ABEADC /* systemStatus.json in Resources */,
 				31A451CD27863A2E00FE81AA /* stripe-account-restricted.json in Resources */,
+				DEC2B08F297AA123003923FB /* reviews-single-without-data.json in Resources */,
 				CE50346721B5DCBE007573C6 /* site-plan.json in Resources */,
 				D865CE5D278CA159002C8520 /* stripe-payment-intent-requires-confirmation.json in Resources */,
 				743E84F322172D0A00FAC9D7 /* shipment_tracking_empty.json in Resources */,

--- a/Networking/Networking/Mapper/ProductReviewListMapper.swift
+++ b/Networking/Networking/Mapper/ProductReviewListMapper.swift
@@ -18,7 +18,11 @@ struct ProductReviewListMapper: Mapper {
             .siteID: siteID
         ]
 
-        return try decoder.decode(ProductReviewListEnvelope.self, from: response).productReviews
+        do {
+            return try decoder.decode(ProductReviewListEnvelope.self, from: response).productReviews
+        } catch {
+            return try decoder.decode([ProductReview].self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Mapper/ProductReviewMapper.swift
+++ b/Networking/Networking/Mapper/ProductReviewMapper.swift
@@ -21,7 +21,11 @@ struct ProductReviewMapper: Mapper {
             .siteID: siteID
         ]
 
-        return try decoder.decode(ProductReviewEnvelope.self, from: response).productReview
+        do {
+            return try decoder.decode(ProductReviewEnvelope.self, from: response).productReview
+        } catch {
+            return try decoder.decode(ProductReview.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Remote/ProductReviewsRemote.swift
+++ b/Networking/Networking/Remote/ProductReviewsRemote.swift
@@ -48,7 +48,12 @@ public final class ProductReviewsRemote: Remote, ProductReviewsRemoteProtocol {
             ]
 
         let path = Path.reviews
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
         let mapper = ProductReviewListMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -63,7 +68,12 @@ public final class ProductReviewsRemote: Remote, ProductReviewsRemoteProtocol {
     ///
     public func loadProductReview(for siteID: Int64, reviewID: Int64, completion: @escaping (Result<ProductReview, Error>) -> Void) {
         let path = "\(Path.reviews)/\(reviewID)"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true)
         let mapper = ProductReviewMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -80,7 +90,12 @@ public final class ProductReviewsRemote: Remote, ProductReviewsRemoteProtocol {
     public func updateProductReviewStatus(for siteID: Int64, reviewID: Int64, statusKey: String, completion: @escaping (ProductReview?, Error?) -> Void) {
         let path = "\(Path.reviews)/\(reviewID)"
         let parameters = [ParameterKey.status: statusKey]
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
         let mapper = ProductReviewMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/NetworkingTests/Mapper/ProductReviewListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductReviewListMapperTests.swift
@@ -31,6 +31,31 @@ final class ProductReviewListMapperTests: XCTestCase {
 
         XCTAssertFalse(firstProductReview.verified)
     }
+
+    /// Verifies that all of the ProductReview Fields are parsed correctly.
+    ///
+    func test_ProductReview_fields_are_properly_parsed_when_response_has_no_data_envelope() {
+        let productReviews = mapLoadAllProductReviewsResponseWithoutDataEnvelope()
+        XCTAssertEqual(productReviews.count, 2)
+
+        let firstProductReview = productReviews[0]
+
+        XCTAssertEqual(firstProductReview.siteID, dummySiteID)
+        XCTAssertEqual(firstProductReview.reviewID, 173)
+        XCTAssertEqual(firstProductReview.productID, 32)
+
+        let dateCreated = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-08-20T06:06:29")
+        XCTAssertEqual(firstProductReview.dateCreated, dateCreated)
+
+        XCTAssertEqual(firstProductReview.status, ProductReviewStatus.approved)
+
+        XCTAssertEqual(firstProductReview.reviewer, "somereviewer")
+        XCTAssertEqual(firstProductReview.reviewerEmail, "somewhere@intheinternet.com")
+        XCTAssertEqual(firstProductReview.review, "<p>The fancy chair gets only three stars</p>\n")
+        XCTAssertEqual(firstProductReview.rating, 3)
+
+        XCTAssertFalse(firstProductReview.verified)
+    }
 }
 
 
@@ -52,5 +77,11 @@ private extension ProductReviewListMapperTests {
     ///
     func mapLoadAllProductReviewsResponse() -> [ProductReview] {
         return mapProductReviews(from: "reviews-all")
+    }
+
+    /// Returns the ProductListMapper output upon receiving `reviews-all-without-data`
+    ///
+    func mapLoadAllProductReviewsResponseWithoutDataEnvelope() -> [ProductReview] {
+        return mapProductReviews(from: "reviews-all-without-data")
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -122,6 +122,26 @@ final class ProductReviewsRemoteTests: XCTestCase {
         XCTAssertNotNil(try result.get())
     }
 
+    /// Verifies that loadProductReview properly parses the `reviews-single-without-data` sample response.
+    ///
+    func test_load_product_review_properly_returns_parsed_product_reviews_without_data_envelope() throws {
+        // Given
+        let remote = ProductReviewsRemote(network: network)
+
+        network.simulateResponse(requestUrlSuffix: "products/reviews/\(sampleReviewID)", filename: "reviews-single-without-data")
+
+        // When
+        let result: Result<ProductReview, Error> = waitFor { promise in
+            remote.loadProductReview(for: self.sampleSiteID, reviewID: self.sampleReviewID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertNotNil(try result.get())
+    }
+
     /// Verifies that loadProductReview properly relays Networking Layer errors.
     ///
     func testLoadProductReviewProperlyRelaysNetworkingErrors() throws {

--- a/Networking/NetworkingTests/Responses/reviews-all-without-data.json
+++ b/Networking/NetworkingTests/Responses/reviews-all-without-data.json
@@ -1,0 +1,76 @@
+[
+    {
+        "id": 173,
+        "date_created": "2019-08-20T06:06:29",
+        "date_created_gmt": "2019-08-20T06:06:29",
+        "product_id": 32,
+        "status": "approved",
+        "reviewer": "somereviewer",
+        "reviewer_email": "somewhere@intheinternet.com",
+        "review": "<p>The fancy chair gets only three stars</p>\n",
+        "rating": 3,
+        "verified": false,
+        "reviewer_avatar_urls": {
+            "24": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=24&d=mm&r=g",
+            "48": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=48&d=mm&r=g",
+            "96": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=96&d=mm&r=g"
+        },
+        "_links": {
+            "self": [
+                {
+                    "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews/173"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews"
+                }
+            ],
+            "up": [
+                {
+                    "href": "http://store.ctarda.com/wp-json/wc/v3/products/32"
+                }
+            ],
+            "reviewer": [
+                {
+                    "embeddable": true,
+                    "href": "http://store.ctarda.com/wp-json/wp/v2/users/1"
+                }
+            ]
+        }
+    },
+    {
+        "id": 169,
+        "date_created": "2019-08-20T06:02:21",
+        "date_created_gmt": "2019-08-20T06:02:21",
+        "product_id": 11,
+        "status": "approved",
+        "reviewer": "Software Engineer",
+        "reviewer_email": "somewhereelse@theinternet.com",
+        "review": "<p>A glowing review with a five star rating for the Colourful dress</p>\n",
+        "rating": 5,
+        "verified": false,
+        "reviewer_avatar_urls": {
+            "24": "http://0.gravatar.com/avatar/ca0e84fbb6e1cf1584c8b8f3ad5e2965?s=24&d=mm&r=g",
+            "48": "http://0.gravatar.com/avatar/ca0e84fbb6e1cf1584c8b8f3ad5e2965?s=48&d=mm&r=g",
+            "96": "http://0.gravatar.com/avatar/ca0e84fbb6e1cf1584c8b8f3ad5e2965?s=96&d=mm&r=g"
+        },
+        "_links": {
+            "self": [
+                {
+                    "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews/169"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews"
+                }
+            ],
+            "up": [
+                {
+                    "href": "http://store.ctarda.com/wp-json/wc/v3/products/11"
+                }
+            ]
+        }
+    }
+]

--- a/Networking/NetworkingTests/Responses/reviews-single-without-data.json
+++ b/Networking/NetworkingTests/Responses/reviews-single-without-data.json
@@ -1,0 +1,40 @@
+{
+    "id": 173,
+    "date_created": "2019-08-20T06:06:29",
+    "date_created_gmt": "2019-08-20T06:06:29",
+    "product_id": 32,
+    "status": "approved",
+    "reviewer": "somereviewer",
+    "reviewer_email": "somewhere@intheinternet.com",
+    "review": "<p>The fancy chair gets only three stars</p>\n",
+    "rating": 3,
+    "verified": false,
+    "reviewer_avatar_urls": {
+        "24": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=24&d=mm&r=g",
+        "48": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=48&d=mm&r=g",
+        "96": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=96&d=mm&r=g"
+    },
+    "_links": {
+        "self": [
+            {
+                "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews/173"
+            }
+        ],
+        "collection": [
+            {
+                "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews"
+            }
+        ],
+        "up": [
+            {
+                "href": "http://store.ctarda.com/wp-json/wc/v3/products/32"
+            }
+        ],
+        "reviewer": [
+            {
+                "embeddable": true,
+                "href": "http://store.ctarda.com/wp-json/wp/v2/users/1"
+            }
+        ]
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -332,7 +332,7 @@ private extension ReviewDetailsViewController {
         commentCell.isTrashEnabled    = true
         commentCell.isSpamEnabled     = true
         commentCell.isApproveSelected = productReview.status == .approved
-        commentCell.isReplyEnabled    = true
+        commentCell.isReplyEnabled    = ServiceLocator.stores.isAuthenticatedWithoutWPCom == false
 
         let reviewID = productReview.reviewID
         let reviewSiteID = productReview.siteID

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -136,9 +136,12 @@ extension ReviewsViewModel {
             }
         }
 
-        group.enter()
-        synchronizeNotifications {
-            group.leave()
+        // skips checking notifications if authenticated without WPCom.
+        if stores.isAuthenticatedWithoutWPCom == false {
+            group.enter()
+            synchronizeNotifications {
+                group.leave()
+            }
         }
 
         group.notify(queue: .main) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8715 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR makes the product review feature work with application password authentication. Changes include:
- Enabled REST API for product review endpoints.
- Updated related mappers to parse contents without the data envelope.
- Hid the Reply button on the review detail screen since this requires requests to a dotcom endpoint, which is unavailable with application passwords.
- Skipped notification fetching on the review list.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address and proceed with the address of a self-hosted store.
- Log in with your site credentials. After the login succeeds, you should be navigated to the home screen.
- Navigate to Menu tab and select Reviews. The review list should be loaded without any errors.
- Select a review in the list - its details should be loaded properly. The Reply button should be hidden.
- Navigate to Products tab and select the product with at least one review. The number of review should be displayed on the Product Form screen. 
- Select the Reviews row, the list of review should be loaded properly.

Please feel free to test again by authenticating with a WPCom account, the Reply button should still be visible on the review detail screen.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/213672998-1547e8ff-0d97-40e6-87eb-7e19d82de2e9.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
