### PR TITLE
[Mobile Payments] Reveal TTP feature toggle in release builds

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -56,7 +56,9 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             // Disabled by default to avoid costs spikes, unless in internal testing builds.
             return buildConfig == .alpha
         case .tapToPayOnIPhone:
-            return buildConfig == .localDeveloper
+            // It is not possible to get the TTPoI entitlement for an enterprise certificate,
+            // so we should not enable this for alpha builds.
+            return buildConfig == .localDeveloper || buildConfig == .appStore
         case .domainSettings:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/WooCommerce/Classes/Model/BetaFeature.swift
+++ b/WooCommerce/Classes/Model/BetaFeature.swift
@@ -70,7 +70,7 @@ extension BetaFeature {
         case .inAppPurchases:
             return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.inAppPurchases)
         case .tapToPayOnIPhone:
-            return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhone)
+            return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhone) && !UIDevice.isPad()
         default:
             return true
         }

--- a/WooCommerce/Classes/Model/BetaFeature.swift
+++ b/WooCommerce/Classes/Model/BetaFeature.swift
@@ -70,10 +70,20 @@ extension BetaFeature {
         case .inAppPurchases:
             return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.inAppPurchases)
         case .tapToPayOnIPhone:
-            return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhone) && !UIDevice.isPad()
+            return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhone) && deviceMaySupportTTP
         default:
             return true
         }
+    }
+
+    // Full checking for support of TTP requires a more complicated call.
+    // This is sufficient for whether the feature toggle should be shown, as full support checks
+    // are done when a payment is started. This is a temporary measure until full release.
+    private var deviceMaySupportTTP: Bool {
+        guard #available(iOS 16, *) else {
+            return false
+        }
+        return !UIDevice.isPad()
     }
 
     static var availableFeatures: [Self] {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8773 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This commit makes Tap to Pay on iPhone available for merchants to opt-in, using the experimental feature toggle, on an App Store build.

The toggle is only available on phones, as TTP is not supported on iPad.

The Tap to Pay on iPhone entitlement is not available for Enterprise certificates, so we can’t enable the feature toggle in our Alpha build, which is used by CI to build the enterprise distribution of the app. Since this is an uncommon configuration for a feature flag, I’ve called that out in the comments.

### ⛔️ Do not merge
This should not be merged until the required backend changes are complete and confirmed that they'll be ready for the relevant release.

Edit 20230208 : this is likely to happen, so we are merging and will remove as a beta fix if required.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

This is fiddly to test, as we can't build Release builds to a real device, and in Release builds we don't allow Stripe's simulated terminal to work.

The simplest test, is just whether the toggle shows up or not for a release build, for iPhone only:

1. Edit the scheme in Xcode to do a Release build: `Product > Scheme > Edit Scheme`
<img width="964" alt="CleanShot 2023-02-02 at 16 12 52@2x" src="https://user-images.githubusercontent.com/2472348/216379295-3b4882ab-9bc6-4302-936d-70e96a014043.png">
2. Build the app to a phone simulator
3. Go to `Menu > Settings > Experimental Features`
4. Observe that the toggle is visible. 

N.B. if you have never used the toggle before on that simulator, it will be off. If you've used it on that simulator (even with the debug version of the app) it will retain the state from the last build.

Repeat the above test using an iPad simulator: the toggle should not show up.

Repeat the above test using a phone simulator and the `Release-Alpha` build configuration: the toggle should not show up.

### Testing a payment
In the release build configuration, the `-simulate-stripe-card-reader` setting is ignored. If you want to test a payment, you can change [the implementation of `StripeCardReaderService.getter:shouldUseSimulatedCardReader`](https://github.com/woocommerce/woocommerce-ios/blob/5924f5636d7b232175bc227802aa425ba76b7c17/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift#L933) to the following:

```
    var shouldUseSimulatedCardReader: Bool {
        return ProcessInfo.processInfo.arguments.contains("-simulate-stripe-card-reader")
    }
```

Then the checkbox in the scheme's arguments will work, and you can try a payment.
---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
