### PR TITLE
Adds .supportRequest Feature Flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -59,6 +59,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper
         case .domainSettings:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .supportRequests:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -141,4 +141,8 @@ public enum FeatureFlag: Int {
     /// Whether to enable domain updates from the settings for a WPCOM site.
     ///
     case domainSettings
+
+    /// Whether to enable the new support request form.
+    ///
+    case supportRequests
 }


### PR DESCRIPTION
Closes: #8792 

# Why

Just a simple PR to add the `.supportRequest` feature flag to hide the ongoing development of the new Support Request Form work.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
