### PR TITLE
Domain credit redemption without contact information

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		0219B03923964BB3007DCD5E /* ProductShippingClassMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0219B03823964BB3007DCD5E /* ProductShippingClassMapper.swift */; };
 		021A84DA257DF92800BC71D1 /* ShippingLabelRefundMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021A84D9257DF92800BC71D1 /* ShippingLabelRefundMapper.swift */; };
 		021C7BF723863D1800A3BCBD /* Encodable+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021C7BF623863D1800A3BCBD /* Encodable+Serialization.swift */; };
+		021D741C2987B1550035687E /* checkout-doman-cart-with-domain-credit-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 021D741B2987B1550035687E /* checkout-doman-cart-with-domain-credit-success.json */; };
 		021E2A1423A9FC5900B1DE07 /* ProductBackordersSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1323A9FC5900B1DE07 /* ProductBackordersSetting.swift */; };
 		021EAA5625493B3600AA8CCD /* OrderItemAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021EAA5525493B3600AA8CCD /* OrderItemAttribute.swift */; };
 		022902D422E2436400059692 /* stats_module_disabled_error.json in Resources */ = {isa = PBXBuildFile; fileRef = 022902D122E2436300059692 /* stats_module_disabled_error.json */; };
@@ -899,6 +900,7 @@
 		0219B03823964BB3007DCD5E /* ProductShippingClassMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductShippingClassMapper.swift; sourceTree = "<group>"; };
 		021A84D9257DF92800BC71D1 /* ShippingLabelRefundMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRefundMapper.swift; sourceTree = "<group>"; };
 		021C7BF623863D1800A3BCBD /* Encodable+Serialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+Serialization.swift"; sourceTree = "<group>"; };
+		021D741B2987B1550035687E /* checkout-doman-cart-with-domain-credit-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "checkout-doman-cart-with-domain-credit-success.json"; sourceTree = "<group>"; };
 		021E2A1323A9FC5900B1DE07 /* ProductBackordersSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBackordersSetting.swift; sourceTree = "<group>"; };
 		021EAA5525493B3600AA8CCD /* OrderItemAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderItemAttribute.swift; sourceTree = "<group>"; };
 		022902D122E2436300059692 /* stats_module_disabled_error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = stats_module_disabled_error.json; sourceTree = "<group>"; };
@@ -2265,6 +2267,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				021D741B2987B1550035687E /* checkout-doman-cart-with-domain-credit-success.json */,
 				DEC2B092297AA60D003923FB /* category-without-data.json */,
 				DEC2B090297AA5A6003923FB /* categories-all-without-data.json */,
 				DEC2B08E297AA123003923FB /* reviews-single-without-data.json */,
@@ -3261,6 +3264,7 @@
 				B58D10CA2114D22E00107ED4 /* new-order-note.json in Resources */,
 				D865CE6B278CA266002C8520 /* stripe-payment-intent-error.json in Resources */,
 				CCB2CAA82620ABCC00285CA0 /* shipping-label-create-package-error.json in Resources */,
+				021D741C2987B1550035687E /* checkout-doman-cart-with-domain-credit-success.json in Resources */,
 				B57B1E6C21C94C9F0046E764 /* timeout_error.json in Resources */,
 				0313651B28AE60E000EEE571 /* payment-gateway-cod.json in Resources */,
 				B5C6FCD620A3768900A4F8E4 /* order.json in Resources */,

