### PR TITLE
[ABTesting] Cache variations of logged out context experiments

### DIFF
--- a/Experiments/Experiments.xcodeproj/project.pbxproj
+++ b/Experiments/Experiments.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		BC10218D75FEA979BDA1E68C /* Pods_Experiments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33CEC0C5283FD4C9EF8C6A3C /* Pods_Experiments.framework */; };
 		C8E16F0EE6954B58A1C402F0 /* Pods_ExperimentsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAC7C082DD376957B4676401 /* Pods_ExperimentsTests.framework */; };
 		CC53FB48275E426900C4CA4F /* ABTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB47275E426900C4CA4F /* ABTest.swift */; };
+		EE2EDFDF29879331004E702B /* ABTestVariationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2EDFDE29879331004E702B /* ABTestVariationProvider.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +48,7 @@
 		AAC7C082DD376957B4676401 /* Pods_ExperimentsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ExperimentsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF72D9DB7771E7A5105C88B0 /* Pods-Experiments.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Experiments.release.xcconfig"; path = "Target Support Files/Pods-Experiments/Pods-Experiments.release.xcconfig"; sourceTree = "<group>"; };
 		CC53FB47275E426900C4CA4F /* ABTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTest.swift; sourceTree = "<group>"; };
+		EE2EDFDE29879331004E702B /* ABTestVariationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestVariationProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -100,6 +102,7 @@
 				0270C0A427069B8900FC799F /* DefaultFeatureFlagService.swift */,
 				0270C0A627069BA500FC799F /* BuildConfiguration.swift */,
 				CC53FB47275E426900C4CA4F /* ABTest.swift */,
+				EE2EDFDE29879331004E702B /* ABTestVariationProvider.swift */,
 			);
 			path = Experiments;
 			sourceTree = "<group>";
@@ -314,6 +317,7 @@
 				0270C0A327069B7800FC799F /* FeatureFlagService.swift in Sources */,
 				0270C0A527069B8900FC799F /* DefaultFeatureFlagService.swift in Sources */,
 				0270C09C27069AE700FC799F /* FeatureFlag.swift in Sources */,
+				EE2EDFDF29879331004E702B /* ABTestVariationProvider.swift in Sources */,
 				0270C0A727069BA500FC799F /* BuildConfiguration.swift in Sources */,
 				CC53FB48275E426900C4CA4F /* ABTest.swift in Sources */,
 			);

--- a/Experiments/Experiments.xcodeproj/project.pbxproj
+++ b/Experiments/Experiments.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		C8E16F0EE6954B58A1C402F0 /* Pods_ExperimentsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAC7C082DD376957B4676401 /* Pods_ExperimentsTests.framework */; };
 		CC53FB48275E426900C4CA4F /* ABTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB47275E426900C4CA4F /* ABTest.swift */; };
 		EE2EDFDF29879331004E702B /* ABTestVariationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2EDFDE29879331004E702B /* ABTestVariationProvider.swift */; };
+		EEC8C0ED298A92F10047B4CB /* CachedABTestVariationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC8C0EC298A92F10047B4CB /* CachedABTestVariationProvider.swift */; };
+		EEC8C0EF298A939C0047B4CB /* VariationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC8C0EE298A939C0047B4CB /* VariationCache.swift */; };
+		EEC8C0F1298B5AFB0047B4CB /* VariationCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC8C0F0298B5AFB0047B4CB /* VariationCacheTests.swift */; };
+		EEC8C0F3298B5F950047B4CB /* CachedABTestVariationProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC8C0F2298B5F950047B4CB /* CachedABTestVariationProviderTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +53,10 @@
 		AF72D9DB7771E7A5105C88B0 /* Pods-Experiments.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Experiments.release.xcconfig"; path = "Target Support Files/Pods-Experiments/Pods-Experiments.release.xcconfig"; sourceTree = "<group>"; };
 		CC53FB47275E426900C4CA4F /* ABTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTest.swift; sourceTree = "<group>"; };
 		EE2EDFDE29879331004E702B /* ABTestVariationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestVariationProvider.swift; sourceTree = "<group>"; };
+		EEC8C0EC298A92F10047B4CB /* CachedABTestVariationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedABTestVariationProvider.swift; sourceTree = "<group>"; };
+		EEC8C0EE298A939C0047B4CB /* VariationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariationCache.swift; sourceTree = "<group>"; };
+		EEC8C0F0298B5AFB0047B4CB /* VariationCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariationCacheTests.swift; sourceTree = "<group>"; };
+		EEC8C0F2298B5F950047B4CB /* CachedABTestVariationProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedABTestVariationProviderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +111,8 @@
 				0270C0A627069BA500FC799F /* BuildConfiguration.swift */,
 				CC53FB47275E426900C4CA4F /* ABTest.swift */,
 				EE2EDFDE29879331004E702B /* ABTestVariationProvider.swift */,
+				EEC8C0EC298A92F10047B4CB /* CachedABTestVariationProvider.swift */,
+				EEC8C0EE298A939C0047B4CB /* VariationCache.swift */,
 			);
 			path = Experiments;
 			sourceTree = "<group>";
@@ -111,6 +121,8 @@
 			isa = PBXGroup;
 			children = (
 				0270C09127069A8900FC799F /* Info.plist */,
+				EEC8C0F0298B5AFB0047B4CB /* VariationCacheTests.swift */,
+				EEC8C0F2298B5F950047B4CB /* CachedABTestVariationProviderTests.swift */,
 			);
 			path = ExperimentsTests;
 			sourceTree = "<group>";
