### PR TITLE
[Support Request] Replace old support chat with the new Support Form

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -508,7 +508,12 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
     /// Presents the Support new request, from a given ViewController, with a specified SourceTag.
     ///
     func presentSupportRequest(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag) {
-        ZendeskProvider.shared.showNewRequestIfPossible(from: sourceViewController, with: sourceTag.name)
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+            let supportForm = SupportFormHostingController(viewModel: .init(sourceTag: sourceTag.name))
+            supportForm.show(from: sourceViewController)
+        } else {
+            ZendeskProvider.shared.showNewRequestIfPossible(from: sourceViewController, with: sourceTag.name)
+        }
     }
 
     /// Indicates if the Login Epilogue should be presented.

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -14,7 +14,12 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
         },
         contactSupportAction: {
             presenting.dismiss(animated: true) {
-                ZendeskProvider.shared.showNewRequestIfPossible(from: presenting)
+                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+                    let supportForm = SupportFormHostingController(viewModel: .init())
+                    supportForm.show(from: presenting)
+                } else {
+                    ZendeskProvider.shared.showNewRequestIfPossible(from: presenting)
+                }
             }
         },
         dismissAction: {

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -302,7 +302,13 @@ private extension StoreCreationCoordinator {
     }
 
     func showSupport(from navigationController: UINavigationController) {
-        ZendeskProvider.shared.showNewRequestIfPossible(from: navigationController, with: "origin:store-creation")
+        let sourceTag = "origin:store-creation"
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+            let supportForm = SupportFormHostingController(viewModel: .init(sourceTag: sourceTag))
+            supportForm.show(from: navigationController)
+        } else {
+            ZendeskProvider.shared.showNewRequestIfPossible(from: navigationController, with: sourceTag)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -323,7 +323,12 @@ private extension AppCoordinator {
             guard let viewController = window.rootViewController else {
                 return
             }
-            ZendeskProvider.shared.showNewRequestIfPossible(from: viewController, with: nil)
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+                let supportForm = SupportFormHostingController(viewModel: .init())
+                supportForm.show(from: viewController)
+            } else {
+                ZendeskProvider.shared.showNewRequestIfPossible(from: viewController, with: nil)
+            }
             analytics.track(.loginLocalNotificationTapped, withProperties: [
                 "action": "contact_support",
                 "type": response.notification.request.identifier

--- a/WooCommerce/Classes/ViewRelated/Coupons/EnableAnalytics/EnableAnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/EnableAnalytics/EnableAnalyticsView.swift
@@ -49,7 +49,12 @@ struct EnableAnalyticsView: View {
 
         self.contactSupportAction = {
             if let viewController = presentingController?.presentedViewController {
-                ZendeskProvider.shared.showNewRequestIfPossible(from: viewController)
+                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+                    let supportForm = SupportFormHostingController(viewModel: .init())
+                    supportForm.show(from: viewController)
+                } else {
+                    ZendeskProvider.shared.showNewRequestIfPossible(from: viewController)
+                }
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -80,7 +80,12 @@ final class DashboardViewController: UIViewController {
                                               },
                                               onContactSupportButtonPressed: { [weak self] in
                                                 guard let self = self else { return }
-                                                ZendeskProvider.shared.showNewRequestIfPossible(from: self, with: nil)
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+                let supportForm = SupportFormHostingController(viewModel: .init())
+                supportForm.show(from: self)
+            } else {
+                ZendeskProvider.shared.showNewRequestIfPossible(from: self, with: nil)
+            }
                                               })
     }()
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackInstall/JetpackInstallView.swift
@@ -6,7 +6,12 @@ final class JetpackInstallHostingController: UIHostingController<JetpackInstallV
     init(siteID: Int64, siteURL: String, siteAdminURL: String) {
         super.init(rootView: JetpackInstallView(siteID: siteID, siteURL: siteURL, siteAdminURL: siteAdminURL))
         rootView.supportAction = { [unowned self] in
-            ZendeskProvider.shared.showNewRequestIfPossible(from: self)
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+                let supportForm = SupportFormHostingController(viewModel: .init())
+                supportForm.show(from: self)
+            } else {
+                ZendeskProvider.shared.showNewRequestIfPossible(from: self)
+            }
         }
 
         // Set presenting view controller to show the notice presenter here

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CloseAccountCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CloseAccountCoordinator.swift
@@ -102,7 +102,12 @@ private extension CloseAccountCoordinator {
                                                 preferredStyle: .alert)
         alertController.addActionWithTitle(Localization.ErrorAlert.contactSupportButtonTitle, style: .default) { [weak self] _ in
             guard let self = self else { return }
-            ZendeskProvider.shared.showNewRequestIfPossible(from: self.sourceViewController, with: nil)
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+                let supportForm = SupportFormHostingController(viewModel: .init())
+                supportForm.show(from: self.sourceViewController)
+            } else {
+                ZendeskProvider.shared.showNewRequestIfPossible(from: self.sourceViewController, with: nil)
+            }
         }
         alertController.addActionWithTitle(Localization.ErrorAlert.dismissButtonTitle, style: .cancel) { _ in }
         sourceViewController.present(alertController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -341,7 +341,7 @@ private extension HelpAndSupportViewController {
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
             let viewController = SupportFormHostingController(viewModel: .init())
-            show(viewController, sender: self)
+            viewController.show(from: self)
         } else {
             ZendeskProvider.shared.showNewRequestIfPossible(from: navController)
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm+Presentation.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm+Presentation.swift
@@ -25,6 +25,18 @@ extension SupportFormHostingController {
         showViewModally(from: controller)
     }
 
+    /// Dismisses the view depending on it's presenting `ViewController` hierarchy.
+    ///
+    func dismissView() {
+        // Only pop the view if we are inside a navigation stack and the support form is not the root view controller
+        if let navigationController, navigationController.viewControllers.count > 1 {
+            navigationController.popViewController(animated: true)
+        } else {
+            // For any other case, attempt a modal dismiss.
+            dismiss(animated: true)
+        }
+    }
+
     /// Shows the `SupportForm` modally inside a NavigationController.
     ///
     private func showViewModally(from controller: UIViewController) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm+Presentation.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm+Presentation.swift
@@ -1,0 +1,39 @@
+import UIKit
+
+// MARK: Presentation Helpers
+extension SupportFormHostingController {
+
+    /// Shows the `SupportForm` according to it's parent view controller hierarchy.
+    /// Code copied from `ZendeskManager`.
+    ///
+    func show(from controller: UIViewController) {
+        // Got some duck typing going on in here. Sorry.
+
+        // If the controller is a UIViewController, set the modal display for iPad.
+        if !controller.isKind(of: UINavigationController.self) && UIDevice.current.userInterfaceIdiom == .pad {
+            return showViewModally(from: controller)
+        }
+
+        if let navController = controller as? UINavigationController {
+            return navController.pushViewController(self, animated: true)
+        }
+
+        if let navController = controller.navigationController {
+            return navController.pushViewController(self, animated: true)
+        }
+
+        showViewModally(from: controller)
+    }
+
+    /// Shows the `SupportForm` modally inside a NavigationController.
+    ///
+    private func showViewModally(from controller: UIViewController) {
+        let navController = WooNavigationController(rootViewController: self)
+        // Keeping the modal fullscreen on iPad like previous implementation.
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            navController.modalPresentationStyle = .fullScreen
+            navController.modalTransitionStyle = .crossDissolve
+        }
+        controller.present(navController, animated: true)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm+Presentation.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm+Presentation.swift
@@ -28,6 +28,7 @@ extension SupportFormHostingController {
     /// Shows the `SupportForm` modally inside a NavigationController.
     ///
     private func showViewModally(from controller: UIViewController) {
+        addCloseNavigationBarButton()
         let navController = WooNavigationController(rootViewController: self)
         // Keeping the modal fullscreen on iPad like previous implementation.
         if UIDevice.current.userInterfaceIdiom == .pad {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -80,18 +80,6 @@ private extension SupportFormHostingController {
         dismissView()
         DDLogError("⛔️ Zendesk Identity could not be created.")
     }
-
-    /// Dismisses the view depending on it's presenting `ViewController` hierarchy.
-    ///
-    func dismissView() {
-        // Only pop the view if we are inside a navigation stack and the support form is not the root view controller
-        if let navigationController, navigationController.viewControllers.count > 1 {
-            navigationController.popViewController(animated: true)
-        } else {
-            // For any other case, attempt a modal dismiss.
-            dismiss(animated: true)
-        }
-    }
 }
 
 private extension SupportFormHostingController {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -17,7 +17,7 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
     }
 
     /// Creates the Zendesk Identity if needed.
-    /// If it fails, it pops back the view and informs the user.
+    /// If it fails, it dismisses the view and informs the user.
     ///
     func createZendeskIdentity() {
         // TODO: We should consider refactoring this to present the email alert using SwiftUI.
@@ -48,14 +48,14 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
 }
 
 private extension SupportFormHostingController {
-    /// Shows an alert informing the support creation success and after confirmation pops the view back.
+    /// Shows an alert informing the support creation success and after confirmation dismisses the view.
     ///
     func informSuccessAndPopBack() {
         let alertController = UIAlertController(title: Localization.requestSent,
                                                 message: Localization.requestSentMessage,
                                                 preferredStyle: .alert)
         alertController.addDefaultActionWithTitle(Localization.gotIt) { _ in
-            self.navigationController?.popViewController(animated: true)
+            self.dismissView()
         }
         present(alertController, animated: true)
     }
@@ -77,8 +77,20 @@ private extension SupportFormHostingController {
         let notice = Notice(title: Localization.badIdentityError, feedbackType: .error)
         ServiceLocator.noticePresenter.enqueue(notice: notice)
 
-        navigationController?.popViewController(animated: true)
+        dismissView()
         DDLogError("⛔️ Zendesk Identity could not be created.")
+    }
+
+    /// Dismisses the view depending on it's presenting `ViewController` hierarchy.
+    ///
+    func dismissView() {
+        // Only pop the view if we are inside a navigation stack and the support form is not the root view controller
+        if let navigationController, navigationController.viewControllers.count > 1 {
+            navigationController.popViewController(animated: true)
+        } else {
+            // For any other case, attempt a modal dismiss.
+            dismiss(animated: true)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -10,7 +10,12 @@ final class InPersonPaymentsViewController: UIHostingController<InPersonPayments
         super.init(rootView: InPersonPaymentsView(viewModel: viewModel))
         rootView.showSupport = { [weak self] in
             guard let self = self else { return }
-            ZendeskProvider.shared.showNewWCPayRequestIfPossible(from: self)
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+                let supportForm = SupportFormHostingController(viewModel: .init())
+                supportForm.show(from: self)
+            } else {
+                ZendeskProvider.shared.showNewWCPayRequestIfPossible(from: self)
+            }
         }
         rootView.showURL = { [weak self] url in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -779,7 +779,12 @@ private extension OrderListViewController {
         },
         onContactSupportButtonPressed: { [weak self] in
             guard let self = self else { return }
-            ZendeskProvider.shared.showNewRequestIfPossible(from: self, with: nil)
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+                let supportForm = SupportFormHostingController(viewModel: .init())
+                supportForm.show(from: self)
+            } else {
+                ZendeskProvider.shared.showNewRequestIfPossible(from: self, with: nil)
+            }
         })
         showTopBannerView()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -712,7 +712,12 @@ private extension ProductsViewController {
             },
             onContactSupportButtonPressed: { [weak self] in
                 guard let self = self else { return }
-                ZendeskProvider.shared.showNewRequestIfPossible(from: self, with: nil)
+                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+                    let supportForm = SupportFormHostingController(viewModel: .init())
+                    supportForm.show(from: self)
+                } else {
+                    ZendeskProvider.shared.showNewRequestIfPossible(from: self, with: nil)
+                }
             })
         topBannerContainerView.updateSubview(errorBanner)
         topBannerView = errorBanner

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -128,7 +128,12 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
                                               },
                                               onContactSupportButtonPressed: { [weak self] in
                                                 guard let self = self else { return }
-                                                ZendeskProvider.shared.showNewRequestIfPossible(from: self, with: nil)
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+                let supportForm = SupportFormHostingController(viewModel: .init())
+                supportForm.show(from: self)
+            } else {
+                ZendeskProvider.shared.showNewRequestIfPossible(from: self, with: nil)
+            }
                                               })
     }()
 
@@ -210,7 +215,12 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
             case .withSupportRequest:
                 return { [weak self] in
                     if let self = self {
-                        self.zendeskManager.showNewRequestIfPossible(from: self, with: nil)
+                        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+                            let supportForm = SupportFormHostingController(viewModel: .init())
+                            supportForm.show(from: self)
+                        } else {
+                            self.zendeskManager.showNewRequestIfPossible(from: self, with: nil)
+                        }
                     }
                 }
             default:

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -110,7 +110,12 @@ final class ReviewsViewController: UIViewController, GhostableViewController {
                                               },
                                               onContactSupportButtonPressed: { [weak self] in
                                                 guard let self = self else { return }
-                                                ZendeskProvider.shared.showNewRequestIfPossible(from: self, with: nil)
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+                let supportForm = SupportFormHostingController(viewModel: .init())
+                supportForm.show(from: self)
+            } else {
+                ZendeskProvider.shared.showNewRequestIfPossible(from: self, with: nil)
+            }
                                               })
     }()
 

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
@@ -72,7 +72,12 @@ private extension SurveyCoordinatingController {
             guard let self = self else {
                 return
             }
-            self.zendeskManager.showNewRequestIfPossible(from: self, with: nil)
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+                let supportForm = SupportFormHostingController(viewModel: .init())
+                supportForm.show(from: self)
+            } else {
+                self.zendeskManager.showNewRequestIfPossible(from: self, with: nil)
+            }
         }, onBackToStoreAction: { [weak self] in
             self?.finishSurveyNavigation()
         })

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -658,6 +658,7 @@
 		2667BFED25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFEC25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift */; };
 		2676F4CC2908284800C7A15B /* ProductCreationTypeCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2676F4CB2908284800C7A15B /* ProductCreationTypeCommand.swift */; };
 		26771A14256FFA8700EE030E /* IssueRefundCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26771A13256FFA8700EE030E /* IssueRefundCoordinatingController.swift */; };
