### PR TITLE
[Mobile Payments] Minor changes from Tap to Pay Test Charter 2

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingToReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingToReader.swift
@@ -38,7 +38,7 @@ final class CardPresentModalBuiltInConnectingToReader: CardPresentPaymentsModalV
 private extension CardPresentModalBuiltInConnectingToReader {
     enum Localization {
         static let title = NSLocalizedString(
-            "Preparing iPhone card reader...",
+            "Preparing iPhone card reader",
             comment: "Title label for modal dialog that appears when connecting to a built in card reader"
         )
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -27,9 +27,6 @@ final class OrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
         }
     }
 
-    private var name: String = ""
-    private var amount: String = ""
-
     private let transactionType: CardPresentTransactionType
 
     private let alertsProvider: CardReaderTransactionAlertsProviding
@@ -58,9 +55,6 @@ final class OrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
                          amount: String,
                          inputMethods: CardReaderInput,
                          onCancel: @escaping () -> Void) {
-        self.name = title
-        self.amount = amount
-
         // Initial presentation of the modal view controller. We need to provide
         // a customer name and an amount.
         let viewModel = alertsProvider.tapOrInsertCard(title: title,
@@ -75,8 +69,8 @@ final class OrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
         presentViewModel(viewModel: viewModel)
     }
 
-    func processingPayment() {
-        let viewModel = alertsProvider.processingTransaction()
+    func processingPayment(title: String) {
+        let viewModel = alertsProvider.processingTransaction(title: title)
         presentViewModel(viewModel: viewModel)
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlertsProtocol.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlertsProtocol.swift
@@ -11,7 +11,7 @@ protocol OrderDetailsPaymentAlertsProtocol {
 
     func displayReaderMessage(message: String)
 
-    func processingPayment()
+    func processingPayment(title: String)
 
     func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptAction: @escaping () -> Void)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
@@ -36,8 +36,9 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
                                        message: message)
     }
 
-    func processingTransaction() -> CardPresentPaymentsModalViewModel {
-        CardPresentModalProcessing(name: name, amount: amount, transactionType: transactionType)
+    func processingTransaction(title: String) -> CardPresentPaymentsModalViewModel {
+        name = title
+        return CardPresentModalProcessing(name: name, amount: amount, transactionType: transactionType)
     }
 
     func success(printReceipt: @escaping () -> Void,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
@@ -30,8 +30,9 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
                                        message: message)
     }
 
-    func processingTransaction() -> CardPresentPaymentsModalViewModel {
-        CardPresentModalBuiltInReaderProcessing(name: name, amount: amount)
+    func processingTransaction(title: String) -> CardPresentPaymentsModalViewModel {
+        name = title
+        return CardPresentModalBuiltInReaderProcessing(name: name, amount: amount)
     }
 
     func success(printReceipt: @escaping () -> Void,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTransactionAlertsProviding.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTransactionAlertsProviding.swift
@@ -23,7 +23,7 @@ protocol CardReaderTransactionAlertsProviding {
 
     /// An alert to show that the transaction is being processed
     ///
-    func processingTransaction() -> CardPresentPaymentsModalViewModel
+    func processingTransaction(title: String) -> CardPresentPaymentsModalViewModel
 
     /// An alert to display successful transaction and provide options related to receipts
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -268,7 +268,9 @@ private extension CollectOrderPaymentUseCase {
             }, onProcessingMessage: { [weak self] in
                 guard let self = self else { return }
                 // Waiting message
-                self.alertsPresenter.present(viewModel: paymentAlerts.processingTransaction())
+                self.alertsPresenter.present(
+                    viewModel: paymentAlerts.processingTransaction(
+                        title: Localization.processingPaymentTitle(username: self.order.billingAddress?.firstName)))
             }, onDisplayMessage: { [weak self] message in
                 guard let self = self else { return }
                 // Reader messages. EG: Remove Card
@@ -552,6 +554,19 @@ private extension CollectOrderPaymentUseCase {
                 return collectPaymentWithoutName
             }
             return .localizedStringWithFormat(collectPaymentWithName, username)
+        }
+
+        private static let processingPaymentWithoutName = NSLocalizedString(
+            "Processing payment",
+            comment: "Alert title when processing a payment without a user name.")
+        private static let processingPaymentWithName = NSLocalizedString(
+            "Processing payment from %1$@",
+            comment: "Alert title when processing a payment with a user name.")
+        static func processingPaymentTitle(username: String?) -> String {
+            guard let username = username, username.isNotEmpty else {
+                return processingPaymentWithoutName
+            }
+            return .localizedStringWithFormat(processingPaymentWithName, username)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
@@ -301,7 +301,7 @@ private extension LegacyCollectOrderPaymentUseCase {
 
             }, onProcessingMessage: { [weak self] in
                 // Waiting message
-                self?.alerts.processingPayment()
+                self?.alerts.processingPayment(title: Localization.collectPaymentTitle(username: self?.order.billingAddress?.firstName))
             }, onDisplayMessage: { [weak self] message in
                 // Reader messages. EG: Remove Card
                 self?.alerts.displayReaderMessage(message: message)

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -314,7 +314,7 @@ private extension RefundSubmissionUseCase {
             })
         }, onProcessingMessage: { [weak self] in
             // Shows waiting message.
-            self?.alerts.processingPayment()
+            self?.alerts.processingPayment(title: Localization.refundPaymentTitle(username: self?.order.billingAddress?.firstName))
         }, onDisplayMessage: { [weak self] message in
             // Shows reader messages (e.g. Remove Card).
             self?.alerts.displayReaderMessage(message: message)

--- a/WooCommerce/WooCommerceTests/Mocks/MockOrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockOrderDetailsPaymentAlerts.swift
@@ -36,7 +36,7 @@ extension MockOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
         // no-op
     }
 
-    func processingPayment() {
+    func processingPayment(title: String) {
         // no-op
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For context: pdcxQM-1GW-p2

### Preparing reader

![Preparing iPhone card reader...](https://user-images.githubusercontent.com/2472348/213693043-e93a30b1-8c6f-4565-bb75-529ff972c316.png)

The `...` in the title suggests that the title is truncated, so we agreed to remove it

### Processing payment title

![Processing payment screen, with title Collect payment from Sally](https://user-images.githubusercontent.com/2472348/213693261-d7093aef-b31c-4642-abf9-b83c87a0f494.png)

The Processing payment screen keeps the title from the Collect payment screen: `Collect payment from {Name}`. This could be perceived as us telling the merchant that [they need to]… collect payment from {name}, which isn’t the case.

This PR replaces that string with `Processing payment from {name}` to make it clearer.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Using a US-based WCPay or Stripe store:

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. When asked for a reader type, tap `Tap to Pay on iPhone` and connect to the reader
6. Observe that the `Preparing iPhone card reader` screen does not have `...` in the title
7. Take a payment. 
8. Observe that the `Processing payment` screen has `Processing payment` as the title instead of `Collect payment`

Repeat the above test using a Cash on Delivery order from the website. Observe that the processing screen has `Processing payment from {name}` as the title.

Repeat the above tests using a Bluetooth reader


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/213695620-72f84f2e-fd0a-4899-afc2-54a62183f396.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
