### PR TITLE
Address a few warnings in the tests targets

### DIFF
--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -919,9 +919,8 @@ extension AppSettingsStoreTests {
         try fileStorage?.deleteFile(at: expectedGeneralStoreSettingsFileURL)
 
         let currentTime = Date()
-        let date = Date()
 
-        let settings = createAppSettings(featureAnnouncementCampaignSettings: [.test: .init(dismissedDate: date, remindAfter: nil)])
+        let settings = createAppSettings(featureAnnouncementCampaignSettings: [.test: .init(dismissedDate: currentTime, remindAfter: nil)])
         try fileStorage?.write(settings, to: expectedGeneralAppSettingsFileURL)
 
         // When
@@ -937,7 +936,7 @@ extension AppSettingsStoreTests {
 
         let otherCampaignDismissDate = try XCTUnwrap(savedSettings.featureAnnouncementCampaignSettings[.test]?.dismissedDate)
 
-        assertEqual(date, otherCampaignDismissDate)
+        assertEqual(currentTime, otherCampaignDismissDate)
     }
 
     func test_getFeatureAnnouncementVisibility_without_stored_setting_calls_completion_with_visibility_true() throws {

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -849,12 +849,12 @@ extension AppSettingsStoreTests {
         subject?.onAction(action)
 
         // Then
-        var savedSettings: GeneralAppSettings? = try XCTUnwrap(fileStorage?.data(for: expectedGeneralAppSettingsFileURL))
+        let savedSettings: GeneralAppSettings? = try XCTUnwrap(fileStorage?.data(for: expectedGeneralAppSettingsFileURL))
         XCTAssertNil(savedSettings)
         guard let savedSettings else {
             return
         }
-        var savedDate: Date? = try XCTUnwrap( savedSettings.featureAnnouncementCampaignSettings[.upsellCardReaders]?.dismissedDate)
+        let savedDate: Date? = try XCTUnwrap( savedSettings.featureAnnouncementCampaignSettings[.upsellCardReaders]?.dismissedDate)
         XCTAssertNil(savedDate)
     }
 

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -919,7 +919,6 @@ extension AppSettingsStoreTests {
         try fileStorage?.deleteFile(at: expectedGeneralStoreSettingsFileURL)
 
         let currentTime = Date()
-        let datePrior = Date(timeIntervalSince1970: 100)
         let date = Date()
 
         let settings = createAppSettings(featureAnnouncementCampaignSettings: [.test: .init(dismissedDate: date, remindAfter: nil)])


### PR DESCRIPTION
## Description
I run into these while testing #8808 locally.

## Testing instructions
Checkout this branch locally, run the unit tests on the WooCommerce scheme, and verify there are no warnings for the tests targets. Note that there are various warnings still, but none in "`.*Tests`" targets.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
