### PR TITLE
[REST API] Migrate product tags endpoints

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -806,6 +806,9 @@
 		EE57C137297F98DB00BC31E7 /* product-variations-load-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C136297F98DB00BC31E7 /* product-variations-load-all-without-data.json */; };
 		EE57C138297F9AC900BC31E7 /* ProductVariationsBulkUpdateMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C130297F97F900BC31E7 /* ProductVariationsBulkUpdateMapperTests.swift */; };
 		EE57C13A297F9EBE00BC31E7 /* ProductVariationsBulkCreateMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C139297F9EBE00BC31E7 /* ProductVariationsBulkCreateMapperTests.swift */; };
+		EE57C13C297FBECB00BC31E7 /* product-tags-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C13B297FBECB00BC31E7 /* product-tags-all-without-data.json */; };
+		EE57C13E297FBEE200BC31E7 /* product-tags-created-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C13D297FBEE200BC31E7 /* product-tags-created-without-data.json */; };
+		EE57C140297FBEFB00BC31E7 /* product-tags-deleted-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C13F297FBEFB00BC31E7 /* product-tags-deleted-without-data.json */; };
 		EE62EE61295ACF8D009C965B /* RequestConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE60295ACF8D009C965B /* RequestConverterTests.swift */; };
 		EE62EE63295AD45E009C965B /* String+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE62295AD45E009C965B /* String+URL.swift */; };
 		EE62EE65295AD46D009C965B /* String+URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE64295AD46D009C965B /* String+URLTests.swift */; };
@@ -1670,6 +1673,9 @@
 		EE57C133297F985A00BC31E7 /* product-variations-bulk-create-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variations-bulk-create-without-data.json"; sourceTree = "<group>"; };
 		EE57C136297F98DB00BC31E7 /* product-variations-load-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variations-load-all-without-data.json"; sourceTree = "<group>"; };
 		EE57C139297F9EBE00BC31E7 /* ProductVariationsBulkCreateMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsBulkCreateMapperTests.swift; sourceTree = "<group>"; };
+		EE57C13B297FBECB00BC31E7 /* product-tags-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-tags-all-without-data.json"; sourceTree = "<group>"; };
+		EE57C13D297FBEE200BC31E7 /* product-tags-created-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-tags-created-without-data.json"; sourceTree = "<group>"; };
+		EE57C13F297FBEFB00BC31E7 /* product-tags-deleted-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-tags-deleted-without-data.json"; sourceTree = "<group>"; };
 		EE62EE60295ACF8D009C965B /* RequestConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestConverterTests.swift; sourceTree = "<group>"; };
 		EE62EE62295AD45E009C965B /* String+URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+URL.swift"; sourceTree = "<group>"; };
 		EE62EE64295AD46D009C965B /* String+URLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+URLTests.swift"; sourceTree = "<group>"; };
@@ -2434,9 +2440,12 @@
 				45D685F923D0C3CF005F87D0 /* product-search-sku.json */,
 				EEA6583F2966C05D00112DF0 /* product-search-sku-without-data.json */,
 				4599FC5B24A6276F0056157A /* product-tags-all.json */,
+				EE57C13B297FBECB00BC31E7 /* product-tags-all-without-data.json */,
 				45AF57A824AB42CD0088E2F7 /* product-tags-extra.json */,
 				45AB8B0E24AA29DC00B5B36E /* product-tags-created.json */,
+				EE57C13D297FBEE200BC31E7 /* product-tags-created-without-data.json */,
 				45AB8B1224AA34CB00B5B36E /* product-tags-deleted.json */,
+				EE57C13F297FBEFB00BC31E7 /* product-tags-deleted-without-data.json */,
 				45AB8B1F24AB3E1F00B5B36E /* product-tags-empty.json */,
 				CEC4BF90234E40B5008D9195 /* refund-single.json */,
 				CEC4BF92234E7EE0008D9195 /* refunds-all.json */,
@@ -3122,6 +3131,7 @@
 				E137619929151C7400FD098F /* error-wp-rest-forbidden.json in Resources */,
 				31A451CE27863A2E00FE81AA /* stripe-account-wrong-json.json in Resources */,
 				26BD9FCD2965EC3C004E0D15 /* product-variations-bulk-create.json in Resources */,
