### PR TITLE
[REST API] `ABTestVariationProvider` for unit testing

### DIFF
--- a/Experiments/Experiments.xcodeproj/project.pbxproj
+++ b/Experiments/Experiments.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		BC10218D75FEA979BDA1E68C /* Pods_Experiments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33CEC0C5283FD4C9EF8C6A3C /* Pods_Experiments.framework */; };
 		C8E16F0EE6954B58A1C402F0 /* Pods_ExperimentsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAC7C082DD376957B4676401 /* Pods_ExperimentsTests.framework */; };
 		CC53FB48275E426900C4CA4F /* ABTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB47275E426900C4CA4F /* ABTest.swift */; };
+		EE2EDFDF29879331004E702B /* ABTestVariationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2EDFDE29879331004E702B /* ABTestVariationProvider.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +48,7 @@
 		AAC7C082DD376957B4676401 /* Pods_ExperimentsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ExperimentsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF72D9DB7771E7A5105C88B0 /* Pods-Experiments.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Experiments.release.xcconfig"; path = "Target Support Files/Pods-Experiments/Pods-Experiments.release.xcconfig"; sourceTree = "<group>"; };
 		CC53FB47275E426900C4CA4F /* ABTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTest.swift; sourceTree = "<group>"; };
+		EE2EDFDE29879331004E702B /* ABTestVariationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestVariationProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -100,6 +102,7 @@
 				0270C0A427069B8900FC799F /* DefaultFeatureFlagService.swift */,
 				0270C0A627069BA500FC799F /* BuildConfiguration.swift */,
 				CC53FB47275E426900C4CA4F /* ABTest.swift */,
+				EE2EDFDE29879331004E702B /* ABTestVariationProvider.swift */,
 			);
 			path = Experiments;
 			sourceTree = "<group>";
@@ -314,6 +317,7 @@
 				0270C0A327069B7800FC799F /* FeatureFlagService.swift in Sources */,
 				0270C0A527069B8900FC799F /* DefaultFeatureFlagService.swift in Sources */,
 				0270C09C27069AE700FC799F /* FeatureFlag.swift in Sources */,
+				EE2EDFDF29879331004E702B /* ABTestVariationProvider.swift in Sources */,
 				0270C0A727069BA500FC799F /* BuildConfiguration.swift in Sources */,
 				CC53FB48275E426900C4CA4F /* ABTest.swift in Sources */,
 			);

--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -20,7 +20,8 @@ public enum ABTest: String, CaseIterable {
     case applicationPasswordAuthentication = "woocommerceios_login_rest_api_project_202301_v2"
 
     /// Returns a variation for the given experiment
-    public var variation: Variation {
+    ///
+    var variation: Variation {
         ExPlat.shared?.experiment(rawValue) ?? .control
     }
 

--- a/Experiments/Experiments/ABTestVariationProvider.swift
+++ b/Experiments/Experiments/ABTestVariationProvider.swift
@@ -1,0 +1,16 @@
+import AutomatticTracks
+
+/// For getting the variation of a `ABTest`
+public protocol ABTestVariationProvider {
+    /// Returns the `Variation` for the provided `ABTest`
+    func variation(for abTest: ABTest) -> Variation
+}
+
+/// Default implementation of `ABTestVariationProvider`
+public struct DefaultABTestVariationProvider: ABTestVariationProvider {
+    public init() { }
+
+    public func variation(for abTest: ABTest) -> Variation {
+        abTest.variation
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -26,6 +26,7 @@ final class AppCoordinator {
     private var authStatesSubscription: AnyCancellable?
     private var localNotificationResponsesSubscription: AnyCancellable?
     private var isLoggedIn: Bool = false
+    private let abTestVariationProvider: ABTestVariationProvider
 
     /// Checks on whether the Apple ID credential is valid when the app is logged in and becomes active.
     ///
@@ -143,7 +144,8 @@ private extension AppCoordinator {
             configureAndDisplayAuthenticator()
         }
 
-        analytics.track(event: .ApplicationPassword.restAPILoginExperiment(variation: ABTest.applicationPasswordAuthentication.variation.analyticsValue))
+        let applicationPasswordABTestVariation = abTestVariationProvider.variation(for: .applicationPasswordAuthentication)
+        analytics.track(event: .ApplicationPassword.restAPILoginExperiment(variation: applicationPasswordABTestVariation.analyticsValue))
     }
 
     /// Configures the WPAuthenticator and sets the authenticator UI as the window's root view.

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -5,6 +5,8 @@ import WordPressAuthenticator
 import Yosemite
 import class AutomatticTracks.CrashLogging
 import protocol Storage.StorageManagerType
+import protocol Experiments.ABTestVariationProvider
+import struct Experiments.DefaultABTestVariationProvider
 
 /// Coordinates app navigation based on authentication state: tab bar UI is shown when the app is logged in, and authentication UI is shown
 /// when the app is logged out.
@@ -40,7 +42,8 @@ final class AppCoordinator {
          analytics: Analytics = ServiceLocator.analytics,
          loggedOutAppSettings: LoggedOutAppSettingsProtocol = LoggedOutAppSettings(userDefaults: .standard),
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         abTestVariationProvider: ABTestVariationProvider = DefaultABTestVariationProvider()) {
         self.window = window
         self.tabBarController = {
             let storyboard = UIStoryboard(name: "Main", bundle: nil) // Main is the name of storyboard
@@ -57,6 +60,7 @@ final class AppCoordinator {
         self.loggedOutAppSettings = loggedOutAppSettings
         self.pushNotesManager = pushNotesManager
         self.featureFlagService = featureFlagService
+        self.abTestVariationProvider = abTestVariationProvider
 
         authenticationManager.setLoggedOutAppSettings(loggedOutAppSettings)
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1970,6 +1970,7 @@
 		E1F52DC62668E03B00349D75 /* CardPresentModalBluetoothRequired.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */; };
 		EE0EE7A628B7415200F6061E /* CustomHelpCenterContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0EE7A528B7415200F6061E /* CustomHelpCenterContent.swift */; };
 		EE0EE7A828B74EF300F6061E /* CustomHelpCenterContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0EE7A728B74EF300F6061E /* CustomHelpCenterContentTests.swift */; };
+		EE2EDFE12987A189004E702B /* MockABTestVariationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2EDFE02987A189004E702B /* MockABTestVariationProvider.swift */; };
 		EE57C11D297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C11C297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift */; };
 		EE57C11F297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */; };
 		EE57C121297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C120297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift */; };
