### PR TITLE
Domain settings: reuse `BadgeView` for the primary domain badge

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/FreeStagingDomainView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/FreeStagingDomainView.swift
@@ -12,16 +12,7 @@ struct FreeStagingDomainView: View {
                     .bold()
             }
             if domain.isPrimary {
-                // TODO: 8558 - refactor to reuse `BadgeView`
-                Text(Localization.primaryDomainNotice)
-                    .foregroundColor(Color(.textBrand))
-                    .padding(.leading, Layout.horizontalPadding)
-                    .padding(.trailing, Layout.horizontalPadding)
-                    .padding(.top, Layout.verticalPadding)
-                    .padding(.bottom, Layout.verticalPadding)
-                    .background(RoundedRectangle(cornerRadius: Layout.cornerRadius)
-                        .fill(Color(.withColorStudio(.wooCommercePurple, shade: .shade0))))
-                    .font(.system(size: 12, weight: .bold))
+                BadgeView(text: Localization.primaryDomainNotice)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
@@ -15,10 +15,18 @@ struct BadgeView: View {
         }
     }
 
-    let type: BadgeType
+    private let text: String
+
+    init(type: BadgeType) {
+        text = type.title.uppercased()
+    }
+
+    init(text: String) {
+        self.text = text
+    }
 
     var body: some View {
-        Text(type.title.uppercased())
+        Text(text)
             .foregroundColor(Color(.textBrand))
             .padding(.leading, Layout.horizontalPadding)
             .padding(.trailing, Layout.horizontalPadding)
@@ -30,7 +38,7 @@ struct BadgeView: View {
     }
 }
 
-extension BadgeView {
+private extension BadgeView {
     enum Localization {
         static let newTitle = NSLocalizedString("New", comment: "Title of the badge shown when advertising a new feature")
         static let tipTitle = NSLocalizedString("Tip", comment: "Title of the badge shown when promoting an existing feature")
@@ -40,5 +48,13 @@ extension BadgeView {
         static let horizontalPadding: CGFloat = 6
         static let verticalPadding: CGFloat = 4
         static let cornerRadius: CGFloat = 8
+    }
+}
+
+struct BadgeView_Previews: PreviewProvider {
+    static var previews: some View {
+        BadgeView(type: .new)
+        BadgeView(type: .tip)
+        BadgeView(text: "Custom text")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
@@ -38,12 +38,14 @@ struct BadgeView: View {
     }
 }
 
-private extension BadgeView {
+private extension BadgeView.BadgeType {
     enum Localization {
         static let newTitle = NSLocalizedString("New", comment: "Title of the badge shown when advertising a new feature")
         static let tipTitle = NSLocalizedString("Tip", comment: "Title of the badge shown when promoting an existing feature")
     }
+}
 
+private extension BadgeView {
     enum Layout {
         static let horizontalPadding: CGFloat = 6
         static let verticalPadding: CGFloat = 4
@@ -53,8 +55,10 @@ private extension BadgeView {
 
 struct BadgeView_Previews: PreviewProvider {
     static var previews: some View {
-        BadgeView(type: .new)
-        BadgeView(type: .tip)
-        BadgeView(text: "Custom text")
+        VStack {
+            BadgeView(type: .new)
+            BadgeView(type: .tip)
+            BadgeView(text: "Custom text")
+        }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8558 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For the "Primary site address" badge in domain settings, I was hoping to reuse the `BadgeView` component but the struct currently takes in a type enum `BadgeType` for specific use cases in all caps (`type.title.uppercased()`). This PR updated `BadgeView` to add an initializer that takes in any text to show in the badge without any text transformation. Some previews were also added for easier comparison before & after the changes.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

I'm not sure if there's an easy way to test the existing use case of `BadgeView` in `FeatureAnnouncementCardView`, SwiftUI previews might be sufficient.

Prerequisite: a WC store **with a WPCOM plan** and **without a custom domain as the site's primary address** (so that the badge is shown)

- Log in if needed, and continue with the store in the prerequisite
- Go to the Menu tab
- Tap on the settings CTA
- Tap the `Domains` row —> the "Primary site address" badge should look as before

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

SwiftUI previews:

<img width="557" alt="Screenshot 2023-02-17 at 4 04 26 PM" src="https://user-images.githubusercontent.com/1945542/219587502-14b122c0-4fae-41c7-8056-fbce71d28df5.png">


Domain settings:
(no changes are expected)

before | after
-- | --
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-17 at 15 44 20](https://user-images.githubusercontent.com/1945542/219586677-4d04ef48-72e9-4e16-a1e3-8f016adfa934.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-17 at 15 45 17](https://user-images.githubusercontent.com/1945542/219586685-681ee87b-5517-45b8-85f3-08dd0fe72ead.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
