### PR TITLE
Bulk Editing: Tweak products toolbar

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.xib
@@ -40,10 +40,12 @@
                             </userDefinedRuntimeAttributes>
                         </tableView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pNN-uJ-nMs" userLabel="Bulk Edit Bar" customClass="ToolbarView" customModule="WooCommerce" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="764" width="414" height="50"/>
+                            <rect key="frame" x="0.0" y="765" width="414" height="49"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
-                                <constraint firstAttribute="height" priority="995" constant="50" id="mXV-oU-3bM"/>
+                                <constraint firstAttribute="height" priority="995" constant="49" id="mXV-oU-3bM">
+                                    <variation key="heightClass=compact" constant="32"/>
+                                </constraint>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xLN-As-fgq" userLabel="Safe Area Placeholder">

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.xib
@@ -34,7 +34,7 @@
                             </constraints>
                         </view>
                         <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="1mE-SE-uK9">
-                            <rect key="frame" x="0.0" y="50" width="414" height="714"/>
+                            <rect key="frame" x="0.0" y="50" width="414" height="715"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="orders-table-view"/>
                             </userDefinedRuntimeAttributes>
@@ -55,8 +55,6 @@
                         <constraint firstItem="9eA-hc-k15" firstAttribute="leading" secondItem="tDW-j0-dUT" secondAttribute="leading" id="2Md-DN-FrJ"/>
                         <constraint firstItem="1mE-SE-uK9" firstAttribute="top" secondItem="9eA-hc-k15" secondAttribute="bottom" id="CRj-o0-2WZ"/>
                         <constraint firstAttribute="trailing" secondItem="9eA-hc-k15" secondAttribute="trailing" id="Qcx-pF-i9M"/>
-                        <constraint firstItem="1mE-SE-uK9" firstAttribute="trailing" secondItem="9eA-hc-k15" secondAttribute="trailing" id="g0z-q4-rFD"/>
-                        <constraint firstItem="1mE-SE-uK9" firstAttribute="leading" secondItem="9eA-hc-k15" secondAttribute="leading" id="i2H-MX-SoN"/>
                         <constraint firstItem="9eA-hc-k15" firstAttribute="top" secondItem="tDW-j0-dUT" secondAttribute="top" id="ilw-mJ-v1G"/>
                         <constraint firstItem="pNN-uJ-nMs" firstAttribute="top" secondItem="1mE-SE-uK9" secondAttribute="bottom" id="mlT-bM-H2X"/>
                     </constraints>
@@ -65,11 +63,13 @@
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="tDW-j0-dUT" secondAttribute="trailing" id="3MC-6D-nnm"/>
+                <constraint firstAttribute="trailing" secondItem="tDW-j0-dUT" secondAttribute="trailing" id="3MC-6D-nnm"/>
                 <constraint firstItem="tDW-j0-dUT" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="9UK-Qy-FXd"/>
                 <constraint firstAttribute="bottom" secondItem="tDW-j0-dUT" secondAttribute="bottom" id="AQF-qF-3wt"/>
+                <constraint firstItem="1mE-SE-uK9" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="E6i-2y-FvV"/>
                 <constraint firstItem="xLN-As-fgq" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="Iu8-XK-w4W"/>
-                <constraint firstItem="tDW-j0-dUT" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="KSv-iL-NFv"/>
+                <constraint firstItem="tDW-j0-dUT" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="KSv-iL-NFv"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="1mE-SE-uK9" secondAttribute="trailing" id="qVI-Qq-E5k"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="pNN-uJ-nMs" secondAttribute="bottom" id="xJE-yf-lID"/>
             </constraints>
             <point key="canvasLocation" x="100.00000000000001" y="48.883928571428569"/>

--- a/WooCommerce/Classes/ViewRelated/Toolbar/ToolbarView.swift
+++ b/WooCommerce/Classes/ViewRelated/Toolbar/ToolbarView.swift
@@ -23,7 +23,7 @@ final class ToolbarView: UIView {
     func setup() {
         translatesAutoresizingMaskIntoConstraints = false
         addSubview(stackView)
-        pinSubviewToAllEdges(stackView)
+        pinSubviewToSafeArea(stackView)
     }
 
     func addDividerOnTop() {


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8625

## Description

This PR updates toolbars layout on Products List.

- top and bottom toolbars now span full width instead of being limited to safe area
- bottom toolbar has different height: instead of static 50 it now has 49 in portrait and 32 in landscape - matching iOS tabbar dimensions.

_Note:_ should we add divider under the top toolbar or is it missing by design?

### How

- To allow toolbars span full width, their container (UIStackView) is now pinned to the superview instead of safe area.
- To keep toolbar buttons out of safe area, its content container (UIStackView) is now pinned to the safe area.
- To keep cells appearance unchanged, UITableView leading and trailing constants are pinned to the safe area.
- To make bottom toolbar match compact tabbar dimensions, a size class variation introduced on its height constraint:
<img width="260" alt="Screenshot 2023-01-20 at 13 57 58" src="https://user-images.githubusercontent.com/3132438/213680863-76a2039c-cd3f-48c7-b6d3-b66efe3d145b.png">

## Testing

1. Build and run the app in debug/alpha mode.
2. On the products list tap the "multi-select" icon in the navbar.
3. Check appearance of the bottom toolbar.
4. Rotate device to the landscape orientation.
5. Check appearance of the bottom toolbar.
6. Trigger bulk editing off/on to check transition to/from tabbar.

## Screenshots

before|after
--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/213682718-5f37b8c9-499c-41bc-938e-a02cd05fadb2.png)|![Simulator Screen Shot - 3](https://user-images.githubusercontent.com/3132438/213682479-4a6f9297-f942-45ad-98b2-8332a6926383.png)
![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/213682622-64c6eba1-0aa2-4623-8197-a050628a844a.png)|![Simulator Screen Shot - 4](https://user-images.githubusercontent.com/3132438/213682463-bc828277-d025-4e75-bac8-4606930a2903.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
