### PR TITLE
REST API: Add new tag for users authenticated with application password

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,10 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+12.4
+-----
+- [Internal] Prologue screen now has only the entry point to site address login flow, and application password authentication is used for sites without Jetpack. [https://github.com/woocommerce/woocommerce-ios/pull/8846]
+- [Internal] A new tag has been added for Zendesk for users authenticated with application password. [https://github.com/woocommerce/woocommerce-ios/pull/8850]
+
 12.3
 -----
 - [Internal] We have updated the Zendesk SDK to version 6.0 [https://github.com/woocommerce/woocommerce-ios/pull/8828]

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -531,6 +531,10 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
             decoratedTags.append(sourceTagOrigin)
         }
 
+        if ServiceLocator.stores.isAuthenticatedWithoutWPCom {
+            decoratedTags.append(Constants.authenticatedWithApplicationPasswordTag)
+        }
+
         return decoratedTags
     }
 }
@@ -1243,6 +1247,7 @@ private extension ZendeskManager {
         static let blogSeperator = "\n----------\n"
         static let jetpackTag = "jetpack"
         static let wpComTag = "wpcom"
+        static let authenticatedWithApplicationPasswordTag = "application_password_authenticated"
         static let logFieldCharacterLimit = 64000
         static let networkWiFi = "WiFi"
         static let networkWWAN = "Mobile"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8849
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new tag for Zendesk tickets when the user is authenticated with application password.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Ensure that you have a self-hosted site with Woo but no Jetpack (e.g a JN site).
- Log out of the app or skip onboarding if needed.
- Tap Enter your site address and proceed with the address of your test site.
- Notice that the site credential screen is then displayed. Proceed to log in with your site credentials.
- When the login completes, you should be navigated to the home screen.
- Navigate to Menu tab and select Settings.
- Select Help & Support and proceed to Contact Support.
- Enter a non-A8C email address in the prompt if needed. Then submit a ticket with a message to indicate that it is for testing purpose only since we don't have the permission to close tickets.
- Log in to Zendesk on the web and search for tickets with the tag `application_password_authenticated`. Make sure that you can find your submitted ticket.
- Open the ticket, notice that tag in the tag list.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="291" alt="Screenshot 2023-02-13 at 17 40 47" src="https://user-images.githubusercontent.com/5533851/218441229-36baa8d6-6525-4f11-b7a1-21101b027823.png">


---
- [ x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
