### PR TITLE
[Support Request] Push & Analytics Leftovers

### DIFF
--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -1228,9 +1228,9 @@ private extension ZendeskManager {
     ///
     @objc func zendeskNotification(_ notification: Notification) {
         switch notification.name.rawValue {
-        case ZDKAPI_RequestSubmissionSuccess:
+        case ZDKAPI_RequestSubmissionSuccess where !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests):
             ServiceLocator.analytics.track(.supportNewRequestCreated)
-        case ZDKAPI_RequestSubmissionError:
+        case ZDKAPI_RequestSubmissionError where !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests):
             ServiceLocator.analytics.track(.supportNewRequestFailed)
         case ZDKAPI_UploadAttachmentSuccess:
             ServiceLocator.analytics.track(.supportNewRequestFileAttached)

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -700,6 +700,12 @@ extension ZendeskManager: SupportManagerAdapter {
     /// This handles Zendesk push notifications.
     ///
     func displaySupportRequest(using userInfo: [AnyHashable: Any]) {
+
+        // Prevent navigating to an individual ticker from a push notification as we won't support viewing individual tickets on the new Support Form.
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+            return
+        }
+
         guard zendeskEnabled == true,
             let requestId = userInfo[PushKey.requestID] as? String else {
                 DDLogInfo("Zendesk push notification payload is invalid.")
@@ -737,6 +743,12 @@ extension ZendeskManager: SupportManagerAdapter {
     /// Delegate method for a received push notification
     ///
     func pushNotificationReceived() {
+        // Do not update the notification count when the new SupportForm is enabled
+        // because we can't clear it back as we won't allow navigating to individual tickets.
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests) {
+            return
+        }
+
         unreadNotificationsCount += 1
         saveUnreadCount()
         postNotificationReceived()


### PR DESCRIPTION
# Why

This PR does 2 small things.

1. Makes sure that `ZendeskManger` do not track `supportNewRequestCreated` and `supportNewRequestFailed` when the feature flag is enabled. This is to prevent double tracking since it happens on the `SupportFormViewModel`.

2. Don't allow `ZendeskManager` to navigate to an individual support ticket from a push notification when the feature flag is enabled. And in the same way, prevent the notification count from being modified when a notification arrives.

# Testing Steps

- When creating a support request, make sure the analytics events are not fired twice.

- When getting a support request-reply, make sure the push notification does not open the individual ticket. (I couldn't test it because I never get support push notifications :-/ )

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
