### PR TITLE
Beta fix: Update bulk editing flow to remove toolbar

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
@@ -102,7 +102,7 @@ final class PriceInputViewModel {
             footerData.append(Localization.variationsWarning)
         }
 
-        let numberOfProducts = productListViewModel.selectedProductsCount - productListViewModel.selectedVariableProductsCount
+        let numberOfProducts = productListViewModel.selectedProductsCount - productListViewModel.selectedNonSimpleProductsCount
         let numberOfProductsText = String.pluralize(numberOfProducts,
                                                     singular: Localization.productsNumberSingularFooter,
                                                     plural: Localization.productsNumberPluralFooter)

--- a/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/PriceInputViewModel.swift
@@ -102,7 +102,7 @@ final class PriceInputViewModel {
             footerData.append(Localization.variationsWarning)
         }
 
-        let numberOfProducts = productListViewModel.selectedProductsCount - productListViewModel.selectedNonSimpleProductsCount
+        let numberOfProducts = productListViewModel.selectedProductsCount - productListViewModel.selectedPriceIncompatibleProductsCount
         let numberOfProductsText = String.pluralize(numberOfProducts,
                                                     singular: Localization.productsNumberSingularFooter,
                                                     plural: Localization.productsNumberPluralFooter)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -14,6 +14,10 @@ class ProductListViewModel {
 
     private(set) var selectedProducts: Set<Product> = .init()
 
+    private var onlySimpleSelectedProducts: Set<Product> {
+        selectedProducts.filter({ $0.productType == .simple })
+    }
+
     init(siteID: Int64, stores: StoresManager) {
         self.siteID = siteID
         self.stores = stores
@@ -32,7 +36,7 @@ class ProductListViewModel {
     }
 
     var onlyNonSimpleProductsSelected: Bool {
-        !selectedProducts.isEmpty && selectedProducts.filter({ $0.productType == .simple }).isEmpty
+        !selectedProducts.isEmpty && onlySimpleSelectedProducts.isEmpty
     }
 
     var bulkEditActionIsEnabled: Bool {
@@ -116,12 +120,12 @@ class ProductListViewModel {
     /// Update selected products with new price and trigger Network action to save the change remotely.
     ///
     func updateSelectedProducts(with newPrice: String, completion: @escaping (Result<Void, Error>) -> Void ) {
-        guard selectedProductsCount > 0 else {
+        guard onlySimpleSelectedProducts.count > 0 else {
             completion(.failure(BulkEditError.noProductsSelected))
             return
         }
 
-        let updatedProducts = selectedProducts.map({ $0.copy(regularPrice: newPrice) })
+        let updatedProducts = onlySimpleSelectedProducts.map({ $0.copy(regularPrice: newPrice) })
         let batchAction = ProductAction.updateProducts(siteID: siteID, products: updatedProducts) { result in
             switch result {
             case .success:

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -27,8 +27,12 @@ class ProductListViewModel {
         selectedProducts.filter({ $0.productType == .variable }).count
     }
 
-    var onlyVariableProductsSelected: Bool {
-        selectedProducts.filter({ $0.productType != .variable }).isEmpty
+    var selectedNonSimpleProductsCount: Int {
+        selectedProducts.filter({ $0.productType != .simple }).count
+    }
+
+    var onlyNonSimpleProductsSelected: Bool {
+        !selectedProducts.isEmpty && selectedProducts.filter({ $0.productType == .simple }).isEmpty
     }
 
     var bulkEditActionIsEnabled: Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -14,10 +14,6 @@ class ProductListViewModel {
 
     private(set) var selectedProducts: Set<Product> = .init()
 
-    private var onlySimpleSelectedProducts: Set<Product> {
-        selectedProducts.filter({ $0.productType == .simple })
-    }
-
     init(siteID: Int64, stores: StoresManager) {
         self.siteID = siteID
         self.stores = stores
@@ -31,12 +27,30 @@ class ProductListViewModel {
         selectedProducts.filter({ $0.productType == .variable }).count
     }
 
-    var selectedNonSimpleProductsCount: Int {
-        selectedProducts.filter({ $0.productType != .simple }).count
+    /// Product types that are incompatible with bulk update of regular price
+    ///
+    private let priceIncompatibleProductsTypes: Set<ProductType> = [
+        .variable,
+        .grouped,
+        .custom("booking")
+    ]
+
+    /// Number of selected products that are incompatible with bulk update of regular price
+    ///
+    var selectedPriceIncompatibleProductsCount: Int {
+        selectedProducts.filter({ priceIncompatibleProductsTypes.contains($0.productType) }).count
     }
 
-    var onlyNonSimpleProductsSelected: Bool {
-        !selectedProducts.isEmpty && onlySimpleSelectedProducts.isEmpty
+    /// Boolean indicating if all of selected products are incompatible with bulk update of regular price
+    ///
+    var onlyPriceIncompatibleProductsSelected: Bool {
+        !selectedProducts.isEmpty && onlyPriceCompatibleSelectedProducts.isEmpty
+    }
+
+    /// Subset of selected products filtered for types that support bulk update of regular price
+    ///
+    private var onlyPriceCompatibleSelectedProducts: Set<Product> {
+        selectedProducts.filter({ !priceIncompatibleProductsTypes.contains($0.productType) })
     }
 
     var bulkEditActionIsEnabled: Bool {
@@ -120,12 +134,12 @@ class ProductListViewModel {
     /// Update selected products with new price and trigger Network action to save the change remotely.
     ///
     func updateSelectedProducts(with newPrice: String, completion: @escaping (Result<Void, Error>) -> Void ) {
-        guard onlySimpleSelectedProducts.count > 0 else {
+        guard !onlyPriceCompatibleSelectedProducts.isEmpty else {
             completion(.failure(BulkEditError.noProductsSelected))
             return
         }
 
-        let updatedProducts = onlySimpleSelectedProducts.map({ $0.copy(regularPrice: newPrice) })
+        let updatedProducts = onlyPriceCompatibleSelectedProducts.map({ $0.copy(regularPrice: newPrice) })
         let batchAction = ProductAction.updateProducts(siteID: siteID, products: updatedProducts) { result in
             switch result {
             case .success:

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -134,7 +134,7 @@ class ProductListViewModel {
     /// Update selected products with new price and trigger Network action to save the change remotely.
     ///
     func updateSelectedProducts(with newPrice: String, completion: @escaping (Result<Void, Error>) -> Void ) {
-        guard !onlyPriceCompatibleSelectedProducts.isEmpty else {
+        guard !onlyPriceIncompatibleProductsSelected else {
             completion(.failure(BulkEditError.noProductsSelected))
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -225,6 +225,12 @@ final class ProductsViewController: UIViewController, GhostableViewController {
         }
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        finishBulkEditing()
+    }
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -297,6 +297,8 @@ private extension ProductsViewController {
         viewModel.deselectAll()
         tableView.setEditing(false, animated: true)
 
+        bulkEditButton.isEnabled = false
+
         // Enable pull-to-refresh
         tableView.addSubview(refreshControl)
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -331,7 +331,7 @@ private extension ProductsViewController {
         let cancelAction = UIAlertAction(title: Localization.cancel, style: .cancel)
 
         actionSheet.addAction(updateStatus)
-        if !viewModel.onlyVariableProductsSelected {
+        if !viewModel.onlyNonSimpleProductsSelected {
             actionSheet.addAction(updatePrice)
         }
         actionSheet.addAction(cancelAction)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -337,7 +337,7 @@ private extension ProductsViewController {
         let cancelAction = UIAlertAction(title: Localization.cancel, style: .cancel)
 
         actionSheet.addAction(updateStatus)
-        if !viewModel.onlyNonSimpleProductsSelected {
+        if !viewModel.onlyPriceIncompatibleProductsSelected {
             actionSheet.addAction(updatePrice)
         }
         actionSheet.addAction(cancelAction)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.xib
@@ -11,8 +11,6 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductsViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
-                <outlet property="bottomPlaceholder" destination="xLN-As-fgq" id="bwi-vq-EvS"/>
-                <outlet property="bottomToolbar" destination="pNN-uJ-nMs" id="Z6G-Im-KE6"/>
                 <outlet property="tableView" destination="1mE-SE-uK9" id="ogX-nu-l5x"/>
                 <outlet property="toolbar" destination="9eA-hc-k15" id="V2c-iT-WpM"/>
                 <outlet property="view" destination="iN0-l3-epB" id="Jh9-wF-LZg"/>
@@ -34,31 +32,17 @@
                             </constraints>
                         </view>
                         <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="1mE-SE-uK9">
-                            <rect key="frame" x="0.0" y="50" width="414" height="715"/>
+                            <rect key="frame" x="0.0" y="50" width="414" height="798"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="orders-table-view"/>
                             </userDefinedRuntimeAttributes>
                         </tableView>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pNN-uJ-nMs" userLabel="Bulk Edit Bar" customClass="ToolbarView" customModule="WooCommerce" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="765" width="414" height="49"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                            <constraints>
-                                <constraint firstAttribute="height" priority="995" constant="49" id="mXV-oU-3bM">
-                                    <variation key="heightClass=compact" constant="32"/>
-                                </constraint>
-                            </constraints>
-                        </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xLN-As-fgq" userLabel="Safe Area Placeholder">
-                            <rect key="frame" x="0.0" y="814" width="414" height="34"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        </view>
                     </subviews>
                     <constraints>
                         <constraint firstItem="9eA-hc-k15" firstAttribute="leading" secondItem="tDW-j0-dUT" secondAttribute="leading" id="2Md-DN-FrJ"/>
                         <constraint firstItem="1mE-SE-uK9" firstAttribute="top" secondItem="9eA-hc-k15" secondAttribute="bottom" id="CRj-o0-2WZ"/>
                         <constraint firstAttribute="trailing" secondItem="9eA-hc-k15" secondAttribute="trailing" id="Qcx-pF-i9M"/>
                         <constraint firstItem="9eA-hc-k15" firstAttribute="top" secondItem="tDW-j0-dUT" secondAttribute="top" id="ilw-mJ-v1G"/>
-                        <constraint firstItem="pNN-uJ-nMs" firstAttribute="top" secondItem="1mE-SE-uK9" secondAttribute="bottom" id="mlT-bM-H2X"/>
                     </constraints>
                 </stackView>
             </subviews>
@@ -69,10 +53,8 @@
                 <constraint firstItem="tDW-j0-dUT" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="9UK-Qy-FXd"/>
                 <constraint firstAttribute="bottom" secondItem="tDW-j0-dUT" secondAttribute="bottom" id="AQF-qF-3wt"/>
                 <constraint firstItem="1mE-SE-uK9" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="E6i-2y-FvV"/>
-                <constraint firstItem="xLN-As-fgq" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="Iu8-XK-w4W"/>
                 <constraint firstItem="tDW-j0-dUT" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="KSv-iL-NFv"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="1mE-SE-uK9" secondAttribute="trailing" id="qVI-Qq-E5k"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="pNN-uJ-nMs" secondAttribute="bottom" id="xJE-yf-lID"/>
             </constraints>
             <point key="canvasLocation" x="100.00000000000001" y="48.883928571428569"/>
         </view>

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
@@ -152,7 +152,7 @@ final class ProductListViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.selectedProductsCount, 2)
         XCTAssertEqual(viewModel.selectedVariableProductsCount, 1)
-        XCTAssertFalse(viewModel.onlyNonSimpleProductsSelected)
+        XCTAssertFalse(viewModel.onlyPriceIncompatibleProductsSelected)
 
         // When
         viewModel.deselectProduct(sampleProduct1)
@@ -160,35 +160,45 @@ final class ProductListViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.selectedProductsCount, 1)
         XCTAssertEqual(viewModel.selectedVariableProductsCount, 1)
-        XCTAssertTrue(viewModel.onlyNonSimpleProductsSelected)
+        XCTAssertTrue(viewModel.onlyPriceIncompatibleProductsSelected)
     }
 
     func test_product_type_helpers_work_correctly() {
         // Given
         let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+
+        // products compatible with bulk price update
         let sampleProduct1 = Product.fake().copy(productID: 1, productTypeKey: "simple")
-        let sampleProduct2 = Product.fake().copy(productID: 2, productTypeKey: "variable")
-        let sampleProduct3 = Product.fake().copy(productID: 3, productTypeKey: "grouped")
-        let sampleProduct4 = Product.fake().copy(productID: 4, productTypeKey: "booking")
+        let sampleProduct2 = Product.fake().copy(productID: 2, productTypeKey: "affiliate")
+        let sampleProduct3 = Product.fake().copy(productID: 3, productTypeKey: "custom-unknown")
+
+        // products incompatible with bulk price update
+        let sampleProduct4 = Product.fake().copy(productID: 4, productTypeKey: "variable")
+        let sampleProduct5 = Product.fake().copy(productID: 5, productTypeKey: "grouped")
+        let sampleProduct6 = Product.fake().copy(productID: 6, productTypeKey: "booking")
 
         // When
         viewModel.selectProduct(sampleProduct1)
         viewModel.selectProduct(sampleProduct2)
         viewModel.selectProduct(sampleProduct3)
         viewModel.selectProduct(sampleProduct4)
+        viewModel.selectProduct(sampleProduct5)
+        viewModel.selectProduct(sampleProduct6)
 
         // Then
-        XCTAssertEqual(viewModel.selectedProductsCount, 4)
-        XCTAssertEqual(viewModel.selectedNonSimpleProductsCount, 3)
-        XCTAssertFalse(viewModel.onlyNonSimpleProductsSelected)
+        XCTAssertEqual(viewModel.selectedProductsCount, 6)
+        XCTAssertEqual(viewModel.selectedPriceIncompatibleProductsCount, 3)
+        XCTAssertFalse(viewModel.onlyPriceIncompatibleProductsSelected)
 
         // When
         viewModel.deselectProduct(sampleProduct1)
+        viewModel.deselectProduct(sampleProduct2)
+        viewModel.deselectProduct(sampleProduct3)
 
         // Then
         XCTAssertEqual(viewModel.selectedProductsCount, 3)
-        XCTAssertEqual(viewModel.selectedNonSimpleProductsCount, 3)
-        XCTAssertTrue(viewModel.onlyNonSimpleProductsSelected)
+        XCTAssertEqual(viewModel.selectedPriceIncompatibleProductsCount, 3)
+        XCTAssertTrue(viewModel.onlyPriceIncompatibleProductsSelected)
     }
 
     func test_common_status_works_correctly() {
@@ -270,7 +280,7 @@ final class ProductListViewModelTests: XCTestCase {
         // Given
         let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
         let sampleProduct1 = Product.fake().copy(productID: 1, productTypeKey: "simple", regularPrice: "100")
-        let sampleProduct2 = Product.fake().copy(productID: 2, productTypeKey: "simple", regularPrice: "200")
+        let sampleProduct2 = Product.fake().copy(productID: 2, productTypeKey: "affiliate", regularPrice: "200")
         let sampleProduct3 = Product.fake().copy(productID: 3, productTypeKey: "variable", regularPrice: "200")
 
         storesManager.whenReceivingAction(ofType: ProductAction.self) { action in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
@@ -142,7 +142,7 @@ final class ProductListViewModelTests: XCTestCase {
     func test_variation_helpers_work_correctly() {
         // Given
         let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
-        let sampleProduct1 = Product.fake().copy(productID: 1)
+        let sampleProduct1 = Product.fake().copy(productID: 1, productTypeKey: "simple")
         let sampleProduct2 = Product.fake().copy(productID: 2, productTypeKey: "variable")
 
         // When
@@ -152,7 +152,7 @@ final class ProductListViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.selectedProductsCount, 2)
         XCTAssertEqual(viewModel.selectedVariableProductsCount, 1)
-        XCTAssertFalse(viewModel.onlyVariableProductsSelected)
+        XCTAssertFalse(viewModel.onlyNonSimpleProductsSelected)
 
         // When
         viewModel.deselectProduct(sampleProduct1)
@@ -160,7 +160,35 @@ final class ProductListViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.selectedProductsCount, 1)
         XCTAssertEqual(viewModel.selectedVariableProductsCount, 1)
-        XCTAssertTrue(viewModel.onlyVariableProductsSelected)
+        XCTAssertTrue(viewModel.onlyNonSimpleProductsSelected)
+    }
+
+    func test_product_type_helpers_work_correctly() {
+        // Given
+        let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
+        let sampleProduct1 = Product.fake().copy(productID: 1, productTypeKey: "simple")
+        let sampleProduct2 = Product.fake().copy(productID: 2, productTypeKey: "variable")
+        let sampleProduct3 = Product.fake().copy(productID: 3, productTypeKey: "grouped")
+        let sampleProduct4 = Product.fake().copy(productID: 4, productTypeKey: "booking")
+
+        // When
+        viewModel.selectProduct(sampleProduct1)
+        viewModel.selectProduct(sampleProduct2)
+        viewModel.selectProduct(sampleProduct3)
+        viewModel.selectProduct(sampleProduct4)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedProductsCount, 4)
+        XCTAssertEqual(viewModel.selectedNonSimpleProductsCount, 3)
+        XCTAssertFalse(viewModel.onlyNonSimpleProductsSelected)
+
+        // When
+        viewModel.deselectProduct(sampleProduct1)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedProductsCount, 3)
+        XCTAssertEqual(viewModel.selectedNonSimpleProductsCount, 3)
+        XCTAssertTrue(viewModel.onlyNonSimpleProductsSelected)
     }
 
     func test_common_status_works_correctly() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductListViewModelTests.swift
@@ -266,16 +266,17 @@ final class ProductListViewModelTests: XCTestCase {
         XCTAssertTrue(result.isSuccess)
     }
 
-    func test_updating_products_with_price_sets_correct_price() throws {
+    func test_updating_products_with_price_sets_correct_price_and_filters_simple_products() throws {
         // Given
         let viewModel = ProductListViewModel(siteID: sampleSiteID, stores: storesManager)
-        let sampleProduct1 = Product.fake().copy(productID: 1, regularPrice: "100")
-        let sampleProduct2 = Product.fake().copy(productID: 2, regularPrice: "100")
-        let sampleProduct3 = Product.fake().copy(productID: 3, regularPrice: "200")
+        let sampleProduct1 = Product.fake().copy(productID: 1, productTypeKey: "simple", regularPrice: "100")
+        let sampleProduct2 = Product.fake().copy(productID: 2, productTypeKey: "simple", regularPrice: "200")
+        let sampleProduct3 = Product.fake().copy(productID: 3, productTypeKey: "variable", regularPrice: "200")
 
         storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .updateProducts(_, products, completion):
+                XCTAssertEqual(products.count, 2)
                 XCTAssertTrue(products.allSatisfy { $0.regularPrice == "150" })
                 completion(.success(products))
             default:


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/8756

## Description

This PR updates layout of selection mode on product list, currently used for bulk editing.
It removes bottom toolbar and "select all" button. "Bulk update" button is moved from bottom toolbar to the top navbar.
As an additional improvement it updates "variable products filter" in the price flow to filter all non-simple products (more info in https://github.com/woocommerce/woocommerce-ios/issues/8756).

Internal refs:
p5T066-3PC-p2
p1674757883082349-slack-C02KUCFCSFP

## Testing

1. On the products list tap the "multi-select" icon in the navbar.
2. Select some products, then tap "Bulk update" in the navbar.
3. Go through status and price update flows.
4. Selecting only non-simple products (variable, grouped, custom).
5. Tap "Bulk update" - price option should be unavailable.

## Screenshots

before|after
--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/214936350-b2d38d6a-c388-4a86-9861-428ccb1721b5.png)|![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/214936378-64bdaa4e-149a-4f17-a011-a711a400e030.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.