### PR TITLE
REST API: Migrate product category endpoints

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -745,6 +745,7 @@
 		DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08C297AA048003923FB /* reviews-all-without-data.json */; };
 		DEC2B08F297AA123003923FB /* reviews-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08E297AA123003923FB /* reviews-single-without-data.json */; };
 		DEC2B091297AA5A6003923FB /* categories-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B090297AA5A6003923FB /* categories-all-without-data.json */; };
+		DEC2B093297AA60D003923FB /* category-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B092297AA60D003923FB /* category-without-data.json */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
 		DEC51A97274DD962009F3DF4 /* plugin.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51A96274DD962009F3DF4 /* plugin.json */; };
 		DEC51A99274DDDC9009F3DF4 /* SitePluginMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */; };
@@ -1597,6 +1598,7 @@
 		DEC2B08C297AA048003923FB /* reviews-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-all-without-data.json"; sourceTree = "<group>"; };
 		DEC2B08E297AA123003923FB /* reviews-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-single-without-data.json"; sourceTree = "<group>"; };
 		DEC2B090297AA5A6003923FB /* categories-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-all-without-data.json"; sourceTree = "<group>"; };
+		DEC2B092297AA60D003923FB /* category-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "category-without-data.json"; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
 		DEC51A96274DD962009F3DF4 /* plugin.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = plugin.json; sourceTree = "<group>"; };
 		DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapperTests.swift; sourceTree = "<group>"; };
@@ -2213,6 +2215,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DEC2B092297AA60D003923FB /* category-without-data.json */,
 				DEC2B090297AA5A6003923FB /* categories-all-without-data.json */,
 				DEC2B08E297AA123003923FB /* reviews-single-without-data.json */,
 				DEC2B08C297AA048003923FB /* reviews-all-without-data.json */,
@@ -3086,6 +3089,7 @@
 				26BD9FCD2965EC3C004E0D15 /* product-variations-bulk-create.json in Resources */,
 				028CB718290223CB00331C09 /* account-username-suggestions.json in Resources */,
 				0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */,
+				DEC2B093297AA60D003923FB /* category-without-data.json in Resources */,
 				45152825257A8B740076B03C /* product-attribute-update.json in Resources */,
 				68C87B342862D40E00A99054 /* setting-all-except-countries.json in Resources */,
 				3158FE6026129ADD00E566B9 /* wcpay-account-none.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -744,6 +744,7 @@
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08C297AA048003923FB /* reviews-all-without-data.json */; };
 		DEC2B08F297AA123003923FB /* reviews-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08E297AA123003923FB /* reviews-single-without-data.json */; };
+		DEC2B091297AA5A6003923FB /* categories-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B090297AA5A6003923FB /* categories-all-without-data.json */; };
 		DEC51A95274CDA52009F3DF4 /* SitePluginMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */; };
 		DEC51A97274DD962009F3DF4 /* plugin.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC51A96274DD962009F3DF4 /* plugin.json */; };
 		DEC51A99274DDDC9009F3DF4 /* SitePluginMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */; };
@@ -1595,6 +1596,7 @@
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC2B08C297AA048003923FB /* reviews-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-all-without-data.json"; sourceTree = "<group>"; };
 		DEC2B08E297AA123003923FB /* reviews-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-single-without-data.json"; sourceTree = "<group>"; };
+		DEC2B090297AA5A6003923FB /* categories-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-all-without-data.json"; sourceTree = "<group>"; };
 		DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapper.swift; sourceTree = "<group>"; };
 		DEC51A96274DD962009F3DF4 /* plugin.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = plugin.json; sourceTree = "<group>"; };
 		DEC51A98274DDDC9009F3DF4 /* SitePluginMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginMapperTests.swift; sourceTree = "<group>"; };
@@ -2211,6 +2213,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DEC2B090297AA5A6003923FB /* categories-all-without-data.json */,
 				DEC2B08E297AA123003923FB /* reviews-single-without-data.json */,
 				DEC2B08C297AA048003923FB /* reviews-all-without-data.json */,
 				DE66C5682977D62700DAA978 /* plugins-without-data.json */,
