### PR TITLE
Load/validate domain contact info before/after the form

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -94,6 +94,9 @@
 		02C254B925637BA000A04423 /* OrderShippingLabelListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C254B825637BA000A04423 /* OrderShippingLabelListMapper.swift */; };
 		02C254D32563992900A04423 /* OrderShippingLabelListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C254D22563992900A04423 /* OrderShippingLabelListMapperTests.swift */; };
 		02C254D72563999300A04423 /* order-shipping-labels.json in Resources */ = {isa = PBXBuildFile; fileRef = 02C254D62563999200A04423 /* order-shipping-labels.json */; };
+		02C4325F298A55D100F14AEE /* domain-contact-info.json in Resources */ = {isa = PBXBuildFile; fileRef = 02C4325C298A55D100F14AEE /* domain-contact-info.json */; };
+		02C43260298A55D100F14AEE /* validate-domain-contact-info-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = 02C4325D298A55D100F14AEE /* validate-domain-contact-info-failure.json */; };
+		02C43261298A55D100F14AEE /* validate-domain-contact-info-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 02C4325E298A55D100F14AEE /* validate-domain-contact-info-success.json */; };
 		02C54CC624D3E938007D658F /* product-variations-load-all-manage-stock-two-states.json in Resources */ = {isa = PBXBuildFile; fileRef = 02C54CC524D3E937007D658F /* product-variations-load-all-manage-stock-two-states.json */; };
 		02DD6492248A3EC00082523E /* product-external.json in Resources */ = {isa = PBXBuildFile; fileRef = 02DD6491248A3EC00082523E /* product-external.json */; };
 		02E7FFCB256218F600C53030 /* ShippingLabelRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */; };
@@ -969,6 +972,9 @@
 		02C254B825637BA000A04423 /* OrderShippingLabelListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderShippingLabelListMapper.swift; sourceTree = "<group>"; };
 		02C254D22563992900A04423 /* OrderShippingLabelListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderShippingLabelListMapperTests.swift; sourceTree = "<group>"; };
 		02C254D62563999200A04423 /* order-shipping-labels.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-shipping-labels.json"; sourceTree = "<group>"; };
+		02C4325C298A55D100F14AEE /* domain-contact-info.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "domain-contact-info.json"; sourceTree = "<group>"; };
+		02C4325D298A55D100F14AEE /* validate-domain-contact-info-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "validate-domain-contact-info-failure.json"; sourceTree = "<group>"; };
+		02C4325E298A55D100F14AEE /* validate-domain-contact-info-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "validate-domain-contact-info-success.json"; sourceTree = "<group>"; };
 		02C54CC524D3E937007D658F /* product-variations-load-all-manage-stock-two-states.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variations-load-all-manage-stock-two-states.json"; sourceTree = "<group>"; };
 		02DD6491248A3EC00082523E /* product-external.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-external.json"; sourceTree = "<group>"; };
 		02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRemoteTests.swift; sourceTree = "<group>"; };
@@ -2270,6 +2276,7 @@
 				021D741B2987B1550035687E /* checkout-doman-cart-with-domain-credit-success.json */,
 				DEC2B092297AA60D003923FB /* category-without-data.json */,
 				DEC2B090297AA5A6003923FB /* categories-all-without-data.json */,
+				02C4325C298A55D100F14AEE /* domain-contact-info.json */,
 				DEC2B08E297AA123003923FB /* reviews-single-without-data.json */,
 				DEC2B08C297AA048003923FB /* reviews-all-without-data.json */,
 				DE66C5682977D62700DAA978 /* plugins-without-data.json */,
@@ -2540,6 +2547,8 @@
 				74ABA1C7213F19FE00FFAD30 /* top-performers-year.json */,
 				FE28F6E726842D57004465C7 /* user-complete.json */,
 				DEF13C4F29629EEA0024A02B /* user-complete-without-data.json */,
