### PR TITLE
Update product form notice to display status-based feedback

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -33,15 +33,36 @@ extension ProductFormViewController {
         alertController.addAction(confirm)
         present(alertController, animated: true)
     }
+
+    enum ProductSavedAlertType {
+        case saved
+        case draftSaved
+        case published
+        case copied
+
+        var alertTitle: String {
+            switch self {
+            case .saved:
+                return Localization.Alert.productSavedAlert
+            case .draftSaved:
+                return Localization.Alert.productDraftSavedAlert
+            case .published:
+                return Localization.Alert.productPublishedAlert
+            case .copied:
+                return Localization.Alert.productCopiedAlert
+            }
+        }
+    }
+
     /// Product Confirmation Save alert
     ///
-    func presentProductConfirmationSaveAlert(title: String = Localization.Alert.presentProductConfirmationSaveAlert) {
+    func presentProductConfirmationSaveAlert(type: ProductSavedAlertType = .saved) {
         let contextNoticePresenter: NoticePresenter = {
             let noticePresenter = DefaultNoticePresenter()
             noticePresenter.presentingViewController = self
             return noticePresenter
         }()
-        contextNoticePresenter.enqueue(notice: .init(title: title))
+        contextNoticePresenter.enqueue(notice: .init(title: type.alertTitle))
     }
 
     /// Product Confirmation Delete alert
@@ -125,8 +146,13 @@ private extension ProductFormViewController {
 private enum Localization {
     enum Alert {
         // Product saved or updated
-        static let presentProductConfirmationSaveAlert = NSLocalizedString("Product saved",
-                                                                           comment: "Title of the alert when a user is saving a product")
+        static let productSavedAlert = NSLocalizedString("Product saved",
+                                                         comment: "Title of the alert when a user is saving a product")
+        static let productDraftSavedAlert = NSLocalizedString("Product draft saved",
+                                                              comment: "Title of the alert when a user is saving a product draft")
+        static let productPublishedAlert = NSLocalizedString("Product published",
+                                                             comment: "Title of the alert when a user is publishing a product")
+        static let productCopiedAlert = NSLocalizedString("Product copied", comment: "Title of the alert when a user has copied a product")
 
         // Product type change
         static let productTypeChangeTitle = NSLocalizedString("Are you sure you want to change the product type?",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -764,6 +764,7 @@ private extension ProductFormViewController {
 
     func saveProductRemotely(status: ProductStatus?, onCompletion: @escaping (Result<Void, ProductUpdateError>) -> Void = { _ in }) {
         let previousStatus = product.status
+        let isNewProduct = !product.existsRemotely
 
         viewModel.saveProductRemotely(status: status) { [weak self] result in
             switch result {
@@ -781,7 +782,7 @@ private extension ProductFormViewController {
 
                 // Presents the confirmation alert
                 let alertType: ProductSavedAlertType
-                if status == .published, previousStatus != .published {
+                if status == .published && (isNewProduct || previousStatus != .published) {
                     alertType = .published
                 } else if status == .draft || (status == nil && previousStatus == .draft) {
                     alertType = .draftSaved


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/8776

## Description

This PR updates success notices after product saving to display correct status-related messages.

## Testing

> Product published
1. Go to the product list and start product creation flow ("+" button in the navbar).
2. Select any type of a product.
3. Tap "Publish".
4. Check "Product published" message in the notice.

> Product draft saved
1. Go to the product list and start product creation flow ("+" button in the navbar).
2. Tap "•••" in the navbar.
3. Tap "Save as draft".
4. Check "Product draft saved" message in the notice.
(Same message should appear when saving changes to an existing draft.)

> Product saved
1. Go to the product list and open details for any published product.
2. Update some fields.
3. Tap "Save".
4. Check "Product saved" message in the notice.

## Screenshots

before|after
--|--
![Simulator Screen Shot - 1](https://user-images.githubusercontent.com/3132438/220083370-5f3e7b04-7959-4bbf-9aa2-f19c03b77f2b.png)|![Simulator Screen Shot - 2](https://user-images.githubusercontent.com/3132438/220083383-099ec401-1507-41ee-8cad-b014e5b67729.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
