### PR TITLE
REST API: Add feature flag and show Jetpack benefit banner for users authenticated with application password

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -71,6 +71,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .simplifyProductEditing:
             return ( buildConfig == .localDeveloper || buildConfig == .alpha ) && !isUITesting
+        case .jetpackSetupWithApplicationPassword:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -149,4 +149,8 @@ public enum FeatureFlag: Int {
     /// Whether to enable the simplified product editing experience.
     ///
     case simplifyProductEditing
+
+    /// Whether to enable Jetpack setup for users authenticated with application passwords.
+    ///
+    case jetpackSetupWithApplicationPassword
 }

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -144,6 +144,14 @@ public extension Site {
     var isJetpackCPConnected: Bool {
         isJetpackConnected && !isJetpackThePluginInstalled
     }
+
+    /// Whether the site has Jetpack plugin install, activated and connected.
+    ///
+    var isNonJetpackSite: Bool {
+        /// when the site ID uses a placeholder ID, we can assume that it's not recognized by Jetpack,
+        /// hence not a Jetpack site.
+        siteID == WooConstants.placeholderSiteID
+    }
 }
 
 /// Defines all of the Site CodingKeys.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -728,7 +728,7 @@ private extension DashboardViewController {
                     guard let self = self else { return }
 
                     let isJetpackCPSite = site?.isJetpackCPConnected == true
-                    let jetpackSetupForApplicationPassword = site?.siteID == WooConstants.placeholderStoreID &&
+                    let jetpackSetupForApplicationPassword = site?.isNonJetpackSite == true &&
                         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.jetpackSetupWithApplicationPassword)
                     let shouldShowJetpackBenefitsBanner = (isJetpackCPSite || jetpackSetupForApplicationPassword) && isVisibleFromAppSettings
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -343,6 +343,11 @@ private extension DashboardViewController {
                     guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
                         return
                     }
+
+                    if ServiceLocator.stores.isAuthenticatedWithoutWPCom {
+                        #warning("TODO: handle Jetpack setup for users authenticated with application passwords")
+                        return
+                    }
                     let installController = JetpackInstallHostingController(siteID: site.siteID, siteURL: site.url, siteAdminURL: site.adminURL)
                     installController.setDismissAction { [weak self] in
                         self?.dismiss(animated: true, completion: nil)
@@ -687,7 +692,10 @@ private extension DashboardViewController {
                                                                                    calendar: .current) { [weak self] isVisibleFromAppSettings in
                     guard let self = self else { return }
 
-                    let shouldShowJetpackBenefitsBanner = site?.isJetpackCPConnected == true && isVisibleFromAppSettings
+                    let isJetpackCPSite = site?.isJetpackCPConnected == true
+                    let jetpackSetupForApplicationPassword = site?.siteID == WooConstants.placeholderStoreID &&
+                        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.jetpackSetupWithApplicationPassword)
+                    let shouldShowJetpackBenefitsBanner = (isJetpackCPSite || jetpackSetupForApplicationPassword) && isVisibleFromAppSettings
 
                     self.updateJetpackBenefitsBannerVisibility(isBannerVisible: shouldShowJetpackBenefitsBanner, contentView: contentView)
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -368,7 +368,7 @@ private extension SettingsViewController {
 
         ServiceLocator.analytics.track(event: .jetpackInstallButtonTapped(source: .settings))
 
-        if stores.isAuthenticatedWithoutWPCom {
+        if site.isNonJetpackSite {
             #warning("TODO: handle jetpack setup with application password")
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -368,6 +368,10 @@ private extension SettingsViewController {
 
         ServiceLocator.analytics.track(event: .jetpackInstallButtonTapped(source: .settings))
 
+        if stores.isAuthenticatedWithoutWPCom {
+            #warning("TODO: handle jetpack setup with application password")
+            return
+        }
         let installJetpackController = JetpackInstallHostingController(siteID: site.siteID, siteURL: site.url, siteAdminURL: site.adminURL)
         installJetpackController.setDismissAction { [weak self] in
             self?.dismiss(animated: true, completion: nil)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -238,8 +238,9 @@ private extension SettingsViewModel {
         let storeSettingsSection: Section? = {
             var rows: [Row] = []
 
-            if stores.sessionManager.defaultSite?.isJetpackCPConnected == true ||
-                (stores.isAuthenticatedWithoutWPCom &&
+            let site = stores.sessionManager.defaultSite
+            if site?.isJetpackCPConnected == true ||
+                (site?.isNonJetpackSite == true &&
                  featureFlagService.isFeatureFlagEnabled(.jetpackSetupWithApplicationPassword)) {
                 rows.append(.installJetpack)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -240,7 +240,7 @@ private extension SettingsViewModel {
 
             if stores.sessionManager.defaultSite?.isJetpackCPConnected == true ||
                 (stores.isAuthenticatedWithoutWPCom &&
-                 featureFlagService.isFeatureFlagEnabled(.jetpackSetupWithApplicationPassword)){
+                 featureFlagService.isFeatureFlagEnabled(.jetpackSetupWithApplicationPassword)) {
                 rows.append(.installJetpack)
             }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -238,7 +238,9 @@ private extension SettingsViewModel {
         let storeSettingsSection: Section? = {
             var rows: [Row] = []
 
-            if stores.sessionManager.defaultSite?.isJetpackCPConnected == true {
+            if stores.sessionManager.defaultSite?.isJetpackCPConnected == true ||
+                (stores.isAuthenticatedWithoutWPCom &&
+                 featureFlagService.isFeatureFlagEnabled(.jetpackSetupWithApplicationPassword)){
                 rows.append(.installJetpack)
             }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8912 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new feature flag for the Jetpack setup feature for users authenticated with application password.
With this flag, the logic to display the Jetpack benefit banner on the Dashboard screen and the Install Jetpack CTA on the Settings screen have been updated. Wording for the benefit modal and action handling for its CTA will be updated in a future PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Create a JN site with WooCommerce and no Jetpack.
- Log out of the app or skip onboarding if needed.
- On the prologue screen, select the Enter your site address.
- Proceed with the address of your test site and log in with correct credentials.
- After the login succeeds, notice on the Dashboard screen that there's a banner for Jetpack benefits at the bottom.
- Switch to the Settings screen, notice that there exists a row named Install Jetpack.

Feel free to disable the feature flag `jetpackSetupWithApplicationPassword` - the benefit banner and Install Jetpack entry point should not be present.

## Screenshots
<!-- Include before and after images or gifs when appropriate. --> 
| Jetpack banner | Install Jetpack entry point |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/220508224-a1a16050-7901-4910-a615-1fe457e74354.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/220508257-1b8044c4-b5db-47b5-8c3f-83e4de4553b8.png" width=320 /> |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
