### PR TITLE
REST API: Authenticate web view with site credentials if possible

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -1,6 +1,7 @@
 import Combine
 import UIKit
 import WebKit
+import class Networking.UserAgent
 import struct WordPressAuthenticator.WordPressOrgCredentials
 
 /// A web view which is authenticated for WordPress.com, when possible.
@@ -13,6 +14,7 @@ final class AuthenticatedWebViewController: UIViewController {
     private lazy var webView: WKWebView = {
         let webView = WKWebView(frame: .zero)
         webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.customUserAgent = UserAgent.defaultUserAgent
         webView.navigationDelegate = self
         webView.uiDelegate = self
         return webView
@@ -85,6 +87,7 @@ private extension AuthenticatedWebViewController {
         ])
 
         extendContentUnderSafeAreas()
+        webView.configureForSandboxEnvironment()
     }
 
     func extendContentUnderSafeAreas() {

--- a/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
+++ b/WooCommerce/Classes/Extensions/WKWebView+Authenticated.swift
@@ -51,4 +51,22 @@ extension WKWebView {
 
         return try URLEncoding.default.encode(request, with: parameters)
     }
+
+    /// For all test cases, to test against the staging server
+    /// please apply the following patch after replacing [secret] with a sandbox secret from the secret store.
+    ///
+    func configureForSandboxEnvironment() {
+#if DEBUG
+        if let cookie = HTTPCookie(properties: [
+            .domain: ".wordpress.com",
+            .path: "/",
+            .name: "store_sandbox",
+            .value: "[secret]",
+            .secure: "TRUE"
+        ]) {
+            configuration.websiteDataStore.httpCookieStore.setCookie(cookie) {
+            }
+        }
+#endif
+    }
 }

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModel.swift
@@ -85,7 +85,7 @@ final class JustInTimeMessageAnnouncementCardViewModel: AnnouncementCardViewMode
         let webViewModel = WebViewSheetViewModel(
             url: url,
             navigationTitle: title,
-            wpComAuthenticated: needsAuthenticatedWebView(url: url))
+            authenticated: needsAuthenticatedWebView(url: url))
         showWebViewSheet = webViewModel
     }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -88,12 +88,20 @@ struct HubMenu: View {
                 .padding(Constants.padding)
                 .background(Color(.listBackground))
             }
