### PR TITLE
Domain settings > domain selector: UI updates - title, subtitle, no contact support CTA

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -381,7 +381,8 @@ private extension StoreCreationCoordinator {
                             countryCode: SiteAddress.CountryCode?,
                             planToPurchase: WPComPlanProduct) {
         let domainSelector = FreeDomainSelectorHostingController(viewModel:
-                .init(subtitle: Localization.domainSelectorSubtitle,
+                .init(title: Localization.domainSelectorTitle,
+                      subtitle: Localization.domainSelectorSubtitle,
                       initialSearchTerm: storeName,
                       dataProvider: FreeDomainSelectorDataProvider()),
                                                                  onDomainSelection: { [weak self] domain in
@@ -642,10 +643,13 @@ private extension StoreCreationCoordinator {
     }
 
     enum Localization {
+        static var domainSelectorTitle: String {
+            NSLocalizedString("Choose a domain", comment: "Title of the domain selector in the store creation flow.")
+        }
         static var domainSelectorSubtitle: String {
             NSLocalizedString(
                 "This is where people will find you on the Internet. You can add another domain later.",
-                comment: "Subtitle of the domain selector.")
+                comment: "Subtitle of the domain selector in the store creation flow.")
         }
 
         enum WaitingForIAPEligibility {

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -380,7 +380,10 @@ private extension StoreCreationCoordinator {
                             sellingStatus: StoreCreationSellingStatusAnswer?,
                             countryCode: SiteAddress.CountryCode?,
                             planToPurchase: WPComPlanProduct) {
-        let domainSelector = FreeDomainSelectorHostingController(viewModel: .init(initialSearchTerm: storeName, dataProvider: FreeDomainSelectorDataProvider()),
+        let domainSelector = FreeDomainSelectorHostingController(viewModel:
+                .init(subtitle: Localization.domainSelectorSubtitle,
+                      initialSearchTerm: storeName,
+                      dataProvider: FreeDomainSelectorDataProvider()),
                                                                  onDomainSelection: { [weak self] domain in
             guard let self else { return }
             await self.createStoreAndContinueToStoreSummary(from: navigationController,
@@ -639,6 +642,12 @@ private extension StoreCreationCoordinator {
     }
 
     enum Localization {
+        static var domainSelectorSubtitle: String {
+            NSLocalizedString(
+                "This is where people will find you on the Internet. You can add another domain later.",
+                comment: "Subtitle of the domain selector.")
+        }
+
         enum WaitingForIAPEligibility {
             static let title = NSLocalizedString(
                 "We are getting ready for your store creation",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorView.swift
@@ -30,10 +30,10 @@ final class PaidDomainSelectorHostingController: UIHostingController<DomainSelec
     /// - Parameters:
     ///   - viewModel: View model for the domain selector.
     ///   - onDomainSelection: Called when the user continues with a selected domain.
-    ///   - onSupport: Called when the user taps to contact support.
+    ///   - onSupport: Called when the user taps to contact support. If `nil`, the contact support CTA is not shown.
     init(viewModel: DomainSelectorViewModel<PaidDomainSelectorDataProvider, PaidDomainSuggestionViewModel>,
          onDomainSelection: @escaping (PaidDomainSuggestionViewModel) async -> Void,
-         onSupport: @escaping () -> Void) {
+         onSupport: (() -> Void)?) {
         super.init(rootView: DomainSelectorView<PaidDomainSelectorDataProvider, PaidDomainSuggestionViewModel>(viewModel: viewModel,
                                                                                                       onDomainSelection: onDomainSelection,
                                                                                                       onSupport: onSupport))
@@ -55,7 +55,7 @@ struct DomainSelectorView<DataProvider: DomainSelectorDataProvider,
                           DomainSuggestion: Equatable & DomainSuggestionViewProperties>: View
 where DataProvider.DomainSuggestion == DomainSuggestion {
     private let onDomainSelection: (DomainSuggestion) async -> Void
-    private let onSupport: () -> Void
+    private let onSupport: (() -> Void)?
 
     /// View model to drive the view.
     @ObservedObject private var viewModel: DomainSelectorViewModel<DataProvider, DomainSuggestion>
@@ -71,7 +71,7 @@ where DataProvider.DomainSuggestion == DomainSuggestion {
 
     init(viewModel: DomainSelectorViewModel<DataProvider, DomainSuggestion>,
          onDomainSelection: @escaping (DomainSuggestion) async -> Void,
-         onSupport: @escaping () -> Void) {
+         onSupport: (() -> Void)?) {
         self.viewModel = viewModel
         self.onDomainSelection = onDomainSelection
         self.onSupport = onSupport
@@ -184,8 +184,10 @@ where DataProvider.DomainSuggestion == DomainSuggestion {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                SupportButton {
-                    onSupport()
+                if let onSupport {
+                    SupportButton {
+                        onSupport()
+                    }
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorView.swift
@@ -189,7 +189,7 @@ where DataProvider.DomainSuggestion == DomainSuggestion {
                 }
             }
         }
-        .navigationTitle(Localization.title)
+        .navigationTitle(viewModel.title)
         .navigationBarTitleDisplayMode(.large)
         .onChange(of: viewModel.isLoadingDomainSuggestions) { isLoadingDomainSuggestions in
             // Resets selected domain when loading domain suggestions.
@@ -208,9 +208,6 @@ private extension DomainSelectorView {
     }
 
     enum Localization {
-        static var title: String {
-            NSLocalizedString("Choose a domain", comment: "Title of the domain selector.")
-        }
         static var searchPlaceholder: String {
             NSLocalizedString("Type a name for your store", comment: "Placeholder of the search text field on the domain selector.")
         }
@@ -261,7 +258,8 @@ struct DomainSelectorView_Previews: PreviewProvider {
             // Empty query state.
             DomainSelectorView<FreeDomainSelectorDataProvider, FreeDomainSuggestionViewModel>(
                 viewModel:
-                        .init(subtitle: "Your domain",
+                        .init(title: "Choose a domain",
+                              subtitle: "Your domain",
                               initialSearchTerm: "",
                               dataProvider: FreeDomainSelectorDataProvider(
                                 stores: DomainSelectorViewStores()
@@ -272,7 +270,8 @@ struct DomainSelectorView_Previews: PreviewProvider {
             // Results state for free domains.
             DomainSelectorView<FreeDomainSelectorDataProvider, FreeDomainSuggestionViewModel>(
                 viewModel:
-                        .init(subtitle: "Your domain",
+                        .init(title: "Choose a domain",
+                              subtitle: "Your domain",
                               initialSearchTerm: "",
                               dataProvider: FreeDomainSelectorDataProvider(
                                 stores: DomainSelectorViewStores(freeDomainsResult: .success([
@@ -290,7 +289,8 @@ struct DomainSelectorView_Previews: PreviewProvider {
             // Results state for paid domains.
             DomainSelectorView<PaidDomainSelectorDataProvider, PaidDomainSuggestionViewModel>(
                 viewModel:
-                        .init(subtitle: "Your domain mapped to **other.domain**",
+                        .init(title: "Search domains",
+                              subtitle: "Your domain mapped to **other.domain**",
                               initialSearchTerm: "fruit",
                               dataProvider: PaidDomainSelectorDataProvider(
                                 stores: DomainSelectorViewStores(paidDomainsResult: .success([
@@ -313,7 +313,8 @@ struct DomainSelectorView_Previews: PreviewProvider {
             // Error state.
             DomainSelectorView<FreeDomainSelectorDataProvider, FreeDomainSuggestionViewModel>(
                 viewModel:
-                        .init(subtitle: "Your domain",
+                        .init(title: "Search domains",
+                              subtitle: "Your domain",
                               initialSearchTerm: "test",
                               dataProvider:
                                 FreeDomainSelectorDataProvider(
@@ -327,7 +328,8 @@ struct DomainSelectorView_Previews: PreviewProvider {
             // Loading state.
             DomainSelectorView<FreeDomainSelectorDataProvider, FreeDomainSuggestionViewModel>(
                 viewModel:
-                        .init(subtitle: "Your domain",
+                        .init(title: "Search domains",
+                              subtitle: "Your domain",
                               initialSearchTerm: "",
                               dataProvider: FreeDomainSelectorDataProvider(
                                 stores: DomainSelectorViewStores()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorView.swift
@@ -81,7 +81,8 @@ where DataProvider.DomainSuggestion == DomainSuggestion {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 // Header label.
-                Text(Localization.subtitle)
+                // The subtitle is in an `.init` in order to support markdown.
+                Text(.init(viewModel.subtitle))
                     .foregroundColor(Color(.secondaryLabel))
                     .bodyStyle()
                     .padding(.horizontal, Layout.defaultHorizontalPadding)
@@ -210,11 +211,6 @@ private extension DomainSelectorView {
         static var title: String {
             NSLocalizedString("Choose a domain", comment: "Title of the domain selector.")
         }
-        static var subtitle: String {
-            NSLocalizedString(
-                "This is where people will find you on the Internet. You can add another domain later.",
-                comment: "Subtitle of the domain selector.")
-        }
         static var searchPlaceholder: String {
             NSLocalizedString("Type a name for your store", comment: "Placeholder of the search text field on the domain selector.")
         }
@@ -265,7 +261,8 @@ struct DomainSelectorView_Previews: PreviewProvider {
             // Empty query state.
             DomainSelectorView<FreeDomainSelectorDataProvider, FreeDomainSuggestionViewModel>(
                 viewModel:
-                        .init(initialSearchTerm: "",
+                        .init(subtitle: "Your domain",
+                              initialSearchTerm: "",
                               dataProvider: FreeDomainSelectorDataProvider(
                                 stores: DomainSelectorViewStores()
                               )),
@@ -275,7 +272,8 @@ struct DomainSelectorView_Previews: PreviewProvider {
             // Results state for free domains.
             DomainSelectorView<FreeDomainSelectorDataProvider, FreeDomainSuggestionViewModel>(
                 viewModel:
-                        .init(initialSearchTerm: "",
+                        .init(subtitle: "Your domain",
+                              initialSearchTerm: "",
                               dataProvider: FreeDomainSelectorDataProvider(
                                 stores: DomainSelectorViewStores(freeDomainsResult: .success([
                                     .init(name: "grapefruitsmoothie.com", isFree: true),
@@ -292,7 +290,8 @@ struct DomainSelectorView_Previews: PreviewProvider {
             // Results state for paid domains.
             DomainSelectorView<PaidDomainSelectorDataProvider, PaidDomainSuggestionViewModel>(
                 viewModel:
-                        .init(initialSearchTerm: "fruit",
+                        .init(subtitle: "Your domain mapped to **other.domain**",
+                              initialSearchTerm: "fruit",
                               dataProvider: PaidDomainSelectorDataProvider(
                                 stores: DomainSelectorViewStores(paidDomainsResult: .success([
                                     .init(productID: 1,
@@ -314,7 +313,8 @@ struct DomainSelectorView_Previews: PreviewProvider {
             // Error state.
             DomainSelectorView<FreeDomainSelectorDataProvider, FreeDomainSuggestionViewModel>(
                 viewModel:
-                        .init(initialSearchTerm: "test",
+                        .init(subtitle: "Your domain",
+                              initialSearchTerm: "test",
                               dataProvider:
                                 FreeDomainSelectorDataProvider(
                                     stores: DomainSelectorViewStores(freeDomainsResult:
@@ -327,7 +327,8 @@ struct DomainSelectorView_Previews: PreviewProvider {
             // Loading state.
             DomainSelectorView<FreeDomainSelectorDataProvider, FreeDomainSuggestionViewModel>(
                 viewModel:
-                        .init(initialSearchTerm: "",
+                        .init(subtitle: "Your domain",
+                              initialSearchTerm: "",
                               dataProvider: FreeDomainSelectorDataProvider(
                                 stores: DomainSelectorViewStores()
                               )),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorViewModel.swift
@@ -27,6 +27,7 @@ where DataProvider.DomainSuggestion == DomainSuggestion {
         case results(domains: [DomainSuggestion])
     }
 
+    let title: String
     let subtitle: String
 
     /// Current search term entered by the user.
@@ -51,10 +52,12 @@ where DataProvider.DomainSuggestion == DomainSuggestion {
     private let dataProvider: DataProvider
     private let debounceDuration: Double
 
-    init(subtitle: String,
+    init(title: String,
+         subtitle: String,
          initialSearchTerm: String = "",
          dataProvider: DataProvider,
          debounceDuration: Double = Constants.fieldDebounceDuration) {
+        self.title = title
         self.subtitle = subtitle
 
         self.dataProvider = dataProvider

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSelectorViewModel.swift
@@ -27,6 +27,8 @@ where DataProvider.DomainSuggestion == DomainSuggestion {
         case results(domains: [DomainSuggestion])
     }
 
+    let subtitle: String
+
     /// Current search term entered by the user.
     /// Each update will trigger a remote call for domain suggestions.
     @Published var searchTerm: String = ""
@@ -49,9 +51,12 @@ where DataProvider.DomainSuggestion == DomainSuggestion {
     private let dataProvider: DataProvider
     private let debounceDuration: Double
 
-    init(initialSearchTerm: String = "",
+    init(subtitle: String,
+         initialSearchTerm: String = "",
          dataProvider: DataProvider,
          debounceDuration: Double = Constants.fieldDebounceDuration) {
+        self.subtitle = subtitle
+
         self.dataProvider = dataProvider
         self.debounceDuration = debounceDuration
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsCoordinator.swift
@@ -43,7 +43,8 @@ private extension DomainSettingsCoordinator {
     func showDomainSelector(from navigationController: UINavigationController, hasDomainCredit: Bool, freeStagingDomain: String?) {
         let subtitle = freeStagingDomain
             .map { String(format: Localization.domainSelectorSubtitleFormat, $0) } ?? Localization.domainSelectorSubtitleWithoutFreeStagingDomain
-        let viewModel = DomainSelectorViewModel(subtitle: subtitle,
+        let viewModel = DomainSelectorViewModel(title: Localization.domainSelectorTitle,
+                                                subtitle: subtitle,
                                                 initialSearchTerm: site.name,
                                                 dataProvider: PaidDomainSelectorDataProvider(stores: stores,
                                                                                              hasDomainCredit: hasDomainCredit))
@@ -151,6 +152,10 @@ private extension DomainSettingsCoordinator {
 
 private extension DomainSettingsCoordinator {
     enum Localization {
+        static let domainSelectorTitle = NSLocalizedString(
+            "Search domains",
+            comment: "Title of the domain selector in domain settings."
+        )
         static let domainSelectorSubtitleFormat = NSLocalizedString(
             "The domain purchased will redirect users to **%1$@**",
             comment: "Subtitle of the domain selector in domain settings. %1$@ is the free domain of the site from WordPress.com."

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsCoordinator.swift
@@ -48,7 +48,7 @@ private extension DomainSettingsCoordinator {
                                                 initialSearchTerm: site.name,
                                                 dataProvider: PaidDomainSelectorDataProvider(stores: stores,
                                                                                              hasDomainCredit: hasDomainCredit))
-        let domainSelector = PaidDomainSelectorHostingController(viewModel: viewModel) { [weak self] domain in
+        let domainSelector = PaidDomainSelectorHostingController(viewModel: viewModel, onDomainSelection: { [weak self] domain in
             guard let self else { return }
             let domainToPurchase = DomainToPurchase(name: domain.name,
                                                     productID: domain.productID,
@@ -65,9 +65,7 @@ private extension DomainSettingsCoordinator {
                     print("⛔️ Error creating cart with the selected domain \(domain): \(error)")
                 }
             }
-        } onSupport: {
-            // TODO: 8558 - remove support action
-        }
+        }, onSupport: nil)
         navigationController.show(domainSelector, sender: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsCoordinator.swift
@@ -30,8 +30,8 @@ final class DomainSettingsCoordinator: Coordinator {
     func start() {
         let settingsNavigationController = WooNavigationController()
         let domainSettings = DomainSettingsHostingController(viewModel: .init(siteID: site.siteID,
-                                                                              stores: stores)) { [weak self] hasDomainCredit in
-            self?.showDomainSelector(from: settingsNavigationController, hasDomainCredit: hasDomainCredit)
+                                                                              stores: stores)) { [weak self] hasDomainCredit, freeStagingDomain in
+            self?.showDomainSelector(from: settingsNavigationController, hasDomainCredit: hasDomainCredit, freeStagingDomain: freeStagingDomain)
         }
         settingsNavigationController.pushViewController(domainSettings, animated: false)
         navigationController.present(settingsNavigationController, animated: true)
@@ -40,8 +40,11 @@ final class DomainSettingsCoordinator: Coordinator {
 
 private extension DomainSettingsCoordinator {
     @MainActor
-    func showDomainSelector(from navigationController: UINavigationController, hasDomainCredit: Bool) {
-        let viewModel = DomainSelectorViewModel(initialSearchTerm: site.name,
+    func showDomainSelector(from navigationController: UINavigationController, hasDomainCredit: Bool, freeStagingDomain: String?) {
+        let subtitle = freeStagingDomain
+            .map { String(format: Localization.domainSelectorSubtitleFormat, $0) } ?? Localization.domainSelectorSubtitleWithoutFreeStagingDomain
+        let viewModel = DomainSelectorViewModel(subtitle: subtitle,
+                                                initialSearchTerm: site.name,
                                                 dataProvider: PaidDomainSelectorDataProvider(stores: stores,
                                                                                              hasDomainCredit: hasDomainCredit))
         let domainSelector = PaidDomainSelectorHostingController(viewModel: viewModel) { [weak self] domain in
@@ -143,5 +146,18 @@ private extension DomainSettingsCoordinator {
                 continuation.resume(with: result)
             })
         }
+    }
+}
+
+private extension DomainSettingsCoordinator {
+    enum Localization {
+        static let domainSelectorSubtitleFormat = NSLocalizedString(
+            "The domain purchased will redirect users to **%1$@**",
+            comment: "Subtitle of the domain selector in domain settings. %1$@ is the free domain of the site from WordPress.com."
+        )
+        static let domainSelectorSubtitleWithoutFreeStagingDomain = NSLocalizedString(
+            "The domain purchased will redirect users to the current staging domain",
+            comment: "Subtitle of the domain selector in domain settings when a free staging domain is unavailable."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Hosting controller that wraps the `DomainSettingsView` view.
 final class DomainSettingsHostingController: UIHostingController<DomainSettingsView> {
     init(viewModel: DomainSettingsViewModel,
-         addDomain: @escaping (_ hasDomainCredit: Bool) -> Void) {
+         addDomain: @escaping (_ hasDomainCredit: Bool, _ freeStagingDomain: String?) -> Void) {
         super.init(rootView: DomainSettingsView(viewModel: viewModel,
                                                 addDomain: addDomain))
     }
@@ -22,9 +22,9 @@ final class DomainSettingsHostingController: UIHostingController<DomainSettingsV
 /// Shows a site's domains with actions to add a domain or redeem a domain credit.
 struct DomainSettingsView: View {
     @ObservedObject private var viewModel: DomainSettingsViewModel
-    private let addDomain: (_ hasDomainCredit: Bool) -> Void
+    private let addDomain: (_ hasDomainCredit: Bool, _ freeStagingDomain: String?) -> Void
 
-    init(viewModel: DomainSettingsViewModel, addDomain: @escaping (Bool) -> Void) {
+    init(viewModel: DomainSettingsViewModel, addDomain: @escaping (Bool, String?) -> Void) {
         self.viewModel = viewModel
         self.addDomain = addDomain
     }
@@ -42,13 +42,13 @@ struct DomainSettingsView: View {
 
                 if viewModel.hasDomainCredit {
                     DomainSettingsDomainCreditView() {
-                        addDomain(viewModel.hasDomainCredit)
+                        addDomain(viewModel.hasDomainCredit, viewModel.freeStagingDomain?.name)
                     }
                 }
 
                 if viewModel.domains.isNotEmpty {
                     DomainSettingsListView(domains: viewModel.domains) {
-                        addDomain(viewModel.hasDomainCredit)
+                        addDomain(viewModel.hasDomainCredit, viewModel.freeStagingDomain?.name)
                     }
                 }
             }
@@ -61,7 +61,7 @@ struct DomainSettingsView: View {
                         .frame(height: Layout.dividerHeight)
                         .foregroundColor(Color(.separator))
                     Button(Localization.searchDomainButton) {
-                        addDomain(viewModel.hasDomainCredit)
+                        addDomain(viewModel.hasDomainCredit, viewModel.freeStagingDomain?.name)
                     }
                     .buttonStyle(PrimaryButtonStyle())
                     .padding(Layout.bottomContentPadding)
@@ -142,7 +142,7 @@ struct DomainSettingsView_Previews: PreviewProvider {
                                 ]),
                                 // The site has domain credit.
                                 sitePlanResult: .success(.init(hasDomainCredit: true)))),
-                                   addDomain: { _ in })
+                                   addDomain: { _, _ in })
             }
 
             NavigationView {
@@ -154,7 +154,7 @@ struct DomainSettingsView_Previews: PreviewProvider {
                                     .init(name: "free.test", isPrimary: true)
                                 ]),
                                 sitePlanResult: .success(.init(hasDomainCredit: true)))),
-                                   addDomain: { _ in })
+                                   addDomain: { _, _ in })
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/Domains/FreeDomainSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Domains/FreeDomainSelectorViewModelTests.swift
@@ -13,13 +13,24 @@ final class FreeDomainSelectorViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
-        viewModel = .init(dataProvider: FreeDomainSelectorDataProvider(stores: stores), debounceDuration: 0)
+        viewModel = .init(title: "", subtitle: "", dataProvider: FreeDomainSelectorDataProvider(stores: stores), debounceDuration: 0)
     }
 
     override func tearDown() {
         viewModel = nil
         stores = nil
         super.tearDown()
+    }
+
+    func test_title_and_subtitle_are_set_by_init_parameter() {
+        // When
+        let viewModel = DomainSelectorViewModel<FreeDomainSelectorDataProvider, FreeDomainSuggestionViewModel>(
+            title: "title", subtitle: "Subtitle", dataProvider: FreeDomainSelectorDataProvider(stores: stores), debounceDuration: 0
+        )
+
+        // Then
+        XCTAssertEqual(viewModel.title, "title")
+        XCTAssertEqual(viewModel.subtitle, "Subtitle")
     }
 
     func test_DomainAction_is_not_dispatched_when_searchTerm_is_empty() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8558 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR includes some design updates on the domain selector screen in the domain settings flow, since the current domain selector has the design from the store creation flow. The differences are:

- Title
- Subtitle: since we're showing a domain name variable in the subtitle in domain settings, I'm using the iOS 15+ markdown support in `Text` which requires a custom initialization like `Text(.init(stringVariable)`. Otherwise, the stinrg is shown as a literal
- No contact support CTA: the contact support closure is updated to an optional value, and the CTA is only shown when it's non-nil

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: a WC store **with a WPCOM plan** is required

- Log in if needed, and continue with a WPCOM store
- Go to the Menu tab
- Tap on the settings CTA
- Tap the `Domain` row
- Tap `Add a domain` or `Search for a domain` depending on if there are existing domains --> the title, subtitle should match the design. Please note that I didn't update the subtitle color in this PR since it's a nice-to-have. There should not be a contact support CTA in the navigation bar

---
- [x] @jaclync tests the domain selector in the store creation flow

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Domain settings

dark | light
-- | --
![Simulator Screen Shot - iPhone 14 - 2023-02-03 at 11 06 46](https://user-images.githubusercontent.com/1945542/216504830-1fd877cb-559a-4e1b-9512-a91cc5ed6523.png) | ![Simulator Screen Shot - iPhone 14 - 2023-02-03 at 11 07 00](https://user-images.githubusercontent.com/1945542/216504838-7f84234f-d035-4083-ad50-8c4f7bbbaed1.png)

Store creation

<img src="https://user-images.githubusercontent.com/1945542/216504860-b6adf575-d5dd-467f-b0a9-af40e6a679f2.png" width="300" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
