### PR TITLE
Allow production iap test.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -60,22 +60,20 @@ struct InAppPurchasesDebugView: View {
                 }.disabled(!inAppPurchasesAreSupported || entitledProductIDs.isEmpty)
             }
 
-            if !inAppPurchasesAreSupported {
-                Section {
-                    Text("In-App Purchases are not supported for this user")
-                        .foregroundColor(.red)
-                }
+            Section {
+                Text("In-App Purchases are not supported for this user")
+                    .foregroundColor(.red)
             }
+            .renderedIf(!inAppPurchasesAreSupported)
 
-            if ProcessInfo.processInfo.environment["wpcom-api-base-url"] == nil {
-                Section {
-                    Text("⚠️ Your WPCOM Sandbox URL is not setup")
-                        .headlineStyle()
-                    Text("To test In-App Purchases in sandbox please make sure that the WPCOM requests are pointing " +
-                         "to your sandbox environment and you have the billing system sandbox-mode enabled there.")
-                    .padding()
-                }
+            Section {
+                Text("⚠️ Your WPCOM Sandbox URL is not setup")
+                    .headlineStyle()
+                Text("To test In-App Purchases in sandbox please make sure that the WPCOM requests are pointing " +
+                     "to your sandbox environment and you have the billing system sandbox-mode enabled there.")
+                .padding()
             }
+            .renderedIf(ProcessInfo.processInfo.environment["wpcom-api-base-url"] == nil)
         }
         .navigationTitle("IAP Debug")
         .task {

--- a/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppPurchases/InAppPurchasesDebugView.swift
@@ -16,72 +16,74 @@ struct InAppPurchasesDebugView: View {
     @State var presentAlert = false
 
     var body: some View {
-        if ProcessInfo.processInfo.environment["wpcom-api-base-url"] == nil {
-            Text("⚠️ Your WPCOM Sandbox URL is not setup")
-                .headlineStyle()
-            Text("To test In-App Purchases please make sure that the WPCOM requests are pointing " +
-                 "to your sandbox environment and you have the billing system sandbox-mode enabled there.")
-            .padding()
-        } else {
-            List {
-                Section {
-                    Button("Reload products") {
-                        Task {
-                            await loadProducts()
-                        }
+        List {
+            Section {
+                Button("Reload products") {
+                    Task {
+                        await loadProducts()
                     }
                 }
-                Section("Products") {
-                    if products.isEmpty {
-                        Text("No products")
-                    } else if isPurchasing {
-                        ActivityIndicator(isAnimating: .constant(true), style: .medium)
-                    } else if let stringSiteID = ProcessInfo.processInfo.environment[Constants.siteIdEnvironmentVariableName],
-                              let siteID = Int64(stringSiteID) {
-                        ForEach(products, id: \.id) { product in
-                            Button(entitledProductIDs.contains(product.id) ? "Entitled: \(product.description)" : product.description) {
-                                Task {
-                                    isPurchasing = true
-                                    do {
-                                        let result = try await inAppPurchasesForWPComPlansManager.purchaseProduct(with: product.id, for: siteID)
-                                        print("[IAP Debug] Purchase result: \(result)")
-                                    } catch {
-                                        purchaseError = PurchaseError(error: error)
-                                    }
-                                    await loadUserEntitlements()
-                                    isPurchasing = false
+            }
+            Section("Products") {
+                if products.isEmpty {
+                    Text("No products")
+                } else if isPurchasing {
+                    ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                } else if let stringSiteID = ProcessInfo.processInfo.environment[Constants.siteIdEnvironmentVariableName],
+                          let siteID = Int64(stringSiteID) {
+                    ForEach(products, id: \.id) { product in
+                        Button(entitledProductIDs.contains(product.id) ? "Entitled: \(product.description)" : product.description) {
+                            Task {
+                                isPurchasing = true
+                                do {
+                                    let result = try await inAppPurchasesForWPComPlansManager.purchaseProduct(with: product.id, for: siteID)
+                                    print("[IAP Debug] Purchase result: \(result)")
+                                } catch {
+                                    purchaseError = PurchaseError(error: error)
                                 }
+                                await loadUserEntitlements()
+                                isPurchasing = false
                             }
-                            .alert(isPresented: $presentAlert, error: purchaseError, actions: {})
                         }
-                    } else {
-                        Text("No valid site id could be retrieved to purchase product. " +
-                             "Please set your Int64 test site id to the Xcode environment variable with name \(Constants.siteIdEnvironmentVariableName).")
-                        .foregroundColor(.red)
+                        .alert(isPresented: $presentAlert, error: purchaseError, actions: {})
                     }
+                } else {
+                    Text("No valid site id could be retrieved to purchase product. " +
+                         "Please set your Int64 test site id to the Xcode environment variable with name \(Constants.siteIdEnvironmentVariableName).")
+                    .foregroundColor(.red)
                 }
+            }
 
+            Section {
+                Button("Retry WPCom Synchronization for entitled products") {
+                    retryWPComSynchronizationForPurchasedProducts()
+                }.disabled(!inAppPurchasesAreSupported || entitledProductIDs.isEmpty)
+            }
+
+            if !inAppPurchasesAreSupported {
                 Section {
-                    Button("Retry WPCom Synchronization for entitled products") {
-                        retryWPComSynchronizationForPurchasedProducts()
-                    }.disabled(!inAppPurchasesAreSupported || entitledProductIDs.isEmpty)
+                    Text("In-App Purchases are not supported for this user")
+                        .foregroundColor(.red)
                 }
+            }
 
-                if !inAppPurchasesAreSupported {
-                    Section {
-                        Text("In-App Purchases are not supported for this user")
-                            .foregroundColor(.red)
-                    }
+            if ProcessInfo.processInfo.environment["wpcom-api-base-url"] == nil {
+                Section {
+                    Text("⚠️ Your WPCOM Sandbox URL is not setup")
+                        .headlineStyle()
+                    Text("To test In-App Purchases in sandbox please make sure that the WPCOM requests are pointing " +
+                         "to your sandbox environment and you have the billing system sandbox-mode enabled there.")
+                    .padding()
                 }
             }
-            .navigationTitle("IAP Debug")
-            .task {
-                await loadProducts()
-            }
-            .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
-                Task {
-                    await loadUserEntitlements()
-                }
+        }
+        .navigationTitle("IAP Debug")
+        .task {
+            await loadProducts()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+            Task {
+                await loadUserEntitlements()
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As [we want now to test on production](pdfdoF-2cq-p2), I modify `InAppPurchasesDebugView` to allow testing without the WPCOM Sandbox URL being set. We leave a warning though, to point how to test on sandbox.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Add an environment variable on Xcode WooCommerce's scheme for `iap-debug-site-id` and check it, but leave `wpcom-api-base-url `empty and unchecked. On device:

1. Go to Menu > Settings > Experimental Features
2. Enable In-App Purchases
3. Go to Menu, tap on [Debug]IAP
4. See that you have a warning about your WPCOM Sandbox URL not being set.
5. Notice that, even with that, the products are loaded and you can trigger a purchase.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/1864060/215122613-b5870f3a-531d-4101-a2e9-6e066e5e1c66.PNG" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.