### PR TITLE
REST API: Update reply comment endpoint to use the REST API

### DIFF
--- a/Networking/Networking/Remote/CommentRemote.swift
+++ b/Networking/Networking/Remote/CommentRemote.swift
@@ -66,7 +66,11 @@ public class CommentRemote: Remote {
     ///    - content: the text of the comment reply
     ///    - completion: callback to be executed on completion
     ///
-    public func replyToComment(siteID: Int64, commentID: Int64, productID: Int64, content: String, completion: @escaping (Result<CommentStatus, Error>) -> Void) {
+    public func replyToComment(siteID: Int64,
+                               commentID: Int64,
+                               productID: Int64,
+                               content: String,
+                               completion: @escaping (Result<CommentStatus, Error>) -> Void) {
         let parameters: [String: Any] = [
             ParameterKeys.content: content,
             ParameterKeys.parent: commentID,

--- a/Networking/Networking/Remote/CommentRemote.swift
+++ b/Networking/Networking/Remote/CommentRemote.swift
@@ -62,17 +62,27 @@ public class CommentRemote: Remote {
     /// - Parameters:
     ///    - siteID: site ID which contains the comment
     ///    - commentID: ID of the comment to reply to
+    ///    - productID: ID of the product that the comment is associated to
     ///    - content: the text of the comment reply
     ///    - completion: callback to be executed on completion
     ///
-    public func replyToComment(siteID: Int64, commentID: Int64, content: String, completion: @escaping (Result<CommentStatus, Error>) -> Void) {
-        let path = "\(Paths.sites)/" + String(siteID) + "/" + "\(Paths.comments)/" + String(commentID) + "/\(Paths.commentReply)"
-        let parameters = [
-            ParameterKeys.content: content
+    public func replyToComment(siteID: Int64, commentID: Int64, productID: Int64, content: String, completion: @escaping (Result<CommentStatus, Error>) -> Void) {
+        let parameters: [String: Any] = [
+            ParameterKeys.content: content,
+            ParameterKeys.parent: commentID,
+            ParameterKeys.post: productID
         ]
         let mapper = CommentResultMapper()
-        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters)
-        enqueue(request, mapper: mapper, completion: completion)
+        do {
+            let request = try DotcomRequest(wordpressApiVersion: .wpMark2,
+                                            method: .post,
+                                            path: Paths.comments,
+                                            parameters: parameters,
+                                            availableAsRESTRequest: true)
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
     }
 }
 
@@ -90,6 +100,8 @@ private extension CommentRemote {
         static let status: String       = "status"
         static let context: String      = "context"
         static let content: String      = "content"
+        static let parent: String       = "parent"
+        static let post: String         = "post"
     }
 
     enum ParameterValues {

--- a/Networking/Networking/Remote/CommentRemote.swift
+++ b/Networking/Networking/Remote/CommentRemote.swift
@@ -71,6 +71,7 @@ public class CommentRemote: Remote {
                                productID: Int64,
                                content: String,
                                completion: @escaping (Result<CommentStatus, Error>) -> Void) {
+        let path = "sites/\(siteID)/\(Paths.comments)"
         let parameters: [String: Any] = [
             ParameterKeys.content: content,
             ParameterKeys.parent: commentID,
@@ -80,7 +81,7 @@ public class CommentRemote: Remote {
         do {
             let request = try DotcomRequest(wordpressApiVersion: .wpMark2,
                                             method: .post,
-                                            path: Paths.comments,
+                                            path: path,
                                             parameters: parameters,
                                             availableAsRESTRequest: true)
             enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/NetworkingTests/Remote/CommentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CommentRemoteTests.swift
@@ -164,7 +164,7 @@ class CommentRemoteTests: XCTestCase {
         // When
         var result: Result<CommentStatus, Error>?
         waitForExpectation { expectation in
-            remote.replyToComment(siteID: sampleSiteID, commentID: sampleCommentID, content: "Sample comment") { aResult in
+            remote.replyToComment(siteID: sampleSiteID, commentID: sampleCommentID, productID: 1234, content: "Sample comment") { aResult in
                 result = aResult
                 expectation.fulfill()
             }
@@ -184,7 +184,7 @@ class CommentRemoteTests: XCTestCase {
         // When
         var result: Result<CommentStatus, Error>?
         waitForExpectation { expectation in
-            remote.replyToComment(siteID: sampleSiteID, commentID: sampleCommentID, content: "Sample comment") { aResult in
+            remote.replyToComment(siteID: sampleSiteID, commentID: sampleCommentID, productID: 1234, content: "Sample comment") { aResult in
                 result = aResult
                 expectation.fulfill()
             }

--- a/Networking/NetworkingTests/Remote/CommentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CommentRemoteTests.swift
@@ -159,7 +159,7 @@ class CommentRemoteTests: XCTestCase {
         // Given
         let remote = CommentRemote(network: network)
 
-        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)/replies/new", filename: "comment-moderate-approved")
+        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments", filename: "comment-moderate-approved")
 
         // When
         var result: Result<CommentStatus, Error>?
@@ -178,8 +178,7 @@ class CommentRemoteTests: XCTestCase {
     func test_replyToComment_properly_parses_error_responses() throws {
         // Given
         let remote = CommentRemote(network: network)
-
-        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)/replies/new", filename: "generic_error")
+        network.simulateError(requestUrlSuffix: "sites/\(sampleSiteID)/comments", error: NetworkError.timeout)
 
         // When
         var result: Result<CommentStatus, Error>?

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -332,7 +332,7 @@ private extension ReviewDetailsViewController {
         commentCell.isTrashEnabled    = true
         commentCell.isSpamEnabled     = true
         commentCell.isApproveSelected = productReview.status == .approved
-        commentCell.isReplyEnabled    = ServiceLocator.stores.isAuthenticatedWithoutWPCom == false
+        commentCell.isReplyEnabled    = true
 
         let reviewID = productReview.reviewID
         let reviewSiteID = productReview.siteID
@@ -383,7 +383,7 @@ private extension ReviewDetailsViewController {
         commentCell.onReply = { [weak self] in
             guard let self else { return }
 
-            let reviewReplyViewModel = ReviewReplyViewModel(siteID: self.siteID, reviewID: self.productReview.reviewID)
+            let reviewReplyViewModel = ReviewReplyViewModel(siteID: self.siteID, reviewID: self.productReview.reviewID, productID: self.productReview.productID)
             let reviewReplyViewController = ReviewReplyHostingController(viewModel: reviewReplyViewModel)
             self.present(reviewReplyViewController, animated: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewReplyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewReplyViewModel.swift
@@ -11,6 +11,10 @@ final class ReviewReplyViewModel: ObservableObject {
     /// ID for the product review being replied to.
     ///
     private let reviewID: Int64
+    
+    /// ID for the product associated with the review.
+    ///
+    private let productID: Int64
 
     /// New reply to send
     ///
@@ -38,10 +42,12 @@ final class ReviewReplyViewModel: ObservableObject {
 
     init(siteID: Int64,
          reviewID: Int64,
+         productID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.reviewID = reviewID
+        self.productID = productID
         self.stores = stores
         self.analytics = analytics
         bindNavigationTrailingItemPublisher()
@@ -56,7 +62,7 @@ final class ReviewReplyViewModel: ObservableObject {
             return
         }
 
-        let action = CommentAction.replyToComment(siteID: siteID, commentID: reviewID, content: newReply) { [weak self] result in
+        let action = CommentAction.replyToComment(siteID: siteID, commentID: reviewID, productID: productID, content: newReply) { [weak self] result in
             guard let self = self else { return }
 
             self.performingNetworkRequest.send(false)

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewReplyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewReplyViewModel.swift
@@ -11,7 +11,7 @@ final class ReviewReplyViewModel: ObservableObject {
     /// ID for the product review being replied to.
     ///
     private let reviewID: Int64
-    
+
     /// ID for the product associated with the review.
     ///
     private let productID: Int64

--- a/WooCommerce/WooCommerceTests/ViewRelated/Reviews/ReviewReplyViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Reviews/ReviewReplyViewModelTests.swift
@@ -9,11 +9,13 @@ class ReviewReplyViewModelTests: XCTestCase {
 
     private let sampleReviewID: Int64 = 7
 
+    private let sampleProductID: Int64 = 123
+
     private var subscriptions: [AnyCancellable] = []
 
     func test_send_button_is_disabled_when_reply_content_is_empty() {
         // Given
-        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID)
+        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, productID: sampleProductID)
 
         // When
         let navigationItem = viewModel.navigationTrailingItem
@@ -24,7 +26,7 @@ class ReviewReplyViewModelTests: XCTestCase {
 
     func test_send_button_is_enabled_when_reply_is_entered() {
         // Given
-        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID)
+        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, productID: sampleProductID)
 
         // When
         viewModel.newReply = "New reply"
@@ -36,7 +38,7 @@ class ReviewReplyViewModelTests: XCTestCase {
     func test_loading_indicator_enabled_during_network_request() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, stores: stores)
+        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, productID: sampleProductID, stores: stores)
         viewModel.newReply = "New reply"
 
         // When
@@ -59,10 +61,10 @@ class ReviewReplyViewModelTests: XCTestCase {
     func test_send_button_renabled_after_network_request_completes() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, stores: stores)
+        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, productID: sampleProductID, stores: stores)
         stores.whenReceivingAction(ofType: CommentAction.self) { action in
             switch action {
-            case let .replyToComment(_, _, _, onCompletion):
+            case let .replyToComment(_, _, _, _, onCompletion):
                 onCompletion(.failure(NSError(domain: "", code: 0)))
             default:
                 XCTFail("Received unsupported action: \(action)")
@@ -84,10 +86,10 @@ class ReviewReplyViewModelTests: XCTestCase {
     func test_sendReply_completion_block_returns_true_after_successful_network_request() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, stores: stores)
+        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, productID: sampleProductID, stores: stores)
         stores.whenReceivingAction(ofType: CommentAction.self) { action in
             switch action {
-            case let .replyToComment(_, _, _, onCompletion):
+            case let .replyToComment(_, _, _, _, onCompletion):
                 onCompletion(.success(.approved))
             default:
                 XCTFail("Received unsupported action: \(action)")
@@ -109,10 +111,10 @@ class ReviewReplyViewModelTests: XCTestCase {
     func test_sendReply_completion_block_returns_false_after_failed_network_request() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, stores: stores)
+        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, productID: sampleProductID, stores: stores)
         stores.whenReceivingAction(ofType: CommentAction.self) { action in
             switch action {
-            case let .replyToComment(_, _, _, onCompletion):
+            case let .replyToComment(_, _, _, _, onCompletion):
                 onCompletion(.failure(NSError(domain: "", code: 0)))
             default:
                 XCTFail("Received unsupported action: \(action)")
@@ -134,10 +136,10 @@ class ReviewReplyViewModelTests: XCTestCase {
     func test_view_model_triggers_success_notice_after_reply_is_sent_successfully() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, stores: stores)
+        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, productID: sampleProductID, stores: stores)
         stores.whenReceivingAction(ofType: CommentAction.self) { action in
             switch action {
-            case let .replyToComment(_, _, _, onCompletion):
+            case let .replyToComment(_, _, _, _, onCompletion):
                 onCompletion(.success(.approved))
             default:
                 XCTFail("Received unsupported action: \(action)")
@@ -160,10 +162,10 @@ class ReviewReplyViewModelTests: XCTestCase {
     func test_view_model_triggers_error_notice_using_modal_notice_presenter_after_reply_fails() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, stores: stores)
+        let viewModel = ReviewReplyViewModel(siteID: sampleSiteID, reviewID: sampleReviewID, productID: sampleProductID, stores: stores)
         stores.whenReceivingAction(ofType: CommentAction.self) { action in
             switch action {
-            case let .replyToComment(_, _, _, onCompletion):
+            case let .replyToComment(_, _, _, _, onCompletion):
                 onCompletion(.failure(NSError(domain: "", code: 0)))
             default:
                 XCTFail("Received unsupported action: \(action)")

--- a/Yosemite/Yosemite/Actions/CommentAction.swift
+++ b/Yosemite/Yosemite/Actions/CommentAction.swift
@@ -25,5 +25,5 @@ public enum CommentAction: Action {
     /// Creates a comment as a reply to another comment (including product reviews).
     /// The completion closure will return the new comment's status or error (if any).
     ///
-    case replyToComment(siteID: Int64, commentID: Int64, content: String, onCompletion: (Result<CommentStatus, Error>) -> Void)
+    case replyToComment(siteID: Int64, commentID: Int64, productID: Int64, content: String, onCompletion: (Result<CommentStatus, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/CommentStore.swift
+++ b/Yosemite/Yosemite/Stores/CommentStore.swift
@@ -33,8 +33,8 @@ public class CommentStore: Store {
             updateSpamStatus(siteID: siteID, commentID: commentID, isSpam: isSpam, onCompletion: onCompletion)
         case .updateTrashStatus(let siteID, let commentID, let isTrash, let onCompletion):
             updateTrashStatus(siteID: siteID, commentID: commentID, isTrash: isTrash, onCompletion: onCompletion)
-        case .replyToComment(let siteID, let commentID, let content, let onCompletion):
-            replyToComment(siteID: siteID, commentID: commentID, content: content, onCompletion: onCompletion)
+        case .replyToComment(let siteID, let commentID, let productID, let content, let onCompletion):
+            replyToComment(siteID: siteID, commentID: commentID, productID: productID, content: content, onCompletion: onCompletion)
         }
     }
 }
@@ -73,8 +73,8 @@ private extension CommentStore {
 
     /// Creates a comment as a reply to another comment (including product reviews).
     ///
-    func replyToComment(siteID: Int64, commentID: Int64, content: String, onCompletion: @escaping (Result<CommentStatus, Error>) -> Void) {
-        remote.replyToComment(siteID: siteID, commentID: commentID, content: content) { result in
+    func replyToComment(siteID: Int64, commentID: Int64, productID: Int64, content: String, onCompletion: @escaping (Result<CommentStatus, Error>) -> Void) {
+        remote.replyToComment(siteID: siteID, commentID: commentID, productID: productID, content: content) { result in
             onCompletion(result)
         }
     }

--- a/Yosemite/YosemiteTests/Stores/CommentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CommentStoreTests.swift
@@ -262,7 +262,10 @@ class CommentStoreTests: XCTestCase {
 
         // When
         let result: Result<Yosemite.CommentStatus, Error> = waitFor { promise in
-            let action = CommentAction.replyToComment(siteID: self.sampleSiteID, commentID: self.sampleCommentID, content: "Test comment") { result in
+            let action = CommentAction.replyToComment(siteID: self.sampleSiteID,
+                                                      commentID: self.sampleCommentID,
+                                                      productID: 123,
+                                                      content: "Test comment") { result in
                 promise(result)
             }
             store.onAction(action)
@@ -281,7 +284,10 @@ class CommentStoreTests: XCTestCase {
 
         // When
         let result: Result<Yosemite.CommentStatus, Error> = waitFor { promise in
-            let action = CommentAction.replyToComment(siteID: self.sampleSiteID, commentID: self.sampleCommentID, content: "Test comment") { result in
+            let action = CommentAction.replyToComment(siteID: self.sampleSiteID,
+                                                      commentID: self.sampleCommentID,
+                                                      productID: 123,
+                                                      content: "Test comment") { result in
                 promise(result)
             }
             store.onAction(action)

--- a/Yosemite/YosemiteTests/Stores/CommentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CommentStoreTests.swift
@@ -258,7 +258,7 @@ class CommentStoreTests: XCTestCase {
         // Given
         let store = CommentStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)/replies/new", filename: "comment-moderate-approved")
+        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments", filename: "comment-moderate-approved")
 
         // When
         let result: Result<Yosemite.CommentStatus, Error> = waitFor { promise in
@@ -280,7 +280,7 @@ class CommentStoreTests: XCTestCase {
         // Given
         let store = CommentStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)/replies/new", filename: "generic_error")
+        network.simulateError(requestUrlSuffix: "sites/\(sampleSiteID)/comments", error: NetworkError.timeout)
 
         // When
         let result: Result<Yosemite.CommentStatus, Error> = waitFor { promise in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8755
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the reply comment feature:
- Switched the endpoint to `wp/v2/comments` and requires product ID as the `post` parameter.
- Updated Yosemite and UI layer to send the product ID with the request.
- Enabled the feature for users authenticated without WPCom.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable `enableSiteAddressLoginOnly` in `AuthenticationManager` to enable site address login.
- Select the Enter your store address and proceed with the address of a self-hosted site.
- Enter the correct credentials for the site to log in.
- After logging in, select Menu tap and tap the Reviews icon.
- Select any review, notice that the Reply button is present.
- Tap the Reply button and enter any content then tap Send. The reply should be sent successfully.

Please feel free to test again with a WPCom site. The reply feature should still work as before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/216513792-c4b15a33-b87d-4094-ba7b-3d526dc5d4f9.png" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