+				02C4325D298A55D100F14AEE /* validate-domain-contact-info-failure.json */,
+				02C4325E298A55D100F14AEE /* validate-domain-contact-info-success.json */,
 				7495AACE225D366D00801A89 /* variation-as-product.json */,
 				02A26F192744F5FC008E4EDB /* wc-site-settings-partial.json */,
 				D800DA0D25EFEC21001E13CE /* wcpay-connection-token.json */,
@@ -3163,6 +3172,7 @@
 				CC9A253C26442C71005DE56E /* shipping-label-eligibility-success.json in Resources */,
 				B5A24179217F98F600595DEF /* notifications-load-all.json in Resources */,
 				DEA6B1C9296D0E8B005AA5E9 /* systemStatusWithPluginsOnly-without-data.json in Resources */,
+				02C4325F298A55D100F14AEE /* domain-contact-info.json in Resources */,
 				EE57C12B297F8F8600BC31E7 /* attribute-term-without-data.json in Resources */,
 				314EDF2927C02CC100A56B6F /* stripe-account-complete-empty-descriptor.json in Resources */,
 				028CB71F2902589E00331C09 /* create-account-error-invalid-email.json in Resources */,
@@ -3171,6 +3181,7 @@
 				31A451CE27863A2E00FE81AA /* stripe-account-wrong-json.json in Resources */,
 				EE57C143297FCCA700BC31E7 /* product-shipping-classes-load-all-without-data.json in Resources */,
 				26BD9FCD2965EC3C004E0D15 /* product-variations-bulk-create.json in Resources */,
+				02C43260298A55D100F14AEE /* validate-domain-contact-info-failure.json in Resources */,
 				EE57C13C297FBECB00BC31E7 /* product-tags-all-without-data.json in Resources */,
 				028CB718290223CB00331C09 /* account-username-suggestions.json in Resources */,
 				0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */,
@@ -3439,6 +3450,7 @@
 				DEF13C5029629EEA0024A02B /* user-complete-without-data.json in Resources */,
 				EE57C123297EB04F00BC31E7 /* product-attribute-create-without-data.json in Resources */,
 				EE57C11929794DCA00BC31E7 /* get-application-passwords-success.json in Resources */,
+				02C43261298A55D100F14AEE /* validate-domain-contact-info-success.json in Resources */,
 				74ABA1CA213F19FE00FFAD30 /* top-performers-year.json in Resources */,
 				DEF13C5C2965812D0024A02B /* order-stats-v4-year-without-data.json in Resources */,
 				31A451CF27863A2E00FE81AA /* stripe-account-rejected-terms-of-service.json in Resources */,

--- a/Networking/Networking/Remote/DomainRemote.swift
+++ b/Networking/Networking/Remote/DomainRemote.swift
@@ -253,20 +253,6 @@ public enum DomainContactInfoError: Error, Equatable {
     case invalid(messages: [String]?)
 }
 
-public enum DomainContactInfoFormField: String, Decodable {
-    case countryCode = "country_code"
-    case postalCode = "postal_code"
-    case address1 = "address_1"
-    case address2 = "address_2"
-    case city
-    case email
-    case firstName = "first_name"
-    case lastName = "last_name"
-    case organization
-    case phone
-    case state
-}
-
 /// Maps to a list of domains to match the API response.
 private struct SiteDomainEnvelope: Decodable {
     let domains: [SiteDomain]

--- a/Networking/Networking/Remote/DomainRemote.swift
+++ b/Networking/Networking/Remote/DomainRemote.swift
@@ -22,8 +22,14 @@ public protocol DomainRemoteProtocol {
     /// - Returns: A list of domains.
     func loadDomains(siteID: Int64) async throws -> [SiteDomain]
 
+    /// Loads the contact info for domain registration.
+    /// - Returns: pre-existing contact info from WPCOM if available.
     func loadDomainContactInfo() async throws -> DomainContactInfo
 
+    /// Validates the contact info for domain registration.
+    /// - Parameters:
+    ///   - domainContactInfo: Contact info to validate.
+    ///   - domain: Domain name for domain registration. The validation rules vary between domains.
     func validate(domainContactInfo: DomainContactInfo, domain: String) async throws
 }
 

--- a/Networking/NetworkingTests/Remote/DomainRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/DomainRemoteTests.swift
@@ -171,8 +171,10 @@ final class DomainRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "domain-contact-information/validate", filename: "validate-domain-contact-info-failure")
 
         // When/Then