+				EE57C13C297FBECB00BC31E7 /* product-tags-all-without-data.json in Resources */,
 				028CB718290223CB00331C09 /* account-username-suggestions.json in Resources */,
 				0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */,
 				DEC2B093297AA60D003923FB /* category-without-data.json in Resources */,
@@ -3131,6 +3141,7 @@
 				743E84FC22174CE100FAC9D7 /* restnoroute_error.json in Resources */,
 				CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */,
 				D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */,
+				EE57C140297FBEFB00BC31E7 /* product-tags-deleted-without-data.json in Resources */,
 				02B41A92296BEB3000FE3311 /* load-site-current-plan-success.json in Resources */,
 				02EF1672292F0D1900D90AD6 /* load-plan-success.json in Resources */,
 				DEA6B1C6296C13FB005AA5E9 /* payment-gateway-list-without-data.json in Resources */,
@@ -3323,6 +3334,7 @@
 				A69FE19D2588D70E0059A96B /* order-with-deleted-refunds.json in Resources */,
 				E18152C228F85E0A0011A0EC /* iap-products.json in Resources */,
 				02B41A90296BC85800FE3311 /* site-domains.json in Resources */,
+				EE57C13E297FBEE200BC31E7 /* product-tags-created-without-data.json in Resources */,
 				EEA658462966C67C00112DF0 /* products-ids-only-without-data.json in Resources */,
 				DE2095C127966EC800171F1C /* coupon-reports.json in Resources */,
 				453305F52459ED2700264E50 /* site-post-update.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -809,6 +809,10 @@
 		EE57C13C297FBECB00BC31E7 /* product-tags-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C13B297FBECB00BC31E7 /* product-tags-all-without-data.json */; };
 		EE57C13E297FBEE200BC31E7 /* product-tags-created-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C13D297FBEE200BC31E7 /* product-tags-created-without-data.json */; };
 		EE57C140297FBEFB00BC31E7 /* product-tags-deleted-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C13F297FBEFB00BC31E7 /* product-tags-deleted-without-data.json */; };
+		EE57C143297FCCA700BC31E7 /* product-shipping-classes-load-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C141297FCCA700BC31E7 /* product-shipping-classes-load-all-without-data.json */; };
+		EE57C144297FCCA700BC31E7 /* product-shipping-classes-load-one-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C142297FCCA700BC31E7 /* product-shipping-classes-load-one-without-data.json */; };
+		EE57C146297FCCD200BC31E7 /* ProductShippingClassListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C145297FCCD200BC31E7 /* ProductShippingClassListMapperTests.swift */; };
+		EE57C148297FCCE000BC31E7 /* ProductShippingClassMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C147297FCCE000BC31E7 /* ProductShippingClassMapperTests.swift */; };
 		EE62EE61295ACF8D009C965B /* RequestConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE60295ACF8D009C965B /* RequestConverterTests.swift */; };
 		EE62EE63295AD45E009C965B /* String+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE62295AD45E009C965B /* String+URL.swift */; };
 		EE62EE65295AD46D009C965B /* String+URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE64295AD46D009C965B /* String+URLTests.swift */; };
@@ -1676,6 +1680,10 @@
 		EE57C13B297FBECB00BC31E7 /* product-tags-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-tags-all-without-data.json"; sourceTree = "<group>"; };
 		EE57C13D297FBEE200BC31E7 /* product-tags-created-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-tags-created-without-data.json"; sourceTree = "<group>"; };
 		EE57C13F297FBEFB00BC31E7 /* product-tags-deleted-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-tags-deleted-without-data.json"; sourceTree = "<group>"; };
+		EE57C141297FCCA700BC31E7 /* product-shipping-classes-load-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-shipping-classes-load-all-without-data.json"; sourceTree = "<group>"; };
+		EE57C142297FCCA700BC31E7 /* product-shipping-classes-load-one-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-shipping-classes-load-one-without-data.json"; sourceTree = "<group>"; };
+		EE57C145297FCCD200BC31E7 /* ProductShippingClassListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingClassListMapperTests.swift; sourceTree = "<group>"; };
+		EE57C147297FCCE000BC31E7 /* ProductShippingClassMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingClassMapperTests.swift; sourceTree = "<group>"; };
 		EE62EE60295ACF8D009C965B /* RequestConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestConverterTests.swift; sourceTree = "<group>"; };
 		EE62EE62295AD45E009C965B /* String+URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+URL.swift"; sourceTree = "<group>"; };
 		EE62EE64295AD46D009C965B /* String+URLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+URLTests.swift"; sourceTree = "<group>"; };
@@ -2408,6 +2416,8 @@
 				4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */,
 				025CA2C7238F4FF400B05C81 /* product-shipping-classes-load-all.json */,
 				020220E123966CD900290165 /* product-shipping-classes-load-one.json */,
