### PR TITLE
Bulk Editing: Fix margins on iPad

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -595,7 +595,6 @@ private extension ProductsViewController {
         tableView.dataSource = self
         tableView.delegate = self
 
-        tableView.cellLayoutMarginsFollowReadableWidth = true
         tableView.estimatedRowHeight = Constants.estimatedRowHeight
         tableView.rowHeight = UITableView.automaticDimension
 


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8722

## Description

This PR fixes huge left margin seen on iPad in landscape orientation.

### How

There was `cellLayoutMarginsFollowReadableWidth` property enabled on tableview. Since our cells are custom - we didn't have any impact from that, until we added multi-selection feature which used those custom margins.

Since we never used readable width margins on this screen anyway - I removed the property.

## Testing

1. Build and run the app in debug/alpha mode on iPad.
2. On the products list tap the "multi-select" icon in the navbar.
3. Check cells appearance.
4. Rotate device to the landscape orientation.
5. Check cells appearance.
6. Trigger bulk editing off/on to check cells transition.

## Screenshots

before|after
--|--
![1](https://user-images.githubusercontent.com/3132438/213727027-5a7d1684-cb33-4dbc-8b72-4f0aca54f91f.png)|![3](https://user-images.githubusercontent.com/3132438/213727113-76a38594-24d4-4bdd-bafb-690cf7fe9d88.png)
![2](https://user-images.githubusercontent.com/3132438/213727036-4bc76e15-79d6-4fe0-9cdb-e7ef764ba800.png)|![4](https://user-images.githubusercontent.com/3132438/213727129-9821ecef-7fc8-451f-9b36-cb472cf8ddd5.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
