### PR TITLE
[Support Requests] Integrate UI with ViewModel

### DIFF
--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -485,10 +485,14 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         let requestProvider = ZDKRequestProvider()
         let request = createAPIRequest(formID: formID, customFields: customFields, tags: tags, subject: subject, description: description)
         requestProvider.createRequest(request) { _, error in
-            if let error {
-                return onCompletion(.failure(error))
+            // `requestProvider.createRequest` invokes it's completion block on a background thread when the request creation fails.
+            // Lets make sure we always dispatch the completion block on the main queue.
+            DispatchQueue.main.async {
+                if let error {
+                    return onCompletion(.failure(error))
+                }
+                onCompletion(.success(()))
             }
-            onCompletion(.success(()))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -84,7 +84,7 @@ private extension SupportFormHostingController {
 private extension SupportFormHostingController {
     enum Localization {
         static let requestSent = NSLocalizedString("Request Sent!", comment: "Title for the alert after the support request is created.")
-        static let requestSentMessage = NSLocalizedString("Your support request has landed safely in our inbox, we will reply shortly via email.",
+        static let requestSentMessage = NSLocalizedString("Your support request has landed safely in our inbox. We will reply via email as quickly as we can.",
                                                           comment: "Message for the alert after the support request is created.")
         static let gotIt = NSLocalizedString("Got It!", comment: "Confirmation button for the alert after the support request is created.")
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -84,7 +84,7 @@ private extension SupportFormHostingController {
 private extension SupportFormHostingController {
     enum Localization {
         static let requestSent = NSLocalizedString("Request Sent!", comment: "Title for the alert after the support request is created.")
-        static let requestSentMessage = NSLocalizedString("RYour support request has landed safely in our inbox, we will reply shortly via email.",
+        static let requestSentMessage = NSLocalizedString("Your support request has landed safely in our inbox, we will reply shortly via email.",
                                                           comment: "Message for the alert after the support request is created.")
         static let gotIt = NSLocalizedString("Got It!", comment: "Confirmation button for the alert after the support request is created.")
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -5,6 +5,15 @@ import SwiftUI
 ///
 final class SupportFormHostingController: UIHostingController<SupportForm> {
 
+    /// Custom notice presenter,
+    ///
+    private lazy var noticePresenter: NoticePresenter = {
+        let presenter = DefaultNoticePresenter()
+        presenter.presentingViewController = navigationController ?? self
+        return presenter
+    }()
+
+
     init(viewModel: SupportFormViewModel) {
         super.init(rootView: SupportForm(viewModel: viewModel))
         handleSupportRequestCompletion(viewModel: viewModel)
@@ -63,8 +72,6 @@ private extension SupportFormHostingController {
     ///
     func logAndInformErrorCreatingRequest(_ error: Error) {
         let notice = Notice(title: Localization.requestSentError, feedbackType: .error)
-        let noticePresenter = DefaultNoticePresenter()
-        noticePresenter.presentingViewController = self
         noticePresenter.enqueue(notice: notice)
 
         DDLogError("⛔️ Could not create Support Request. Error: \(error.localizedDescription)")
@@ -74,7 +81,7 @@ private extension SupportFormHostingController {
     ///
     func logIdentityErrorAndPopBack() {
         let notice = Notice(title: Localization.badIdentityError, feedbackType: .error)
-        ServiceLocator.noticePresenter.enqueue(notice: notice)
+        noticePresenter.enqueue(notice: notice)
 
         navigationController?.popViewController(animated: true)
         DDLogError("⛔️ Zendesk Identity could not be created.")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -28,9 +28,7 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
         // TODO: We should consider refactoring this to present the email alert using SwiftUI.
         ZendeskProvider.shared.createIdentity(presentIn: self) { [weak self] identityCreated in
             if !identityCreated {
-                DDLogError("⛔️ Zendesk Identity could not be created.")
-                self?.navigationController?.popViewController(animated: true)
-                // TODO: show error notice
+                self?.logIdentityErrorAndPopBack()
             }
         }
     }
@@ -43,8 +41,8 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
             switch result {
             case .success:
                 self.informSuccessAndPopBack()
-            case .failure:
-                break // TODO: log error, show error notice
+            case .failure(let error):
+                self.logAndInformErrorCreatingRequest(error)
             }
         }
     }
@@ -65,6 +63,25 @@ private extension SupportFormHostingController {
             self.navigationController?.popViewController(animated: true)
         }
         present(alertController, animated: true)
+    }
+
+    /// Logs and informs the user that a support request could not be created
+    ///
+    func logAndInformErrorCreatingRequest(_ error: Error) {
+        let notice = Notice(title: "Sorry, we could not create your support request, please try again later.", feedbackType: .error)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
+
+        DDLogError("⛔️ Could not create Support Request. Error: \(error.localizedDescription)")
+    }
+
+    /// Informs user about identity error and pop back
+    ///
+    func logIdentityErrorAndPopBack() {
+        let notice = Notice(title: "Sorry, we cannot create support request right now, please try again later.", feedbackType: .error)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
+
+        navigationController?.popViewController(animated: true)
+        DDLogError("⛔️ Zendesk Identity could not be created.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -12,6 +12,12 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
     override func viewDidLoad() {
         super.viewDidLoad()
         createZendeskIdentity()
+    }
+
+    /// `handleSupportRequestCompletion` accesses a view object, hence we need to wait for the view to be properly rendered.
+    ///
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         handleSupportRequestCompletion()
     }
 
@@ -34,10 +40,9 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
     func handleSupportRequestCompletion() {
         rootView.viewModel.onCompletion = { [weak self] result in
             guard let self else { return }
-
             switch result {
             case .success:
-                break // TODO: show alert and pop back
+                self.informSuccessAndPopBack()
             case .failure:
                 break // TODO: log error, show error notice
             }
@@ -46,6 +51,20 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension SupportFormHostingController {
+    /// Shows an alert informing the support creation success and after confirmation pops the view back.
+    ///
+    func informSuccessAndPopBack() {
+        let alertController = UIAlertController(title: "Request Sent!",
+                                                message: "Your support request has landed safely in our inbox, we will reply shortly via email.",
+                                                preferredStyle: .alert)
+        alertController.addDefaultActionWithTitle("Got it!") { _ in
+            self.navigationController?.popViewController(animated: true)
+        }
+        present(alertController, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -78,11 +78,11 @@ struct SupportForm: View {
             }
 
             Button {
-                viewModel.submitSupportRequest { _ in }
+                viewModel.submitSupportRequest()
             } label: {
                 Text(Localization.submitRequest)
             }
-            .buttonStyle(PrimaryButtonStyle())
+            .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.showLoadingIndicator))
             .disabled(viewModel.submitButtonDisabled)
         }
         .padding()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -36,6 +36,7 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
     /// Registers a completion block on the view model to properly show alerts and notices.
     ///
     func handleSupportRequestCompletion() {
+        // TODO: Solve warning
         rootView.viewModel.onCompletion = { [weak self] result in
             guard let self else { return }
             switch result {
@@ -56,10 +57,10 @@ private extension SupportFormHostingController {
     /// Shows an alert informing the support creation success and after confirmation pops the view back.
     ///
     func informSuccessAndPopBack() {
-        let alertController = UIAlertController(title: "Request Sent!",
-                                                message: "Your support request has landed safely in our inbox, we will reply shortly via email.",
+        let alertController = UIAlertController(title: Localization.requestSent,
+                                                message: Localization.requestSentMessage,
                                                 preferredStyle: .alert)
-        alertController.addDefaultActionWithTitle("Got it!") { _ in
+        alertController.addDefaultActionWithTitle(Localization.gotIt) { _ in
             self.navigationController?.popViewController(animated: true)
         }
         present(alertController, animated: true)
@@ -68,8 +69,10 @@ private extension SupportFormHostingController {
     /// Logs and informs the user that a support request could not be created
     ///
     func logAndInformErrorCreatingRequest(_ error: Error) {
-        let notice = Notice(title: "Sorry, we could not create your support request, please try again later.", feedbackType: .error)
-        ServiceLocator.noticePresenter.enqueue(notice: notice)
+        let notice = Notice(title: Localization.requestSentError, feedbackType: .error)
+        let noticePresenter = DefaultNoticePresenter()
+        noticePresenter.presentingViewController = self
+        noticePresenter.enqueue(notice: notice)
 
         DDLogError("⛔️ Could not create Support Request. Error: \(error.localizedDescription)")
     }
@@ -77,11 +80,25 @@ private extension SupportFormHostingController {
     /// Informs user about identity error and pop back
     ///
     func logIdentityErrorAndPopBack() {
-        let notice = Notice(title: "Sorry, we cannot create support request right now, please try again later.", feedbackType: .error)
+        let notice = Notice(title: Localization.badIdentityError, feedbackType: .error)
         ServiceLocator.noticePresenter.enqueue(notice: notice)
 
         navigationController?.popViewController(animated: true)
         DDLogError("⛔️ Zendesk Identity could not be created.")
+    }
+}
+
+private extension SupportFormHostingController {
+    enum Localization {
+        static let requestSent = NSLocalizedString("Request Sent!", comment: "Title for the alert after the support request is created.")
+        static let requestSentMessage = NSLocalizedString("RYour support request has landed safely in our inbox, we will reply shortly via email.",
+                                                          comment: "Message for the alert after the support request is created.")
+        static let gotIt = NSLocalizedString("Got It!", comment: "Confirmation button for the alert after the support request is created.")
+
+        static let badIdentityError = NSLocalizedString("Sorry, we cannot create support requests right now, please try again later.",
+                                                        comment: "Error message when the app can't create a zendesk identity.")
+        static let requestSentError = NSLocalizedString("Sorry, we could not create your support request, please try again later.",
+                                                        comment: "Error message when the app can't create a support request.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -78,11 +78,12 @@ struct SupportForm: View {
             }
 
             Button {
-                // No Op
+                viewModel.submitSupportRequest { _ in }
             } label: {
                 Text(Localization.submitRequest)
             }
             .buttonStyle(PrimaryButtonStyle())
+            .disabled(viewModel.submitButtonDisabled)
         }
         .padding()
         .navigationTitle(Localization.title)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -9,6 +9,25 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
         super.init(rootView: SupportForm(viewModel: viewModel))
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        createZendeskIdentity()
+    }
+
+    /// Creates the Zendesk Identity if needed.
+    /// If it fails, it pops back the view and informs the user.
+    ///
+    func createZendeskIdentity() {
+        // TODO: We should consider refactoring this to present the email alert using SwiftUI.
+        ZendeskProvider.shared.createIdentity(presentIn: self) { [weak self] identityCreated in
+            if !identityCreated {
+                DDLogError("⛔️ Zendesk Identity could not be created.")
+                self?.navigationController?.popViewController(animated: true)
+                // TODO: show error notice
+            }
+        }
+    }
+
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -64,7 +83,6 @@ struct SupportForm: View {
                 Text(Localization.submitRequest)
             }
             .buttonStyle(PrimaryButtonStyle())
-
         }
         .padding()
         .navigationTitle(Localization.title)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -12,6 +12,7 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
     override func viewDidLoad() {
         super.viewDidLoad()
         createZendeskIdentity()
+        handleSupportRequestCompletion()
     }
 
     /// Creates the Zendesk Identity if needed.
@@ -24,6 +25,21 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
                 DDLogError("⛔️ Zendesk Identity could not be created.")
                 self?.navigationController?.popViewController(animated: true)
                 // TODO: show error notice
+            }
+        }
+    }
+
+    /// Registers a completion block on the view model to properly show alerts and notices.
+    ///
+    func handleSupportRequestCompletion() {
+        rootView.viewModel.onCompletion = { [weak self] result in
+            guard let self else { return }
+
+            switch result {
+            case .success:
+                break // TODO: show alert and pop back
+            case .failure:
+                break // TODO: log error, show error notice
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -7,18 +7,12 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
 
     init(viewModel: SupportFormViewModel) {
         super.init(rootView: SupportForm(viewModel: viewModel))
+        handleSupportRequestCompletion(viewModel: viewModel)
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         createZendeskIdentity()
-    }
-
-    /// `handleSupportRequestCompletion` accesses a view object, hence we need to wait for the view to be properly rendered.
-    ///
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        handleSupportRequestCompletion()
     }
 
     /// Creates the Zendesk Identity if needed.
@@ -35,9 +29,8 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
 
     /// Registers a completion block on the view model to properly show alerts and notices.
     ///
-    func handleSupportRequestCompletion() {
-        // TODO: Solve warning
-        rootView.viewModel.onCompletion = { [weak self] result in
+    func handleSupportRequestCompletion(viewModel: SupportFormViewModel) {
+        viewModel.onCompletion = { [weak self] result in
             guard let self else { return }
             switch result {
             case .success:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -37,6 +37,12 @@ public final class SupportFormViewModel: ObservableObject {
     ///
     let areas: [Area]
 
+    /// Defines when the submit button should be enabled or not.
+    ///
+    var submitButtonDisabled: Bool {
+        subject.isEmpty || description.isEmpty
+    }
+
     init(areas: [Area] = wooSupportAreas()) {
         self.areas = areas
         self.area = areas[0] // Preselect the first area.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -69,7 +69,8 @@ public final class SupportFormViewModel: ObservableObject {
             //                                                    description: description) { [weak self] result in
             guard let self else { return }
             self.showLoadingIndicator = false
-            self.onCompletion?(.success(()))
+            //self.onCompletion?(.success(()))
+            self.onCompletion?(.failure(NSError(domain: "Server error 500", code: 500)))
         }
             //print(result)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -60,19 +60,15 @@ public final class SupportFormViewModel: ObservableObject {
     ///
     func submitSupportRequest() {
         showLoadingIndicator = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
-
-            //        ZendeskProvider.shared.createSupportRequest(formID: area.datasource.formID,
-            //                                                    customFields: area.datasource.customFields,
-            //                                                    tags: area.datasource.tags,
-            //                                                    subject: subject,
-            //                                                    description: description) { [weak self] result in
+        ZendeskProvider.shared.createSupportRequest(formID: area.datasource.formID,
+                                                    customFields: area.datasource.customFields,
+                                                    tags: area.datasource.tags,
+                                                    subject: subject,
+                                                    description: description) { [weak self] result in
             guard let self else { return }
             self.showLoadingIndicator = false
-            //self.onCompletion?(.success(()))
-            self.onCompletion?(.failure(NSError(domain: "Server error 500", code: 500)))
+            self.onCompletion?(result)
         }
-            //print(result)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -41,6 +41,10 @@ public final class SupportFormViewModel: ObservableObject {
     ///
     let areas: [Area]
 
+    /// Assign this closure to get notified when a support request creation finishes.
+    ///
+    var onCompletion: ((Result<Void, Error>) -> Void)?
+
     /// Defines when the submit button should be enabled or not.
     ///
     var submitButtonDisabled: Bool {
@@ -58,16 +62,16 @@ public final class SupportFormViewModel: ObservableObject {
         showLoadingIndicator = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
 
-//        ZendeskProvider.shared.createSupportRequest(formID: area.datasource.formID,
-//                                                    customFields: area.datasource.customFields,
-//                                                    tags: area.datasource.tags,
-//                                                    subject: subject,
-//                                                    description: description) { [weak self] result in
+            //        ZendeskProvider.shared.createSupportRequest(formID: area.datasource.formID,
+            //                                                    customFields: area.datasource.customFields,
+            //                                                    tags: area.datasource.tags,
+            //                                                    subject: subject,
+            //                                                    description: description) { [weak self] result in
             guard let self else { return }
             self.showLoadingIndicator = false
-
-            //print(result)
+            self.onCompletion?(.success(()))
         }
+            //print(result)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -33,6 +33,10 @@ public final class SupportFormViewModel: ObservableObject {
     ///
     @Published var description = ""
 
+    /// Determines if the loading indicator should be visible or not.
+    ///
+    @Published var showLoadingIndicator = false
+
     /// Supported support areas.
     ///
     let areas: [Area]
@@ -50,13 +54,20 @@ public final class SupportFormViewModel: ObservableObject {
 
     /// Submits the support request using the Zendesk Provider.
     ///
-    func submitSupportRequest(onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        ZendeskProvider.shared.createSupportRequest(formID: area.datasource.formID,
-                                                    customFields: area.datasource.customFields,
-                                                    tags: area.datasource.tags,
-                                                    subject: subject,
-                                                    description: description,
-                                                    onCompletion: onCompletion)
+    func submitSupportRequest() {
+        showLoadingIndicator = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+
+//        ZendeskProvider.shared.createSupportRequest(formID: area.datasource.formID,
+//                                                    customFields: area.datasource.customFields,
+//                                                    tags: area.datasource.tags,
+//                                                    subject: subject,
+//                                                    description: description) { [weak self] result in
+            guard let self else { return }
+            self.showLoadingIndicator = false
+
+            //print(result)
+        }
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -621,6 +621,7 @@
 		262EB5B0298C7C3A009DCC36 /* SupportFormsDataSources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262EB5AF298C7C3A009DCC36 /* SupportFormsDataSources.swift */; };
 		262EB5B3298D66FE009DCC36 /* SupportDataSourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262EB5B2298D66FE009DCC36 /* SupportDataSourcesTests.swift */; };
 		26309F17277D0AEA0012797F /* SafeAreaInsetsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26309F16277D0AEA0012797F /* SafeAreaInsetsKey.swift */; };
+		263491D5299C923400594566 /* SupportFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263491D4299C923300594566 /* SupportFormViewModelTests.swift */; };
 		263C4CC02963784900CA7E05 /* ProductVariationGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */; };
 		263E37E12641AD8300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; };
 		263E37E22641AD8300260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -2720,6 +2721,7 @@
 		262EB5AF298C7C3A009DCC36 /* SupportFormsDataSources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportFormsDataSources.swift; sourceTree = "<group>"; };
 		262EB5B2298D66FE009DCC36 /* SupportDataSourcesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataSourcesTests.swift; sourceTree = "<group>"; };
 		26309F16277D0AEA0012797F /* SafeAreaInsetsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeAreaInsetsKey.swift; sourceTree = "<group>"; };
+		263491D4299C923300594566 /* SupportFormViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportFormViewModelTests.swift; sourceTree = "<group>"; };
 		263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationGenerator.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
 		2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubView.swift; sourceTree = "<group>"; };
@@ -5602,6 +5604,7 @@
 		262EB5B1298D66E8009DCC36 /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				263491D4299C923300594566 /* SupportFormViewModelTests.swift */,
 				262EB5B2298D66FE009DCC36 /* SupportDataSourcesTests.swift */,
 			);
 			path = Support;
@@ -11434,6 +11437,7 @@
 				DEC51B04276B30F6009F3DF4 /* SystemStatusReportViewModelTests.swift in Sources */,
 				26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */,
 				26100B202722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift in Sources */,
+				263491D5299C923400594566 /* SupportFormViewModelTests.swift in Sources */,
 				0279F0DC252DBF1F0098D7DE /* ProductVariationDetailsFactoryTests.swift in Sources */,
 				450C2CB324D0803000D570DD /* ProductSettingsRowsTests.swift in Sources */,
 				45AF9DAF265CFAB4001EB794 /* MockShippingLabelCarrierRate.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import WooCommerce
+
+final class SupportFormViewModelTests: XCTestCase {
+
+    func test_submit_button_is_disabled_when_subject_and_description_are_empty() {
+        // Given
+        let viewModel = SupportFormViewModel(areas: Self.sampleAreas())
+
+        // When
+        viewModel.subject = ""
+        viewModel.description = ""
+
+        // Then
+        XCTAssertTrue(viewModel.submitButtonDisabled)
+    }
+
+    func test_submit_button_is_disabled_when_subject_is_not_empty_and_description_is_empty() {
+        // Given
+        let viewModel = SupportFormViewModel(areas: Self.sampleAreas())
+
+        // When
+        viewModel.subject = "Subject"
+        viewModel.description = ""
+
+        // Then
+        XCTAssertTrue(viewModel.submitButtonDisabled)
+    }
+
+    func test_submit_button_is_disabled_when_subject_is_empty_and_description_is_not_empty() {
+        // Given
+        let viewModel = SupportFormViewModel(areas: Self.sampleAreas())
+
+        // When
+        viewModel.subject = ""
+        viewModel.description = "Description"
+
+        // Then
+        XCTAssertTrue(viewModel.submitButtonDisabled)
+    }
+
+    func test_submit_button_is_enabled_when_subject_is_and_description_are_not_empty() {
+        // Given
+        let viewModel = SupportFormViewModel(areas: Self.sampleAreas())
+
+        // When
+        viewModel.subject = "Subject"
+        viewModel.description = "Description"
+
+        // Then
+        XCTAssertFalse(viewModel.submitButtonDisabled)
+    }
+}
+
+private extension SupportFormViewModelTests {
+    private struct MockDataSource: SupportFormMetaDataSource {
+        let formID: Int64 = 0
+        let tags: [String] = []
+        let customFields: [Int64: String] = [:]
+    }
+
+    static func sampleAreas() -> [SupportFormViewModel.Area] {
+        [
+            .init(title: "Area 1", datasource: MockDataSource()),
+            .init(title: "Area 2", datasource: MockDataSource())
+        ]
+    }
+}


### PR DESCRIPTION
Closes: #8796

# Why

This PR makes sure that the new Support UI is well integrated with it's ViewModel. In particular this PR:

- Creates Zendesk identity when as the view loads.
- Handles identity creation failure - Pops the view back and shows an error notice.
- Controls that the submit button is disabled until the proper information is filled in.
- Shows a loading indicator while the request is being submitted.
- Creates the support request and handles it's completion: 
   - If success: Show alert and pop the view back.
   - If error: Show an error notice

# Demo

## Identity Error
https://user-images.githubusercontent.com/562080/219081811-428b9db0-a150-4d65-964e-8aeb5ed51dcc.mov

## Creation Error
https://user-images.githubusercontent.com/562080/219081798-8a1aca1b-dccf-43cc-b40d-f1452d73c4a0.mov

## Creation Success
https://user-images.githubusercontent.com/562080/219081818-e90ad14e-7f3c-473e-8f46-9c3ce70156ed.mov

# Testing Steps

- Delete the app to make sure we delete the zen desk Identity
- Install the app and navigate to support, make sure the form requests for your email and name. Make sure to not use an A8C email.
   - If tapping cancel, you should see an error notice and the view gets popped.

----

- Fill in the support request, turn off the wifi, and try to submit the support request.
- See that an error notice is presented and the view remains in place

----

- Turn on the wifi and submit the support request.
- See that the success alert is presented and the view gets popped back.

----

- On Zendesk search for your email(non A8C) and see the support ticket created. Mark it as closed if possible.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
