### PR TITLE
[Mobile Payments] Move Payment Gateway and Reader state to analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -974,6 +974,12 @@ extension WooAnalyticsEvent {
             gatewayID ?? unknownGatewayID
         }
 
+        static let noReaderConnected = "none_connected"
+
+        static func readerModel(for connectedReaderModel: String?) -> String {
+            connectedReaderModel ?? noReaderConnected
+        }
+
         /// Tracked when we ask the user to choose between Built In and Bluetooth readers
         /// at the start of the connection flow
         ///
@@ -1065,9 +1071,9 @@ extension WooAnalyticsEvent {
         static func cardReaderConnectionSuccess(forGatewayID: String?,
                                                 batteryLevel: Float?,
                                                 countryCode: String,
-                                                cardReaderModel: String) -> WooAnalyticsEvent {
+                                                cardReaderModel: String?) -> WooAnalyticsEvent {
             var properties = [
-                Keys.cardReaderModel: cardReaderModel,
+                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                 Keys.countryCode: countryCode,
                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
             ]
@@ -1087,10 +1093,10 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderConnectionFailed(forGatewayID: String?, error: Error, countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
+        static func cardReaderConnectionFailed(forGatewayID: String?, error: Error, countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderConnectionFailed,
                               properties: [
-                                Keys.cardReaderModel: cardReaderModel,
+                                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.errorDescription: error.localizedDescription
@@ -1106,10 +1112,10 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderDisconnectTapped(forGatewayID: String?, countryCode: String, cardReaderModel: String) -> WooAnalyticsEvent {
+        static func cardReaderDisconnectTapped(forGatewayID: String?, countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderDisconnectTapped,
                               properties: [
-                                Keys.cardReaderModel: cardReaderModel,
+                                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
                               ]
@@ -1127,10 +1133,10 @@ extension WooAnalyticsEvent {
         static func cardReaderSoftwareUpdateTapped(forGatewayID: String?,
                                                    updateType: SoftwareUpdateTypeProperty,
                                                    countryCode: String,
-                                                   cardReaderModel: String) -> WooAnalyticsEvent {
+                                                   cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateTapped,
                               properties: [
-                                Keys.cardReaderModel: cardReaderModel,
+                                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
@@ -1149,10 +1155,10 @@ extension WooAnalyticsEvent {
         static func cardReaderSoftwareUpdateStarted(forGatewayID: String?,
                                                     updateType: SoftwareUpdateTypeProperty,
                                                     countryCode: String,
-                                                    cardReaderModel: String) -> WooAnalyticsEvent {
+                                                    cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateStarted,
                               properties: [
-                                Keys.cardReaderModel: cardReaderModel,
+                                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
@@ -1177,7 +1183,7 @@ extension WooAnalyticsEvent {
         ) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateFailed,
                               properties: [
-                                Keys.cardReaderModel: cardReaderModel,
+                                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue,
@@ -1197,10 +1203,10 @@ extension WooAnalyticsEvent {
         static func cardReaderSoftwareUpdateSuccess(forGatewayID: String?,
                                                     updateType: SoftwareUpdateTypeProperty,
                                                     countryCode: String,
-                                                    cardReaderModel: String) -> WooAnalyticsEvent {
+                                                    cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateSuccess,
                               properties: [
-                                Keys.cardReaderModel: cardReaderModel,
+                                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
@@ -1219,10 +1225,10 @@ extension WooAnalyticsEvent {
         static func cardReaderSoftwareUpdateCancelTapped(forGatewayID: String?,
                                                          updateType: SoftwareUpdateTypeProperty,
                                                          countryCode: String,
-                                                         cardReaderModel: String) -> WooAnalyticsEvent {
+                                                         cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateCancelTapped,
                               properties: [
-                                Keys.cardReaderModel: cardReaderModel,
+                                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
@@ -1241,10 +1247,10 @@ extension WooAnalyticsEvent {
         static func cardReaderSoftwareUpdateCanceled(forGatewayID: String?,
                                                      updateType: SoftwareUpdateTypeProperty,
                                                      countryCode: String,
-                                                     cardReaderModel: String) -> WooAnalyticsEvent {
+                                                     cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSoftwareUpdateCanceled,
                               properties: [
-                                Keys.cardReaderModel: cardReaderModel,
+                                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
@@ -1306,11 +1312,11 @@ extension WooAnalyticsEvent {
         ///
         static func collectPaymentCanceled(forGatewayID: String?,
                                            countryCode: String,
-                                           cardReaderModel: String,
+                                           cardReaderModel: String?,
                                            cancellationSource: CancellationSource) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentCanceled,
                               properties: [
-                                Keys.cardReaderModel: cardReaderModel,
+                                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                                 Keys.cancellationSource: cancellationSource.rawValue
@@ -1343,15 +1349,15 @@ extension WooAnalyticsEvent {
         static func collectPaymentSuccess(forGatewayID: String?,
                                           countryCode: String,
                                           paymentMethod: PaymentMethod,
-                                          cardReaderModel: String,
+                                          cardReaderModel: String?,
                                           millisecondsSinceOrderAddNew: Int64?,
                                           millisecondsSinceCardPaymentStarted: Int64?) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [
-                Keys.cardReaderModel: cardReaderModel,
+                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                 Keys.countryCode: countryCode,
                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                 Keys.paymentMethodType: paymentMethod.analyticsValue
-              ]
+            ]
 
             if let lapseSinceLastOrderAddNew = millisecondsSinceOrderAddNew {
                 properties[Orders.GlobalKeys.millisecondsSinceOrderAddNew] = lapseSinceLastOrderAddNew
@@ -1375,10 +1381,10 @@ extension WooAnalyticsEvent {
         ///
         static func collectInteracPaymentSuccess(gatewayID: String?,
                                                  countryCode: String,
-                                                 cardReaderModel: String) -> WooAnalyticsEvent {
+                                                 cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectInteracPaymentSuccess,
                               properties: [
-                                Keys.cardReaderModel: cardReaderModel,
+                                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID)
                               ])
@@ -1393,10 +1399,10 @@ extension WooAnalyticsEvent {
         ///
         static func interacRefundSuccess(gatewayID: String?,
                                          countryCode: String,
-                                         cardReaderModel: String) -> WooAnalyticsEvent {
+                                         cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .interacRefundSuccess,
                               properties: [
-                                Keys.cardReaderModel: cardReaderModel,
+                                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID)
                               ])
@@ -1413,10 +1419,10 @@ extension WooAnalyticsEvent {
         static func interacRefundFailed(error: Error,
                                         gatewayID: String?,
                                         countryCode: String,
-                                        cardReaderModel: String) -> WooAnalyticsEvent {
+                                        cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .interacRefundFailed,
                               properties: [
-                                Keys.cardReaderModel: cardReaderModel,
+                                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID)
                               ],
@@ -1432,10 +1438,10 @@ extension WooAnalyticsEvent {
         ///
         static func interacRefundCanceled(gatewayID: String?,
                                           countryCode: String,
-                                          cardReaderModel: String) -> WooAnalyticsEvent {
+                                          cardReaderModel: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .interacRefundCanceled,
                               properties: [
-                                Keys.cardReaderModel: cardReaderModel,
+                                Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID)
                               ])

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptActionCoordinator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptActionCoordinator.swift
@@ -7,7 +7,7 @@ struct ReceiptActionCoordinator {
                              countryCode: String,
                              cardReaderModel: String?,
                              stores: StoresManager,
-                             analytics: Analytics) async {
+                             analytics: Analytics = ServiceLocator.analytics) async {
         analytics.track(event: .InPersonPayments.receiptPrintTapped(countryCode: countryCode, cardReaderModel: cardReaderModel))
 
          await withCheckedContinuation { continuation in

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
@@ -9,8 +9,8 @@ final class CollectOrderPaymentAnalytics {
     private var connectedReader: CardReader?
     private var paymentGatewayAccount: PaymentGatewayAccount?
 
-    var connectedReaderModel: String {
-        connectedReader?.readerType.model ?? ""
+    var connectedReaderModel: String? {
+        connectedReader?.readerType.model
     }
 
     init(analytics: Analytics = ServiceLocator.analytics,

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Yosemite
+
+final class CollectOrderPaymentAnalytics {
+
+    private let analytics: Analytics
+    private let configuration: CardPresentPaymentsConfiguration
+    private let orderDurationRecorder: OrderDurationRecorderProtocol
+    private var connectedReader: CardReader?
+    private var paymentGatewayAccount: PaymentGatewayAccount?
+
+    var connectedReaderModel: String {
+        connectedReader?.readerType.model ?? ""
+    }
+
+    init(analytics: Analytics = ServiceLocator.analytics,
+         configuration: CardPresentPaymentsConfiguration,
+         orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
+         connectedReader: CardReader? = nil,
+         paymentGatewayAccount: PaymentGatewayAccount? = nil) {
+        self.analytics = analytics
+        self.configuration = configuration
+        self.orderDurationRecorder = orderDurationRecorder
+        self.connectedReader = connectedReader
+        self.paymentGatewayAccount = paymentGatewayAccount
+    }
+
+    func preflightResultRecieved(_ result: CardReaderPreflightResult?) {
+        switch result {
+        case .completed(let connectedReader, let paymentGatewayAccount):
+            self.connectedReader = connectedReader
+            self.paymentGatewayAccount = paymentGatewayAccount
+        case .canceled(_, let paymentGatewayAccount):
+            self.connectedReader = nil
+            self.paymentGatewayAccount = paymentGatewayAccount
+        case .none:
+            break
+        }
+    }
+
+    func trackProcessingCompletion(intent: PaymentIntent) {
+        guard let paymentMethod = intent.paymentMethod() else {
+            return
+        }
+        switch paymentMethod {
+        case .interacPresent:
+            analytics.track(event: .InPersonPayments
+                .collectInteracPaymentSuccess(gatewayID: paymentGatewayAccount?.gatewayID,
+                                              countryCode: configuration.countryCode,
+                                              cardReaderModel: connectedReaderModel))
+        default:
+            return
+        }
+    }
+
+    func trackSuccessfulPayment(capturedPaymentData: CardPresentCapturedPaymentData) {
+        analytics.track(event: WooAnalyticsEvent.InPersonPayments
+            .collectPaymentSuccess(forGatewayID: paymentGatewayAccount?.gatewayID,
+                                   countryCode: configuration.countryCode,
+                                   paymentMethod: capturedPaymentData.paymentMethod,
+                                   cardReaderModel: connectedReaderModel,
+                                   millisecondsSinceOrderAddNew: try? orderDurationRecorder.millisecondsSinceOrderAddNew(),
+                                   millisecondsSinceCardPaymentStarted: try? orderDurationRecorder.millisecondsSinceCardPaymentStarted()))
+        orderDurationRecorder.reset()
+    }
+
+    func trackPaymentFailure(with error: Error) {
+        analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentFailed(forGatewayID: paymentGatewayAccount?.gatewayID,
+                                                                                       error: error,
+                                                                                       countryCode: configuration.countryCode,
+                                                                                       cardReaderModel: connectedReader?.readerType.model))
+    }
+
+    func trackPaymentCancelation(cancelationSource: WooAnalyticsEvent.InPersonPayments.CancellationSource) {
+        analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentCanceled(forGatewayID: paymentGatewayAccount?.gatewayID,
+                                                                                         countryCode: configuration.countryCode,
+                                                                                         cardReaderModel: connectedReaderModel,
+                                                                                         cancellationSource: cancelationSource))
+    }
+
+    func trackEmailTapped() {
+        analytics.track(event: .InPersonPayments
+            .receiptEmailTapped(countryCode: configuration.countryCode,
+                                cardReaderModel: connectedReader?.readerType.model ?? ""))
+    }
+
+    func trackReceiptPrintTapped() {
+        analytics.track(event: .InPersonPayments.receiptPrintTapped(countryCode: configuration.countryCode,
+                                                                    cardReaderModel: connectedReaderModel))
+    }
+
+    func trackReceiptPrintSuccess() {
+        analytics.track(event: .InPersonPayments.receiptPrintSuccess(countryCode: configuration.countryCode,
+                                                                     cardReaderModel: connectedReaderModel))
+    }
+
+    func trackReceiptPrintCanceled() {
+        analytics.track(event: .InPersonPayments.receiptPrintCanceled(countryCode: configuration.countryCode,
+                                                                      cardReaderModel: connectedReaderModel))
+    }
+
+    func trackReceiptPrintFailed(error: Error) {
+        analytics.track(event: .InPersonPayments.receiptPrintFailed(error: error,
+                                                                    countryCode: configuration.countryCode,
+                                                                    cardReaderModel: connectedReaderModel))
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -499,6 +499,7 @@
 		03191AE928E20C9200670723 /* PluginDetailsRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03191AE828E20C9200670723 /* PluginDetailsRowView.swift */; };
 		031B10E3274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */; };
 		032E481D2982996E00469D92 /* CardPresentModalBuiltInConnectingFailedNonRetryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032E481C2982996E00469D92 /* CardPresentModalBuiltInConnectingFailedNonRetryable.swift */; };
+		03582BE2299A9CC8007B7AA3 /* CollectOrderPaymentAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03582BE1299A9CC8007B7AA3 /* CollectOrderPaymentAnalytics.swift */; };
 		035BA3A8291000E90056F0AD /* JustInTimeMessageAnnouncementCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035BA3A7291000E90056F0AD /* JustInTimeMessageAnnouncementCardViewModelTests.swift */; };
 		035C6DEB273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */; };
 		035DBA45292D0164003E5125 /* CollectOrderPaymentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035DBA44292D0163003E5125 /* CollectOrderPaymentUseCase.swift */; };
@@ -2597,6 +2598,7 @@
 		03191AE828E20C9200670723 /* PluginDetailsRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDetailsRowView.swift; sourceTree = "<group>"; };
 		031B10E2274FE2AE007390BA /* CardPresentModalConnectionFailedUpdateAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalConnectionFailedUpdateAddress.swift; sourceTree = "<group>"; };
 		032E481C2982996E00469D92 /* CardPresentModalBuiltInConnectingFailedNonRetryable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInConnectingFailedNonRetryable.swift; sourceTree = "<group>"; };
+		03582BE1299A9CC8007B7AA3 /* CollectOrderPaymentAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectOrderPaymentAnalytics.swift; sourceTree = "<group>"; };
 		035BA3A7291000E90056F0AD /* JustInTimeMessageAnnouncementCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JustInTimeMessageAnnouncementCardViewModelTests.swift; sourceTree = "<group>"; };
 		035C6DEA273EA12D00F70406 /* SoftwareUpdateTypeProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdateTypeProperty.swift; sourceTree = "<group>"; };
 		035DBA44292D0163003E5125 /* CollectOrderPaymentUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectOrderPaymentUseCase.swift; sourceTree = "<group>"; };
@@ -5722,6 +5724,7 @@
 			isa = PBXGroup;
 			children = (
 				035DBA44292D0163003E5125 /* CollectOrderPaymentUseCase.swift */,
+				03582BE1299A9CC8007B7AA3 /* CollectOrderPaymentAnalytics.swift */,
 				035DBA4A292E248C003E5125 /* CardPresentPaymentAlertsPresenter.swift */,
 				268FD44627580A81008FDF9B /* LegacyCollectOrderPaymentUseCase.swift */,
 				0375799A28227EDE0083F2E1 /* CardPresentPaymentsOnboardingPresenter.swift */,
@@ -11096,6 +11099,7 @@
 				DE279BA626E9C582002BA963 /* ShippingLabelPackagesFormViewModel.swift in Sources */,
 				CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */,
 				DEC1508227F450AC00F4487C /* CouponAllowedEmails.swift in Sources */,
+				03582BE2299A9CC8007B7AA3 /* CollectOrderPaymentAnalytics.swift in Sources */,
 				02F36F472978349500D97EA0 /* DomainPurchaseSuccessView.swift in Sources */,
 				B9DA153C280EC7D700FC67DD /* OrderRefundsOptionsDeterminer.swift in Sources */,
 				453227B723C4D6EC00D816B3 /* TimeZone+Woo.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As part of the ongoing refactor of the payments classes while we add support for Tap to Pay on iPhone, this PR moves the stored state of `paymentGatewayAccount` and `connectedReader` to a new class, making it clearer that they are kept only for Analytics purposes. 

Where these properties are used for payment flow, they are taken directly from the result from the preflight controller.

Preflight is responsible for onboarding (output: PaymentGateway) and connecting a reader (output: a connected reader.)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Take a card present payment using the built in reader and the bluetooth reader. Observe that the analytics are logged as expected, e.g.

`card_reader_connection_success`
`card_present_collect_payment_success`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
