### PR TITLE
Bulk Editing: Fix disappearing separators

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -158,6 +158,9 @@ private extension ProductsTabProductTableViewCell {
         //Background when selected
         selectedBackgroundView = UIView()
         selectedBackgroundView?.backgroundColor = .listBackground
+
+        // Prevents overflow of selectedBackgroundView above dividers from adjacent cells
+        clipsToBounds = true
     }
 
     func configureNameLabel() {

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -140,7 +140,7 @@ private extension ProductsTabProductTableViewCell {
             bottomBorderView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             bottomBorderView.trailingAnchor.constraint(equalTo: trailingAnchor),
             bottomBorderView.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
-            bottomBorderView.heightAnchor.constraint(equalToConstant: 0.5)
+            bottomBorderView.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale)
         ])
     }
 


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8608

## Description

This PR updates layout of product cells in the list to prevent clipping of selected cells dividers during scrolling.

### Why

All changes done in ProductsTabProductTableViewCell. The main reason is that `selectedBackgroundView` have height slightly bigger than its cell. During scrolling and cells layout it ended up hiding divider of the top adjacent cell.

Here are dividers are 2px. Unselected are displayed as 2px, selected hide half of divider.
<img width=350 src="https://user-images.githubusercontent.com/3132438/213691502-02f42491-e12b-4577-98bb-e6dd9c26dc15.png">

cell size | selected bg size
--|--
![cell](https://user-images.githubusercontent.com/3132438/213692302-fc395e3d-1982-4d19-82a5-1702a4ecd92f.jpg)|![bg](https://user-images.githubusercontent.com/3132438/213692296-bf331238-242c-4291-8a28-3e2c81fe029b.jpg)

### How

- Divider is updated to have exactly 1px size
- Added `clipToBounds = true` to cell view to prevent overflow of selected bg

## Testing

1. Build and run the app in debug/alpha mode.
2. On the products list tap the "multi-select" icon in the navbar.
3. Select some products.
4. Scroll to hide selected products, then back to check dividers.

## Screenshots

before|after
--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/213692761-4b079be5-f3e8-49a3-a260-be0499839edf.png)|![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/213692765-92406372-f506-4016-a334-27a5497bebf4.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