+		2677B559299F322300862180 /* SupportForm+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2677B558299F322300862180 /* SupportForm+Presentation.swift */; };
 		2678897C270E6E8B00BD249E /* SimplePaymentsAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2678897B270E6E8B00BD249E /* SimplePaymentsAmount.swift */; };
 		267D6882296485850072ED0C /* ProductVariationGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267D6881296485850072ED0C /* ProductVariationGeneratorTests.swift */; };
 		26838354296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26838353296F460B00CCF60A /* GenerateVariationsOptionPresenter.swift */; };
@@ -2753,6 +2754,7 @@
 		2667BFEC25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingCalculationUseCaseTests.swift; sourceTree = "<group>"; };
 		2676F4CB2908284800C7A15B /* ProductCreationTypeCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCreationTypeCommand.swift; sourceTree = "<group>"; };
 		26771A13256FFA8700EE030E /* IssueRefundCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundCoordinatingController.swift; sourceTree = "<group>"; };
+		2677B558299F322300862180 /* SupportForm+Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SupportForm+Presentation.swift"; sourceTree = "<group>"; };
 		2678897B270E6E8B00BD249E /* SimplePaymentsAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsAmount.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267D6881296485850072ED0C /* ProductVariationGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationGeneratorTests.swift; sourceTree = "<group>"; };
@@ -5595,6 +5597,7 @@
 			isa = PBXGroup;
 			children = (
 				268D7C9B2984752A00D38709 /* SupportForm.swift */,
