### PR TITLE
[REST API] Logout if application password authentication fails

### DIFF
--- a/Networking/Networking/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Networking/Networking/CookieNonce/CookieNonceAuthenticator.swift
@@ -87,6 +87,10 @@ private extension CookieNonceAuthenticator {
                 invalidateLoginSequence(error: error)
             } catch {
                 DDLogError("⛔️ Cookie nonce authenticator failed with uncaught error: \(error)")
+
+                //  Complete the pending requests without retrying. This informs the clients waiting for response about the failure.
+                //
+                completeRequests(false)
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8506
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR force logs out the user when the application password regenaration fails. 

## Testing instructions

**Prerequisite**
To force the `treatment` variation, we have to change some code in the `ABTEST.swift` file. Replace the `variation` computed property with the following.
```swift
    /// Returns a variation for the given experiment
    public var variation: Variation {
        if self == .applicationPasswordAuthentication {
            return .treatment
        }
        return ExPlat.shared?.experiment(rawValue) ?? .control
    }
```

**Feature disabled/blocked by plugin**
- Log out if needed and launch the app
- Login using your JN site store address
- Validate that you can load Orders/Products
- Install "WordFence" plugin on your site and enable it. This step disables the application passwords feature on your site.
- Reload Orders/Products you should be logged out of the app.

**Password changed**
- Log out if needed and launch the app
- Login using your JN site store address
- Validate that you can load Orders/Products
- Change your wp-admin password from your site.
- Delete the application password from the wp-admin page.
- Reload Orders/Products, and you should be logged out of the app.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/524475/215077115-1c42d547-d801-4e7f-bbdd-b22a1c03484e.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