--- a/Networking/NetworkingTests/Remote/PaymentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/PaymentRemoteTests.swift
@@ -155,7 +155,9 @@ final class PaymentRemoteTests: XCTestCase {
 
         // When
         do {
-            let response = try await remote.createCart(siteID: siteID, domain: .init(name: "fun.toys", productID: 254, supportsPrivacy: true))
+            let response = try await remote.createCart(siteID: siteID,
+                                                       domain: .init(name: "fun.toys", productID: 254, supportsPrivacy: true),
+                                                       isTemporary: false)
             // Then
             XCTAssertFalse(response.values.isEmpty)
         } catch {
@@ -172,7 +174,7 @@ final class PaymentRemoteTests: XCTestCase {
 
         // When
         await assertThrowsError {
-            _ = try await remote.createCart(siteID: siteID, domain: .init(name: "fun.toys", productID: 685, supportsPrivacy: true))
+            _ = try await remote.createCart(siteID: siteID, domain: .init(name: "fun.toys", productID: 685, supportsPrivacy: true), isTemporary: false)
         } errorAssert: { error in
             // Then
             (error as? CreateCartError) == .productNotInCart
@@ -185,7 +187,36 @@ final class PaymentRemoteTests: XCTestCase {
 
         // When
         await assertThrowsError {
-            _ = try await remote.createCart(siteID: 606, domain: .init(name: "fun.toys", productID: 254, supportsPrivacy: true))
+            _ = try await remote.createCart(siteID: 606, domain: .init(name: "fun.toys", productID: 254, supportsPrivacy: true), isTemporary: false)
+        } errorAssert: { error in
+            // Then
+            (error as? NetworkError) == .notFound
+        }
+    }
+
+    // MARK: - `checkoutCartWithDomainCredit` with a domain
+
+    func test_checkoutCartWithDomainCredit_returns_on_success() async throws {
+        // Given
+        let remote = PaymentRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "me/transactions", filename: "checkout-doman-cart-with-domain-credit-success")
+
+        // When
+        do {
+            try await remote.checkoutCartWithDomainCredit(cart: [:])
+        } catch {
+            // Then
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_checkoutCartWithDomainCredit_throws_notFound_error_when_no_response() async throws {
+        // Given
+        let remote = PaymentRemote(network: network)
+
+        // When
+        await assertThrowsError {
+            try await remote.checkoutCartWithDomainCredit(cart: [:])
         } errorAssert: { error in
             // Then
             (error as? NetworkError) == .notFound

--- a/Networking/NetworkingTests/Responses/checkout-doman-cart-with-domain-credit-success.json
+++ b/Networking/NetworkingTests/Responses/checkout-doman-cart-with-domain-credit-success.json
@@ -1,0 +1,49 @@
+{
+    "receipt_id": 76588039,
+    "purchases": {
+        "16": [
+            {
+                "is_gift_purchase": false,
+                "will_auto_renew": false,
+                "expiry": "2024-01-30",
+                "user_email": "",
+                "product_id": 76,
+                "product_slug": "dotblog_domain",
+                "product_name": ".blog Domain Registration",
+                "product_name_short": null,
+                "product_type": "domain_reg",
+                "free_trial": false,
+                "is_domain_registration": true,
+                "meta": "testing.blog",
+                "ownership_id": 36,
+                "is_renewal": false
+            },
+            {
+                "is_gift_purchase": false,
+                "will_auto_renew": false,
+                "expiry": "2024-01-30",
+                "user_email": "",
+                "product_id": 5,
+                "product_slug": "domain_map",
+                "product_name": "Domain Connection",
+                "product_name_short": null,
+                "product_type": "domain_map",
+                "free_trial": false,
+                "is_domain_registration": false,
+                "meta": "testing.blog",
+                "ownership_id": 36,
+                "is_renewal": false
+            }
+        ]
+    },
+    "display_price": "US$0.00",
+    "price_integer": 0,
+    "price_float": 0,
+    "currency": "USD",
+    "is_gift_purchase": false,
+    "success": true,
+    "error_code": "",
+    "error_message": "",
+    "order_id": "",
+    "failed_purchases": []
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorDataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorDataProvider.swift
@@ -104,8 +104,7 @@ final class PaidDomainSelectorDataProvider: DomainSelectorDataProvider {
 
     @MainActor
     func loadDomainSuggestions(query: String) async throws -> [PaidDomainSuggestionViewModel] {
-        let hasDomainCredit = hasDomainCredit
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withCheckedThrowingContinuation { [hasDomainCredit] continuation in
             stores.dispatch(DomainAction.loadPaidDomainSuggestions(query: query) { result in
                 continuation.resume(with: result.map { $0.map { PaidDomainSuggestionViewModel(domainSuggestion: $0,
                                                                                               hasDomainCredit: hasDomainCredit) } })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorDataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorDataProvider.swift
@@ -52,8 +52,9 @@ struct PaidDomainSuggestionViewModel: DomainSuggestionViewProperties, Equatable 
     // Properties for cart creation after a domain is selected.
     let productID: Int64
     let supportsPrivacy: Bool
+    let hasDomainCredit: Bool
 
-    init(domainSuggestion: PaidDomainSuggestion) {
+    init(domainSuggestion: PaidDomainSuggestion, hasDomainCredit: Bool) {
         self.name = domainSuggestion.name
         self.attributedDetail = {
             var attributedCost = AttributedString(.init(format: Localization.priceFormat, domainSuggestion.cost, domainSuggestion.term))
@@ -77,6 +78,7 @@ struct PaidDomainSuggestionViewModel: DomainSuggestionViewProperties, Equatable 
         }()
         self.productID = domainSuggestion.productID
         self.supportsPrivacy = domainSuggestion.supportsPrivacy
+        self.hasDomainCredit = hasDomainCredit
     }
 }
 
@@ -93,16 +95,20 @@ extension PaidDomainSuggestionViewModel {
 /// Provides domain suggestions that are paid.
 final class PaidDomainSelectorDataProvider: DomainSelectorDataProvider {
     private let stores: StoresManager
+    private let hasDomainCredit: Bool
 
-    init(stores: StoresManager = ServiceLocator.stores) {
+    init(stores: StoresManager = ServiceLocator.stores, hasDomainCredit: Bool) {
         self.stores = stores
+        self.hasDomainCredit = hasDomainCredit
     }
 
     @MainActor
     func loadDomainSuggestions(query: String) async throws -> [PaidDomainSuggestionViewModel] {
-        try await withCheckedThrowingContinuation { continuation in
+        let hasDomainCredit = hasDomainCredit
+        return try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(DomainAction.loadPaidDomainSuggestions(query: query) { result in
-                continuation.resume(with: result.map { $0.map { PaidDomainSuggestionViewModel(domainSuggestion: $0) } })
+                continuation.resume(with: result.map { $0.map { PaidDomainSuggestionViewModel(domainSuggestion: $0,
+                                                                                              hasDomainCredit: hasDomainCredit) } })
             })
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorView.swift
@@ -306,8 +306,8 @@ struct DomainSelectorView_Previews: PreviewProvider {
                                           term: "year",
                                           cost: "NT$610.00",
                                           saleCost: "NT$154.00")
-                                ]))
-                              )),
+                                ])),
+                                hasDomainCredit: true)),
                 onDomainSelection: { _ in },
                 onSupport: {}
             )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsCoordinator.swift
@@ -66,7 +66,6 @@ private extension DomainSettingsCoordinator {
                     print("⛔️ Error creating cart with the selected domain \(domain): \(error)")
                 }
             }
-
         } onSupport: {
             // TODO: 8558 - remove support action
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsCoordinator.swift
@@ -55,7 +55,7 @@ private extension DomainSettingsCoordinator {
                     self.showSuccessView(from: navigationController, domainName: domain.name)
                 } catch {
                     // TODO: 8558 - error handling
-                    print("⛔️ Error creating cart with the selected domain \(domain) with domain credit: \(error)")
+                    print("⛔️ Error redeeming domain credit with the selected domain \(domain): \(error)")
                 }
             } else {
                 do {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 /// Hosting controller that wraps the `DomainSettingsView` view.
 final class DomainSettingsHostingController: UIHostingController<DomainSettingsView> {
-    init(viewModel: DomainSettingsViewModel, addDomain: @escaping () -> Void) {
+    init(viewModel: DomainSettingsViewModel,
+         addDomain: @escaping (_ hasDomainCredit: Bool) -> Void) {
         super.init(rootView: DomainSettingsView(viewModel: viewModel,
                                                 addDomain: addDomain))
     }
@@ -21,9 +22,9 @@ final class DomainSettingsHostingController: UIHostingController<DomainSettingsV
 /// Shows a site's domains with actions to add a domain or redeem a domain credit.
 struct DomainSettingsView: View {
     @ObservedObject private var viewModel: DomainSettingsViewModel
-    private let addDomain: () -> Void
+    private let addDomain: (_ hasDomainCredit: Bool) -> Void
 
-    init(viewModel: DomainSettingsViewModel, addDomain: @escaping () -> Void) {
+    init(viewModel: DomainSettingsViewModel, addDomain: @escaping (Bool) -> Void) {
         self.viewModel = viewModel
         self.addDomain = addDomain
     }
@@ -41,13 +42,13 @@ struct DomainSettingsView: View {
 
                 if viewModel.hasDomainCredit {
                     DomainSettingsDomainCreditView() {
-                        addDomain()
+                        addDomain(viewModel.hasDomainCredit)
                     }
                 }
 
                 if viewModel.domains.isNotEmpty {
                     DomainSettingsListView(domains: viewModel.domains) {
-                        addDomain()
+                        addDomain(viewModel.hasDomainCredit)
                     }
                 }
             }
@@ -60,7 +61,7 @@ struct DomainSettingsView: View {
                         .frame(height: Layout.dividerHeight)
                         .foregroundColor(Color(.separator))
                     Button(Localization.searchDomainButton) {
-                        addDomain()
+                        addDomain(viewModel.hasDomainCredit)
                     }
                     .buttonStyle(PrimaryButtonStyle())
                     .padding(Layout.bottomContentPadding)
@@ -141,7 +142,7 @@ struct DomainSettingsView_Previews: PreviewProvider {
                                 ]),
                                 // The site has domain credit.
                                 sitePlanResult: .success(.init(hasDomainCredit: true)))),
-                                   addDomain: {})
+                                   addDomain: { _ in })
             }
 
             NavigationView {
@@ -153,7 +154,7 @@ struct DomainSettingsView_Previews: PreviewProvider {
                                     .init(name: "free.test", isPrimary: true)
                                 ]),
                                 sitePlanResult: .success(.init(hasDomainCredit: true)))),
-                                   addDomain: {})
+                                   addDomain: { _ in })
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/Domains/PaidDomainSelectorDataProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Domains/PaidDomainSelectorDataProviderTests.swift
@@ -9,7 +9,7 @@ final class PaidDomainSelectorDataProviderTests: XCTestCase {
     override func setUp() {
         super.setUp()
         stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
-        dataProvider = PaidDomainSelectorDataProvider(stores: stores)
+        dataProvider = PaidDomainSelectorDataProvider(stores: stores, hasDomainCredit: false)
     }
 
     override func tearDown() {

--- a/Yosemite/Yosemite/Actions/DomainAction.swift
+++ b/Yosemite/Yosemite/Actions/DomainAction.swift
@@ -9,6 +9,9 @@ public enum DomainAction: Action {
     case createDomainShoppingCart(siteID: Int64,
                                   domain: DomainToPurchase,
                                   completion: (Result<Void, Error>) -> Void)
+    case redeemDomainCredit(siteID: Int64,
+                            domain: DomainToPurchase,
+                            completion: (Result<Void, Error>) -> Void)
 }
 
 /// Necessary data for the domain selector flow with paid domains.

--- a/Yosemite/Yosemite/Stores/DomainStore.swift
+++ b/Yosemite/Yosemite/Stores/DomainStore.swift
@@ -46,6 +46,8 @@ public final class DomainStore: Store {
             loadDomains(siteID: siteID, completion: completion)
         case .createDomainShoppingCart(let siteID, let domain, let completion):
             createDomainShoppingCart(siteID: siteID, domain: domain, completion: completion)
+        case .redeemDomainCredit(let siteID, let domain, let completion):
+            redeemDomainCredit(siteID: siteID, domain: domain, completion: completion)
         }
     }
 }
@@ -103,9 +105,28 @@ private extension DomainStore {
                 try await paymentRemote.createCart(siteID: siteID,
                                                    domain: .init(name: domain.name,
                                                                  productID: domain.productID,
-                                                                 supportsPrivacy: domain.supportsPrivacy))
+                                                                 supportsPrivacy: domain.supportsPrivacy),
+                                                   isTemporary: false)
             }
             completion(result.map { _ in () })
