### PR TITLE
Remove Buildkite commands that are included in the VM

### DIFF
--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -4,7 +4,6 @@ echo "--- :arrow_down: Installing Release Dependencies"
 brew update # Update homebrew to temporarily fix a bintray issue
 brew install imagemagick
 brew install ghostscript
-brew install sentry-cli
 
 echo "--- :rubygems: Setting up Gems"
 install_gems

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -13,10 +13,6 @@ else
   export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPAD
 fi
 
-# FIXIT-13.1: Temporary fix until all VMs have a JVM
-brew install openjdk@11
-sudo ln -sfn /usr/local/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
-
 echo "--- 📦 Downloading Build Artifacts"
 buildkite-agent artifact download build-products.tar .
 tar -xf build-products.tar


### PR DESCRIPTION
### Summary of Changes

This PR removes: 
- The JDK install and fix commands from `run-ui-tests.sh`
- The Sentry CLI install command from `release-build.sh`

Both of those are already included in the CI image manifest ([latest for the Xcode 14.2 image](https://github.com/Automattic/buildkite-ci/blob/trunk/src/macos-vms/manifests/xcode-14.2.yml)), so they don't need to be included in these scripts. 

### How to Test
- For the UI test script change, you can see in [a build before this change](https://buildkite.com/automattic/woocommerce-ios/builds/11094#01865fb0-7f42-45b3-9a49-9f77cfa315f8) that CI reports that the JDK is already installed. After this change, the UI test step should still complete successfully. 

<img width="588" alt="Screenshot 2023-02-17 at 11 29 31 AM" src="https://user-images.githubusercontent.com/17955542/219752452-fc935895-fdaf-4f49-8b25-9855a3f78903.png">


- For the Release build script change, you can see in [a build before this change](https://buildkite.com/automattic/woocommerce-ios/builds/11095#01865fb0-dc32-44c2-84fb-a84ed34adffe) that CI reports that Sentry is already installed. We won't do another release build just to test this, but I am confident that Sentry is working on CI because none of the other apps have had this manual install command. 


<img width="648" alt="Screenshot 2023-02-17 at 11 32 36 AM" src="https://user-images.githubusercontent.com/17955542/219753103-89d0c527-fcda-467d-aa2c-bd90fa8390ff.png">

