### PR TITLE
[Support Request] Add source tag support

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -43,7 +43,11 @@ public final class SupportFormViewModel: ObservableObject {
 
     /// Custom tag to identify where in the app the request is coming from.
     ///
-    let sourceTag: String?
+    private let sourceTag: String?
+
+    /// Handles the communication with Zendesk.
+    ///
+    private let zendeskProvider: ZendeskManagerProtocol
 
     /// Assign this closure to get notified when a support request creation finishes.
     ///
@@ -55,21 +59,22 @@ public final class SupportFormViewModel: ObservableObject {
         subject.isEmpty || description.isEmpty
     }
 
-    init(areas: [Area] = wooSupportAreas(), sourceTag: String? = nil) {
+    init(areas: [Area] = wooSupportAreas(), sourceTag: String? = nil, zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared) {
         self.areas = areas
         self.area = areas[0] // Preselect the first area.
         self.sourceTag = sourceTag
+        self.zendeskProvider = zendeskProvider
     }
 
     /// Submits the support request using the Zendesk Provider.
     ///
     func submitSupportRequest() {
         showLoadingIndicator = true
-        ZendeskProvider.shared.createSupportRequest(formID: area.datasource.formID,
-                                                    customFields: area.datasource.customFields,
-                                                    tags: assembleTags(),
-                                                    subject: subject,
-                                                    description: description) { [weak self] result in
+        zendeskProvider.createSupportRequest(formID: area.datasource.formID,
+                                             customFields: area.datasource.customFields,
+                                             tags: assembleTags(),
+                                             subject: subject,
+                                             description: description) { [weak self] result in
             guard let self else { return }
             self.showLoadingIndicator = false
             self.onCompletion?(result)

--- a/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
+++ b/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
@@ -16,6 +16,10 @@ final class MockZendeskManager: ZendeskManagerProtocol {
     ///
     private(set) var newRequestIfPossibleInvocations = [NewRequestIfPossibleInvocation]()
 
+    /// Tracks which tags were invoked via the create request method.
+    ///
+    private(set) var latestInvokedTags: [String] = []
+
     func showNewRequestIfPossible(from controller: UIViewController, with sourceTag: String?) {
         let invocation = NewRequestIfPossibleInvocation(controller: controller, sourceTag: sourceTag)
         newRequestIfPossibleInvocations.append(invocation)
@@ -88,7 +92,7 @@ extension MockZendeskManager {
                               subject: String,
                               description: String,
                               onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        // no-op
+        latestInvokedTags = tags
     }
 
     func formID() -> Int64 {

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
@@ -50,6 +50,19 @@ final class SupportFormViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.submitButtonDisabled)
     }
+
+    func test_source_tag_is_properly_sent_when_creating_a_request() {
+        // Given
+        let sourceTag = "custom-tag"
+        let zendesk = MockZendeskManager()
+        let viewModel = SupportFormViewModel(areas: Self.sampleAreas(), sourceTag: sourceTag, zendeskProvider: zendesk)
+
+        // When
+        viewModel.submitSupportRequest()
+
+        // Then
+        XCTAssertTrue(zendesk.latestInvokedTags.contains(sourceTag))
+    }
 }
 
 private extension SupportFormViewModelTests {


### PR DESCRIPTION
Closes: #8863 

# Why

The current support implementation allows the consumer to send a source tag depending on when the flow is initiated.
This PR adds support for that source tag in the new `SupportFormViewModel`.

# How

- Add a `sourceTag` parameter in the ViewModel initializer.
- Append the `sourceTag` to the support area tags before creating the request.
- Add unit tests.

# Testing Steps

This code is not yet used anywhere but the unit test passing should be enough.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