+				EE57C141297FCCA700BC31E7 /* product-shipping-classes-load-all-without-data.json */,
+				EE57C142297FCCA700BC31E7 /* product-shipping-classes-load-one-without-data.json */,
 				457FC68B2382B2FD00B41B02 /* product-update.json */,
 				AEA056E3296DBA6E00948D52 /* products-batch-update.json */,
 				45152818257A84A60076B03C /* product-attributes-all.json */,
@@ -2770,6 +2780,8 @@
 				45D685FB23D0C739005F87D0 /* ProductSkuMapperTests.swift */,
 				4599FC5924A626B70056157A /* ProductTagListMapperTests.swift */,
 				CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */,
+				EE57C145297FCCD200BC31E7 /* ProductShippingClassListMapperTests.swift */,
+				EE57C147297FCCE000BC31E7 /* ProductShippingClassMapperTests.swift */,
 				CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */,
 				7412A8ED21B6E335005D182A /* ReportOrderMapperTests.swift */,
 				743E84F722172E1F00FAC9D7 /* ShipmentTrackingListMapperTests.swift */,
@@ -3130,6 +3142,7 @@
 				DE66C55F2977C67D00DAA978 /* shipping-label-account-settings-without-data.json in Resources */,
 				E137619929151C7400FD098F /* error-wp-rest-forbidden.json in Resources */,
 				31A451CE27863A2E00FE81AA /* stripe-account-wrong-json.json in Resources */,
+				EE57C143297FCCA700BC31E7 /* product-shipping-classes-load-all-without-data.json in Resources */,
 				26BD9FCD2965EC3C004E0D15 /* product-variations-bulk-create.json in Resources */,
 				EE57C13C297FBECB00BC31E7 /* product-tags-all-without-data.json in Resources */,
 				028CB718290223CB00331C09 /* account-username-suggestions.json in Resources */,
@@ -3228,6 +3241,7 @@
 				B5C6FCD620A3768900A4F8E4 /* order.json in Resources */,
 				3158FE7426129D9F00E566B9 /* wcpay-account-rejected-other.json in Resources */,
 				CC0786C7267BB10700BA9AC1 /* shipping-label-status-success.json in Resources */,
+				EE57C144297FCCA700BC31E7 /* product-shipping-classes-load-one-without-data.json in Resources */,
 				028CB71B290224D700331C09 /* create-account-error-username.json in Resources */,
 				EEA6583E2966B41E00112DF0 /* products-load-all-without-data.json in Resources */,
 				68F48B1328E3E5750045C15B /* wc-analytics-customers.json in Resources */,
@@ -3898,6 +3912,7 @@
 				03DCB7442624AD9B00C8953D /* CouponListMapperTests.swift in Sources */,
 				AE2D6623272A8F6E004A2C3A /* TelemetryRemoteTests.swift in Sources */,
 				B5C151C0217EE3FB00C7BDC1 /* NoteListMapperTests.swift in Sources */,
+				EE57C146297FCCD200BC31E7 /* ProductShippingClassListMapperTests.swift in Sources */,
 				026CF622237D7E61009563D4 /* ProductVariationsRemoteTests.swift in Sources */,
 				DEC51A99274DDDC9009F3DF4 /* SitePluginMapperTests.swift in Sources */,
 				EEFAA581295D78E9003583BE /* AuthenticatedRESTRequestTests.swift in Sources */,
@@ -3967,6 +3982,7 @@
 				CC07866526790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift in Sources */,
 				74002D6A2118B26100A63C19 /* SiteVisitStatsMapperTests.swift in Sources */,
 				743E84FA221742E300FAC9D7 /* ShipmentsRemoteTests.swift in Sources */,
