### PR TITLE
Add fallback to URL encoding to account for special chars

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -162,9 +162,9 @@ extension WooConstants {
         /// URL for the IPP feedback survey for testing purposes
         ///
 #if DEBUG
-        case inPersonPaymentsCashOnDeliveryFeedback,
-             inPersonPaymentsFirstTransactionFeedback,
-             inPersonPaymentsPowerUsersFeedback = "https://automattic.survey.fm/woo-app-ipp-in-app-feedback-testing"
+        case inPersonPaymentsCashOnDeliveryFeedback = "https://automattic.survey.fm/woo-app-–-cod-survey"
+        case inPersonPaymentsFirstTransactionFeedback = "https://automattic.survey.fm/woo-app-–-ipp-first-transaction-survey"
+        case inPersonPaymentsPowerUsersFeedback = "https://automattic.survey.fm/woo-app-–-ipp-survey-for-power-users"
 #else
         /// URL for the IPP feedback survey (COD case). Used when merchants have COD enabled, but no IPP transactions.
         ///
@@ -270,10 +270,10 @@ private extension WooConstants.URLs {
     /// Convert a `string` to a `URL`. Crash if it is malformed.
     ///
     private static func trustedURL(_ url: String) -> URL {
-        if let url = URL(string: url) {
-            return url
-        } else {
-            fatalError("Expected URL \(url) to be a well-formed URL.")
+        guard let url = URL(string: url) else {
+            let fallback = URL(string: url.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.urlQueryAllowed) ?? "")
+            return fallback ?? URL(string: "")!
         }
+        return url
     }
 }

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -270,10 +270,14 @@ private extension WooConstants.URLs {
     /// Convert a `string` to a `URL`. Crash if it is malformed.
     ///
     private static func trustedURL(_ url: String) -> URL {
-        guard let url = URL(string: url) else {
-            let fallback = URL(string: url.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.urlQueryAllowed) ?? "")
-            return fallback ?? URL(string: "")!
+
+        if let url = URL(string: url) {
+            return url
+        } else if let escapedString = url.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.urlQueryAllowed),
+                  let escapedURL = URL(string: escapedString) {
+            return escapedURL
+        } else {
+            fatalError("Expected URL \(url) to be a well-formed URL.")
         }
-        return url
     }
 }

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -256,6 +256,10 @@ extension WooConstants {
         /// URL for creating a store.
         case storeCreation = "https://woocommerce.com/start"
 
+        /// URL with un-escaped characters for testing purposes. It should read as `https://test.com/test-%E2%80%93-survey`
+        ///
+        case testURLStringWithSpecialCharacters = "https://test.com/test-–-survey"
+
         /// Returns the URL version of the receiver
         ///
         func asURL() -> URL {

--- a/WooCommerce/WooCommerceTests/System/WooConstantsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooConstantsTests.swift
@@ -12,7 +12,32 @@ final class WooConstantsTests: XCTestCase {
 
         // Then
         zip(allTrustedURLPaths, allTrustedURLs).forEach { (path, url) in
-            XCTAssertEqual(path.rawValue, url.absoluteString)
+            XCTAssertEqual(path.asURL().absoluteString, url.absoluteString)
         }
+    }
+
+    func test_URLs_that_contains_special_characters_when_are_escaped_properly_then_do_not_return_nil() throws {
+        // Given
+        let urlsWithSpecialCharacters = [
+            WooConstants.URLs.inPersonPaymentsCashOnDeliveryFeedback,
+            WooConstants.URLs.inPersonPaymentsFirstTransactionFeedback,
+            WooConstants.URLs.inPersonPaymentsPowerUsersFeedback
+        ]
+
+        let escapedURLsWithSpecialCharacters = [
+            "https://automattic.survey.fm/woo-app-%E2%80%93-cod-survey",
+            "https://automattic.survey.fm/woo-app-%E2%80%93-ipp-first-transaction-survey",
+            "https://automattic.survey.fm/woo-app-%E2%80%93-ipp-survey-for-power-users"
+        ]
+
+        // When
+        let _ = urlsWithSpecialCharacters.map { trustedURL in
+            XCTAssertNotNil(trustedURL)
+        }
+
+        // Then
+        XCTAssertEqual(urlsWithSpecialCharacters[0].asURL().absoluteString, escapedURLsWithSpecialCharacters[0])
+        XCTAssertEqual(urlsWithSpecialCharacters[1].asURL().absoluteString, escapedURLsWithSpecialCharacters[1])
+        XCTAssertEqual(urlsWithSpecialCharacters[2].asURL().absoluteString, escapedURLsWithSpecialCharacters[2])
     }
 }

--- a/WooCommerce/WooCommerceTests/System/WooConstantsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooConstantsTests.swift
@@ -16,28 +16,16 @@ final class WooConstantsTests: XCTestCase {
         }
     }
 
