### PR TITLE
Domain settings: add a learn more footnote

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
@@ -102,12 +102,12 @@ private extension DomainSettingsView {
         )
         static let learnMoreFormat = NSLocalizedString(
             "%1$@ about domains and how to take domain-related actions.",
-            comment: "Learn more text on the domain settings screen to search for a domain. " +
+            comment: "Learn more format at the bottom of the domain settings screen. " +
             "%1$@ is a tappable link like \"Learn more\" that opens a webview for the user to learn more about domains."
         )
         static let learnMore = NSLocalizedString(
             "Learn more",
-            comment: "Learn more text on the domain settings screen to search for a domain."
+            comment: "Tappable text at the bottom of the domain settings screen that opens a webview."
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
@@ -61,10 +61,21 @@ struct DomainSettingsView: View {
                     Divider()
                         .frame(height: Layout.dividerHeight)
                         .foregroundColor(Color(.separator))
-                    Button(Localization.searchDomainButton) {
-                        addDomain(viewModel.hasDomainCredit, viewModel.freeStagingDomain?.name)
+
+                    VStack(spacing: Layout.bottomContentSpacing) {
+                        Button(Localization.searchDomainButton) {
+                            addDomain(viewModel.hasDomainCredit, viewModel.freeStagingDomain?.name)
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+
+                        HStack(alignment: .top, spacing: Layout.learnMoreImageAndTextSpacing) {
+                            Image(uiImage: .infoOutlineFootnoteImage)
+                                .foregroundColor(.init(uiColor: .textSubtle))
+                            LearnMoreAttributedText(format: Localization.learnMoreFormat,
+                                                    tappableLearnMoreText: Localization.learnMore,
+                                                    url: URLs.learnMore)
+                        }
                     }
-                    .buttonStyle(PrimaryButtonStyle())
                     .padding(Layout.bottomContentPadding)
                 }
                 .background(Color(.systemBackground))
@@ -89,6 +100,19 @@ private extension DomainSettingsView {
             "Search for a Domain",
             comment: "Title of the button on the domain settings screen to search for a domain."
         )
+        static let learnMoreFormat = NSLocalizedString(
+            "%1$@ about domains and how to take domain-related actions.",
+            comment: "Learn more text on the domain settings screen to search for a domain. " +
+            "%1$@ is a tappable link like \"Learn more\" that opens a webview for the user to learn more about domains."
+        )
+        static let learnMore = NSLocalizedString(
+            "Learn more",
+            comment: "Learn more text on the domain settings screen to search for a domain."
+        )
+    }
+
+    enum URLs {
+        static let learnMore: URL = URL(string: "https://wordpress.com/go/tutorials/what-is-a-domain-name")!
     }
 }
 
@@ -99,6 +123,8 @@ private extension DomainSettingsView {
         static let contentPadding: EdgeInsets = .init(top: 39, leading: 0, bottom: 16, trailing: 0)
         static let defaultHorizontalPadding: EdgeInsets = .init(top: 0, leading: 16, bottom: 0, trailing: 16)
         static let contentSpacing: CGFloat = 36
+        static let bottomContentSpacing: CGFloat = 16
+        static let learnMoreImageAndTextSpacing: CGFloat = 12
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LearnMoreAttributedText.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LearnMoreAttributedText.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// Displays an attributed text where a "learn more" or any other substring is tappable in a longer text to show a Safari sheet.
+struct LearnMoreAttributedText: View {
+    private let attributedLearnMoreText: AttributedString
+    @State private var learnMoreURL: URL?
+
+    /// - Parameters:
+    ///   - format: A format string with one variable for the learn more text.
+    ///   - learnMoreText: A string that is tappable that opens a Safari sheet for the user to learn more.
+    ///   - url: URL to display in a Safari sheet when the learn more text is tapped.
+    init(format: String, tappableLearnMoreText learnMoreText: String, url: URL) {
+        attributedLearnMoreText = {
+            var attributedText = AttributedString(.init(format: format, learnMoreText))
+            attributedText.font = .footnote
+            attributedText.foregroundColor = .init(.textSubtle)
+
+            // Link styles for the learn more string.
+            if let range = attributedText.range(of: learnMoreText) {
+                let linkContainer = AttributeContainer()
+                    .link(url)
+                    .foregroundColor(.init(uiColor: .accent))
+                    .underlineStyle(.single)
+                attributedText[range].mergeAttributes(linkContainer)
+            }
+            return attributedText
+        }()
+    }
+
+    var body: some View {
+        Text(attributedLearnMoreText)
+            .environment(\.openURL, OpenURLAction { url in
+                learnMoreURL = url
+                return .handled
+            })
+            .safariSheet(url: $learnMoreURL)
+    }
+}
+
+struct LearnMoreAttributedText_Previews: PreviewProvider {
+    static var previews: some View {
+        LearnMoreAttributedText(format: "%1$@ about dev.",
+                                tappableLearnMoreText: "Learn more",
+                                url: .init(string: "https://developer.apple.com")!)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		02077F72253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02077F71253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift */; };
 		020886572499E643001D784E /* ProductExternalLinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020886562499E642001D784E /* ProductExternalLinkViewController.swift */; };
 		020A55F127F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020A55F027F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift */; };
+		020ACF88299A809000B3638B /* LearnMoreAttributedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020ACF87299A809000B3638B /* LearnMoreAttributedText.swift */; };
 		020AF66329235860007760E5 /* StoreCreationPlanViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020AF66229235860007760E5 /* StoreCreationPlanViewModel.swift */; };
 		020AF6662923C7ED007760E5 /* StoreNameForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020AF6652923C7ED007760E5 /* StoreNameForm.swift */; };
 		020B2F8F23BD9F1F00BD79AD /* IntegerInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */; };