@@ -3163,6 +3166,7 @@
 				3105471C262E2F8000C5C02B /* wcpay-payment-intent-requires-action.json in Resources */,
 				3158FE6826129CE200E566B9 /* wcpay-account-rejected-fraud.json in Resources */,
 				02AAD53F250092A400BA1E26 /* product-add-or-delete.json in Resources */,
+				DEC2B091297AA5A6003923FB /* categories-all-without-data.json in Resources */,
 				D823D90B22376EFE00C90817 /* shipment_tracking_delete.json in Resources */,
 				31A451D727863A2E00FE81AA /* stripe-account-dev-test.json in Resources */,
 				74C947832193A6C70024CB60 /* comment-moderate-trash.json in Resources */,

--- a/Networking/Networking/Mapper/ProductCategoryListMapper.swift
+++ b/Networking/Networking/Mapper/ProductCategoryListMapper.swift
@@ -17,7 +17,11 @@ struct ProductCategoryListMapper: Mapper {
             .siteID: siteID
         ]
 
-        return try decoder.decode(ProductCategoryListEnvelope.self, from: response).productCategories
+        do {
+            return try decoder.decode(ProductCategoryListEnvelope.self, from: response).productCategories
+        } catch {
+            return try decoder.decode([ProductCategory].self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Mapper/ProductCategoryMapper.swift
+++ b/Networking/Networking/Mapper/ProductCategoryMapper.swift
@@ -20,7 +20,11 @@ struct ProductCategoryMapper: Mapper {
             .siteID: siteID
         ]
 
-        return try decoder.decode(ProductCategoryEnvelope.self, from: response).productCategory
+        do {
+            return try decoder.decode(ProductCategoryEnvelope.self, from: response).productCategory
+        } catch {
+            return try decoder.decode(ProductCategory.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Remote/ProductCategoriesRemote.swift
+++ b/Networking/Networking/Remote/ProductCategoriesRemote.swift
@@ -25,7 +25,12 @@ public final class ProductCategoriesRemote: Remote {
         ]
 
         let path = Path.categories
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
         let mapper = ProductCategoryListMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -42,7 +47,11 @@ public final class ProductCategoriesRemote: Remote {
                                     siteID: Int64,
                                     completion: @escaping (Result<ProductCategory, Error>) -> Void) -> Void {
         let path = Path.categories + "/\(categoryID)"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     availableAsRESTRequest: true)
         let mapper = ProductCategoryMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -69,7 +78,12 @@ public final class ProductCategoriesRemote: Remote {
         }
 
         let path = Path.categories
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
         let mapper = ProductCategoryMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/NetworkingTests/Mapper/ProductCategoryMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductCategoryMapperTests.swift
@@ -22,6 +22,17 @@ final class ProductCategoryMapperTests: XCTestCase {
         XCTAssertEqual(productCategory.slug, "Shirt")
     }
 
+    /// Verifies that all of the ProductCategory Fields are parsed correctly.
+    ///
+    func test_ProductCategory_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
+        let productCategory = try XCTUnwrap(mapProductCategoryResponseWithoutDataEnvelope())
+
+        XCTAssertEqual(productCategory.categoryID, 104)
+        XCTAssertEqual(productCategory.parentID, 0)
+        XCTAssertEqual(productCategory.siteID, dummySiteID)
+        XCTAssertEqual(productCategory.name, "Dress")
+        XCTAssertEqual(productCategory.slug, "Shirt")
+    }
 }
 
 
@@ -43,5 +54,11 @@ private extension ProductCategoryMapperTests {
     ///
     func mapProductCategoryResponse() throws -> ProductCategory? {
         return try mapProductCategory(from: "category")
+    }
+
+    /// Returns the ProductCategoryMapper output upon receiving `category-without-data`
+    ///
+    func mapProductCategoryResponseWithoutDataEnvelope() throws -> ProductCategory? {
+        return try mapProductCategory(from: "category-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/ProductCategoyListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductCategoyListMapperTests.swift
@@ -19,6 +19,20 @@ final class ProductCategoryListMapperTests: XCTestCase {
         XCTAssertEqual(secondProductCategory.name, "American")
         XCTAssertEqual(secondProductCategory.slug, "american")
     }
+
+    /// Verifies that all of the ProductCategory Fields are parsed correctly.
+    ///
+    func test_ProductCategory_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
+        let productCategories = try mapLoadAllProductCategoriesResponseWithoutDataEnvelope()
+        XCTAssertEqual(productCategories.count, 2)
+
+        let secondProductCategory = productCategories[1]
+        XCTAssertEqual(secondProductCategory.categoryID, 20)
+        XCTAssertEqual(secondProductCategory.parentID, 17)
+        XCTAssertEqual(secondProductCategory.siteID, dummySiteID)
+        XCTAssertEqual(secondProductCategory.name, "American")
+        XCTAssertEqual(secondProductCategory.slug, "american")
+    }
 }
 
 
@@ -40,5 +54,11 @@ private extension ProductCategoryListMapperTests {
     ///
     func mapLoadAllProductCategoriesResponse() throws -> [ProductCategory] {
         return try mapProductCategories(from: "categories-all")
+    }
+
+    /// Returns the ProductListMapper output upon receiving `categories-all-without-data`
+    ///
+    func mapLoadAllProductCategoriesResponseWithoutDataEnvelope() throws -> [ProductCategory] {
+        return try mapProductCategories(from: "categories-all-without-data")
     }
 }

--- a/Networking/NetworkingTests/Responses/categories-all-without-data.json
+++ b/Networking/NetworkingTests/Responses/categories-all-without-data.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": 104,
+    "name": "Dress",
+    "slug": "Shirt",
+    "parent": 0,
+    "description": "",
+    "display": "default",
+    "image": {
+      "id": 1310,
+      "date_created": "2018-08-28T13:09:22",
+      "date_created_gmt": "2018-08-28T17:09:22",
+      "date_modified": "2018-08-28T13:09:22",
+      "date_modified_gmt": "2018-08-28T17:09:22",
+      "src": "https://some-website.com/2018.jpg",
+      "name": "2018",
+      "alt": ""
+    },
+    "menu_order": 0,
+    "count": 1,
+    "_links": {
+      "self": [
+        {
+          "href": "https://some-website.com/products/categories/104"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://some-website.com/products/categories"
+        }
+      ]
+    }
+  },
+  {
+    "id": 20,
+    "name": "American",
+    "slug": "american",
+    "parent": 17,
+    "description": "",
+    "display": "default",
+    "image": null,
+    "menu_order": 5,
+    "count": 0,
+    "_links": {
+      "self": [
+        {
+          "href": "https://some-website.com/products/categories/20"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://some-website.com/products/categories"
+        }
+      ],
+      "up": [
+        {
+          "href": "https://some-website.com/products/categories/17"
+        }
+      ]
+    }
+  }
+]

--- a/Networking/NetworkingTests/Responses/category-without-data.json
+++ b/Networking/NetworkingTests/Responses/category-without-data.json
@@ -1,0 +1,32 @@
+{
+    "id": 104,
+    "name": "Dress",
+    "slug": "Shirt",
+    "parent": 0,
+    "description": "",
+    "display": "default",
+    "image": {
+        "id": 1310,
+        "date_created": "2018-08-28T13:09:22",
+        "date_created_gmt": "2018-08-28T17:09:22",
+        "date_modified": "2018-08-28T13:09:22",
+        "date_modified_gmt": "2018-08-28T17:09:22",
+        "src": "https://some-website.com/2018.jpg",
+        "name": "2018",
+        "alt": ""
+    },
+    "menu_order": 0,
+    "count": 1,
+    "_links": {
+        "self": [
+            {
+                "href": "https://some-website.com/products/categories/104"
+            }
+        ],
+        "collection": [
+            {
+                "href": "https://some-website.com/products/categories"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8715 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR migrates the product category endpoints and updates the related mappers to parse contents without the data envelope.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address and proceed with the address of a self-hosted store.
- Log in with your site credentials. After the login succeeds, you should be navigated to the home screen.
- Navigate to Products tab and select any product. The correct category should be displayed on the Category row.
- Select Category row, the complete list of categories in your test store should be loaded. 
- Select Add Category and choose a name and parent. The new category should be added successfully.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/213676037-5f682cf5-981c-4487-80e4-066f4707f992.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
