### PR TITLE
[Mobile Payments] Measure Order Creation IPP Flows

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -416,7 +416,7 @@ extension WooAnalyticsEvent {
         }
 
         enum GlobalKeys {
-            static let timestampSinceOrderAddNew = "timestamp_since_order_add_new"
+            static let timeIntervalSinceOrderAddNew = "time_interval_since_order_add_new"
         }
 
         private enum Keys {
@@ -524,8 +524,8 @@ extension WooAnalyticsEvent {
         static func orderCreationSuccess() -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [:]
 
-            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timestampSinceOrderAddNew() {
-                properties[GlobalKeys.timestampSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timeIntervalSinceOrderAddNew() {
+                properties[GlobalKeys.timeIntervalSinceOrderAddNew] = lapseSinceLastOrderAddNew
             }
 
             return WooAnalyticsEvent(statName: .orderCreationSuccess, properties: properties)
@@ -904,8 +904,8 @@ extension WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [Keys.flow: flow.rawValue,
                               Keys.paymentMethod: method.rawValue]
 
-            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timestampSinceOrderAddNew() {
-                properties[Orders.GlobalKeys.timestampSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timeIntervalSinceOrderAddNew() {
+                properties[Orders.GlobalKeys.timeIntervalSinceOrderAddNew] = lapseSinceLastOrderAddNew
             }
 
             return WooAnalyticsEvent(statName: .paymentsFlowCollect, properties: properties)
@@ -965,7 +965,7 @@ extension WooAnalyticsEvent {
             static let source = "source"
             static let enabled = "enabled"
             static let cancellationSource = "cancellation_source"
-            static let timestampSinceCardCollectPaymentFlow = "timestamp_since_card_collect_payment_flow"
+            static let timeIntervalSinceCardCollectPaymentFlow = "time_interval_since_card_collect_payment_flow"
         }
 
         static let unknownGatewayID = "unknown"
@@ -1351,12 +1351,12 @@ extension WooAnalyticsEvent {
                 Keys.paymentMethodType: paymentMethod.analyticsValue
               ]
 
-            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timestampSinceOrderAddNew() {
-                properties[Orders.GlobalKeys.timestampSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timeIntervalSinceOrderAddNew() {
+                properties[Orders.GlobalKeys.timeIntervalSinceOrderAddNew] = lapseSinceLastOrderAddNew
             }
 
-            if let timestampSinceCardCollectPaymentFlow = try? OrderDurationRecorder.shared.timestampSinceCardPaymentStarted() {
-                properties[Keys.timestampSinceCardCollectPaymentFlow] = timestampSinceCardCollectPaymentFlow
+            if let timeIntervalSinceCardCollectPaymentFlow = try? OrderDurationRecorder.shared.timeIntervalSinceCardPaymentStarted() {
+                properties[Keys.timeIntervalSinceCardCollectPaymentFlow] = timeIntervalSinceCardCollectPaymentFlow
             }
 
             return WooAnalyticsEvent(statName: .collectPaymentSuccess,
@@ -1380,12 +1380,12 @@ extension WooAnalyticsEvent {
                 Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
               ]
 
-            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timestampSinceOrderAddNew() {
-                properties[Orders.GlobalKeys.timestampSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timeIntervalSinceOrderAddNew() {
+                properties[Orders.GlobalKeys.timeIntervalSinceOrderAddNew] = lapseSinceLastOrderAddNew
             }
 
-            if let timestampSinceCardCollectPaymentFlow = try? OrderDurationRecorder.shared.timestampSinceCardPaymentStarted() {
-                properties[Keys.timestampSinceCardCollectPaymentFlow] = timestampSinceCardCollectPaymentFlow
+            if let timeIntervalSinceCardCollectPaymentFlow = try? OrderDurationRecorder.shared.timeIntervalSinceCardPaymentStarted() {
+                properties[Keys.timeIntervalSinceCardCollectPaymentFlow] = timeIntervalSinceCardCollectPaymentFlow
             }
 
             return WooAnalyticsEvent(statName: .collectInteracPaymentSuccess,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -415,6 +415,10 @@ extension WooAnalyticsEvent {
             case list
         }
 
+        enum GlobalKeys {
+            static let timestampSinceOrderAddNew = "timestamp_since_order_add_new"
+        }
+
         private enum Keys {
             static let flow = "flow"
             static let hasDifferentShippingDetails = "has_different_shipping_details"
@@ -518,7 +522,13 @@ extension WooAnalyticsEvent {
         }
 
         static func orderCreationSuccess() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .orderCreationSuccess, properties: [:])
+            var properties: [String: WooAnalyticsEventPropertyType] = [:]
+
+            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.currentLapse() {
+                properties[GlobalKeys.timestampSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            }
+
+            return WooAnalyticsEvent(statName: .orderCreationSuccess, properties: properties)
         }
 
         static func orderCreationFailed(errorContext: String, errorDescription: String) -> WooAnalyticsEvent {
@@ -891,8 +901,14 @@ extension WooAnalyticsEvent {
         }
 
         static func paymentsFlowCollect(flow: Flow, method: PaymentMethod) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .paymentsFlowCollect, properties: [Keys.flow: flow.rawValue,
-                                                                           Keys.paymentMethod: method.rawValue])
+            var properties: [String: WooAnalyticsEventPropertyType] = [Keys.flow: flow.rawValue,
+                              Keys.paymentMethod: method.rawValue]
+
+            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.currentLapse() {
+                properties[Orders.GlobalKeys.timestampSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            }
+
+            return WooAnalyticsEvent(statName: .paymentsFlowCollect, properties: properties)
         }
     }
 }
@@ -1327,13 +1343,19 @@ extension WooAnalyticsEvent {
                                           countryCode: String,
                                           paymentMethod: PaymentMethod,
                                           cardReaderModel: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .collectPaymentSuccess,
-                              properties: [
-                                Keys.cardReaderModel: cardReaderModel,
-                                Keys.countryCode: countryCode,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
-                                Keys.paymentMethodType: paymentMethod.analyticsValue
-                              ]
+            var properties: [String: WooAnalyticsEventPropertyType] = [
+                Keys.cardReaderModel: cardReaderModel,
+                Keys.countryCode: countryCode,
+                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                Keys.paymentMethodType: paymentMethod.analyticsValue
+              ]
+
+            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.currentLapse() {
+                properties[Orders.GlobalKeys.timestampSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            }
+
+            return WooAnalyticsEvent(statName: .collectPaymentSuccess,
+                              properties: properties
             )
         }
 
@@ -1347,12 +1369,18 @@ extension WooAnalyticsEvent {
         static func collectInteracPaymentSuccess(gatewayID: String?,
                                                  countryCode: String,
                                                  cardReaderModel: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .collectInteracPaymentSuccess,
-                              properties: [
-                                Keys.cardReaderModel: cardReaderModel,
-                                Keys.countryCode: countryCode,
-                                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
-                              ])
+            var properties: [String: WooAnalyticsEventPropertyType] = [
+                Keys.cardReaderModel: cardReaderModel,
+                Keys.countryCode: countryCode,
+                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
+              ]
+
+            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.currentLapse() {
+                properties[Orders.GlobalKeys.timestampSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            }
+
+            return WooAnalyticsEvent(statName: .collectInteracPaymentSuccess,
+                              properties: properties)
         }
 
         /// Tracked when an Interac client-side refund succeeds

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1376,7 +1376,7 @@ extension WooAnalyticsEvent {
         static func collectInteracPaymentSuccess(gatewayID: String?,
                                                  countryCode: String,
                                                  cardReaderModel: String) -> WooAnalyticsEvent {
-            return WooAnalyticsEvent(statName: .collectInteracPaymentSuccess,
+            WooAnalyticsEvent(statName: .collectInteracPaymentSuccess,
                                      properties: [
                                         Keys.cardReaderModel: cardReaderModel,
                                         Keys.countryCode: countryCode,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -416,7 +416,7 @@ extension WooAnalyticsEvent {
         }
 
         enum GlobalKeys {
-            static let milisecondsSinceOrderAddNew = "miliseconds_since_order_add_new"
+            static let millisecondsSinceOrderAddNew = "milliseconds_since_order_add_new"
         }
 
         private enum Keys {
@@ -521,11 +521,11 @@ extension WooAnalyticsEvent {
             ])
         }
 
-        static func orderCreationSuccess(milisecondsSinceSinceOrderAddNew: Int64?) -> WooAnalyticsEvent {
+        static func orderCreationSuccess(millisecondsSinceSinceOrderAddNew: Int64?) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [:]
 
-            if let lapseSinceLastOrderAddNew = milisecondsSinceSinceOrderAddNew {
-                properties[GlobalKeys.milisecondsSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            if let lapseSinceLastOrderAddNew = millisecondsSinceSinceOrderAddNew {
+                properties[GlobalKeys.millisecondsSinceOrderAddNew] = lapseSinceLastOrderAddNew
             }
 
             return WooAnalyticsEvent(statName: .orderCreationSuccess, properties: properties)
@@ -900,12 +900,12 @@ extension WooAnalyticsEvent {
                                                                           Keys.source: source.rawValue])
         }
 
-        static func paymentsFlowCollect(flow: Flow, method: PaymentMethod, milisecondsSinceOrderAddNew: Int64?) -> WooAnalyticsEvent {
+        static func paymentsFlowCollect(flow: Flow, method: PaymentMethod, millisecondsSinceOrderAddNew: Int64?) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [Keys.flow: flow.rawValue,
                               Keys.paymentMethod: method.rawValue]
 
-            if let lapseSinceLastOrderAddNew = milisecondsSinceOrderAddNew {
-                properties[Orders.GlobalKeys.milisecondsSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            if let lapseSinceLastOrderAddNew = millisecondsSinceOrderAddNew {
+                properties[Orders.GlobalKeys.millisecondsSinceOrderAddNew] = lapseSinceLastOrderAddNew
             }
 
             return WooAnalyticsEvent(statName: .paymentsFlowCollect, properties: properties)
@@ -965,7 +965,7 @@ extension WooAnalyticsEvent {
             static let source = "source"
             static let enabled = "enabled"
             static let cancellationSource = "cancellation_source"
-            static let milisecondsSinceCardCollectPaymentFlow = "miliseconds_since_card_collect_payment_flow"
+            static let millisecondsSinceCardCollectPaymentFlow = "milliseconds_since_card_collect_payment_flow"
         }
 
         static let unknownGatewayID = "unknown"
@@ -1344,8 +1344,8 @@ extension WooAnalyticsEvent {
                                           countryCode: String,
                                           paymentMethod: PaymentMethod,
                                           cardReaderModel: String,
-                                          milisecondsSinceOrderAddNew: Int64?,
-                                          milisecondsSinceCardPaymentStarted: Int64?) -> WooAnalyticsEvent {
+                                          millisecondsSinceOrderAddNew: Int64?,
+                                          millisecondsSinceCardPaymentStarted: Int64?) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [
                 Keys.cardReaderModel: cardReaderModel,
                 Keys.countryCode: countryCode,
@@ -1353,12 +1353,12 @@ extension WooAnalyticsEvent {
                 Keys.paymentMethodType: paymentMethod.analyticsValue
               ]
 
-            if let lapseSinceLastOrderAddNew = milisecondsSinceOrderAddNew {
-                properties[Orders.GlobalKeys.milisecondsSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            if let lapseSinceLastOrderAddNew = millisecondsSinceOrderAddNew {
+                properties[Orders.GlobalKeys.millisecondsSinceOrderAddNew] = lapseSinceLastOrderAddNew
             }
 
-            if let timeIntervalSinceCardCollectPaymentFlow = milisecondsSinceCardPaymentStarted {
-                properties[Keys.milisecondsSinceCardCollectPaymentFlow] = timeIntervalSinceCardCollectPaymentFlow
+            if let timeIntervalSinceCardCollectPaymentFlow = millisecondsSinceCardPaymentStarted {
+                properties[Keys.millisecondsSinceCardCollectPaymentFlow] = timeIntervalSinceCardCollectPaymentFlow
             }
 
             return WooAnalyticsEvent(statName: .collectPaymentSuccess,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -524,7 +524,7 @@ extension WooAnalyticsEvent {
         static func orderCreationSuccess() -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [:]
 
-            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.currentLapse() {
+            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timestampSinceOrderAddNew() {
                 properties[GlobalKeys.timestampSinceOrderAddNew] = lapseSinceLastOrderAddNew
             }
 
@@ -904,7 +904,7 @@ extension WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [Keys.flow: flow.rawValue,
                               Keys.paymentMethod: method.rawValue]
 
-            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.currentLapse() {
+            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timestampSinceOrderAddNew() {
                 properties[Orders.GlobalKeys.timestampSinceOrderAddNew] = lapseSinceLastOrderAddNew
             }
 
@@ -965,6 +965,7 @@ extension WooAnalyticsEvent {
             static let source = "source"
             static let enabled = "enabled"
             static let cancellationSource = "cancellation_source"
+            static let timestampSinceCardCollectPaymentFlow = "timestamp_since_card_collect_payment_flow"
         }
 
         static let unknownGatewayID = "unknown"
@@ -1350,8 +1351,12 @@ extension WooAnalyticsEvent {
                 Keys.paymentMethodType: paymentMethod.analyticsValue
               ]
 
-            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.currentLapse() {
+            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timestampSinceOrderAddNew() {
                 properties[Orders.GlobalKeys.timestampSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            }
+
+            if let timestampSinceCardCollectPaymentFlow = try? OrderDurationRecorder.shared.timestampSinceCardPaymentStarted() {
+                properties[Keys.timestampSinceCardCollectPaymentFlow] = timestampSinceCardCollectPaymentFlow
             }
 
             return WooAnalyticsEvent(statName: .collectPaymentSuccess,
@@ -1375,8 +1380,12 @@ extension WooAnalyticsEvent {
                 Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
               ]
 
-            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.currentLapse() {
+            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timestampSinceOrderAddNew() {
                 properties[Orders.GlobalKeys.timestampSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            }
+
+            if let timestampSinceCardCollectPaymentFlow = try? OrderDurationRecorder.shared.timestampSinceCardPaymentStarted() {
+                properties[Keys.timestampSinceCardCollectPaymentFlow] = timestampSinceCardCollectPaymentFlow
             }
 
             return WooAnalyticsEvent(statName: .collectInteracPaymentSuccess,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -416,7 +416,7 @@ extension WooAnalyticsEvent {
         }
 
         enum GlobalKeys {
-            static let timeIntervalSinceOrderAddNew = "time_interval_since_order_add_new"
+            static let milisecondsSinceOrderAddNew = "miliseconds_since_order_add_new"
         }
 
         private enum Keys {
@@ -521,11 +521,11 @@ extension WooAnalyticsEvent {
             ])
         }
 
-        static func orderCreationSuccess() -> WooAnalyticsEvent {
+        static func orderCreationSuccess(milisecondsSinceSinceOrderAddNew: Int64?) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [:]
 
-            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timeIntervalSinceOrderAddNew() {
-                properties[GlobalKeys.timeIntervalSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            if let lapseSinceLastOrderAddNew = milisecondsSinceSinceOrderAddNew {
+                properties[GlobalKeys.milisecondsSinceOrderAddNew] = lapseSinceLastOrderAddNew
             }
 
             return WooAnalyticsEvent(statName: .orderCreationSuccess, properties: properties)
@@ -900,12 +900,12 @@ extension WooAnalyticsEvent {
                                                                           Keys.source: source.rawValue])
         }
 
-        static func paymentsFlowCollect(flow: Flow, method: PaymentMethod) -> WooAnalyticsEvent {
+        static func paymentsFlowCollect(flow: Flow, method: PaymentMethod, milisecondsSinceOrderAddNew: Int64?) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [Keys.flow: flow.rawValue,
                               Keys.paymentMethod: method.rawValue]
 
-            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timeIntervalSinceOrderAddNew() {
-                properties[Orders.GlobalKeys.timeIntervalSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            if let lapseSinceLastOrderAddNew = milisecondsSinceOrderAddNew {
+                properties[Orders.GlobalKeys.milisecondsSinceOrderAddNew] = lapseSinceLastOrderAddNew
             }
 
             return WooAnalyticsEvent(statName: .paymentsFlowCollect, properties: properties)
@@ -965,7 +965,7 @@ extension WooAnalyticsEvent {
             static let source = "source"
             static let enabled = "enabled"
             static let cancellationSource = "cancellation_source"
-            static let timeIntervalSinceCardCollectPaymentFlow = "time_interval_since_card_collect_payment_flow"
+            static let milisecondsSinceCardCollectPaymentFlow = "miliseconds_since_card_collect_payment_flow"
         }
 
         static let unknownGatewayID = "unknown"
@@ -1343,7 +1343,9 @@ extension WooAnalyticsEvent {
         static func collectPaymentSuccess(forGatewayID: String?,
                                           countryCode: String,
                                           paymentMethod: PaymentMethod,
-                                          cardReaderModel: String) -> WooAnalyticsEvent {
+                                          cardReaderModel: String,
+                                          milisecondsSinceOrderAddNew: Int64?,
+                                          milisecondsSinceCardPaymentStarted: Int64?) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [
                 Keys.cardReaderModel: cardReaderModel,
                 Keys.countryCode: countryCode,
@@ -1351,12 +1353,12 @@ extension WooAnalyticsEvent {
                 Keys.paymentMethodType: paymentMethod.analyticsValue
               ]
 
-            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timeIntervalSinceOrderAddNew() {
-                properties[Orders.GlobalKeys.timeIntervalSinceOrderAddNew] = lapseSinceLastOrderAddNew
+            if let lapseSinceLastOrderAddNew = milisecondsSinceOrderAddNew {
+                properties[Orders.GlobalKeys.milisecondsSinceOrderAddNew] = lapseSinceLastOrderAddNew
             }
 
-            if let timeIntervalSinceCardCollectPaymentFlow = try? OrderDurationRecorder.shared.timeIntervalSinceCardPaymentStarted() {
-                properties[Keys.timeIntervalSinceCardCollectPaymentFlow] = timeIntervalSinceCardCollectPaymentFlow
+            if let timeIntervalSinceCardCollectPaymentFlow = milisecondsSinceCardPaymentStarted {
+                properties[Keys.milisecondsSinceCardCollectPaymentFlow] = timeIntervalSinceCardCollectPaymentFlow
             }
 
             return WooAnalyticsEvent(statName: .collectPaymentSuccess,
@@ -1374,22 +1376,12 @@ extension WooAnalyticsEvent {
         static func collectInteracPaymentSuccess(gatewayID: String?,
                                                  countryCode: String,
                                                  cardReaderModel: String) -> WooAnalyticsEvent {
-            var properties: [String: WooAnalyticsEventPropertyType] = [
-                Keys.cardReaderModel: cardReaderModel,
-                Keys.countryCode: countryCode,
-                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
-              ]
-
-            if let lapseSinceLastOrderAddNew = try? OrderDurationRecorder.shared.timeIntervalSinceOrderAddNew() {
-                properties[Orders.GlobalKeys.timeIntervalSinceOrderAddNew] = lapseSinceLastOrderAddNew
-            }
-
-            if let timeIntervalSinceCardCollectPaymentFlow = try? OrderDurationRecorder.shared.timeIntervalSinceCardPaymentStarted() {
-                properties[Keys.timeIntervalSinceCardCollectPaymentFlow] = timeIntervalSinceCardCollectPaymentFlow
-            }
-
             return WooAnalyticsEvent(statName: .collectInteracPaymentSuccess,
-                              properties: properties)
+                                     properties: [
+                                        Keys.cardReaderModel: cardReaderModel,
+                                        Keys.countryCode: countryCode,
+                                        Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
+                                     ])
         }
 
         /// Tracked when an Interac client-side refund succeeds

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1377,11 +1377,11 @@ extension WooAnalyticsEvent {
                                                  countryCode: String,
                                                  cardReaderModel: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectInteracPaymentSuccess,
-                                     properties: [
-                                        Keys.cardReaderModel: cardReaderModel,
-                                        Keys.countryCode: countryCode,
-                                        Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
-                                     ])
+                              properties: [
+                                Keys.cardReaderModel: cardReaderModel,
+                                Keys.countryCode: countryCode,
+                                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID)
+                              ])
         }
 
         /// Tracked when an Interac client-side refund succeeds

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -306,6 +306,7 @@ private extension CollectOrderPaymentUseCase {
                                                    countryCode: configuration.countryCode,
                                                    paymentMethod: capturedPaymentData.paymentMethod,
                                                    cardReaderModel: connectedReader?.readerType.model ?? ""))
+        OrderDurationRecorder.shared.reset()
 
         // Success Callback
         onCompletion(.success(capturedPaymentData))

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -307,8 +307,8 @@ private extension CollectOrderPaymentUseCase {
                                                    countryCode: configuration.countryCode,
                                                    paymentMethod: capturedPaymentData.paymentMethod,
                                                    cardReaderModel: connectedReader?.readerType.model ?? "",
-                                                   milisecondsSinceOrderAddNew: try? orderDurationRecorder.milisecondsSinceOrderAddNew(),
-                                                   milisecondsSinceCardPaymentStarted: try? orderDurationRecorder.milisecondsSinceCardPaymentStarted()))
+                                                   millisecondsSinceOrderAddNew: try? orderDurationRecorder.millisecondsSinceOrderAddNew(),
+                                                   millisecondsSinceCardPaymentStarted: try? orderDurationRecorder.millisecondsSinceCardPaymentStarted()))
         orderDurationRecorder.reset()
 
         // Success Callback

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -300,13 +300,16 @@ private extension CollectOrderPaymentUseCase {
     ///
     func handleSuccessfulPayment(capturedPaymentData: CardPresentCapturedPaymentData,
                                  onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
+        let orderDurationRecorder = OrderDurationRecorder.shared
         // Record success
         analytics.track(event: WooAnalyticsEvent.InPersonPayments
                             .collectPaymentSuccess(forGatewayID: paymentGatewayAccount.gatewayID,
                                                    countryCode: configuration.countryCode,
                                                    paymentMethod: capturedPaymentData.paymentMethod,
-                                                   cardReaderModel: connectedReader?.readerType.model ?? ""))
-        OrderDurationRecorder.shared.reset()
+                                                   cardReaderModel: connectedReader?.readerType.model ?? "",
+                                                   milisecondsSinceOrderAddNew: try? orderDurationRecorder.milisecondsSinceOrderAddNew(),
+                                                   milisecondsSinceCardPaymentStarted: try? orderDurationRecorder.milisecondsSinceCardPaymentStarted()))
+        orderDurationRecorder.reset()
 
         // Success Callback
         onCompletion(.success(capturedPaymentData))

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -96,6 +96,8 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
 
     private var preflightController: CardPresentPaymentPreflightController?
 
+    private let orderDurationRecorder: OrderDurationRecorderProtocol
+
     private var cancellables: Set<AnyCancellable> = []
 
     init(siteID: Int64,
@@ -106,6 +108,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
          configuration: CardPresentPaymentsConfiguration,
          stores: StoresManager = ServiceLocator.stores,
          paymentCaptureCelebration: PaymentCaptureCelebrationProtocol = PaymentCaptureCelebration(),
+         orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.order = order
@@ -116,6 +119,7 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
         self.configuration = configuration
         self.stores = stores
         self.paymentCaptureCelebration = paymentCaptureCelebration
+        self.orderDurationRecorder = orderDurationRecorder
         self.analytics = analytics
     }
 
@@ -300,7 +304,6 @@ private extension CollectOrderPaymentUseCase {
     ///
     func handleSuccessfulPayment(capturedPaymentData: CardPresentCapturedPaymentData,
                                  onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
-        let orderDurationRecorder = OrderDurationRecorder.shared
         // Record success
         analytics.track(event: WooAnalyticsEvent.InPersonPayments
                             .collectPaymentSuccess(forGatewayID: paymentGatewayAccount.gatewayID,

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
@@ -332,6 +332,7 @@ private extension LegacyCollectOrderPaymentUseCase {
                                                    countryCode: configuration.countryCode,
                                                    paymentMethod: capturedPaymentData.paymentMethod,
                                                    cardReaderModel: connectedReader?.readerType.model ?? ""))
+        OrderDurationRecorder.shared.reset()
 
         // Success Callback
         onCompletion(.success(capturedPaymentData))

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
@@ -100,6 +100,8 @@ final class LegacyCollectOrderPaymentUseCase: NSObject, LegacyCollectOrderPaymen
     /// Coordinates emailing a receipt after payment success.
     private var receiptEmailCoordinator: CardPresentPaymentReceiptEmailCoordinator?
 
+    private let orderDurationRecorder: OrderDurationRecorderProtocol
+
     init(siteID: Int64,
          order: Order,
          formattedAmount: String,
@@ -109,6 +111,7 @@ final class LegacyCollectOrderPaymentUseCase: NSObject, LegacyCollectOrderPaymen
          configuration: CardPresentPaymentsConfiguration,
          stores: StoresManager = ServiceLocator.stores,
          paymentCaptureCelebration: PaymentCaptureCelebrationProtocol = PaymentCaptureCelebration(),
+         orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.order = order
@@ -119,6 +122,7 @@ final class LegacyCollectOrderPaymentUseCase: NSObject, LegacyCollectOrderPaymen
         self.configuration = configuration
         self.stores = stores
         self.paymentCaptureCelebration = paymentCaptureCelebration
+        self.orderDurationRecorder = orderDurationRecorder
         self.analytics = analytics
     }
 
@@ -326,7 +330,6 @@ private extension LegacyCollectOrderPaymentUseCase {
     ///
     func handleSuccessfulPayment(capturedPaymentData: CardPresentCapturedPaymentData,
                                  onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
-        let orderDurationRecorder = OrderDurationRecorder.shared
         // Record success
         analytics.track(event: WooAnalyticsEvent.InPersonPayments
                             .collectPaymentSuccess(forGatewayID: paymentGatewayAccount.gatewayID,

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
@@ -333,8 +333,8 @@ private extension LegacyCollectOrderPaymentUseCase {
                                                    countryCode: configuration.countryCode,
                                                    paymentMethod: capturedPaymentData.paymentMethod,
                                                    cardReaderModel: connectedReader?.readerType.model ?? "",
-                                                   milisecondsSinceOrderAddNew: try? orderDurationRecorder.milisecondsSinceOrderAddNew(),
-                                                   milisecondsSinceCardPaymentStarted: try? orderDurationRecorder.milisecondsSinceCardPaymentStarted()))
+                                                   millisecondsSinceOrderAddNew: try? orderDurationRecorder.millisecondsSinceOrderAddNew(),
+                                                   millisecondsSinceCardPaymentStarted: try? orderDurationRecorder.millisecondsSinceCardPaymentStarted()))
         orderDurationRecorder.reset()
 
         // Success Callback

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
@@ -326,13 +326,16 @@ private extension LegacyCollectOrderPaymentUseCase {
     ///
     func handleSuccessfulPayment(capturedPaymentData: CardPresentCapturedPaymentData,
                                  onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
+        let orderDurationRecorder = OrderDurationRecorder.shared
         // Record success
         analytics.track(event: WooAnalyticsEvent.InPersonPayments
                             .collectPaymentSuccess(forGatewayID: paymentGatewayAccount.gatewayID,
                                                    countryCode: configuration.countryCode,
                                                    paymentMethod: capturedPaymentData.paymentMethod,
-                                                   cardReaderModel: connectedReader?.readerType.model ?? ""))
-        OrderDurationRecorder.shared.reset()
+                                                   cardReaderModel: connectedReader?.readerType.model ?? "",
+                                                   milisecondsSinceOrderAddNew: try? orderDurationRecorder.milisecondsSinceOrderAddNew(),
+                                                   milisecondsSinceCardPaymentStarted: try? orderDurationRecorder.milisecondsSinceCardPaymentStarted()))
+        orderDurationRecorder.reset()
 
         // Success Callback
         onCompletion(.success(capturedPaymentData))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
@@ -28,15 +28,15 @@ class OrderDurationRecorder {
         cardPaymentStartedTimestamp = nil
     }
 
-    func milisecondsSinceOrderAddNew() throws -> Int64 {
-        try milisecondsSince(orderAddNewTimestamp)
+    func millisecondsSinceOrderAddNew() throws -> Int64 {
+        try millisecondsSince(orderAddNewTimestamp)
     }
 
-    func milisecondsSinceCardPaymentStarted() throws -> Int64 {
-        try milisecondsSince(cardPaymentStartedTimestamp)
+    func millisecondsSinceCardPaymentStarted() throws -> Int64 {
+        try millisecondsSince(cardPaymentStartedTimestamp)
     }
 
-    private func milisecondsSince(_ origin: TimeInterval?) throws -> Int64 {
+    private func millisecondsSince(_ origin: TimeInterval?) throws -> Int64 {
         guard let startTimestamp = origin else {
             throw OrderDurationRecorderError.noStartRecordingTimestamp
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
@@ -2,27 +2,49 @@ import Foundation
 
 enum OrderDurationRecorderError: Error {
     case noStartRecordingTimestamp
+    case durationExceededTimeout
 }
 
 class OrderDurationRecorder {
     static let shared = OrderDurationRecorder()
-    private var startTimestamp: TimeInterval?
+    private var orderAddNewTimestamp: TimeInterval?
+    private var cardPaymentStartedTimestamp: TimeInterval?
+    private static let timeout = 60*10
 
     private init() { }
 
     func startRecording() {
-        startTimestamp = Date().timeIntervalSince1970
+        orderAddNewTimestamp = Date().timeIntervalSince1970
+    }
+
+    func recordCardPaymentStarted() {
+        cardPaymentStartedTimestamp = Date().timeIntervalSince1970
     }
 
     func reset() {
-        startTimestamp = nil
+        orderAddNewTimestamp = nil
+        cardPaymentStartedTimestamp = nil
     }
 
-    func currentLapse() throws -> Int64 {
-        guard let startTimestamp = startTimestamp else {
+    func timestampSinceOrderAddNew() throws -> Int64 {
+        try timestampSince(orderAddNewTimestamp)
+    }
+
+    func timestampSinceCardPaymentStarted() throws -> Int64 {
+        try timestampSince(cardPaymentStartedTimestamp)
+    }
+
+    private func timestampSince(_ origin: TimeInterval?) throws -> Int64 {
+        guard let startTimestamp = origin else {
             throw OrderDurationRecorderError.noStartRecordingTimestamp
         }
 
-        return Int64(Date().timeIntervalSince1970 - startTimestamp)
+        let timestamp = Int64(Date().timeIntervalSince1970 - startTimestamp)
+
+        guard timestamp < OrderDurationRecorder.timeout else {
+            throw OrderDurationRecorderError.durationExceededTimeout
+        }
+
+        return timestamp
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
@@ -28,15 +28,15 @@ class OrderDurationRecorder {
         cardPaymentStartedTimestamp = nil
     }
 
-    func timeIntervalSinceOrderAddNew() throws -> TimeInterval {
-        return try timeIntervalSince(orderAddNewTimestamp)
+    func milisecondsSinceOrderAddNew() throws -> Int64 {
+        try milisecondsSince(orderAddNewTimestamp)
     }
 
-    func timeIntervalSinceCardPaymentStarted() throws -> TimeInterval {
-        try timeIntervalSince(cardPaymentStartedTimestamp)
+    func milisecondsSinceCardPaymentStarted() throws -> Int64 {
+        try milisecondsSince(cardPaymentStartedTimestamp)
     }
 
-    private func timeIntervalSince(_ origin: TimeInterval?) throws -> TimeInterval {
+    private func milisecondsSince(_ origin: TimeInterval?) throws -> Int64 {
         guard let startTimestamp = origin else {
             throw OrderDurationRecorderError.noStartRecordingTimestamp
         }
@@ -47,6 +47,6 @@ class OrderDurationRecorder {
             throw OrderDurationRecorderError.durationExceededTimeout
         }
 
-        return timestamp
+        return Int64(timestamp*1000)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
@@ -5,6 +5,8 @@ enum OrderDurationRecorderError: Error {
     case durationExceededTimeout
 }
 
+/// Measures the duration of Order Creation and In-Person Payments flows for analytical purposes
+///
 class OrderDurationRecorder {
     static let shared = OrderDurationRecorder()
     private var orderAddNewTimestamp: TimeInterval?

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
@@ -26,15 +26,15 @@ class OrderDurationRecorder {
         cardPaymentStartedTimestamp = nil
     }
 
-    func timestampSinceOrderAddNew() throws -> Int64 {
-        try timestampSince(orderAddNewTimestamp)
+    func timeIntervalSinceOrderAddNew() throws -> Int64 {
+        try timeIntervalSince(orderAddNewTimestamp)
     }
 
-    func timestampSinceCardPaymentStarted() throws -> Int64 {
-        try timestampSince(cardPaymentStartedTimestamp)
+    func timeIntervalSinceCardPaymentStarted() throws -> Int64 {
+        try timeIntervalSince(cardPaymentStartedTimestamp)
     }
 
-    private func timestampSince(_ origin: TimeInterval?) throws -> Int64 {
+    private func timeIntervalSince(_ origin: TimeInterval?) throws -> Int64 {
         guard let startTimestamp = origin else {
             throw OrderDurationRecorderError.noStartRecordingTimestamp
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum OrderDurationRecorderError: Error {
+    case noStartRecordingTimestamp
+}
+
+class OrderDurationRecorder {
+    static let shared = OrderDurationRecorder()
+    private var startTimestamp: TimeInterval?
+
+    private init() { }
+
+    func startRecording() {
+        startTimestamp = Date().timeIntervalSince1970
+    }
+
+    func reset() {
+        startTimestamp = nil
+    }
+
+    func currentLapse() throws -> Int64 {
+        guard let startTimestamp = startTimestamp else {
+            throw OrderDurationRecorderError.noStartRecordingTimestamp
+        }
+
+        return Int64(Date().timeIntervalSince1970 - startTimestamp)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
@@ -11,16 +11,16 @@ class OrderDurationRecorder {
     static let shared = OrderDurationRecorder()
     private var orderAddNewTimestamp: TimeInterval?
     private var cardPaymentStartedTimestamp: TimeInterval?
-    private static let timeout = 60*10
+    private static let timeout: TimeInterval = 60*10
 
     private init() { }
 
     func startRecording() {
-        orderAddNewTimestamp = Date().timeIntervalSince1970
+        orderAddNewTimestamp = ProcessInfo.processInfo.systemUptime
     }
 
     func recordCardPaymentStarted() {
-        cardPaymentStartedTimestamp = Date().timeIntervalSince1970
+        cardPaymentStartedTimestamp = ProcessInfo.processInfo.systemUptime
     }
 
     func reset() {
@@ -28,20 +28,20 @@ class OrderDurationRecorder {
         cardPaymentStartedTimestamp = nil
     }
 
-    func timeIntervalSinceOrderAddNew() throws -> Int64 {
-        try timeIntervalSince(orderAddNewTimestamp)
+    func timeIntervalSinceOrderAddNew() throws -> TimeInterval {
+        return try timeIntervalSince(orderAddNewTimestamp)
     }
 
-    func timeIntervalSinceCardPaymentStarted() throws -> Int64 {
+    func timeIntervalSinceCardPaymentStarted() throws -> TimeInterval {
         try timeIntervalSince(cardPaymentStartedTimestamp)
     }
 
-    private func timeIntervalSince(_ origin: TimeInterval?) throws -> Int64 {
+    private func timeIntervalSince(_ origin: TimeInterval?) throws -> TimeInterval {
         guard let startTimestamp = origin else {
             throw OrderDurationRecorderError.noStartRecordingTimestamp
         }
 
-        let timestamp = Int64(Date().timeIntervalSince1970 - startTimestamp)
+        let timestamp = ProcessInfo.processInfo.systemUptime - startTimestamp
 
         guard timestamp < OrderDurationRecorder.timeout else {
             throw OrderDurationRecorderError.durationExceededTimeout

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/DurationRecorder/OrderDurationRecorder.swift
@@ -5,9 +5,17 @@ enum OrderDurationRecorderError: Error {
     case durationExceededTimeout
 }
 
+protocol OrderDurationRecorderProtocol {
+    func startRecording()
+    func recordCardPaymentStarted()
+    func reset()
+    func millisecondsSinceOrderAddNew() throws -> Int64
+    func millisecondsSinceCardPaymentStarted() throws -> Int64
+}
+
 /// Measures the duration of Order Creation and In-Person Payments flows for analytical purposes
 ///
-class OrderDurationRecorder {
+class OrderDurationRecorder: OrderDurationRecorderProtocol {
     static let shared = OrderDurationRecorder()
     private var orderAddNewTimestamp: TimeInterval?
     private var cardPaymentStartedTimestamp: TimeInterval?

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -839,8 +839,8 @@ private extension EditableOrderViewModel {
     /// Tracks an order creation success
     ///
     func trackCreateOrderSuccess() {
-        analytics.track(event: WooAnalyticsEvent.Orders.orderCreationSuccess(milisecondsSinceSinceOrderAddNew:
-                                                                                try? OrderDurationRecorder.shared.milisecondsSinceOrderAddNew()))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCreationSuccess(millisecondsSinceSinceOrderAddNew:
+                                                                                try? OrderDurationRecorder.shared.millisecondsSinceOrderAddNew()))
     }
 
     /// Tracks an order creation failure

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -839,7 +839,8 @@ private extension EditableOrderViewModel {
     /// Tracks an order creation success
     ///
     func trackCreateOrderSuccess() {
-        analytics.track(event: WooAnalyticsEvent.Orders.orderCreationSuccess())
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCreationSuccess(milisecondsSinceSinceOrderAddNew:
+                                                                                try? OrderDurationRecorder.shared.milisecondsSinceOrderAddNew()))
     }
 
     /// Tracks an order creation failure

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -254,13 +254,16 @@ final class EditableOrderViewModel: ObservableObject {
     ///
     private let orderSynchronizer: OrderSynchronizer
 
+    private let orderDurationRecorder: OrderDurationRecorderProtocol
+
     init(siteID: Int64,
          flow: Flow = .creation,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          analytics: Analytics = ServiceLocator.analytics,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared) {
         self.siteID = siteID
         self.flow = flow
         self.stores = stores
@@ -269,6 +272,7 @@ final class EditableOrderViewModel: ObservableObject {
         self.analytics = analytics
         self.orderSynchronizer = RemoteOrderSynchronizer(siteID: siteID, flow: flow, stores: stores, currencySettings: currencySettings)
         self.featureFlagService = featureFlagService
+        self.orderDurationRecorder = orderDurationRecorder
 
         // Set a temporary initial view model, as a workaround to avoid making it optional.
         // Needs to be reset before the view model is used.
@@ -840,7 +844,7 @@ private extension EditableOrderViewModel {
     ///
     func trackCreateOrderSuccess() {
         analytics.track(event: WooAnalyticsEvent.Orders.orderCreationSuccess(millisecondsSinceSinceOrderAddNew:
-                                                                                try? OrderDurationRecorder.shared.millisecondsSinceOrderAddNew()))
+                                                                                try? orderDurationRecorder.millisecondsSinceOrderAddNew()))
     }
 
     /// Tracks an order creation failure

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -65,13 +65,17 @@ final class OrdersRootViewController: UIViewController {
 
     private let featureFlagService: FeatureFlagService
 
+    private let orderDurationRecorder: OrderDurationRecorderProtocol
+
     // MARK: View Lifecycle
 
     init(siteID: Int64,
-         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.featureFlagService = ServiceLocator.featureFlagService
+        self.orderDurationRecorder = orderDurationRecorder
         super.init(nibName: Self.nibName, bundle: nil)
 
         configureTitle()
@@ -377,7 +381,7 @@ private extension OrdersRootViewController {
         }
 
         ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderAddNew())
-        OrderDurationRecorder.shared.startRecording()
+        orderDurationRecorder.startRecording()
     }
 
     /// Pushes an `OrderDetailsViewController` onto the navigation stack.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -377,6 +377,7 @@ private extension OrdersRootViewController {
         }
 
         ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderAddNew())
+        OrderDurationRecorder.shared.startRecording()
     }
 
     /// Pushes an `OrderDetailsViewController` onto the navigation stack.

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -437,8 +437,8 @@ private extension PaymentMethodsViewModel {
     func trackCollectIntention(method: WooAnalyticsEvent.PaymentsFlow.PaymentMethod) {
         analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCollect(flow: flow,
                                                                                   method: method,
-                                                                                  milisecondsSinceOrderAddNew:
-                                                                                    try? OrderDurationRecorder.shared.milisecondsSinceOrderAddNew()))
+                                                                                  millisecondsSinceOrderAddNew:
+                                                                                    try? OrderDurationRecorder.shared.millisecondsSinceOrderAddNew()))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -435,7 +435,10 @@ private extension PaymentMethodsViewModel {
     /// Tracks `paymentsFlowCollect` event.
     ///
     func trackCollectIntention(method: WooAnalyticsEvent.PaymentsFlow.PaymentMethod) {
-        analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCollect(flow: flow, method: method))
+        analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCollect(flow: flow,
+                                                                                  method: method,
+                                                                                  milisecondsSinceOrderAddNew:
+                                                                                    try? OrderDurationRecorder.shared.milisecondsSinceOrderAddNew()))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -219,6 +219,7 @@ final class PaymentMethodsViewModel: ObservableObject {
                            onSuccess: @escaping () -> (),
                            onFailure: @escaping () -> ()) {
         trackCollectIntention(method: .card)
+        OrderDurationRecorder.shared.recordCardPaymentStarted()
 
         guard let rootViewController = rootViewController else {
             DDLogError("⛔️ Root ViewController is nil, can't present payment alerts.")
@@ -285,6 +286,7 @@ final class PaymentMethodsViewModel: ObservableObject {
                               useCase: LegacyCollectOrderPaymentProtocol? = nil,
                               onSuccess: @escaping () -> ()) {
         trackCollectIntention(method: .card)
+        OrderDurationRecorder.shared.recordCardPaymentStarted()
 
         guard let rootViewController = rootViewController else {
             DDLogError("⛔️ Root ViewController is nil, can't present payment alerts.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -86,6 +86,8 @@ final class PaymentMethodsViewModel: ObservableObject {
     ///
     private let flow: WooAnalyticsEvent.PaymentsFlow.Flow
 
+    private let orderDurationRecorder: OrderDurationRecorderProtocol
+
     /// Stored orders.
     /// We need to fetch this from our storage layer because we are only provide IDs as dependencies
     /// To keep previews/UIs decoupled from our business logic.
@@ -121,13 +123,15 @@ final class PaymentMethodsViewModel: ObservableObject {
         let storage: StorageManagerType
         let analytics: Analytics
         let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
+        let orderDurationRecorder: OrderDurationRecorderProtocol
 
         init(presentNoticeSubject: PassthroughSubject<SimplePaymentsNotice, Never> = PassthroughSubject(),
              cardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardingPresenting = CardPresentPaymentsOnboardingPresenter(),
              stores: StoresManager = ServiceLocator.stores,
              storage: StorageManagerType = ServiceLocator.storageManager,
              analytics: Analytics = ServiceLocator.analytics,
-             cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration? = nil) {
+             cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration? = nil,
+             orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared) {
             self.presentNoticeSubject = presentNoticeSubject
             self.cardPresentPaymentsOnboardingPresenter = cardPresentPaymentsOnboardingPresenter
             self.stores = stores
@@ -135,6 +139,7 @@ final class PaymentMethodsViewModel: ObservableObject {
             self.analytics = analytics
             let configuration = cardPresentPaymentsConfiguration ?? CardPresentConfigurationLoader(stores: stores).configuration
             self.cardPresentPaymentsConfiguration = configuration
+            self.orderDurationRecorder = orderDurationRecorder
         }
     }
 
@@ -150,6 +155,7 @@ final class PaymentMethodsViewModel: ObservableObject {
         self.paymentLink = paymentLink
         self.formattedTotal = formattedTotal
         self.flow = flow
+        self.orderDurationRecorder = dependencies.orderDurationRecorder
         self.isTapToPayOnIPhoneEnabled = isTapToPayOnIPhoneEnabled
         presentNoticeSubject = dependencies.presentNoticeSubject
         cardPresentPaymentsOnboardingPresenter = dependencies.cardPresentPaymentsOnboardingPresenter
@@ -219,7 +225,7 @@ final class PaymentMethodsViewModel: ObservableObject {
                            onSuccess: @escaping () -> (),
                            onFailure: @escaping () -> ()) {
         trackCollectIntention(method: .card)
-        OrderDurationRecorder.shared.recordCardPaymentStarted()
+        orderDurationRecorder.recordCardPaymentStarted()
 
         guard let rootViewController = rootViewController else {
             DDLogError("⛔️ Root ViewController is nil, can't present payment alerts.")
@@ -286,7 +292,7 @@ final class PaymentMethodsViewModel: ObservableObject {
                               useCase: LegacyCollectOrderPaymentProtocol? = nil,
                               onSuccess: @escaping () -> ()) {
         trackCollectIntention(method: .card)
-        OrderDurationRecorder.shared.recordCardPaymentStarted()
+        orderDurationRecorder.recordCardPaymentStarted()
 
         guard let rootViewController = rootViewController else {
             DDLogError("⛔️ Root ViewController is nil, can't present payment alerts.")
@@ -438,7 +444,7 @@ private extension PaymentMethodsViewModel {
         analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCollect(flow: flow,
                                                                                   method: method,
                                                                                   millisecondsSinceOrderAddNew:
-                                                                                    try? OrderDurationRecorder.shared.millisecondsSinceOrderAddNew()))
+                                                                                    try? orderDurationRecorder.millisecondsSinceOrderAddNew()))
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1452,6 +1452,7 @@
 		B958A7D328B52A2300823EEF /* MockRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958A7D228B52A2300823EEF /* MockRoute.swift */; };
 		B958A7D628B5310100823EEF /* URLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958A7D428B5302500823EEF /* URLOpener.swift */; };
 		B958A7D828B5316A00823EEF /* MockURLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958A7D728B5316A00823EEF /* MockURLOpener.swift */; };
+		B958B4DA2983E3F40010286B /* OrderDurationRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958B4D92983E3F40010286B /* OrderDurationRecorder.swift */; };
 		B96B536B2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */; };
 		B96D6C0729081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */; };
 		B9B0391628A6824200DC1C83 /* PermanentNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B0391528A6824200DC1C83 /* PermanentNoticePresenter.swift */; };
@@ -3538,6 +3539,7 @@
 		B958A7D228B52A2300823EEF /* MockRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRoute.swift; sourceTree = "<group>"; };
 		B958A7D428B5302500823EEF /* URLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLOpener.swift; sourceTree = "<group>"; };
 		B958A7D728B5316A00823EEF /* MockURLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLOpener.swift; sourceTree = "<group>"; };
+		B958B4D92983E3F40010286B /* OrderDurationRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDurationRecorder.swift; sourceTree = "<group>"; };
 		B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPluginsDataProviderTests.swift; sourceTree = "<group>"; };
 		B96D6C0629081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchasesForWPComPlansManager.swift; sourceTree = "<group>"; };
 		B9B0391528A6824200DC1C83 /* PermanentNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermanentNoticePresenter.swift; sourceTree = "<group>"; };
@@ -7773,6 +7775,14 @@
 			path = "Universal Links";
 			sourceTree = "<group>";
 		};
+		B958B4D82983E3E00010286B /* DurationRecorder */ = {
+			isa = PBXGroup;
+			children = (
+				B958B4D92983E3F40010286B /* OrderDurationRecorder.swift */,
+			);
+			path = DurationRecorder;
+			sourceTree = "<group>";
+		};
 		B9B0391B28A690DA00DC1C83 /* PermanentNotice */ = {
 			isa = PBXGroup;
 			children = (
@@ -8133,6 +8143,7 @@
 		CCFC50532743BBBF001E505F /* Order Creation */ = {
 			isa = PBXGroup;
 			children = (
+				B958B4D82983E3E00010286B /* DurationRecorder */,
 				B651474327D644DE00C9C4E6 /* CustomerNoteSection */,
 				CCFC50542743BC0D001E505F /* OrderForm.swift */,
 				CCFC50582743E021001E505F /* EditableOrderViewModel.swift */,
@@ -11285,6 +11296,7 @@
 				DE3404E828B4B96800CF0D97 /* NonAtomicSiteViewModel.swift in Sources */,
 				D8815B0126385E3F00EDAD62 /* CardPresentModalTapCard.swift in Sources */,
 				773077EE251E943700178696 /* ProductDownloadFileViewController.swift in Sources */,
+				B958B4DA2983E3F40010286B /* OrderDurationRecorder.swift in Sources */,
 				CC3B35DB28E5A6830036B097 /* ReviewReply.swift in Sources */,
 				45D1CF4523BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift in Sources */,
 				319A626127ACAE3400BC96C3 /* InPersonPaymentsPluginChoicesView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/ReviewAgeTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ReviewAgeTests.swift
@@ -20,7 +20,7 @@ final class ReviewAgeTests: XCTestCase {
         XCTAssertEqual(age?.description, Expectations.olderThan7Days)
     }
 
-    /// We are going to assume that days are 84400 miliseconds
+    /// We are going to assume that days are 84400 milliseconds
     /// which is wrong and inaccurate, but after all, this is software engineering,
     /// not real life
     func testAgeCalculationsReturnLast24HoursAgeFor12Hours() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We track here the duration of Order Creation and IPP flows to gather good baseline numbers to evaluate the improvements of the Speedy IPP projects.

We measure:

Flow 1: Add new order button tapped to order was successfully created.
Flow 2: Add new order button tapped to card payment method was selected.
Flow 3: Add new order button tapped to card payment collection was successful (in both regular and interac).
Flow 4: Card payment method was selected to Card payment collection was successful (in both regular and interac).

We reported those values by adding a new properties to the related events:

| Event      | New properties |
| ----------- | ----------- |
| `"order_creation_success" `     | `"milliseconds_since_order_add_new"`       |
| `"payments_flow_collect"`   | `"milliseconds_since_order_add_new"`        |
|`"card_present_collect_payment_success"` |  `"milliseconds_since_order_add_new"`, `"milliseconds_since_card_collect_payment_flow"`|

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Orders
2. Tap on New
3. Add products to the order, and tap on Create
4. Tap on Collect payment
5. Follow the flow to collect the payment with card

Check that the events are tracked, e.g.:
`"order_creation_success" `:

`🔵 Tracked order_creation_success, properties: [AnyHashable("blog_id"): 214354650, AnyHashable("milliseconds_since_order_add_new"): 17492, AnyHashable("is_wpcom_store"): true]`

`"payments_flow_collect"`:

` 🔵 Tracked payments_flow_collect, properties: [AnyHashable("flow"): "order_payment", AnyHashable("milliseconds_since_order_add_new"): 22675, AnyHashable("payment_method"): "card", AnyHashable("blog_id"): 214354650, AnyHashable("is_wpcom_store"): true]`

`card_present_collect_payment_success`:

`🔵 Tracked card_present_collect_payment_success, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("country"): "US", AnyHashable("plugin_slug"): "woocommerce-payments", AnyHashable("milliseconds_since_order_add_new"): 83651, AnyHashable("milliseconds_since_card_collect_payment_flow"): 32618, AnyHashable("blog_id"): 214354650, AnyHashable("payment_method_type"): "card", AnyHashable("card_reader_model"): "COTS_DEVICE"]`

Repeat the process to check that the measurements are properly resetted after a successful order.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
