### PR TITLE
[Mobile Payments] Move onboarding checks to PreflightController

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -49,12 +49,6 @@ final class PaymentCaptureOrchestrator {
                         onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> Void) {
         onPreparingReader()
 
-        /// Set state of CardPresentPaymentStore
-        ///
-        let setAccount = CardPresentPaymentAction.use(paymentGatewayAccount: paymentGatewayAccount)
-
-        stores.dispatch(setAccount)
-
         let parameters = paymentParameters(order: order,
                                            orderTotal: orderTotal,
                                            country: paymentGatewayAccount.country,

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -35,9 +35,18 @@ final class CardPresentPaymentPreflightController {
     ///
     private let analytics: Analytics
 
-    /// Stores the connected card reader
-    private var connectedReader: CardReader?
+    /// Root View Controller
+    /// Used for showing onboarding alerts
+    private let rootViewController: UIViewController
 
+    /// Onboarding presenter.
+    /// Shows messages to help a merchant get correctly set up for card payments, prior to taking a payment.
+    ///
+    private let onboardingPresenter: CardPresentPaymentsOnboardingPresenting
+
+    /// Stores the connected card reader
+    ///
+    private var connectedReader: CardReader?
 
     /// Controller to connect a card reader.
     ///
@@ -53,13 +62,17 @@ final class CardPresentPaymentPreflightController {
     init(siteID: Int64,
          paymentGatewayAccount: PaymentGatewayAccount,
          configuration: CardPresentPaymentsConfiguration,
+         rootViewController: UIViewController,
          alertsPresenter: CardPresentPaymentAlertsPresenting,
+         onboardingPresenter: CardPresentPaymentsOnboardingPresenting,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.paymentGatewayAccount = paymentGatewayAccount
         self.configuration = configuration
+        self.rootViewController = rootViewController
         self.alertsPresenter = alertsPresenter
+        self.onboardingPresenter = onboardingPresenter
         self.stores = stores
         self.analytics = analytics
         self.connectedReader = nil
@@ -92,7 +105,7 @@ final class CardPresentPaymentPreflightController {
             return
         }
 
-        // TODO: Run onboarding if needed
+        await onboardingPresenter.showOnboardingIfRequired(from: rootViewController)
 
         // Ask for a Reader type if supported by device/in country
         guard await localMobileReaderSupported(),

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -170,13 +170,6 @@ final class CardPresentPaymentPreflightController {
         }
     }
 
-    /// Configure the CardPresentPaymentStore to use the appropriate backend
-    ///
-    private func configureBackend() {
-        let setAccount = CardPresentPaymentAction.use(paymentGatewayAccount: paymentGatewayAccount)
-        stores.dispatch(setAccount)
-    }
-
     private func observeConnectedReaders() {
         let action = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
             self?.connectedReader = readers.first

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -1,9 +1,6 @@
 import Foundation
 import Yosemite
 import Combine
-#if !targetEnvironment(simulator)
-import ProximityReader
-#endif
 
 enum CardReaderPreflightResult {
     case completed(CardReader, PaymentGatewayAccount)

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -8,10 +8,6 @@ import protocol Storage.StorageManagerType
 import enum Hardware.CardReaderServiceError
 import enum Hardware.UnderlyingError
 
-enum CollectOrderPaymentUseCaseError: Error {
-    case flowCanceledByUser
-}
-
 /// Protocol to abstract the `CollectOrderPaymentUseCase`.
 /// Currently only used to facilitate unit tests.
 ///
@@ -246,7 +242,7 @@ private extension CollectOrderPaymentUseCase {
         }
 
         guard let paymentGatewayAccount = paymentGatewayAccount else {
-            onCompletion(.failure(CollectOrderPaymentError.paymentGatewayNotFound))
+            onCompletion(.failure(CollectOrderPaymentUseCaseError.paymentGatewayNotFound))
             return
         }
 
@@ -610,7 +606,8 @@ extension CollectOrderPaymentUseCase {
         }
     }
 
-    enum CollectOrderPaymentError: Error {
+    enum CollectOrderPaymentUseCaseError: Error {
+        case flowCanceledByUser
         case paymentGatewayNotFound
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -605,9 +605,9 @@ extension CollectOrderPaymentUseCase {
             )
         }
     }
+}
 
-    enum CollectOrderPaymentUseCaseError: Error {
-        case flowCanceledByUser
-        case paymentGatewayNotFound
-    }
+enum CollectOrderPaymentUseCaseError: Error {
+    case flowCanceledByUser
+    case paymentGatewayNotFound
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -73,6 +73,10 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
     ///
     private let alertsPresenter: CardPresentPaymentAlertsPresenting
 
+    /// Onboarding presenter: shows steps for payment setup when required
+    ///
+    private let onboardingPresenter: CardPresentPaymentsOnboardingPresenting
+
     /// Stores the card reader listener subscription while trying to connect to one.
     ///
     private var readerSubscription: AnyCancellable?
@@ -103,6 +107,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
          formattedAmount: String,
          paymentGatewayAccount: PaymentGatewayAccount,
          rootViewController: UIViewController,
+         onboardingPresenter: CardPresentPaymentsOnboardingPresenting,
          configuration: CardPresentPaymentsConfiguration,
          stores: StoresManager = ServiceLocator.stores,
          paymentCaptureCelebration: PaymentCaptureCelebrationProtocol = PaymentCaptureCelebration(),
@@ -112,6 +117,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
         self.formattedAmount = formattedAmount
         self.paymentGatewayAccount = paymentGatewayAccount
         self.rootViewController = rootViewController
+        self.onboardingPresenter = onboardingPresenter
         self.alertsPresenter = CardPresentPaymentAlertsPresenter(rootViewController: rootViewController)
         self.configuration = configuration
         self.stores = stores
@@ -144,7 +150,9 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
         preflightController = CardPresentPaymentPreflightController(siteID: siteID,
                                                                     paymentGatewayAccount: paymentGatewayAccount,
                                                                     configuration: configuration,
-                                                                    alertsPresenter: alertsPresenter)
+                                                                    rootViewController: rootViewController,
+                                                                    alertsPresenter: alertsPresenter,
+                                                                    onboardingPresenter: onboardingPresenter)
         preflightController?.readerConnection.sink { [weak self] connectionResult in
             guard let self = self else { return }
             switch connectionResult {

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -178,7 +178,7 @@ final class PaymentMethodsViewModel: ObservableObject {
 
     /// Mark an order as paid and notify if successful.
     ///
-    func markOrderAsPaid(onSuccess: @escaping () -> ()) {
+    func markOrderAsPaid(onSuccess: @escaping () -> Void) {
         showLoadingIndicator = true
         let action = OrderAction.updateOrderStatus(siteID: siteID, orderID: orderID, status: .completed) { [weak self] error in
             guard let self = self else { return }
@@ -204,8 +204,8 @@ final class PaymentMethodsViewModel: ObservableObject {
     ///
     func collectPayment(on rootViewController: UIViewController?,
                         useCase: LegacyCollectOrderPaymentProtocol? = nil,
-                        onSuccess: @escaping () -> (),
-                        onFailure: @escaping () -> ()) {
+                        onSuccess: @escaping () -> Void,
+                        onFailure: @escaping () -> Void) {
         switch isTapToPayOnIPhoneEnabled {
         case true:
             newCollectPayment(on: rootViewController, onSuccess: onSuccess, onFailure: onFailure)
@@ -216,8 +216,8 @@ final class PaymentMethodsViewModel: ObservableObject {
 
     func newCollectPayment(on rootViewController: UIViewController?,
                            useCase: CollectOrderPaymentProtocol? = nil,
-                           onSuccess: @escaping () -> (),
-                           onFailure: @escaping () -> ()) {
+                           onSuccess: @escaping () -> Void,
+                           onFailure: @escaping () -> Void) {
         trackCollectIntention(method: .card)
 
         guard let rootViewController = rootViewController else {
@@ -269,7 +269,7 @@ final class PaymentMethodsViewModel: ObservableObject {
 
     func legacyCollectPayment(on rootViewController: UIViewController?,
                               useCase: LegacyCollectOrderPaymentProtocol? = nil,
-                              onSuccess: @escaping () -> ()) {
+                              onSuccess: @escaping () -> Void) {
         trackCollectIntention(method: .card)
 
         guard let rootViewController = rootViewController else {

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsOnboardingPresenter.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsOnboardingPresenter.swift
@@ -5,9 +5,13 @@ final class MockCardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboa
     var spyShowOnboardingWasCalled = false
 
     func showOnboardingIfRequired(from viewController: UIViewController,
-                                  readyToCollectPayment completion: @escaping (() -> ())) {
+                                  readyToCollectPayment completion: @escaping () -> Void) {
         spyShowOnboardingWasCalled = true
         completion()
+    }
+
+    func showOnboardingIfRequired(from: UIViewController) async {
+        spyShowOnboardingWasCalled = true
     }
 
     func refresh() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As part of the refactor of the card payments classes for Tap to Pay, we planned to move the responsibility for the onboarding check to the new `CardPresentPaymentsPreflightController`. This PR makes that change.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Using a US-based WCPay or Stripe store:

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. Observe that if you tap `Card` quickly, you see onboarding briefly ("Connecting to your account"), but if you wait a few seconds you don't see that before the payment.

### On your site's wp-admin plugin page, deactivate WCPay and/or Stripe

1. Navigate to `Menu > Settings > Experimental features`
2. Turn on `Tap to Pay on iPhone`
3. Navigate to `Menu > Payments > Collect payment`
4. Go through the payment flow, and select `Card` on the payment method screen
5. Observe that you see the `Activate WooCommerce Payments` onboarding screen 
6. Reactivate the plugin on your site
7. Tap `Refresh after updating` in the app
8. Observe that you can complete the payment.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
