### PR TITLE
Support Request: Enable Feature

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -62,7 +62,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .domainSettings:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .supportRequests:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .simplifyProductEditing:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [Internal] A new tag has been added for Zendesk for users authenticated with application password. [https://github.com/woocommerce/woocommerce-ios/pull/8850]
 - [Internal] Failures in the logged-out state are now tracked with anonymous ID. [https://github.com/woocommerce/woocommerce-ios/pull/8861]
 - [*] Fix: Fixed a crash when switching away from the Products tab. [https://github.com/woocommerce/woocommerce-ios/pull/8874]
+- [**] Support Requests: We have added a new way of Contacting Support with an improved UX. [https://github.com/woocommerce/woocommerce-ios/pull/8886]
 
 12.3
 -----


### PR DESCRIPTION
# Why 

This PR enables the `Support Request` feature flag for the feature to be released on `v12.4`

# Test Plan 
pe5pgL-2dS-p2

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