@@ -4070,6 +4071,7 @@
 		E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalBluetoothRequired.swift; sourceTree = "<group>"; };
 		EE0EE7A528B7415200F6061E /* CustomHelpCenterContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHelpCenterContent.swift; sourceTree = "<group>"; };
 		EE0EE7A728B74EF300F6061E /* CustomHelpCenterContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHelpCenterContentTests.swift; sourceTree = "<group>"; };
+		EE2EDFE02987A189004E702B /* MockABTestVariationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockABTestVariationProvider.swift; sourceTree = "<group>"; };
 		EE57C11C297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackEventRequestNotificationHandler.swift; sourceTree = "<group>"; };
 		EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ApplicationPassword.swift"; sourceTree = "<group>"; };
 		EE57C120297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackEventRequestNotificationHandlerTests.swift; sourceTree = "<group>"; };
@@ -6804,6 +6806,7 @@
 				EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */,
 				AEB4DB98290AE8F300AE4340 /* MockCookieJar.swift */,
 				02660503293D8D24004084EA /* PaymentCaptureCelebration.swift */,
+				EE2EDFE02987A189004E702B /* MockABTestVariationProvider.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -11420,6 +11423,7 @@
 				DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */,
 				D89C009425B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift in Sources */,
 				573A960324F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift in Sources */,
