### PR TITLE
[Support Request] Expose Zendesk CreateIdentity method

### DIFF
--- a/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
+++ b/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
@@ -78,6 +78,10 @@ final class MockZendeskManager: ZendeskManagerProtocol {
 }
 
 extension MockZendeskManager {
+    func createIdentity(presentIn viewController: UIViewController, completion: @escaping (Bool) -> Void) {
+        // no-op
+    }
+
     func createSupportRequest(formID: Int64,
                               customFields: [Int64: String],
                               tags: [String],


### PR DESCRIPTION
Closes: #8829 

# Why

This PR simply exposes the `createIdentity` method from `ZendeskManager`. 
This is done to be able to use the method from the new support form. 
This PR does not change any login so it doesn't require any testing.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
