### PR TITLE
REST API: Hide Close account button and fix account name on Log out alert

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -297,7 +297,12 @@ private extension SettingsViewController {
 
     func logoutWasPressed() {
         ServiceLocator.analytics.track(.settingsLogoutTapped)
-        let messageFormatted = String(format: Localization.LogoutAlert.alertMessage, viewModel.accountName)
+        let messageFormatted: String = {
+            guard viewModel.accountName.isNotEmpty else {
+                return Localization.LogoutAlert.alertMessageWithoutDisplayName
+            }
+            return String(format: Localization.LogoutAlert.alertMessage, viewModel.accountName)
+        }()
         let alertController = UIAlertController(title: "", message: messageFormatted, preferredStyle: .alert)
 
         alertController.addActionWithTitle(Localization.LogoutAlert.cancelButtonTitle, style: .cancel) { _ in
@@ -809,6 +814,10 @@ private extension SettingsViewController {
         enum LogoutAlert {
             static let alertMessage = NSLocalizedString(
                 "Are you sure you want to log out of the account %@?",
+                comment: "Alert message to confirm a user meant to log out."
+            )
+            static let alertMessageWithoutDisplayName = NSLocalizedString(
+                "Are you sure you want to log out of your account?",
                 comment: "Alert message to confirm a user meant to log out."
             )
             static let cancelButtonTitle = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -285,6 +285,10 @@ private extension SettingsViewModel {
 
         // Close account
         let closeAccountSection: Section? = {
+            // Do not show the Close Account CTA when authenticated with application password
+            guard stores.isAuthenticatedWithoutWPCom == false else {
+                return nil
+            }
             guard appleIDCredentialChecker.hasAppleUserID()
                     || featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
                     || featureFlagService.isFeatureFlagEnabled(.storeCreationM2) else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -65,7 +65,7 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     /// Main Account's displayName
     ///
     var accountName: String {
-        stores.sessionManager.defaultAccount?.displayName ?? String()
+        stores.sessionManager.defaultCredentials?.username ?? ""
     }
 
     /// Announcement for the current app version

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -65,7 +65,7 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     /// Main Account's displayName
     ///
     var accountName: String {
-        stores.sessionManager.defaultCredentials?.username ?? ""
+        stores.sessionManager.defaultAccount?.displayName ?? String()
     }
 
     /// Announcement for the current app version

--- a/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
+++ b/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
@@ -42,8 +42,8 @@ extension SessionManagerProtocol {
 // MARK: - Testing Constants
 //
 enum SessionSettings {
-    static let wpcomCredentials = Credentials(username: "wpcomUsername", authToken: "authToken", siteAddress: "siteAddress")
-    static let wporgCredentials = Credentials(username: "wporgUsername", password: "password", siteAddress: "siteAddress")
+    static let wpcomCredentials = Credentials(username: "username", authToken: "authToken", siteAddress: "siteAddress")
+    static let wporgCredentials = Credentials(username: "username", password: "password", siteAddress: "siteAddress")
     static let defaults = UserDefaults(suiteName: "storesManagerTests")!
     static let keychainServiceName = "com.woocommerce.storesmanagertests"
 }

--- a/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
+++ b/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
@@ -42,8 +42,8 @@ extension SessionManagerProtocol {
 // MARK: - Testing Constants
 //
 enum SessionSettings {
-    static let wpcomCredentials = Credentials(username: "username", authToken: "authToken", siteAddress: "siteAddress")
-    static let wporgCredentials = Credentials(username: "username", password: "password", siteAddress: "siteAddress")
+    static let wpcomCredentials = Credentials(username: "wpcomUsername", authToken: "authToken", siteAddress: "siteAddress")
+    static let wporgCredentials = Credentials(username: "wporgUsername", password: "password", siteAddress: "siteAddress")
     static let defaults = UserDefaults(suiteName: "storesManagerTests")!
     static let keychainServiceName = "com.woocommerce.storesmanagertests"
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -233,6 +233,37 @@ final class SettingsViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.domain) })
     }
+
+    // MARK: - `accountName` tests
+    func test_accountName_is_correct_when_authenticated_without_wpcom() {
+        // Given
+        let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: false)
+        let stores = DefaultStoresManager(sessionManager: sessionManager)
+        let viewModel = SettingsViewModel(stores: stores,
+                                          storageManager: storageManager,
+                                          appleIDCredentialChecker: appleIDCredentialChecker)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertEqual(viewModel.accountName, SessionSettings.wporgCredentials.username)
+    }
+
+    func test_accountName_is_correct_when_authenticated_with_wpcom() {
+        // Given
+        let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: true)
+        let stores = DefaultStoresManager(sessionManager: sessionManager)
+        let viewModel = SettingsViewModel(stores: stores,
+                                          storageManager: storageManager,
+                                          appleIDCredentialChecker: appleIDCredentialChecker)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertEqual(viewModel.accountName, SessionSettings.wpcomCredentials.username)
+    }
 }
 
 private final class MockSettingsPresenter: SettingsViewPresenter {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -233,37 +233,6 @@ final class SettingsViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.domain) })
     }
