### PR TITLE
SPE: Restrict "Add options" button visibility

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -115,7 +115,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
 
     /// Returns an array of actions that are visible in the product form options CTA section.
     func optionsCTASectionActions() -> [ProductFormEditAction] {
-        guard isAddOptionsButtonEnabled, product.product.productType == .simple else {
+        guard isAddOptionsButtonEnabled, product.product.productType == .simple, editable else {
             return []
         }
         return [.addOptions]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -16,8 +16,9 @@ enum ProductFormEditAction: Equatable {
     case tags(editable: Bool)
     case shortDescription(editable: Bool)
     case linkedProducts(editable: Bool)
-    case addOptions
     case convertToVariable
+    // Simple products only
+    case addOptions
     // Affiliate products only
     case sku(editable: Bool)
     case externalURL(editable: Bool)
@@ -114,7 +115,10 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
 
     /// Returns an array of actions that are visible in the product form options CTA section.
     func optionsCTASectionActions() -> [ProductFormEditAction] {
-        isAddOptionsButtonEnabled ? [.addOptions] : []
+        guard isAddOptionsButtonEnabled, product.product.productType == .simple else {
+            return []
+        }
+        return [.addOptions]
     }
 
     /// Returns an array of actions that are visible in the product form bottom sheet.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ReadonlyProductTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ReadonlyProductTests.swift
@@ -56,6 +56,18 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
         XCTAssert(factory.settingsSectionActions().contains(.inventorySettings(editable: false)))
     }
 
+    func test_read_only_simple_product_does_not_contain_add_options_row() {
+        // Given
+        let product = Fixtures.simpleProduct
+        let model = EditableProductModel(product: product)
+
+        // When
+        let factory = ProductFormActionsFactory(product: model, formType: .readonly, isAddOptionsButtonEnabled: true)
+
+        // Then
+        XCTAssertFalse(factory.optionsCTASectionActions().contains(.addOptions))
+    }
+
     // MARK: - Affiliate products
 
     func test_readonly_affiliate_product_form_actions_are_all_not_editable() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -519,9 +519,9 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         XCTAssertTrue(factory.settingsSectionActions().contains(.categories(editable: true)))
     }
 
-    func test_options_CTA_actions_contain_add_options_when_it_is_enabled() {
+    func test_options_CTA_actions_for_simple_product_contain_add_options_when_it_is_enabled() {
         // Given
-        let product = Product.fake()
+        let product = Fixtures.physicalSimpleProductWithoutImages
         let model = EditableProductModel(product: product)
 
         // When
@@ -529,6 +529,26 @@ final class ProductFormActionsFactoryTests: XCTestCase {
 
         // Then
         XCTAssertTrue(factory.optionsCTASectionActions().contains(.addOptions))
+    }
+
+    func test_options_CTA_actions_for_non_simple_products_do_not_contain_add_options_when_it_is_enabled() {
+        // Given
+        let products = [
+            Fixtures.affiliateProduct,
+            Fixtures.groupedProduct,
+            Fixtures.variableProductWithoutVariations,
+            Fixtures.nonCoreProductWithPrice
+        ]
+
+        products.forEach { product in
+            let model = EditableProductModel(product: product)
+
+            // When
+            let factory = ProductFormActionsFactory(product: model, formType: .edit, isAddOptionsButtonEnabled: true)
+
+            // Then
+            XCTAssertFalse(factory.optionsCTASectionActions().contains(.addOptions))
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8927
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For Simplified Product Editing, we have a new "Add options" button in product details (which opens the "Add product details" bottom sheet). However, that button is meant to highlight the "Add product variations" item in the bottom sheet, so it should only be visible in these conditions:

* When the feature flag is enabled
* On simple products (which show the "Add product variations" item to convert them to variable products)
* When the product is editable

Internal ref: pe5pgL-1Gv-p2#comment-1835

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

"Add Options" visible (editable simple products):

1. Build and run the app (with the `simplifyProductEditing` feature flag enabled).
2. Open product details for any simple product (or start product creation flow).
3. Confirm "Add Options" row appears at the bottom of product details.

"Add Options" not visible (editable non-simple products):

1. Open product details for any non-simple product (or start product creation flow).
2. Confirm "Add Options" row does NOT appear.

"Add Options" not visible (read-only simple products):

1. Open order details for an order including a simple product.
2. Tap on a simple product in the order to open read-only product details.
3. Confirm "Add Options" row does NOT appear.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Editable, simple product|Editable, variable product|Read-only, simple product
-|-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-21 at 18 59 21](https://user-images.githubusercontent.com/8658164/220435018-092a8ee8-379f-487f-ba34-56b51b9442ea.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-21 at 18 27 44](https://user-images.githubusercontent.com/8658164/220434543-3006739d-ef17-4867-bebf-e6ae19d7b948.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-21 at 18 26 45](https://user-images.githubusercontent.com/8658164/220434612-2ea94580-78f6-4a8c-8a66-02bd7d133043.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.