### PR TITLE
[Variable Product] - Variation name input should start with uppercase

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 12.2
 -----
-
+- [*] Fix: Adding a new attribute will auto-capitalize the first letter for each word in the attribute name. [https://github.com/woocommerce/woocommerce-ios/pull/8772]
 
 12.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeViewController.swift
@@ -214,7 +214,8 @@ private extension AddAttributeViewController {
                                                             self?.doneButtonPressed()
                                                          }, inputFormatter: nil,
                                                          keyboardType: .default,
-                                                         returnKeyType: .next)
+                                                         returnKeyType: .next,
+                                                         autocapitalizationType: .words)
         cell.configure(viewModel: viewModel)
         cell.applyStyle(style: .body)
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
@@ -4,6 +4,17 @@ import UIKit
 ///
 final class TextFieldTableViewCell: UITableViewCell {
     struct ViewModel {
+        internal init(text: String? = nil, placeholder: String? = nil, onTextChange: ((String?) -> Void)? = nil, onTextDidBeginEditing: (() -> Void)? = nil, onTextDidReturn: ((String?) -> Void)? = nil, inputFormatter: UnitInputFormatter? = nil, keyboardType: UIKeyboardType, returnKeyType: UIReturnKeyType = .default, autocapitalizationType: UITextAutocapitalizationType = .none) {
+            self.text = text
+            self.placeholder = placeholder
+            self.onTextChange = onTextChange
+            self.onTextDidBeginEditing = onTextDidBeginEditing
+            self.onTextDidReturn = onTextDidReturn
+            self.inputFormatter = inputFormatter
+            self.keyboardType = keyboardType
+            self.returnKeyType = returnKeyType
+            self.autocapitalizationType = autocapitalizationType
+        }
         let text: String?
         let placeholder: String?
         let onTextChange: ((_ text: String?) -> Void)?
@@ -11,7 +22,8 @@ final class TextFieldTableViewCell: UITableViewCell {
         let onTextDidReturn: ((_ text: String?) -> Void)?
         let inputFormatter: UnitInputFormatter?
         let keyboardType: UIKeyboardType
-        var returnKeyType: UIReturnKeyType = .default
+        let returnKeyType: UIReturnKeyType
+        let autocapitalizationType: UITextAutocapitalizationType
     }
 
     @IBOutlet private weak var textField: UITextField!
@@ -41,6 +53,7 @@ final class TextFieldTableViewCell: UITableViewCell {
         textField.returnKeyType = viewModel.returnKeyType
         textField.addTarget(self, action: #selector(textFieldDidChange(textField:)), for: .editingChanged)
         textField.addTarget(self, action: #selector(textFieldDidBegin(textField:)), for: .editingDidBegin)
+        textField.autocapitalizationType = viewModel.autocapitalizationType
     }
 
     @discardableResult

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
@@ -4,10 +4,15 @@ import UIKit
 ///
 final class TextFieldTableViewCell: UITableViewCell {
     struct ViewModel {
-        init(text: String? = nil, placeholder: String? = nil, onTextChange: ((String?) -> Void)? = nil,
-                      onTextDidBeginEditing: (() -> Void)? = nil, onTextDidReturn: ((String?) -> Void)? = nil,
-                      inputFormatter: UnitInputFormatter? = nil, keyboardType: UIKeyboardType,
-                      returnKeyType: UIReturnKeyType = .default, autocapitalizationType: UITextAutocapitalizationType = .none) {
+        init(text: String? = nil,
+             placeholder: String? = nil,
+             onTextChange: ((String?) -> Void)? = nil,
+             onTextDidBeginEditing: (() -> Void)? = nil,
+             onTextDidReturn: ((String?) -> Void)? = nil,
+             inputFormatter: UnitInputFormatter? = nil,
+             keyboardType: UIKeyboardType,
+             returnKeyType: UIReturnKeyType = .default,
+             autocapitalizationType: UITextAutocapitalizationType = .none) {
             self.text = text
             self.placeholder = placeholder
             self.onTextChange = onTextChange
@@ -54,9 +59,9 @@ final class TextFieldTableViewCell: UITableViewCell {
         textField.borderStyle = .none
         textField.keyboardType = viewModel.keyboardType
         textField.returnKeyType = viewModel.returnKeyType
+        textField.autocapitalizationType = viewModel.autocapitalizationType
         textField.addTarget(self, action: #selector(textFieldDidChange(textField:)), for: .editingChanged)
         textField.addTarget(self, action: #selector(textFieldDidBegin(textField:)), for: .editingDidBegin)
-        textField.autocapitalizationType = viewModel.autocapitalizationType
     }
 
     @discardableResult

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
@@ -4,7 +4,7 @@ import UIKit
 ///
 final class TextFieldTableViewCell: UITableViewCell {
     struct ViewModel {
-        internal init(text: String? = nil, placeholder: String? = nil, onTextChange: ((String?) -> Void)? = nil,
+        init(text: String? = nil, placeholder: String? = nil, onTextChange: ((String?) -> Void)? = nil,
                       onTextDidBeginEditing: (() -> Void)? = nil, onTextDidReturn: ((String?) -> Void)? = nil,
                       inputFormatter: UnitInputFormatter? = nil, keyboardType: UIKeyboardType,
                       returnKeyType: UIReturnKeyType = .default, autocapitalizationType: UITextAutocapitalizationType = .none) {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
@@ -4,7 +4,10 @@ import UIKit
 ///
 final class TextFieldTableViewCell: UITableViewCell {
     struct ViewModel {
-        internal init(text: String? = nil, placeholder: String? = nil, onTextChange: ((String?) -> Void)? = nil, onTextDidBeginEditing: (() -> Void)? = nil, onTextDidReturn: ((String?) -> Void)? = nil, inputFormatter: UnitInputFormatter? = nil, keyboardType: UIKeyboardType, returnKeyType: UIReturnKeyType = .default, autocapitalizationType: UITextAutocapitalizationType = .none) {
+        internal init(text: String? = nil, placeholder: String? = nil, onTextChange: ((String?) -> Void)? = nil,
+                      onTextDidBeginEditing: (() -> Void)? = nil, onTextDidReturn: ((String?) -> Void)? = nil,
+                      inputFormatter: UnitInputFormatter? = nil, keyboardType: UIKeyboardType,
+                      returnKeyType: UIReturnKeyType = .default, autocapitalizationType: UITextAutocapitalizationType = .none) {
             self.text = text
             self.placeholder = placeholder
             self.onTextChange = onTextChange


### PR DESCRIPTION
Closes: #8692 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
The first letter is not capitalized when adding a new variation attribute name. The merchant would need to do an extra tap to make it uppercase. This only happens on the add variation screen.

Since `AddAttributeViewController` uses `TextFieldTableViewCell` to initialize the text fields, I added `UITextAutocapitalizationType` option to auto-capitalized the attribute name in the Add Variation Screen.

## Testing instructions

1. Go to Product > Add new product > Variable product > Add variation
2. Click on Add Attributes
3. Add a new attribute name
4. See that the first letter of the attribute name is in uppercase

## Screenshots

https://user-images.githubusercontent.com/40906847/215433722-d52a88db-5561-4dfb-9475-f7e599d6537f.mp4

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
