### PR TITLE
Update domain settings data

### DIFF
--- a/Networking/NetworkingTests/Remote/DomainRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/DomainRemoteTests.swift
@@ -105,9 +105,9 @@ final class DomainRemoteTests: XCTestCase {
         dateFormatter.dateFormat = "MMMM d, yyyy"
         let renewalDate = try XCTUnwrap(dateFormatter.date(from: "December 10, 2023"))
         XCTAssertEqual(domains, [
-            .init(name: "crabparty.wpcomstaging.com", isPrimary: true),
-            .init(name: "crabparty.com", isPrimary: false, renewalDate: renewalDate),
-            .init(name: "crabparty.wordpress.com", isPrimary: false)
+            .init(name: "crabparty.wpcomstaging.com", isPrimary: true, isWPCOMStagingDomain: true, type: .wpcom),
+            .init(name: "crabparty.com", isPrimary: false, isWPCOMStagingDomain: false, type: .mapping, renewalDate: renewalDate),
+            .init(name: "crabparty.wordpress.com", isPrimary: false, isWPCOMStagingDomain: false, type: .mapping)
         ])
     }
 

--- a/Networking/NetworkingTests/Remote/DomainRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/DomainRemoteTests.swift
@@ -104,10 +104,10 @@ final class DomainRemoteTests: XCTestCase {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MMMM d, yyyy"
         let renewalDate = try XCTUnwrap(dateFormatter.date(from: "December 10, 2023"))
-        XCTAssertEqual(domains, [
+        assertEqual(domains, [
             .init(name: "crabparty.wpcomstaging.com", isPrimary: true, isWPCOMStagingDomain: true, type: .wpcom),
             .init(name: "crabparty.com", isPrimary: false, isWPCOMStagingDomain: false, type: .mapping, renewalDate: renewalDate),
-            .init(name: "crabparty.wordpress.com", isPrimary: false, isWPCOMStagingDomain: false, type: .mapping)
+            .init(name: "crabparty.wordpress.com", isPrimary: false, isWPCOMStagingDomain: false, type: .wpcom)
         ])
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
@@ -143,9 +143,9 @@ struct DomainSettingsView_Previews: PreviewProvider {
                               stores: DomainSettingsViewStores(
                                 // There is one free domain and two paid domains.
                                 domainsResult: .success([
-                                    .init(name: "free.test", isPrimary: true),
-                                    .init(name: "one.test", isPrimary: false, renewalDate: .distantFuture),
-                                    .init(name: "duo.test", isPrimary: true, renewalDate: .now)
+                                    .init(name: "free.test", isPrimary: true, isWPCOMStagingDomain: true, type: .wpcom),
+                                    .init(name: "one.test", isPrimary: false, isWPCOMStagingDomain: false, type: .mapping, renewalDate: .distantFuture),
+                                    .init(name: "duo.test", isPrimary: true, isWPCOMStagingDomain: false, type: .mapping, renewalDate: .now)
                                 ]),
                                 // The site has domain credit.
                                 sitePlanResult: .success(.init(hasDomainCredit: true)))),
@@ -158,7 +158,7 @@ struct DomainSettingsView_Previews: PreviewProvider {
                               stores: DomainSettingsViewStores(
                                 // There is one free domain and no other paid domains.
                                 domainsResult: .success([
-                                    .init(name: "free.test", isPrimary: true)
+                                    .init(name: "free.test", isPrimary: true, isWPCOMStagingDomain: true, type: .wpcom)
                                 ]),
                                 sitePlanResult: .success(.init(hasDomainCredit: true)))),
                                    addDomain: { _, _ in })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsViewModel.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// View model for `DomainSettingsView`.
 final class DomainSettingsViewModel: ObservableObject {
-    struct Domain {
+    struct Domain: Equatable {
         /// Whether the domain is the site's primary domain.
         let isPrimary: Bool
 
@@ -14,7 +14,7 @@ final class DomainSettingsViewModel: ObservableObject {
         let autoRenewalDate: Date?
     }
 
-    struct FreeStagingDomain {
+    struct FreeStagingDomain: Equatable {
         /// Whether the domain is the site's primary domain.
         let isPrimary: Bool
 
@@ -68,10 +68,10 @@ private extension DomainSettingsViewModel {
     func handleDomainsResult(_ result: Result<[SiteDomain], Error>) {
         switch result {
         case .success(let domains):
-            let stagingDomain = domains.first(where: { $0.renewalDate == nil })
+            let stagingDomain = domains.first(where: { $0.isWPCOMStagingDomain || $0.type == .wpcom })
             freeStagingDomain = stagingDomain
                 .map { FreeStagingDomain(isPrimary: $0.isPrimary, name: $0.name) }
-            self.domains = domains.filter { $0 != stagingDomain }
+            self.domains = domains.filter { $0 != stagingDomain && $0.type != .wpcom }
                 .map { Domain(isPrimary: $0.isPrimary, name: $0.name, autoRenewalDate: $0.renewalDate) }
         case .failure(let error):
             DDLogError("⛔️ Error retrieving domains for siteID \(siteID): \(error)")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsViewModel.swift
@@ -68,10 +68,10 @@ private extension DomainSettingsViewModel {
     func handleDomainsResult(_ result: Result<[SiteDomain], Error>) {
         switch result {
         case .success(let domains):
-            let stagingDomain = domains.first(where: { $0.isWPCOMStagingDomain || $0.type == .wpcom })
-            freeStagingDomain = stagingDomain
+            let stagingOrWPCOMDomain = domains.first(where: { $0.isWPCOMStagingDomain || $0.type == .wpcom })
+            freeStagingDomain = stagingOrWPCOMDomain
                 .map { FreeStagingDomain(isPrimary: $0.isPrimary, name: $0.name) }
-            self.domains = domains.filter { $0 != stagingDomain && $0.type != .wpcom }
+            self.domains = domains.filter { $0 != stagingOrWPCOMDomain && $0.type != .wpcom }
                 .map { Domain(isPrimary: $0.isPrimary, name: $0.name, autoRenewalDate: $0.renewalDate) }
         case .failure(let error):
             DDLogError("⛔️ Error retrieving domains for siteID \(siteID): \(error)")

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		02312797277D4F650060E180 /* StoreStatsPeriodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02312796277D4F640060E180 /* StoreStatsPeriodViewModel.swift */; };
 		023453F22579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023453F12579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift */; };
 		0234680A282CEA5F00CFC503 /* ReceiptViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02346809282CEA5F00CFC503 /* ReceiptViewModelTests.swift */; };
+		0235354E2999D17A00BF77D3 /* DomainSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0235354D2999D17A00BF77D3 /* DomainSettingsViewModelTests.swift */; };
 		0235595024496853004BE2B8 /* BottomSheetListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0235594E24496853004BE2B8 /* BottomSheetListSelectorViewController.swift */; };
 		0235595124496853004BE2B8 /* BottomSheetListSelectorViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0235594F24496853004BE2B8 /* BottomSheetListSelectorViewController.xib */; };
 		0235595324496A93004BE2B8 /* BottomSheetListSelectorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0235595224496A93004BE2B8 /* BottomSheetListSelectorViewProperties.swift */; };
@@ -2237,6 +2238,7 @@
 		02312796277D4F640060E180 /* StoreStatsPeriodViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsPeriodViewModel.swift; sourceTree = "<group>"; };
 		023453F12579DA1A00A6BB20 /* ShippingLabelPrintingInstructionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintingInstructionsViewController.swift; sourceTree = "<group>"; };
 		02346809282CEA5F00CFC503 /* ReceiptViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptViewModelTests.swift; sourceTree = "<group>"; };
+		0235354D2999D17A00BF77D3 /* DomainSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		0235594E24496853004BE2B8 /* BottomSheetListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelectorViewController.swift; sourceTree = "<group>"; };
 		0235594F24496853004BE2B8 /* BottomSheetListSelectorViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BottomSheetListSelectorViewController.xib; sourceTree = "<group>"; };
 		0235595224496A93004BE2B8 /* BottomSheetListSelectorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelectorViewProperties.swift; sourceTree = "<group>"; };
@@ -5239,6 +5241,7 @@
 			children = (
 				02DAE7FE291B8C8A009342B7 /* FreeDomainSelectorViewModelTests.swift */,
 				022C7D7629793ABE0036568D /* PaidDomainSelectorDataProviderTests.swift */,
+				0235354D2999D17A00BF77D3 /* DomainSettingsViewModelTests.swift */,
 			);
 			path = Domains;
 			sourceTree = "<group>";
@@ -11574,6 +11577,7 @@
 				FE3E427726A8545B00C596CE /* MockRoleEligibilityUseCase.swift in Sources */,
 				02F67FF525806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift in Sources */,
 				2602A64227BD89CE00B347F1 /* NewOrderInitialStatusResolverTests.swift in Sources */,
+				0235354E2999D17A00BF77D3 /* DomainSettingsViewModelTests.swift in Sources */,
 				4535EE80281BE4E0004212B4 /* CouponAmountInputFormatterTests.swift in Sources */,
 				570AAB052472FACB00516C0C /* OrderDetailsDataSourceTests.swift in Sources */,
 				CC77488E2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewModels/Domains/DomainSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Domains/DomainSettingsViewModelTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class DomainSettingsViewModelTests: XCTestCase {
+    private var stores: MockStoresManager!
+    private var viewModel: DomainSettingsViewModel!
+
+    override func setUp() {
+        super.setUp()
+        stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+        viewModel = DomainSettingsViewModel(siteID: 134, stores: stores)
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        stores = nil
+        super.tearDown()
+    }
+
+    // MARK: - `freeStagingDomain`
+
+    func test_onAppear_sets_freeStagingDomain_from_first_domain_matching_isWPCOMStagingDomain() async throws {
+        // Given
+        mockLoadDomains(result: .success([
+            .init(name: "woo.dm", isPrimary: false, isWPCOMStagingDomain: false, type: .mapping),
+            .init(name: "woo.wpcomstaging.com", isPrimary: true, isWPCOMStagingDomain: true, type: .mapping),
+            .init(name: "another.woo.wpcomstaging.com", isPrimary: true, isWPCOMStagingDomain: false, type: .wpcom)
+        ]))
+        mockLoadSiteCurrentPlan(result: .success(.init(hasDomainCredit: false)))
+
+        // When
+        await viewModel.onAppear()
+
+        // Then
+        XCTAssertEqual(viewModel.freeStagingDomain, .init(isPrimary: true, name: "woo.wpcomstaging.com"))
+    }
+
+    func test_onAppear_sets_freeStagingDomain_from_first_domain_matching_type() async throws {
+        // Given
+        mockLoadDomains(result: .success([
+            .init(name: "woo.dm", isPrimary: false, isWPCOMStagingDomain: false, type: .mapping),
+            .init(name: "woo.wordpress.com", isPrimary: true, isWPCOMStagingDomain: false, type: .wpcom),
+            .init(name: "woo.wpcomstaging.com", isPrimary: true, isWPCOMStagingDomain: true, type: .mapping)
+        ]))
+        mockLoadSiteCurrentPlan(result: .success(.init(hasDomainCredit: false)))
+
+        // When
+        await viewModel.onAppear()
+
+        // Then
+        XCTAssertEqual(viewModel.freeStagingDomain, .init(isPrimary: true, name: "woo.wordpress.com"))
+    }
+
+    func test_onAppear_sets_freeStagingDomain_to_nil_when_no_domain_matches_isWPCOMStagingDomain_and_type() async throws {
+        // Given
+        mockLoadDomains(result: .success([
+            .init(name: "woo.com", isPrimary: true, isWPCOMStagingDomain: false, type: .mapping)
+        ]))
+        mockLoadSiteCurrentPlan(result: .success(.init(hasDomainCredit: false)))
+
+        // When
+        await viewModel.onAppear()
+
+        // Then
+        XCTAssertNil(viewModel.freeStagingDomain)
+    }
+
+    // MARK: - `domains`
+
+    func test_onAppear_sets_domains_to_non_wpcom_domains() async throws {
+        // Given
+        mockLoadDomains(result: .success([
+            .init(name: "woo.wpcomstaging.com", isPrimary: true, isWPCOMStagingDomain: true, type: .wpcom),
+            .init(name: "woo.com", isPrimary: true, isWPCOMStagingDomain: true, type: .mapping),
+            .init(name: "woo.wordpress.com", isPrimary: true, isWPCOMStagingDomain: false, type: .wpcom),
+        ]))
+        mockLoadSiteCurrentPlan(result: .success(.init(hasDomainCredit: false)))
+        XCTAssertEqual(viewModel.domains, [])
+
+        // When
+        await viewModel.onAppear()
+
+        // Then
+        XCTAssertEqual(viewModel.domains, [.init(isPrimary: true, name: "woo.com", autoRenewalDate: nil)])
+    }
+}
+
+private extension DomainSettingsViewModelTests {
+    func mockLoadDomains(result: Result<[SiteDomain], Error>) {
+        stores.whenReceivingAction(ofType: DomainAction.self) { action in
+            guard case let .loadDomains(_, completion) = action else {
+                return XCTFail()
+            }
+            completion(result)
+        }
+    }
+
+    func mockLoadSiteCurrentPlan(result: Result<WPComSitePlan, Error>) {
+        stores.whenReceivingAction(ofType: PaymentAction.self) { action in
+            guard case let .loadSiteCurrentPlan(_, completion) = action else {
+                return XCTFail()
+            }
+            completion(result)
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/DomainStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/DomainStoreTests.swift
@@ -142,8 +142,8 @@ final class DomainStoreTests: XCTestCase {
     func test_loadDomains_returns_domains_on_success() throws {
         // Given
         remote.whenLoadingDomains(thenReturn: .success([
-            .init(name: "candy.land", isPrimary: true, renewalDate: .distantFuture),
-            .init(name: "pods.pro", isPrimary: true)
+            .init(name: "candy.land", isPrimary: true, isWPCOMStagingDomain: true, type: .wpcom, renewalDate: .distantFuture),
+            .init(name: "pods.pro", isPrimary: true, isWPCOMStagingDomain: false, type: .mapping)
         ]))
 
         // When
@@ -157,8 +157,8 @@ final class DomainStoreTests: XCTestCase {
         XCTAssertTrue(result.isSuccess)
         let suggestions = try XCTUnwrap(result.get())
         XCTAssertEqual(suggestions, [
-            .init(name: "candy.land", isPrimary: true, renewalDate: .distantFuture),
-            .init(name: "pods.pro", isPrimary: true)
+            .init(name: "candy.land", isPrimary: true, isWPCOMStagingDomain: true, type: .wpcom, renewalDate: .distantFuture),
+            .init(name: "pods.pro", isPrimary: true, isWPCOMStagingDomain: false, type: .mapping)
         ])
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8558 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After checking the web code as summarized in parts of pe5sF9-16Z-p2, I made two major changes in this PR to match the data on the domain settings screen:

- Free staging domain: it is the first domain that matches either `type == "wpcom"` or `is_wpcom_staging_domain == true` from the site domains API
- Domain list: the list should not contain any WPCOM domains by excluding domains with `type == "wpcom"`

I also added some test cases for the view model on these changes.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: a WC store **with a WPCOM plan** is required

- Log in if needed, and continue with a WPCOM store
- Go to the Menu tab
- Tap on the settings CTA
- Tap the `Domain` row --> the free staging domain should be either `*.wpcomstaging.com` or `*.wordpress.com`, and the list below (if any) should not contain any WPCOM domains (`*.wpcomstaging.com` or `*.wordpress.com`)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

free staging domain | domain list
-- | --
![Simulator Screen Shot - iPhone 14 - 2023-02-13 at 10 02 09 copy](https://user-images.githubusercontent.com/1945542/218394359-2474cebb-de77-402a-bff1-15e548575f92.png) | ![Simulator Screen Shot - iPhone 14 - 2023-02-13 at 10 02 09 copy 2](https://user-images.githubusercontent.com/1945542/218394352-17a63e29-9c40-4ac7-bb94-6802ec471992.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.