### PR TITLE
REST API: Use generic error message for when application password generation is unauthorized

### DIFF
--- a/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
+++ b/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
@@ -56,7 +56,7 @@ private extension PostSiteCredentialLoginChecker {
                     let errorUI = applicationPasswordDisabledUI(for: siteURL)
                     navigationController.show(errorUI, sender: nil)
                 case ApplicationPasswordUseCaseError.unauthorizedRequest:
-                    showAlert(message: Localization.invalidLoginOrAdminURL, in: navigationController)
+                    showAlert(message: Localization.unauthorizedForAppPassword, in: navigationController)
                 default:
                     DDLogError("⛔️ Error generating application password: \(error)")
                     showAlert(
@@ -199,9 +199,9 @@ private extension PostSiteCredentialLoginChecker {
             "Error checking for the WooCommerce plugin.",
             comment: "Error message displayed when the WooCommerce plugin detail cannot be fetched after authentication"
         )
-        static let invalidLoginOrAdminURL = NSLocalizedString(
-            "Application password cannot be generated due to a custom login or admin URL on your site.",
-            comment: "Message to display when the constructed admin or login URL for the logged-in site is not accessible"
+        static let unauthorizedForAppPassword = NSLocalizedString(
+            "The request to generate application password is not authorized.",
+            comment: "Message to display when the generating application password fails with unauthorized error"
         )
         static let contactSupport = NSLocalizedString("Contact Support", comment: "Button to contact support for login")
         static let retryButton = NSLocalizedString("Try Again", comment: "Button to refetch application password for the current site")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8760 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the wording for the unauthorized application password error to make it generic since this error can happen not only when login or admin URL is updated.

Also: added an update to reuse the check for the application password A/B test variant to make it easier to test the treatment variant.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Update your self-hosted site's admin/login URL with "Change wp-admin login" plugin (or reproduce with the steps mentioned in #8760).
- Set the check for `enableSiteAddressLoginOnly` in `AuthenticationManager` to `true` to force the treatment variant and build the app.
- On the prologue screen, select Enter your store address and proceed with the address of your test store.
- Log in with the correct site credentials.
- Notice that an alert shows up saying the request is unauthorized.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/215451467-3e006d74-7e93-46e9-990c-7efa94deaa9d.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
