### PR TITLE
Use anonymous ID to track logged-out users with Sentry

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 -----
 - [Internal] Prologue screen now has only the entry point to site address login flow, and application password authentication is used for sites without Jetpack. [https://github.com/woocommerce/woocommerce-ios/pull/8846]
 - [Internal] A new tag has been added for Zendesk for users authenticated with application password. [https://github.com/woocommerce/woocommerce-ios/pull/8850]
-
+- [Internal] Failures in the logged-out state are now tracked with anonymous ID. [https://github.com/woocommerce/woocommerce-ios/pull/8861]
 
 12.3
 -----

--- a/WooCommerce/Classes/Tools/Logging/WooCrashLoggingStack.swift
+++ b/WooCommerce/Classes/Tools/Logging/WooCrashLoggingStack.swift
@@ -108,7 +108,8 @@ class WCCrashLoggingDataProvider: CrashLoggingDataProvider {
         }
 
         guard let account = ServiceLocator.stores.sessionManager.defaultAccount else {
-            return nil
+            let anonymousID = ServiceLocator.stores.sessionManager.anonymousUserID
+            return TracksUser(userID: anonymousID, email: nil, username: nil)
         }
 
         return TracksUser(userID: "\(account.userID)", email: account.email, username: account.username)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8727 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, we could not track the correct number of failure events on Sentry when they happened in the logged-out state. All of those events are tracked with 0 users on Sentry.

In their [documentation](https://docs.sentry.io/platforms/apple/guides/ios/enriching-events/identify-user/), Sentry states that when user ID is not found, they use `installationID` to track, but it doesn't seem to be the case as we see now.

This PR fixes this by using our existing anonymous ID set to `SentryUser` so that we can have the correct number of events for failures.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: in any place of the app during the login flow (e.g in `handleSiteCredentialLogin` of `AuthenticationManager`), put this snippet of code to force a failure:
```Swift
UserDefaults.standard.set(true, forKey: CrashLogging.forceCrashLoggingKey)
CrashLoggingSettings.didOptIn = true
ServiceLocator.crashLogging.logMessage("Test Crash", properties: nil, level: .fatal)
```

Then build and run the app to execute the above code. When done, check on Sentry for the issue - notice that it has the correct number of events and users.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
