### PR TITLE
Settings: only show Domains row for admin users

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -207,7 +207,9 @@ private extension SettingsViewModel {
         let configureSection: Section? = {
             var rows: [Row] = []
 
-            if featureFlagService.isFeatureFlagEnabled(.domainSettings) && stores.sessionManager.defaultSite?.isWordPressComStore == true {
+            if featureFlagService.isFeatureFlagEnabled(.domainSettings)
+                && stores.sessionManager.defaultSite?.isWordPressComStore == true
+                && stores.sessionManager.defaultRoles.contains(.administrator) {
                 rows.append(.domain)
             }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -219,7 +219,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.domain) })
     }
 
-    func test_domain_is_shown_when_domainSettings_feature_is_disabled_and_site_is_wpcom_for_shop_manager_role() {
+    func test_domain_is_not_shown_when_domainSettings_feature_is_enabled_and_site_is_wpcom_for_shop_manager_role() {
         // Given
         let featureFlagService = MockFeatureFlagService(isDomainSettingsEnabled: true)
         sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -206,6 +206,7 @@ final class SettingsViewModelTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(isDomainSettingsEnabled: true)
         sessionManager.defaultSite = .fake().copy(isWordPressComStore: false)
+        sessionManager.defaultRoles = [.administrator]
         let viewModel = SettingsViewModel(stores: stores,
                                           storageManager: storageManager,
                                           featureFlagService: featureFlagService,
@@ -218,10 +219,28 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.domain) })
     }
 
-    func test_domain_is_shown_when_domainSettings_feature_is_enabled_and_site_is_wpcom() {
+    func test_domain_is_shown_when_domainSettings_feature_is_disabled_and_site_is_wpcom_for_shop_manager_role() {
         // Given
         let featureFlagService = MockFeatureFlagService(isDomainSettingsEnabled: true)
         sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)
+        sessionManager.defaultRoles = [.shopManager]
+        let viewModel = SettingsViewModel(stores: stores,
+                                          storageManager: storageManager,
+                                          featureFlagService: featureFlagService,
+                                          appleIDCredentialChecker: appleIDCredentialChecker)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.domain) })
+    }
+
+    func test_domain_is_shown_when_domainSettings_feature_is_enabled_and_site_is_wpcom_for_admin_role() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isDomainSettingsEnabled: true)
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)
+        sessionManager.defaultRoles = [.administrator]
         let viewModel = SettingsViewModel(stores: stores,
                                           storageManager: storageManager,
                                           featureFlagService: featureFlagService,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8558
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

I was testing if custom domains are allowed for users with the Shop Manager role, and the feature is disabled both in Calypso and the API at least for fetching site domains (pe5sF9-Ug-p2#comment-1716). This PR added a check on the user role to be `administrator` in order to show the `Domains` row in settings. The related unit tests were also updated.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Admin user

Prerequisite: an **admin user** with a WC store **with a WPCOM plan**, you can create a site like this in Calypso with store credit

- Log in if needed, and continue with the store in the prerequisite
- Go to the Menu tab
- Tap on the settings CTA --> there should be a `Domains` row

### Shop Manager user

Prerequisite: a **shop manager user** with a WC store **with a WPCOM plan**, you can create a site like this in Calypso with store credit and add another user with the "shop manager" role in Calypso > Users

- Log in if needed, and continue with the store in the prerequisite
- Go to the Menu tab
- Tap on the settings CTA --> there should **not** be a `Domains` row

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Shop Manager user | Admin user
-- | --
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-17 at 15 14 48](https://user-images.githubusercontent.com/1945542/219577116-e160179e-a29c-45e9-999f-fdae705309e5.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-17 at 15 15 00](https://user-images.githubusercontent.com/1945542/219577132-7e4ba0fc-153a-4ecd-8b6c-2d99da0ed3b4.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.