-        let error = DomainContactInfoError.invalid(messagesByField: [.lastName: ["Enter your last name."],
-                                                                     .phone: ["Enter a valid country code followed by a dot (for example +1.6285550199)."]])
+        let error = DomainContactInfoError.invalid(messages: [
+            "There was an error validating your contact information. The field \"Last Name\" is not valid.",
+            "There was an error validating your contact information. The field \"Phone\" is not valid."
+        ])
         await assertThrowsError({ _ = try await remote.validate(domainContactInfo: .fake(), domain: "") },
                                 errorAssert: { ($0 as? DomainContactInfoError) == error })
     }

--- a/Networking/NetworkingTests/Responses/domain-contact-info.json
+++ b/Networking/NetworkingTests/Responses/domain-contact-info.json
@@ -1,0 +1,15 @@
+{
+    "first_name": "Woo",
+    "last_name": "Merch",
+    "organization": null,
+    "address_1": "No 77",
+    "address_2": null,
+    "postal_code": "94111",
+    "city": "SF",
+    "state": null,
+    "country_code": "US",
+    "email": "woo@merch.com",
+    "phone": "+886.123456",
+    "fax": null,
+    "extra": null
+}

--- a/Networking/NetworkingTests/Responses/validate-domain-contact-info-failure.json
+++ b/Networking/NetworkingTests/Responses/validate-domain-contact-info-failure.json
@@ -1,0 +1,15 @@
+{
+    "success": false,
+    "messages": {
+        "last_name": [
+            "Enter your last name."
+        ],
+        "phone": [
+            "Enter a valid country code followed by a dot (for example +1.6285550199)."
+        ]
+    },
+    "messages_simple": [
+        "There was an error validating your contact information. The field \"Last Name\" is not valid.",
+        "There was an error validating your contact information. The field \"Phone\" is not valid."
+    ]
+}