+				2677B558299F322300862180 /* SupportForm+Presentation.swift */,
 				262EB5AD298C70EF009DCC36 /* SupportFormViewModel.swift */,
 				262EB5AF298C7C3A009DCC36 /* SupportFormsDataSources.swift */,
 			);
@@ -10852,6 +10855,7 @@
 				0235BFD9246E959500778909 /* ProductFormActionsFactory.swift in Sources */,
 				024EFA6923FCC10B00F36918 /* Product+Media.swift in Sources */,
 				0202B68D23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift in Sources */,
+				2677B559299F322300862180 /* SupportForm+Presentation.swift in Sources */,
 				D8B4D5F426C30E7C00F34E94 /* InPersonPaymentsStripeRejectedView.swift in Sources */,
 				DE0A2EAD281BA1FA007A8015 /* ProductCategorySelector.swift in Sources */,
 				57612989245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
@@ -158,34 +158,6 @@ final class EmptyStateViewControllerTests: XCTestCase {
         XCTAssertEqual(mirror.actionButton.titleLabel?.text, "Contact You!")
     }
 
-    func test_given_a_supportRequest_config_when_tapping_on_button_then_the_contact_us_page_is_presented() throws {
-        // Given
-        let zendeskManager = MockZendeskManager()
-        let viewController = EmptyStateViewController(style: .basic, zendeskManager: zendeskManager)
-        XCTAssertNotNil(viewController.view)
-
-        let mirror = try self.mirror(of: viewController)
-
-        viewController.configure(.withSupportRequest(
-            message: NSAttributedString(string: ""),
-            image: .infoImage,
-            details: "",
-            buttonTitle: "Dolores"
-        ))
-
-        assertEmpty(zendeskManager.newRequestIfPossibleInvocations)
-
-        // When
-        mirror.actionButton.sendActions(for: .touchUpInside)
-
-        // Then
-        XCTAssertEqual(zendeskManager.newRequestIfPossibleInvocations.count, 1)
-
-        let invocation = try XCTUnwrap(zendeskManager.newRequestIfPossibleInvocations.first)
-        XCTAssertEqual(invocation.controller, viewController)
-        XCTAssertNil(invocation.sourceTag)
-    }
-
     // MARK: - Pull to refresh
 
     func test_given_a_simple_config_with_pull_to_refresh_handler_when_pulled_to_refresh_fires_callback() throws {


### PR DESCRIPTION
Closes #8815 

# Why

This PR replaces all usages of `ZendeskProvider.shared.showNewRequestIfPossible` with the new SupportForm. The change is still behind the feature flag.

# How

- `showNewRequestIfPossible` had some special handling on how to present or push the zendesk view. I have copied that logic to an extension to avoid any regression.

- Due to the change above, I've had to add a custom dismiss method as the flow can now be popped or dismissed depending on how it was presented initially.

# Demos

## Navigation Presentation
https://user-images.githubusercontent.com/562080/219556998-149c8dd4-f5c7-4d7b-995d-c7413f8719ce.mov

## Modal Presentation
https://user-images.githubusercontent.com/562080/219557011-4211ae7c-8c54-489e-b962-ee0b3758b32f.mov

# Testing Steps

- Test contacting support on an iPhone for a navigation presentation.

----

- Test contacting support on an iPad for modal presentation.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
