### PR TITLE
[SPE] Add Simplify Product Editing feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -63,6 +63,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .supportRequests:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .simplifyProductEditing:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -145,4 +145,8 @@ public enum FeatureFlag: Int {
     /// Whether to enable the new support request form.
     ///
     case supportRequests
+
+    /// Whether to enable the simplified product editing experience.
+    ///
+    case simplifyProductEditing
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8875
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds a feature flag (`simplifyProductEditing`) to hide development for the Simplify Product Editing project. This flag isn't being used yet.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
