### PR TITLE
Domain contact info: replace phone field with country code and number fields

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
@@ -44,6 +44,7 @@ struct DomainContactInfoForm: View {
                                   stateViewModelClosure: viewModel.createStateViewModel,
                                   sectionTitle: viewModel.sectionTitle,
                                   showEmailField: viewModel.showEmailField,
+                                  showPhoneCountryCodeField: viewModel.showPhoneCountryCodeField,
                                   showStateFieldAsSelector: viewModel.showStateFieldAsSelector)
                 .accessibilityElement(children: .contain)
 
@@ -99,15 +100,58 @@ private extension DomainContactInfoForm {
     }
 }
 
-struct DomainContactInfoForm_Previews: PreviewProvider {
-    static let sampleViewModel = DomainContactInfoFormViewModel(siteID: 134,
-                                                                contactInfoToEdit: nil,
-                                                                domain: "",
-                                                                stores: ServiceLocator.stores)
+#if DEBUG
 
-    static var previews: some View {
-        NavigationView {
-            DomainContactInfoForm(viewModel: sampleViewModel) { _ in }
+import Yosemite
+
+/// StoresManager that specifically handles `DomainAction` for `DomainSelectorView` previews.
+final private class DomainContactInfoFormStores: DefaultStoresManager {
+    init() {
+        super.init(sessionManager: ServiceLocator.stores.sessionManager)
+    }
+
+    override func dispatch(_ action: Action) {
+        if let action = action as? DataAction {
+            if case let .synchronizeCountries(_, completion) = action {
+                completion(.success([.init(code: "US", name: "United States", states: [.init(code: "CA", name: "California")])]))
+            }
         }
     }
 }
+
+
+struct DomainContactInfoForm_Previews: PreviewProvider {
+    private static let viewModelWithoutContactInfo = DomainContactInfoFormViewModel(siteID: 134,
+                                                                            contactInfoToEdit: nil,
+                                                                            domain: "",
+                                                                            stores: DomainContactInfoFormStores())
+    private static let contactInfo = DomainContactInfo(firstName: "Woo",
+                                                       lastName: "Testing",
+                                                       organization: "WooCommerce org",
+                                                       address1: "335 2nd St",
+                                                       address2: "Apt 222",
+                                                       postcode: "94111",
+                                                       city: "San Francisco",
+                                                       state: "CA",
+                                                       countryCode: "US",
+                                                       phone: "+886.911123456",
+                                                       email: "woo@store.com")
+    private static let viewModelWithContactInfo = DomainContactInfoFormViewModel(siteID: 134,
+                                                                                 contactInfoToEdit: contactInfo,
+                                                                                 domain: "",
+                                                                                 stores: DomainContactInfoFormStores())
+
+    static var previews: some View {
+        NavigationView {
+            DomainContactInfoForm(viewModel: viewModelWithoutContactInfo) { _ in }
+        }
+        .previewDisplayName("Empty contact info")
+
+        NavigationView {
+            DomainContactInfoForm(viewModel: viewModelWithContactInfo) { _ in }
+        }
+        .previewDisplayName("Pre-filled contact info")
+    }
+}
+
+#endif

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
@@ -122,9 +122,9 @@ final private class DomainContactInfoFormStores: DefaultStoresManager {
 
 struct DomainContactInfoForm_Previews: PreviewProvider {
     private static let viewModelWithoutContactInfo = DomainContactInfoFormViewModel(siteID: 134,
-                                                                            contactInfoToEdit: nil,
-                                                                            domain: "",
-                                                                            stores: DomainContactInfoFormStores())
+                                                                                    contactInfoToEdit: nil,
+                                                                                    domain: "",
+                                                                                    stores: DomainContactInfoFormStores())
     private static let contactInfo = DomainContactInfo(firstName: "Woo",
                                                        lastName: "Testing",
                                                        organization: "WooCommerce org",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
@@ -43,7 +43,9 @@ final class DomainContactInfoFormViewModel: AddressFormViewModel, AddressFormVie
 
             let (phoneCountryCode, phoneNumber): (String?, String?) = {
                 // The phone number in the contact info API is in the format of `+\(countryCode).\(phoneNumber)`.
-                let phoneParts = contactInfoToEdit.phone?.replacingOccurrences(of: Constants.phoneNumberPrefix, with: "").split(separator: ".")
+                let phoneParts = contactInfoToEdit.phone?
+                    .replacingOccurrences(of: Constants.phoneNumberPrefix, with: "")
+                    .split(separator: Constants.phoneNumberSeparator)
                 guard let phoneParts, phoneParts.count == 2 else {
                     return (nil, nil)
                 }
@@ -161,7 +163,7 @@ private extension DomainContactInfoFormViewModel {
     }
 
     enum Constants {
-        static let phoneNumberPrefix = "+"
-        static let phoneNumberSeparator = "."
+        static let phoneNumberPrefix: String = "+"
+        static let phoneNumberSeparator: Character = "."
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
@@ -82,13 +82,16 @@ final class DomainContactInfoFormViewModel: AddressFormViewModel, AddressFormVie
     /// Email is a required field for domain contact info.
     let showEmailField: Bool = true
 
+    /// Phone country code is a required field for domain contact info.
+    let showPhoneCountryCodeField: Bool = true
+
     let viewTitle: String = Localization.title
 
     let sectionTitle: String = Localization.addressSection
 
-    var secondarySectionTitle: String = ""
+    let secondarySectionTitle: String = ""
 
-    var showAlternativeUsageToggle: Bool = false
+    let showAlternativeUsageToggle: Bool = false
 
     let alternativeUsageToggleTitle: String? = nil
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
@@ -8,7 +8,13 @@ final class DomainContactInfoFormViewModel: AddressFormViewModel, AddressFormVie
     private let domain: String
 
     private var contactInfo: DomainContactInfo {
-        .init(firstName: fields.firstName,
+        let phone: String = {
+            // The user can enter characters like `-` or `.` into the field, and the API expects digits only.
+            let countryCode = fields.phoneCountryCode.filter { $0.isNumber }
+            let number = fields.phone.filter { $0.isNumber }
+            return "\(Constants.phoneNumberPrefix)\(countryCode)\(Constants.phoneNumberSeparator)\(number)"
+        }()
+        return .init(firstName: fields.firstName,
               lastName: fields.lastName,
               organization: fields.company,
               address1: fields.address1,
@@ -17,7 +23,7 @@ final class DomainContactInfoFormViewModel: AddressFormViewModel, AddressFormVie
               city: fields.city,
               state: fields.selectedState?.code ?? "",
               countryCode: fields.selectedCountry?.code ?? "",
-              phone: fields.phone,
+              phone: phone,
               email: fields.email)
     }
 
@@ -30,25 +36,35 @@ final class DomainContactInfoFormViewModel: AddressFormViewModel, AddressFormVie
         self.siteID = siteID
         self.domain = domain
 
-        let addressToEdit: Address = {
+        let (addressToEdit, phoneCountryCode): (Address, String?) = {
             guard let contactInfoToEdit else {
-                return .empty
+                return (.empty, nil)
             }
-            return .init(firstName: contactInfoToEdit.firstName,
-                         lastName: contactInfoToEdit.lastName,
-                         company: contactInfoToEdit.organization,
-                         address1: contactInfoToEdit.address1,
-                         address2: contactInfoToEdit.address2,
-                         city: contactInfoToEdit.city,
-                         state: contactInfoToEdit.state ?? "",
-                         postcode: contactInfoToEdit.postcode,
-                         country: contactInfoToEdit.countryCode,
-                         phone: contactInfoToEdit.phone,
-                         email: contactInfoToEdit.email)
+
+            let (phoneCountryCode, phoneNumber): (String?, String?) = {
+                // The phone number in the contact info API is in the format of `+\(countryCode).\(phoneNumber)`.
+                let phoneParts = contactInfoToEdit.phone?.replacingOccurrences(of: Constants.phoneNumberPrefix, with: "").split(separator: ".")
+                guard let phoneParts, phoneParts.count == 2 else {
+                    return (nil, nil)
+                }
+                return (String(phoneParts[0]), String(phoneParts[1]))
+            }()
+            return (.init(firstName: contactInfoToEdit.firstName,
+                          lastName: contactInfoToEdit.lastName,
+                          company: contactInfoToEdit.organization,
+                          address1: contactInfoToEdit.address1,
+                          address2: contactInfoToEdit.address2,
+                          city: contactInfoToEdit.city,
+                          state: contactInfoToEdit.state ?? "",
+                          postcode: contactInfoToEdit.postcode,
+                          country: contactInfoToEdit.countryCode,
+                          phone: phoneNumber,
+                          email: contactInfoToEdit.email), phoneCountryCode)
         }()
 
         super.init(siteID: siteID,
                    address: addressToEdit,
+                   phoneCountryCode: phoneCountryCode ?? "",
                    isDoneButtonAlwaysEnabled: true,
                    storageManager: storageManager,
                    stores: stores,
@@ -142,5 +158,10 @@ private extension DomainContactInfoFormViewModel {
             "Some unexpected error with the validation. Please check the fields and try again.",
             comment: "Message in the error notice when an unknown validation error occurs after submitting domain contact info."
         )
+    }
+
+    enum Constants {
+        static let phoneNumberPrefix = "+"
+        static let phoneNumberSeparator = "."
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -38,9 +38,9 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
 
     // MARK: - Protocol conformance
 
-    var showEmailField: Bool {
-        true
-    }
+    let showEmailField: Bool = true
+
+    let showPhoneCountryCodeField: Bool = false
 
     var viewTitle: String {
         Localization.customerDetailsTitle

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -48,6 +48,10 @@ protocol AddressFormViewModelProtocol: ObservableObject {
     ///
     var showEmailField: Bool { get }
 
+    /// Defines if the phone country code field should be shown
+    ///
+    var showPhoneCountryCodeField: Bool { get }
+
     /// Defines navbar title
     ///
     var viewTitle: String { get }
@@ -117,6 +121,8 @@ struct AddressFormFields {
     var lastName: String = ""
     var email: String = ""
     var phone: String = ""
+    // Not available in `Address` conversion, currently only available in domain contact info form.
+    var phoneCountryCode: String = ""
 
     // MARK: Address Fields
     var company: String = ""
@@ -254,6 +260,7 @@ open class AddressFormViewModel: ObservableObject {
 
     init(siteID: Int64,
          address: Address,
+         phoneCountryCode: String = "",
          secondaryAddress: Address? = nil,
          isDoneButtonAlwaysEnabled: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -262,7 +269,9 @@ open class AddressFormViewModel: ObservableObject {
         self.siteID = siteID
 
         self.originalAddress = address
-        self.fields = .init(with: originalAddress)
+        var fields: AddressFormFields = .init(with: originalAddress)
+        fields.phoneCountryCode = phoneCountryCode
+        self.fields = fields
 
         self.secondaryOriginalAddress = secondaryAddress ?? .empty
         self.secondaryFields = .init(with: secondaryOriginalAddress)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -280,7 +280,7 @@ struct SingleAddressForm: View {
                                      text: $fields.phoneCountryCode,
                                      symbol: nil,
                                      fieldAlignment: .leading,
-                                     keyboardType: .phonePad)
+                                     keyboardType: .asciiCapableNumberPad)
                 .autocapitalization(.none)
                 Divider()
                     .padding(.leading, Constants.dividerPadding)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -99,6 +99,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                                   stateViewModelClosure: viewModel.createStateViewModel,
                                   sectionTitle: viewModel.sectionTitle,
                                   showEmailField: viewModel.showEmailField,
+                                  showPhoneCountryCodeField: viewModel.showPhoneCountryCodeField,
                                   showStateFieldAsSelector: viewModel.showStateFieldAsSelector)
                          .accessibilityElement(children: .contain)
                          .accessibilityIdentifier("order-address-form")
@@ -128,6 +129,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
                                       stateViewModelClosure: viewModel.createSecondaryStateViewModel,
                                       sectionTitle: viewModel.secondarySectionTitle,
                                       showEmailField: false,
+                                      showPhoneCountryCodeField: viewModel.showPhoneCountryCodeField,
                                       showStateFieldAsSelector: viewModel.showSecondaryStateFieldAsSelector)
                         .accessibilityElement(children: .contain)
                         .accessibilityIdentifier("secondary-order-address-form")
@@ -205,6 +207,7 @@ struct SingleAddressForm: View {
 
     let sectionTitle: String
     let showEmailField: Bool
+    let showPhoneCountryCodeField: Bool
     let showStateFieldAsSelector: Bool
 
     /// Set it to `true` to present the country selector.
@@ -268,6 +271,19 @@ struct SingleAddressForm: View {
                 Divider()
                     .padding(.leading, Constants.dividerPadding)
 
+            }
+
+            if showPhoneCountryCodeField {
+                TitleAndTextFieldRow(title: Localization.phoneCountryCodeField,
+                                     titleWidth: $titleWidth,
+                                     placeholder: Localization.phoneCountryCodeHint,
+                                     text: $fields.phoneCountryCode,
+                                     symbol: nil,
+                                     fieldAlignment: .leading,
+                                     keyboardType: .phonePad)
+                .autocapitalization(.none)
+                Divider()
+                    .padding(.leading, Constants.dividerPadding)
             }
 
             TitleAndTextFieldRow(title: Localization.phoneField,
@@ -416,6 +432,8 @@ private enum Localization {
     static let lastNameHint = NSLocalizedString("Enter Last Name", comment: "Last name field placeholder in Edit Address Form")
     static let emailField = NSLocalizedString("Email", comment: "Text field email in Edit Address Form")
     static let emailHint = NSLocalizedString("Enter Email", comment: "Email field placeholder in Edit Address Form")
+    static let phoneCountryCodeField = NSLocalizedString("Phone country code", comment: "Text field phone country code in Edit Address Form")
+    static let phoneCountryCodeHint = NSLocalizedString("Enter Country Code", comment: "Phone country code field placeholder in Edit Address Form")
     static let phoneField = NSLocalizedString("Phone", comment: "Text field phone in Edit Address Form")
     static let phoneHint = NSLocalizedString("Enter Phone", comment: "Phone field placeholder in Edit Address Form")
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -60,6 +60,8 @@ final class EditOrderAddressFormViewModel: AddressFormViewModel, AddressFormView
         }
     }
 
+    let showPhoneCountryCodeField: Bool = false
+
     var viewTitle: String {
         switch type {
         case .shipping:

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		020886572499E643001D784E /* ProductExternalLinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020886562499E642001D784E /* ProductExternalLinkViewController.swift */; };
 		020A55F127F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020A55F027F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift */; };
 		020ACF88299A809000B3638B /* LearnMoreAttributedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020ACF87299A809000B3638B /* LearnMoreAttributedText.swift */; };
+		020ACF8A299B746700B3638B /* DomainContactInfoFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020ACF89299B746700B3638B /* DomainContactInfoFormViewModelTests.swift */; };
 		020AF66329235860007760E5 /* StoreCreationPlanViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020AF66229235860007760E5 /* StoreCreationPlanViewModel.swift */; };
 		020AF6662923C7ED007760E5 /* StoreNameForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020AF6652923C7ED007760E5 /* StoreNameForm.swift */; };
 		020B2F8F23BD9F1F00BD79AD /* IntegerInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */; };
@@ -2139,6 +2140,7 @@
 		020886562499E642001D784E /* ProductExternalLinkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductExternalLinkViewController.swift; sourceTree = "<group>"; };
 		020A55F027F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionAnalyticsTracker.swift; sourceTree = "<group>"; };
 		020ACF87299A809000B3638B /* LearnMoreAttributedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreAttributedText.swift; sourceTree = "<group>"; };
+		020ACF89299B746700B3638B /* DomainContactInfoFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainContactInfoFormViewModelTests.swift; sourceTree = "<group>"; };
 		020AF66229235860007760E5 /* StoreCreationPlanViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationPlanViewModel.swift; sourceTree = "<group>"; };
 		020AF6652923C7ED007760E5 /* StoreNameForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreNameForm.swift; sourceTree = "<group>"; };
 		020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerInputFormatter.swift; sourceTree = "<group>"; };
@@ -5246,6 +5248,7 @@
 				02DAE7FE291B8C8A009342B7 /* FreeDomainSelectorViewModelTests.swift */,
 				022C7D7629793ABE0036568D /* PaidDomainSelectorDataProviderTests.swift */,
 				0235354D2999D17A00BF77D3 /* DomainSettingsViewModelTests.swift */,
+				020ACF89299B746700B3638B /* DomainContactInfoFormViewModelTests.swift */,
 			);
 			path = Domains;
 			sourceTree = "<group>";
@@ -11551,6 +11554,7 @@
 				CCD2E68925DD52C100BD975D /* ProductVariationsViewModelTests.swift in Sources */,
 				0203C11C293058CB00EE61BF /* WebPurchasesForWPComPlansTests.swift in Sources */,
 				2683835A296F9C1A00CCF60A /* GenerateAllVariationsUseCaseTests.swift in Sources */,
+				020ACF8A299B746700B3638B /* DomainContactInfoFormViewModelTests.swift in Sources */,
 				26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */,
 				0215320D2423309B003F2BBD /* UIStackView+SubviewsTests.swift in Sources */,
 				027B8BBD23FE0DE10040944E /* ProductImageActionHandlerTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewModels/Domains/DomainContactInfoFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Domains/DomainContactInfoFormViewModelTests.swift
@@ -1,0 +1,120 @@
+import Networking
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class DomainContactInfoFormViewModelTests: XCTestCase {
+    private var stores: MockStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+    }
+
+    override func tearDown() {
+        stores = nil
+        super.tearDown()
+    }
+
+    func test_init_with_contact_info_pre_fills_all_fields() throws {
+        // Given
+        let viewModel = DomainContactInfoFormViewModel(siteID: 134,
+                                                       contactInfoToEdit: Fixtures.contactInfo,
+                                                       domain: "woo.com",
+                                                       storageManager: ServiceLocator.storageManager,
+                                                       stores: ServiceLocator.stores,
+                                                       analytics: ServiceLocator.analytics)
+
+        // Then
+        XCTAssertEqual(viewModel.fields.firstName, "Woo")
+        XCTAssertEqual(viewModel.fields.lastName, "Testing")
+        XCTAssertEqual(viewModel.fields.company, "WooCommerce org")
+        XCTAssertEqual(viewModel.fields.address1, "335 2nd St")
+        XCTAssertEqual(viewModel.fields.address2, "Apt 222")
+        XCTAssertEqual(viewModel.fields.postcode, "94111")
+        XCTAssertEqual(viewModel.fields.city, "San Francisco")
+        XCTAssertEqual(viewModel.fields.state, "CA")
+        XCTAssertEqual(viewModel.fields.country, "US")
+        XCTAssertEqual(viewModel.fields.phoneCountryCode, "886")
+        XCTAssertEqual(viewModel.fields.phone, "911123456")
+        XCTAssertEqual(viewModel.fields.email, "woo@store.com")
+    }
+
+    func test_validating_contact_info_after_editing_all_fields_returns_updated_fields() async throws {
+        // Given
+        let viewModel = DomainContactInfoFormViewModel(siteID: 134,
+                                                       contactInfoToEdit: Fixtures.contactInfo,
+                                                       domain: "woo.com",
+                                                       storageManager: ServiceLocator.storageManager,
+                                                       stores: stores,
+                                                       analytics: ServiceLocator.analytics)
+        mockRemoteValidation(result: .success(()))
+        mockCountriesData(result: .success(Fixtures.countries))
+
+        // When
+        viewModel.fields.firstName = "Oow"
+        viewModel.fields.lastName = "Woo"
+        viewModel.fields.company = "Woo"
+        viewModel.fields.address1 = "333 1st St"
+        viewModel.fields.address2 = "#228"
+        viewModel.fields.postcode = "94303"
+        viewModel.fields.city = "Palo Alto"
+        viewModel.fields.state = ""
+        viewModel.fields.selectedCountry = .init(code: "CA", name: "Canada", states: [])
+        viewModel.fields.phoneCountryCode = "+1"
+        viewModel.fields.phone = "650-123-4567"
+        viewModel.fields.email = "woo+test@store.com"
+        let validatedContactInfo = try await viewModel.validateContactInfo()
+
+        // Then
+        XCTAssertEqual(validatedContactInfo.firstName, "Oow")
+        XCTAssertEqual(validatedContactInfo.lastName, "Woo")
+        XCTAssertEqual(validatedContactInfo.organization, "Woo")
+        XCTAssertEqual(validatedContactInfo.address1, "333 1st St")
+        XCTAssertEqual(validatedContactInfo.address2, "#228")
+        XCTAssertEqual(validatedContactInfo.postcode, "94303")
+        XCTAssertEqual(validatedContactInfo.city, "Palo Alto")
+        XCTAssertEqual(validatedContactInfo.state, "")
+        XCTAssertEqual(validatedContactInfo.countryCode, "CA")
+        XCTAssertEqual(validatedContactInfo.phone, "+1.6501234567")
+        XCTAssertEqual(validatedContactInfo.email, "woo+test@store.com")
+    }
+}
+
+private extension DomainContactInfoFormViewModelTests {
+    func mockRemoteValidation(result: Result<Void, Error>) {
+        stores.whenReceivingAction(ofType: DomainAction.self) { action in
+            if case let .validate(_, _, completion) = action {
+                completion(result)
+            }
+        }
+    }
+
+    func mockCountriesData(result: Result<[Country], Error>) {
+        stores.whenReceivingAction(ofType: DataAction.self) { action in
+            if case let .synchronizeCountries(_, completion) = action {
+                completion(result)
+            }
+        }
+    }
+}
+
+private extension DomainContactInfoFormViewModelTests {
+    enum Fixtures {
+        static let contactInfo: DomainContactInfo = .init(firstName: "Woo",
+                                                          lastName: "Testing",
+                                                          organization: "WooCommerce org",
+                                                          address1: "335 2nd St",
+                                                          address2: "Apt 222",
+                                                          postcode: "94111",
+                                                          city: "San Francisco",
+                                                          state: "CA",
+                                                          countryCode: "US",
+                                                          phone: "+886.911123456",
+                                                          email: "woo@store.com")
+        static let countries: [Country] = [
+            .init(code: "US", name: "United States", states: [.init(code: "CA", name: "California")]),
+            .init(code: "CA", name: "Canada", states: [])
+        ]
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8558 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

From pe5sF9-16Z-p2, the API returns and expects the phone number of domain contact info to be in the format of `+{{country_code}}.{{number}}`. This presents some challenges for the user if they don't have a pre-existing phone number on WPCOM to prefill the field, because they can't enter a `.` with the phone pad keyboard. I decided to follow the JPiOS implementation to split the phone field into two fields, one for the country code and the other one for the number.

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

UI changes:
- Added an optional phone country code field to `SingleAddressForm`
- Because the phone country code field is not in the `Address` model, it's set separately in the initializer
- I considered not including `showPhoneCountryCodeField` in `AddressFormViewModelProtocol` so that it doesn't affect pre-existing order forms, but thought it might be useful for any other address form that requires the phone country code

`DomainContactInfoFormViewModel` changes:
- Given the pre-existing domain contact info, it prefills the two phone fields by splitting the phone string by `.` and removing the prefix `+`
- When converting the `AddressFormFields` fields to `DomainContactInfo`, it combines the two phone fields into one following the format
- Unit tests were added for the changes above

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: a WC store with an annual WPCOM plan whose domain credit hasn't been claimed, you can create a site like this in Calypso with store credit

- Log in if needed, and continue with the store in the prerequisite
- Go to the Menu tab
- Tap on the settings CTA
- Tap the `Domain` row
- Tap `Claim Domain` --> domain selector with paid domains should be shown that are free for the first year
- Select a domain and tap `Continue` --> domain contact info form should be shown with "phone country code" and "phone" fields. if the WPCOM account has a phone number, it should be pre-filled. Otherwise, the two phone fields should be empty
- Leave a mandatory field like first/last name blank (so that it results in a validation error), update the phone country code and number fields, and tap `Done`
- Exit the domain settings by dragging it to dismiss
- In Settings, tap `Launch Wormholy Debug` and search for `validate` --> in the latest `domain-contact-information/validate` request, the request body should include `%5Bphone%5D=%2B{{country_code}}.{{phone_number}}` with the values you entered 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

pre-filled | empty
-- | --
![Simulator Screen Shot - iPhone 14 - 2023-02-15 at 10 44 49](https://user-images.githubusercontent.com/1945542/218914661-42186380-3c78-43d5-8d17-bce40f76c9f8.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-15 at 10 43 49](https://user-images.githubusercontent.com/1945542/218914665-fe7f2b40-0a68-463e-a0e0-f214ca6f36b3.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.