### PR TITLE
[REST API] Migrate product shipping class endpoints

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -809,6 +809,10 @@
 		EE57C13C297FBECB00BC31E7 /* product-tags-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C13B297FBECB00BC31E7 /* product-tags-all-without-data.json */; };
 		EE57C13E297FBEE200BC31E7 /* product-tags-created-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C13D297FBEE200BC31E7 /* product-tags-created-without-data.json */; };
 		EE57C140297FBEFB00BC31E7 /* product-tags-deleted-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C13F297FBEFB00BC31E7 /* product-tags-deleted-without-data.json */; };
+		EE57C143297FCCA700BC31E7 /* product-shipping-classes-load-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C141297FCCA700BC31E7 /* product-shipping-classes-load-all-without-data.json */; };
+		EE57C144297FCCA700BC31E7 /* product-shipping-classes-load-one-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE57C142297FCCA700BC31E7 /* product-shipping-classes-load-one-without-data.json */; };
+		EE57C146297FCCD200BC31E7 /* ProductShippingClassListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C145297FCCD200BC31E7 /* ProductShippingClassListMapperTests.swift */; };
+		EE57C148297FCCE000BC31E7 /* ProductShippingClassMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C147297FCCE000BC31E7 /* ProductShippingClassMapperTests.swift */; };
 		EE62EE61295ACF8D009C965B /* RequestConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE60295ACF8D009C965B /* RequestConverterTests.swift */; };
 		EE62EE63295AD45E009C965B /* String+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE62295AD45E009C965B /* String+URL.swift */; };
 		EE62EE65295AD46D009C965B /* String+URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE62EE64295AD46D009C965B /* String+URLTests.swift */; };
@@ -1676,6 +1680,10 @@
 		EE57C13B297FBECB00BC31E7 /* product-tags-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-tags-all-without-data.json"; sourceTree = "<group>"; };
 		EE57C13D297FBEE200BC31E7 /* product-tags-created-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-tags-created-without-data.json"; sourceTree = "<group>"; };
 		EE57C13F297FBEFB00BC31E7 /* product-tags-deleted-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-tags-deleted-without-data.json"; sourceTree = "<group>"; };
+		EE57C141297FCCA700BC31E7 /* product-shipping-classes-load-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-shipping-classes-load-all-without-data.json"; sourceTree = "<group>"; };
+		EE57C142297FCCA700BC31E7 /* product-shipping-classes-load-one-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-shipping-classes-load-one-without-data.json"; sourceTree = "<group>"; };
+		EE57C145297FCCD200BC31E7 /* ProductShippingClassListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingClassListMapperTests.swift; sourceTree = "<group>"; };
+		EE57C147297FCCE000BC31E7 /* ProductShippingClassMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingClassMapperTests.swift; sourceTree = "<group>"; };
 		EE62EE60295ACF8D009C965B /* RequestConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestConverterTests.swift; sourceTree = "<group>"; };
 		EE62EE62295AD45E009C965B /* String+URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+URL.swift"; sourceTree = "<group>"; };
 		EE62EE64295AD46D009C965B /* String+URLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+URLTests.swift"; sourceTree = "<group>"; };
@@ -2408,6 +2416,8 @@
 				4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */,
 				025CA2C7238F4FF400B05C81 /* product-shipping-classes-load-all.json */,
 				020220E123966CD900290165 /* product-shipping-classes-load-one.json */,
+				EE57C141297FCCA700BC31E7 /* product-shipping-classes-load-all-without-data.json */,
+				EE57C142297FCCA700BC31E7 /* product-shipping-classes-load-one-without-data.json */,
 				457FC68B2382B2FD00B41B02 /* product-update.json */,
 				AEA056E3296DBA6E00948D52 /* products-batch-update.json */,
 				45152818257A84A60076B03C /* product-attributes-all.json */,
@@ -2770,6 +2780,8 @@
 				45D685FB23D0C739005F87D0 /* ProductSkuMapperTests.swift */,
 				4599FC5924A626B70056157A /* ProductTagListMapperTests.swift */,
 				CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */,
