### PR TITLE
[Product Multi-selection] Enable multi-selection in the Order's Configuration properties

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -34,7 +34,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .loginMagicLinkEmphasisM2:
             return true
         case .productMultiselectionM1:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
         case .promptToEnableCodInIppOnboarding:
             return true
         case .searchProductsBySKU:

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -297,7 +297,7 @@ struct AddEditCoupon: View {
                 }
             }
             .sheet(isPresented: $showingSelectProducts) {
-                ProductSelector(configuration: ProductSelector.Configuration.productsForCoupons,
+                ProductSelectorView(configuration: ProductSelectorView.Configuration.productsForCoupons,
                                 isPresented: $showingSelectProducts,
                                 viewModel: viewModel.productSelectorViewModel)
                     .onDisappear {
@@ -416,7 +416,7 @@ struct AddEditCoupon_Previews: PreviewProvider {
 }
 #endif
 
-private extension ProductSelector.Configuration {
+private extension ProductSelectorView.Configuration {
     static let productsForCoupons: Self =
         .init(showsFilters: true,
               multipleSelectionsEnabled: true,

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
@@ -154,7 +154,7 @@ struct CouponRestrictions: View {
             .background(Color(.listForeground(modal: false)))
             .ignoresSafeArea(.container, edges: [.horizontal])
             .sheet(isPresented: $showingExcludeProducts) {
-                ProductSelector(configuration: ProductSelector.Configuration.excludedProductsForCoupons,
+                ProductSelectorView(configuration: ProductSelectorView.Configuration.excludedProductsForCoupons,
                                 isPresented: $showingExcludeProducts,
                                 viewModel: viewModel.productSelectorViewModel)
                     .onDisappear {
@@ -257,7 +257,7 @@ struct CouponRestrictions_Previews: PreviewProvider {
 }
 #endif
 
-private extension ProductSelector.Configuration {
+private extension ProductSelectorView.Configuration {
     static let excludedProductsForCoupons: Self =
         .init(showsFilters: true,
               multipleSelectionsEnabled: true,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -352,7 +352,7 @@ struct OrderForm_Previews: PreviewProvider {
 
 private extension ProductSelectorView.Configuration {
     static let addProductToOrder: Self =
-        .init(multipleSelectionsEnabled: true,
+        .init(multipleSelectionsEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiselectionM1),
               searchHeaderBackgroundColor: .listBackground,
               prefersLargeTitle: false,
               title: Localization.title,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -352,7 +352,8 @@ struct OrderForm_Previews: PreviewProvider {
 
 private extension ProductSelector.Configuration {
     static let addProductToOrder: Self =
-        .init(searchHeaderBackgroundColor: .listBackground,
+        .init(multipleSelectionsEnabled: true,
+              searchHeaderBackgroundColor: .listBackground,
               prefersLargeTitle: false,
               title: Localization.title,
               cancelButtonTitle: Localization.close,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -352,7 +352,7 @@ struct OrderForm_Previews: PreviewProvider {
 
 private extension ProductSelectorView.Configuration {
     static let addProductToOrder: Self =
-        .init(multipleSelectionsEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiselectionM1),
+        .init(multipleSelectionsEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1),
               searchHeaderBackgroundColor: .listBackground,
               prefersLargeTitle: false,
               title: Localization.title,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -278,7 +278,7 @@ private struct ProductsSection: View {
                 .sheet(isPresented: $showAddProduct, onDismiss: {
                     scroll.scrollTo(addProductButton)
                 }, content: {
-                    ProductSelector(configuration: ProductSelector.Configuration.addProductToOrder,
+                    ProductSelectorView(configuration: ProductSelectorView.Configuration.addProductToOrder,
                                     isPresented: $showAddProduct,
                                     viewModel: viewModel.addProductViewModel)
                         .onDisappear {
@@ -350,7 +350,7 @@ struct OrderForm_Previews: PreviewProvider {
     }
 }
 
-private extension ProductSelector.Configuration {
+private extension ProductSelectorView.Configuration {
     static let addProductToOrder: Self =
         .init(multipleSelectionsEnabled: true,
               searchHeaderBackgroundColor: .listBackground,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Kingfisher
 
-/// Represent a single product or variation row in the Product section of a New Order or in the ProductSelector
+/// Represent a single product or variation row in the Product section of a New Order or in the ProductSelectorView
 ///
 struct ProductRow: View {
     /// Whether more than one row can be selected.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// View showing a list of products to select.
 ///
-struct ProductSelector: View {
+struct ProductSelectorView: View {
 
     let configuration: Configuration
 
@@ -177,7 +177,7 @@ struct ProductSelector: View {
     }
 }
 
-extension ProductSelector {
+extension ProductSelectorView {
     struct Configuration {
         var showsFilters: Bool = false
         var multipleSelectionsEnabled: Bool = false
@@ -192,7 +192,7 @@ extension ProductSelector {
     }
 }
 
-private extension ProductSelector {
+private extension ProductSelectorView {
     enum Constants {
         static let dividerHeight: CGFloat = 1
         static let defaultPadding: CGFloat = 16
@@ -212,13 +212,13 @@ private extension ProductSelector {
 struct AddProduct_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = ProductSelectorViewModel(siteID: 123)
-        let configuration = ProductSelector.Configuration(
+        let configuration = ProductSelectorView.Configuration(
             showsFilters: true,
             multipleSelectionsEnabled: true,
             title: "Add Product",
             cancelButtonTitle: "Close",
             productRowAccessibilityHint: "Add product to order",
             variableProductRowAccessibilityHint: "Open variation list")
-        ProductSelector(configuration: configuration, isPresented: .constant(true), viewModel: viewModel)
+        ProductSelectorView(configuration: configuration, isPresented: .constant(true), viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -4,7 +4,7 @@ import Combine
 import Foundation
 import WooFoundation
 
-/// View model for `ProductSelector`.
+/// View model for `ProductSelectorView`.
 ///
 final class ProductSelectorViewModel: ObservableObject {
     private let siteID: Int64

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1527,7 +1527,7 @@
 		CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1D8525E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift */; };
 		CC4D1E7925EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */; };
 		CC53FB3527551A6E00C4CA4F /* ProductRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB3427551A6E00C4CA4F /* ProductRow.swift */; };
-		CC53FB382755213900C4CA4F /* ProductSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB372755213900C4CA4F /* ProductSelector.swift */; };
+		CC53FB382755213900C4CA4F /* ProductSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB372755213900C4CA4F /* ProductSelectorView.swift */; };
 		CC53FB3A275697B000C4CA4F /* ProductRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB39275697B000C4CA4F /* ProductRowViewModel.swift */; };
 		CC53FB3C2757EC7200C4CA4F /* ProductSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB3B2757EC7200C4CA4F /* ProductSelectorViewModel.swift */; };
 		CC53FB3E2758E2D500C4CA4F /* ProductRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC53FB3D2758E2D500C4CA4F /* ProductRowViewModelTests.swift */; };
@@ -3635,7 +3635,7 @@
 		CC4D1D8525E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModel.swift; sourceTree = "<group>"; };
 		CC4D1E7825EE415D00B6E4E7 /* RenameAttributesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameAttributesViewModelTests.swift; sourceTree = "<group>"; };
 		CC53FB3427551A6E00C4CA4F /* ProductRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRow.swift; sourceTree = "<group>"; };
-		CC53FB372755213900C4CA4F /* ProductSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSelector.swift; sourceTree = "<group>"; };
+		CC53FB372755213900C4CA4F /* ProductSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSelectorView.swift; sourceTree = "<group>"; };
 		CC53FB39275697B000C4CA4F /* ProductRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRowViewModel.swift; sourceTree = "<group>"; };
 		CC53FB3B2757EC7200C4CA4F /* ProductSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSelectorViewModel.swift; sourceTree = "<group>"; };
 		CC53FB3D2758E2D500C4CA4F /* ProductRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRowViewModelTests.swift; sourceTree = "<group>"; };
@@ -9128,7 +9128,7 @@
 		DE4FB771280E758D003D20D6 /* ProductSelector */ = {
 			isa = PBXGroup;
 			children = (
-				CC53FB372755213900C4CA4F /* ProductSelector.swift */,
+				CC53FB372755213900C4CA4F /* ProductSelectorView.swift */,
 				CC53FB3B2757EC7200C4CA4F /* ProductSelectorViewModel.swift */,
 				CCF87BBF2790582400461C43 /* ProductVariationSelector.swift */,
 				CC13C0CA278E021300C0B5B5 /* ProductVariationSelectorViewModel.swift */,
@@ -10868,7 +10868,7 @@
 				57612989245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift in Sources */,
 				B5A8532220BDBFAF00FAAB4D /* CircularImageView.swift in Sources */,
 				CE1F51252064179A00C6C810 /* UILabel+Helpers.swift in Sources */,
-				CC53FB382755213900C4CA4F /* ProductSelector.swift in Sources */,
+				CC53FB382755213900C4CA4F /* ProductSelectorView.swift in Sources */,
 				03191AE928E20C9200670723 /* PluginDetailsRowView.swift in Sources */,
 				0235595324496A93004BE2B8 /* BottomSheetListSelectorViewProperties.swift in Sources */,
 				452FE6522565849B00EB54A0 /* LinkedProductsViewModel.swift in Sources */,


### PR DESCRIPTION
Closes: #8917 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
In order to allow multiple product selection during the Order Creation flow, we can reuse the multi-product selection support that was introduced during the [coupons project](https://github.com/woocommerce/woocommerce-ios/pull/6679). This PR addresses it by adding the `multipleSelectionsEnabled` property to the `ProductSelector` initializer, and switching it to be `true`, so we can get the basic multi-selection functionality to continue building on top.

## Changes:
- Renames `ProductSelector` to `ProductSelectorView`
- Adds `&& !isUITesting` to the feature flag switch, this disables the feature flag specifically for UI testing. This is temporary while we build the feature. UI tests will be addressed separately on https://github.com/woocommerce/woocommerce-ios/issues/8932
- Adds the `multipleSelectionsEnabled` property to the `ProductSelectorView.Configuration` initializer, which enables multiple-selection if the feature flag is switched on.

Note that this PR does not address toggle/un-toggle UI or logic, that will be addressed on a different PR. Is it expected that there's no UI changes when we tap on a product.

## Testing instructions

- Go to Orders -> Tap on `+` -> Tap on `+ Add Product`
- Tap on multiple products, or variable products. The UI will be blocked temporarily while a product is added to the Order.
- See that adding products is tracked correctly in the console:

```
2023-02-21 22:05:40.672794+0700 WooCommerce[15749:231669] 🔵 Tracked order_product_add, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("flow"): "creation", AnyHashable("blog_id"): 215063064]
```
- Tap on `Done` to finish Order editing
- See that all products are listed in the Order.
- Tapping `Create` creates the Order will all listed products.

|  New Order | Editing Order  | 
|---|---|
| <img width=450 src="https://user-images.githubusercontent.com/3812076/220383984-94faaac5-0bb1-4d5f-878e-e8c82054eef5.png">| <img width=450 src="https://user-images.githubusercontent.com/3812076/220518522-b7b2e4d2-7806-4c06-9f21-9b6328b4d89a.png"> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
