### PR TITLE
Show "free for the first year" for domain suggestions with a domain credit

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorDataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorDataProvider.swift
@@ -67,9 +67,9 @@ struct PaidDomainSuggestionViewModel: DomainSuggestionViewProperties, Equatable 
 
                 var attributedDomainCreditPricing = AttributedString(Localization.domainCreditPricing)
                 attributedDomainCreditPricing.font = .body
-                attributedDomainCreditPricing.foregroundColor = .init(.info)
+                attributedDomainCreditPricing.foregroundColor = .init(.domainCreditPricing)
 
-                return attributedDomainCreditPricing + .init(" ") + attributedCost
+                return attributedCost + .init(" ") + attributedDomainCreditPricing
             } else if let saleCost = domainSuggestion.saleCost {
                 // Strikethrough style for the original cost string.
                 if let range = attributedCost.range(of: domainSuggestion.cost) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorDataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorDataProvider.swift
@@ -61,7 +61,16 @@ struct PaidDomainSuggestionViewModel: DomainSuggestionViewProperties, Equatable 
             attributedCost.font = .body
             attributedCost.foregroundColor = .init(.secondaryLabel)
 
-            if let saleCost = domainSuggestion.saleCost {
+            if hasDomainCredit {
+                // Strikethrough style for the original cost string.
+                attributedCost.strikethroughStyle = .single
+
+                var attributedDomainCreditPricing = AttributedString(Localization.domainCreditPricing)
+                attributedDomainCreditPricing.font = .body
+                attributedDomainCreditPricing.foregroundColor = .init(.info)
+
+                return attributedDomainCreditPricing + .init(" ") + attributedCost
+            } else if let saleCost = domainSuggestion.saleCost {
                 // Strikethrough style for the original cost string.
                 if let range = attributedCost.range(of: domainSuggestion.cost) {
                     attributedCost[range].strikethroughStyle = .single
@@ -88,6 +97,10 @@ extension PaidDomainSuggestionViewModel {
             "%1$@ / %2$@",
             comment: "The original price of a domain. %1$@ is the price per term. " +
             "%2$@ is the duration of each pricing term, usually year."
+        )
+        static let domainCreditPricing = NSLocalizedString(
+            "Free for the first year",
+            comment: "Label shown for domains that are free for the first year with available domain credit."
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/Domains/PaidDomainSelectorDataProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Domains/PaidDomainSelectorDataProviderTests.swift
@@ -104,6 +104,6 @@ final class PaidDomainSelectorDataProviderTests: XCTestCase {
         XCTAssertEqual(viewModel.productID, 18)
         let viewModelPrice = String(format: PaidDomainSuggestionViewModel.Localization.priceFormat, "US$25.00", "year")
         let viewModelDetailText = try XCTUnwrap(viewModel.attributedDetail)
-        XCTAssertEqual(String(viewModelDetailText.characters), "\(PaidDomainSuggestionViewModel.Localization.domainCreditPricing) \(viewModelPrice)")
+        XCTAssertEqual(String(viewModelDetailText.characters), "\(viewModelPrice) \(PaidDomainSuggestionViewModel.Localization.domainCreditPricing)")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/Domains/PaidDomainSelectorDataProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Domains/PaidDomainSelectorDataProviderTests.swift
@@ -74,4 +74,36 @@ final class PaidDomainSelectorDataProviderTests: XCTestCase {
         let viewModelDetailText = try XCTUnwrap(viewModel.attributedDetail)
         XCTAssertEqual(String(viewModelDetailText.characters), "US$3.90 \(viewModelPrice)")
     }
+
+    func test_loadDomainSuggestions_with_domain_credit_returns_detail_with_first_year_free_text() async throws {
+        // Given
+        let domainWithSale = PaidDomainSuggestion(productID: 18,
+                                                  supportsPrivacy: true,
+                                                  name: "domain.credit",
+                                                  term: "year",
+                                                  cost: "US$25.00",
+                                                  saleCost: "US$3.90")
+        stores.whenReceivingAction(ofType: DomainAction.self) { action in
+            switch action {
+            case let .loadPaidDomainSuggestions(_, completion):
+                completion(.success([domainWithSale]))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let dataProvider = PaidDomainSelectorDataProvider(stores: stores, hasDomainCredit: true)
+
+        // When
+        let viewModels = try await dataProvider.loadDomainSuggestions(query: "domain")
+
+        // Then
+        XCTAssertEqual(viewModels.count, 1)
+
+        let viewModel = viewModels[0]
+        XCTAssertEqual(viewModel.name, "domain.credit")
+        XCTAssertEqual(viewModel.productID, 18)
+        let viewModelPrice = String(format: PaidDomainSuggestionViewModel.Localization.priceFormat, "US$25.00", "year")
+        let viewModelDetailText = try XCTUnwrap(viewModel.attributedDetail)
+        XCTAssertEqual(String(viewModelDetailText.characters), "\(PaidDomainSuggestionViewModel.Localization.domainCreditPricing) \(viewModelPrice)")
+    }
 }

--- a/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
+++ b/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
@@ -324,6 +324,13 @@ public extension UIColor {
                        dark: .withColorStudio(.yellow, shade: .shade30))
     }
 
+    /// Domain credit pricing color.
+    ///
+    static var domainCreditPricing: UIColor {
+        return UIColor(light: .withColorStudio(.green, shade: .shade50),
+                       dark: .withColorStudio(.green, shade: .shade30))
+    }
+
     /// Color for loading indicators within navigation bars
     ///
     static var navigationBarLoadingIndicator: UIColor {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8558 
Based on https://github.com/woocommerce/woocommerce-ios/pull/8771, please review the base PR first
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When the site has a domain credit, the merchant can get a paid domain for free for the first year. In this PR, it shows this "free for the first year" info on the domain suggestions with the original price (in strikethrough style) following design VyLr7LvKodHE4kINfBE7Lw-fi-682%3A39944.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: a WC store with an annual WPCOM plan whose domain credit hasn't been claimed, you can create a site like this in Calypso with store credit

- Log in if needed, and continue with a WPCOM store
- Go to the Menu tab
- Tap on the settings CTA
- Tap the `Domain` row --> there should be a section about the free domain for the first year
- Tap `Claim Domain` --> domain selector with paid domains should be shown, with the original cost crossed out and "free for the first year" is shown

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light
-- | --
![Simulator Screen Shot - iPhone 14 - 2023-01-31 at 09 23 42](https://user-images.githubusercontent.com/1945542/215635349-51458d3a-7a24-4a33-a58e-126a5fb0e011.png) | ![Simulator Screen Shot - iPhone 14 - 2023-01-31 at 09 23 49](https://user-images.githubusercontent.com/1945542/215635360-47cb3052-7abb-42cf-afee-9f86b25feaa6.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.