+				EE57C148297FCCE000BC31E7 /* ProductShippingClassMapperTests.swift in Sources */,
 				03DCB7822627394500C8953D /* CouponMapperTests.swift in Sources */,
 				03DCB76C262591C400C8953D /* CouponsRemoteTests.swift in Sources */,
 				31A451BD2786344B00FE81AA /* StripeRemoteTests.swift in Sources */,

--- a/Networking/Networking/Mapper/ProductShippingClassListMapper.swift
+++ b/Networking/Networking/Mapper/ProductShippingClassListMapper.swift
@@ -17,7 +17,11 @@ struct ProductShippingClassListMapper: Mapper {
             .siteID: siteID
         ]
 
-        return try decoder.decode(ProductShippingClassListEnvelope.self, from: response).data
+        do {
+            return try decoder.decode(ProductShippingClassListEnvelope.self, from: response).data
+        } catch {
+            return try decoder.decode([ProductShippingClass].self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Mapper/ProductShippingClassMapper.swift
+++ b/Networking/Networking/Mapper/ProductShippingClassMapper.swift
@@ -17,7 +17,11 @@ struct ProductShippingClassMapper: Mapper {
             .siteID: siteID
         ]
 
-        return try decoder.decode(ProductShippingClassEnvelope.self, from: response).productShippingClass
+        do {
+            return try decoder.decode(ProductShippingClassEnvelope.self, from: response).productShippingClass
+        } catch {
+            return try decoder.decode(ProductShippingClass.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Remote/ProductShippingClassRemote.swift
+++ b/Networking/Networking/Remote/ProductShippingClassRemote.swift
@@ -26,7 +26,12 @@ public class ProductShippingClassRemote: Remote {
         ]
 
         let path = "\(Path.models)"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
         let mapper = ProductShippingClassListMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -41,7 +46,12 @@ public class ProductShippingClassRemote: Remote {
     ///
     public func loadOne(for siteID: Int64, remoteID: Int64, completion: @escaping (ProductShippingClass?, Error?) -> Void) {
         let path = "\(Path.models)/\(remoteID)"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true)
         let mapper = ProductShippingClassMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/Networking/Remote/ProductTagsRemote.swift
+++ b/Networking/Networking/Remote/ProductTagsRemote.swift
@@ -25,7 +25,12 @@ public final class ProductTagsRemote: Remote {
         ]
 
         let path = Path.tags
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
         let mapper = ProductTagListMapper(siteID: siteID, responseType: .load)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -47,7 +52,12 @@ public final class ProductTagsRemote: Remote {
         ]
 
         let path = Path.tagsBatch
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
         let mapper = ProductTagListMapper(siteID: siteID, responseType: .create)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -69,7 +79,12 @@ public final class ProductTagsRemote: Remote {
         ]
 
         let path = Path.tagsBatch
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
         let mapper = ProductTagListMapper(siteID: siteID, responseType: .delete)
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/NetworkingTests/Mapper/ProductShippingClassListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductShippingClassListMapperTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import Networking
+
+/// Unit Tests for `ProductShippingClassListMapper`
+///
+final class ProductShippingClassListMapperTests: XCTestCase {
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 33334444
+
+    /// Verifies that all of the ProductShippingClass Fields are parsed correctly.
+    ///
+    func test_ProductShippingClass_fields_are_properly_parsed() throws {
+        let productVariation = try XCTUnwrap(mapLoadAllProductShippingClassResponse()?.first)
+
+        let expected = ProductShippingClass(count: 3,
+                                            descriptionHTML: "Limited offer!",
+                                            name: "Free Shipping",
+                                            shippingClassID: 94,
+                                            siteID: dummySiteID,
+                                            slug: "free-shipping")
+
+        XCTAssertEqual(productVariation, expected)
+    }
+
+    /// Verifies that all of the ProductShippingClass Fields are parsed correctly when response has no data envelope.
+    ///
+    func test_ProductShippingClass_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
+        let productVariation = try XCTUnwrap(mapLoadAllProductShippingClassResponseWithoutDataEnvelope()?.first)
+
+        let expected = ProductShippingClass(count: 3,
+                                            descriptionHTML: "Limited offer!",
+                                            name: "Free Shipping",
+                                            shippingClassID: 94,
+                                            siteID: dummySiteID,
+                                            slug: "free-shipping")
+
+        XCTAssertEqual(productVariation, expected)
+    }
+}
+
+/// Private Helpers
+///
+private extension ProductShippingClassListMapperTests {
+    /// Returns the ProductShippingClassListMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapProductShippingClass(from filename: String) -> [ProductShippingClass]? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try? ProductShippingClassListMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    /// Returns the ProductShippingClassListMapper output upon receiving `product-shipping-classes-load-all`
+    ///
+    func mapLoadAllProductShippingClassResponse() -> [ProductShippingClass]? {
+        return mapProductShippingClass(from: "product-shipping-classes-load-all")
+    }
+
+    /// Returns the ProductShippingClassListMapper output upon receiving `product-shipping-classes-load-all-without-data`
+    ///
+    func mapLoadAllProductShippingClassResponseWithoutDataEnvelope() -> [ProductShippingClass]? {
+        return mapProductShippingClass(from: "product-shipping-classes-load-all-without-data")
+    }
+}

--- a/Networking/NetworkingTests/Mapper/ProductShippingClassMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductShippingClassMapperTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import Networking
+
+/// Unit Tests for `ProductShippingClassMapper`
+///
+final class ProductShippingClassMapperTests: XCTestCase {
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 33334444
+
+    /// Verifies that all of the ProductShippingClass Fields are parsed correctly.
+    ///
+    func test_ProductShippingClass_fields_are_properly_parsed() throws {
+        let productVariation = try XCTUnwrap(mapLoadProductShippingClassResponse())
+
+        let expected = ProductShippingClass(count: 3,
+                                            descriptionHTML: "Limited offer!",
+                                            name: "Free Shipping",
+                                            shippingClassID: 94,
+                                            siteID: dummySiteID,
+                                            slug: "free-shipping")
+
+        XCTAssertEqual(productVariation, expected)
+    }
+
+    /// Verifies that all of the ProductShippingClass Fields are parsed correctly when response has no data envelope.
+    ///
+    func test_ProductShippingClass_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
+        let productVariation = try XCTUnwrap(mapLoadProductShippingClassResponseWithoutDataEnvelope())
+
+        let expected = ProductShippingClass(count: 3,
+                                            descriptionHTML: "Limited offer!",
+                                            name: "Free Shipping",
+                                            shippingClassID: 94,
+                                            siteID: dummySiteID,
+                                            slug: "free-shipping")
+
+        XCTAssertEqual(productVariation, expected)
+    }
+}
+
+/// Private Helpers
+///
+private extension ProductShippingClassMapperTests {
+    /// Returns the ProductShippingClassMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapProductShippingClass(from filename: String) -> ProductShippingClass? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try? ProductShippingClassMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    /// Returns the ProductShippingClassMapper output upon receiving `product-shipping-classes-load-one`
+    ///
+    func mapLoadProductShippingClassResponse() -> ProductShippingClass? {
+        return mapProductShippingClass(from: "product-shipping-classes-load-one")
+    }
+
+    /// Returns the ProductShippingClassMapper output upon receiving `product-shipping-classes-load-one-without-data`
+    ///
+    func mapLoadProductShippingClassResponseWithoutDataEnvelope() -> ProductShippingClass? {
+        return mapProductShippingClass(from: "product-shipping-classes-load-one-without-data")
+    }
+}

--- a/Networking/NetworkingTests/Mapper/ProductTagListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductTagListMapperTests.swift
@@ -18,6 +18,18 @@ final class ProductTagListMapperTests: XCTestCase {
         XCTAssertEqual(secondTag.slug, "oxford-shoes")
     }
 
+    /// Verifies that all of the ProductTag Fields are parsed correctly.
+    ///
+    func test_ProductTag_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
+        let tags = try mapLoadAllProductTagsResponseWithoutDataEnvelope()
+        XCTAssertEqual(tags.count, 4)
+
+        let secondTag = tags[1]
+        XCTAssertEqual(secondTag.tagID, 35)
+        XCTAssertEqual(secondTag.name, "Oxford Shoes")
+        XCTAssertEqual(secondTag.slug, "oxford-shoes")
+    }
+
     /// Verifies that all of the ProductTag Fields under `create` field are parsed correctly.
     ///
     func test_ProductTag_fields_when_created_are_properly_parsed() throws {
@@ -30,10 +42,34 @@ final class ProductTagListMapperTests: XCTestCase {
         XCTAssertEqual(firstTag.slug, "round-toe")
     }
 
+    /// Verifies that all of the ProductTag Fields under `create` field are parsed correctly.
+    ///
+    func test_ProductTag_fields_when_created_are_properly_parsed_when_response_has_no_data_envelope() throws {
+        let tags = try mapLoadProductTagsCreatedResponseWithoutDataEnvelope()
+        XCTAssertEqual(tags.count, 2)
+
+        let firstTag = tags[0]
+        XCTAssertEqual(firstTag.tagID, 36)
+        XCTAssertEqual(firstTag.name, "Round toe")
+        XCTAssertEqual(firstTag.slug, "round-toe")
+    }
+
     /// Verifies that all of the ProductTag Fields under `delete` field are parsed correctly.
     ///
     func test_ProductTag_fields_when_deleted_are_properly_parsed() throws {
         let tags = try mapLoadProductTagsDeletedResponse()
+        XCTAssertEqual(tags.count, 1)
+
+        let firstTag = tags[0]
+        XCTAssertEqual(firstTag.tagID, 35)
+        XCTAssertEqual(firstTag.name, "Oxford Shoes")
+        XCTAssertEqual(firstTag.slug, "oxford-shoes")
+    }
+
+    /// Verifies that all of the ProductTag Fields under `delete` field are parsed correctly.
+    ///
+    func test_ProductTag_fields_when_deleted_are_properly_parsed_when_response_has_no_data_envelope() throws {
+        let tags = try mapLoadProductTagsDeletedResponseWithoutDataEnvelope()
         XCTAssertEqual(tags.count, 1)
 
         let firstTag = tags[0]
@@ -64,15 +100,33 @@ private extension ProductTagListMapperTests {
         return try mapProductTags(from: "product-tags-all", responseType: .load)
     }
 
+    /// Returns the ProductTagListMapper output upon receiving `product-tags-all-without-data`
+    ///
+    func mapLoadAllProductTagsResponseWithoutDataEnvelope() throws -> [ProductTag] {
+        return try mapProductTags(from: "product-tags-all-without-data", responseType: .load)
+    }
+
     /// Returns the ProductTagListMapper output upon receiving `product-tags-created`
     ///
     func mapLoadProductTagsCreatedResponse() throws -> [ProductTag] {
         return try mapProductTags(from: "product-tags-created", responseType: .create)
     }
 
+    /// Returns the ProductTagListMapper output upon receiving `product-tags-created-without-data`
+    ///
+    func mapLoadProductTagsCreatedResponseWithoutDataEnvelope() throws -> [ProductTag] {
+        return try mapProductTags(from: "product-tags-created-without-data", responseType: .create)
+    }
+
     /// Returns the ProductTagListMapper output upon receiving `product-tags-deleted`
     ///
     func mapLoadProductTagsDeletedResponse() throws -> [ProductTag] {
         return try mapProductTags(from: "product-tags-deleted", responseType: .delete)
+    }
+
+    /// Returns the ProductTagListMapper output upon receiving `product-tags-deleted-without-data`
+    ///
+    func mapLoadProductTagsDeletedResponseWithoutDataEnvelope() throws -> [ProductTag] {
+        return try mapProductTags(from: "product-tags-deleted-without-data", responseType: .delete)
     }
 }

--- a/Networking/NetworkingTests/Responses/product-shipping-classes-load-all-without-data.json
+++ b/Networking/NetworkingTests/Responses/product-shipping-classes-load-all-without-data.json
@@ -1,0 +1,59 @@
+[
+    {
+        "id": 94,
+        "name": "Free Shipping",
+        "slug": "free-shipping",
+        "description": "Limited offer!",
+        "count": 3,
+        "_links": {
+            "self": [
+                {
+                    "href": "https://shop.com/shipping_classes/94"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://shop.com/wp-json/wc/v3/products/shipping_classes"
+                }
+            ]
+        }
+    },
+    {
+        "id": 66,
+        "name": "Full Product Size",
+        "slug": "full-product-size",
+        "description": "",
+        "count": 1,
+        "_links": {
+            "self": [
+                {
+                    "href": "https://shop.com/wp-json/wc/v3/products/shipping_classes/66"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://shop.com/wp-json/wc/v3/products/shipping_classes"
+                }
+            ]
+        }
+    },
+    {
+        "id": 95,
+        "name": "Machine Shipping",
+        "slug": "machine-shipping",
+        "description": "",
+        "count": 0,
+        "_links": {
+            "self": [
+                {
+                    "href": "https://shop.com/wp-json/wc/v3/products/shipping_classes/95"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://shop.com/wp-json/wc/v3/products/shipping_classes"
+                }
+            ]
+        }
+    }
+]

--- a/Networking/NetworkingTests/Responses/product-shipping-classes-load-one-without-data.json
+++ b/Networking/NetworkingTests/Responses/product-shipping-classes-load-one-without-data.json
@@ -1,0 +1,19 @@
+{
+    "id": 94,
+    "name": "Free Shipping",
+    "slug": "free-shipping",
+    "description": "Limited offer!",
+    "count": 3,
+    "_links": {
+        "self": [
+            {
+                "href": "https://shop.com/shipping_classes/94"
+            }
+        ],
+        "collection": [
+            {
+                "href": "https://shop.com/wp-json/wc/v3/products/shipping_classes"
+            }
+        ]
+    }
+}

--- a/Networking/NetworkingTests/Responses/product-tags-all-without-data.json
+++ b/Networking/NetworkingTests/Responses/product-tags-all-without-data.json
@@ -1,0 +1,78 @@
+[
+  {
+    "id": 34,
+    "name": "Leather Shoes",
+    "slug": "leather-shoes",
+    "description": "",
+    "count": 0,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/tags/34"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/tags"
+        }
+      ]
+    }
+  },
+  {
+    "id": 35,
+    "name": "Oxford Shoes",
+    "slug": "oxford-shoes",
+    "description": "",
+    "count": 0,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/tags/35"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/tags"
+        }
+      ]
+    }
+  },
+  {
+    "id": 14,
+    "name": "Leather Boots",
+    "slug": "leather-boots",
+    "description": "",
+    "count": 0,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/tags/14"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/tags"
+        }
+      ]
+    }
+  },
+  {
+    "id": 15,
+    "name": "Sneakers",
+    "slug": "sneakers",
+    "description": "A shoe suitable for playing sports",
+    "count": 0,
+    "_links": {
+      "self": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/tags/15"
+        }
+      ],
+      "collection": [
+        {
+          "href": "https://example.com/wp-json/wc/v3/products/tags"
+        }
+      ]
+    }
+  }
+]

