### PR TITLE
[Support Request] Update UI with proper designs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -111,21 +111,25 @@ struct SupportForm: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             VStack(spacing: .zero) {
+
+                // Scrollable Form
                 ScrollView {
                     VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
-
 
                         Text(Localization.iNeedHelp.uppercased())
                             .footnoteStyle()
                             .padding([.horizontal, .top])
 
+                        // Area List
                         VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
                             ForEach(viewModel.areas.indexed(), id: \.0.self) { index, area in
                                 HStack(alignment: .center, spacing: Layout.radioButtonSpacing) {
+                                    // Radio-Button emulation
                                     Circle()
                                         .stroke(Color(.separator), lineWidth: 2)
                                         .frame(width: 20, height: 20)
                                         .background(
+                                            // Use a clear color for non-selected radio buttons.
                                             Circle()
                                                 .fill( viewModel.isAreaSelected(area) ? Color(.accent) : .clear)
                                                 .padding(2)
@@ -134,12 +138,12 @@ struct SupportForm: View {
                                     Text(area.title)
                                         .headlineStyle()
                                 }
-                                .onTapGesture {
+                                .onTapGesture { // TODO: improve tap area
                                     viewModel.selectArea(area)
                                 }
 
                                 Divider()
-                                    .renderedIf(index < viewModel.areas.count - 1)
+                                    .renderedIf(index < viewModel.areas.count - 1) // Don't render the last divider
                             }
                         }
                         .padding()
@@ -147,6 +151,7 @@ struct SupportForm: View {
                         .cornerRadius(Layout.cornerRadius)
                         .padding(.bottom)
 
+                        // Info Section
                         VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
                             Text(Localization.letsGetItSorted)
                                 .headlineStyle()
@@ -155,6 +160,7 @@ struct SupportForm: View {
                                 .subheadlineStyle()
                         }
 
+                        // Subject Text Field
                         VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
                             Text(Localization.subject)
                                 .foregroundColor(Color(.text))
@@ -169,6 +175,7 @@ struct SupportForm: View {
                                 )
                         }
 
+                        // Description Text Editor
                         VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
                             Text(Localization.message)
                                 .foregroundColor(Color(.text))
@@ -185,6 +192,7 @@ struct SupportForm: View {
                     .padding()
                 }
 
+                // Submit Request Footer
                 VStack() {
                     Divider()
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -106,110 +106,105 @@ struct SupportForm: View {
     @StateObject var viewModel: SupportFormViewModel
 
     var body: some View {
-        ZStack() {
-            // Background
-            Color(.listBackground)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        VStack(spacing: .zero) {
 
-            VStack(spacing: .zero) {
+            // Scrollable Form
+            ScrollView {
+                VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
 
-                // Scrollable Form
-                ScrollView {
-                    VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+                    Text(Localization.iNeedHelp.uppercased())
+                        .footnoteStyle()
+                        .padding([.horizontal, .top])
 
-                        Text(Localization.iNeedHelp.uppercased())
-                            .footnoteStyle()
-                            .padding([.horizontal, .top])
+                    // Area List
+                    VStack(alignment: .leading, spacing: .zero) {
+                        ForEach(viewModel.areas.indexed(), id: \.0.self) { index, area in
+                            HStack(alignment: .center, spacing: Layout.radioButtonSpacing) {
+                                // Radio-Button emulation
+                                Circle()
+                                    .stroke(Color(.separator), lineWidth: Layout.radioButtonBorderWidth)
+                                    .frame(width: Layout.radioButtonSize, height: Layout.radioButtonSize)
+                                    .background(
+                                        // Use a clear color for non-selected radio buttons.
+                                        Circle()
+                                            .fill( viewModel.isAreaSelected(area) ? Color(.accent) : .clear)
+                                            .padding(Layout.radioButtonBorderWidth)
+                                    )
 
-                        // Area List
-                        VStack(alignment: .leading, spacing: .zero) {
-                            ForEach(viewModel.areas.indexed(), id: \.0.self) { index, area in
-                                HStack(alignment: .center, spacing: Layout.radioButtonSpacing) {
-                                    // Radio-Button emulation
-                                    Circle()
-                                        .stroke(Color(.separator), lineWidth: Layout.radioButtonBorderWidth)
-                                        .frame(width: Layout.radioButtonSize, height: Layout.radioButtonSize)
-                                        .background(
-                                            // Use a clear color for non-selected radio buttons.
-                                            Circle()
-                                                .fill( viewModel.isAreaSelected(area) ? Color(.accent) : .clear)
-                                                .padding(Layout.radioButtonBorderWidth)
-                                        )
-
-                                    Text(area.title)
-                                        .headlineStyle()
-                                }
-                                .padding()
-                                .frame(maxWidth: .infinity, alignment: .leading) // Needed to make tap area the whole width
-                                .background(Color(.listForeground(modal: false)))
-                                .onTapGesture {
-                                    viewModel.selectArea(area)
-                                }
-
-                                Divider()
-                                    .renderedIf(index < viewModel.areas.count - 1) // Don't render the last divider
+                                Text(area.title)
+                                    .headlineStyle()
                             }
-                        }
-                        .cornerRadius(Layout.cornerRadius)
-                        .padding(.bottom)
+                            .padding()
+                            .frame(maxWidth: .infinity, alignment: .leading) // Needed to make tap area the whole width
+                            .background(Color(.listForeground(modal: false)))
+                            .onTapGesture {
+                                viewModel.selectArea(area)
+                            }
 
-                        // Info Section
-                        VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
-                            Text(Localization.letsGetItSorted)
-                                .headlineStyle()
-
-                            Text(Localization.tellUsInfo)
-                                .subheadlineStyle()
-                        }
-
-                        // Subject Text Field
-                        VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
-                            Text(Localization.subject)
-                                .foregroundColor(Color(.text))
-                                .subheadlineStyle()
-
-                            TextField("", text: $viewModel.subject)
-                                .bodyStyle()
-                                .padding(insets: Layout.subjectInsets)
-                                .background(Color(.listForeground(modal: false)))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
-                                )
-                        }
-
-                        // Description Text Editor
-                        VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
-                            Text(Localization.message)
-                                .foregroundColor(Color(.text))
-                                .subheadlineStyle()
-
-                            TextEditor(text: $viewModel.description)
-                                .bodyStyle()
-                                .frame(minHeight: Layout.minimuEditorSize)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
-                                )
+                            Divider()
+                                .renderedIf(index < viewModel.areas.count - 1) // Don't render the last divider
                         }
                     }
-                    .padding()
-                }
+                    .cornerRadius(Layout.cornerRadius)
+                    .padding(.bottom)
 
-                // Submit Request Footer
-                VStack() {
-                    Divider()
+                    // Info Section
+                    VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
+                        Text(Localization.letsGetItSorted)
+                            .headlineStyle()
 
-                    Button {
-                        viewModel.submitSupportRequest()
-                    } label: {
-                        Text(Localization.submitRequest)
+                        Text(Localization.tellUsInfo)
+                            .subheadlineStyle()
                     }
-                    .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.showLoadingIndicator))
-                    .disabled(viewModel.submitButtonDisabled)
-                    .padding()
+
+                    // Subject Text Field
+                    VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
+                        Text(Localization.subject)
+                            .foregroundColor(Color(.text))
+                            .subheadlineStyle()
+
+                        TextField("", text: $viewModel.subject)
+                            .bodyStyle()
+                            .padding(insets: Layout.subjectInsets)
+                            .background(Color(.listForeground(modal: false)))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
+                            )
+                    }
+
+                    // Description Text Editor
+                    VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
+                        Text(Localization.message)
+                            .foregroundColor(Color(.text))
+                            .subheadlineStyle()
+
+                        TextEditor(text: $viewModel.description)
+                            .bodyStyle()
+                            .frame(minHeight: Layout.minimuEditorSize)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
+                            )
+                    }
                 }
-                .background(Color(.listForeground(modal: false)))
+                .padding()
             }
+
+            // Submit Request Footer
+            VStack() {
+                Divider()
+
+                Button {
+                    viewModel.submitSupportRequest()
+                } label: {
+                    Text(Localization.submitRequest)
+                }
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.showLoadingIndicator))
+                .disabled(viewModel.submitButtonDisabled)
+                .padding()
+            }
+            .background(Color(.listForeground(modal: false)))
         }
