### PR TITLE
[Mobile Payments] Start search again when Try Again tapped on Built-in reader connection errors

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -470,10 +470,6 @@ extension StripeCardReaderService: CardReaderService {
                         .softwareUpdate(underlyingError: underlyingError, batteryLevel: nil) :
                         .connection(underlyingError: underlyingError)
                     promise(.failure(serviceError))
-
-                    if case .appleBuiltInReaderTOSAcceptanceCanceled = underlyingError {
-                        self.discoveryCancellable?.cancel({ _ in })
-                    }
                 }
 
                 if let reader = reader {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingFailed.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectingFailed.swift
@@ -4,7 +4,7 @@ import Yosemite
 /// Modal presented when an error occurs while connecting to a reader
 ///
 final class CardPresentModalConnectingFailed: CardPresentPaymentsModalViewModel {
-    private let continueSearchAction: () -> Void
+    private let retrySearchAction: () -> Void
     private let cancelSearchAction: () -> Void
 
     let textMode: PaymentsModalTextMode = .reducedTopInfo
@@ -31,9 +31,9 @@ final class CardPresentModalConnectingFailed: CardPresentPaymentsModalViewModel 
     }
 
     init(error: Error,
-         continueSearch: @escaping () -> Void,
+         retrySearch: @escaping () -> Void,
          cancelSearch: @escaping () -> Void) {
-        self.continueSearchAction = continueSearch
+        self.retrySearchAction = retrySearch
         self.cancelSearchAction = cancelSearch
 
         switch error {
@@ -45,7 +45,7 @@ final class CardPresentModalConnectingFailed: CardPresentPaymentsModalViewModel 
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        continueSearchAction()
+        retrySearchAction()
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -237,7 +237,7 @@ private extension BuiltInCardReaderConnectionController {
                 guard case .searching = self.state else {
                     return
                 }
-                
+
                 /// If we have a found reader, advance to `connectToReader`
                 ///
                 if cardReaders.isNotEmpty {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -645,7 +645,7 @@ private extension CardReaderConnectionController {
         guard case CardReaderServiceError.connection(let underlyingError) = error else {
             return alertsPresenter.present(
                 viewModel: alertsProvider.connectingFailed(error: error,
-                                                           continueSearch: continueSearch,
+                                                           retrySearch: continueSearch,
                                                            cancelSearch: cancelSearch))
         }
 
@@ -668,10 +668,12 @@ private extension CardReaderConnectionController {
                     retrySearch: retrySearch,
                     cancelSearch: cancelSearch))
         default:
+            // We continueSearch here from a button labeled `Try again`, rather than retrying from the beginning,
+            // this is because the original reader can be re-discovered in the same process.
             alertsPresenter.present(
                 viewModel: alertsProvider.connectingFailed(
                     error: error,
-                    continueSearch: continueSearch,
+                    retrySearch: continueSearch,
                     cancelSearch: cancelSearch))
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
@@ -16,9 +16,9 @@ struct BluetoothReaderConnectionAlertsProvider: BluetoothReaderConnnectionAlerts
     }
 
     func connectingFailed(error: Error,
-                          continueSearch: @escaping () -> Void,
+                          retrySearch: @escaping () -> Void,
                           cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalConnectingFailed(error: error, continueSearch: continueSearch, cancelSearch: cancelSearch)
+        CardPresentModalConnectingFailed(error: error, retrySearch: retrySearch, cancelSearch: cancelSearch)
     }
 
     func connectingFailedNonRetryable(error: Error, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
@@ -16,10 +16,10 @@ struct BuiltInReaderConnectionAlertsProvider: CardReaderConnectionAlertsProvidin
     }
 
     func connectingFailed(error: Error,
-                          continueSearch: @escaping () -> Void,
+                          retrySearch: @escaping () -> Void,
                           cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalBuiltInConnectingFailed(error: error,
-                                                continueSearch: continueSearch,
+                                                continueSearch: retrySearch,
                                                 cancelSearch: cancelSearch)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
@@ -23,7 +23,7 @@ protocol CardReaderConnectionAlertsProviding {
     /// or cancel
     ///
     func connectingFailed(error: Error,
-                          continueSearch: @escaping () -> Void,
+                          retrySearch: @escaping () -> Void,
                           cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
 
     /// Defines an alert indicating connecting failed, in a way which must be resolved outside

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -190,7 +190,7 @@ private extension CardReaderSettingsAlerts {
     func connectingFailed(error: Error,
                           continueSearch: @escaping () -> Void,
                           cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalConnectingFailed(error: error, continueSearch: continueSearch, cancelSearch: cancelSearch)
+        CardPresentModalConnectingFailed(error: error, retrySearch: continueSearch, cancelSearch: cancelSearch)
     }
 
     func connectingFailedUpdateAddress(openWCSettings: ((UIViewController) -> Void)?,

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalConnectingFailedTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CardPresentModalConnectingFailedTests.swift
@@ -12,7 +12,7 @@ final class CardPresentModalConnectingFailedTests: XCTestCase {
         closures = Closures()
         viewModel = CardPresentModalConnectingFailed(
             error: CardReaderServiceError.connection(underlyingError: .alreadyConnectedToReader),
-            continueSearch: closures.continueSearch(),
+            retrySearch: closures.continueSearch(),
             cancelSearch: closures.cancelSearch()
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8750
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The `Try again` button on Built-in reader connection errors did not work.

This was because it was based on the `CardReaderConnectionController`, which continues the discovery process when `Try again` is tapped. Doing that with the built in reader would not result in the original reader being found again... so the "preparing reader" modal would be shown forever.

This PR changes the button to start discovery again in that case, and that means that the built-in reader is found.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

It's difficult to simulate connection errors for the built in reader. The only ways I've found involve code changes.

Replace the [local mobile connection configuration](https://github.com/woocommerce/woocommerce-ios/blob/669dc77664c4b8b0d68c949f0669a9904a14e604/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift#L402) with the following:

```
return promise(.success(LocalMobileConnectionConfiguration(locationId: locationId, merchantDisplayName: nil, onBehalfOf: nil, tosAcceptancePermitted: false)))
```

Using a store for which Apple's terms of service haven't been connected (or disconnect the store using `https://register.apple.com/`)

1. Navigate to `Menu > Payments > Collect payment`
2. Follow the flow through to the `Payment Method` screen
3. Choose `Card`
4. Wait for the error to show
5. Tap `Try again`
6. Observe that the `Preparing iPhone card reader` screen shows again
7. Observe that the error then shows again.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/2472348/214869271-aa55f6c0-03ad-49ae-bf24-703c7efd1c2b.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
