### PR TITLE
[Mobile Payments] Move IPP Learn More Link to Menu

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInReaderCheckingDeviceSupport.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInReaderCheckingDeviceSupport.swift
@@ -23,27 +23,6 @@ final class CardPresentModalBuiltInReaderCheckingDeviceSupport: CardPresentPayme
 
     let auxiliaryButtonimage: UIImage? = .infoOutlineImage
 
-    var auxiliaryAttributedButtonTitle: NSAttributedString? {
-        let result = NSMutableAttributedString(
-            string: .localizedStringWithFormat(
-                Localization.learnMoreText,
-                Localization.learnMoreLink
-            ),
-            attributes: [.foregroundColor: UIColor.text]
-        )
-        result.replaceFirstOccurrence(
-            of: Localization.learnMoreLink,
-            with: NSAttributedString(
-                string: Localization.learnMoreLink,
-                attributes: [
-                    .foregroundColor: UIColor.accent,
-                    .underlineStyle: NSUnderlineStyle.single.rawValue
-                ]
-            ))
-        result.addAttribute(.font, value: UIFont.footnote, range: NSRange(location: 0, length: result.length))
-        return result
-    }
-
     let bottomTitle: String? = nil
 
     var bottomSubtitle: String? = Localization.instruction
@@ -93,27 +72,6 @@ private extension CardPresentModalBuiltInReaderCheckingDeviceSupport {
             "cardPresent.builtIn.modalCheckingDeviceSupport.cancelButton",
             value: "Cancel",
             comment: "Label for a cancel button"
-        )
-
-        static let learnMoreLink = NSLocalizedString(
-            "cardPresent.builtIn.modalCheckingDeviceSupport.learnMore.link",
-            value: "Learn more",
-            comment: """
-                     A label prompting users to learn more about In-Person Payments.
-                     This is the link to the website, and forms part of a longer sentence which it should be considered a part of.
-                     """
-        )
-
-        static let learnMoreText = NSLocalizedString(
-            "cardPresent.builtIn.modalCheckingDeviceSupport.learnMore.text",
-            value: "%1$@ about In‑Person Payments",
-            comment: """
-                     A label prompting users to learn more about In-Person Payments.
-                     The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
-                     If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it.
-                     %1$@ is a placeholder that always replaced with \"Learn more\" string,
-                     which should be translated separately and considered part of this sentence.
-                     """
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -21,27 +21,6 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
 
     let auxiliaryButtonTitle: String? = nil
 
-    var auxiliaryAttributedButtonTitle: NSAttributedString? {
-        let result = NSMutableAttributedString(
-            string: .localizedStringWithFormat(
-                Localization.learnMoreText,
-                Localization.learnMoreLink
-            ),
-            attributes: [.foregroundColor: UIColor.text]
-        )
-        result.replaceFirstOccurrence(
-            of: Localization.learnMoreLink,
-            with: NSAttributedString(
-                string: Localization.learnMoreLink,
-                attributes: [
-                    .foregroundColor: UIColor.accent,
-                    .underlineStyle: NSUnderlineStyle.single.rawValue
-                ]
-            ))
-        result.addAttribute(.font, value: UIFont.footnote, range: NSRange(location: 0, length: result.length))
-        return result
-    }
-
     let bottomTitle: String? = Localization.instruction
 
     var bottomSubtitle: String?
@@ -94,27 +73,6 @@ private extension CardPresentModalScanningForReader {
             "cardPresent.modalScanningForReader.cancelButton",
             value: "Cancel",
             comment: "Label for a cancel button"
-        )
-
-        static let learnMoreLink = NSLocalizedString(
-            "cardPresent.modalScanningForReader.learnMore.link",
-            value: "Learn more",
-            comment: """
-                     A label prompting users to learn more about In-Person Payments.
-                     This is the link to the website, and forms part of a longer sentence which it should be considered a part of.
-                     """
-        )
-
-        static let learnMoreText = NSLocalizedString(
-            "cardPresent.modalScanningForReader.learnMore.text",
-            value: "%1$@ about In‑Person Payments",
-            comment: """
-                     A label prompting users to learn more about In-Person Payments.
-                     The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
-                     If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it.
-                     %1$@ is a placeholder that always replaced with \"Learn more\" string,
-                     which should be translated separately and considered part of this sentence.
-                     """
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -455,10 +455,9 @@ extension InPersonPaymentsMenuViewController: UITableViewDataSource {
         guard section == sections.firstIndex(where: { $0 == cardReadersSection }) else {
             return nil
         }
-
+        
         return inPersonPaymentsLearnMoreButton
     }
-
 }
 
 // MARK: - UITableViewDelegate

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -41,6 +41,36 @@ final class InPersonPaymentsMenuViewController: UIViewController {
 
     private var activityIndicator: UIActivityIndicatorView?
 
+    private var inPersonPaymentsLearnMoreButtonTitle: NSAttributedString? {
+        let result = NSMutableAttributedString(
+            string: .localizedStringWithFormat(
+                Localization.learnMoreText,
+                Localization.learnMoreLink
+            ),
+            attributes: [.foregroundColor: UIColor.textSubtle]
+        )
+        result.replaceFirstOccurrence(
+            of: Localization.learnMoreLink,
+            with: NSAttributedString(
+                string: Localization.learnMoreLink,
+                attributes: [
+                    .foregroundColor: UIColor.textLink
+                ]
+            ))
+        result.addAttribute(.font, value: UIFont.footnote, range: NSRange(location: 0, length: result.length))
+        return result
+    }
+
+    private var inPersonPaymentsLearnMoreButton: UIButton {
+        let button = UIButton()
+        button.addTarget(self, action: #selector(learnMoreAboutInPersonPaymentsButtonWasTapped), for: .touchUpInside)
+        button.setAttributedTitle(inPersonPaymentsLearnMoreButtonTitle, for: .normal)
+        button.naturalContentHorizontalAlignment = .leading
+        button.configuration = UIButton.Configuration.plain()
+
+        return button
+    }
+
     init(stores: StoresManager = ServiceLocator.stores,
         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService
     ) {
@@ -392,6 +422,11 @@ extension InPersonPaymentsMenuViewController {
 
         SimplePaymentsAmountFlowOpener.openSimplePaymentsAmountFlow(from: navigationController, siteID: siteID)
     }
+
+    @objc func learnMoreAboutInPersonPaymentsButtonWasTapped() {
+        WebviewHelper.launch(WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL(), with: self)
+    }
+
 }
 
 // MARK: - UITableViewDataSource
@@ -415,6 +450,15 @@ extension InPersonPaymentsMenuViewController: UITableViewDataSource {
 
         return cell
     }
+
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        guard section == sections.firstIndex(where: { $0 == cardReadersSection }) else {
+            return nil
+        }
+
+        return inPersonPaymentsLearnMoreButton
+    }
+
 }
 
 // MARK: - UITableViewDelegate
@@ -516,10 +560,32 @@ private extension InPersonPaymentsMenuViewController {
             "Continue setup",
             comment: "Call to Action to finish the setup of In-Person Payments in the Menu"
         )
+
+        static let learnMoreLink = NSLocalizedString(
+            "cardPresent.modalScanningForReader.learnMore.link",
+            value: "Learn more",
+            comment: """
+                     A label prompting users to learn more about In-Person Payments.
+                     This is the link to the website, and forms part of a longer sentence which it should be considered a part of.
+                     """
+        )
+
+        static let learnMoreText = NSLocalizedString(
+            "cardPresent.modalScanningForReader.learnMore.text",
+            value: "%1$@ about In‑Person Payments",
+            comment: """
+                     A label prompting users to learn more about In-Person Payments.
+                     The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                     If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it.
+                     %1$@ is a placeholder that always replaced with \"Learn more\" string,
+                     which should be translated separately and considered part of this sentence.
+                     """
+        )
+
     }
 }
 
