### PR TITLE
[ABTest] Reload all experiments irrespective of logged in/out context

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -45,19 +45,15 @@ public extension ABTest {
     @MainActor
     static func start(for context: ExperimentContext) async {
         let experiments = ABTest.allCases.filter { $0.context == context }
+        await start(experiments: experiments)
+    }
 
-        await withCheckedContinuation { continuation in
-            guard !experiments.isEmpty else {
-                return continuation.resume(returning: ())
-            }
-
-            let experimentNames = experiments.map { $0.rawValue }
-            ExPlat.shared?.register(experiments: experimentNames)
-
-            ExPlat.shared?.refresh {
-                continuation.resume(returning: ())
-            }
-        } as Void
+    /// Start the AB Testing platform for all experiments
+    ///
+    @MainActor
+    static func start() async {
+        let experiments = ABTest.allCases
+        await start(experiments: experiments)
     }
 }
 
@@ -81,4 +77,24 @@ public enum ExperimentContext: Equatable {
     case loggedOut
     case loggedIn
     case none // For the `null` experiment case
+}
+
+private extension ABTest {
+    /// Start the AB Testing platform using the given `experiments`
+    ///
+    @MainActor
+    static func start(experiments: [ABTest]) async {
+        await withCheckedContinuation { continuation in
+            guard !experiments.isEmpty else {
+                return continuation.resume(returning: ())
+            }
+
+            let experimentNames = experiments.map { $0.rawValue }
+            ExPlat.shared?.register(experiments: experimentNames)
+
+            ExPlat.shared?.refresh {
+                continuation.resume(returning: ())
+            }
+        } as Void
+    }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -65,10 +65,8 @@ public extension WooAnalytics {
         // Refreshes A/B experiments since `ExPlat.shared` is reset after each `TracksProvider.refreshUserData` call
         // and any A/B test assignments that come back after the shared instance is reset won't be saved for later
         // access.
-        let context: ExperimentContext = ServiceLocator.stores.isAuthenticated ?
-            .loggedIn: .loggedOut
-        Task { @MainActor in
-            await ABTest.start(for: context)
+        Task {
+            await ABTest.start()
         }
     }
 


### PR DESCRIPTION
Closes: #8782 

## Description

**Problem**

User who was originally assigned `treatment` variation for a logged-out experimnent sees a different variation for the same experiment after logging out.

**Reason for the change in assignment**
1. User launches app -> ABTest variations for logged-out context experiments are fetched from the server and saved. 
1. After login, due to Explat being reset, the locally saved experiments are deleted.
1. We load the experiments for logged-in context. Now, only logged-in experiments have a variation assigned.
1. User logs out from the Settings screen.
   1. [Due to change in `state`](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift#L196), `AppCoordinator` navigates to the login screen [here](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/ViewRelated/AppCoordinator.swift#L79).
   1. This navigation to the login screen happens even before [this line](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift#L433) from Settings is executed.
   1. The navigation also happens before analytics (i.e. ABTest) is reloaded [here](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift#L199).
1. When the login screen is displayed, no variation value is assigned for the logged-out experiment, and by default, the `control` variant is shown to the user. 

**My fix in this PR**

We fetched the variations for only specific contexts (logged in/out) when analytics is reset. I changed that behaviour and instead started fetching the variations for all available experiments.

- The idea is to load the variations for all experiments irrespective of whether the user is logged in or not.
- As an anonymous ID is assigned to requests sent in both logged in/out state [here](https://github.com/Automattic/Automattic-Tracks-iOS/blob/trunk/Sources/Experiments/ExPlatService.swift#L47), we are receiving the correct variation for logged out experiments even if the user is logged in/
- I believe the backend can use the [provided `anonID`](https://github.com/Automattic/Automattic-Tracks-iOS/blob/trunk/Sources/Experiments/ExPlatService.swift#L47) and [auth token](https://github.com/Automattic/Automattic-Tracks-iOS/blob/trunk/Sources/Experiments/ExPlatService.swift#L63) values to identify the device and user and provide correct variation values.

To verify this change works as expected
- [ ] @selanthiraiyan to add logged-in and logged-out A/A tests to verify the behaviour and check for crossovers.

**A better solution (Not in this PR)**

Wait for the ABTest variations to reload and proceed.
- Make [WooAnalytics.refreshUserData()](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/Analytics/WooAnalytics.swift#L58) async and wait for it to finish from everywhere we call the method.
- Stop navigating to the login screen from AppCoordinator. (I am not sure how and the impact  of this change)
- We will have to revisit the sequence of changes done in [DefaultStoresManager.deauthenticate()](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift#L190-L209) method. The order of the execution matters. For example, the `state` is being set to `DeauthenticatedState` even before we clear/reset other things.
- `WooAnalytics.refreshUserData()` method is currently called from
  - Upon switching store in [`SwitchStoreUseCase.finalizeStoreSelection()`](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift#L135) and upon switching store in [`DefaultStoresManager.removeDefaultStore()`](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift#L182). I hope one of these calls can be avoided.
  - Upon `deauthentication` from [`DefaultStoresManager.deauthenticate()`](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift#L199)
  - Upon `synchronizeAccount` from [`DefaultStoresManager.synchronizeAccount()`](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift#L279)
- As this solution requires changes to several critical areas, I opted for the other solution for now.

## Testing instructions
- Install and launch the app. Logout if needed.
- Launch and skip onboarding.
- If you don't see the "Continue With WordPress.com" button to login you have been assigned `treatment` variation for the `woocommerceios_login_rest_api_project_202301_v2` experiment and you can test this PR (If not you need to use a sandbox to for a variation. You can follow the instructions from [this PR](https://github.com/woocommerce/woocommerce-ios/pull/8744) to assign a varition to your device.)
- Login into the app using site creds.
- Go to settings and logout.
- You will be navigated to the login screen and ensure that you still don't see "Continue With WordPress.com" button. i.e. You are still assigned the `treatment` variation.

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
