### PR TITLE
Update the Buildkite CI image to Xcode 14.2

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -16,7 +16,7 @@ common_params:
         repo: "automattic/woocommerce-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-14
+    IMAGE_ID: xcode-14.2
 
 steps:
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,7 @@ common_params:
   # Common environment values to use with the `env` key.
   - &common_env
     # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-    IMAGE_ID: xcode-14
+    IMAGE_ID: xcode-14.2
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -14,7 +14,7 @@ common_params:
   # Common environment values to use with the `env` key.
   - &common_env
     # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-    IMAGE_ID: xcode-14
+    IMAGE_ID: xcode-14.2
 
 steps:
 


### PR DESCRIPTION
### Summary
This PR updates the Buildkite image from `xcode-14` to `xcode-14.2`. I noticed that some of the CI nodes were spending a long time downloading the `xcode-14` image, so we shouldn't run into that again after merging this PR. 

About the "# Be sure to also update the `.xcode-version` file when updating the Xcode image/version here" comment in those files. The `.xcode-version` for WCiOS says `~> 14.0`, so we don't need to update it for this PR. 


### Testing
If CI passes, this is good to go.

