### PR TITLE
REST API: Remove A/B test and update login flow

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -14,10 +14,6 @@ public enum ABTest: String, Codable, CaseIterable {
     /// Experiment ref: pbxNRc-1S0-p2
     case aaTestLoggedOut = "woocommerceios_explat_aa_test_logged_out_202212_v2"
 
-    /// A/B test for the REST API project
-    /// Experiment ref: pbxNRc-2i4-p2
-    case applicationPasswordAuthentication = "woocommerceios_login_rest_api_project_202301_v2"
-
     /// Returns a variation for the given experiment
     ///
     public var variation: Variation? {
@@ -31,7 +27,7 @@ public enum ABTest: String, Codable, CaseIterable {
         switch self {
         case .aaTestLoggedIn:
             return .loggedIn
-        case .aaTestLoggedOut, .applicationPasswordAuthentication:
+        case .aaTestLoggedOut:
             return .loggedOut
         // Mocks
         case .mockLoggedIn:

--- a/Podfile
+++ b/Podfile
@@ -87,8 +87,8 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
 #  pod 'WordPressAuthenticator', '~> 5.1.0'
-#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '05661d2b012c21b2b1a2993fa4c1a7d2d3249ed4'
+#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 2.0'

--- a/Podfile
+++ b/Podfile
@@ -87,8 +87,8 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
 #  pod 'WordPressAuthenticator', '~> 5.1.0'
-   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '05661d2b012c21b2b1a2993fa4c1a7d2d3249ed4'
-#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 2.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -84,7 +84,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.14)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `05661d2b012c21b2b1a2993fa4c1a7d2d3249ed4`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `trunk`)
   - WordPressKit (~> 6.0)
   - WordPressShared (~> 2.0)
   - WordPressUI (~> 1.12.5)
@@ -133,12 +133,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: 05661d2b012c21b2b1a2993fa4c1a7d2d3249ed4
+    :branch: trunk
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: 05661d2b012c21b2b1a2993fa4c1a7d2d3249ed4
+    :commit: ce4e10adab0340bad721b3381ad6fefc59738af9
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -178,6 +178,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 068625578dcf035aba3f234a25600b100c535bd1
+PODFILE CHECKSUM: 069fec0d7db5d08f2248504260b92ab63bc898da
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -39,7 +39,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (5.3.0-beta.2):
+  - WordPressAuthenticator (5.4.0-beta.1):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -84,7 +84,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.14)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `trunk`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `05661d2b012c21b2b1a2993fa4c1a7d2d3249ed4`)
   - WordPressKit (~> 6.0)
   - WordPressShared (~> 2.0)
   - WordPressUI (~> 1.12.5)
@@ -133,12 +133,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :branch: trunk
+    :commit: 05661d2b012c21b2b1a2993fa4c1a7d2d3249ed4
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: 6d7f8576841863e70db08a662a3b0c48e73c75a1
+    :commit: 05661d2b012c21b2b1a2993fa4c1a7d2d3249ed4
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -162,7 +162,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: b6725385948625ec7f8c6426bc22b0ebb9c8d0d4
+  WordPressAuthenticator: cb33aace25e044c96b40957826df5e9060cb0924
   WordPressKit: 159e2ae8f5eb2c768d3cc04bdea0dedef81301a3
   WordPressShared: 35d41bdf0927e714af1fc85fa9cb692f934473be
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -178,6 +178,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 069fec0d7db5d08f2248504260b92ab63bc898da
+PODFILE CHECKSUM: 068625578dcf035aba3f234a25600b100c535bd1
 
 COCOAPODS: 1.11.3

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ApplicationPassword.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ApplicationPassword.swift
@@ -5,7 +5,6 @@ extension WooAnalyticsEvent {
         private enum Key {
             static let scenario = "scenario"
             static let cause = "cause"
-            static let experimentVariant = "experiment_variant"
         }
 
         enum Scenario: String {
@@ -18,13 +17,6 @@ extension WooAnalyticsEvent {
             case featureDisabled = "feature_disabled"
             case customLoginOrAdminUrl = "custom_login_or_admin_url"
             case other = "other"
-        }
-
-        /// Tracks the REST API A/B test variation
-        ///
-        static func restAPILoginExperiment(variation: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .trackRestAPILoginExperimentVariation,
-                              properties: [Key.experimentVariant: variation])
         }
 
         /// Tracks when generating application password succeeds

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -821,7 +821,6 @@ public enum WooAnalyticsStat: String {
     // MARK: Application password Events
     case applicationPasswordsNewPasswordCreated = "application_passwords_new_password_created"
     case applicationPasswordsGenerationFailed = "application_passwords_generation_failed"
-    case trackRestAPILoginExperimentVariation = "rest_api_login_experiment"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -102,7 +102,8 @@ class AuthenticationManager: Authentication {
                                                                 skipXMLRPCCheckForSiteAddressLogin: true,
                                                                 enableManualSiteCredentialLogin: true,
                                                                 useEnterEmailAddressAsStepValueForGetStartedVC: true,
-                                                                enableSiteAddressLoginOnlyInPrologue: true)
+                                                                enableSiteAddressLoginOnlyInPrologue: true,
+                                                                enableSiteCredentialLoginForJetpackSites: false)
 
         let systemGray3LightModeColor = UIColor(red: 199/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1)
         let systemLabelLightModeColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -55,10 +55,6 @@ class AuthenticationManager: Authentication {
     /// Keeps a reference to the use case
     private var siteCredentialLoginUseCase: SiteCredentialLoginUseCase?
 
-    private var enableSiteAddressLoginOnly: Bool {
-        abTestVariationProvider.variation(for: .applicationPasswordAuthentication) == .treatment
-    }
-
     init(storageManager: StorageManagerType = ServiceLocator.storageManager,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          analytics: Analytics = ServiceLocator.analytics,
@@ -75,7 +71,6 @@ class AuthenticationManager: Authentication {
         let isWPComMagicLinkPreferredToPassword = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasis)
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasisM2)
         let isStoreCreationMVPEnabled = featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
-        let enableSiteAddressLoginOnly = abTestVariationProvider.variation(for: .applicationPasswordAuthentication) == .treatment
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
                                                                 wpcomScheme: ApiCredentials.dotcomAuthScheme,
@@ -93,7 +88,7 @@ class AuthenticationManager: Authentication {
                                                                 enableUnifiedAuth: true,
                                                                 continueWithSiteAddressFirst: false,
                                                                 enableSiteCredentialsLoginForSelfHostedSites: true,
-                                                                isWPComLoginRequiredForSiteCredentialsLogin: !enableSiteAddressLoginOnly,
+                                                                isWPComLoginRequiredForSiteCredentialsLogin: false,
                                                                 isWPComMagicLinkPreferredToPassword: isWPComMagicLinkPreferredToPassword,
                                                                 isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen:
                                                                     isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen,
@@ -104,10 +99,10 @@ class AuthenticationManager: Authentication {
                                                                 wpcomPasswordInstructions:
                                                                 AuthenticationConstants.wpcomPasswordInstructions,
                                                                 skipXMLRPCCheckForSiteDiscovery: true,
-                                                                skipXMLRPCCheckForSiteAddressLogin: enableSiteAddressLoginOnly,
-                                                                enableManualSiteCredentialLogin: enableSiteAddressLoginOnly,
+                                                                skipXMLRPCCheckForSiteAddressLogin: true,
+                                                                enableManualSiteCredentialLogin: true,
                                                                 useEnterEmailAddressAsStepValueForGetStartedVC: true,
-                                                                enableSiteAddressLoginOnlyInPrologue: enableSiteAddressLoginOnly)
+                                                                enableSiteAddressLoginOnlyInPrologue: true)
 
         let systemGray3LightModeColor = UIColor(red: 199/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1)
         let systemLabelLightModeColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)
@@ -356,13 +351,10 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         /// save the site to memory to check for jetpack requirement in epilogue
         currentSelfHostedSite = site
 
-        let enableWPComOnlyForWPComSites = abTestVariationProvider.variation(for: .applicationPasswordAuthentication) == .treatment
-
-        switch (enableWPComOnlyForWPComSites, site.isWPCom) {
-        case (true, true), (false, _):
+        if site.isWPCom || site.isJetpackConnected {
             let authenticationResult: WordPressAuthenticatorResult = .presentEmailController
             onCompletion(authenticationResult)
-        case (true, false):
+        } else {
             let authenticationResult: WordPressAuthenticatorResult = .presentPasswordController(value: true)
             onCompletion(authenticationResult)
         }
@@ -421,10 +413,9 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             return DDLogError("⛔️ No site URL found to present Login Epilogue.")
         }
 
-        /// If the user logged in with site credentials and application password feature flag is enabled,
+        /// If the user logged in with site credentials,
         /// check if they can use the app and navigates to the home screen.
-        if let siteCredentials = credentials.wporg,
-           abTestVariationProvider.variation(for: .applicationPasswordAuthentication) == .treatment {
+        if let siteCredentials = credentials.wporg {
             return didAuthenticateUser(to: siteURL,
                                        with: siteCredentials,
                                        in: navigationController)
@@ -535,8 +526,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
     /// Synchronizes the specified WordPress Account.
     ///
     func sync(credentials: AuthenticatorCredentials, onCompletion: @escaping () -> Void) {
-        if let wporg = credentials.wporg,
-           abTestVariationProvider.variation(for: .applicationPasswordAuthentication) == .treatment {
+        if let wporg = credentials.wporg {
             ServiceLocator.stores.authenticate(credentials: .wporg(username: wporg.username,
                                                                    password: wporg.password,
                                                                    siteAddress: wporg.siteURL))

--- a/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
@@ -164,6 +164,7 @@ private extension LoginProloguePageTypeViewController {
 
         // Label contents
         titleLabel.text = pageType.title
+        titleLabel.accessibilityIdentifier = "prologue-title-label"
     }
 
     func configureSubtitle() {

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -28,7 +28,6 @@ final class AppCoordinator {
     private var authStatesSubscription: AnyCancellable?
     private var localNotificationResponsesSubscription: AnyCancellable?
     private var isLoggedIn: Bool = false
-    private let abTestVariationProvider: ABTestVariationProvider
 
     /// Checks on whether the Apple ID credential is valid when the app is logged in and becomes active.
     ///
@@ -42,8 +41,7 @@ final class AppCoordinator {
          analytics: Analytics = ServiceLocator.analytics,
          loggedOutAppSettings: LoggedOutAppSettingsProtocol = LoggedOutAppSettings(userDefaults: .standard),
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         abTestVariationProvider: ABTestVariationProvider = CachedABTestVariationProvider()) {
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.window = window
         self.tabBarController = {
             let storyboard = UIStoryboard(name: "Main", bundle: nil) // Main is the name of storyboard
@@ -60,7 +58,6 @@ final class AppCoordinator {
         self.loggedOutAppSettings = loggedOutAppSettings
         self.pushNotesManager = pushNotesManager
         self.featureFlagService = featureFlagService
-        self.abTestVariationProvider = abTestVariationProvider
 
         authenticationManager.setLoggedOutAppSettings(loggedOutAppSettings)
 
@@ -147,9 +144,6 @@ private extension AppCoordinator {
         } else {
             configureAndDisplayAuthenticator()
         }
-
-        let applicationPasswordABTestVariation = abTestVariationProvider.variation(for: .applicationPasswordAuthentication)
-        analytics.track(event: .ApplicationPassword.restAPILoginExperiment(variation: applicationPasswordABTestVariation.analyticsValue))
     }
 
     /// Configures the WPAuthenticator and sets the authenticator UI as the window's root view.

--- a/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
@@ -43,4 +43,8 @@ public final class PrologueScreen: ScreenObject {
     public func isSiteAddressLoginAvailable() throws -> Bool {
         selectSiteButton.waitForExistence(timeout: 1)
     }
+
+    public func isWPComLoginAvailable() throws -> Bool {
+        continueButton.waitForExistence(timeout: 1)
+    }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
@@ -3,6 +3,10 @@ import XCTest
 
 public final class PrologueScreen: ScreenObject {
 
+    private let titleLabelGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["prologue-title-label"]
+    }
+
     private let continueButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Prologue Continue Button"]
     }
@@ -17,8 +21,9 @@ public final class PrologueScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
-                continueButtonGetter,
-                selectSiteButtonGetter
+                /// due to the changes of CTAs on the prologue screen,
+                /// it is safer to check for the title label only.
+                titleLabelGetter
             ],
             app: app
         )

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -321,31 +321,6 @@ final class AppCoordinatorTests: XCTestCase {
         _ = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.loginOnboardingShown.rawValue}))
     }
 
-    func test_trackRestAPILoginExperimentVariation_is_tracked_after_presenting_onboarding() throws {
-        // Given
-        stores.deauthenticate()
-        let analytics = MockAnalyticsProvider()
-
-        let mockABTestVariationProvider = MockABTestVariationProvider()
-        mockABTestVariationProvider.mockVariationValue = .control
-
-        let appCoordinator = makeCoordinator(window: window,
-                                             stores: stores,
-                                             authenticationManager: authenticationManager,
-                                             analytics: WooAnalytics(analyticsProvider: analytics),
-                                             abTestVariationProvider: mockABTestVariationProvider)
-
-        // When
-        appCoordinator.start()
-
-        // Then
-        let indexOfEvent = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == "rest_api_login_experiment" }))
-        let eventProperties = try XCTUnwrap(analytics.receivedProperties[indexOfEvent])
-
-        let variant = try XCTUnwrap(eventProperties["experiment_variant"] as? String)
-        XCTAssertEqual(variant, "control")
-    }
-
     // MARK: - Login reminder analytics
 
     func test_loginLocalNotificationTapped_is_tracked_after_notification_contact_support_action() throws {
@@ -460,8 +435,7 @@ private extension AppCoordinatorTests {
                          analytics: Analytics = ServiceLocator.analytics,
                          loggedOutAppSettings: LoggedOutAppSettingsProtocol = MockLoggedOutAppSettings(),
                          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
-                         featureFlagService: FeatureFlagService = MockFeatureFlagService(),
-                         abTestVariationProvider: ABTestVariationProvider = CachedABTestVariationProvider()) -> AppCoordinator {
+                         featureFlagService: FeatureFlagService = MockFeatureFlagService()) -> AppCoordinator {
         return AppCoordinator(window: window ?? self.window,
                               stores: stores ?? self.stores,
                               storageManager: storageManager ?? self.storageManager,
@@ -470,7 +444,6 @@ private extension AppCoordinatorTests {
                               analytics: analytics,
                               loggedOutAppSettings: loggedOutAppSettings,
                               pushNotesManager: pushNotesManager,
-                              featureFlagService: featureFlagService,
-                              abTestVariationProvider: abTestVariationProvider)
+                              featureFlagService: featureFlagService)
     }
 }

--- a/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
@@ -3,6 +3,15 @@ import XCTest
 
 class LoginFlow {
 
+    /// Attempts to log in with WPCom if the CTA is available, otherwise try site address login.
+    @discardableResult
+    static func login() throws -> MyStoreScreen {
+        if try PrologueScreen().isWPComLoginAvailable() {
+            return try logInWithWPcom()
+        }
+        return try logInWithSiteAddress()
+    }
+
     @discardableResult
     static func logInWithWPcom() throws -> MyStoreScreen {
         try PrologueScreen().selectContinueWithWordPress()
@@ -12,5 +21,15 @@ class LoginFlow {
         return try LoginEpilogueScreen()
             .verifyEpilogueDisplays(email: "e2eflowtestingmobile@example.com", siteUrl: TestCredentials.siteUrl)
             .continueWithSelectedSite()
+    }
+
+    @discardableResult
+    static func logInWithSiteAddress() throws -> MyStoreScreen {
+        try PrologueScreen()
+            .selectSiteAddress()
+            .proceedWith(siteUrl: TestCredentials.siteUrl)
+            .proceedWith(email: TestCredentials.emailAddress)
+            .proceedWith(password: TestCredentials.password)
+        return try MyStoreScreen()
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -12,7 +12,7 @@ final class LoginTests: XCTestCase {
     }
 
     func test_site_address_login_logout() throws {
-        // do not test this case for simplified login since site address login is not available
+        // do not test this case if site address login is not available
         guard try PrologueScreen().isSiteAddressLoginAvailable() else {
             return
         }
@@ -31,7 +31,10 @@ final class LoginTests: XCTestCase {
     }
 
     func test_WordPress_login_logout() throws {
-
+        // do not test this case if wpcom login is not available
+        guard try PrologueScreen().isWPComLoginAvailable() else {
+            return
+        }
         try PrologueScreen().selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
@@ -49,6 +52,10 @@ final class LoginTests: XCTestCase {
     }
 
     func test_WordPress_unsuccessfull_login() throws {
+        // do not test this case if wpcom login is not available
+        guard try PrologueScreen().isWPComLoginAvailable() else {
+            return
+        }
         _ = try PrologueScreen().selectContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .tryProceed(password: "invalidPswd")

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -10,7 +10,7 @@ final class OrdersTests: XCTestCase {
         let app = XCUIApplication()
         app.launchArguments = ["logout-at-launch", "disable-animations", "mocked-wpcom-api", "-ui_testing"]
         app.launch()
-        try LoginFlow.logInWithWPcom()
+        try LoginFlow.login()
     }
 
     func test_load_orders_screen() throws {

--- a/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
@@ -9,7 +9,7 @@ final class ProductsTests: XCTestCase {
         let app = XCUIApplication()
         app.launchArguments = ["logout-at-launch", "disable-animations", "mocked-wpcom-api", "-ui_testing"]
         app.launch()
-        try LoginFlow.logInWithWPcom()
+        try LoginFlow.login()
     }
 
     func test_load_products_screen() throws {

--- a/WooCommerce/WooCommerceUITests/Tests/ReviewsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/ReviewsTests.swift
@@ -9,7 +9,7 @@ final class ReviewsTests: XCTestCase {
         let app = XCUIApplication()
         app.launchArguments = ["logout-at-launch", "disable-animations", "mocked-wpcom-api", "-ui_testing"]
         app.launch()
-        try LoginFlow.logInWithWPcom()
+        try LoginFlow.login()
 
         // Extra step needed to get products mock data to appear on Reviews screen
         // GH Issue: https://github.com/woocommerce/woocommerce-ios/issues/1907

--- a/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
@@ -11,7 +11,7 @@ final class StatsTests: XCTestCase {
         app.launchArguments = ["logout-at-launch", "disable-animations", "mocked-wpcom-api", "-ui_testing"]
         app.launch()
 
-        try LoginFlow.logInWithWPcom()
+        try LoginFlow.login()
     }
 
     func test_load_stats_screen() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8845 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes the A/B experiment for application password authentication and updates the login flow:
- Always show only the entry point to site address login on the prologue screen - WPCom login is hidden.
- When an address is entered, we do the following checks:
   - If the site is WPCom, show the WPCom login flow.
   - If the site is not WPCom but has Jetpack installed, activated and connected: show the WPCom login flow.
   - If the site is not WPCom and Jetpack is not installed, activated or connected: show the site credential login flow.

Unit tests have been updated accordingly. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
**1. Log in to a WPCom site:**
- Log out of the app or skip onboarding if needed.
- On the prologue screen, notice that there are only 2 CTAs: Enter your site address and Get started.
- Tap Enter your site address and proceed with the address of your WPCom site.
- Notice that the WPCom email screen is displayed. Proceed to log in with your WPCom credentials.
- When the login completes, you should be navigated to the home screen.

**2. Log in to a self-hosted site with Jetpack:**
- Log out of the app or skip onboarding if needed.
- Tap Enter your site address and proceed with the address of your self-hosted site that has Jetpack installed and connected to a WPCom account.
- Notice that the WPCom email screen is displayed. Proceed to log in with your WPCom credentials.
- When the login completes, you should be navigated to the home screen.
- All features should be available: site switching, notifications, site visitors on the dashboard, password-protected product visibility.

**3. Log in to a self-hosted site without Jetpack.**
- Log out of the app or skip onboarding if needed.
- Tap Enter your site address and proceed with the address of your self-hosted site that doesn't have Jetpack installed, activated or connected to a WPCom account.
- Notice that the site credential screen is then displayed. Proceed to log in with your site credentials.
- When the login completes, you should be navigated to the home screen.
- Notice that a few features are missing:
   - Site visitors on the dashboard.
   - Site switching on the Menu tab.
   - Notifications for new orders or reviews.
   - Password-protected visibility for products.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
