### PR TITLE
Settings: update domain settings CTA

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsView.swift
@@ -95,7 +95,7 @@ struct DomainSettingsView: View {
 
 private extension DomainSettingsView {
     enum Localization {
-        static let title = NSLocalizedString("Domain", comment: "Navigation bar title of the domain settings screen.")
+        static let title = NSLocalizedString("Domains", comment: "Navigation bar title of the domain settings screen.")
         static let searchDomainButton = NSLocalizedString(
             "Search for a Domain",
             comment: "Title of the button on the domain settings screen to search for a domain."

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -735,7 +735,7 @@ private extension SettingsViewController {
         )
 
         static let domain = NSLocalizedString(
-            "Domain",
+            "Domains",
             comment: "Navigates to domain settings screen."
         )
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -204,6 +204,21 @@ private extension SettingsViewModel {
     }
 
     func configureSections() {
+        let configureSection: Section? = {
+            var rows: [Row] = []
+
+            if featureFlagService.isFeatureFlagEnabled(.domainSettings) && stores.sessionManager.defaultSite?.isWordPressComStore == true {
+                rows.append(.domain)
+            }
+
+            guard rows.isNotEmpty else {
+                return nil
+            }
+            return Section(title: Localization.configureTitle,
+                           rows: rows,
+                           footerHeight: UITableView.automaticDimension)
+        }()
+
         // Plugins
         let pluginsSection: Section? = {
             // Show the plugins section only if the user has an `admin` role for the default store site.
@@ -220,10 +235,6 @@ private extension SettingsViewModel {
         // Store settings
         let storeSettingsSection: Section? = {
             var rows: [Row] = []
-
-            if featureFlagService.isFeatureFlagEnabled(.domainSettings) && stores.sessionManager.defaultSite?.isWordPressComStore == true {
-                rows.append(.domain)
-            }
 
             if stores.sessionManager.defaultSite?.isJetpackCPConnected == true {
                 rows.append(.installJetpack)
@@ -305,6 +316,7 @@ private extension SettingsViewModel {
                                     footerHeight: CGFloat.leastNonzeroMagnitude)
 
         sections = [
+            configureSection,
             pluginsSection,
             storeSettingsSection,
             helpAndFeedbackSection,
@@ -374,6 +386,11 @@ private extension SettingsViewModel {
 //
 private extension SettingsViewModel {
     enum Localization {
+        static let configureTitle = NSLocalizedString(
+            "Configure",
+            comment: "My Store > Settings > Configure section title"
+        ).uppercased()
+
         static let pluginsTitle = NSLocalizedString(
             "Plugins",
             comment: "My Store > Settings > Plugins section title"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8558 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In the latest design VyLr7LvKodHE4kINfBE7Lw-fi-1664%3A81188, the domain settings CTA has been moved from "store settings" to a new section "configure" at the top. This PR implemented the menu change, and updated the title of the CTA and domain settings screen from `Domain` to `Domains`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: a WC store **with a WPCOM plan** is required

- Log in if needed, and continue with a WPCOM store
- Go to the Menu tab
- Tap on the settings CTA --> the Domains row should be in the first section "CONFIGURE"
- Tap on `Domains` --> the title of the domain settings should also be `Domains`

---
- [x] @jaclync tests that the CTA is hidden when the `domainSettings` feature flag is off

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

settings menu | updated title
-- | --
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-15 at 13 30 16](https://user-images.githubusercontent.com/1945542/218943074-10930d9d-a56c-4e24-a5fd-f1d66e0b0e56.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-15 at 13 30 28](https://user-images.githubusercontent.com/1945542/218943082-bb5f4993-1e33-4987-ba14-f3e65396f185.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.