--- a/Networking/NetworkingTests/Responses/validate-domain-contact-info-success.json
+++ b/Networking/NetworkingTests/Responses/validate-domain-contact-info-success.json
@@ -1,0 +1,3 @@
+{
+    "success": true
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
@@ -101,6 +101,8 @@ private extension DomainContactInfoForm {
 
 struct DomainContactInfoForm_Previews: PreviewProvider {
     static let sampleViewModel = DomainContactInfoFormViewModel(siteID: 134,
+                                                                contactInfoToEdit: nil,
+                                                                domain: "",
                                                                 stores: ServiceLocator.stores)
 
     static var previews: some View {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
@@ -65,11 +65,15 @@ final class DomainContactInfoFormViewModel: AddressFormViewModel, AddressFormVie
 
         do {
             try await validate()
+            return contactInfo
+        } catch DomainContactInfoError.invalid(let messages) {
+            let message = messages?.joined(separator: "\n") ?? Localization.defaultValidationErrorMessage
+            notice = .init(title: message, feedbackType: .error)
+            throw DomainContactInfoError.invalid(messages: messages)
         } catch {
             notice = .init(title: error.localizedDescription, feedbackType: .error)
+            throw error
         }
-
-        return contactInfo
     }
 
     // MARK: - Protocol conformance
@@ -126,5 +130,9 @@ private extension DomainContactInfoFormViewModel {
     enum Localization {
         static let title = NSLocalizedString("Register domain", comment: "Title of the domain contact info form.")
         static let addressSection = NSLocalizedString("ADDRESS", comment: "Address section title in the domain contact info form.")
+        static let defaultValidationErrorMessage = NSLocalizedString(
+            "Some unexpected error with the validation. Please check the fields and try again.",
+            comment: "Message in the error notice when an unknown validation error occurs after submitting domain contact info."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
@@ -69,7 +69,7 @@ final class DomainContactInfoFormViewModel: AddressFormViewModel, AddressFormVie
             return contactInfo
         } catch DomainContactInfoError.invalid(let messages) {
             let message = messages?.joined(separator: "\n") ?? Localization.defaultValidationErrorMessage
-            notice = .init(title: message, feedbackType: .error)
+            notice = .init(title: Localization.validationErrorTitle, message: message, feedbackType: .error)
             throw DomainContactInfoError.invalid(messages: messages)
         } catch {
             notice = .init(title: error.localizedDescription, feedbackType: .error)
@@ -131,6 +131,10 @@ private extension DomainContactInfoFormViewModel {
     enum Localization {
         static let title = NSLocalizedString("Register domain", comment: "Title of the domain contact info form.")
         static let addressSection = NSLocalizedString("ADDRESS", comment: "Address section title in the domain contact info form.")
+        static let validationErrorTitle = NSLocalizedString(
+            "Form Validation Error",
+            comment: "Title in the error notice when a validation error occurs after submitting domain contact info."
+        )
         static let defaultValidationErrorMessage = NSLocalizedString(
             "Some unexpected error with the validation. Please check the fields and try again.",
             comment: "Message in the error notice when an unknown validation error occurs after submitting domain contact info."

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
@@ -49,6 +49,7 @@ final class DomainContactInfoFormViewModel: AddressFormViewModel, AddressFormVie
 
         super.init(siteID: siteID,
                    address: addressToEdit,
+                   isDoneButtonAlwaysEnabled: true,
                    storageManager: storageManager,
                    stores: stores,
                    analytics: analytics)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -519,12 +519,15 @@ private extension AddressFormViewModel {
                     return .done(enabled: true)
                 }
 
+                guard !isDoneButtonAlwaysEnabled else {
+                    return .done(enabled: true)
+                }
+
                 let addressesAreDifferentButSecondAddressSwitchIsDisabled = secondaryOriginalAddress != .empty &&
                 originalAddress != secondaryOriginalAddress &&
                 !showDifferentAddressForm
 
-                return .done(enabled: isDoneButtonAlwaysEnabled ||
-                             addressesAreDifferentButSecondAddressSwitchIsDisabled ||
+                return .done(enabled: addressesAreDifferentButSecondAddressSwitchIsDisabled ||
                              originalAddress != fields.toAddress() ||
                              secondaryOriginalAddress != secondaryFields.toAddress())
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -244,6 +244,10 @@ open class AddressFormViewModel: ObservableObject {
     ///
     let analytics: Analytics
 
+    /// Whether the Done button in the navigation bar is always enabled.
+    ///
+    private let isDoneButtonAlwaysEnabled: Bool
+
     /// Store for publishers subscriptions
     ///
     private var subscriptions = Set<AnyCancellable>()
@@ -251,6 +255,7 @@ open class AddressFormViewModel: ObservableObject {
     init(siteID: Int64,
          address: Address,
          secondaryAddress: Address? = nil,
+         isDoneButtonAlwaysEnabled: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
@@ -261,6 +266,9 @@ open class AddressFormViewModel: ObservableObject {
 
         self.secondaryOriginalAddress = secondaryAddress ?? .empty
         self.secondaryFields = .init(with: secondaryOriginalAddress)
+
+        self.isDoneButtonAlwaysEnabled = isDoneButtonAlwaysEnabled
+        self.navigationTrailingItem = .done(enabled: isDoneButtonAlwaysEnabled)
 
         self.storageManager = storageManager
         self.stores = stores
@@ -313,7 +321,7 @@ open class AddressFormViewModel: ObservableObject {
     /// Active navigation bar trailing item.
     /// Defaults to a disabled done button.
     ///
-    @Published private(set) var navigationTrailingItem: AddressFormNavigationItem = .done(enabled: false)
+    @Published private(set) var navigationTrailingItem: AddressFormNavigationItem
 
     /// Define if the view should show placeholders instead of the real elements.
     ///
@@ -501,7 +509,7 @@ private extension AddressFormViewModel {
     ///
     func bindNavigationTrailingItemPublisher() {
         Publishers.CombineLatest4($fields, $secondaryFields, $showDifferentAddressForm, performingNetworkRequest)
-            .map { [originalAddress, secondaryOriginalAddress]
+            .map { [isDoneButtonAlwaysEnabled, originalAddress, secondaryOriginalAddress]
                 fields, secondaryFields, showDifferentAddressForm, performingNetworkRequest -> AddressFormNavigationItem in
                 guard !performingNetworkRequest else {
                     return .loading
@@ -515,7 +523,8 @@ private extension AddressFormViewModel {
                 originalAddress != secondaryOriginalAddress &&
                 !showDifferentAddressForm
 
-                return .done(enabled: addressesAreDifferentButSecondAddressSwitchIsDisabled ||
+                return .done(enabled: isDoneButtonAlwaysEnabled ||
+                             addressesAreDifferentButSecondAddressSwitchIsDisabled ||
                              originalAddress != fields.toAddress() ||
                              secondaryOriginalAddress != secondaryFields.toAddress())
             }

--- a/Yosemite/Yosemite/Actions/DomainAction.swift
+++ b/Yosemite/Yosemite/Actions/DomainAction.swift
@@ -13,6 +13,8 @@ public enum DomainAction: Action {
                             domain: DomainToPurchase,
                             contactInfo: DomainContactInfo,
                             completion: (Result<Void, Error>) -> Void)
+    case loadDomainContactInfo(completion: (Result<DomainContactInfo, Error>) -> Void)
+    case validate(domainContactInfo: DomainContactInfo, domain: String, completion: (Result<Void, Error>) -> Void)
 }
 
 /// Necessary data for the domain selector flow with paid domains.

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -25,6 +25,7 @@ public typealias Credentials = Networking.Credentials
 public typealias CreateProductVariation = Networking.CreateProductVariation
 public typealias Customer = Networking.Customer
 public typealias DomainContactInfo = Networking.DomainContactInfo
+public typealias DomainContactInfoError = Networking.DomainContactInfoError
 public typealias DomainToPurchase = Networking.PaidDomainSuggestion
 public typealias DotcomDevice = Networking.DotcomDevice
 public typealias DotcomUser = Networking.DotcomUser

--- a/Yosemite/Yosemite/Stores/DomainStore.swift
+++ b/Yosemite/Yosemite/Stores/DomainStore.swift
@@ -48,6 +48,10 @@ public final class DomainStore: Store {
             createDomainShoppingCart(siteID: siteID, domain: domain, completion: completion)
         case .redeemDomainCredit(let siteID, let domain, let contactInfo, let completion):
             redeemDomainCredit(siteID: siteID, domain: domain, contactInfo: contactInfo, completion: completion)
+        case .loadDomainContactInfo(let completion):
+            loadDomainContactInfo(completion: completion)
+        case .validate(let domainContactInfo, let domain, let completion):
+            validate(domainContactInfo: domainContactInfo, domain: domain, completion: completion)
         }
     }
 }
@@ -128,6 +132,20 @@ private extension DomainStore {
             } catch {
                 completion(.failure(error))
             }
+        }
+    }
+
+    func loadDomainContactInfo(completion: @escaping (Result<DomainContactInfo, Error>) -> Void) {
+        Task { @MainActor in
+            let result = await Result { try await remote.loadDomainContactInfo() }
+            completion(result)
+        }
+    }
+
+    func validate(domainContactInfo: DomainContactInfo, domain: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        Task { @MainActor in
+            let result = await Result { try await remote.validate(domainContactInfo: domainContactInfo, domain: domain) }
+            completion(result)
         }
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDomainRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockDomainRemote.swift
@@ -16,6 +16,12 @@ final class MockDomainRemote {
     /// The results to return in `loadDomains`.
     private var loadDomainsResult: Result<[SiteDomain], Error>?
 
+    /// The results to return in `loadDomainContactInfo`.
+    private var loadDomainContactInfoResult: Result<DomainContactInfo, Error>?
+
+    /// The results to return in `validateDomainContactInfo`.
+    private var validateDomainContactInfoResult: Result<Void, Error>?
+
     /// Returns the value when `loadDomainSuggestions` is called.
     func whenLoadingDomainSuggestions(thenReturn result: Result<[FreeDomainSuggestion], Error>) {
         loadDomainSuggestionsResult = result
@@ -34,6 +40,16 @@ final class MockDomainRemote {
     /// Returns the value when `loadDomains` is called.
     func whenLoadingDomains(thenReturn result: Result<[SiteDomain], Error>) {
         loadDomainsResult = result
+    }
+
+    /// Returns the value when `loadDomainContactInfo` is called.
+    func whenLoadingDomainContactInfo(thenReturn result: Result<DomainContactInfo, Error>) {
+        loadDomainContactInfoResult = result
+    }
+
+    /// Returns the value when `validateDomainContactInfo` is called.
+    func whenValidatingDomainContactInfo(thenReturn result: Result<Void, Error>) {
+        validateDomainContactInfoResult = result
     }
 }
 
@@ -65,6 +81,22 @@ extension MockDomainRemote: DomainRemoteProtocol {
     func loadDomains(siteID: Int64) async throws -> [SiteDomain] {
         guard let result = loadDomainsResult else {
             XCTFail("Could not find result for loading domains.")
+            throw NetworkError.notFound
+        }
+        return try result.get()
+    }
+
+    func loadDomainContactInfo() async throws -> DomainContactInfo {
+        guard let result = loadDomainContactInfoResult else {
+            XCTFail("Could not find result for loading domain contact info.")
+            throw NetworkError.notFound
+        }
+        return try result.get()
+    }
+
+    func validate(domainContactInfo: DomainContactInfo, domain: String) async throws {
+        guard let result = validateDomainContactInfoResult else {
+            XCTFail("Could not find result for validating domain contact info.")
             throw NetworkError.notFound
         }
         return try result.get()

--- a/Yosemite/YosemiteTests/Stores/DomainStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/DomainStoreTests.swift
@@ -296,17 +296,7 @@ final class DomainStoreTests: XCTestCase {
                                             countryCode: "US",
                                             phone: "181800",
                                             email: "woo@merch.com")
-        remote.whenLoadingDomainContactInfo(thenReturn: .success(.init(firstName: "woo",
-                                                                       lastName: "Merch",
-                                                                       organization: "Woo",
-                                                                       address1: "No 300",
-                                                                       address2: nil,
-                                                                       postcode: "18888",
-                                                                       city: "SF",
-                                                                       state: "CA",
-                                                                       countryCode: "US",
-                                                                       phone: "181800",
-                                                                       email: "woo@merch.com")))
+        remote.whenLoadingDomainContactInfo(thenReturn: .success(contactInfo))
 
         // When
         let result = waitFor { promise in
@@ -317,6 +307,8 @@ final class DomainStoreTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
+        let returnedContactInfo = try XCTUnwrap(result.get())
+        XCTAssertEqual(returnedContactInfo, contactInfo)
     }
 
     func test_loadDomainContactInfo_returns_error_on_failure() throws {

--- a/Yosemite/YosemiteTests/Stores/DomainStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/DomainStoreTests.swift
@@ -280,4 +280,93 @@ final class DomainStoreTests: XCTestCase {
         let error = try XCTUnwrap(result.failure)
         XCTAssertEqual(error as? NetworkError, .notFound)
     }
+
+    // MARK: - `loadDomainContactInfo`
+
+    func test_loadDomainContactInfo_returns_contact_info_on_success() throws {
+        // Given
+        let contactInfo = DomainContactInfo(firstName: "woo",
+                                            lastName: "Merch",
+                                            organization: "Woo",
+                                            address1: "No 300",
+                                            address2: nil,
+                                            postcode: "18888",
+                                            city: "SF",
+                                            state: "CA",
+                                            countryCode: "US",
+                                            phone: "181800",
+                                            email: "woo@merch.com")
+        remote.whenLoadingDomainContactInfo(thenReturn: .success(.init(firstName: "woo",
+                                                                       lastName: "Merch",
+                                                                       organization: "Woo",
+                                                                       address1: "No 300",
+                                                                       address2: nil,
+                                                                       postcode: "18888",
+                                                                       city: "SF",
+                                                                       state: "CA",
+                                                                       countryCode: "US",
+                                                                       phone: "181800",
+                                                                       email: "woo@merch.com")))
+
+        // When
+        let result = waitFor { promise in
+            self.store.onAction(DomainAction.loadDomainContactInfo { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+    }
+
+    func test_loadDomainContactInfo_returns_error_on_failure() throws {
+        // Given
+        remote.whenLoadingDomainContactInfo(thenReturn: .failure(NetworkError.timeout))
+
+        // When
+        let result = waitFor { promise in
+            self.store.onAction(DomainAction.loadDomainContactInfo { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? NetworkError, .timeout)
+    }
+
+    // MARK: - `validateDomainContactInfo`
+
+    func test_validateDomainContactInfo_returns_on_success() throws {
+        // Given
+        remote.whenValidatingDomainContactInfo(thenReturn: .success(()))
+
+        // When
+        let result = waitFor { promise in
+            self.store.onAction(DomainAction.validate(domainContactInfo: .fake(), domain: "") { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+    }
+
+    func test_validateDomainContactInfo_returns_error_on_failure() throws {
+        // Given
+        remote.whenValidatingDomainContactInfo(thenReturn: .failure(NetworkError.timeout))
+
+        // When
+        let result = waitFor { promise in
+            self.store.onAction(DomainAction.validate(domainContactInfo: .fake(), domain: "") { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? NetworkError, .timeout)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8558 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When checking out a cart with a domain using domain credit, the contact info needs to be validated first. Otherwise, contact info validation errors are thrown. In this PR, two API requests are made before & after the domain contact info form:
- Load pre-existing contact info after selecting a domain and before entering the form. If it fails, then the contact info form is blank
- Validate contact info when tapping `Done`: if there are validation errors, a list of error messages is returned in a new error `DomainContactInfoError`

Since we're validating most of the fields on the server side, we want to always enable the `Done` CTA to validate the current form. However, the current address form has the `Done` CTA disabled by default. In order to always enable the `Done` CTA for this use case, I added a new parameter `isDoneButtonAlwaysEnabled: Bool` to `AddressFormViewModel` with a default value `false` to not affect the order editing/creation use case.

One note on the phone number field: it has to be in the format of a valid country code followed by a dot (for example +1.1233456). The current form doesn't support dot with the phone pad keyboard type, in a future subtask I'm going to add a new field for phone country code to improve the UX.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: a WC store with an annual WPCOM plan whose domain credit hasn't been claimed, you can create a site like this in Calypso with store credit

- Log in if needed, and continue with a WPCOM store
- Go to the Menu tab
- Tap on the settings CTA
- Tap the `Domain` row --> there should be a section about the free domain for the first year
- Tap `Claim Domain` --> domain selector with paid domains should be shown
- Select a domain and tap `Continue` --> the CTA should become a spinner while loading contact info, then the domain contact info form should be shown with the existing contact info pre-filled
- Remove the email field and tap `Done` --> an "invalid email" notice should be shown
- Enter a valid email but remove the first or last name, then tap `Done` --> an error notice should be shown
- Update the form with valid info (note the phone value needs to follow the format mentioned above) and tap `Done` --> the spinner should show up, then continue to the success screen
- Tap `Continue` to go back to domain settings --> the new domain should show up shortly

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

local email validation error | phone validation error
-- | --
![Simulator Screen Shot - iPhone 14 - 2023-02-02 at 10 27 00](https://user-images.githubusercontent.com/1945542/216216244-64774876-fe6c-4317-9503-f6f3649fc9f4.png) | ![Simulator Screen Shot - iPhone 14 - 2023-02-02 at 10 27 17](https://user-images.githubusercontent.com/1945542/216216259-a7a2dfc3-5a29-4292-b9ac-09d9aa62519f.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