-            .safariSheet(isPresented: $showingWooCommerceAdmin,
-                         url: viewModel.woocommerceAdminURL,
-                         onDismiss: enableMenuItemTaps)
-            .safariSheet(isPresented: $showingViewStore,
-                         url: viewModel.storeURL,
-                         onDismiss: enableMenuItemTaps)
+            .sheet(isPresented: $showingWooCommerceAdmin, onDismiss: enableMenuItemTaps) {
+                WebViewSheet(viewModel: WebViewSheetViewModel(url: viewModel.woocommerceAdminURL,
+                                                              navigationTitle: HubMenuViewModel.Localization.woocommerceAdmin,
+                                                              authenticated: true)) {
+                    showingWooCommerceAdmin = false
+                }
+            }
+            .sheet(isPresented: $showingViewStore, onDismiss: enableMenuItemTaps) {
+                WebViewSheet(viewModel: WebViewSheetViewModel(url: viewModel.storeURL,
+                                                              navigationTitle: HubMenuViewModel.Localization.viewStore,
+                                                              authenticated: false)) {
+                    showingViewStore = false
+                }
+            }
             NavigationLink(destination:
                             InPersonPaymentsMenu()
                             .navigationTitle(InPersonPaymentsView.Localization.title),

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -250,7 +250,7 @@ extension HubMenuViewModel {
         let trackingOption: String = "debug-iap"
     }
 
-    private enum Localization {
+    enum Localization {
         static let payments = NSLocalizedString("Payments",
                                                 comment: "Title of the hub menu payments button")
         static let myStore = NSLocalizedString("My Store",

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -114,7 +114,7 @@ struct PaymentMethodsView: View {
                 viewModel: WebViewSheetViewModel(
                     url: viewModel.purchaseCardReaderUrl,
                     navigationTitle: UpsellCardReadersCampaign.Localization.cardReaderWebViewTitle,
-                    wpComAuthenticated: true),
+                    authenticated: true),
                 done: {
                     showingPurchaseCardReaderView = false
                 })

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebViewSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebViewSheet.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct WebViewSheetViewModel {
     let url: URL
     let navigationTitle: String
-    let wpComAuthenticated: Bool
+    let authenticated: Bool
 }
 
 struct WebViewSheet: View {
@@ -14,7 +14,7 @@ struct WebViewSheet: View {
     var body: some View {
         WooNavigationSheet(viewModel: .init(navigationTitle: viewModel.navigationTitle,
                                             done: done)) {
-            switch viewModel.wpComAuthenticated {
+            switch viewModel.authenticated {
             case true:
                 AuthenticatedWebView(isPresented: .constant(true),
                                      url: viewModel.url)
@@ -32,7 +32,7 @@ struct WebViewSheet_Previews: PreviewProvider {
             viewModel: WebViewSheetViewModel.init(
                 url: URL(string: "https://woocommerce.com")!,
                 navigationTitle: "WooCommerce.com",
-                wpComAuthenticated: true),
+                authenticated: true),
             done: { })
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/JustInTimeMessageAnnouncementCardViewModelTests.swift
@@ -66,7 +66,7 @@ final class JustInTimeMessageAnnouncementCardViewModelTests: XCTestCase {
 
         // Then
         let webViewViewModel = try XCTUnwrap(webviewPublishes.last)
-        XCTAssertTrue(webViewViewModel.wpComAuthenticated)
+        XCTAssertTrue(webViewViewModel.authenticated)
     }
 
     func test_ctaTapped_presents_an_authenticated_webview_for_wordpress() throws {
@@ -78,7 +78,7 @@ final class JustInTimeMessageAnnouncementCardViewModelTests: XCTestCase {
 
         // Then
         let webViewViewModel = try XCTUnwrap(webviewPublishes.last)
-        XCTAssertTrue(webViewViewModel.wpComAuthenticated)
+        XCTAssertTrue(webViewViewModel.authenticated)
     }
 
     func test_ctaTapped_presents_an_unauthenticated_webview_for_other_url() throws {
@@ -90,7 +90,7 @@ final class JustInTimeMessageAnnouncementCardViewModelTests: XCTestCase {
 
         // Then
         let webViewViewModel = try XCTUnwrap(webviewPublishes.last)
-        XCTAssertFalse(webViewViewModel.wpComAuthenticated)
+        XCTAssertFalse(webViewViewModel.authenticated)
     }
 
     func test_ctaTapped_tracks_jitm_cta_tapped_event() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8643 
Also closes: #7884 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds enhancements to the authenticated web view:
- Retrieved WPOrg credentials and authenticate the web view in `AuthenticatedWebViewController` if possible.
- Updated `AuthenticatedWebView` to use `AuthenticatedWebViewController`.
- Updated `AuthenticatedWebViewController` with custom user agent and added option to configure sandbox environment.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable `enableSiteAddressLoginOnly` in `AuthenticationManager` and build the app.
- On the prologue screen, select Enter your store address and proceed with a self-hosted store.
- Enter the correct credentials.
- When the login completes, select the Menu tab.
- Select WooCommerce Admin. A web view should be presented in authenticated mode (no login needed).
- Dismiss the view, select Open Store. Another web view should be presented showing the store.

If possible, also test the add payment method feature of shipping labels following steps in this [PR](https://github.com/woocommerce/woocommerce-ios/pull/5023). This feature should still work correctly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/216548156-7cba974b-0405-4a2f-8403-c760bde661af.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