+				EE57C145297FCCD200BC31E7 /* ProductShippingClassListMapperTests.swift */,
+				EE57C147297FCCE000BC31E7 /* ProductShippingClassMapperTests.swift */,
 				CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */,
 				7412A8ED21B6E335005D182A /* ReportOrderMapperTests.swift */,
 				743E84F722172E1F00FAC9D7 /* ShipmentTrackingListMapperTests.swift */,
@@ -3130,6 +3142,7 @@
 				DE66C55F2977C67D00DAA978 /* shipping-label-account-settings-without-data.json in Resources */,
 				E137619929151C7400FD098F /* error-wp-rest-forbidden.json in Resources */,
 				31A451CE27863A2E00FE81AA /* stripe-account-wrong-json.json in Resources */,
+				EE57C143297FCCA700BC31E7 /* product-shipping-classes-load-all-without-data.json in Resources */,
 				26BD9FCD2965EC3C004E0D15 /* product-variations-bulk-create.json in Resources */,
 				EE57C13C297FBECB00BC31E7 /* product-tags-all-without-data.json in Resources */,
 				028CB718290223CB00331C09 /* account-username-suggestions.json in Resources */,
@@ -3228,6 +3241,7 @@
 				B5C6FCD620A3768900A4F8E4 /* order.json in Resources */,
 				3158FE7426129D9F00E566B9 /* wcpay-account-rejected-other.json in Resources */,
 				CC0786C7267BB10700BA9AC1 /* shipping-label-status-success.json in Resources */,
+				EE57C144297FCCA700BC31E7 /* product-shipping-classes-load-one-without-data.json in Resources */,
 				028CB71B290224D700331C09 /* create-account-error-username.json in Resources */,
 				EEA6583E2966B41E00112DF0 /* products-load-all-without-data.json in Resources */,
 				68F48B1328E3E5750045C15B /* wc-analytics-customers.json in Resources */,
@@ -3898,6 +3912,7 @@
 				03DCB7442624AD9B00C8953D /* CouponListMapperTests.swift in Sources */,
 				AE2D6623272A8F6E004A2C3A /* TelemetryRemoteTests.swift in Sources */,
 				B5C151C0217EE3FB00C7BDC1 /* NoteListMapperTests.swift in Sources */,
+				EE57C146297FCCD200BC31E7 /* ProductShippingClassListMapperTests.swift in Sources */,
 				026CF622237D7E61009563D4 /* ProductVariationsRemoteTests.swift in Sources */,
 				DEC51A99274DDDC9009F3DF4 /* SitePluginMapperTests.swift in Sources */,
 				EEFAA581295D78E9003583BE /* AuthenticatedRESTRequestTests.swift in Sources */,
@@ -3967,6 +3982,7 @@
 				CC07866526790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift in Sources */,
 				74002D6A2118B26100A63C19 /* SiteVisitStatsMapperTests.swift in Sources */,
 				743E84FA221742E300FAC9D7 /* ShipmentsRemoteTests.swift in Sources */,
+				EE57C148297FCCE000BC31E7 /* ProductShippingClassMapperTests.swift in Sources */,
 				03DCB7822627394500C8953D /* CouponMapperTests.swift in Sources */,
 				03DCB76C262591C400C8953D /* CouponsRemoteTests.swift in Sources */,
 				31A451BD2786344B00FE81AA /* StripeRemoteTests.swift in Sources */,

--- a/Networking/Networking/Mapper/ProductShippingClassListMapper.swift
+++ b/Networking/Networking/Mapper/ProductShippingClassListMapper.swift
@@ -17,7 +17,11 @@ struct ProductShippingClassListMapper: Mapper {
             .siteID: siteID
         ]
 
-        return try decoder.decode(ProductShippingClassListEnvelope.self, from: response).data
+        do {
+            return try decoder.decode(ProductShippingClassListEnvelope.self, from: response).data
+        } catch {
+            return try decoder.decode([ProductShippingClass].self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Mapper/ProductShippingClassMapper.swift
+++ b/Networking/Networking/Mapper/ProductShippingClassMapper.swift
@@ -17,7 +17,11 @@ struct ProductShippingClassMapper: Mapper {
             .siteID: siteID
         ]
 
-        return try decoder.decode(ProductShippingClassEnvelope.self, from: response).productShippingClass
+        do {
+            return try decoder.decode(ProductShippingClassEnvelope.self, from: response).productShippingClass
+        } catch {
+            return try decoder.decode(ProductShippingClass.self, from: response)
+        }
     }
 }
 