@@ -206,6 +218,7 @@
 					};
 					0270C08927069A8900FC799F = {
 						CreatedOnToolsVersion = 12.5.1;
+						LastSwiftMigration = 1420;
 					};
 				};
 			};
@@ -314,11 +327,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EEC8C0EF298A939C0047B4CB /* VariationCache.swift in Sources */,
 				0270C0A327069B7800FC799F /* FeatureFlagService.swift in Sources */,
 				0270C0A527069B8900FC799F /* DefaultFeatureFlagService.swift in Sources */,
 				0270C09C27069AE700FC799F /* FeatureFlag.swift in Sources */,
 				EE2EDFDF29879331004E702B /* ABTestVariationProvider.swift in Sources */,
 				0270C0A727069BA500FC799F /* BuildConfiguration.swift in Sources */,
+				EEC8C0ED298A92F10047B4CB /* CachedABTestVariationProvider.swift in Sources */,
 				CC53FB48275E426900C4CA4F /* ABTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -327,6 +342,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EEC8C0F1298B5AFB0047B4CB /* VariationCacheTests.swift in Sources */,
+				EEC8C0F3298B5F950047B4CB /* CachedABTestVariationProviderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -521,6 +538,7 @@
 			baseConfigurationReference = 3022E2766134CE2735C73FC6 /* Pods-ExperimentsTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "${inherited}";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ExperimentsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -530,6 +548,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.ExperimentsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -540,6 +559,7 @@
 			baseConfigurationReference = 7C831644164B49828A485590 /* Pods-ExperimentsTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "${inherited}";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ExperimentsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -644,6 +664,7 @@
 			baseConfigurationReference = 3F9DB5FBFF7A42EFBCB746F3 /* Pods-ExperimentsTests.release-alpha.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "${inherited}";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = ExperimentsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -19,6 +19,9 @@ public enum ABTest: String, CaseIterable, Codable {
     /// Experiment ref: pbxNRc-2i4-p2
     case applicationPasswordAuthentication = "woocommerceios_login_rest_api_project_202301_v2"
 
+    /// Mocks for unit testing
+    case mockLoggedIn, mockLoggedOut
+
     /// Returns a variation for the given experiment
     ///
     public var variation: Variation? {
@@ -36,6 +39,10 @@ public enum ABTest: String, CaseIterable, Codable {
             return .loggedOut
         case .null:
             return .none
+        case .mockLoggedIn:
+            return .loggedIn
+        case .mockLoggedOut:
+            return .loggedOut
         }
     }
 }

--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -21,8 +21,8 @@ public enum ABTest: String, CaseIterable, Codable {
 
     /// Returns a variation for the given experiment
     ///
-    var variation: Variation {
-        ExPlat.shared?.experiment(rawValue) ?? .control
+    public var variation: Variation? {
+        ExPlat.shared?.experiment(rawValue)
     }
 
     /// Returns the context for the given experiment.

--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -2,7 +2,7 @@ import AutomatticTracks
 
 /// ABTest adds A/B testing experiments and runs the tests based on their variations from the ExPlat service.
 ///
-public enum ABTest: String, CaseIterable {
+public enum ABTest: String, CaseIterable, Codable {
     /// Throwaway case, to prevent a compiler error:
     /// `An enum with no cases cannot declare a raw type`
     case null

--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -20,7 +20,8 @@ public enum ABTest: String, CaseIterable {
     case applicationPasswordAuthentication = "woocommerceios_login_rest_api_project_202301_v2"
 
     /// Returns a variation for the given experiment
-    public var variation: Variation {
+    ///
+    var variation: Variation {
         ExPlat.shared?.experiment(rawValue) ?? .control
     }
 

--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -2,10 +2,9 @@ import AutomatticTracks
 
 /// ABTest adds A/B testing experiments and runs the tests based on their variations from the ExPlat service.
 ///
-public enum ABTest: String, CaseIterable, Codable {
-    /// Throwaway case, to prevent a compiler error:
-    /// `An enum with no cases cannot declare a raw type`
-    case null
+public enum ABTest: String, Codable, CaseIterable {
+    /// Mocks for unit testing
+    case mockLoggedIn, mockLoggedOut
 
     /// A/A test to make sure there is no bias in the logged out state.
     /// Experiment ref: pbxNRc-1QS-p2
@@ -18,9 +17,6 @@ public enum ABTest: String, CaseIterable, Codable {
     /// A/B test for the REST API project
     /// Experiment ref: pbxNRc-2i4-p2
     case applicationPasswordAuthentication = "woocommerceios_login_rest_api_project_202301_v2"
-
-    /// Mocks for unit testing
-    case mockLoggedIn, mockLoggedOut
 
     /// Returns a variation for the given experiment
     ///
@@ -37,13 +33,18 @@ public enum ABTest: String, CaseIterable, Codable {
             return .loggedIn
         case .aaTestLoggedOut, .applicationPasswordAuthentication:
             return .loggedOut
-        case .null:
-            return .none
+        // Mocks
         case .mockLoggedIn:
             return .loggedIn
         case .mockLoggedOut:
             return .loggedOut
         }
+    }
+
+    // Returns only the genuine ABTest cases. (After removing unit test mocks)
+    //
+    static var genuineCases: [ABTest] {
+        ABTest.allCases.filter { [.mockLoggedIn, .mockLoggedOut].contains($0) == false }
     }
 }
 
@@ -52,7 +53,7 @@ public extension ABTest {
     ///
     @MainActor
     static func start(for context: ExperimentContext) async {
-        let experiments = ABTest.allCases.filter { $0.context == context }
+        let experiments = ABTest.genuineCases.filter { $0.context == context }
 
         await withCheckedContinuation { continuation in
             guard !experiments.isEmpty else {

--- a/Experiments/Experiments/ABTestVariationProvider.swift
+++ b/Experiments/Experiments/ABTestVariationProvider.swift
@@ -1,0 +1,16 @@
+import AutomatticTracks
+
+/// For getting the variation of a `ABTest`
+public protocol ABTestVariationProvider {
+    /// Returns the `Variation` for the provided `ABTest`
+    func variation(for abTest: ABTest) -> Variation
+}
+
+/// Default implementation of `ABTestVariationProvider`
+public struct DefaultABTestVariationProvider: ABTestVariationProvider {
+    public init() { }
+
+    public func variation(for abTest: ABTest) -> Variation {
+        abTest.variation
+    }
+}

--- a/Experiments/Experiments/ABTestVariationProvider.swift
+++ b/Experiments/Experiments/ABTestVariationProvider.swift
@@ -11,6 +11,6 @@ public struct DefaultABTestVariationProvider: ABTestVariationProvider {
     public init() { }
 
     public func variation(for abTest: ABTest) -> Variation {
-        abTest.variation
+        abTest.variation ?? .control
     }
 }

--- a/Experiments/Experiments/CachedABTestVariationProvider.swift
+++ b/Experiments/Experiments/CachedABTestVariationProvider.swift
@@ -18,11 +18,11 @@ public struct CachedABTestVariationProvider: ABTestVariationProvider {
             return abTest.variation ?? .control
         }
 
-        if let cachedVariation = cache.variation(for: abTest) {
-            return cachedVariation
-        } else if let variation = abTest.variation {
+        if let variation = abTest.variation {
             try? cache.assign(variation: variation, for: abTest)
             return variation
+        } else if let cachedVariation = cache.variation(for: abTest) {
+            return cachedVariation
         } else {
             return .control
         }

--- a/Experiments/Experiments/CachedABTestVariationProvider.swift
+++ b/Experiments/Experiments/CachedABTestVariationProvider.swift
@@ -11,6 +11,9 @@ public struct CachedABTestVariationProvider: ABTestVariationProvider {
     }
 
     public func variation(for abTest: ABTest) -> Variation {
+        // We cache only logged out ABTests as they are assigned based on `anonId` by `ExPlat`.
+        // There will be one value assigned to one device and it won't change.
+        //
         guard abTest.context == .loggedOut else {
             return abTest.variation ?? .control
         }

--- a/Experiments/Experiments/CachedABTestVariationProvider.swift
+++ b/Experiments/Experiments/CachedABTestVariationProvider.swift
@@ -1,0 +1,27 @@
+import AutomatticTracks
+
+/// Cache based implementation of `ABTestVariationProvider`
+///
+public struct CachedABTestVariationProvider: ABTestVariationProvider {
+
+    private let cache: VariationCache
+
+    public init(cache: VariationCache = VariationCache(userDefaults: .standard)) {
+        self.cache = cache
+    }
+
+    public func variation(for abTest: ABTest) -> Variation {
+        guard abTest.context == .loggedOut else {
+            return abTest.variation ?? .control
+        }
+
+        if let cachedVariation = cache.variation(for: abTest) {
+            return cachedVariation
+        } else if let variation = abTest.variation {
+            try? cache.assign(variation: variation, for: abTest)
+            return variation
+        } else {
+            return .control
+        }
+    }
+}

--- a/Experiments/Experiments/VariationCache.swift
+++ b/Experiments/Experiments/VariationCache.swift
@@ -1,0 +1,47 @@
+import AutomatticTracks
+
+enum VariationCacheError: Error {
+    case onlyLoggedOutExperimentsShouldBeCached
+}
+
+public struct VariationCache {
+    private let variationKey = "VariationCacheKey"
+
+    private let userDefaults: UserDefaults
+
+    public init(userDefaults: UserDefaults) {
+        self.userDefaults = userDefaults
+    }
+
+    func variation(for abTest: ABTest) -> Variation? {
+        guard abTest.context == .loggedOut else {
+            return nil
+        }
+
+        guard let data = userDefaults.object(forKey: variationKey) as? Data,
+              let cachedVariations = try? JSONDecoder().decode([CachedVariation].self, from: data),
+              case let variation = cachedVariations.first(where: { $0.abTest == abTest })?.variation
+        else {
+            return nil
+        }
+
+        return variation
+    }
+
+    func assign(variation: Variation, for abTest: ABTest) throws {
+        guard abTest.context == .loggedOut else {
+            throw VariationCacheError.onlyLoggedOutExperimentsShouldBeCached
+        }
+
+        var variations = userDefaults.object(forKey: variationKey) as? [CachedVariation] ?? []
+        variations.append(CachedVariation(abTest: abTest, variation: variation))
+
+        let encodedVariation = try JSONEncoder().encode(variations)
+        userDefaults.set(encodedVariation, forKey: variationKey)
+    }
+}
+
+public struct CachedVariation: Codable {
+    let abTest: ABTest
+    let variation: Variation
+}

--- a/Experiments/ExperimentsTests/CachedABTestVariationProviderTests.swift
+++ b/Experiments/ExperimentsTests/CachedABTestVariationProviderTests.swift
@@ -11,7 +11,7 @@ final class CachedABTestVariationProviderTests: XCTestCase {
         let provider = CachedABTestVariationProvider(cache: cache)
 
         // Then
-        XCTAssertEqual(provider.variation(for: .applicationPasswordAuthentication), .control)
+        XCTAssertEqual(provider.variation(for: .mockLoggedOut), .control)
     }
 
     func test_correct_variation_is_returned_after_caching_it() throws {
@@ -21,9 +21,9 @@ final class CachedABTestVariationProviderTests: XCTestCase {
         let provider = CachedABTestVariationProvider(cache: cache)
 
         // When
-        try cache.assign(variation: .treatment, for: .applicationPasswordAuthentication)
+        try cache.assign(variation: .treatment, for: .mockLoggedOut)
 
         // Then
-        XCTAssertEqual(provider.variation(for: .applicationPasswordAuthentication), .treatment)
+        XCTAssertEqual(provider.variation(for: .mockLoggedOut), .treatment)
     }
 }

--- a/Experiments/ExperimentsTests/CachedABTestVariationProviderTests.swift
+++ b/Experiments/ExperimentsTests/CachedABTestVariationProviderTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import Experiments
+
+final class CachedABTestVariationProviderTests: XCTestCase {
+    func test_variation_is_control_when_the_value_does_not_exist() throws {
+        // Given
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
+
+        // When
+        let cache = VariationCache(userDefaults: userDefaults)
+        let provider = CachedABTestVariationProvider(cache: cache)
+
+        // Then
+        XCTAssertEqual(provider.variation(for: .applicationPasswordAuthentication), .control)
+    }
+
+    func test_correct_variation_is_returned_after_caching_it() throws {
+        // Given
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
+        let cache = VariationCache(userDefaults: userDefaults)
+        let provider = CachedABTestVariationProvider(cache: cache)
+
+        // When
+        try cache.assign(variation: .treatment, for: .applicationPasswordAuthentication)
+
+        // Then
+        XCTAssertEqual(provider.variation(for: .applicationPasswordAuthentication), .treatment)
+    }
+}

--- a/Experiments/ExperimentsTests/VariationCacheTests.swift
+++ b/Experiments/ExperimentsTests/VariationCacheTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Experiments
+
+final class VariationCacheTests: XCTestCase {
+    func test_variation_is_nil_when_the_value_does_not_exist() throws {
+        // Given
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
+
+        // When
+        let cache = VariationCache(userDefaults: userDefaults)
+
+        // Then
+        XCTAssertNil(cache.variation(for: .applicationPasswordAuthentication))
+    }
+
+    func test_correct_variation_is_returned_after_setting_it() throws {
+        // Given
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
+        let cache = VariationCache(userDefaults: userDefaults)
+
+        // When
+        try cache.assign(variation: .treatment, for: .applicationPasswordAuthentication)
+
+        // Then
+        XCTAssertEqual(cache.variation(for: .applicationPasswordAuthentication), .treatment)
+    }
+
+    func test_it_throws_when_trying_to_cache_logged_in_experiment() throws {
+        // Given
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
+        let cache = VariationCache(userDefaults: userDefaults)
+
+        // When
+        XCTAssertThrowsError(try cache.assign(variation: .treatment, for: .aaTestLoggedIn))
+    }
+}

--- a/Experiments/ExperimentsTests/VariationCacheTests.swift
+++ b/Experiments/ExperimentsTests/VariationCacheTests.swift
@@ -10,7 +10,7 @@ final class VariationCacheTests: XCTestCase {
         let cache = VariationCache(userDefaults: userDefaults)
 
         // Then
-        XCTAssertNil(cache.variation(for: .applicationPasswordAuthentication))
+        XCTAssertNil(cache.variation(for: .mockLoggedOut))
     }
 
     func test_correct_variation_is_returned_after_setting_it() throws {
@@ -19,10 +19,10 @@ final class VariationCacheTests: XCTestCase {
         let cache = VariationCache(userDefaults: userDefaults)
 
         // When
-        try cache.assign(variation: .treatment, for: .applicationPasswordAuthentication)
+        try cache.assign(variation: .treatment, for: .mockLoggedOut)
 
         // Then
-        XCTAssertEqual(cache.variation(for: .applicationPasswordAuthentication), .treatment)
+        XCTAssertEqual(cache.variation(for: .mockLoggedOut), .treatment)
     }
 
     func test_it_throws_when_trying_to_cache_logged_in_experiment() throws {
@@ -31,6 +31,6 @@ final class VariationCacheTests: XCTestCase {
         let cache = VariationCache(userDefaults: userDefaults)
 
         // When
-        XCTAssertThrowsError(try cache.assign(variation: .treatment, for: .aaTestLoggedIn))
+        XCTAssertThrowsError(try cache.assign(variation: .treatment, for: .mockLoggedIn))
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -27,9 +27,9 @@ def aztec
 end
 
 def tracks
-  pod 'Automattic-Tracks-iOS', '~> 1.0.0'
+  # pod 'Automattic-Tracks-iOS', '~> 1.0.0'
   # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'trunk'
-  # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => ''
+  pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => '3c15eb0450aa5f70aff29bc2e465e6005ce41a47'
   # pod 'Automattic-Tracks-iOS', :path => '../Automattic-Tracks-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -29,7 +29,7 @@ end
 def tracks
   # pod 'Automattic-Tracks-iOS', '~> 1.0.0'
   # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'trunk'
-  pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => '3c15eb0450aa5f70aff29bc2e465e6005ce41a47'
+  pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => 'f990056f1d7f5ccac2d8c8d6e0a41ef60ea9c004'
   # pod 'Automattic-Tracks-iOS', :path => '../Automattic-Tracks-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -27,7 +27,7 @@ def aztec
 end
 
 def tracks
-  pod 'Automattic-Tracks-iOS', '~> 1.1.0-beta.1'
+  pod 'Automattic-Tracks-iOS', '~> 2.0.0-beta.1'
   # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'trunk'
   # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => ''
   # pod 'Automattic-Tracks-iOS', :path => '../Automattic-Tracks-iOS'

--- a/Podfile
+++ b/Podfile
@@ -27,9 +27,9 @@ def aztec
 end
 
 def tracks
-  # pod 'Automattic-Tracks-iOS', '~> 1.0.0'
+  pod 'Automattic-Tracks-iOS', '~> 1.1.0-beta.1'
   # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'trunk'
-  pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => 'f990056f1d7f5ccac2d8c8d6e0a41ef60ea9c004'
+  # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => ''
   # pod 'Automattic-Tracks-iOS', :path => '../Automattic-Tracks-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - AppAuth/Core (1.6.0)
   - AppAuth/ExternalUserAgent (1.6.0):
     - AppAuth/Core
-  - Automattic-Tracks-iOS (1.0.0):
+  - Automattic-Tracks-iOS (1.1.0-beta):
     - Sentry (~> 7.25)
     - Sodium (>= 0.9.1)
     - UIDeviceIdentifier (~> 2.0)
@@ -75,7 +75,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 4.8)
-  - Automattic-Tracks-iOS (~> 1.0.0)
+  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, commit `3c15eb0450aa5f70aff29bc2e465e6005ce41a47`)
   - CocoaLumberjack (~> 3.7.4)
   - CocoaLumberjack/Swift (~> 3.7.4)
   - Gridicons (~> 1.2.0)
@@ -99,7 +99,6 @@ SPEC REPOS:
   trunk:
     - Alamofire
     - AppAuth
-    - Automattic-Tracks-iOS
     - CocoaLumberjack
     - GoogleSignIn
     - Gridicons
@@ -132,10 +131,20 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  Automattic-Tracks-iOS:
+    :commit: 3c15eb0450aa5f70aff29bc2e465e6005ce41a47
+    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
+
+CHECKOUT OPTIONS:
+  Automattic-Tracks-iOS:
+    :commit: 3c15eb0450aa5f70aff29bc2e465e6005ce41a47
+    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
+
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 8fca6b5563a5baef2c04bee27538025e4ceb2add
-  Automattic-Tracks-iOS: 93df154824af31eba947718110023acce1ce7905
+  Automattic-Tracks-iOS: 382b2275c332d370b3c74f90d979b58f562ab5c1
   CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
   GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
@@ -169,6 +178,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 5611275f2e251a88706eac841eb27ae63383a7ac
+PODFILE CHECKSUM: dc236dd54fdfff69ac2a6ea7b31e8b35545227e2
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -75,7 +75,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 4.8)
-  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, commit `3c15eb0450aa5f70aff29bc2e465e6005ce41a47`)
+  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, commit `f990056f1d7f5ccac2d8c8d6e0a41ef60ea9c004`)
   - CocoaLumberjack (~> 3.7.4)
   - CocoaLumberjack/Swift (~> 3.7.4)
   - Gridicons (~> 1.2.0)
@@ -133,12 +133,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
-    :commit: 3c15eb0450aa5f70aff29bc2e465e6005ce41a47
+    :commit: f990056f1d7f5ccac2d8c8d6e0a41ef60ea9c004
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
-    :commit: 3c15eb0450aa5f70aff29bc2e465e6005ce41a47
+    :commit: f990056f1d7f5ccac2d8c8d6e0a41ef60ea9c004
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
 
 SPEC CHECKSUMS:
@@ -178,6 +178,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: dc236dd54fdfff69ac2a6ea7b31e8b35545227e2
+PODFILE CHECKSUM: 707be8e6bec5ee95efd80c5e966878e21e9e537f
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - AppAuth/Core (1.6.0)
   - AppAuth/ExternalUserAgent (1.6.0):
     - AppAuth/Core
-  - Automattic-Tracks-iOS (1.1.0-beta):
+  - Automattic-Tracks-iOS (1.1.0-beta.1):
     - Sentry (~> 7.25)
     - Sodium (>= 0.9.1)
     - UIDeviceIdentifier (~> 2.0)
@@ -75,7 +75,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 4.8)
-  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, commit `f990056f1d7f5ccac2d8c8d6e0a41ef60ea9c004`)
+  - Automattic-Tracks-iOS (~> 1.1.0-beta.1)
   - CocoaLumberjack (~> 3.7.4)
   - CocoaLumberjack/Swift (~> 3.7.4)
   - Gridicons (~> 1.2.0)
@@ -99,6 +99,7 @@ SPEC REPOS:
   trunk:
     - Alamofire
     - AppAuth
+    - Automattic-Tracks-iOS
     - CocoaLumberjack
     - GoogleSignIn
     - Gridicons
@@ -131,20 +132,10 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
-EXTERNAL SOURCES:
-  Automattic-Tracks-iOS:
-    :commit: f990056f1d7f5ccac2d8c8d6e0a41ef60ea9c004
-    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-
-CHECKOUT OPTIONS:
-  Automattic-Tracks-iOS:
-    :commit: f990056f1d7f5ccac2d8c8d6e0a41ef60ea9c004
-    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 8fca6b5563a5baef2c04bee27538025e4ceb2add
-  Automattic-Tracks-iOS: 382b2275c332d370b3c74f90d979b58f562ab5c1
+  Automattic-Tracks-iOS: a30ebcffcdc33e5dd41aaa8a60999b4ef0e86700
   CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
   GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
@@ -178,6 +169,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 707be8e6bec5ee95efd80c5e966878e21e9e537f
+PODFILE CHECKSUM: 7b77ea6b3b7ca7a6a8b75a3c174d2ca7b1a4bbc2
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - AppAuth/Core (1.6.0)
   - AppAuth/ExternalUserAgent (1.6.0):
     - AppAuth/Core
-  - Automattic-Tracks-iOS (1.1.0-beta.1):
+  - Automattic-Tracks-iOS (2.0.0-beta.1):
     - Sentry (~> 7.25)
     - Sodium (>= 0.9.1)
     - UIDeviceIdentifier (~> 2.0)
@@ -75,7 +75,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 4.8)
-  - Automattic-Tracks-iOS (~> 1.1.0-beta.1)
+  - Automattic-Tracks-iOS (~> 2.0.0-beta.1)
   - CocoaLumberjack (~> 3.7.4)
   - CocoaLumberjack/Swift (~> 3.7.4)
   - Gridicons (~> 1.2.0)
@@ -135,7 +135,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 8fca6b5563a5baef2c04bee27538025e4ceb2add
-  Automattic-Tracks-iOS: a30ebcffcdc33e5dd41aaa8a60999b4ef0e86700
+  Automattic-Tracks-iOS: 20220d63a075787a890513ae56214a17a160ec43
   CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
   GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
@@ -169,6 +169,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
-PODFILE CHECKSUM: 7b77ea6b3b7ca7a6a8b75a3c174d2ca7b1a4bbc2
+PODFILE CHECKSUM: 60adb2c26ae523f8b998d67c2c81cddce40b9809
 
 COCOAPODS: 1.11.3

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -10,7 +10,7 @@ import protocol Experiments.FeatureFlagService
 import protocol Storage.StorageManagerType
 import class Networking.DefaultApplicationPasswordUseCase
 import protocol Experiments.ABTestVariationProvider
-import struct Experiments.DefaultABTestVariationProvider
+import struct Experiments.CachedABTestVariationProvider
 
 /// Encapsulates all of the interactions with the WordPress Authenticator
 ///
@@ -55,7 +55,7 @@ class AuthenticationManager: Authentication {
     init(storageManager: StorageManagerType = ServiceLocator.storageManager,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          analytics: Analytics = ServiceLocator.analytics,
-         abTestVariationProvider: ABTestVariationProvider = DefaultABTestVariationProvider()) {
+         abTestVariationProvider: ABTestVariationProvider = CachedABTestVariationProvider()) {
         self.storageManager = storageManager
         self.featureFlagService = featureFlagService
         self.analytics = analytics

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -26,6 +26,7 @@ final class AppCoordinator {
     private var authStatesSubscription: AnyCancellable?
     private var localNotificationResponsesSubscription: AnyCancellable?
     private var isLoggedIn: Bool = false
+    private let abTestVariationProvider: ABTestVariationProvider
 
     /// Checks on whether the Apple ID credential is valid when the app is logged in and becomes active.
     ///
@@ -143,7 +144,8 @@ private extension AppCoordinator {
             configureAndDisplayAuthenticator()
         }
 
-        analytics.track(event: .ApplicationPassword.restAPILoginExperiment(variation: ABTest.applicationPasswordAuthentication.variation.analyticsValue))
+        let applicationPasswordABTestVariation = abTestVariationProvider.variation(for: .applicationPasswordAuthentication)
+        analytics.track(event: .ApplicationPassword.restAPILoginExperiment(variation: applicationPasswordABTestVariation.analyticsValue))
     }
 
     /// Configures the WPAuthenticator and sets the authenticator UI as the window's root view.

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -5,6 +5,8 @@ import WordPressAuthenticator
 import Yosemite
 import class AutomatticTracks.CrashLogging
 import protocol Storage.StorageManagerType
+import protocol Experiments.ABTestVariationProvider
+import struct Experiments.DefaultABTestVariationProvider
 
 /// Coordinates app navigation based on authentication state: tab bar UI is shown when the app is logged in, and authentication UI is shown
 /// when the app is logged out.
@@ -40,7 +42,8 @@ final class AppCoordinator {
          analytics: Analytics = ServiceLocator.analytics,
          loggedOutAppSettings: LoggedOutAppSettingsProtocol = LoggedOutAppSettings(userDefaults: .standard),
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         abTestVariationProvider: ABTestVariationProvider = DefaultABTestVariationProvider()) {
         self.window = window
         self.tabBarController = {
             let storyboard = UIStoryboard(name: "Main", bundle: nil) // Main is the name of storyboard
@@ -57,6 +60,7 @@ final class AppCoordinator {
         self.loggedOutAppSettings = loggedOutAppSettings
         self.pushNotesManager = pushNotesManager
         self.featureFlagService = featureFlagService
+        self.abTestVariationProvider = abTestVariationProvider
 
         authenticationManager.setLoggedOutAppSettings(loggedOutAppSettings)
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -6,7 +6,7 @@ import Yosemite
 import class AutomatticTracks.CrashLogging
 import protocol Storage.StorageManagerType
 import protocol Experiments.ABTestVariationProvider
-import struct Experiments.DefaultABTestVariationProvider
+import struct Experiments.CachedABTestVariationProvider
 
 /// Coordinates app navigation based on authentication state: tab bar UI is shown when the app is logged in, and authentication UI is shown
 /// when the app is logged out.
@@ -43,7 +43,7 @@ final class AppCoordinator {
          loggedOutAppSettings: LoggedOutAppSettingsProtocol = LoggedOutAppSettings(userDefaults: .standard),
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         abTestVariationProvider: ABTestVariationProvider = DefaultABTestVariationProvider()) {
+         abTestVariationProvider: ABTestVariationProvider = CachedABTestVariationProvider()) {
         self.window = window
         self.tabBarController = {
             let storyboard = UIStoryboard(name: "Main", bundle: nil) // Main is the name of storyboard

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1968,6 +1968,7 @@
 		E1F52DC62668E03B00349D75 /* CardPresentModalBluetoothRequired.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */; };
 		EE0EE7A628B7415200F6061E /* CustomHelpCenterContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0EE7A528B7415200F6061E /* CustomHelpCenterContent.swift */; };
 		EE0EE7A828B74EF300F6061E /* CustomHelpCenterContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0EE7A728B74EF300F6061E /* CustomHelpCenterContentTests.swift */; };
