### PR TITLE
[REST API] Track assigned A/B test variant

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ApplicationPassword.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ApplicationPassword.swift
@@ -5,6 +5,7 @@ extension WooAnalyticsEvent {
         private enum Key {
             static let scenario = "scenario"
             static let cause = "cause"
+            static let experimentVariant = "experiment_variant"
         }
 
         enum Scenario: String {
@@ -17,6 +18,13 @@ extension WooAnalyticsEvent {
             case featureDisabled = "feature_disabled"
             case customLoginOrAdminUrl = "custom_login_or_admin_url"
             case other = "other"
+        }
+
+        /// Tracks the REST API A/B test variation
+        ///
+        static func restAPILoginExperiment(variation: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .trackRestAPILoginExperimentVariation,
+                              properties: [Key.experimentVariant: variation])
         }
 
         /// Tracks when generating application password succeeds

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -821,6 +821,7 @@ public enum WooAnalyticsStat: String {
     // MARK: Application password Events
     case applicationPasswordsNewPasswordCreated = "application_passwords_new_password_created"
     case applicationPasswordsGenerationFailed = "application_passwords_generation_failed"
+    case trackRestAPILoginExperimentVariation = "rest_api_login_experiment"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -142,6 +142,8 @@ private extension AppCoordinator {
         } else {
             configureAndDisplayAuthenticator()
         }
+
+        analytics.track(event: .ApplicationPassword.restAPILoginExperiment(variation: ABTest.applicationPasswordAuthentication.variation.analyticsValue))
     }
 
     /// Configures the WPAuthenticator and sets the authenticator UI as the window's root view.

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -340,10 +340,12 @@ final class AppCoordinatorTests: XCTestCase {
         pushNotesManager.sendLocalNotificationResponse(response)
 
         // Then
-        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.loginLocalNotificationTapped.rawValue])
-        let actionPropertyValue = try XCTUnwrap(analytics.receivedProperties.first?["action"] as? String)
+        let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.loginLocalNotificationTapped.rawValue}))
+        let eventProperties = try XCTUnwrap(analytics.receivedProperties[indexOfEvent])
+
+        let actionPropertyValue = try XCTUnwrap(eventProperties["action"] as? String)
         XCTAssertEqual(actionPropertyValue, "contact_support")
-        let typePropertyValue = try XCTUnwrap(analytics.receivedProperties.first?["type"] as? String)
+        let typePropertyValue = try XCTUnwrap(eventProperties["type"] as? String)
         XCTAssertEqual(typePropertyValue, "site_address_error")
     }
 
@@ -364,10 +366,12 @@ final class AppCoordinatorTests: XCTestCase {
         pushNotesManager.sendLocalNotificationResponse(response)
 
         // Then
-        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.loginLocalNotificationTapped.rawValue])
-        let actionPropertyValue = try XCTUnwrap(analytics.receivedProperties.first?["action"] as? String)
+        let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.loginLocalNotificationTapped.rawValue}))
+        let eventProperties = try XCTUnwrap(analytics.receivedProperties[indexOfEvent])
+
+        let actionPropertyValue = try XCTUnwrap(eventProperties["action"] as? String)
         XCTAssertEqual(actionPropertyValue, "login_with_wpcom")
-        let typePropertyValue = try XCTUnwrap(analytics.receivedProperties.first?["type"] as? String)
+        let typePropertyValue = try XCTUnwrap(eventProperties["type"] as? String)
         XCTAssertEqual(typePropertyValue, "site_address_error")
     }
 
@@ -388,10 +392,12 @@ final class AppCoordinatorTests: XCTestCase {
         pushNotesManager.sendLocalNotificationResponse(response)
 
         // Then
-        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.loginLocalNotificationTapped.rawValue])
-        let actionPropertyValue = try XCTUnwrap(analytics.receivedProperties.first?["action"] as? String)
+        let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.loginLocalNotificationTapped.rawValue}))
+        let eventProperties = try XCTUnwrap(analytics.receivedProperties[indexOfEvent])
+
+        let actionPropertyValue = try XCTUnwrap(eventProperties["action"] as? String)
         XCTAssertEqual(actionPropertyValue, "default")
-        let typePropertyValue = try XCTUnwrap(analytics.receivedProperties.first?["type"] as? String)
+        let typePropertyValue = try XCTUnwrap(eventProperties["type"] as? String)
         XCTAssertEqual(typePropertyValue, "site_address_error")
     }
 
@@ -412,8 +418,10 @@ final class AppCoordinatorTests: XCTestCase {
         pushNotesManager.sendLocalNotificationResponse(response)
 
         // Then
-        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.loginLocalNotificationDismissed.rawValue])
-        let typePropertyValue = try XCTUnwrap(analytics.receivedProperties.first?["type"] as? String)
+        let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.loginLocalNotificationDismissed.rawValue}))
+        let eventProperties = try XCTUnwrap(analytics.receivedProperties[indexOfEvent])
+
+        let typePropertyValue = try XCTUnwrap(eventProperties["type"] as? String)
         XCTAssertEqual(typePropertyValue, "site_address_error")
     }
 }

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -318,7 +318,25 @@ final class AppCoordinatorTests: XCTestCase {
         appCoordinator.start()
 
         // Then
-        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.loginOnboardingShown.rawValue])
+        _ = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.loginOnboardingShown.rawValue}))
+    }
+
+    func test_trackRestAPILoginExperimentVariation_is_tracked_after_presenting_onboarding() throws {
+        // Given
+        stores.deauthenticate()
+        let analytics = MockAnalyticsProvider()
+        let appCoordinator = makeCoordinator(window: window,
+                                             stores: stores,
+                                             authenticationManager: authenticationManager,
+                                             analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        appCoordinator.start()
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == "rest_api_login_experiment" }))
+        let eventProperties = try XCTUnwrap(analytics.receivedProperties[indexOfEvent])
+        XCTAssertNotNil(eventProperties["experiment_variant"] as? String)
     }
 
     // MARK: - Login reminder analytics


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8679
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds tracking for the REST API A/B test. This lets us track the variant assigned to the user.
Internal ref - pe5sF9-13h-p2

**Changes**
- Added track event to track the assigned variant.
- Unit test to validate tracking.
- Refactor unit tests.

### Testing instructions

- Log out of the app
- Launch the app and skip onboarding if needed.
- From the prologue screen you can know which variant has been assigned to your device. 
- Control will have the existing login screen has both WPCOM and store address login options.
- Treatment will only have the store address login option.
- Check Xcode logs and ensure that the following event is tracked.
```
Tracked rest_api_login_experiment, properties: [AnyHashable("experiment_variant"): "control"]
```
- Value for `experiment_variant` will vary based on the assigned variant. Currently, the experiment is `staging, so we will always get the value `control` here. 21039-explat-experiment

### Screenshots
| | Control | Treatment |
| -----| ----- | ----- |
| Prologue screen | <image src="https://user-images.githubusercontent.com/5533851/213160111-3f6c0fec-2dc8-402e-8b8a-5dd5bda07ebc.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/213160207-d5fa8774-7407-4e36-a9dd-30438c9e1d59.png" width=320 /> |

### Tracks event registration
https://github.com/Automattic/tracks-events-registration/pull/1355

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.