--- a/Networking/Networking/Remote/ProductShippingClassRemote.swift
+++ b/Networking/Networking/Remote/ProductShippingClassRemote.swift
@@ -26,7 +26,12 @@ public class ProductShippingClassRemote: Remote {
         ]
 
         let path = "\(Path.models)"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
         let mapper = ProductShippingClassListMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -41,7 +46,12 @@ public class ProductShippingClassRemote: Remote {
     ///
     public func loadOne(for siteID: Int64, remoteID: Int64, completion: @escaping (ProductShippingClass?, Error?) -> Void) {
         let path = "\(Path.models)/\(remoteID)"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true)
         let mapper = ProductShippingClassMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/NetworkingTests/Mapper/ProductShippingClassListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductShippingClassListMapperTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import Networking
+
+/// Unit Tests for `ProductShippingClassListMapper`
+///
+final class ProductShippingClassListMapperTests: XCTestCase {
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 33334444
+
+    /// Verifies that all of the ProductShippingClass Fields are parsed correctly.
+    ///
+    func test_ProductShippingClass_fields_are_properly_parsed() throws {
+        let productVariation = try XCTUnwrap(mapLoadAllProductShippingClassResponse()?.first)
+
+        let expected = ProductShippingClass(count: 3,
+                                            descriptionHTML: "Limited offer!",
+                                            name: "Free Shipping",
+                                            shippingClassID: 94,
+                                            siteID: dummySiteID,
+                                            slug: "free-shipping")
+
+        XCTAssertEqual(productVariation, expected)
+    }
+
+    /// Verifies that all of the ProductShippingClass Fields are parsed correctly when response has no data envelope.
+    ///
+    func test_ProductShippingClass_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
+        let productVariation = try XCTUnwrap(mapLoadAllProductShippingClassResponseWithoutDataEnvelope()?.first)
+
+        let expected = ProductShippingClass(count: 3,
+                                            descriptionHTML: "Limited offer!",
+                                            name: "Free Shipping",
+                                            shippingClassID: 94,
+                                            siteID: dummySiteID,
+                                            slug: "free-shipping")
+
+        XCTAssertEqual(productVariation, expected)
+    }
+}
+
+/// Private Helpers
+///
+private extension ProductShippingClassListMapperTests {
+    /// Returns the ProductShippingClassListMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapProductShippingClass(from filename: String) -> [ProductShippingClass]? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try? ProductShippingClassListMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    /// Returns the ProductShippingClassListMapper output upon receiving `product-shipping-classes-load-all`
+    ///
+    func mapLoadAllProductShippingClassResponse() -> [ProductShippingClass]? {
+        return mapProductShippingClass(from: "product-shipping-classes-load-all")
+    }
+
+    /// Returns the ProductShippingClassListMapper output upon receiving `product-shipping-classes-load-all-without-data`
+    ///
+    func mapLoadAllProductShippingClassResponseWithoutDataEnvelope() -> [ProductShippingClass]? {
+        return mapProductShippingClass(from: "product-shipping-classes-load-all-without-data")
+    }
+}