+		EE2EDFE12987A189004E702B /* MockABTestVariationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2EDFE02987A189004E702B /* MockABTestVariationProvider.swift */; };
 		EE57C11D297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C11C297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift */; };
 		EE57C11F297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */; };
 		EE57C121297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C120297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift */; };
@@ -4066,6 +4067,7 @@
 		E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalBluetoothRequired.swift; sourceTree = "<group>"; };
 		EE0EE7A528B7415200F6061E /* CustomHelpCenterContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHelpCenterContent.swift; sourceTree = "<group>"; };
 		EE0EE7A728B74EF300F6061E /* CustomHelpCenterContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHelpCenterContentTests.swift; sourceTree = "<group>"; };
+		EE2EDFE02987A189004E702B /* MockABTestVariationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockABTestVariationProvider.swift; sourceTree = "<group>"; };
 		EE57C11C297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackEventRequestNotificationHandler.swift; sourceTree = "<group>"; };
 		EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ApplicationPassword.swift"; sourceTree = "<group>"; };
 		EE57C120297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackEventRequestNotificationHandlerTests.swift; sourceTree = "<group>"; };
@@ -6798,6 +6800,7 @@
 				EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */,
 				AEB4DB98290AE8F300AE4340 /* MockCookieJar.swift */,
 				02660503293D8D24004084EA /* PaymentCaptureCelebration.swift */,
