### PR TITLE
[Support Request] Migrate Analytics

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -151,6 +151,9 @@ struct SupportForm: View {
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
         .wooNavigationBarStyle()
+        .onAppear {
+            viewModel.trackSupportFormViewed()
+        }
     }
 }
 


### PR DESCRIPTION
Closes: #8864 

# Why

This PR copies the relevant analytics from `ZendeskManager` to the `SupportFormViewModel`. Specifically, it tracks:

- When the view gets loaded 
- When the request is created successfully
- When there is an error creating a request.

# Testing Steps

- Navigate to the support form
- See the `. supportNewRequestViewed ` being tracked

----

- Navigate to the support form
- Create a support request successfully.
- See the `.supportNewRequestCreated`

----

- Navigate to the support form
- Create a support request without internet so it fails.
- See the `. supportNewRequestFailed`

---

**Note: The `supportNewRequestCreated` and `supportNewRequestFailed` events will be tracked twice but that will be resolved once we delete the unused code in https://github.com/woocommerce/woocommerce-ios/issues/8815**


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
