### PR TITLE
[Mobile Payments] Show error reason when TTPoI connection requirements aren't met

### DIFF
--- a/Hardware/Hardware/CardReader/UnderlyingError.swift
+++ b/Hardware/Hardware/CardReader/UnderlyingError.swift
@@ -411,25 +411,25 @@ extension UnderlyingError: LocalizedError {
 
             // MARK: - Built-in reader errors
         case .passcodeNotEnabled:
-            return NSLocalizedString("Your device needs a lock screen passcode set to use the built-in card reader",
+            return NSLocalizedString("You need to set a lock screen passcode to use Tap to Pay on iPhone",
                                      comment: "Error message shown when the built-in reader cannot be used because " +
                                      "the device does not have a passcode set.")
         case .appleBuiltInReaderTOSAcceptanceRequiresiCloudSignIn:
-            return NSLocalizedString("Please sign in to iCloud on this device, so you can use the built-in card reader",
+            return NSLocalizedString("Please sign in to iCloud on this device to use Tap to Pay on iPhone",
                                      comment: "Error message shown when the built-in reader cannot be used because " +
                                      "the device is not signed in to iCloud.")
         case .nfcDisabled:
-            return NSLocalizedString("The app could not enable the card reader, because the NFC chip is disabled. " +
+            return NSLocalizedString("The app could not enable Tap to Pay on iPhone, because the NFC chip is disabled. " +
                                      "Please contact support for more details.",
                                      comment: "Error message shown when the built-in reader cannot be used because " +
                                      "the device's NFC chipset has been disabled by a device management policy.")
         case .appleBuiltInReaderFailedToPrepare, .readerNotAccessibleInBackground:
-            return NSLocalizedString("There was an issue preparing the built in reader for payment – please try again.",
+            return NSLocalizedString("There was an issue preparing to use Tap to Pay on iPhone – please try again.",
                                      comment: "Error message shown when the built-in reader cannot be used because " +
                                      "there was some issue with the connection. Retryable.")
         case .appleBuiltInReaderTOSAcceptanceCanceled, .appleBuiltInReaderTOSNotYetAccepted:
-            return NSLocalizedString("Please try again, and accept Apple's Terms of Service, so you can use the " +
-                                     "built-in card reader",
+            return NSLocalizedString("Please try again, and accept Apple's Terms of Service, so you can use Tap to " +
+                                     "Pay on iPhone",
                                      comment: "Error message shown when the built-in reader cannot be used because " +
                                      "the merchant cancelled or did not complete the Terms of Service acceptance flow")
         case .appleBuiltInReaderTOSAcceptanceFailed:
@@ -439,7 +439,7 @@ extension UnderlyingError: LocalizedError {
                                      "the Terms of Service acceptance flow failed, possibly due to issues with " +
                                      "the Apple ID")
         case .appleBuiltInReaderMerchantBlocked, .appleBuiltInReaderInvalidMerchant, .appleBuiltInReaderDeviceBanned:
-            return NSLocalizedString("Please contact support – there was an issue connecting to the built-in reader",
+            return NSLocalizedString("Please contact support – there was an issue starting Tap to Pay on iPhone",
                                      comment: "Error message shown when the built-in reader cannot be used because " +
                                      "there is an issue with the merchant account or device")
         case .unsupportedMobileDeviceConfiguration:
@@ -449,17 +449,17 @@ extension UnderlyingError: LocalizedError {
                                      comment: "Error message shown when the built-in reader cannot be used because " +
                                      "the device does not meet minimum requirements.")
         case .commandNotAllowedDuringCall:
-            return NSLocalizedString("The built-in reader cannot be used during a phone call. Please try again after " +
+            return NSLocalizedString("Tap to Pay on iPhone cannot be used during a phone call. Please try again after " +
                                      "you finish your call.",
                                      comment: "Error message shown when the built-in reader cannot be used because " +
                                      "there is a call in progress")
         case .invalidAmount:
-            return NSLocalizedString("The amount is not supported by the built in reader – please try a hardware " +
+            return NSLocalizedString("The amount is not supported for Tap to Pay on iPhone – please try a hardware " +
                                      "reader or another payment method.",
                                      comment: "Error message shown when the built-in reader cannot be used because " +
                                      "the amount for payment is not supported by the built in reader.")
         case .invalidCurrency:
-            return NSLocalizedString("The currency is not supported by the built in reader – please try a hardware " +
+            return NSLocalizedString("The currency is not supported for Tap to Pay on iPhone – please try a hardware " +
                                      "reader or another payment method.",
                                      comment: "Error message shown when the built-in reader cannot be used because " +
                                      "the currency for payment is not supported by the built in reader.")

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailed.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailed.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// Modal presented when an error occurs while connecting to a reader
 ///
-final class CardPresentModalConnectingFailed: CardPresentPaymentsModalViewModel {
+final class CardPresentModalBuiltInConnectingFailed: CardPresentPaymentsModalViewModel {
     private let continueSearchAction: () -> Void
     private let cancelSearchAction: () -> Void
 
@@ -14,7 +14,7 @@ final class CardPresentModalConnectingFailed: CardPresentPaymentsModalViewModel 
 
     var topSubtitle: String? = nil
 
-    let image: UIImage = .paymentErrorImage
+    let image: UIImage = .builtInReaderError
 
     let primaryButtonTitle: String? = Localization.tryAgain
 
@@ -55,21 +55,21 @@ final class CardPresentModalConnectingFailed: CardPresentPaymentsModalViewModel 
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }
 }
 
-private extension CardPresentModalConnectingFailed {
+private extension CardPresentModalBuiltInConnectingFailed {
     enum Localization {
         static let title = NSLocalizedString(
-            "We couldn't connect your reader",
-            comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails"
+            "We couldn't start Tap to Pay on iPhone",
+            comment: "Title of the alert presented when the user tries to start Tap to Pay on iPhone and it fails"
         )
 
         static let tryAgain = NSLocalizedString(
             "Try again",
-            comment: "Button to dismiss the alert presented when connecting to a specific reader fails. This allows the search to continue."
+            comment: "Button to dismiss the alert presented when starting Tap to Pay on iPhone fails. This allows the search to continue."
         )
 
         static let cancel = NSLocalizedString(
             "Cancel",
-            comment: "Button to dismiss the alert presented when connecting to a specific reader fails. This also cancels searching."
+            comment: "Button to dismiss the alert presented when starting Tap to Pay on iPhone fails. This also cancels searching."
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailed.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailed.swift
@@ -58,7 +58,7 @@ final class CardPresentModalBuiltInConnectingFailed: CardPresentPaymentsModalVie
 private extension CardPresentModalBuiltInConnectingFailed {
     enum Localization {
         static let title = NSLocalizedString(
-            "We couldn't start Tap to Pay on iPhone",
+            "Setup failed",
             comment: "Title of the alert presented when the user tries to start Tap to Pay on iPhone and it fails"
         )
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailedNonRetryable.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailedNonRetryable.swift
@@ -53,7 +53,7 @@ final class CardPresentModalBuiltInConnectingFailedNonRetryable: CardPresentPaym
 private extension CardPresentModalBuiltInConnectingFailedNonRetryable {
     enum Localization {
         static let title = NSLocalizedString(
-            "We couldn't start Tap to Pay on iPhone",
+            "Setup failed",
             comment: "Title of the alert presented when the user tries to start Tap to Pay on iPhone and it fails"
         )
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailedNonRetryable.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailedNonRetryable.swift
@@ -1,0 +1,65 @@
+import UIKit
+import Yosemite
+
+/// Modal presented when an error occurs while connecting to a reader
+///
+final class CardPresentModalBuiltInConnectingFailedNonRetryable: CardPresentPaymentsModalViewModel {
+    private let closeAction: () -> Void
+
+    let textMode: PaymentsModalTextMode = .reducedTopInfo
+    let actionsMode: PaymentsModalActionsMode = .oneAction
+
+    let topTitle: String = Localization.title
+
+    var topSubtitle: String? = nil
+
+    let image: UIImage = .builtInReaderError
+
+    let primaryButtonTitle: String? = Localization.close
+
+    let secondaryButtonTitle: String? = nil
+
+    let auxiliaryButtonTitle: String? = nil
+
+    var bottomTitle: String? = nil
+
+    let bottomSubtitle: String? = nil
+
+    var accessibilityLabel: String? {
+        return topTitle
+    }
+
+    init(error: Error,
+         close: @escaping () -> Void) {
+        self.closeAction = close
+
+        switch error {
+        case CardReaderServiceError.connection(let underlyingError):
+            bottomTitle = underlyingError.localizedDescription
+        default:
+            break
+        }
+    }
+
+    func didTapPrimaryButton(in viewController: UIViewController?) {
+        closeAction()
+    }
+
+    func didTapSecondaryButton(in viewController: UIViewController?) { }
+
+    func didTapAuxiliaryButton(in viewController: UIViewController?) { }
+}
+
+private extension CardPresentModalBuiltInConnectingFailedNonRetryable {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "We couldn't start Tap to Pay on iPhone",
+            comment: "Title of the alert presented when the user tries to start Tap to Pay on iPhone and it fails"
+        )
+
+        static let close = NSLocalizedString(
+            "Close",
+            comment: "Button to dismiss the alert presented when starting Tap to Pay on iPhone fails. This also cancels searching."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingFailed.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingFailed.swift
@@ -31,11 +31,19 @@ final class CardPresentModalConnectingFailed: CardPresentPaymentsModalViewModel 
     }
 
     init(image: UIImage = .paymentErrorImage,
+         error: Error,
          continueSearch: @escaping () -> Void,
          cancelSearch: @escaping () -> Void) {
         self.image = image
         self.continueSearchAction = continueSearch
         self.cancelSearchAction = cancelSearch
+
+        switch error {
+        case CardReaderServiceError.connection(let underlyingError):
+            bottomTitle = underlyingError.localizedDescription
+        default:
+            break
+        }
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -452,7 +452,9 @@ private extension BuiltInCardReaderConnectionController {
 
         guard case CardReaderServiceError.connection(let underlyingError) = error else {
             return alertsPresenter.present(
-                viewModel: alertsProvider.connectingFailed(continueSearch: continueSearch, cancelSearch: cancelSearch))
+                viewModel: alertsProvider.connectingFailed(error: error,
+                                                           continueSearch: continueSearch,
+                                                           cancelSearch: cancelSearch))
         }
 
         switch underlyingError {
@@ -471,6 +473,7 @@ private extension BuiltInCardReaderConnectionController {
         default:
             alertsPresenter.present(
                 viewModel: alertsProvider.connectingFailed(
+                    error: error,
                     continueSearch: continueSearch,
                     cancelSearch: cancelSearch))
         }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -644,7 +644,9 @@ private extension CardReaderConnectionController {
 
         guard case CardReaderServiceError.connection(let underlyingError) = error else {
             return alertsPresenter.present(
-                viewModel: alertsProvider.connectingFailed(continueSearch: continueSearch, cancelSearch: cancelSearch))
+                viewModel: alertsProvider.connectingFailed(error: error,
+                                                           continueSearch: continueSearch,
+                                                           cancelSearch: cancelSearch))
         }
 
         switch underlyingError {
@@ -668,6 +670,7 @@ private extension CardReaderConnectionController {
         default:
             alertsPresenter.present(
                 viewModel: alertsProvider.connectingFailed(
+                    error: error,
                     continueSearch: continueSearch,
                     cancelSearch: cancelSearch))
         }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionController.swift
@@ -679,7 +679,7 @@ private extension LegacyCardReaderConnectionController {
         }
 
         guard case CardReaderServiceError.connection(let underlyingError) = error else {
-            return alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
+            return alerts.connectingFailed(from: from, error: error, continueSearch: continueSearch, cancelSearch: cancelSearch)
         }
 
         switch underlyingError {
@@ -695,7 +695,7 @@ private extension LegacyCardReaderConnectionController {
         case .bluetoothConnectionFailedBatteryCriticallyLow:
             alerts.connectingFailedCriticallyLowBattery(from: from, retrySearch: retrySearch, cancelSearch: cancelSearch)
         default:
-            alerts.connectingFailed(from: from, continueSearch: continueSearch, cancelSearch: cancelSearch)
+            alerts.connectingFailed(from: from, error: error, continueSearch: continueSearch, cancelSearch: cancelSearch)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
@@ -15,9 +15,10 @@ struct BluetoothReaderConnectionAlertsProvider: BluetoothReaderConnnectionAlerts
         CardPresentModalConnectingToReader()
     }
 
-    func connectingFailed(continueSearch: @escaping () -> Void,
+    func connectingFailed(error: Error,
+                          continueSearch: @escaping () -> Void,
                           cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalConnectingFailed(continueSearch: continueSearch, cancelSearch: cancelSearch)
+        CardPresentModalConnectingFailed(error: error, continueSearch: continueSearch, cancelSearch: cancelSearch)
     }
 
     func connectingFailedIncompleteAddress(openWCSettings: ((UIViewController) -> Void)?,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
@@ -21,6 +21,10 @@ struct BluetoothReaderConnectionAlertsProvider: BluetoothReaderConnnectionAlerts
         CardPresentModalConnectingFailed(error: error, continueSearch: continueSearch, cancelSearch: cancelSearch)
     }
 
+    func connectingFailedNonRetryable(error: Error, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalNonRetryableError(amount: "", error: error, onDismiss: close)
+    }
+
     func connectingFailedIncompleteAddress(openWCSettings: ((UIViewController) -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
@@ -18,10 +18,9 @@ struct BuiltInReaderConnectionAlertsProvider: CardReaderConnectionAlertsProvidin
     func connectingFailed(error: Error,
                           continueSearch: @escaping () -> Void,
                           cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalConnectingFailed(image: .builtInReaderError,
-                                         error: error,
-                                         continueSearch: continueSearch,
-                                         cancelSearch: cancelSearch)
+        CardPresentModalBuiltInConnectingFailed(error: error,
+                                                continueSearch: continueSearch,
+                                                cancelSearch: cancelSearch)
     }
 
     func connectingFailedIncompleteAddress(openWCSettings: ((UIViewController) -> Void)?,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
@@ -23,6 +23,12 @@ struct BuiltInReaderConnectionAlertsProvider: CardReaderConnectionAlertsProvidin
                                                 cancelSearch: cancelSearch)
     }
 
+    func connectingFailedNonRetryable(error: Error, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalBuiltInConnectingFailedNonRetryable(error: error,
+                                                            close: close)
+    }
+
+
     func connectingFailedIncompleteAddress(openWCSettings: ((UIViewController) -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
@@ -15,9 +15,13 @@ struct BuiltInReaderConnectionAlertsProvider: CardReaderConnectionAlertsProvidin
         CardPresentModalBuiltInConnectingToReader()
     }
 
-    func connectingFailed(continueSearch: @escaping () -> Void,
+    func connectingFailed(error: Error,
+                          continueSearch: @escaping () -> Void,
                           cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalConnectingFailed(image: .builtInReaderError, continueSearch: continueSearch, cancelSearch: cancelSearch)
+        CardPresentModalConnectingFailed(image: .builtInReaderError,
+                                         error: error,
+                                         continueSearch: continueSearch,
+                                         cancelSearch: cancelSearch)
     }
 
     func connectingFailedIncompleteAddress(openWCSettings: ((UIViewController) -> Void)?,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
@@ -22,7 +22,8 @@ protocol CardReaderConnectionAlertsProviding {
     /// Defines an alert indicating connecting failed. The user may continue the search
     /// or cancel
     ///
-    func connectingFailed(continueSearch: @escaping () -> Void,
+    func connectingFailed(error: Error,
+                          continueSearch: @escaping () -> Void,
                           cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
 
     /// Defines an alert indicating connecting failed because their address needs updating.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
@@ -26,6 +26,12 @@ protocol CardReaderConnectionAlertsProviding {
                           continueSearch: @escaping () -> Void,
                           cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
 
+    /// Defines an alert indicating connecting failed, in a way which must be resolved outside
+    /// the connection flow. The user can close the alert.
+    ///
+    func connectingFailedNonRetryable(error: Error,
+                                      close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+
     /// Defines an alert indicating connecting failed because their address needs updating.
     /// The user may try again or cancel
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -21,8 +21,11 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
         setViewModelAndPresent(from: from, viewModel: connectingToReader())
     }
 
-    func connectingFailed(from: UIViewController, continueSearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
-        setViewModelAndPresent(from: from, viewModel: connectingFailed(continueSearch: continueSearch, cancelSearch: cancelSearch))
+    func connectingFailed(from: UIViewController, error: Error, continueSearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
+        setViewModelAndPresent(from: from,
+                               viewModel: connectingFailed(error: error,
+                                                           continueSearch: continueSearch,
+                                                           cancelSearch: cancelSearch))
     }
 
     func connectingFailedIncompleteAddress(from: UIViewController,
@@ -184,8 +187,10 @@ private extension CardReaderSettingsAlerts {
         CardPresentModalConnectingToReader()
     }
 
-    func connectingFailed(continueSearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalConnectingFailed(continueSearch: continueSearch, cancelSearch: cancelSearch)
+    func connectingFailed(error: Error,
+                          continueSearch: @escaping () -> Void,
+                          cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalConnectingFailed(error: error, continueSearch: continueSearch, cancelSearch: cancelSearch)
     }
 
     func connectingFailedUpdateAddress(openWCSettings: ((UIViewController) -> Void)?,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
@@ -44,6 +44,7 @@ protocol CardReaderSettingsAlertsProvider {
     /// or cancel
     ///
     func connectingFailed(from: UIViewController,
+                          error: Error,
                           continueSearch: @escaping () -> Void,
                           cancelSearch: @escaping () -> Void)
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -493,6 +493,7 @@
 		03191AE628E1DF0600670723 /* WooCommercePluginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03191AE528E1DF0600670723 /* WooCommercePluginViewModel.swift */; };
 		03191AE928E20C9200670723 /* PluginDetailsRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03191AE828E20C9200670723 /* PluginDetailsRowView.swift */; };
 		031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */; };
+		032E481D2982996E00469D92 /* CardPresentModalBuiltInConnectingFailedNonRetryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032E481C2982996E00469D92 /* CardPresentModalBuiltInConnectingFailedNonRetryable.swift */; };
 		035BA3A8291000E90056F0AD /* JustInTimeMessageAnnouncementCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035BA3A7291000E90056F0AD /* JustInTimeMessageAnnouncementCardViewModelTests.swift */; };
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
 		035DBA45292D0164003E5125 /* CollectOrderPaymentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035DBA44292D0163003E5125 /* CollectOrderPaymentUseCase.swift */; };
@@ -2578,6 +2579,7 @@
 		03191AE528E1DF0600670723 /* WooCommercePluginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooCommercePluginViewModel.swift; sourceTree = "<group>"; };
 		03191AE828E20C9200670723 /* PluginDetailsRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDetailsRowView.swift; sourceTree = "<group>"; };
 		031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectionFailedUpdateAddress.swift; sourceTree = "<group>"; };
+		032E481C2982996E00469D92 /* CardPresentModalBuiltInConnectingFailedNonRetryable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInConnectingFailedNonRetryable.swift; sourceTree = "<group>"; };
 		035BA3A7291000E90056F0AD /* JustInTimeMessageAnnouncementCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessageAnnouncementCardViewModelTests.swift; sourceTree = "<group>"; };
 		035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdateTypeProperty.swift; sourceTree = "<group>"; };
 		035DBA44292D0163003E5125 /* CollectOrderPaymentUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectOrderPaymentUseCase.swift; sourceTree = "<group>"; };
@@ -8823,6 +8825,7 @@
 			children = (
 				D8815AE626383FD600EDAD62 /* CardPresentPaymentsModalViewModel.swift */,
 				0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */,
+				032E481C2982996E00469D92 /* CardPresentModalBuiltInConnectingFailedNonRetryable.swift */,
 				03E471C5293A2E95001A58AD /* CardPresentModalBuiltInReaderCheckingDeviceSupport.swift */,
 				03E471C9293E0A2F001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift */,
 				03E471CB293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift */,
@@ -10996,6 +10999,7 @@
 				023A059A24135F2600E3FC99 /* ReviewsViewController.swift in Sources */,
 				B5C3876421C41B9F006CE970 /* UIApplication+Woo.swift in Sources */,
 				09E41E1D27B90B3C00BFCB7C /* BulkUpdateViewModel.swift in Sources */,
+				032E481D2982996E00469D92 /* CardPresentModalBuiltInConnectingFailedNonRetryable.swift in Sources */,
 				0379C51B27BFE23F00A7E284 /* RefundConfirmationCardDetailsCell.swift in Sources */,
 				D85136B9231CED5800DD0539 /* ReviewAge.swift in Sources */,
 				5718852C2465D9EC00E2486F /* ReviewsCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -514,6 +514,7 @@
 		0379C51B27BFE23F00A7E284 /* RefundConfirmationCardDetailsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0379C51A27BFE23F00A7E284 /* RefundConfirmationCardDetailsCell.swift */; };
 		037D270D28CA444F00A3F924 /* CardReaderModalFlowViewControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037D270C28CA444F00A3F924 /* CardReaderModalFlowViewControllerProtocol.swift */; };
 		0386CFEB2852108B00134466 /* PaymentMethodsHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0386CFEA2852108B00134466 /* PaymentMethodsHostingController.swift */; };
+		0396CFAD2981476900E91436 /* CardPresentModalBuiltInConnectingFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */; };
 		039D948D27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */; };
 		039D948F276113490044EF38 /* UIView+SuperviewConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */; };
 		03A6C18428B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A6C18328B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift */; };
@@ -2598,6 +2599,7 @@
 		0379C51A27BFE23F00A7E284 /* RefundConfirmationCardDetailsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundConfirmationCardDetailsCell.swift; sourceTree = "<group>"; };
 		037D270C28CA444F00A3F924 /* CardReaderModalFlowViewControllerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderModalFlowViewControllerProtocol.swift; sourceTree = "<group>"; };
 		0386CFEA2852108B00134466 /* PaymentMethodsHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsHostingController.swift; sourceTree = "<group>"; };
+		0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInConnectingFailed.swift; sourceTree = "<group>"; };
 		039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SafeAreaConstraints.swift"; sourceTree = "<group>"; };
 		039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SuperviewConstraints.swift"; sourceTree = "<group>"; };
 		03A6C18328B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift; sourceTree = "<group>"; };
@@ -8820,6 +8822,7 @@
 			isa = PBXGroup;
 			children = (
 				D8815AE626383FD600EDAD62 /* CardPresentPaymentsModalViewModel.swift */,
+				0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */,
 				03E471C5293A2E95001A58AD /* CardPresentModalBuiltInReaderCheckingDeviceSupport.swift */,
 				03E471C9293E0A2F001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift */,
 				03E471CB293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift */,
@@ -11108,6 +11111,7 @@
 				D81F2D37225F0D160084BF9C /* EmptyListMessageWithActionView.swift in Sources */,
 				684AB83C2873DF04003DFDD1 /* CardReaderManualsViewModel.swift in Sources */,
 				575472812452185300A94C3C /* PushNotification.swift in Sources */,
+				0396CFAD2981476900E91436 /* CardPresentModalBuiltInConnectingFailed.swift in Sources */,
 				02C1853B27FF0D9C00ABD764 /* RefundSubmissionUseCase.swift in Sources */,
 				E10BD16D27CF890800CE6449 /* InPersonPaymentsCountryNotSupportedStripe.swift in Sources */,
 				26F94E26267A559300DB6CCF /* ProductAddOn.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -89,7 +89,10 @@ extension MockCardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
         }
     }
 
-    func connectingFailed(from: UIViewController, continueSearch: @escaping () -> Void, cancelSearch: @escaping () -> Void) {
+    func connectingFailed(from: UIViewController,
+                          error: Error,
+                          continueSearch: @escaping () -> Void,
+                          cancelSearch: @escaping () -> Void) {
         if mode == .continueSearchingAfterConnectionFailure {
             continueSearch()
         }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalConnectingFailedTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalConnectingFailedTests.swift
@@ -1,4 +1,6 @@
 import XCTest
+import Hardware
+import TestKit
 @testable import WooCommerce
 
 final class CardPresentModalConnectingFailedTests: XCTestCase {
@@ -9,6 +11,7 @@ final class CardPresentModalConnectingFailedTests: XCTestCase {
         super.setUp()
         closures = Closures()
         viewModel = CardPresentModalConnectingFailed(
+            error: CardReaderServiceError.connection(underlyingError: .alreadyConnectedToReader),
             continueSearch: closures.continueSearch(),
             cancelSearch: closures.cancelSearch()
         )
@@ -40,8 +43,8 @@ final class CardPresentModalConnectingFailedTests: XCTestCase {
         XCTAssertNotNil(viewModel.secondaryButtonTitle)
     }
 
-    func test_bottom_title_is_nil() {
-        XCTAssertNil(viewModel.bottomTitle)
+    func test_bottom_title_is_error_description() {
+        assertEqual(UnderlyingError.alreadyConnectedToReader.localizedDescription, viewModel.bottomTitle)
     }
 
     func test_bottom_subTitle_is_nil() {

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -147,6 +147,7 @@ public typealias CardReaderInput = Hardware.CardReaderInput
 public typealias CardReaderSoftwareUpdateState = Hardware.CardReaderSoftwareUpdateState
 public typealias CardReaderServiceDiscoveryStatus = Hardware.CardReaderServiceDiscoveryStatus
 public typealias CardReaderServiceError = Hardware.CardReaderServiceError
+public typealias CardReaderServiceUnderlyingError = Hardware.UnderlyingError
 public typealias CardReaderType = Hardware.CardReaderType
 public typealias CardReaderConfigError = Hardware.CardReaderConfigError
 public typealias PaymentMethod = Hardware.PaymentMethod


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8353 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Apple require that to use Tap to Pay on iPhone, a device has a passcode set and is signed in to an iCloud account.

Some users may not meet these requirements, but at the moment the first time they try to use Tap to Pay on iPhone, we will just show a generic "couldn't connect to your reader" error, with no information about why it's failed.

This PR adds the localised error description for the underlying connection error on our connection error screens, so that merchants in this situation will know how to resolve the issue.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

It's disruptive to test these errors fully: removing the passcode or iCloud sign in from a device can cause significant setup issues. I've tested them by simulating the errors instead.

Update the closure passed to `connectLocalMobileReader` in `StripeCardReaderService.connect(_:configuration:)` to the following:

```
Terminal.shared.connectLocalMobileReader(reader, delegate: self, connectionConfig: configuration) { [weak self] (reader, error) in
    guard let self = self else {
        promise(.failure(CardReaderServiceError.connection()))
        return
    }
    // Clear cached readers, as per Stripe's documentation.
    self.discoveredStripeReadersCache.clear()

    return promise(.failure(CardReaderServiceError.connection(underlyingError: .appleBuiltInReaderTOSAcceptanceRequiresiCloudSignIn)))
}
```

Then attempt to take a Tap to Pay on iPhone payment. You'll see the "Please sign in to iCloud...." error, and the reader won't connect.

Update the error in the promise returned to:

```
return promise(.failure(CardReaderServiceError.connection(underlyingError: .passcodeNotEnabled)))
```

To see the passcode error.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![passcode](https://user-images.githubusercontent.com/2472348/214555752-18ab9b43-0ad6-4a08-a486-e8525612576b.jpg)
![icloud](https://user-images.githubusercontent.com/2472348/214555760-7c6c3d1c-15e6-48f6-8355-d64d159d2da0.jpg)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
