### PR TITLE
Issue/8397 ipp learn more link payment methods

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -20,6 +20,8 @@ final class InPersonPaymentsMenuViewController: UIViewController {
                             countryCode: viewModel.cardPresentPaymentsConfiguration.countryCode))
     }()
 
+    private lazy var inPersonPaymentsLearnMoreViewModel = LearnMoreViewModel.InPersonPayments()
+
     private let viewModel: InPersonPaymentsMenuViewModel = InPersonPaymentsMenuViewModel()
 
     private let cashOnDeliveryToggleRowViewModel: InPersonPaymentsCashOnDeliveryToggleRowViewModel
@@ -41,30 +43,10 @@ final class InPersonPaymentsMenuViewController: UIViewController {
 
     private var activityIndicator: UIActivityIndicatorView?
 
-    private var inPersonPaymentsLearnMoreButtonTitle: NSAttributedString? {
-        let result = NSMutableAttributedString(
-            string: .localizedStringWithFormat(
-                Localization.learnMoreText,
-                Localization.learnMoreLink
-            ),
-            attributes: [.foregroundColor: UIColor.textSubtle]
-        )
-        result.replaceFirstOccurrence(
-            of: Localization.learnMoreLink,
-            with: NSAttributedString(
-                string: Localization.learnMoreLink,
-                attributes: [
-                    .foregroundColor: UIColor.textLink
-                ]
-            ))
-        result.addAttribute(.font, value: UIFont.footnote, range: NSRange(location: 0, length: result.length))
-        return result
-    }
-
     private var inPersonPaymentsLearnMoreButton: UIButton {
         let button = UIButton()
         button.addTarget(self, action: #selector(learnMoreAboutInPersonPaymentsButtonWasTapped), for: .touchUpInside)
-        button.setAttributedTitle(inPersonPaymentsLearnMoreButtonTitle, for: .normal)
+        button.setAttributedTitle(inPersonPaymentsLearnMoreViewModel.learnMoreAttributedString, for: .normal)
         button.naturalContentHorizontalAlignment = .leading
         button.configuration = UIButton.Configuration.plain()
 
@@ -424,7 +406,7 @@ extension InPersonPaymentsMenuViewController {
     }
 
     @objc func learnMoreAboutInPersonPaymentsButtonWasTapped() {
-        WebviewHelper.launch(WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL(), with: self)
+        WebviewHelper.launch(inPersonPaymentsLearnMoreViewModel.url, with: self)
     }
 
 }
@@ -568,19 +550,6 @@ private extension InPersonPaymentsMenuViewController {
                      This is the link to the website, and forms part of a longer sentence which it should be considered a part of.
                      """
         )
-
-        static let learnMoreText = NSLocalizedString(
-            "cardPresent.modalScanningForReader.learnMore.text",
-            value: "%1$@ about In‑Person Payments",
-            comment: """
-                     A label prompting users to learn more about In-Person Payments.
-                     The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
-                     If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it.
-                     %1$@ is a placeholder that always replaced with \"Learn more\" string,
-                     which should be translated separately and considered part of this sentence.
-                     """
-        )
-
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -20,7 +20,7 @@ final class InPersonPaymentsMenuViewController: UIViewController {
                             countryCode: viewModel.cardPresentPaymentsConfiguration.countryCode))
     }()
 
-    private lazy var inPersonPaymentsLearnMoreViewModel = LearnMoreViewModel.InPersonPayments()
+    private lazy var inPersonPaymentsLearnMoreViewModel = LearnMoreViewModel.inPersonPayments()
 
     private let viewModel: InPersonPaymentsMenuViewModel = InPersonPaymentsMenuViewModel()
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/LearnMoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/LearnMoreViewModel.swift
@@ -63,4 +63,24 @@ private enum Localization {
                  which should be translated separately and considered part of this sentence.
                  """
     )
+
+    static let inPersonPaymentslearnMoreText = NSLocalizedString(
+        "cardPresent.modalScanningForReader.learnMore.text",
+        value: "%1$@ about In‑Person Payments",
+        comment: """
+                 A label prompting users to learn more about In-Person Payments.
+                 The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
+                 If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it.
+                 %1$@ is a placeholder that always replaced with \"Learn more\" string,
+                 which should be translated separately and considered part of this sentence.
+                 """
+    )
+}
+
+extension LearnMoreViewModel {
+    static func InPersonPayments() -> LearnMoreViewModel {
+        LearnMoreViewModel(url: WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL(),
+                           linkText: Localization.learnMoreLink,
+                           formatText: Localization.inPersonPaymentslearnMoreText)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/LearnMoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/LearnMoreViewModel.swift
@@ -78,7 +78,7 @@ private enum Localization {
 }
 
 extension LearnMoreViewModel {
-    static func InPersonPayments() -> LearnMoreViewModel {
+    static func inPersonPayments() -> LearnMoreViewModel {
         LearnMoreViewModel(url: WooConstants.URLs.inPersonPaymentsLearnMoreWCPay.asURL(),
                            linkText: Localization.learnMoreLink,
                            formatText: Localization.inPersonPaymentslearnMoreText)

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -23,6 +23,8 @@ struct PaymentMethodsView: View {
 
     @State private var showingPurchaseCardReaderView = false
 
+    private let learnMoreViewModel = LearnMoreViewModel.InPersonPayments()
+
     ///   Environment safe areas
     ///
     @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
@@ -86,6 +88,10 @@ struct PaymentMethodsView: View {
                         })
                         .padding(.horizontal, insets: safeAreaInsets)
                         .background(Color(.listForeground(modal: false)))
+                    }
+
+                    NavigationLink(destination: WebView(isPresented: .constant(true), url: learnMoreViewModel.url)) {
+                        AttributedText(learnMoreViewModel.learnMoreAttributedString)
                     }
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -23,7 +23,7 @@ struct PaymentMethodsView: View {
 
     @State private var showingPurchaseCardReaderView = false
 
-    private let learnMoreViewModel = LearnMoreViewModel.InPersonPayments()
+    private let learnMoreViewModel = LearnMoreViewModel.inPersonPayments()
 
     ///   Environment safe areas
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -92,7 +92,7 @@ struct PaymentMethodsView: View {
 
                     NavigationLink(destination: WebView(isPresented: .constant(true), url: learnMoreViewModel.url)) {
                         AttributedText(learnMoreViewModel.learnMoreAttributedString)
-                    }
+                    }.padding(.horizontal)
                 }
 
                 // Pushes content to the top


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8397 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In https://github.com/woocommerce/woocommerce-ios/pull/8724 we moved the IPP Learn more Link from the loading alerts to the Payments Menu. After some discussion in pdfdoF-2eL-p2 we realized that we were missing some cases, that are covered by adding the link in our Payment Methods screen. This is done here.
Furthermore, we take advantage of this PR to refactor how the Learn More link is rendered in the Payments Menu and Methods screens, in order to reuse the component.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Menu
2. Tap on Payments
3. Tap on Collect Payment
4. Follow the flow until Payment Methods
5. Note that the Learn More link is there
6. Tap on it; a web view is opened with the IPP content

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/1864060/214320714-fdba095c-7b5d-4454-82ae-b242c4fec735.mp4

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.