+				EE2EDFE12987A189004E702B /* MockABTestVariationProvider.swift in Sources */,
 				0273707E24C0047800167204 /* SequenceHelpersTests.swift in Sources */,
 				D802547326551D0F001B2CC1 /* CardPresentModalTapCardTests.swift in Sources */,
 				F997174723DC070D00592D8E /* XLPagerStrip+AccessibilityIdentifierTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -5,7 +5,6 @@ import XCTest
 @testable import WooCommerce
 import Yosemite
 import protocol Storage.StorageManagerType
-@testable import AutomatticTracks
 
 final class AppCoordinatorTests: XCTestCase {
     private var sessionManager: SessionManager!
@@ -473,13 +472,5 @@ private extension AppCoordinatorTests {
                               pushNotesManager: pushNotesManager,
                               featureFlagService: featureFlagService,
                               abTestVariationProvider: abTestVariationProvider)
-    }
-}
-
-private class MockABTestVariationProvider: ABTestVariationProvider {
-    var mockVariationValue: Variation!
-
-    func variation(for abTest: ABTest) -> Variation {
-        mockVariationValue
     }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -158,6 +158,27 @@ final class AuthenticationManagerTests: XCTestCase {
         }
     }
 
+    func test_it_presents_username_and_password_controller_for_non_jetpack_site_when_using_application_password_authentication() {
+        // Given
+        let mockABTestVariationProvider = MockABTestVariationProvider()
+        mockABTestVariationProvider.mockVariationValue = .treatment
+
+        let manager = AuthenticationManager(abTestVariationProvider: mockABTestVariationProvider)
+        let siteInfo = WordPressComSiteInfo(remote: ["isWordPress": true, "hasJetpack": false])
+        var result: WordPressAuthenticatorResult?
+        let completionHandler: (WordPressAuthenticatorResult) -> Void = { completionResult in
+            result = completionResult
+        }
+
+        // When
+        manager.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: completionHandler)
+
+        // Then
+        guard case .presentPasswordController = result else {
+            return XCTFail("Unexpected result returned for non-Jetpack site")
+        }
+    }
+
     func test_it_shows_error_upon_login_epilogue_if_the_self_hosted_site_does_not_have_jetpack() {
         // Given
         let manager = AuthenticationManager()
@@ -228,6 +249,27 @@ final class AuthenticationManagerTests: XCTestCase {
         // Then
         let rootController = navigationController.viewControllers.first
         XCTAssertTrue(rootController is ULErrorViewController)
+    }
+
+    func test_it_does_not_display_jetpack_error_for_org_site_credentials_sign_in_when_using_application_password_authentication() {
+        // Given
+        let mockABTestVariationProvider = MockABTestVariationProvider()
+        mockABTestVariationProvider.mockVariationValue = .treatment
+
+        let manager = AuthenticationManager(abTestVariationProvider: mockABTestVariationProvider)
+        let testSite = "http://test.com"
+        let siteInfo = WordPressComSiteInfo(remote: ["isWordPress": true, "hasJetpack": false, "urlAfterRedirects": testSite])
+        let wporgCredentials = WordPressOrgCredentials(username: "cba", password: "password", xmlrpc: "http://test.com/xmlrpc.php", options: [:])
+        let credentials = AuthenticatorCredentials(wpcom: nil, wporg: wporgCredentials)
+        let navigationController = UINavigationController()
+
+        // When
+        manager.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { _ in })
+        manager.presentLoginEpilogue(in: navigationController, for: credentials, source: nil, onDismiss: {})
+
+        // Then
+        let rootController = navigationController.viewControllers.first
+        XCTAssertFalse(rootController is ULErrorViewController)
     }
 
     func test_errorViewController_display_account_mismatch_screen_if_no_site_matches_the_given_self_hosted_site() {

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -137,7 +137,7 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertTrue(viewModel is NoSecureConnectionErrorViewModel)
     }
 
-    func test_it_presents_username_and_password_controller_for_non_jetpack_site_when_not_using_application_password_authentication() {
+    func test_it_presents_email_controller_for_non_jetpack_site_when_not_using_application_password_authentication() {
         // Given
         let mockABTestVariationProvider = MockABTestVariationProvider()
         mockABTestVariationProvider.mockVariationValue = .control

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -3,8 +3,6 @@ import WordPressKit
 import WordPressAuthenticator
 import Yosemite
 @testable import WooCommerce
-@testable import Experiments
-@testable import AutomatticTracks
 
 /// Test cases for `AuthenticationManager`.
 final class AuthenticationManagerTests: XCTestCase {
@@ -503,13 +501,5 @@ private extension AuthenticationManagerTests {
                                       "isJetpackActive": isJetpackActive,
                                       "isJetpackConnected": isJetpackConnected,
                                       "isWordPressDotCom": isWordPressCom])
-    }
-}
-
-private class MockABTestVariationProvider: ABTestVariationProvider {
-    var mockVariationValue: Variation!
-
-    func variation(for abTest: ABTest) -> Variation {
-        mockVariationValue
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockABTestVariationProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockABTestVariationProvider.swift
@@ -1,0 +1,11 @@
+import protocol Experiments.ABTestVariationProvider
+import enum Experiments.ABTest
+import enum AutomatticTracks.Variation
+
+final class MockABTestVariationProvider: ABTestVariationProvider {
+    var mockVariationValue: Variation!
+
+    func variation(for abTest: ABTest) -> Variation {
+        mockVariationValue
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8768 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds mocking ability for ABTesting using `ABTestVariationProvider`.

- Introduces `ABTestVariationProvider` protocol to have the ability to inject and mock ABTest variations. 
- Fixes flaky tests in `AuthenticationManagerTests` by injecting `MockABTestVariationProvider`
- Unit test the experiment value from tracks event in `AppCoordinatorTests`

## Testing instructions
CI passing should be enough.


## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