@@ -2136,6 +2137,7 @@
 		02077F71253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+ReadonlyProductTests.swift"; sourceTree = "<group>"; };
 		020886562499E642001D784E /* ProductExternalLinkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductExternalLinkViewController.swift; sourceTree = "<group>"; };
 		020A55F027F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionAnalyticsTracker.swift; sourceTree = "<group>"; };
+		020ACF87299A809000B3638B /* LearnMoreAttributedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreAttributedText.swift; sourceTree = "<group>"; };
 		020AF66229235860007760E5 /* StoreCreationPlanViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationPlanViewModel.swift; sourceTree = "<group>"; };
 		020AF6652923C7ED007760E5 /* StoreNameForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreNameForm.swift; sourceTree = "<group>"; };
 		020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerInputFormatter.swift; sourceTree = "<group>"; };
@@ -6474,6 +6476,7 @@
 				26E7EE6F29300F6200793045 /* DeltaTag.swift */,
 				AEE9A87F293A3E5500227C92 /* RefreshablePlainList.swift */,
 				26B71DB5293FE490004D8052 /* RangedDatePicker.swift */,
+				020ACF87299A809000B3638B /* LearnMoreAttributedText.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -11032,6 +11035,7 @@
 				02562AD0296D1FD100980404 /* View+DividerStyle.swift in Sources */,
 				CE5F462723AAC8C0006B1A5C /* RefundDetailsViewModel.swift in Sources */,
 				D8815B132638686200EDAD62 /* CardPresentModalError.swift in Sources */,
+				020ACF88299A809000B3638B /* LearnMoreAttributedText.swift in Sources */,
 				02EAA4CA2911004B00918DAB /* TextFieldStyles.swift in Sources */,
 				453DBF8E2387F34A006762A5 /* UICollectionViewCell+Helpers.swift in Sources */,
 				45B9C63E23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8558 
<!-- Id number of the GitHub issue this PR addresses. -->

Based on https://github.com/woocommerce/woocommerce-ios/pull/8848, otherwise the domain list is always non-empty with the `*.wordpress.com` domain

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When the site doesn't have any custom domains, we currently show a CTA at the bottom to add a domain. In the design, there's also a footnote below the CTA with a tappable "Learn more" text to open a webview at https://wordpress.com/go/tutorials/what-is-a-domain-name. This PR added the footnote, and after some trials and errors I decided to create a reusable SwiftUI view `LearnMoreAttributedText` with a tappable link using `AttirubtedString` and styling it with `AttributeContainer`. I also tried with the iOS 15+ markdown for the URL, but I wasn't able to show an underline on the link to match the design.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: a WC store **with a WPCOM plan** and **without any custom domains** is required

- Log in if needed, and continue with a WPCOM store as in the prerequisite
- Go to the Menu tab
- Tap on the settings CTA
- Tap the `Domain` row --> there should be a footnote below the bottom CTA, with a "Learn more" link to open a Safari sheet at https://wordpress.com/go/tutorials/what-is-a-domain-name

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light
-- | --
![Simulator Screen Shot - iPhone 14 - 2023-02-14 at 09 28 57](https://user-images.githubusercontent.com/1945542/218616359-ed55f541-ba51-46ee-a786-00c701ea4a70.png) | ![Simulator Screen Shot - iPhone 14 - 2023-02-14 at 09 29 07](https://user-images.githubusercontent.com/1945542/218616371-c8dc85ea-b596-49f7-853b-41fb8db72c8d.png)

tablet (I tried aligning the footnote with the CTA on the leading edge but IMO it looks better when it's center aligned):
<img src="https://user-images.githubusercontent.com/1945542/218617483-bbb211a6-48b1-48c9-bd92-505c1f6a14a2.png" width="500" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