+				EE2EDFE02987A189004E702B /* MockABTestVariationProvider.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -11412,6 +11415,7 @@
 				DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */,
 				D89C009425B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift in Sources */,
 				573A960324F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift in Sources */,
+				EE2EDFE12987A189004E702B /* MockABTestVariationProvider.swift in Sources */,
 				0273707E24C0047800167204 /* SequenceHelpersTests.swift in Sources */,
 				D802547326551D0F001B2CC1 /* CardPresentModalTapCardTests.swift in Sources */,
 				F997174723DC070D00592D8E /* XLPagerStrip+AccessibilityIdentifierTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -5,7 +5,6 @@ import XCTest
 @testable import WooCommerce
 import Yosemite
 import protocol Storage.StorageManagerType
-@testable import AutomatticTracks
 
 final class AppCoordinatorTests: XCTestCase {
     private var sessionManager: SessionManager!
@@ -473,13 +472,5 @@ private extension AppCoordinatorTests {
                               pushNotesManager: pushNotesManager,
                               featureFlagService: featureFlagService,
                               abTestVariationProvider: abTestVariationProvider)
-    }
-}
-
-private class MockABTestVariationProvider: ABTestVariationProvider {
-    var mockVariationValue: Variation!
-
-    func variation(for abTest: ABTest) -> Variation {
-        mockVariationValue
     }
 }

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -461,7 +461,7 @@ private extension AppCoordinatorTests {
                          loggedOutAppSettings: LoggedOutAppSettingsProtocol = MockLoggedOutAppSettings(),
                          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
                          featureFlagService: FeatureFlagService = MockFeatureFlagService(),
-                         abTestVariationProvider: ABTestVariationProvider = DefaultABTestVariationProvider()) -> AppCoordinator {
+                         abTestVariationProvider: ABTestVariationProvider = CachedABTestVariationProvider()) -> AppCoordinator {
         return AppCoordinator(window: window ?? self.window,
                               stores: stores ?? self.stores,
                               storageManager: storageManager ?? self.storageManager,

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -158,6 +158,27 @@ final class AuthenticationManagerTests: XCTestCase {
         }
     }
 
+    func test_it_presents_username_and_password_controller_for_non_jetpack_site_when_using_application_password_authentication() {
+        // Given
+        let mockABTestVariationProvider = MockABTestVariationProvider()
+        mockABTestVariationProvider.mockVariationValue = .treatment
+
+        let manager = AuthenticationManager(abTestVariationProvider: mockABTestVariationProvider)
+        let siteInfo = WordPressComSiteInfo(remote: ["isWordPress": true, "hasJetpack": false])
+        var result: WordPressAuthenticatorResult?
+        let completionHandler: (WordPressAuthenticatorResult) -> Void = { completionResult in
+            result = completionResult
+        }
+
+        // When
+        manager.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: completionHandler)
+
+        // Then
+        guard case .presentPasswordController = result else {
+            return XCTFail("Unexpected result returned for non-Jetpack site")
+        }
+    }
+
     func test_it_shows_error_upon_login_epilogue_if_the_self_hosted_site_does_not_have_jetpack() {
         // Given
         let manager = AuthenticationManager()
@@ -228,6 +249,27 @@ final class AuthenticationManagerTests: XCTestCase {
         // Then
         let rootController = navigationController.viewControllers.first
         XCTAssertTrue(rootController is ULErrorViewController)
+    }
+
+    func test_it_does_not_display_jetpack_error_for_org_site_credentials_sign_in_when_using_application_password_authentication() {
+        // Given
+        let mockABTestVariationProvider = MockABTestVariationProvider()
+        mockABTestVariationProvider.mockVariationValue = .treatment
+
+        let manager = AuthenticationManager(abTestVariationProvider: mockABTestVariationProvider)
+        let testSite = "http://test.com"
+        let siteInfo = WordPressComSiteInfo(remote: ["isWordPress": true, "hasJetpack": false, "urlAfterRedirects": testSite])
+        let wporgCredentials = WordPressOrgCredentials(username: "cba", password: "password", xmlrpc: "http://test.com/xmlrpc.php", options: [:])
+        let credentials = AuthenticatorCredentials(wpcom: nil, wporg: wporgCredentials)
+        let navigationController = UINavigationController()
+
+        // When
+        manager.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { _ in })
+        manager.presentLoginEpilogue(in: navigationController, for: credentials, source: nil, onDismiss: {})
+
+        // Then
+        let rootController = navigationController.viewControllers.first
+        XCTAssertFalse(rootController is ULErrorViewController)
     }
 
     func test_errorViewController_display_account_mismatch_screen_if_no_site_matches_the_given_self_hosted_site() {

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -137,7 +137,7 @@ final class AuthenticationManagerTests: XCTestCase {
         XCTAssertTrue(viewModel is NoSecureConnectionErrorViewModel)
     }
 
-    func test_it_presents_username_and_password_controller_for_non_jetpack_site_when_not_using_application_password_authentication() {
+    func test_it_presents_email_controller_for_non_jetpack_site_when_not_using_application_password_authentication() {
         // Given
         let mockABTestVariationProvider = MockABTestVariationProvider()
         mockABTestVariationProvider.mockVariationValue = .control

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -3,8 +3,6 @@ import WordPressKit
 import WordPressAuthenticator
 import Yosemite
 @testable import WooCommerce
-@testable import Experiments
-@testable import AutomatticTracks
 
 /// Test cases for `AuthenticationManager`.
 final class AuthenticationManagerTests: XCTestCase {
@@ -503,13 +501,5 @@ private extension AuthenticationManagerTests {
                                       "isJetpackActive": isJetpackActive,
                                       "isJetpackConnected": isJetpackConnected,
                                       "isWordPressDotCom": isWordPressCom])
-    }
-}
-
-private class MockABTestVariationProvider: ABTestVariationProvider {
-    var mockVariationValue: Variation!
-
-    func variation(for abTest: ABTest) -> Variation {
-        mockVariationValue
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockABTestVariationProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockABTestVariationProvider.swift
@@ -1,0 +1,11 @@
+import protocol Experiments.ABTestVariationProvider
+import enum Experiments.ABTest
+import enum AutomatticTracks.Variation
+
+final class MockABTestVariationProvider: ABTestVariationProvider {
+    var mockVariationValue: Variation!
+
+    func variation(for abTest: ABTest) -> Variation {
+        mockVariationValue
+    }
+}

--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -78,6 +78,13 @@
         "identifier" : "B9C9C63D283E703C001B879F",
         "name" : "WooFoundationTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/Experiments\/Experiments.xcodeproj",
+        "identifier" : "0270C08927069A8900FC799F",
+        "name" : "ExperimentsTests"
+      }
     }
   ],
   "version" : 1


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8782 
<!-- Id number of the GitHub issue this PR addresses. -->

- [ ] ⚠️ Kindly review https://github.com/Automattic/Automattic-Tracks-iOS/pull/247

## Description

Raising this PR based on the solution we reached after discussions in this PR - https://github.com/woocommerce/woocommerce-ios/pull/8788

We are caching the variation values of logged-out experiments to try to address the high crossovers that we see in Explat.


As this PR targets the release branch, I have cherry-picked commits from this PR #8769. This is done to import `ABTestVariationProvider`

## Testing instructions
- Install and launch the app. Log out if needed.
- Launch and skip onboarding.
- If you don't see the "Continue With WordPress.com" button to log in you have been assigned `treatment` variation for the `woocommerceios_login_rest_api_project_202301_v2` experiment and you can test this PR (If not, you need to use a sandbox to force a variation. You can follow the instructions from [this PR](https://github.com/woocommerce/woocommerce-ios/pull/8744) to assign a variation to your device.)
- Login into the app using site creds.
- Go to settings and log out.
- You will be navigated to the login screen and ensure that you still don't see the "Continue With WordPress.com" button. i.e. You are still assigned the `treatment` variation.

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