+        }
+    }
+
+    func redeemDomainCredit(siteID: Int64,
+                            domain: DomainToPurchase,
+                            completion: @escaping (Result<Void, Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let cart = try await paymentRemote.createCart(siteID: siteID,
+                                                              domain: .init(name: domain.name,
+                                                                            productID: domain.productID,
+                                                                            supportsPrivacy: domain.supportsPrivacy),
+                                                              isTemporary: true)
+                try await paymentRemote.checkoutCartWithDomainCredit(cart: cart)
+                completion(.success(()))
+            } catch {
+                completion(.failure(error))
+            }
         }
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockPaymentRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockPaymentRemote.swift
@@ -16,6 +16,9 @@ final class MockPaymentRemote {
     /// The results to return in `createCart` with a domain.
     private var createDomainCartResult: Result<CartResponse, Error>?
 
+    /// The results to return in `checkoutCartWithDomainCredit` with a domain.
+    private var checkoutCartWithDomainCreditResult: Result<Void, Error>?
+
     /// Returns the value when `loadPlan` is called.
     func whenLoadingPlan(thenReturn result: Result<WPComPlan, Error>) {
         loadPlanResult = result
@@ -34,6 +37,11 @@ final class MockPaymentRemote {
     /// Returns the value when `createCart` with a domain is called.
     func whenCreatingDomainCart(thenReturn result: Result<CartResponse, Error>) {
         createDomainCartResult = result
+    }
+
+    /// Returns the value when `checkoutCartWithDomainCredit` with a domain is called.
+    func whenCheckingOutCartWithDomainCredit(thenReturn result: Result<Void, Error>) {
+        checkoutCartWithDomainCreditResult = result
     }
 }
 
@@ -62,9 +70,17 @@ extension MockPaymentRemote: PaymentRemoteProtocol {
         return try result.get()
     }
 
-    func createCart(siteID: Int64, domain: PaidDomainSuggestion) async throws -> CartResponse {
+    func createCart(siteID: Int64, domain: PaidDomainSuggestion, isTemporary: Bool) async throws -> CartResponse {
         guard let result = createDomainCartResult else {
             XCTFail("Could not find result for creating a domain cart.")
+            throw NetworkError.notFound
+        }
+        return try result.get()
+    }
+
+    func checkoutCartWithDomainCredit(cart: CartResponse) async throws {
+        guard let result = checkoutCartWithDomainCreditResult else {
+            XCTFail("Could not find result for checking out a cart with domain credit.")
             throw NetworkError.notFound
         }
         return try result.get()

--- a/Yosemite/YosemiteTests/Stores/DomainStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/DomainStoreTests.swift
@@ -218,4 +218,63 @@ final class DomainStoreTests: XCTestCase {
         let error = try XCTUnwrap(result.failure)
         XCTAssertEqual(error as? NetworkError, .timeout)
     }
+
+    // MARK: - `redeemDomainCredit`
+
+    func test_redeemDomainCredit_returns_response_on_success() throws {
+        // Given
+        paymentRemote.whenCreatingDomainCart(thenReturn: .success([:]))
+        paymentRemote.whenCheckingOutCartWithDomainCredit(thenReturn: .success(()))
+
+        // When
+        let result = waitFor { promise in
+            self.store.onAction(DomainAction.redeemDomainCredit(siteID: 606, domain: .init(name: "",
+                                                                                           productID: 1,
+                                                                                           supportsPrivacy: true)) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+    }
+
+    func test_redeemDomainCredit_returns_createCart_error_on_failure() throws {
+        // Given
+        paymentRemote.whenCreatingDomainCart(thenReturn: .failure(NetworkError.timeout))
+
+        // When
+        let result = waitFor { promise in
+            self.store.onAction(DomainAction.redeemDomainCredit(siteID: 606, domain: .init(name: "",
+                                                                                           productID: 1,
+                                                                                           supportsPrivacy: true)) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? NetworkError, .timeout)
+    }
+
+    func test_redeemDomainCredit_returns_checkoutCartWithDomainCredit_error_on_failure() throws {
+        // Given
+        paymentRemote.whenCreatingDomainCart(thenReturn: .success([:]))
+        paymentRemote.whenCheckingOutCartWithDomainCredit(thenReturn: .failure(NetworkError.notFound))
+
+        // When
+        let result = waitFor { promise in
+            self.store.onAction(DomainAction.redeemDomainCredit(siteID: 606, domain: .init(name: "",
+                                                                                           productID: 1,
+                                                                                           supportsPrivacy: true)) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? NetworkError, .notFound)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8558 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When a site has a domain credit (a free domain for the first year that is usually offered for annual WPCOM plans), the merchant can redeem the domain credit by selecting a paid domain. Domain credit redemption can be achieved by a few API calls without the web checkout flow. This PR includes the API call (in `PaymentRemote.checkoutCartWithDomainCredit`) to check out a domain cart with domain credit, and integrates with the UI by making use of the `hasDomainCredit` value.

What's missing in the current implementation is the domain contact information required in the domain cart checkout API. Since it involves extra API & UI, I'm saving this for future work. This means that the current flow results in an error with missing contact information.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: a WC store with an annual WPCOM plan whose domain credit hasn't been claimed, you can create a site like this in Calypso with store credit

- Log in if needed, and continue with a WPCOM store
- Go to the Menu tab
- Tap on the settings CTA
- Tap the `Domain` row --> there should be a section about the free domain for the first year
- Tap `Claim Domain` --> domain selector with paid domains should be shown, and each domain should have price info (there's a future subtask to update the price info to mention that it's free for the first year)
- Select a domain and tap `Continue` --> after a bit, it should fail with an error in the console like `⛔️ Error redeeming domain credit with the selected domain **: Dotcom Error: [missing_contact_information] Missing contact information parameter while creating shopping cart`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
