### PR TITLE
[Support Request] Hide redundant sections

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -159,12 +159,16 @@ private extension HelpAndSupportViewController {
 
     private func calculateRows() -> [Row] {
         var rows: [Row] = [.helpCenter, .contactSupport]
-        if isPaymentsAvailable {
-            rows.append(.contactWCPaySupport)
+
+        // Only show `contactWCPaySupport` and `myTickets` when the `supportRequests` flag is not enabled.
+        if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+            if isPaymentsAvailable {
+                rows.append(.contactWCPaySupport)
+            }
+            rows.append(.myTickets)
         }
 
-        rows.append(contentsOf: [.myTickets,
-                                 .contactEmail,
+        rows.append(contentsOf: [.contactEmail,
                                  .applicationLog,
                                  .systemStatusReport])
         return rows


### PR DESCRIPTION
Closes #8830 
Closes #8876 

# Why 

This PR hide the `My Tickets` & `Contact WooCommerce Payments Support` rows from `HelpAndSupportViewController` as they are now redundant or won't be used anymore.

The hiding happens only when the feature flag is enabled.

# Screenshots

<img width="442" alt="Screenshot 2023-02-17 at 12 53 25 AM" src="https://user-images.githubusercontent.com/562080/219561391-2de924d4-c629-49b7-9efc-6d0cf991ce4f.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
