### PR TITLE
[Bulk Editing] Fix bulk editing crash when ProductsViewController disappears

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [Internal] Prologue screen now has only the entry point to site address login flow, and application password authentication is used for sites without Jetpack. [https://github.com/woocommerce/woocommerce-ios/pull/8846]
 - [Internal] A new tag has been added for Zendesk for users authenticated with application password. [https://github.com/woocommerce/woocommerce-ios/pull/8850]
+- [*] Fix: Fixed a crash when switching away from the Products tab. [https://github.com/woocommerce/woocommerce-ios/pull/8874]
 
 
 12.3

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -300,6 +300,10 @@ private extension ProductsViewController {
     }
 
     @objc func finishBulkEditing() {
+        guard tableView.isEditing else {
+            return
+        }
+
         viewModel.deselectAll()
         tableView.setEditing(false, animated: true)
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -300,7 +300,7 @@ private extension ProductsViewController {
     }
 
     @objc func finishBulkEditing() {
-        guard tableView.isEditing else {
+        guard let tableView, tableView.isEditing else {
             return
         }
 


### PR DESCRIPTION
Closes: #8847

## Description

Some users experience a crash in `finishBulkEditing` when `ProductsViewController` disappears. The error in the crash logs is `Swift runtime failure: Unexpectedly found nil while implicitly unwrapping an Optional value` on this line:

```swift
tableView.setEditing(false, animated: true)
```

We call `finishBulkEditing` in `viewWillDisappear` to make sure we exit/reset the bulk editing flow when switching to another tab (see https://github.com/woocommerce/woocommerce-ios/pull/8759#pullrequestreview-1272479679). Since `tableView` is a `weak` variable, however, it could be deallocated before that cleanup is done.

## Changes

I've added a `guard` statement to `finishBulkEditing` to unwrap `tableView`, to prevent this crash if the table view is nil. I also added a check for `tableView.isEditing` so we only continue if it's actually needed (if bulk edited was started).

## Testing

I couldn't actually find steps to reproduce the crash on my end, but you can confirm the changes work as expected:

1. Build and run the app.
2. Select the Products tab.
3. Select the bulk editing icon in the top nav bar.
4. Select a different tab.
5. Select the Products tab and confirm bulk editing was cancelled.

You can also test switching tabs while not bulk editing, and completing bulk editing actions, to confirm they continue to work as expected.

## Submitter Checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