-
-    // MARK: - `accountName` tests
-    func test_accountName_is_correct_when_authenticated_without_wpcom() {
-        // Given
-        let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: false)
-        let stores = DefaultStoresManager(sessionManager: sessionManager)
-        let viewModel = SettingsViewModel(stores: stores,
-                                          storageManager: storageManager,
-                                          appleIDCredentialChecker: appleIDCredentialChecker)
-
-        // When
-        viewModel.onViewDidLoad()
-
-        // Then
-        XCTAssertEqual(viewModel.accountName, SessionSettings.wporgCredentials.username)
-    }
-
-    func test_accountName_is_correct_when_authenticated_with_wpcom() {
-        // Given
-        let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: true)
-        let stores = DefaultStoresManager(sessionManager: sessionManager)
-        let viewModel = SettingsViewModel(stores: stores,
-                                          storageManager: storageManager,
-                                          appleIDCredentialChecker: appleIDCredentialChecker)
-
-        // When
-        viewModel.onViewDidLoad()
-
-        // Then
-        XCTAssertEqual(viewModel.accountName, SessionSettings.wpcomCredentials.username)
-    }
 }
 
 private final class MockSettingsPresenter: SettingsViewPresenter {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -168,6 +168,24 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.closeAccount) })
     }
 
+    func test_closeAccount_section_is_hidden_when_authenticated_without_wpcom() {
+        // Given
+        let appleIDCredentialChecker = MockAppleIDCredentialChecker(hasAppleUserID: false)
+        let featureFlagService = MockFeatureFlagService(isStoreCreationMVPEnabled: true, isStoreCreationM2Enabled: true)
+        let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: false)
+        let stores = DefaultStoresManager(sessionManager: sessionManager)
+        let viewModel = SettingsViewModel(stores: stores,
+                                          storageManager: storageManager,
+                                          featureFlagService: featureFlagService,
+                                          appleIDCredentialChecker: appleIDCredentialChecker)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.closeAccount) })
+    }
+
     func test_domain_is_hidden_when_domainSettings_feature_is_disabled() {
         // Given
         let featureFlagService = MockFeatureFlagService(isDomainSettingsEnabled: false)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8779 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes 2 issues regarding the settings screen for users authenticated with application passwords:
- Hid the Close account button since this is only necessary to close WPCom accounts
- Hid the account name on the log-out alert when authenticated with application passwords.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Set the check for `enableSiteAddressLoginOnly` in `AuthenticationManager` to `true` to force the treatment variant and build the app.
- On the prologue screen, select Enter your store address and proceed with the address of your test store.
- Log in with the correct site credentials.
- After the login succeeds, navigate to the Menu tab and navigate to the Settings screen.
- Notice that the Close account button is not present.
- Select the Log out button. Notice that the correct username is displayed on the confirmation alert.

Please feel free to test again with a WPCom site and WPCom credentials. The Close account button should still be present on the Settings screen.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| | Authenticated with WPCom | Authenticated with application password |
| ----- | ----- | ----- |
| Close Account | <img src="https://user-images.githubusercontent.com/5533851/215655115-f4755c82-6c66-4584-ae17-89fa7334e9cd.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/215655152-7da36da5-d9ba-4282-90f6-63327c895eb0.png" width=320 /> |
| Log out alert | <img src="https://user-images.githubusercontent.com/5533851/215657416-ecc5622d-7e1f-4355-b6c2-cd6211e7ea63.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/215657357-adcbb1ed-9012-47bc-8892-8e82d3fed450.png" width=320 /> | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