-    func test_URLs_that_contains_special_characters_when_are_escaped_properly_then_do_not_return_nil() throws {
+    func test_URL_that_contains_special_characters_when_is_escaped_properly_then_does_not_return_nil() throws {
         // Given
-        let urlsWithSpecialCharacters = [
-            WooConstants.URLs.inPersonPaymentsCashOnDeliveryFeedback,
-            WooConstants.URLs.inPersonPaymentsFirstTransactionFeedback,
-            WooConstants.URLs.inPersonPaymentsPowerUsersFeedback
-        ]
-
-        let escapedURLsWithSpecialCharacters = [
-            "https://automattic.survey.fm/woo-app-%E2%80%93-cod-survey",
-            "https://automattic.survey.fm/woo-app-%E2%80%93-ipp-first-transaction-survey",
-            "https://automattic.survey.fm/woo-app-%E2%80%93-ipp-survey-for-power-users"
-        ]
+        let urlStringWithSpecialCharacters = "https://test.com/test-–-survey"
+        let escapedURLStringWithSpecialCharacter = "https://test.com/test-%E2%80%93-survey"
 
         // When
-        let _ = urlsWithSpecialCharacters.map { trustedURL in
-            XCTAssertNotNil(trustedURL)
-        }
+        let trustedURL = try urlStringWithSpecialCharacters.asURL()
 
         // Then
-        XCTAssertEqual(urlsWithSpecialCharacters[0].asURL().absoluteString, escapedURLsWithSpecialCharacters[0])
-        XCTAssertEqual(urlsWithSpecialCharacters[1].asURL().absoluteString, escapedURLsWithSpecialCharacters[1])
-        XCTAssertEqual(urlsWithSpecialCharacters[2].asURL().absoluteString, escapedURLsWithSpecialCharacters[2])
+        XCTAssertNotNil(trustedURL)
+        XCTAssertEqual(trustedURL.absoluteString, escapedURLStringWithSpecialCharacter)
     }
 }

--- a/WooCommerce/WooCommerceTests/System/WooConstantsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooConstantsTests.swift
@@ -18,14 +18,14 @@ final class WooConstantsTests: XCTestCase {
 
     func test_URL_that_contains_special_characters_when_is_escaped_properly_then_does_not_return_nil() throws {
         // Given
-        let urlStringWithSpecialCharacters = "https://test.com/test-–-survey"
+        let urlStringWithSpecialCharacters = WooConstants.URLs.testURLStringWithSpecialCharacters
         let escapedURLStringWithSpecialCharacter = "https://test.com/test-%E2%80%93-survey"
 
         // When
-        let trustedURL = try urlStringWithSpecialCharacters.asURL()
+        let trustedURL = urlStringWithSpecialCharacters.asURL()
 
         // Then
         XCTAssertNotNil(trustedURL)
-        XCTAssertEqual(trustedURL.absoluteString, escapedURLStringWithSpecialCharacter)
+        XCTAssertEqual(try trustedURL.asURL().absoluteString, escapedURLStringWithSpecialCharacter)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8791

## Description
This PR addresses a crash found in TestFlight for 12.1 during beta testing

When unwrapping URLs from `WooConstants` we trust that these are well-formed and do not contain any un-escaped character, we perform this check [here](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/System/WooConstants.swift#L272-L278) or return a `fatalError` otherwise.

This PR adds a fallback to attempt and escape the URL format before returning this error

## Testing instructions
Confirm that Unit Tests pass

