### PR TITLE
Domain settings analytics & release

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -60,7 +60,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             // so we should not enable this for alpha builds.
             return buildConfig == .localDeveloper || buildConfig == .appStore
         case .domainSettings:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .supportRequests:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 12.4
 -----
+- [**] Menu > Settings: adds a `Domains` row for WPCOM sites to see their site domains, add a new domain, or redeems a domain credit if available. [https://github.com/woocommerce/woocommerce-ios/pull/8870]
 - [Internal] Prologue screen now has only the entry point to site address login flow, and application password authentication is used for sites without Jetpack. [https://github.com/woocommerce/woocommerce-ios/pull/8846]
 - [Internal] A new tag has been added for Zendesk for users authenticated with application password. [https://github.com/woocommerce/woocommerce-ios/pull/8850]
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DomainSettings.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DomainSettings.swift
@@ -5,27 +5,16 @@ extension WooAnalyticsEvent {
         /// Event property keys.
         private enum Key {
             static let source = "source"
-            static let hasDomainCredit = "has_domain_credit"
+            static let step = "step"
             static let useDomainCredit = "use_domain_credit"
         }
 
-        /// Tracked when the user taps to search for domains from the domain dashboard screen.
-        static func domainSettingsAddDomainTapped(source: DomainSettingsCoordinator.Source, hasDomainCredit: Bool) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .domainSettingsAddDomainTapped,
-                              properties: [Key.source: source.analyticsValue,
-                                           Key.hasDomainCredit: hasDomainCredit])
-        }
-
-        /// Tracked when the user selects a domain from the domain selector to purchase or redeem.
-        static func domainSettingsCustomDomainSelected(source: DomainSettingsCoordinator.Source, useDomainCredit: Bool) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .domainSettingsCustomDomainSelected,
-                              properties: [Key.source: source.analyticsValue,
-                                           Key.useDomainCredit: useDomainCredit])
-        }
-
-        /// Tracked when the domain contact info validation succeeds when redeeming a domain with domain credit.
-        static func domainContactInfoValidationSuccess(source: DomainSettingsCoordinator.Source) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .domainContactInfoValidationSuccess, properties: [Key.source: source.analyticsValue])
+        /// Tracked step for each step in the custom domains.
+        static func domainSettingsStep(source: DomainSettingsCoordinator.Source, step: Step) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .domainSettingsStep, properties: [
+                Key.source: source.analyticsValue,
+                Key.step: step.rawValue
+            ])
         }
 
         /// Tracked when the domain contact info validation fails when redeeming a domain with domain credit.
@@ -49,6 +38,17 @@ extension WooAnalyticsEvent {
                               properties: [Key.source: source.analyticsValue, Key.useDomainCredit: useDomainCredit],
                               error: error)
         }