-private struct Section {
+private struct Section: Equatable {
     let header: String
     let rows: [Row]
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -455,7 +455,7 @@ extension InPersonPaymentsMenuViewController: UITableViewDataSource {
         guard section == sections.firstIndex(where: { $0 == cardReadersSection }) else {
             return nil
         }
-        
+
         return inPersonPaymentsLearnMoreButton
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8397 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Before, we show "Learn More" about IPP links in the "Built-in reader support check" and "scanning for reader" alerts.

Apart from making these screens crowded, they only show for a short period, which makes it difficult to tap on the link. Furthermore, as explained in the original issue, the link in the "Built-in reader support check" screen does not interact well.

Because of that, we decided to move the links out of these alerts to the Payments Menu, where it is more visible and there are no interaction problems.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Menu
2. Go to Payments
3. Observe the Learn More Link below the Card Readers section
4. Check that tapping on it opens the link

<img src="https://user-images.githubusercontent.com/1864060/213749814-3f6eb7b6-8492-4b2d-9dd7-4d3207fde20f.PNG" width="375">

--

1. Go to Menu
2. Go to Payments
3. Tap on Collect Payment and follow the flow
5. Choose card to pay
6. Select Tap to Pay on iPhone
7. No links are displayed in the "Built-in reader support check" alert

<img src="https://user-images.githubusercontent.com/1864060/213751696-474e8d94-8cbf-4526-8d36-eab2e621f281.PNG" width="375">

--

1. Go to Menu
2. Go to Payments
3. Tap on Collect Payment and follow the flow
5. Choose card to pay
6. Select Bluetooth Reader
7. No links are displayed in the "Scanning for reader" alert

<img src="https://user-images.githubusercontent.com/1864060/213751840-5833d720-1843-4324-acfb-be0d6278aa18.PNG" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
