### PR TITLE
Domain contact information form before redeeming domain credit

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -196,6 +196,25 @@ extension Networking.Customer {
         )
     }
 }
+extension Networking.DomainContactInfo {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.DomainContactInfo {
+        .init(
+            firstName: .fake(),
+            lastName: .fake(),
+            organization: .fake(),
+            address1: .fake(),
+            address2: .fake(),
+            postcode: .fake(),
+            city: .fake(),
+            state: .fake(),
+            countryCode: .fake(),
+            phone: .fake(),
+            email: .fake()
+        )
+    }
+}
 extension DotcomError {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking/Remote/DomainRemote.swift
+++ b/Networking/Networking/Remote/DomainRemote.swift
@@ -165,6 +165,59 @@ public struct SiteDomain: Decodable, Equatable {
     }
 }
 
+/// Contact info required for redeeming a domain with domain credit.
+public struct DomainContactInfo: Codable {
+    public let firstName: String
+    public let lastName: String
+    public let organization: String
+    public let address1: String
+    public let address2: String?
+    public let postcode: String
+    public let city: String
+    public let state: String
+    public let countryCode: String
+    public let phone: String?
+    public let email: String?
+
+    public init(firstName: String,
+                lastName: String,
+                organization: String,
+                address1: String,
+                address2: String?,
+                postcode: String,
+                city: String,
+                state: String,
+                countryCode: String,
+                phone: String?,
+                email: String?) {
+        self.firstName = firstName
+        self.lastName = lastName
+        self.organization = organization
+        self.address1 = address1
+        self.address2 = address2
+        self.postcode = postcode
+        self.city = city
+        self.state = state
+        self.countryCode = countryCode
+        self.phone = phone
+        self.email = email
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case firstName = "first_name"
+        case lastName = "last_name"
+        case organization
+        case address1 = "address_1"
+        case address2 = "address_2"
+        case postcode = "postal_code"
+        case city
+        case state
+        case countryCode = "country_code"
+        case phone
+        case email
+    }
+}
+
 /// Maps to a list of domains to match the API response.
 private struct SiteDomainEnvelope: Decodable {
     let domains: [SiteDomain]

--- a/Networking/Networking/Remote/DomainRemote.swift
+++ b/Networking/Networking/Remote/DomainRemote.swift
@@ -1,3 +1,4 @@
+import Codegen
 import Foundation
 
 /// Protocol for `DomainRemote` mainly used for mocking.
@@ -166,7 +167,7 @@ public struct SiteDomain: Decodable, Equatable {
 }
 
 /// Contact info required for redeeming a domain with domain credit.
-public struct DomainContactInfo: Codable {
+public struct DomainContactInfo: Codable, GeneratedFakeable {
     public let firstName: String
     public let lastName: String
     public let organization: String

--- a/Networking/Networking/Remote/PaymentRemote.swift
+++ b/Networking/Networking/Remote/PaymentRemote.swift
@@ -36,7 +36,8 @@ public protocol PaymentRemoteProtocol {
 
     /// Checks out the given cart using domain credit as the payment method.
     /// - Parameter cart: Cart generated from one of the `createCart` functions.
-    func checkoutCartWithDomainCredit(cart: CartResponse) async throws
+    /// - Parameter contactInfo: Contact info for the domain that needs to be validated beforehand.
+    func checkoutCartWithDomainCredit(cart: CartResponse, contactInfo: DomainContactInfo) async throws
 }
 
 /// WPCOM Payment Endpoints
@@ -104,11 +105,13 @@ public class PaymentRemote: Remote, PaymentRemoteProtocol {
         return response
     }
 
-    public func checkoutCartWithDomainCredit(cart: CartResponse) async throws {
+    public func checkoutCartWithDomainCredit(cart: CartResponse, contactInfo: DomainContactInfo) async throws {
         let path = "\(Path.cartCheckout)"
         let cartDictionary = try cart.toDictionary()
+        let contactInformationDictionary = try contactInfo.toDictionary()
         let parameters: [String: Any] = [
             "cart": cartDictionary,
+            "domain_details": contactInformationDictionary,
             "payment": ["payment_method": PaymentMethod.credit.rawValue]
         ]
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters, encoding: JSONEncoding.default)

--- a/Networking/NetworkingTests/Remote/PaymentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/PaymentRemoteTests.swift
@@ -203,7 +203,7 @@ final class PaymentRemoteTests: XCTestCase {
 
         // When
         do {
-            try await remote.checkoutCartWithDomainCredit(cart: [:])
+            try await remote.checkoutCartWithDomainCredit(cart: [:], contactInfo: .fake())
         } catch {
             // Then
             XCTFail("Unexpected error: \(error)")
@@ -216,7 +216,7 @@ final class PaymentRemoteTests: XCTestCase {
 
         // When
         await assertThrowsError {
-            try await remote.checkoutCartWithDomainCredit(cart: [:])
+            try await remote.checkoutCartWithDomainCredit(cart: [:], contactInfo: .fake())
         } errorAssert: { error in
             // Then
             (error as? NetworkError) == .notFound

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
@@ -81,6 +81,8 @@ struct DomainContactInfoForm: View {
                         let contactInfo = try await viewModel.validateContactInfo()
                         await onCompletion(contactInfo)
                         viewModel.performingNetworkRequest.send(false)
+                    } catch {
+                        viewModel.performingNetworkRequest.send(false)
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
@@ -23,7 +23,7 @@ final class DomainContactInfoFormHostingController: UIHostingController<DomainCo
     }
 }
 
-/// Allows the user to edit contact info for a domain.
+/// Allows the user to edit contact info when claiming a domain with domain credit.
 struct DomainContactInfoForm: View {
     @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
     @State private var showingCustomerSearch: Bool = false

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
@@ -82,7 +82,6 @@ struct DomainContactInfoForm: View {
                     }
                 }
             }
-            .accessibilityIdentifier("order-customer-details-done-button")
             .disabled(!enabled)
         case .loading:
             ProgressView()
@@ -92,7 +91,7 @@ struct DomainContactInfoForm: View {
 
 private extension DomainContactInfoForm {
     enum Localization {
-        static let done = NSLocalizedString("Done", comment: "Text for the done button in the Edit Address Form")
+        static let done = NSLocalizedString("Done", comment: "Text for the done button in the domain contact info form.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+import struct Yosemite.DomainContactInfo
+
+/// Hosting controller that wraps the `DomainContactInfoForm` view for the user to edit contact info for redeeming a domain.
+final class DomainContactInfoFormHostingController: UIHostingController<DomainContactInfoForm> {
+    /// - Parameters:
+    ///   - viewModel: View model for the domain contact info form.
+    ///   - onCompletion: Called when the contact info is complete and validated.
+    init(viewModel: DomainContactInfoFormViewModel,
+         onCompletion: @escaping (DomainContactInfo) async -> Void) {
+        super.init(rootView: DomainContactInfoForm(viewModel: viewModel,
+                                                  onCompletion: onCompletion))
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureTransparentNavigationBar()
+    }
+}
+
+/// Allows the user to edit contact info for a domain.
+struct DomainContactInfoForm: View {
+    @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
+    @State private var showingCustomerSearch: Bool = false
+    @StateObject private var viewModel: DomainContactInfoFormViewModel
+    private let onCompletion: (DomainContactInfo) async -> Void
+
+    init(viewModel: DomainContactInfoFormViewModel,
+         onCompletion: @escaping (DomainContactInfo) async -> Void) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+        self.onCompletion = onCompletion
+    }
+
+    var body: some View {
+        Group {
+            ScrollView {
+                SingleAddressForm(fields: $viewModel.fields,
+                                  countryViewModelClosure: viewModel.createCountryViewModel,
+                                  stateViewModelClosure: viewModel.createStateViewModel,
+                                  sectionTitle: viewModel.sectionTitle,
+                                  showEmailField: viewModel.showEmailField,
+                                  showStateFieldAsSelector: viewModel.showStateFieldAsSelector)
+                .accessibilityElement(children: .contain)
+
+                Spacer(minLength: safeAreaInsets.bottom)
+            }
+            .disableAutocorrection(true)
+            .background(Color(.listBackground))
+            .ignoresSafeArea(.container, edges: [.horizontal, .bottom])
+        }
+        .navigationTitle(viewModel.viewTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                navigationBarTrailingItem()
+            }
+        }
+        .wooNavigationBarStyle()
+        .redacted(reason: viewModel.showPlaceholders ? .placeholder : [])
+        .shimmering(active: viewModel.showPlaceholders)
+        .onAppear {
+            viewModel.onLoadTrigger.send()
+        }
+        .notice($viewModel.notice)
+    }
+
+    /// Decides if the navigation trailing item should be a done button or a loading indicator.
+    ///
+    @ViewBuilder func navigationBarTrailingItem() -> some View {
+        switch viewModel.navigationTrailingItem {
+        case .done(let enabled):
+            Button(Localization.done) {
+                Task { @MainActor in
+                    do {
+                        let contactInfo = try await viewModel.validateContactInfo()
+                        await onCompletion(contactInfo)
+                    }
+                }
+            }
+            .accessibilityIdentifier("order-customer-details-done-button")
+            .disabled(!enabled)
+        case .loading:
+            ProgressView()
+        }
+    }
+}
+
+private extension DomainContactInfoForm {
+    enum Localization {
+        static let done = NSLocalizedString("Done", comment: "Text for the done button in the Edit Address Form")
+    }
+}
+
+struct DomainContactInfoForm_Previews: PreviewProvider {
+    static let sampleViewModel = DomainContactInfoFormViewModel(siteID: 134,
+                                                                stores: ServiceLocator.stores)
+
+    static var previews: some View {
+        NavigationView {
+            DomainContactInfoForm(viewModel: sampleViewModel) { _ in }
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
@@ -77,8 +77,10 @@ struct DomainContactInfoForm: View {
             Button(Localization.done) {
                 Task { @MainActor in
                     do {
+                        viewModel.performingNetworkRequest.send(true)
                         let contactInfo = try await viewModel.validateContactInfo()
                         await onCompletion(contactInfo)
+                        viewModel.performingNetworkRequest.send(false)
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
@@ -35,8 +35,9 @@ final class DomainContactInfoFormViewModel: AddressFormViewModel, AddressFormVie
 
     /// Validates and returns the contact info on success.
     /// - Returns: Contact info after it is validated remotely.
+    @MainActor
     func validateContactInfo() async throws -> DomainContactInfo {
-        guard validateEmail() else {
+        guard fields.email.isNotEmpty, validateEmail() else {
             notice = AddressFormViewModel.NoticeFactory.createInvalidEmailNotice()
             throw ContactInfoError.invalidEmail
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
@@ -87,7 +87,7 @@ private extension DomainContactInfoFormViewModel {
 private extension DomainContactInfoFormViewModel {
     // MARK: Constants
     enum Localization {
-        static let title = NSLocalizedString("Register domain", comment: "Title for the Edit Shipping Address Form")
-        static let addressSection = NSLocalizedString("ADDRESS", comment: "Details section title in the Edit Address Form")
+        static let title = NSLocalizedString("Register domain", comment: "Title of the domain contact info form.")
+        static let addressSection = NSLocalizedString("ADDRESS", comment: "Address section title in the domain contact info form.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
@@ -1,0 +1,93 @@
+import Combine
+import Yosemite
+import protocol Storage.StorageManagerType
+
+/// View model for `DomainContactInfoForm`.
+final class DomainContactInfoFormViewModel: AddressFormViewModel, AddressFormViewModelProtocol {
+    let siteID: Int64
+
+    private var contactInfo: DomainContactInfo {
+        .init(firstName: fields.firstName,
+              lastName: fields.lastName,
+              organization: fields.company,
+              address1: fields.address1,
+              address2: fields.address2,
+              postcode: fields.postcode,
+              city: fields.city,
+              state: fields.selectedState?.code ?? "",
+              countryCode: fields.selectedCountry?.code ?? "",
+              phone: fields.phone,
+              email: fields.email)
+    }
+
+    init(siteID: Int64,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+
+        super.init(siteID: siteID,
+                   address: .empty,
+                   storageManager: storageManager,
+                   stores: stores,
+                   analytics: analytics)
+    }
+
+    /// Validates and returns the contact info on success.
+    /// - Returns: Contact info after it is validated remotely.
+    func validateContactInfo() async throws -> DomainContactInfo {
+        guard validateEmail() else {
+            notice = AddressFormViewModel.NoticeFactory.createInvalidEmailNotice()
+            throw ContactInfoError.invalidEmail
+        }
+
+        // TODO: 8558 - validate contact info remotely
+
+        return contactInfo
+    }
+
+    // MARK: - Protocol conformance
+
+    /// Email is a required field for domain contact info.
+    let showEmailField: Bool = true
+
+    let viewTitle: String = Localization.title
+
+    let sectionTitle: String = Localization.addressSection
+
+    var secondarySectionTitle: String = ""
+
+    var showAlternativeUsageToggle: Bool = false
+
+    let alternativeUsageToggleTitle: String? = nil
+
+    let showDifferentAddressToggle: Bool = false
+
+    let differentAddressToggleTitle: String? = nil
+
+    func saveAddress(onFinish: @escaping (Bool) -> Void) {
+        fatalError("Please call `validateContactInfo` instead.")
+    }
+
+    override func trackOnLoad() {
+        // TODO: 8558 - analytics
+    }
+
+    func userDidCancelFlow() {
+        // TODO: 8558 - analytics
+    }
+}
+
+private extension DomainContactInfoFormViewModel {
+    enum ContactInfoError: Error {
+        case invalidEmail
+    }
+}
+
+private extension DomainContactInfoFormViewModel {
+    // MARK: Constants
+    enum Localization {
+        static let title = NSLocalizedString("Register domain", comment: "Title for the Edit Shipping Address Form")
+        static let addressSection = NSLocalizedString("ADDRESS", comment: "Details section title in the Edit Address Form")
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		020624F027951113000D024C /* StoreStatsDataOrRedactedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020624EF27951113000D024C /* StoreStatsDataOrRedactedView.swift */; };
 		02063C8929260AA000130906 /* StoreCreationSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02063C8829260A9F00130906 /* StoreCreationSuccessView.swift */; };
 		0206483A23FA4160008441BB /* OrdersRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0206483923FA4160008441BB /* OrdersRootViewController.swift */; };
+		020732042988AB7B000A53C2 /* DomainContactInfoForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020732032988AB7B000A53C2 /* DomainContactInfoForm.swift */; };
+		020732062988AC4D000A53C2 /* DomainContactInfoFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020732052988AC4D000A53C2 /* DomainContactInfoFormViewModel.swift */; };
 		02077F72253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02077F71253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift */; };
 		020886572499E643001D784E /* ProductExternalLinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020886562499E642001D784E /* ProductExternalLinkViewController.swift */; };
 		020A55F127F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020A55F027F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift */; };
@@ -2123,6 +2125,8 @@
 		020624EF27951113000D024C /* StoreStatsDataOrRedactedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsDataOrRedactedView.swift; sourceTree = "<group>"; };
 		02063C8829260A9F00130906 /* StoreCreationSuccessView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreCreationSuccessView.swift; sourceTree = "<group>"; };
 		0206483923FA4160008441BB /* OrdersRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersRootViewController.swift; sourceTree = "<group>"; };
+		020732032988AB7B000A53C2 /* DomainContactInfoForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainContactInfoForm.swift; sourceTree = "<group>"; };
+		020732052988AC4D000A53C2 /* DomainContactInfoFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainContactInfoFormViewModel.swift; sourceTree = "<group>"; };
 		02077F71253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+ReadonlyProductTests.swift"; sourceTree = "<group>"; };
 		020886562499E642001D784E /* ProductExternalLinkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductExternalLinkViewController.swift; sourceTree = "<group>"; };
 		020A55F027F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionAnalyticsTracker.swift; sourceTree = "<group>"; };
@@ -4591,6 +4595,8 @@
 				028203CE297662A200217369 /* DomainSelectorDataProvider.swift */,
 				02F36F462978349500D97EA0 /* DomainPurchaseSuccessView.swift */,
 				022C7D782979778E0036568D /* DomainSettingsDomainCreditView.swift */,
+				020732032988AB7B000A53C2 /* DomainContactInfoForm.swift */,
+				020732052988AC4D000A53C2 /* DomainContactInfoFormViewModel.swift */,
 			);
 			path = Domains;
 			sourceTree = "<group>";
@@ -10291,6 +10297,7 @@
 				684AB83A2870677F003DFDD1 /* CardReaderManualsView.swift in Sources */,
 				E1BAAEA026BBECEF00F2C037 /* ButtonStyles.swift in Sources */,
 				CC13C0CB278E021300C0B5B5 /* ProductVariationSelectorViewModel.swift in Sources */,
+				020732042988AB7B000A53C2 /* DomainContactInfoForm.swift in Sources */,
 				DE2FE595292737330018040A /* LoginJetpackSetupView.swift in Sources */,
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,
 				024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */,
@@ -11039,6 +11046,7 @@
 				02E3B63129066858007E0F13 /* StoreCreationCoordinator.swift in Sources */,
 				B554E1792152F20000F31188 /* UINavigationBar+Appearance.swift in Sources */,
 				26AE31B0251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift in Sources */,
+				020732062988AC4D000A53C2 /* DomainContactInfoFormViewModel.swift in Sources */,
 				262A09A5262F65690033AD20 /* OrderAddOnTopBanner.swift in Sources */,
 				4515262E2577D56C0076B03C /* AddAttributeViewController.swift in Sources */,
 				57EBC92024EEE61800C1D45B /* WooAnalyticsEvent.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/DomainAction.swift
+++ b/Yosemite/Yosemite/Actions/DomainAction.swift
@@ -11,6 +11,7 @@ public enum DomainAction: Action {
                                   completion: (Result<Void, Error>) -> Void)
     case redeemDomainCredit(siteID: Int64,
                             domain: DomainToPurchase,
+                            contactInfo: DomainContactInfo,
                             completion: (Result<Void, Error>) -> Void)
 }
 

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -24,6 +24,7 @@ public typealias CreateAccountError = Networking.CreateAccountError
 public typealias Credentials = Networking.Credentials
 public typealias CreateProductVariation = Networking.CreateProductVariation
 public typealias Customer = Networking.Customer
+public typealias DomainContactInfo = Networking.DomainContactInfo
 public typealias DomainToPurchase = Networking.PaidDomainSuggestion
 public typealias DotcomDevice = Networking.DotcomDevice
 public typealias DotcomUser = Networking.DotcomUser

--- a/Yosemite/Yosemite/Stores/DomainStore.swift
+++ b/Yosemite/Yosemite/Stores/DomainStore.swift
@@ -46,8 +46,8 @@ public final class DomainStore: Store {
             loadDomains(siteID: siteID, completion: completion)
         case .createDomainShoppingCart(let siteID, let domain, let completion):
             createDomainShoppingCart(siteID: siteID, domain: domain, completion: completion)
-        case .redeemDomainCredit(let siteID, let domain, let completion):
-            redeemDomainCredit(siteID: siteID, domain: domain, completion: completion)
+        case .redeemDomainCredit(let siteID, let domain, let contactInfo, let completion):
+            redeemDomainCredit(siteID: siteID, domain: domain, contactInfo: contactInfo, completion: completion)
         }
     }
 }
@@ -114,6 +114,7 @@ private extension DomainStore {
 
     func redeemDomainCredit(siteID: Int64,
                             domain: DomainToPurchase,
+                            contactInfo: DomainContactInfo,
                             completion: @escaping (Result<Void, Error>) -> Void) {
         Task { @MainActor in
             do {
@@ -122,7 +123,7 @@ private extension DomainStore {
                                                                             productID: domain.productID,
                                                                             supportsPrivacy: domain.supportsPrivacy),
                                                               isTemporary: true)
-                try await paymentRemote.checkoutCartWithDomainCredit(cart: cart)
+                try await paymentRemote.checkoutCartWithDomainCredit(cart: cart, contactInfo: contactInfo)
                 completion(.success(()))
             } catch {
                 completion(.failure(error))

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockPaymentRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockPaymentRemote.swift
@@ -78,7 +78,7 @@ extension MockPaymentRemote: PaymentRemoteProtocol {
         return try result.get()
     }
 
-    func checkoutCartWithDomainCredit(cart: CartResponse) async throws {
+    func checkoutCartWithDomainCredit(cart: CartResponse, contactInfo: DomainContactInfo) async throws {
         guard let result = checkoutCartWithDomainCreditResult else {
             XCTFail("Could not find result for checking out a cart with domain credit.")
             throw NetworkError.notFound

--- a/Yosemite/YosemiteTests/Stores/DomainStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/DomainStoreTests.swift
@@ -230,7 +230,8 @@ final class DomainStoreTests: XCTestCase {
         let result = waitFor { promise in
             self.store.onAction(DomainAction.redeemDomainCredit(siteID: 606, domain: .init(name: "",
                                                                                            productID: 1,
-                                                                                           supportsPrivacy: true)) { result in
+                                                                                           supportsPrivacy: true),
+                                                                contactInfo: .fake()) { result in
                 promise(result)
             })
         }
@@ -247,7 +248,8 @@ final class DomainStoreTests: XCTestCase {
         let result = waitFor { promise in
             self.store.onAction(DomainAction.redeemDomainCredit(siteID: 606, domain: .init(name: "",
                                                                                            productID: 1,
-                                                                                           supportsPrivacy: true)) { result in
+                                                                                           supportsPrivacy: true),
+                                                                contactInfo: .fake()) { result in
                 promise(result)
             })
         }
@@ -267,7 +269,8 @@ final class DomainStoreTests: XCTestCase {
         let result = waitFor { promise in
             self.store.onAction(DomainAction.redeemDomainCredit(siteID: 606, domain: .init(name: "",
                                                                                            productID: 1,
-                                                                                           supportsPrivacy: true)) { result in
+                                                                                           supportsPrivacy: true),
+                                                                contactInfo: .fake()) { result in
                 promise(result)
             })
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8558 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Since domain redemption doesn't use the web checkout flow, we have to implement the contact info form in the app like in the Jetpack app. This PR includes the addition of contact info form UI reusing the address form ??? from the order address form. The result of the form, `DomainContactInfo`, is then included in the API request to check out a domain cart with domain credit.

A new SwiftUI view was created `DomainContactInfoForm` for the contact info form with a view model `DomainContactInfoFormViewModel`. The only validation so far is email reusing the email validation logic from its parent class `AddressFormViewModel`. There are a few future subtasks for this screen:

- Load the existing domain contact info remotely
- Validate the domain contact info after the user submits the form, before redeeming the domain credit
- The phone number in the API field needs to follow a format like `+countrycode.number` and some extra UI work is required
- Any other UI polishes, there's no design right now so I'm reusing the component from order form
- Analytics

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: a WC store with an annual WPCOM plan whose domain credit hasn't been claimed, you can create a site like this in Calypso with store credit

- Log in if needed, and continue with a WPCOM store
- Go to the Menu tab
- Tap on the settings CTA
- Tap the `Domain` row --> there should be a section about the free domain for the first year
- Tap `Claim Domain` --> domain selector with paid domains should be shown
- Select a domain and tap `Continue` --> domain contact info form should be shown
- Enter some info and tap `Done` --> an "invalid email" notice should be shown
- Enter a valid email and tap `Done` --> a spinner should be shown at the navigation bar, and you should see an error message in the console `⛔️ Error redeeming domain credit with the selected domain ...`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

light | dark | dark - loading state
-- | -- | --
![Simulator Screen Shot - iPhone 14 - 2023-01-31 at 16 43 49](https://user-images.githubusercontent.com/1945542/215713120-6cd8a854-14e1-49af-91a8-d108b4f83838.png) | ![Simulator Screen Shot - iPhone 14 - 2023-01-31 at 16 49 02](https://user-images.githubusercontent.com/1945542/215713140-f759d497-c391-46b4-8981-ae5f7d583218.png) | ![Simulator Screen Shot - iPhone 14 - 2023-01-31 at 16 51 29](https://user-images.githubusercontent.com/1945542/215713151-49edd3f1-fd6c-492f-8886-e369c8a605ef.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
