### PR TITLE
[IPPInAppFeedback] Workaround to survey content UI glitch

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -111,6 +111,7 @@ private extension TopBannerView {
         } else {
             // It is necessary to remove the subview when no text, otherwise the stack view spacing stays.
             infoLabel.removeFromSuperview()
+            labelHolderStackView.removeFromSuperview()
         }
 
         iconImageView.image = viewModel.icon

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -99,18 +99,18 @@ private extension TopBannerView {
     }
 
     func renderContent(of viewModel: TopBannerViewModel) {
+        // It is necessary to remove the subview when there is no text,
+        // otherwise the stack view spacing stays, breaking the view.
+        // See: https://github.com/woocommerce/woocommerce-ios/issues/8747
         if let title = viewModel.title, !title.isEmpty {
             titleLabel.text = title
         } else {
-            // It is necessary to remove the subview when no text, otherwise the stack view spacing stays.
             titleLabel.removeFromSuperview()
         }
 
         if let infoText = viewModel.infoText, !infoText.isEmpty {
             infoLabel.text = infoText
         } else {
-            // It is necessary to remove the subview when no text, otherwise the stack view spacing stays.
-            infoLabel.removeFromSuperview()
             labelHolderStackView.removeFromSuperview()
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8747 

## Description:
The In-Person Payments survey banner sometimes seems to appear broken. If would seem this is because the content assigned in the StackView can't be loaded, which breaks the view as the StackView where this is located tries to compensate filling the missing gap.

As shared in the bug report, while this proposed solution is not perfect, I'd say is better to display the title and the feedback button rather than showing a broken banner.

## Changes:
- If the info text happens to be empty when rendering the TopBannerView, we remove the labelHolderStackView from its superview.

## Testing instructions
I wasn't able to find a way to reproduce this but, but generally:
1. On a US/CA store, with COD enabled:
2. Run the app, go to Orders, and check the survey banner
3. It it's "broken", will only display the title and the "Share Feedback" link, rather than a deformed icon:

## Screenshots

| Expected banner (1) | Broken banner (2) | Proposed solution (3) |
|--|--|--|
| ![Simulator Screen Shot - iPhone 14 - 2023-01-25 at 19 01 09](https://user-images.githubusercontent.com/3812076/214554542-ab0c7337-f00d-4a6f-bb7a-eaff3832814c.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2023-01-25 at 19 34 47](https://user-images.githubusercontent.com/3812076/214554400-83fe9621-1d8f-4c08-8c5c-face5643e137.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2023-01-25 at 19 38 29](https://user-images.githubusercontent.com/3812076/214554499-0e32f88a-1e99-4672-aa39-3f469b5cfcd8.png) |


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
