### PR TITLE
Store onboarding: feature flag, barebone UI and navigation

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -72,7 +72,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .simplifyProductEditing:
             return ( buildConfig == .localDeveloper || buildConfig == .alpha ) && !isUITesting
         case .dashboardOnboarding:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return ( buildConfig == .localDeveloper || buildConfig == .alpha ) && !isUITesting
         default:
             return true
         }

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -65,6 +65,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .simplifyProductEditing:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .dashboardOnboarding:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -149,4 +149,8 @@ public enum FeatureFlag: Int {
     /// Whether to enable the simplified product editing experience.
     ///
     case simplifyProductEditing
+
+    /// Whether to enable the onboarding checklist in the dashboard for WPCOM stores.
+    ///
+    case dashboardOnboarding
 }

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -256,6 +256,12 @@ extension UIImage {
         return UIImage(named: "domain-purchase-success")!
     }
 
+    /// Domains image.
+    ///
+    static var domainsImage: UIImage {
+        UIImage.gridicon(.domains)
+    }
+
     /// Domain search placeholder image.
     ///
     static var domainSearchPlaceholderImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -96,7 +96,6 @@ final class DashboardViewController: UIViewController {
     /// Onboarding card.
     private var onboardingHostingController: ConstraintsUpdatingHostingController<StoreOnboardingView>?
     private var onboardingView: UIView?
-    private let onboardingViewModel: StoreOnboardingViewModel = .init(isExpanded: false)
     private var onboardingCoordinator: StoreOnboardingCoordinator?
 
     /// Bottom Jetpack benefits banner, shown when the site is connected to Jetpack without Jetpack-the-plugin.
@@ -542,7 +541,13 @@ private extension DashboardViewController {
     }
 
     func showOnboardingCard() {
-        let hostingController = ConstraintsUpdatingHostingController(rootView: StoreOnboardingView(viewModel: .init(isExpanded: false)))
+        let hostingController = ConstraintsUpdatingHostingController(rootView: StoreOnboardingView(viewModel: .init(isExpanded: false),
+                                                                                                   taskTapped: { [weak self] task in
+            guard let self, let navigationController = self.navigationController else { return }
+            let coordinator = StoreOnboardingCoordinator(navigationController: navigationController)
+            self.onboardingCoordinator = coordinator
+            coordinator.start(task: task)
+        }))
         guard let uiView = hostingController.view else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -622,25 +622,9 @@ private extension DashboardViewController {
     }
 }
 
-// MARK: - Public API
-//
-extension DashboardViewController {
-    func presentSettings() {
-        settingsTapped()
-    }
-}
-
-
 // MARK: - Action Handlers
 //
 private extension DashboardViewController {
-
-    @objc func settingsTapped() {
-        let settingsViewController = SettingsViewController()
-        ServiceLocator.analytics.track(.settingsTapped)
-        show(settingsViewController, sender: self)
-    }
-
     func pullToRefresh() async {
         ServiceLocator.analytics.track(.dashboardPulledToRefresh)
         await viewModel.syncAnnouncements(for: siteID)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -17,6 +17,8 @@ final class DashboardViewModel {
 
     @Published private(set) var showWebViewSheet: WebViewSheetViewModel? = nil
 
+    @Published private(set) var showOnboarding: Bool = false
+
     /// Trigger to start the Add Product flow
     ///
     let addProductTrigger = PassthroughSubject<Void, Never>()
@@ -33,6 +35,8 @@ final class DashboardViewModel {
         self.featureFlagService = featureFlags
         self.analytics = analytics
         self.justInTimeMessagesManager = JustInTimeMessagesProvider(stores: stores, analytics: analytics)
+        // TODO: 8893 - determine if the onboarding view should be shown based on more criteria
+        self.showOnboarding = featureFlags.isFeatureFlagEnabled(.dashboardOnboarding)
     }
 
     /// Syncs store stats for dashboard UI.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 import UIKit
 
+/// Coordinates navigation for store onboarding.
 final class StoreOnboardingCoordinator: Coordinator {
     let navigationController: UINavigationController
 
@@ -17,6 +18,8 @@ final class StoreOnboardingCoordinator: Coordinator {
         navigationController.show(onboardingController, sender: self)
     }
 
+    /// Navigates to complete an onboarding task.
+    /// - Parameter task: the task to complete.
     func start(task: StoreOnboardingTask) {
         print("TODO: navigate to \(task)")
         start()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -1,0 +1,21 @@
+import Foundation
+import SwiftUI
+import UIKit
+
+final class StoreOnboardingCoordinator: Coordinator {
+    let navigationController: UINavigationController
+
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+
+    /// Navigates to the fullscreen store onboarding view.
+    func start() {
+        let onboarding = UIHostingController(rootView: StoreOnboardingView(viewModel: .init(isExpanded: true)))
+        navigationController.show(onboarding, sender: self)
+    }
+
+    func start(task: StoreOnboardingTask) {
+        print("TODO: navigate to \(task)")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -11,11 +11,14 @@ final class StoreOnboardingCoordinator: Coordinator {
 
     /// Navigates to the fullscreen store onboarding view.
     func start() {
-        let onboarding = UIHostingController(rootView: StoreOnboardingView(viewModel: .init(isExpanded: true)))
-        navigationController.show(onboarding, sender: self)
+        let onboardingController = UIHostingController(rootView: StoreOnboardingView(viewModel: .init(isExpanded: true), taskTapped: { [weak self] task in
+            self?.start(task: task)
+        }))
+        navigationController.show(onboardingController, sender: self)
     }
 
     func start(task: StoreOnboardingTask) {
         print("TODO: navigate to \(task)")
+        start()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -21,7 +21,7 @@ final class StoreOnboardingCoordinator: Coordinator {
     /// Navigates to complete an onboarding task.
     /// - Parameter task: the task to complete.
     func start(task: StoreOnboardingTask) {
-        print("TODO: navigate to \(task)")
+        #warning("TODO: handle navigation for each onboarding task")
         start()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+struct StoreOnboardingTaskView: View {
+    let viewModel: StoreOnboardingViewModel.TaskViewModel
+
+    /// Scale of the view based on accessibility changes
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    var body: some View {
+        HStack(alignment: .center) {
+            // Check icon or task icon.
+            if viewModel.isComplete {
+                Image(uiImage: .checkCircleImage.withRenderingMode(.alwaysTemplate))
+                    .foregroundColor(.init(uiColor: .accent))
+                    .frame(width: scale * Layout.imageDimension,
+                           height: scale * Layout.imageDimension)
+            } else {
+                Image(uiImage: viewModel.icon)
+                    .frame(width: scale * Layout.imageDimension,
+                           height: scale * Layout.imageDimension)
+            }
+
+            VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
+                Spacer().frame(height: Layout.spacerHeight)
+                Text(viewModel.task.title)
+                    .fontWeight(.bold)
+                Text(viewModel.task.subtitle)
+                Spacer().frame(height: Layout.spacerHeight)
+                Divider().dividerStyle()
+            }
+        }
+        .padding(.horizontal, insets: Layout.taskInsets)
+    }
+}
+
+private extension StoreOnboardingTaskView {
+    enum Layout {
+        static let taskInsets: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+        static let verticalSpacing: CGFloat = 4
+        static let spacerHeight: CGFloat = 12
+        static let imageDimension: CGFloat = 24
+    }
+}
+
+private extension StoreOnboardingTask {
+    var title: String {
+        switch self {
+        case .storeDetails:
+            return NSLocalizedString(
+                "Tell us more about your store",
+                comment: "Title of the store onboarding task to add more store details."
+            )
+        case .addFirstProduct:
+            return NSLocalizedString(
+                "Add your first product",
+                comment: "Title of the store onboarding task to add the first product."
+            )
+        case .launchStore:
+            return NSLocalizedString(
+                "Launch your store",
+                comment: "Title of the store onboarding task to launch the store."
+            )
+        case .customizeDomains:
+            return NSLocalizedString(
+                "Customize your domain",
+                comment: "Title of the store onboarding task to customize the store domain."
+            )
+        case .payments:
+            return NSLocalizedString(
+                "Get paid",
+                comment: "Title of the store onboarding task to get paid."
+            )
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .storeDetails:
+            return NSLocalizedString(
+                "We’ll use the info to get a head start on your shipping, tax, and payments settings.",
+                comment: "Subtitle of the store onboarding task to add more store details."
+            )
+        case .addFirstProduct:
+            return NSLocalizedString(
+                "Start selling by adding products or services to your store.",
+                comment: "Subtitle of the store onboarding task to add the first product."
+            )
+        case .launchStore:
+            return NSLocalizedString(
+                "Publish your site to the world anytime you want!",
+                comment: "Subtitle of the store onboarding task to launch the store."
+            )
+        case .customizeDomains:
+            return NSLocalizedString(
+                "Have a custom URL to host your store.",
+                comment: "Subtitle of the store onboarding task to customize the store domain."
+            )
+        case .payments:
+            return NSLocalizedString(
+                "Give your customers an easy and convenient way to pay!",
+                comment: "Subtitle of the store onboarding task to get paid."
+            )
+        }
+    }
+}
+
+struct StoreOnboardingTaskView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            Group {
+                StoreOnboardingTaskView(viewModel: .init(task: .customizeDomains, isComplete: false, icon: .domainsImage))
+                StoreOnboardingTaskView(viewModel: .init(task: .customizeDomains, isComplete: true, icon: .domainsImage))
+            }
+            .previewDisplayName("Customize your domains")
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -7,15 +7,18 @@ struct StoreOnboardingTaskView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
 
     var body: some View {
-        HStack(alignment: .center) {
+        HStack(alignment: .center, spacing: Layout.horizontalSpacing) {
             // Check icon or task icon.
             if viewModel.isComplete {
                 Image(uiImage: .checkCircleImage.withRenderingMode(.alwaysTemplate))
+                    .resizable()
                     .foregroundColor(.init(uiColor: .accent))
                     .frame(width: scale * Layout.imageDimension,
                            height: scale * Layout.imageDimension)
             } else {
-                Image(uiImage: viewModel.icon)
+                Image(uiImage: viewModel.icon.withRenderingMode(.alwaysTemplate))
+                    .resizable()
+                    .foregroundColor(.init(uiColor: .text))
                     .frame(width: scale * Layout.imageDimension,
                            height: scale * Layout.imageDimension)
             }
@@ -36,6 +39,7 @@ struct StoreOnboardingTaskView: View {
 private extension StoreOnboardingTaskView {
     enum Layout {
         static let taskInsets: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+        static let horizontalSpacing: CGFloat = 16
         static let verticalSpacing: CGFloat = 4
         static let spacerHeight: CGFloat = 12
         static let imageDimension: CGFloat = 24

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -39,10 +39,11 @@ struct StoreOnboardingTaskView: View {
                     // TODO: 8907 - show a chevron icon at the trailing edge
                     // Task title.
                     Text(viewModel.task.title)
-                        .fontWeight(.bold)
+                        .headlineStyle()
                         .multilineTextAlignment(.leading)
                     // Task subtitle.
                     Text(viewModel.task.subtitle)
+                        .subheadlineStyle()
                         .multilineTextAlignment(.leading)
                     Spacer().frame(height: Layout.spacerHeight)
                     Divider().dividerStyle()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -20,19 +20,12 @@ struct StoreOnboardingTaskView: View {
         } label: {
             HStack(alignment: .center, spacing: Layout.horizontalSpacing) {
                 // Check icon or task icon.
-                if viewModel.isComplete {
-                    Image(uiImage: .checkCircleImage.withRenderingMode(.alwaysTemplate))
-                        .resizable()
-                        .foregroundColor(.init(uiColor: .accent))
-                        .frame(width: scale * Layout.imageDimension,
-                               height: scale * Layout.imageDimension)
-                } else {
-                    Image(uiImage: viewModel.icon.withRenderingMode(.alwaysTemplate))
-                        .resizable()
-                        .foregroundColor(.init(uiColor: .text))
-                        .frame(width: scale * Layout.imageDimension,
-                               height: scale * Layout.imageDimension)
-                }
+                Image(uiImage: viewModel.isComplete ? .checkCircleImage : viewModel.icon)
+                    .renderingMode(.template)
+                    .resizable()
+                    .foregroundColor(.init(uiColor: viewModel.isComplete ? .accent : .text))
+                    .frame(width: scale * Layout.imageDimension,
+                           height: scale * Layout.imageDimension)
 
                 VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
                     Spacer().frame(height: Layout.spacerHeight)
@@ -51,7 +44,7 @@ struct StoreOnboardingTaskView: View {
             }
             .padding(.horizontal, insets: Layout.taskInsets)
         }
-        .buttonStyle(PlainButtonStyle())
+        .buttonStyle(.plain)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// Shows a tappable onboarding task to set up the store. If the task is complete, a checkmark is shown.
 struct StoreOnboardingTaskView: View {
     private let viewModel: StoreOnboardingViewModel.TaskViewModel
     private let onTap: (StoreOnboardingTask) -> Void
@@ -10,7 +11,7 @@ struct StoreOnboardingTaskView: View {
         self.onTap = onTap
     }
 
-    /// Scale of the view based on accessibility changes
+    /// Scale of the view based on accessibility changes.
     @ScaledMetric private var scale: CGFloat = 1.0
 
     var body: some View {
@@ -35,9 +36,12 @@ struct StoreOnboardingTaskView: View {
 
                 VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
                     Spacer().frame(height: Layout.spacerHeight)
+                    // TODO: 8907 - show a chevron icon at the trailing edge
+                    // Task title.
                     Text(viewModel.task.title)
                         .fontWeight(.bold)
                         .multilineTextAlignment(.leading)
+                    // Task subtitle.
                     Text(viewModel.task.subtitle)
                         .multilineTextAlignment(.leading)
                     Spacer().frame(height: Layout.spacerHeight)
@@ -63,11 +67,6 @@ private extension StoreOnboardingTaskView {
 private extension StoreOnboardingTask {
     var title: String {
         switch self {
-        case .storeDetails:
-            return NSLocalizedString(
-                "Tell us more about your store",
-                comment: "Title of the store onboarding task to add more store details."
-            )
         case .addFirstProduct:
             return NSLocalizedString(
                 "Add your first product",
@@ -93,11 +92,6 @@ private extension StoreOnboardingTask {
 
     var subtitle: String {
         switch self {
-        case .storeDetails:
-            return NSLocalizedString(
-                "We’ll use the info to get a head start on your shipping, tax, and payments settings.",
-                comment: "Subtitle of the store onboarding task to add more store details."
-            )
         case .addFirstProduct:
             return NSLocalizedString(
                 "Start selling by adding products or services to your store.",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -1,38 +1,52 @@
 import SwiftUI
 
 struct StoreOnboardingTaskView: View {
-    let viewModel: StoreOnboardingViewModel.TaskViewModel
+    private let viewModel: StoreOnboardingViewModel.TaskViewModel
+    private let onTap: (StoreOnboardingTask) -> Void
+
+    init(viewModel: StoreOnboardingViewModel.TaskViewModel,
+         onTap: @escaping (StoreOnboardingTask) -> Void) {
+        self.viewModel = viewModel
+        self.onTap = onTap
+    }
 
     /// Scale of the view based on accessibility changes
     @ScaledMetric private var scale: CGFloat = 1.0
 
     var body: some View {
-        HStack(alignment: .center, spacing: Layout.horizontalSpacing) {
-            // Check icon or task icon.
-            if viewModel.isComplete {
-                Image(uiImage: .checkCircleImage.withRenderingMode(.alwaysTemplate))
-                    .resizable()
-                    .foregroundColor(.init(uiColor: .accent))
-                    .frame(width: scale * Layout.imageDimension,
-                           height: scale * Layout.imageDimension)
-            } else {
-                Image(uiImage: viewModel.icon.withRenderingMode(.alwaysTemplate))
-                    .resizable()
-                    .foregroundColor(.init(uiColor: .text))
-                    .frame(width: scale * Layout.imageDimension,
-                           height: scale * Layout.imageDimension)
-            }
+        Button {
+            onTap(viewModel.task)
+        } label: {
+            HStack(alignment: .center, spacing: Layout.horizontalSpacing) {
+                // Check icon or task icon.
+                if viewModel.isComplete {
+                    Image(uiImage: .checkCircleImage.withRenderingMode(.alwaysTemplate))
+                        .resizable()
+                        .foregroundColor(.init(uiColor: .accent))
+                        .frame(width: scale * Layout.imageDimension,
+                               height: scale * Layout.imageDimension)
+                } else {
+                    Image(uiImage: viewModel.icon.withRenderingMode(.alwaysTemplate))
+                        .resizable()
+                        .foregroundColor(.init(uiColor: .text))
+                        .frame(width: scale * Layout.imageDimension,
+                               height: scale * Layout.imageDimension)
+                }
 
-            VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
-                Spacer().frame(height: Layout.spacerHeight)
-                Text(viewModel.task.title)
-                    .fontWeight(.bold)
-                Text(viewModel.task.subtitle)
-                Spacer().frame(height: Layout.spacerHeight)
-                Divider().dividerStyle()
+                VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
+                    Spacer().frame(height: Layout.spacerHeight)
+                    Text(viewModel.task.title)
+                        .fontWeight(.bold)
+                        .multilineTextAlignment(.leading)
+                    Text(viewModel.task.subtitle)
+                        .multilineTextAlignment(.leading)
+                    Spacer().frame(height: Layout.spacerHeight)
+                    Divider().dividerStyle()
+                }
             }
+            .padding(.horizontal, insets: Layout.taskInsets)
         }
-        .padding(.horizontal, insets: Layout.taskInsets)
+        .buttonStyle(PlainButtonStyle())
     }
 }
 
@@ -112,8 +126,8 @@ struct StoreOnboardingTaskView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
             Group {
-                StoreOnboardingTaskView(viewModel: .init(task: .customizeDomains, isComplete: false, icon: .domainsImage))
-                StoreOnboardingTaskView(viewModel: .init(task: .customizeDomains, isComplete: true, icon: .domainsImage))
+                StoreOnboardingTaskView(viewModel: .init(task: .customizeDomains, isComplete: false, icon: .domainsImage), onTap: { _ in })
+                StoreOnboardingTaskView(viewModel: .init(task: .customizeDomains, isComplete: true, icon: .domainsImage), onTap: { _ in })
             }
             .previewDisplayName("Customize your domains")
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct StoreOnboardingView: View {
+    private let viewModel: StoreOnboardingViewModel
+
+    init(viewModel: StoreOnboardingViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        VStack {
+            ForEach(viewModel.taskViewModels, id: \.task) { taskViewModel in
+                StoreOnboardingTaskView(viewModel: taskViewModel)
+            }
+        }
+    }
+}
+
+struct StoreOnboardingCardView_Previews: PreviewProvider {
+    static var previews: some View {
+        StoreOnboardingView(viewModel: .init(isExpanded: false))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// Shows a list of onboarding tasks for store setup with completion state.
 struct StoreOnboardingView: View {
     private let viewModel: StoreOnboardingViewModel
     private let taskTapped: (StoreOnboardingTask) -> Void

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -2,15 +2,19 @@ import SwiftUI
 
 struct StoreOnboardingView: View {
     private let viewModel: StoreOnboardingViewModel
+    private let taskTapped: (StoreOnboardingTask) -> Void
 
-    init(viewModel: StoreOnboardingViewModel) {
+    init(viewModel: StoreOnboardingViewModel, taskTapped: @escaping (StoreOnboardingTask) -> Void) {
         self.viewModel = viewModel
+        self.taskTapped = taskTapped
     }
 
     var body: some View {
         VStack {
             ForEach(viewModel.taskViewModels, id: \.task) { taskViewModel in
-                StoreOnboardingTaskView(viewModel: taskViewModel)
+                StoreOnboardingTaskView(viewModel: taskViewModel) { task in
+                    taskTapped(task)
+                }
             }
         }
     }
@@ -18,6 +22,6 @@ struct StoreOnboardingView: View {
 
 struct StoreOnboardingCardView_Previews: PreviewProvider {
     static var previews: some View {
-        StoreOnboardingView(viewModel: .init(isExpanded: false))
+        StoreOnboardingView(viewModel: .init(isExpanded: false), taskTapped: { _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -1,0 +1,35 @@
+import Foundation
+import UIKit
+
+enum StoreOnboardingTask {
+    case storeDetails
+    case addFirstProduct
+    case launchStore
+    case customizeDomains
+    case payments
+}
+
+final class StoreOnboardingViewModel: ObservableObject {
+    struct TaskViewModel {
+        let task: StoreOnboardingTask
+        let isComplete: Bool
+        let icon: UIImage
+    }
+
+    @Published private(set) var taskViewModels: [TaskViewModel]
+
+    private let isExpanded: Bool
+
+    /// - Parameter isExpanded: Whether the onboarding view is in the expanded state. The expanded state is shown when the view is in fullscreen.
+    init(isExpanded: Bool) {
+        self.isExpanded = isExpanded
+        // TODO: 8892 - check the complete state from the API
+        taskViewModels = [
+            .init(task: .storeDetails, isComplete: false, icon: .productImage),
+            .init(task: .addFirstProduct, isComplete: false, icon: .productImage),
+            .init(task: .launchStore, isComplete: false, icon: .storeImage),
+            .init(task: .customizeDomains, isComplete: false, icon: .domainsImage),
+            .init(task: .payments, isComplete: false, icon: .currencyImage)
+        ]
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -1,14 +1,15 @@
 import Foundation
 import UIKit
 
+/// Onboarding tasks to set up a store.
 enum StoreOnboardingTask {
-    case storeDetails
     case addFirstProduct
     case launchStore
     case customizeDomains
     case payments
 }
 
+/// View model for `StoreOnboardingView`.
 final class StoreOnboardingViewModel: ObservableObject {
     struct TaskViewModel {
         let task: StoreOnboardingTask
@@ -25,7 +26,6 @@ final class StoreOnboardingViewModel: ObservableObject {
         self.isExpanded = isExpanded
         // TODO: 8892 - check the complete state from the API
         taskViewModels = [
-            .init(task: .storeDetails, isComplete: false, icon: .productImage),
             .init(task: .addFirstProduct, isComplete: false, icon: .productImage),
             .init(task: .launchStore, isComplete: false, icon: .storeImage),
             .init(task: .customizeDomains, isComplete: false, icon: .domainsImage),

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -388,18 +388,6 @@ extension MainTabBarController {
         }
     }
 
-    /// Switches to the My Store Tab, and presents the Settings .
-    ///
-    static func presentSettings() {
-        switchToMyStoreTab(animated: false)
-
-        guard let dashBoard: DashboardViewController = childViewController() else {
-            return
-        }
-
-        dashBoard.presentSettings()
-    }
-
     static func navigateToOrderDetails(with orderID: Int64, siteID: Int64) {
         showStore(with: siteID, onCompletion: { storeIsShown in
             switchToOrdersTab {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -392,6 +392,10 @@
 		02BAB02324D0250300F8B06E /* ProductVariation+ProductFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB02224D0250300F8B06E /* ProductVariation+ProductFormTests.swift */; };
 		02BAB02724D13A6400F8B06E /* ProductVariationFormActionsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB02624D13A6400F8B06E /* ProductVariationFormActionsFactory.swift */; };
 		02BAB02924D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB02824D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift */; };
+		02BBD6E529A2678100243BE2 /* StoreOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BBD6E429A2678100243BE2 /* StoreOnboardingView.swift */; };
+		02BBD6E729A268F300243BE2 /* StoreOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BBD6E629A268F300243BE2 /* StoreOnboardingViewModel.swift */; };
+		02BBD6E929A3024400243BE2 /* StoreOnboardingTaskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BBD6E829A3024400243BE2 /* StoreOnboardingTaskView.swift */; };
+		02BBD6EB29A316FB00243BE2 /* StoreOnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BBD6EA29A316FB00243BE2 /* StoreOnboardingCoordinator.swift */; };
 		02BC5AA024D27D8E00C43326 /* ProductVariationFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BC5A9F24D27D8E00C43326 /* ProductVariationFormViewModel.swift */; };
 		02BC5AA424D27F8900C43326 /* ProductVariationFormViewModel+ObservablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BC5AA124D27F8800C43326 /* ProductVariationFormViewModel+ObservablesTests.swift */; };
 		02BC5AA524D27F8900C43326 /* ProductVariationFormViewModel+UpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BC5AA224D27F8800C43326 /* ProductVariationFormViewModel+UpdatesTests.swift */; };
@@ -2495,6 +2499,10 @@
 		02BAB02224D0250300F8B06E /* ProductVariation+ProductFormTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariation+ProductFormTests.swift"; sourceTree = "<group>"; };
 		02BAB02624D13A6400F8B06E /* ProductVariationFormActionsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormActionsFactory.swift; sourceTree = "<group>"; };
 		02BAB02824D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormActionsFactoryTests.swift; sourceTree = "<group>"; };
+		02BBD6E429A2678100243BE2 /* StoreOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingView.swift; sourceTree = "<group>"; };
+		02BBD6E629A268F300243BE2 /* StoreOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingViewModel.swift; sourceTree = "<group>"; };
+		02BBD6E829A3024400243BE2 /* StoreOnboardingTaskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingTaskView.swift; sourceTree = "<group>"; };
+		02BBD6EA29A316FB00243BE2 /* StoreOnboardingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingCoordinator.swift; sourceTree = "<group>"; };
 		02BC5A9F24D27D8E00C43326 /* ProductVariationFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormViewModel.swift; sourceTree = "<group>"; };
 		02BC5AA124D27F8800C43326 /* ProductVariationFormViewModel+ObservablesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductVariationFormViewModel+ObservablesTests.swift"; sourceTree = "<group>"; };
 		02BC5AA224D27F8800C43326 /* ProductVariationFormViewModel+UpdatesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductVariationFormViewModel+UpdatesTests.swift"; sourceTree = "<group>"; };
@@ -5156,6 +5164,17 @@
 				4574745E24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift */,
 			);
 			path = BottomSheetListSelector;
+			sourceTree = "<group>";
+		};
+		02BBD6E329A2674C00243BE2 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				02BBD6E429A2678100243BE2 /* StoreOnboardingView.swift */,
+				02BBD6E629A268F300243BE2 /* StoreOnboardingViewModel.swift */,
+				02BBD6E829A3024400243BE2 /* StoreOnboardingTaskView.swift */,
+				02BBD6EA29A316FB00243BE2 /* StoreOnboardingCoordinator.swift */,
+			);
+			path = Onboarding;
 			sourceTree = "<group>";
 		};
 		02C0CD2823B5BAFB00F880B1 /* ImageService */ = {
@@ -8544,6 +8563,7 @@
 				2647F7B329280A5000D59FDF /* Analytics Hub */,
 				DE23CFF827462CD2003BE54E /* JetpackInstall */,
 				02F843D8273646190017FE12 /* JetpackConnectionPackageSites */,
+				02BBD6E329A2674C00243BE2 /* Onboarding */,
 				028BAC4322F3AE3B008BB4AF /* Stats v4 */,
 				029D444B22F1417400DEFA8A /* Stats v3 */,
 				029D444722F13F5C00DEFA8A /* Factories */,
@@ -10285,6 +10305,7 @@
 				CC53FB3C2757EC7200C4CA4F /* ProductSelectorViewModel.swift in Sources */,
 				CCA1D5FE293F537400B40560 /* DeltaPercentage.swift in Sources */,
 				4569D3C325DC008700CDC3E2 /* SiteAddress.swift in Sources */,
+				02BBD6E729A268F300243BE2 /* StoreOnboardingViewModel.swift in Sources */,
 				B9B0391828A6838400DC1C83 /* PermanentNoticeView.swift in Sources */,
 				DEC6C51827466B59006832D3 /* StoreStatsEmptyView.swift in Sources */,
 				31FE28C225E6D338003519F2 /* LearnMoreTableViewCell.swift in Sources */,
@@ -10519,6 +10540,7 @@
 				2664210126F3E1BB001FC5B4 /* ModalHostingPresentationController.swift in Sources */,
 				D8B4D5F026C2C7EC00F34E94 /* InPersonPaymentsStripeAccountPendingView.swift in Sources */,
 				B92639FF293E2D4C00A257E0 /* JustInTimeMessagesProvider.swift in Sources */,
+				02BBD6E529A2678100243BE2 /* StoreOnboardingView.swift in Sources */,
 				02784A03238B8BC800BDD6A8 /* UIView+Border.swift in Sources */,
 				CE1CCB402056F21C000EE3AC /* Style.swift in Sources */,
 				45EF7984244F26BB00B22BA2 /* Array+IndexPath.swift in Sources */,
@@ -10707,6 +10729,7 @@
 				B586906621A5F4B1001F1EFC /* UINavigationController+Woo.swift in Sources */,
 				45FBDF3A238D3F8B00127F77 /* ExtendedAddProductImageCollectionViewCell.swift in Sources */,
 				02A410F52583A84C005E2925 /* SpacerTableViewCell.swift in Sources */,
+				02BBD6EB29A316FB00243BE2 /* StoreOnboardingCoordinator.swift in Sources */,
 				D881FE062579DC78008DE6F2 /* NotWPAccountViewModel.swift in Sources */,
 				311D21ED264AF0E700102316 /* CardReaderSettingsAlerts.swift in Sources */,
 				02C0CD2A23B5BB1C00F880B1 /* ImageService.swift in Sources */,
@@ -11194,6 +11217,7 @@
 				03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */,
 				09EA565527C8ACEE00407D40 /* BulkUpdateViewController.swift in Sources */,
 				2602A64627BDBEBA00B347F1 /* ProductInputTransformer.swift in Sources */,
+				02BBD6E929A3024400243BE2 /* StoreOnboardingTaskView.swift in Sources */,
 				028203CF297662A200217369 /* DomainSelectorDataProvider.swift in Sources */,
 				DE74F2A327E41D650002FE59 /* EnableAnalyticsViewModel.swift in Sources */,
 				AE77EA5027A47C99006A21BD /* View+AddingDividers.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -140,6 +140,10 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.domainPurchaseSuccessImage)
     }
 
+    func test_domainsImage_is_not_nil() {
+        XCTAssertNotNil(UIImage.domainsImage)
+    }
+
     func test_domainSearchPlaceholderImage_is_not_nil() {
         XCTAssertNotNil(UIImage.domainSearchPlaceholderImage)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8891 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR enables a few starting points of future tasks to allow parallel work:
- https://github.com/woocommerce/woocommerce-ios/issues/8907
- https://github.com/woocommerce/woocommerce-ios/issues/8908
- https://github.com/woocommerce/woocommerce-ios/issues/8909
- https://github.com/woocommerce/woocommerce-ios/issues/8892
- https://github.com/woocommerce/woocommerce-ios/issues/8893

Major changes:
- Added a new feature flag `dashboardOnboarding`
- Created SwiftUI views `StoreOnboardingView`+view model, `StoreOnboardingTaskView` with barebone design
- Created a coordinator `StoreOnboardingCoordinator` to navigate to the expanded state and handle navigation for each task
- Added `showOnboarding: Bool` to `DashboardViewModel`, and onboarding card show/hide logic to `DashboardViewController` similar to the announcement card so that the card is always shown for now for easier development. Since the onboarding card can be quite tall, ideally the card can scroll with the stats below. However, we're currently using a third-party library `XLPagerTabStrip` for the stats view so I'm working on replacing `XLPagerTabStrip` with our own implementation next https://github.com/woocommerce/woocommerce-ios/issues/1911
- Removed some dead code in `DashboardViewController` from the old settings CTA

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in if needed --> on the My store tab, an onboarding card should be shown above the stats

---
- [x] @jaclync tests that the onboarding UI isn't shown when the feature flag is off

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

light | dark
-- | --
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-21 at 10 35 43](https://user-images.githubusercontent.com/1945542/220235141-8331288a-97a3-4026-a607-ec33993bcb8c.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-21 at 10 35 49](https://user-images.githubusercontent.com/1945542/220235145-3acce23c-cc7c-437a-a4b2-b4fd23e38c0b.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