+    }
+}
+
+extension WooAnalyticsEvent.DomainSettings {
+    /// Steps of the domain settings flow. The raw value is used for the event property.
+    enum Step: String {
+        case dashboard = "dashboard"
+        case domainSelector = "domain_picker"
+        case webCheckout = "domain_web_checkout"
+        case contactInfo = "domain_contact_info"
+        case purchaseSuccess = "domain_purchase_success"
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DomainSettings.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DomainSettings.swift
@@ -1,0 +1,62 @@
+import enum Yosemite.CreateAccountError
+
+extension WooAnalyticsEvent {
+    enum DomainSettings {
+        /// Event property keys.
+        private enum Key {
+            static let source = "source"
+            static let hasDomainCredit = "has_domain_credit"
+            static let useDomainCredit = "use_domain_credit"
+        }
+
+        /// Tracked when the user taps to search for domains from the domain dashboard screen.
+        static func domainSettingsAddDomainTapped(source: DomainSettingsCoordinator.Source, hasDomainCredit: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .domainSettingsAddDomainTapped,
+                              properties: [Key.source: source.analyticsValue,
+                                           Key.hasDomainCredit: hasDomainCredit])
+        }
+
+        /// Tracked when the user selects a domain from the domain selector to purchase or redeem.
+        static func domainSettingsCustomDomainSelected(source: DomainSettingsCoordinator.Source, useDomainCredit: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .domainSettingsCustomDomainSelected,
+                              properties: [Key.source: source.analyticsValue,
+                                           Key.useDomainCredit: useDomainCredit])
+        }
+
+        /// Tracked when the domain contact info validation succeeds when redeeming a domain with domain credit.
+        static func domainContactInfoValidationSuccess(source: DomainSettingsCoordinator.Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .domainContactInfoValidationSuccess, properties: [Key.source: source.analyticsValue])
+        }
+
+        /// Tracked when the domain contact info validation fails when redeeming a domain with domain credit.
+        static func domainContactInfoValidationFailed(source: DomainSettingsCoordinator.Source, error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .domainContactInfoValidationFailed,
+                              properties: [Key.source: source.analyticsValue],
+                              error: error)
+        }
+
+        /// Tracked when the custom domain purchase or redemption succeeds.
+        static func domainSettingsCustomDomainPurchaseSuccess(source: DomainSettingsCoordinator.Source, useDomainCredit: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .domainSettingsCustomDomainPurchaseSuccess,
+                              properties: [Key.source: source.analyticsValue, Key.useDomainCredit: useDomainCredit])
+        }
+
+        /// Tracked when the custom domain purchase or redemption fails.
+        static func domainSettingsCustomDomainPurchaseFailed(source: DomainSettingsCoordinator.Source,
+                                                             useDomainCredit: Bool,
+                                                             error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .domainSettingsCustomDomainPurchaseFailed,
+                              properties: [Key.source: source.analyticsValue, Key.useDomainCredit: useDomainCredit],
+                              error: error)
+        }
+    }
+}
+
+private extension DomainSettingsCoordinator.Source {
+    var analyticsValue: String {
+        switch self {
+        case .settings:
+            return "settings"
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DomainSettings.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DomainSettings.swift
@@ -45,10 +45,10 @@ extension WooAnalyticsEvent.DomainSettings {
     /// Steps of the domain settings flow. The raw value is used for the event property.
     enum Step: String {
         case dashboard = "dashboard"
-        case domainSelector = "domain_picker"
-        case webCheckout = "domain_web_checkout"
-        case contactInfo = "domain_contact_info"
-        case purchaseSuccess = "domain_purchase_success"
+        case domainSelector = "picker"
+        case webCheckout = "web_checkout"
+        case contactInfo = "contact_info"
+        case purchaseSuccess = "purchase_success"
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -242,9 +242,7 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Domain Settings
     //
-    case domainSettingsAddDomainTapped = "domain_dashboard_add_domain_tapped"
-    case domainSettingsCustomDomainSelected = "domain_dashboard_custom_domain_selected"
-    case domainContactInfoValidationSuccess = "domain_contact_info_validation_success"
+    case domainSettingsStep = "custom_domains_step"
     case domainContactInfoValidationFailed = "domain_contact_info_validation_failed"
     case domainSettingsCustomDomainPurchaseSuccess = "custom_domain_purchase_success"
     case domainSettingsCustomDomainPurchaseFailed = "custom_domain_purchase_failed"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -220,6 +220,7 @@ public enum WooAnalyticsStat: String {
     case settingsTapped = "main_menu_settings_tapped"
     case settingsSelectedStoreTapped = "settings_selected_site_tapped"
     case settingsContactSupportTapped = "main_menu_contact_support_tapped"
+    case settingsDomainsTapped = "settings_domains_tapped"
 
     case settingsBetaFeaturesButtonTapped = "settings_beta_features_button_tapped"
     case settingsBetaFeaturesProductsToggled = "settings_beta_features_products_toggled"
@@ -238,6 +239,15 @@ public enum WooAnalyticsStat: String {
     case settingsLogoutTapped = "settings_logout_button_tapped"
     case settingsLogoutConfirmation = "settings_logout_confirmation_dialog_result"
     case settingsWereHiringTapped = "settings_we_are_hiring_button_tapped"
+
+    // MARK: Domain Settings
+    //
+    case domainSettingsAddDomainTapped = "domain_dashboard_add_domain_tapped"
+    case domainSettingsCustomDomainSelected = "domain_dashboard_custom_domain_selected"
+    case domainContactInfoValidationSuccess = "domain_contact_info_validation_success"
+    case domainContactInfoValidationFailed = "domain_contact_info_validation_failed"
+    case domainSettingsCustomDomainPurchaseSuccess = "custom_domain_purchase_success"
+    case domainSettingsCustomDomainPurchaseFailed = "custom_domain_purchase_failed"
 
     // MARK: Card Reader Connection Events
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoForm.swift
@@ -124,6 +124,7 @@ struct DomainContactInfoForm_Previews: PreviewProvider {
     private static let viewModelWithoutContactInfo = DomainContactInfoFormViewModel(siteID: 134,
                                                                                     contactInfoToEdit: nil,
                                                                                     domain: "",
+                                                                                    source: .settings,
                                                                                     stores: DomainContactInfoFormStores())
     private static let contactInfo = DomainContactInfo(firstName: "Woo",
                                                        lastName: "Testing",
@@ -139,6 +140,7 @@ struct DomainContactInfoForm_Previews: PreviewProvider {
     private static let viewModelWithContactInfo = DomainContactInfoFormViewModel(siteID: 134,
                                                                                  contactInfoToEdit: contactInfo,
                                                                                  domain: "",
+                                                                                 source: .settings,
                                                                                  stores: DomainContactInfoFormStores())
 
     static var previews: some View {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainContactInfoFormViewModel.swift
@@ -87,7 +87,6 @@ final class DomainContactInfoFormViewModel: AddressFormViewModel, AddressFormVie
 
         do {
             try await validate()
-            analytics.track(event: .DomainSettings.domainContactInfoValidationSuccess(source: source))
             return contactInfo
         } catch DomainContactInfoError.invalid(let messages) {
             analytics.track(event: .DomainSettings.domainContactInfoValidationFailed(source: source, error: DomainContactInfoError.invalid(messages: messages)))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -354,7 +354,7 @@ private extension SettingsViewController {
             return
         }
 
-        // TODO: 8558 - analytics
+        ServiceLocator.analytics.track(.settingsDomainsTapped)
 
         let coordinator = DomainSettingsCoordinator(source: .settings, site: site, navigationController: navigationController)
         domainSettingsCoordinator = coordinator

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		020624F027951113000D024C /* StoreStatsDataOrRedactedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020624EF27951113000D024C /* StoreStatsDataOrRedactedView.swift */; };
 		02063C8929260AA000130906 /* StoreCreationSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02063C8829260A9F00130906 /* StoreCreationSuccessView.swift */; };
 		0206483A23FA4160008441BB /* OrdersRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0206483923FA4160008441BB /* OrdersRootViewController.swift */; };
+		0206E296299CD2C900C061C1 /* WooAnalyticsEvent+DomainSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0206E295299CD2C900C061C1 /* WooAnalyticsEvent+DomainSettings.swift */; };
 		020732042988AB7B000A53C2 /* DomainContactInfoForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020732032988AB7B000A53C2 /* DomainContactInfoForm.swift */; };
 		020732062988AC4D000A53C2 /* DomainContactInfoFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020732052988AC4D000A53C2 /* DomainContactInfoFormViewModel.swift */; };
 		02077F72253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02077F71253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift */; };
@@ -2134,6 +2135,7 @@
 		020624EF27951113000D024C /* StoreStatsDataOrRedactedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsDataOrRedactedView.swift; sourceTree = "<group>"; };
 		02063C8829260A9F00130906 /* StoreCreationSuccessView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreCreationSuccessView.swift; sourceTree = "<group>"; };
 		0206483923FA4160008441BB /* OrdersRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersRootViewController.swift; sourceTree = "<group>"; };
+		0206E295299CD2C900C061C1 /* WooAnalyticsEvent+DomainSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+DomainSettings.swift"; sourceTree = "<group>"; };
 		020732032988AB7B000A53C2 /* DomainContactInfoForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainContactInfoForm.swift; sourceTree = "<group>"; };
 		020732052988AC4D000A53C2 /* DomainContactInfoFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainContactInfoFormViewModel.swift; sourceTree = "<group>"; };
 		02077F71253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+ReadonlyProductTests.swift"; sourceTree = "<group>"; };
@@ -6878,6 +6880,7 @@
 				53284FB62FF7F94F18F0D3FF /* WaitingTimeTracker.swift */,
 				0263E3BA290BB21800E5F88F /* WooAnalyticsEvent+StoreCreation.swift */,
 				EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */,
+				0206E295299CD2C900C061C1 /* WooAnalyticsEvent+DomainSettings.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -10498,6 +10501,7 @@
 				02F6800925807CD300C3BAD2 /* GridStackView.swift in Sources */,
 				DE279BB126EA184A002BA963 /* ShippingLabelPackageListViewModel.swift in Sources */,
 				02B1AFEC24BC5AE5005DB1E3 /* LinkedProductListSelectorDataSource.swift in Sources */,
+				0206E296299CD2C900C061C1 /* WooAnalyticsEvent+DomainSettings.swift in Sources */,
 				26F94E1C267A3E4500DB6CCF /* ProductAddOnsListViewController.swift in Sources */,
 				451A04EC2386D2B300E368C9 /* ProductImagesCollectionViewDataSource.swift in Sources */,
 				02DD81F9242CAA400060E50B /* WordPressMediaLibraryImagePickerViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewModels/Domains/DomainContactInfoFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Domains/DomainContactInfoFormViewModelTests.swift
@@ -21,6 +21,7 @@ final class DomainContactInfoFormViewModelTests: XCTestCase {
         let viewModel = DomainContactInfoFormViewModel(siteID: 134,
                                                        contactInfoToEdit: Fixtures.contactInfo,
                                                        domain: "woo.com",
+                                                       source: .settings,
                                                        storageManager: ServiceLocator.storageManager,
                                                        stores: ServiceLocator.stores,
                                                        analytics: ServiceLocator.analytics)
@@ -45,6 +46,7 @@ final class DomainContactInfoFormViewModelTests: XCTestCase {
         let viewModel = DomainContactInfoFormViewModel(siteID: 134,
                                                        contactInfoToEdit: Fixtures.contactInfo,
                                                        domain: "woo.com",
+                                                       source: .settings,
                                                        storageManager: ServiceLocator.storageManager,
                                                        stores: stores,
                                                        analytics: ServiceLocator.analytics)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8558 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As the custom domains feature based on design i2 is complete, this PR implemented the analytics plan proposed in pe5sF9-15a-p2#comment-1694 (I left some time for feedback but didn't see any so I went ahead with the plan). Also, the feature flag was enabled for all targeting release 12.4 (I can also move it to release 12.5 if it can't be reviewed and wrapped up by Friday APAC time).

There are two more nice-to-have features that I'm working on after this release (these aren't available in the Jetpack apps):
- https://github.com/woocommerce/woocommerce-ios/issues/8871
- https://github.com/woocommerce/woocommerce-ios/issues/8872



Event name | Trigger | Properties
-- | -- | --
settings_domains_tapped | When the user taps on the Domains CTA in the Menu tab > Settings > Domains. |  
custom_domains_step | Each step in the custom domains. | – source: settings\|onboarding (just settings for now) – step: dashboard/picker/web_checkout/contact_info/purchase_success
domain_contact_info_validation_failed | When the domain contact info validation fails when redeeming a domain with domain credit. | – source: settings\|onboarding (just settings for now) – error
custom_domain_purchase_success | When the custom domain purchase or redemption succeeds. | – source: settings\|onboarding (just settings for now) – use_domain_credit: Bool: whether the merchant redeems a custom domain with domain credit
custom_domain_purchase_failed | When the custom domain purchase or redemption fails. | – source: settings\|onboarding (just settings for now) – use_domain_credit: Bool: whether the merchant redeems a custom domain with domain credit– error

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### With domain credit

Prerequisite: a WC store with an annual WPCOM plan whose domain credit hasn't been claimed, you can create a site like this in Calypso with store credit

- Log in if needed, and continue with the store in the prerequisite
- Go to the Menu tab
- Tap on the settings CTA
- Tap the `Domains` row —> an event should be logged like `🔵 Tracked settings_domains_tapped, properties: [AnyHashable("is_wpcom_store"): true, …]`. After the domain dashboard is shown, an event should be logged like `🔵 Tracked custom_domains_step, properties: [AnyHashable("step"): "dashboard", AnyHashable("source"): "settings", ...]`
- Tap `Claim Domain` or `Search for a Domain` at the bottom --> the domain picker should be shown, and an event should be logged like `🔵 Tracked custom_domains_step, properties: [AnyHashable("step"): "picker", AnyHashable("source"): "settings", ...]`
- Select a domain and tap `Continue` --> the domain contact info form should be shown, and an event should be logged like `🔵 Tracked custom_domains_step, properties: [AnyHashable("step"): "contact_info", AnyHashable("source"): "settings"]`
- Enter a valid email if needed, but leave a mandatory field like first/last name blank to trigger a remote validation error,  and tap `Done` —> an event should be logged like `🔵 Tracked domain_contact_info_validation_failed, properties: [AnyHashable("error_code"): "0", AnyHashable("is_wpcom_store"): true, AnyHashable("error_domain"): "Networking.DomainContactInfoError", AnyHashable("error_description"): “…”, AnyHashable("source"): "settings", …]`
- Fix all the validation errors, and tap `Done` —> after a while with a spinner on the `Done` CTA, a success screen should be shown with two events like `🔵 Tracked custom_domains_step, properties: [AnyHashable("source"): "settings", AnyHashable("step"): "purchase_success", ...]` and `🔵 Tracked custom_domain_purchase_success, properties: [AnyHashable("use_domain_credit"): true, AnyHashable("source"): "settings", …]`

### Without domain credit

Prerequisite: a WC store with a WPCOM plan without a domain credit

- Continue from the previous test case. Alternatively, you can continue with another store in the prerequisite
- Go to the Menu tab
- Tap on the settings CTA
- Tap the `Domains` row —> an event should be logged like `🔵 Tracked settings_domains_tapped, properties: [AnyHashable("is_wpcom_store"): true, …]`. After the domain dashboard is shown, an event should be logged like `🔵 Tracked custom_domains_step, properties: [AnyHashable("step"): "dashboard", AnyHashable("source"): "settings", ...]`
- Tap `Add a domain` (if there are other custom domains) or `Search for a Domain` at the bottom --> the domain picker should shown, and an event should be logged like `🔵 Tracked custom_domains_step, properties: [AnyHashable("source"): "settings", AnyHashable("step"): "domain_picker", ...]`
- Select a domain and tap `Continue` --> the web checkout should be shown, and an event should be logged like `🔵 Tracked custom_domains_step, properties: [AnyHashable("source"): "settings", AnyHashable("step"): "web_checkout", ...]`
- Complete the web checkout —> after a bit, the success screen should be shown with two events logged like `🔵 Tracked custom_domains_step, properties: [AnyHashable("source"): "settings", AnyHashable("step"): "purchase_success", ...]` and  `🔵 Tracked custom_domain_purchase_success, properties: [AnyHashable("source"): "settings", AnyHashable("use_domain_credit"): false, …]` (this event includes the event property on whether the purchase was using domain credit)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.