### PR TITLE
[Variable Product] Variation list order shouldn't change on refresh

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -458,7 +458,7 @@ private extension AddAttributeOptionsViewModel {
 
 private extension AddAttributeOptionsViewModel {
     enum Localization {
-        static let footerTextField = NSLocalizedString("Add each option and press enter",
+        static let footerTextField = NSLocalizedString("Add each option and press return",
                                                        comment: "Footer of text field section in Add Attribute Options screen")
         static let headerSelectedOptions = NSLocalizedString("OPTIONS OFFERED",
                                                            comment: "Header of selected attribute options section in Add Attribute Options screen")

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -340,11 +340,12 @@ private extension ProductVariationsViewController {
     func createResultsController() -> ResultsController<StorageProductVariation> {
         let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "product.siteID == %lld AND product.productID == %lld", siteID, productID)
-        let descriptor = NSSortDescriptor(keyPath: \StorageProductVariation.menuOrder, ascending: true)
+        let menuOrderDescriptor = NSSortDescriptor(keyPath: \StorageProductVariation.menuOrder, ascending: true)
+        let variationIdDescriptor = NSSortDescriptor(keyPath: \StorageProductVariation.productVariationID, ascending: false)
 
         return ResultsController<StorageProductVariation>(storageManager: storageManager,
                                                           matching: predicate,
-                                                          sortedBy: [descriptor])
+                                                          sortedBy: [menuOrderDescriptor, variationIdDescriptor])
     }
 
     func configureResultsController(_ resultsController: ResultsController<StorageProductVariation>) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8695 and #8694

## Description

When viewing product variations, the product variation list order would change randomly on every refresh. This happened because the list was sorted by `menuOrder`, and sometimes all variations can have `menuOrder` set to `0.`

This PR fixes the issue by sorting the list by `menuOrder`, and then followed by `productVariationID` (descending).

The PR also fixes a minor issue in #8694, where the on-screen instruction didn't match the key on the keyboard.

## Changes

### Changes for #8695
In `ProductVariationsViewController`:

Add two `NSSortDescriptor` for `menuOrder` (ascending) and `productVariationID` (descending) to the `sortedBy` parameter.

### Changes for #8694

In `AddAttributeOptionsViewModel`:

Renamed the string in `footerTextField`, from `Add each option and press enter` to `Add each option and press return`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Products and create a variable product with at least 10 variations
2. Go back to the products list and tap to view Product > Variations
3. Refresh the screen a few times by pulling to refresh
4. Verify that the variation list order remains the same after each refresh

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Screen recording for #8695

**Before change**

https://user-images.githubusercontent.com/40906847/215697186-5d5a2f71-8abb-4a1d-94d8-63e52e97d638.mp4

**After change**

https://user-images.githubusercontent.com/40906847/215697218-5a367dba-2fee-4395-959d-8db9fa11ac4f.mp4

### Screenshot for #8694

**Before change**

<img src="https://user-images.githubusercontent.com/17252150/213348591-399f5d2a-abb6-4a45-becb-629a48b78103.PNG" width=300 />

**After change**

<img src="https://user-images.githubusercontent.com/40906847/215697441-c5b11e3f-4947-464f-bbba-ca593a9d6fb5.png" width=300 />

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