--- a/Networking/NetworkingTests/Mapper/ProductShippingClassMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductShippingClassMapperTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import Networking
+
+/// Unit Tests for `ProductShippingClassMapper`
+///
+final class ProductShippingClassMapperTests: XCTestCase {
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 33334444
+
+    /// Verifies that all of the ProductShippingClass Fields are parsed correctly.
+    ///
+    func test_ProductShippingClass_fields_are_properly_parsed() throws {
+        let productVariation = try XCTUnwrap(mapLoadProductShippingClassResponse())
+
+        let expected = ProductShippingClass(count: 3,
+                                            descriptionHTML: "Limited offer!",
+                                            name: "Free Shipping",
+                                            shippingClassID: 94,
+                                            siteID: dummySiteID,
+                                            slug: "free-shipping")
+
+        XCTAssertEqual(productVariation, expected)
+    }
+
+    /// Verifies that all of the ProductShippingClass Fields are parsed correctly when response has no data envelope.
+    ///
+    func test_ProductShippingClass_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
+        let productVariation = try XCTUnwrap(mapLoadProductShippingClassResponseWithoutDataEnvelope())
+
+        let expected = ProductShippingClass(count: 3,
+                                            descriptionHTML: "Limited offer!",
+                                            name: "Free Shipping",
+                                            shippingClassID: 94,
+                                            siteID: dummySiteID,
+                                            slug: "free-shipping")
+
+        XCTAssertEqual(productVariation, expected)
+    }
+}
+
+/// Private Helpers
+///
+private extension ProductShippingClassMapperTests {
+    /// Returns the ProductShippingClassMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapProductShippingClass(from filename: String) -> ProductShippingClass? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try? ProductShippingClassMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    /// Returns the ProductShippingClassMapper output upon receiving `product-shipping-classes-load-one`
+    ///
+    func mapLoadProductShippingClassResponse() -> ProductShippingClass? {
+        return mapProductShippingClass(from: "product-shipping-classes-load-one")
+    }
+
+    /// Returns the ProductShippingClassMapper output upon receiving `product-shipping-classes-load-one-without-data`
+    ///
+    func mapLoadProductShippingClassResponseWithoutDataEnvelope() -> ProductShippingClass? {
+        return mapProductShippingClass(from: "product-shipping-classes-load-one-without-data")
+    }
+}

--- a/Networking/NetworkingTests/Responses/product-shipping-classes-load-all-without-data.json
+++ b/Networking/NetworkingTests/Responses/product-shipping-classes-load-all-without-data.json
@@ -1,0 +1,59 @@
+[
+    {
+        "id": 94,
+        "name": "Free Shipping",
+        "slug": "free-shipping",
+        "description": "Limited offer!",
+        "count": 3,
+        "_links": {
+            "self": [
+                {
+                    "href": "https://shop.com/shipping_classes/94"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://shop.com/wp-json/wc/v3/products/shipping_classes"
+                }
+            ]
+        }
+    },
+    {
+        "id": 66,
+        "name": "Full Product Size",
+        "slug": "full-product-size",
+        "description": "",
+        "count": 1,
+        "_links": {
+            "self": [
+                {
+                    "href": "https://shop.com/wp-json/wc/v3/products/shipping_classes/66"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://shop.com/wp-json/wc/v3/products/shipping_classes"
+                }
+            ]
+        }
+    },
+    {
+        "id": 95,
+        "name": "Machine Shipping",
+        "slug": "machine-shipping",
+        "description": "",
+        "count": 0,
+        "_links": {
+            "self": [
+                {
+                    "href": "https://shop.com/wp-json/wc/v3/products/shipping_classes/95"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://shop.com/wp-json/wc/v3/products/shipping_classes"
+                }
+            ]
+        }
+    }
+]

--- a/Networking/NetworkingTests/Responses/product-shipping-classes-load-one-without-data.json
+++ b/Networking/NetworkingTests/Responses/product-shipping-classes-load-one-without-data.json
@@ -1,0 +1,19 @@
+{
+    "id": 94,
+    "name": "Free Shipping",
+    "slug": "free-shipping",
+    "description": "Limited offer!",
+    "count": 3,
+    "_links": {
+        "self": [
+            {
+                "href": "https://shop.com/shipping_classes/94"
+            }
+        ],
+        "collection": [
+            {
+                "href": "https://shop.com/wp-json/wc/v3/products/shipping_classes"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Part of: #8715 

## Description
This PR migrates the product shipping class endpoints and updates the related mappers to parse contents without the data envelope.

## Testing instructions

**Prerequisite**
- Create a Woo site using JN. (without Jetpack)
- Add shipping class to your site following this guide - https://woocommerce.com/document/product-shipping-classes/#section-1

**Steps**
- Enable the feature flag `applicationPasswordAuthenticationForSiteCredentialLogin` and build the app.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select Enter your site address and proceed with the address of a self-hosted store.
- Log in with your site credentials. After the login succeeds, you should be navigated to the home screen.
- Navigate to the Products and open a Product.
- Tap on "Add more details" -> "Shipping" -> "Shipping class" and try selecting shipping classes
- You should be able to select shipping classes for products as before.

## Screenshots
![Simulator Screen Recording - iPhone 14 Pro - 2023-01-24 at 14 57 49](https://user-images.githubusercontent.com/524475/214299346-6241e413-e7f5-44fc-a768-6b8f088b2d07.gif)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