--- a/Networking/NetworkingTests/Responses/product-tags-created-without-data.json
+++ b/Networking/NetworkingTests/Responses/product-tags-created-without-data.json
@@ -1,0 +1,42 @@
+{
+  "create": [
+    {
+      "id": 36,
+      "name": "Round toe",
+      "slug": "round-toe",
+      "description": "",
+      "count": 0,
+      "_links": {
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/tags/36"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/tags"
+          }
+        ]
+      }
+    },
+    {
+      "id": 37,
+      "name": "Flat",
+      "slug": "flat",
+      "description": "",
+      "count": 0,
+      "_links": {
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/tags/37"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/tags"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Networking/NetworkingTests/Responses/product-tags-deleted-without-data.json
+++ b/Networking/NetworkingTests/Responses/product-tags-deleted-without-data.json
@@ -1,0 +1,23 @@
+{
+  "delete": [
+    {
+      "id": 35,
+      "name": "Oxford Shoes",
+      "slug": "oxford-shoes",
+      "description": "",
+      "count": 0,
+      "_links": {
+        "self": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/tags/35"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://example.com/wp-json/wc/v3/products/tags"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8715 

## Description
This PR migrates the product tags endpoints and updates the related mappers to parse contents without the data envelope.


## Testing instructions
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address and proceed with the address of a self-hosted store.
- Log in with your site credentials. After the login succeeds, you should be navigated to the home screen.
- Navigate to the Products and open a Product.
- Tap on "Add more details" -> "Tags" and try adding Tags
- You should be able to add/edit tags to products as before.

Note: 
I apologize for the 500+ changes. The changes related to shipping class have been reviewed and tested in [a child PR](https://github.com/woocommerce/woocommerce-ios/pull/8739). I accidentally merged the child PR before merging this PR. There is no testing needed for the changes related to shipping class.

## Screenshots
<img src="https://user-images.githubusercontent.com/524475/214238138-b1e417f2-708f-40bc-9318-ca7334924aad.png" width="320">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