+        .background(Color(.listBackground))
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
         .wooNavigationBarStyle()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -114,17 +114,31 @@ struct SupportForm: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
 
+
                         Text(Localization.iNeedHelp.uppercased())
                             .footnoteStyle()
-                            .padding()
+                            .padding([.horizontal, .top])
 
-                        Picker(Localization.iNeedHelp, selection: $viewModel.area) {
-                            ForEach(viewModel.areas, id: \.self) { area in
-                                Text(area.title).tag(area)
+                        VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+                            ForEach(viewModel.areas.indexed(), id: \.0.self) { index, area in
+                                HStack(alignment: .center, spacing: Layout.radioButtonSpacing) {
+                                    Circle()
+                                        .stroke(Color(.separator), lineWidth: 2)
+                                        .frame(width: 20, height: 20)
+                                        //.background(Circle().fill(Color(.accent)).padding(2))
+
+                                    Text(area.title)
+                                        .headlineStyle()
+                                }
+
+                                Divider()
+                                    .renderedIf(index < viewModel.areas.count - 1)
                             }
                         }
-                        .pickerStyle(.inline)
+                        .padding()
                         .background(Color(.listForeground(modal: false)))
+                        .cornerRadius(Layout.cornerRadius)
+                        .padding(.bottom)
 
                         VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
                             Text(Localization.letsGetItSorted)
@@ -203,7 +217,7 @@ private extension SupportForm {
 
     enum Layout {
         static let sectionSpacing: CGFloat = 16
-        static let optionsSpacing: CGFloat = 8
+        static let radioButtonSpacing: CGFloat = 12
         static let subSectionsSpacing: CGFloat = 8
         static let cornerRadius: CGFloat = 8
         static let subjectInsets = EdgeInsets(top: 8, leading: 5, bottom: 8, trailing: 5)
@@ -223,8 +237,10 @@ struct SupportFormProvider: PreviewProvider {
     static var previews: some View {
         NavigationView {
             SupportForm(viewModel: .init(areas: [
-                .init(title: "Mobile Aps", datasource: MockDataSource()),
+                .init(title: "Mobile Apps", datasource: MockDataSource()),
+                .init(title: "Card Reader / In Person Payments", datasource: MockDataSource()),
                 .init(title: "WooCommerce Payments", datasource: MockDataSource()),
+                .init(title: "WooCommerce Plugins", datasource: MockDataSource()),
                 .init(title: "Other Plugins", datasource: MockDataSource()),
             ]))
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -126,13 +126,13 @@ struct SupportForm: View {
                                 HStack(alignment: .center, spacing: Layout.radioButtonSpacing) {
                                     // Radio-Button emulation
                                     Circle()
-                                        .stroke(Color(.separator), lineWidth: 2)
-                                        .frame(width: 20, height: 20)
+                                        .stroke(Color(.separator), lineWidth: Layout.radioButtonBorderWidth)
+                                        .frame(width: Layout.radioButtonSize, height: Layout.radioButtonSize)
                                         .background(
                                             // Use a clear color for non-selected radio buttons.
                                             Circle()
                                                 .fill( viewModel.isAreaSelected(area) ? Color(.accent) : .clear)
-                                                .padding(2)
+                                                .padding(Layout.radioButtonBorderWidth)
                                         )
 
                                     Text(area.title)
@@ -234,6 +234,8 @@ private extension SupportForm {
     enum Layout {
         static let sectionSpacing: CGFloat = 16
         static let radioButtonSpacing: CGFloat = 12
+        static let radioButtonBorderWidth: CGFloat = 2
+        static let radioButtonSize: CGFloat = 20
         static let subSectionsSpacing: CGFloat = 8
         static let cornerRadius: CGFloat = 8
         static let subjectInsets = EdgeInsets(top: 8, leading: 5, bottom: 8, trailing: 5)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -8,6 +8,7 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
     init(viewModel: SupportFormViewModel) {
         super.init(rootView: SupportForm(viewModel: viewModel))
         handleSupportRequestCompletion(viewModel: viewModel)
+        hidesBottomBarWhenPushed = true
     }
 
     override func viewDidLoad() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -121,7 +121,7 @@ struct SupportForm: View {
                             .padding([.horizontal, .top])
 
                         // Area List
-                        VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+                        VStack(alignment: .leading, spacing: .zero) {
                             ForEach(viewModel.areas.indexed(), id: \.0.self) { index, area in
                                 HStack(alignment: .center, spacing: Layout.radioButtonSpacing) {
                                     // Radio-Button emulation
@@ -138,7 +138,10 @@ struct SupportForm: View {
                                     Text(area.title)
                                         .headlineStyle()
                                 }
-                                .onTapGesture { // TODO: improve tap area
+                                .padding()
+                                .frame(maxWidth: .infinity, alignment: .leading) // Needed to make tap area the whole width
+                                .background(Color(.listForeground(modal: false)))
+                                .onTapGesture {
                                     viewModel.selectArea(area)
                                 }
 
@@ -146,8 +149,6 @@ struct SupportForm: View {
                                     .renderedIf(index < viewModel.areas.count - 1) // Don't render the last divider
                             }
                         }
-                        .padding()
-                        .background(Color(.listForeground(modal: false)))
                         .cornerRadius(Layout.cornerRadius)
                         .padding(.bottom)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -105,49 +105,80 @@ struct SupportForm: View {
     @StateObject var viewModel: SupportFormViewModel
 
     var body: some View {
-        VStack(spacing: Layout.sectionSpacing) {
+        ZStack() {
+            // Background
+            Color(.listBackground)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            HStack(spacing: -Layout.optionsSpacing) {
-                Text(Localization.iNeedHelp)
-                    .bold()
-                Picker(Localization.iNeedHelp, selection: $viewModel.area) {
-                    ForEach(viewModel.areas, id: \.self) { area in
-                        Text(area.title).tag(area)
+            VStack(spacing: .zero) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+
+                        Text(Localization.iNeedHelp.uppercased())
+                            .footnoteStyle()
+                            .padding()
+
+                        Picker(Localization.iNeedHelp, selection: $viewModel.area) {
+                            ForEach(viewModel.areas, id: \.self) { area in
+                                Text(area.title).tag(area)
+                            }
+                        }
+                        .pickerStyle(.inline)
+                        .background(Color(.listForeground(modal: false)))
+
+                        VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
+                            Text(Localization.letsGetItSorted)
+                                .headlineStyle()
+
+                            Text(Localization.tellUsInfo)
+                                .subheadlineStyle()
+                        }
+
+                        VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
+                            Text(Localization.subject)
+                                .foregroundColor(Color(.text))
+                                .subheadlineStyle()
+
+                            TextField("", text: $viewModel.subject)
+                                .bodyStyle()
+                                .padding(insets: Layout.subjectInsets)
+                                .background(Color(.listForeground(modal: false)))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
+                                )
+                        }
+
+                        VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
+                            Text(Localization.message)
+                                .foregroundColor(Color(.text))
+                                .subheadlineStyle()
+
+                            TextEditor(text: $viewModel.description)
+                                .bodyStyle()
+                                .frame(minHeight: Layout.minimuEditorSize)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
+                                )
+                        }
                     }
+                    .padding()
                 }
-                .pickerStyle(.menu)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
 
-            VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
-                Text(Localization.subject)
-                    .bold()
-                TextField("", text: $viewModel.subject)
-                    .bodyStyle()
-                    .padding(Layout.subjectPadding)
-                    .border(Color(.separator))
-                    .cornerRadius(Layout.cornerRadius)
-            }
+                VStack() {
+                    Divider()
 
-            VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
-                Text(Localization.whatToDo)
-                    .bold()
-                TextEditor(text: $viewModel.description)
-                    .bodyStyle()
-                    .border(Color(.separator))
-                    .cornerRadius(Layout.cornerRadius)
+                    Button {
+                        viewModel.submitSupportRequest()
+                    } label: {
+                        Text(Localization.submitRequest)
+                    }
+                    .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.showLoadingIndicator))
+                    .disabled(viewModel.submitButtonDisabled)
+                    .padding()
+                }
+                .background(Color(.listForeground(modal: false)))
             }
-
-            Button {
-                viewModel.submitSupportRequest()
-            } label: {
-                Text(Localization.submitRequest)
-            }
-            .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.showLoadingIndicator))
-            .disabled(viewModel.submitButtonDisabled)
         }
-        .padding()
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
         .wooNavigationBarStyle()
@@ -161,18 +192,22 @@ struct SupportForm: View {
 private extension SupportForm {
     enum Localization {
         static let title = NSLocalizedString("Contact Support", comment: "Title of the view for contacting support.")
-        static let iNeedHelp = NSLocalizedString("I need help with:", comment: "Text on the support form to refer to what area the user has problem with.")
+        static let iNeedHelp = NSLocalizedString("I need help with", comment: "Text on the support form to refer to what area the user has problem with.")
+        static let letsGetItSorted = NSLocalizedString("Let’s get this sorted", comment: "Title to let the user know what do we want on the support screen.")
+        static let tellUsInfo = NSLocalizedString("Tell us much as you can about the problem, and we will be in touch soon.",
+                                                  comment: "Message info on the support screen.")
         static let subject = NSLocalizedString("Subject", comment: "Subject title on the support form")
-        static let whatToDo = NSLocalizedString("What are you trying to do?", comment: "Text on the support form to ask the user what are they trying to do.")
+        static let message = NSLocalizedString("Message", comment: "Message on the support form")
         static let submitRequest = NSLocalizedString("Submit Support Request", comment: "Button title to submit a support request.")
     }
 
     enum Layout {
         static let sectionSpacing: CGFloat = 16
         static let optionsSpacing: CGFloat = 8
-        static let subSectionsSpacing: CGFloat = 2
-        static let cornerRadius: CGFloat = 2
-        static let subjectPadding: CGFloat = 5
+        static let subSectionsSpacing: CGFloat = 8
+        static let cornerRadius: CGFloat = 8
+        static let subjectInsets = EdgeInsets(top: 8, leading: 5, bottom: 8, trailing: 5)
+        static let minimuEditorSize: CGFloat = 300
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -142,6 +142,7 @@ struct SupportForm: View {
                             }
 
                             Divider()
+                                .padding(.leading)
                                 .renderedIf(index < viewModel.areas.count - 1) // Don't render the last divider
                         }
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -125,10 +125,17 @@ struct SupportForm: View {
                                     Circle()
                                         .stroke(Color(.separator), lineWidth: 2)
                                         .frame(width: 20, height: 20)
-                                        //.background(Circle().fill(Color(.accent)).padding(2))
+                                        .background(
+                                            Circle()
+                                                .fill( viewModel.isAreaSelected(area) ? Color(.accent) : .clear)
+                                                .padding(2)
+                                        )
 
                                     Text(area.title)
                                         .headlineStyle()
+                                }
+                                .onTapGesture {
+                                    viewModel.selectArea(area)
                                 }
 
                                 Divider()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -23,7 +23,7 @@ public final class SupportFormViewModel: ObservableObject {
 
     /// Variable that holds the area of support for better routing.
     ///
-    @Published var area: Area
+    @Published var area: Area?
 
     /// Variable that holds the subject of the ticket.
     ///
@@ -60,7 +60,7 @@ public final class SupportFormViewModel: ObservableObject {
     /// Defines when the submit button should be enabled or not.
     ///
     var submitButtonDisabled: Bool {
-        subject.isEmpty || description.isEmpty
+        area == nil || subject.isEmpty || description.isEmpty
     }
 
     init(areas: [Area] = wooSupportAreas(),
@@ -68,7 +68,6 @@ public final class SupportFormViewModel: ObservableObject {
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
          analyticsProvider: Analytics = ServiceLocator.analytics) {
         self.areas = areas
-        self.area = areas[0] // Preselect the first area.
         self.sourceTag = sourceTag
         self.zendeskProvider = zendeskProvider
         self.analyticsProvider = analyticsProvider
@@ -80,10 +79,14 @@ public final class SupportFormViewModel: ObservableObject {
         analyticsProvider.track(.supportNewRequestViewed)
     }
 
+    /// Selects an area.
+    ///
     func selectArea(_ area: Area) {
         self.area = area
     }
 
+    /// Determines if the given area is selected.
+    ///
     func isAreaSelected(_ area: Area) -> Bool {
         self.area == area
     }
@@ -91,6 +94,8 @@ public final class SupportFormViewModel: ObservableObject {
     /// Submits the support request using the Zendesk Provider.
     ///
     func submitSupportRequest() {
+        guard let area else { return }
+
         showLoadingIndicator = true
         zendeskProvider.createSupportRequest(formID: area.datasource.formID,
                                              customFields: area.datasource.customFields,
@@ -114,6 +119,7 @@ public final class SupportFormViewModel: ObservableObject {
     /// Joins the selected area tags with the source tag(if available).
     ///
     func assembleTags() -> [String] {
+        guard let area else { return [] }
         guard let sourceTag, sourceTag.isNotEmpty else {
             return area.datasource.tags
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -80,6 +80,14 @@ public final class SupportFormViewModel: ObservableObject {
         analyticsProvider.track(.supportNewRequestViewed)
     }
 
+    func selectArea(_ area: Area) {
+        self.area = area
+    }
+
+    func isAreaSelected(_ area: Area) -> Bool {
+        self.area == area
+    }
+
     /// Submits the support request using the Zendesk Provider.
     ///
     func submitSupportRequest() {

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
@@ -3,11 +3,12 @@ import XCTest
 
 final class SupportFormViewModelTests: XCTestCase {
 
-    func test_submit_button_is_disabled_when_subject_and_description_are_empty() {
+    func test_submit_button_is_disabled_when_area_and_subject_and_description_are_empty() {
         // Given
         let viewModel = SupportFormViewModel(areas: Self.sampleAreas())
 
         // When
+        viewModel.area = nil
         viewModel.subject = ""
         viewModel.description = ""
 
@@ -15,11 +16,12 @@ final class SupportFormViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.submitButtonDisabled)
     }
 
-    func test_submit_button_is_disabled_when_subject_is_not_empty_and_description_is_empty() {
+    func test_submit_button_is_disabled_when_area_is_empty_and_subject_is_not_empty_and_description_is_empty() {
         // Given
         let viewModel = SupportFormViewModel(areas: Self.sampleAreas())
 
         // When
+        viewModel.area = nil
         viewModel.subject = "Subject"
         viewModel.description = ""
 
@@ -27,11 +29,12 @@ final class SupportFormViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.submitButtonDisabled)
     }
 
-    func test_submit_button_is_disabled_when_subject_is_empty_and_description_is_not_empty() {
+    func test_submit_button_is_disabled_when_area_is_empty_and_subject_is_empty_and_description_is_not_empty() {
         // Given
         let viewModel = SupportFormViewModel(areas: Self.sampleAreas())
 
         // When
+        viewModel.area = nil
         viewModel.subject = ""
         viewModel.description = "Description"
 
@@ -39,11 +42,12 @@ final class SupportFormViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.submitButtonDisabled)
     }
 
-    func test_submit_button_is_enabled_when_subject_is_and_description_are_not_empty() {
+    func test_submit_button_is_enabled_when_area_and_subject_and_description_are_not_empty() {
         // Given
         let viewModel = SupportFormViewModel(areas: Self.sampleAreas())
 
         // When
+        viewModel.area = viewModel.areas.first
         viewModel.subject = "Subject"
         viewModel.description = "Description"
 
@@ -56,6 +60,7 @@ final class SupportFormViewModelTests: XCTestCase {
         let sourceTag = "custom-tag"
         let zendesk = MockZendeskManager()
         let viewModel = SupportFormViewModel(areas: Self.sampleAreas(), sourceTag: sourceTag, zendeskProvider: zendesk)
+        viewModel.area = viewModel.areas.first
 
         // When
         viewModel.submitSupportRequest()


### PR DESCRIPTION
Closes: #8868 

# Why

This PR updates the UI per the latest design review.

All the fields behave mostly the same except for the support area, where now it is a list with radio buttons instead of a picker menu.

Because of that, the View Model changed a bit to make the area optional, now the merchant has to choose one as the first step.

# Demo

https://user-images.githubusercontent.com/562080/219288344-97f29603-0fa7-49e6-adcb-732222b7b6e7.mov

# Testing

Only the UI has changed so I don't expect any regression but it doesn't hurt to create a support request and make sure the UI keeps being functional.

Note: Landscape and bigger fonts support will be added later to not make this PR even bigger 😇 


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
