### PR TITLE
[Support Requests] Add Support Areas Tags & Form IDs

### DIFF
--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -597,11 +597,11 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
 ///
 extension ZendeskManager {
     func formID() -> Int64 {
-        createRequest(supportSourceTag: nil).ticketFormID?.int64Value ?? .zero
+        TicketFieldIDs.form
     }
 
     func wcPayFormID() -> Int64 {
-        createWCPayRequest(supportSourceTag: nil).ticketFormID?.int64Value ?? .zero
+        TicketFieldIDs.paymentsForm
     }
 
     func generalTags() -> [String] {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -340,7 +340,7 @@ private extension HelpAndSupportViewController {
         }
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
-            let viewController = SupportFormHostingController(viewModel: .init(dataSource: GeneralSupportDataSource()))
+            let viewController = SupportFormHostingController(viewModel: .init(dataSource: MobileAppSupportDataSource()))
             show(viewController, sender: self)
         } else {
             ZendeskProvider.shared.showNewRequestIfPossible(from: navController)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -340,7 +340,7 @@ private extension HelpAndSupportViewController {
         }
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
-            let viewController = SupportFormHostingController(viewModel: .init(dataSource: MobileAppSupportDataSource()))
+            let viewController = SupportFormHostingController(viewModel: .init())
             show(viewController, sender: self)
         } else {
             ZendeskProvider.shared.showNewRequestIfPossible(from: navController)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -103,7 +103,11 @@ struct SupportFormProvider: PreviewProvider {
 
     static var previews: some View {
         NavigationView {
-            SupportForm(viewModel: .init(dataSource: MockDataSource()))
+            SupportForm(viewModel: .init(areas: [
+                .init(title: "Mobile Aps", datasource: MockDataSource()),
+                .init(title: "WooCommerce Payments", datasource: MockDataSource()),
+                .init(title: "Other Plugins", datasource: MockDataSource()),
+            ]))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-/// Provides general Zendesk metadata.
+/// Provides Mobile App Zendesk metadata.
 ///
-struct GeneralSupportDataSource: SupportFormMetaDataSource {
+struct MobileAppSupportDataSource: SupportFormMetaDataSource {
     var formID: Int64 {
         ZendeskProvider.shared.formID()
     }
 
     var tags: [String] {
-        ZendeskProvider.shared.generalTags()
+        ZendeskProvider.shared.generalTags() + ["mobile_app"]
     }
 
     var customFields: [Int64: String] {
@@ -16,7 +16,39 @@ struct GeneralSupportDataSource: SupportFormMetaDataSource {
     }
 }
 
-/// Provides WCPay Zendesk metadata.
+/// Provides IPP Zendesk metadata.
+///
+struct IPPSupportDataSource: SupportFormMetaDataSource {
+    var formID: Int64 {
+        ZendeskProvider.shared.formID()
+    }
+
+    var tags: [String] {
+        ZendeskProvider.shared.generalTags() + ["woocommerce_mobile_apps", "product_area_apps_in_person_payments"]
+    }
+
+    var customFields: [Int64: String] {
+        ZendeskProvider.shared.generalCustomFields()
+    }
+}
+
+/// Provides WC Plugins Zendesk metadata.
+///
+struct WCPluginsSupportDataSource: SupportFormMetaDataSource {
+    var formID: Int64 {
+        ZendeskProvider.shared.wcPayFormID()
+    }
+
+    var tags: [String] {
+        ZendeskProvider.shared.generalTags() + ["woocommerce_core"]
+    }
+
+    var customFields: [Int64: String] {
+        ZendeskProvider.shared.generalCustomFields()
+    }
+}
+
+/// Provides WC Payments Zendesk metadata.
 ///
 struct WCPaySupportDataSource: SupportFormMetaDataSource {
     var formID: Int64 {
@@ -29,5 +61,21 @@ struct WCPaySupportDataSource: SupportFormMetaDataSource {
 
     var customFields: [Int64: String] {
         ZendeskProvider.shared.wcPayCustomFields()
+    }
+}
+
+/// Provides Other Plugins Zendesk metadata.
+///
+struct OtherPluginsSupportDataSource: SupportFormMetaDataSource {
+    var formID: Int64 {
+        ZendeskProvider.shared.wcPayFormID()
+    }
+
+    var tags: [String] {
+        ZendeskProvider.shared.generalTags() + ["product_area_woo_extensions"]
+    }
+
+    var customFields: [Int64: String] {
+        ZendeskProvider.shared.generalCustomFields()
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportDataSourcesTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportDataSourcesTests.swift
@@ -3,23 +3,85 @@ import XCTest
 
 final class SupportDataSourcesTests: XCTestCase {
 
-    func test_general_formID_has_correct_value() {
-        let dataSource = GeneralSupportDataSource()
+    func test_mobile_app_formID_has_correct_value() {
+        let dataSource = MobileAppSupportDataSource()
         XCTAssertEqual(dataSource.formID, 360000010286)
     }
 
-    func test_general_tags_have_correct_values() {
+    func test_mobile_app_tags_have_correct_values() {
         // Given
-        let dataSource = GeneralSupportDataSource()
+        let dataSource = MobileAppSupportDataSource()
         let tagsSet = Set(dataSource.tags)
-        let expectedSet = Set(["iOS", "woo-mobile-sdk", "jetpack"])
+        let expectedSet = Set(["iOS", "woo-mobile-sdk", "jetpack", "mobile_app"])
 
         // When & Then
         XCTAssertTrue(expectedSet.isSubset(of: tagsSet))
     }
 
-    func test_general_custom_fields_have_correct_ids() {
-        let dataSource = GeneralSupportDataSource()
+    func test_mobile_app_fields_have_correct_ids() {
+        let dataSource = MobileAppSupportDataSource()
+        let customFieldsKeys = dataSource.customFields.keys.sorted()
+        XCTAssertEqual(customFieldsKeys, [
+            360008583691, // App Language
+            360000103103, // Current Site
+            360009311651, // Source Platform
+            360000086966, // Network Information
+            360000086866, // App Version
+            22871957, // Legacy Logs
+            25176023, // Sub Category
+            10901699622036, // Logs
+            360000089123 // Device Free Space
+        ].sorted())
+    }
+
+    func test_ipp_formID_has_correct_value() {
+        let dataSource = IPPSupportDataSource()
+        XCTAssertEqual(dataSource.formID, 360000010286)
+    }
+
+    func test_ipp_tags_have_correct_values() {
+        // Given
+        let dataSource = IPPSupportDataSource()
+        let tagsSet = Set(dataSource.tags)
+        let expectedSet = Set(["iOS", "woo-mobile-sdk", "jetpack", "woocommerce_mobile_apps", "product_area_apps_in_person_payments"])
+
+        // When & Then
+        XCTAssertTrue(expectedSet.isSubset(of: tagsSet))
+    }
+
+    func test_ipp_fields_have_correct_ids() {
+        let dataSource = IPPSupportDataSource()
+        let customFieldsKeys = dataSource.customFields.keys.sorted()
+        XCTAssertEqual(customFieldsKeys, [
+            360008583691, // App Language
+            360000103103, // Current Site
+            360009311651, // Source Platform
+            360000086966, // Network Information
+            360000086866, // App Version
+            22871957, // Legacy Logs
+            25176023, // Sub Category
+            10901699622036, // Logs
+            360000089123 // Device Free Space
+        ].sorted())
+    }
+
+    func test_wc_plugins_formID_has_correct_value() {
+        let dataSource = WCPluginsSupportDataSource()
+        XCTAssertEqual(dataSource.formID, 189946)
+    }
+
+    func test_wc_plugins_tags_have_correct_values() {
+        // Given
+        let dataSource = WCPluginsSupportDataSource()
+        let tagsSet = Set(dataSource.tags)
+        let expectedSet = Set(["iOS", "woo-mobile-sdk", "jetpack", "woocommerce_core"])
+
+        // When & Then
+        XCTAssertTrue(expectedSet.isSubset(of: tagsSet))
+    }
+
+    func test_wc_plugins_fields_have_correct_ids() {
+        let dataSource = WCPluginsSupportDataSource()
         let customFieldsKeys = dataSource.customFields.keys.sorted()
         XCTAssertEqual(customFieldsKeys, [
             360008583691, // App Language
@@ -59,6 +121,36 @@ final class SupportDataSourcesTests: XCTestCase {
             360000086866, // App Version
             22871957, // Legacy Logs
             25176003, // Category
+            25176023, // Sub Category
+            10901699622036, // Logs
+            360000089123 // Device Free Space
+        ].sorted())
+    }
+
+    func test_other_plugins_formID_has_correctValue() {
+        let dataSource = OtherPluginsSupportDataSource()
+        XCTAssertEqual(dataSource.formID, 189946)
+    }
+
+    func test_other_plugins_tags_have_correct_values() {
+        let dataSource = OtherPluginsSupportDataSource()
+        let tagsSet = Set(dataSource.tags)
+        let expectedSet = Set(["iOS", "woo-mobile-sdk", "jetpack", "product_area_woo_extensions"])
+
+        // When & Then
+        XCTAssertTrue(expectedSet.isSubset(of: tagsSet))
+    }
+
+    func test_other_plugins_custom_fields_have_correct_values() {
+        let dataSource = OtherPluginsSupportDataSource()
+        let customFieldsKeys = dataSource.customFields.keys.sorted()
+        XCTAssertEqual(customFieldsKeys, [
+            360008583691, // App Language
+            360000103103, // Current Site
+            360009311651, // Source Platform
+            360000086966, // Network Information
+            360000086866, // App Version
+            22871957, // Legacy Logs
             25176023, // Sub Category
             10901699622036, // Logs
             360000089123 // Device Free Space


### PR DESCRIPTION
Closes: #8797 

# Why

One of the key parts of this project is to create tickets with the [appropriate tags & form IDs](https://wp.me/pe5pgL-2cg) so they can be routed to the correct support queues automatically.

This PR makes sure that metadata is linked with the support area the merchant chooses.

# How

- Added  `MobileAppSupportDataSource`, `IPPSupportDataSource`, `WCPaySupportDataSource`,  `WCPluginsSupportDataSource` and `OtherPluginsSupportDataSource` which contains the metadata each support area should send when creating a ticket.

- Updated the view model so those areas are received on its `init`.  This in order for the module to be reused easily on other apps or projects.


# Testing Steps

User-facing Behaviour hasn't changed yet, I have added unit tests to make sure the Data Sources contain the appropriate metadata.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
