### PR TITLE
REST API: Clear login error notification after successful login with site credentials

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -777,13 +777,14 @@ private extension AuthenticationManager {
         }
         let checker = PostSiteCredentialLoginChecker(applicationPasswordUseCase: useCase)
         checker.checkEligibility(for: siteURL, from: navigationController) { [weak self] in
+            guard let self else { return }
             // clear scheduled local notifications
-            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginErrorNotifications) {
+            if self.featureFlagService.isFeatureFlagEnabled(.loginErrorNotifications) {
                 ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: LocalNotification.Scenario.allCases)
             }
 
             // navigates to home screen immediately with a placeholder store ID
-            self?.startStorePicker(with: WooConstants.placeholderStoreID, in: navigationController)
+            self.startStorePicker(with: WooConstants.placeholderStoreID, in: navigationController)
         }
         self.postSiteCredentialLoginChecker = checker
     }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -777,6 +777,11 @@ private extension AuthenticationManager {
         }
         let checker = PostSiteCredentialLoginChecker(applicationPasswordUseCase: useCase)
         checker.checkEligibility(for: siteURL, from: navigationController) { [weak self] in
+            // clear scheduled local notifications
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loginErrorNotifications) {
+                ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: LocalNotification.Scenario.allCases)
+            }
+
             // navigates to home screen immediately with a placeholder store ID
             self?.startStorePicker(with: WooConstants.placeholderStoreID, in: navigationController)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8786 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a fix to clear any scheduled login error notifications after site credential login succeeds. This was handled for WPCom login but missed for this new case.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Update the [duration](https://github.com/woocommerce/woocommerce-ios/blob/d6122655050ef973c1281307ae3cc86481ef6447/WooCommerce/Classes/Authentication/AuthenticationManager.swift#L611) for scheduled login error notifications for testing purpose.
- Set `enableSiteAddressLoginOnly` in `AuthenticationManager` to `true`
- Reinstall the app to clear any previous notifications permission state if needed
- Skip the onboarding if needed
- Tap either CTA
- If choosing to log in with a site address, enter an invalid site address
- Enter an invalid WP.com email to trigger a local notification scheduling with an event in the console `login_local_notification_scheduled`
- Enter the valid address a self-hosted site of after the error
- Quickly continue to enter the correct credentials to log in, then put the app to the background since we don't support local notifications in the foreground --> a local notification should **not** be shown after the duration you set in `AuthenticationManager`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
