### PR TITLE
[Product Multi-selection] Resolve toggle state for product multi-selection

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -34,7 +34,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .loginMagicLinkEmphasisM2:
             return true
         case .productMultiSelectionM1:
-            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
+            return false
         case .promptToEnableCodInIppOnboarding:
             return true
         case .searchProductsBySKU:

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -107,7 +107,7 @@ final class AddEditCouponViewModel: ObservableObject {
     var productSelectorViewModel: ProductSelectorViewModel {
         ProductSelectorViewModel(siteID: siteID,
                                  selectedItemIDs: productOrVariationIDs,
-                                 supportsMultipleSelections: true,
+                                 supportsMultipleSelection: true,
                                  onMultipleSelectionCompleted: { [weak self] ids in
             self?.productOrVariationIDs = ids
         })

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -105,7 +105,10 @@ final class AddEditCouponViewModel: ObservableObject {
     /// View model for the product selector
     ///
     var productSelectorViewModel: ProductSelectorViewModel {
-        ProductSelectorViewModel(siteID: siteID, selectedItemIDs: productOrVariationIDs, onMultipleSelectionCompleted: { [weak self] ids in
+        ProductSelectorViewModel(siteID: siteID,
+                                 selectedItemIDs: productOrVariationIDs,
+                                 supportsMultipleSelections: true,
+                                 onMultipleSelectionCompleted: { [weak self] ids in
             self?.productOrVariationIDs = ids
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
@@ -59,7 +59,10 @@ final class CouponRestrictionsViewModel: ObservableObject {
     /// View model for the product selector
     ///
     lazy var productSelectorViewModel = {
-        ProductSelectorViewModel(siteID: siteID, selectedItemIDs: excludedProductOrVariationIDs, onMultipleSelectionCompleted: { [weak self] ids in
+        ProductSelectorViewModel(siteID: siteID,
+                                 selectedItemIDs: excludedProductOrVariationIDs,
+                                 supportsMultipleSelections: true,
+                                 onMultipleSelectionCompleted: { [weak self] ids in
             self?.excludedProductOrVariationIDs = ids
         })
     }()

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictionsViewModel.swift
@@ -61,7 +61,7 @@ final class CouponRestrictionsViewModel: ObservableObject {
     lazy var productSelectorViewModel = {
         ProductSelectorViewModel(siteID: siteID,
                                  selectedItemIDs: excludedProductOrVariationIDs,
-                                 supportsMultipleSelections: true,
+                                 supportsMultipleSelection: true,
                                  onMultipleSelectionCompleted: { [weak self] ids in
             self?.excludedProductOrVariationIDs = ids
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -173,7 +173,7 @@ final class EditableOrderViewModel: ObservableObject {
             purchasableItemsOnly: true,
             storageManager: storageManager,
             stores: stores,
-            shouldToggleItemOnSelection: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1)) { [weak self] product in
+            supportsMultipleSelections: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1)) { [weak self] product in
                 guard let self = self else { return }
                 self.addProductToOrder(product)
             } onVariationSelected: { [weak self] variation, parentProduct in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -174,7 +174,7 @@ final class EditableOrderViewModel: ObservableObject {
             storageManager: storageManager,
             stores: stores,
             supportsMultipleSelections: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1),
-            enableTogglingSelectionForAllVariations: false,
+            toggleAllVariationsOnSelection: false,
             onProductSelected: { [weak self] product in
                 guard let self = self else { return }
                 self.addProductToOrder(product)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -173,13 +173,15 @@ final class EditableOrderViewModel: ObservableObject {
             purchasableItemsOnly: true,
             storageManager: storageManager,
             stores: stores,
-            supportsMultipleSelections: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1)) { [weak self] product in
+            supportsMultipleSelections: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1),
+            onProductSelected: { [weak self] product in
                 guard let self = self else { return }
                 self.addProductToOrder(product)
-            } onVariationSelected: { [weak self] variation, parentProduct in
+            },
+            onVariationSelected: { [weak self] variation, parentProduct in
                 guard let self = self else { return }
                 self.addProductVariationToOrder(variation, parent: parentProduct)
-            }
+            })
     }()
 
     /// View models for each product row in the order.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -173,7 +173,7 @@ final class EditableOrderViewModel: ObservableObject {
             purchasableItemsOnly: true,
             storageManager: storageManager,
             stores: stores,
-            isOrderCreationViewModel: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1)) { [weak self] product in
+            shouldToggleItemOnSelection: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1)) { [weak self] product in
                 guard let self = self else { return }
                 self.addProductToOrder(product)
             } onVariationSelected: { [weak self] variation, parentProduct in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -173,7 +173,7 @@ final class EditableOrderViewModel: ObservableObject {
             purchasableItemsOnly: true,
             storageManager: storageManager,
             stores: stores,
-            supportsMultipleSelections: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1),
+            supportsMultipleSelection: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1),
             toggleAllVariationsOnSelection: false,
             onProductSelected: { [weak self] product in
                 guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -168,13 +168,18 @@ final class EditableOrderViewModel: ObservableObject {
     /// View model for the product list
     ///
     lazy var addProductViewModel = {
-        ProductSelectorViewModel(siteID: siteID, purchasableItemsOnly: true, storageManager: storageManager, stores: stores) { [weak self] product in
-            guard let self = self else { return }
-            self.addProductToOrder(product)
-        } onVariationSelected: { [weak self] variation, parentProduct in
-            guard let self = self else { return }
-            self.addProductVariationToOrder(variation, parent: parentProduct)
-        }
+        ProductSelectorViewModel(
+            siteID: siteID,
+            purchasableItemsOnly: true,
+            storageManager: storageManager,
+            stores: stores,
+            isOrderCreationViewModel: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1)) { [weak self] product in
+                guard let self = self else { return }
+                self.addProductToOrder(product)
+            } onVariationSelected: { [weak self] variation, parentProduct in
+                guard let self = self else { return }
+                self.addProductVariationToOrder(variation, parent: parentProduct)
+            }
     }()
 
     /// View models for each product row in the order.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -174,6 +174,7 @@ final class EditableOrderViewModel: ObservableObject {
             storageManager: storageManager,
             stores: stores,
             supportsMultipleSelections: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1),
+            enableTogglingSelectionForAllVariations: false,
             onProductSelected: { [weak self] product in
                 guard let self = self else { return }
                 self.addProductToOrder(product)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -355,6 +355,8 @@ private extension ProductSelectorView.Configuration {
         .init(multipleSelectionsEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1),
               searchHeaderBackgroundColor: .listBackground,
               prefersLargeTitle: false,
+              doneButtonTitleSingularFormat: Localization.doneButtonSingular,
+              doneButtonTitlePluralFormat: Localization.doneButtonPlural, 
               title: Localization.title,
               cancelButtonTitle: Localization.close,
               productRowAccessibilityHint: Localization.productRowAccessibilityHint,
@@ -363,6 +365,11 @@ private extension ProductSelectorView.Configuration {
     enum Localization {
         static let title = NSLocalizedString("Add Product", comment: "Title for the screen to add a product to an order")
         static let close = NSLocalizedString("Close", comment: "Text for the close button in the Add Product screen")
+        static let doneButtonSingular = NSLocalizedString("1 Product selected",
+                                                          comment: "Title of the action button at the bottom of the Select Products screen when one product is selected")
+        static let doneButtonPlural = NSLocalizedString("%1$d Products selected",
+                                                        comment: "Title of the action button at the bottom of the Select Products screen " +
+                                                        "when more than 1 item is selected, reads like: 5 Products selected")
         static let productRowAccessibilityHint = NSLocalizedString("Adds product to order.",
                                                                    comment: "Accessibility hint for selecting a product in the Add Product screen")
         static let variableProductRowAccessibilityHint = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -356,7 +356,7 @@ private extension ProductSelectorView.Configuration {
               searchHeaderBackgroundColor: .listBackground,
               prefersLargeTitle: false,
               doneButtonTitleSingularFormat: Localization.doneButtonSingular,
-              doneButtonTitlePluralFormat: Localization.doneButtonPlural, 
+              doneButtonTitlePluralFormat: Localization.doneButtonPlural,
               title: Localization.title,
               cancelButtonTitle: Localization.close,
               productRowAccessibilityHint: Localization.productRowAccessibilityHint,
@@ -366,7 +366,8 @@ private extension ProductSelectorView.Configuration {
         static let title = NSLocalizedString("Add Product", comment: "Title for the screen to add a product to an order")
         static let close = NSLocalizedString("Close", comment: "Text for the close button in the Add Product screen")
         static let doneButtonSingular = NSLocalizedString("1 Product selected",
-                                                          comment: "Title of the action button at the bottom of the Select Products screen when one product is selected")
+                                                          comment: "Title of the action button at the bottom of the Select Products screen " +
+                                                          "when one product is selected")
         static let doneButtonPlural = NSLocalizedString("%1$d Products selected",
                                                         comment: "Title of the action button at the bottom of the Select Products screen " +
                                                         "when more than 1 item is selected, reads like: 5 Products selected")

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -152,7 +152,7 @@ struct ProductSelectorView: View {
             HStack {
                 ProductRow(multipleSelectionsEnabled: configuration.multipleSelectionsEnabled,
                            viewModel: rowViewModel) {
-                    viewModel.toggleSelectionForVariations(of: rowViewModel.productOrVariationID)
+                    viewModel.toggleSelectionForAllVariations(of: rowViewModel.productOrVariationID)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .onTapGesture {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -153,7 +153,7 @@ struct ProductSelectorView: View {
                 ProductRow(multipleSelectionsEnabled: configuration.multipleSelectionsEnabled,
                            viewModel: rowViewModel,
                            onCheckboxSelected: {
-                    if viewModel.enableTogglingSelectionForAllVariations {
+                    if viewModel.toggleAllVariationsOnSelection {
                         viewModel.toggleSelectionForAllVariations(of: rowViewModel.productOrVariationID)
                     }
                 })

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -151,9 +151,7 @@ struct ProductSelectorView: View {
         if let variationListViewModel = viewModel.getVariationsViewModel(for: rowViewModel.productOrVariationID) {
             HStack {
                 ProductRow(multipleSelectionsEnabled: configuration.multipleSelectionsEnabled,
-                           viewModel: rowViewModel) {
-                    viewModel.toggleSelectionForAllVariations(of: rowViewModel.productOrVariationID)
-                }
+                           viewModel: rowViewModel)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .onTapGesture {
                     isShowingVariationList.toggle()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -151,7 +151,12 @@ struct ProductSelectorView: View {
         if let variationListViewModel = viewModel.getVariationsViewModel(for: rowViewModel.productOrVariationID) {
             HStack {
                 ProductRow(multipleSelectionsEnabled: configuration.multipleSelectionsEnabled,
-                           viewModel: rowViewModel)
+                           viewModel: rowViewModel,
+                           onCheckboxSelected: {
+                    if viewModel.enableTogglingSelectionForAllVariations {
+                        viewModel.toggleSelectionForAllVariations(of: rowViewModel.productOrVariationID)
+                    }
+                })
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .onTapGesture {
                     isShowingVariationList.toggle()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -153,9 +153,7 @@ struct ProductSelectorView: View {
                 ProductRow(multipleSelectionsEnabled: configuration.multipleSelectionsEnabled,
                            viewModel: rowViewModel,
                            onCheckboxSelected: {
-                    if viewModel.toggleAllVariationsOnSelection {
-                        viewModel.toggleSelectionForAllVariations(of: rowViewModel.productOrVariationID)
-                    }
+                    viewModel.toggleSelectionForAllVariations(of: rowViewModel.productOrVariationID)
                 })
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .onTapGesture {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -52,10 +52,10 @@ final class ProductSelectorViewModel: ObservableObject {
     ///
     @Published private(set) var productRows: [ProductRowViewModel] = []
 
-    /// Determines if products should be toggled on selection
-    /// `false` by default, mainly used to allow multi-selection on the Order Creation flow
+    /// Determines if multiple item selection is supported, `false` by default.
+    /// Mainly used to allow multi-selection on the Order Creation flow
     ///
-    let shouldToggleItemOnSelection: Bool
+    let supportsMultipleSelections: Bool
 
     /// Closure to be invoked when a product is selected
     ///
@@ -137,13 +137,13 @@ final class ProductSelectorViewModel: ObservableObject {
          purchasableItemsOnly: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
-         shouldToggleItemOnSelection: Bool = false,
+         supportsMultipleSelections: Bool = false,
          onProductSelected: ((Product) -> Void)? = nil,
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
-        self.shouldToggleItemOnSelection = shouldToggleItemOnSelection
+        self.supportsMultipleSelections = supportsMultipleSelections
         self.onProductSelected = onProductSelected
         self.onVariationSelected = onVariationSelected
         self.onMultipleSelectionCompleted = nil
@@ -163,12 +163,12 @@ final class ProductSelectorViewModel: ObservableObject {
          purchasableItemsOnly: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
-         shouldToggleItemOnSelection: Bool = false,
+         supportsMultipleSelections: Bool = false,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
-        self.shouldToggleItemOnSelection = shouldToggleItemOnSelection
+        self.supportsMultipleSelections = supportsMultipleSelections
         self.onProductSelected = nil
         self.onVariationSelected = nil
         self.onMultipleSelectionCompleted = onMultipleSelectionCompleted
@@ -187,8 +187,8 @@ final class ProductSelectorViewModel: ObservableObject {
         guard let selectedProduct = products.first(where: { $0.productID == productID }) else {
             return
         }
-        
-        if shouldToggleItemOnSelection, let onProductSelected {
+
+        if supportsMultipleSelections, let onProductSelected {
             // The selector supports multiple selection. Toggles the item, and triggers the selection
             toggleSelection(productID: productID)
             onProductSelected(selectedProduct)
@@ -211,7 +211,7 @@ final class ProductSelectorViewModel: ObservableObject {
                                                  product: variableProduct,
                                                  selectedProductVariationIDs: selectedItems,
                                                  purchasableItemsOnly: purchasableItemsOnly,
-                                                 shouldToggleItemOnSelection: shouldToggleItemOnSelection,
+                                                 supportsMultipleSelections: supportsMultipleSelections,
                                                  onVariationSelected: onVariationSelected)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -242,7 +242,7 @@ final class ProductSelectorViewModel: ObservableObject {
 
     /// Select all variations for a given product
     ///
-    func toggleSelectionForVariations(of productID: Int64) {
+    func toggleSelectionForAllVariations(of productID: Int64) {
         guard let variableProduct = products.first(where: { $0.productID == productID }),
               variableProduct.variations.isNotEmpty else {
             return

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -53,7 +53,7 @@ final class ProductSelectorViewModel: ObservableObject {
     @Published private(set) var productRows: [ProductRowViewModel] = []
 
     /// Determines if products should be toggled on selection
-    /// `false` by default, mainly used to allow multi-seleciton on the Order Creation flow
+    /// `false` by default, mainly used to allow multi-selection on the Order Creation flow
     ///
     let shouldToggleItemOnSelection: Bool
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -248,6 +248,9 @@ final class ProductSelectorViewModel: ObservableObject {
     /// Select all variations for a given product
     ///
     func toggleSelectionForAllVariations(of productID: Int64) {
+        guard toggleAllVariationsOnSelection else {
+            return
+        }
         guard let variableProduct = products.first(where: { $0.productID == productID }),
               variableProduct.variations.isNotEmpty else {
             return

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -191,11 +191,6 @@ final class ProductSelectorViewModel: ObservableObject {
     /// Select a product to add to the order
     ///
     func selectProduct(_ productID: Int64) {
-        // If it's synching and there's an attempt to select a product, return early
-        if shouldShowScrollIndicator {
-            return
-        }
-
         guard let selectedProduct = products.first(where: { $0.productID == productID }) else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -203,7 +203,7 @@ final class ProductSelectorViewModel: ObservableObject {
         } else if let onProductSelected {
             // The selector supports single selection only
             onProductSelected(selectedProduct)
-        } else {
+        } else if supportsMultipleSelections {
             toggleSelection(productID: productID)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -191,6 +191,11 @@ final class ProductSelectorViewModel: ObservableObject {
     /// Select a product to add to the order
     ///
     func selectProduct(_ productID: Int64) {
+        // If it's synching and there's an attempt to select a product, return early
+        if shouldShowScrollIndicator {
+            return
+        }
+
         guard let selectedProduct = products.first(where: { $0.productID == productID }) else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -58,7 +58,7 @@ final class ProductSelectorViewModel: ObservableObject {
 
     /// Determines if it is possible to toggle all variation items upon selection
     ///
-    let enableTogglingSelectionForAllVariations: Bool
+    let toggleAllVariationsOnSelection: Bool
 
     /// Closure to be invoked when a product is selected
     ///
@@ -141,14 +141,14 @@ final class ProductSelectorViewModel: ObservableObject {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          supportsMultipleSelections: Bool = false,
-         enableTogglingSelectionForAllVariations: Bool = true,
+         toggleAllVariationsOnSelection: Bool = true,
          onProductSelected: ((Product) -> Void)? = nil,
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
         self.supportsMultipleSelections = supportsMultipleSelections
-        self.enableTogglingSelectionForAllVariations = enableTogglingSelectionForAllVariations
+        self.toggleAllVariationsOnSelection = toggleAllVariationsOnSelection
         self.onProductSelected = onProductSelected
         self.onVariationSelected = onVariationSelected
         self.onMultipleSelectionCompleted = nil
@@ -169,13 +169,13 @@ final class ProductSelectorViewModel: ObservableObject {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          supportsMultipleSelections: Bool = false,
-         enableTogglingSelectionForAllVariations: Bool = true,
+         toggleAllVariationsOnSelection: Bool = true,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
         self.supportsMultipleSelections = supportsMultipleSelections
-        self.enableTogglingSelectionForAllVariations = enableTogglingSelectionForAllVariations
+        self.toggleAllVariationsOnSelection = toggleAllVariationsOnSelection
         self.onProductSelected = nil
         self.onVariationSelected = nil
         self.onMultipleSelectionCompleted = onMultipleSelectionCompleted

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -194,17 +194,18 @@ final class ProductSelectorViewModel: ObservableObject {
         guard let selectedProduct = products.first(where: { $0.productID == productID }) else {
             return
         }
-
-        if supportsMultipleSelection, let onProductSelected {
-            // The selector supports multiple selection. Toggles the item, and triggers the selection
+        guard let onProductSelected else {
             toggleSelection(productID: productID)
-            onProductSelected(selectedProduct)
-        } else if let onProductSelected {
+            return
+        }
+        guard supportsMultipleSelection else {
             // The selector supports single selection only
             onProductSelected(selectedProduct)
-        } else if supportsMultipleSelection {
-            toggleSelection(productID: productID)
+            return
         }
+        // The selector supports multiple selection. Toggles the item, and triggers the selection
+        toggleSelection(productID: productID)
+        onProductSelected(selectedProduct)
     }
 
     /// Get the view model for a list of product variations to add to the order

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -57,6 +57,10 @@ final class ProductSelectorViewModel: ObservableObject {
     ///
     let supportsMultipleSelections: Bool
 
+    /// Determines if is possible to toggle all variatoon items upon selection
+    ///
+    let enableTogglingSelectionForAllVariations: Bool
+
     /// Closure to be invoked when a product is selected
     ///
     private let onProductSelected: ((Product) -> Void)?
@@ -138,12 +142,14 @@ final class ProductSelectorViewModel: ObservableObject {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          supportsMultipleSelections: Bool = false,
+         enableTogglingSelectionForAllVariations: Bool = true,
          onProductSelected: ((Product) -> Void)? = nil,
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
         self.supportsMultipleSelections = supportsMultipleSelections
+        self.enableTogglingSelectionForAllVariations = enableTogglingSelectionForAllVariations
         self.onProductSelected = onProductSelected
         self.onVariationSelected = onVariationSelected
         self.onMultipleSelectionCompleted = nil
@@ -164,11 +170,13 @@ final class ProductSelectorViewModel: ObservableObject {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          supportsMultipleSelections: Bool = false,
+         enableTogglingSelectionForAllVariations: Bool = true,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
         self.supportsMultipleSelections = supportsMultipleSelections
+        self.enableTogglingSelectionForAllVariations = enableTogglingSelectionForAllVariations
         self.onProductSelected = nil
         self.onVariationSelected = nil
         self.onMultipleSelectionCompleted = onMultipleSelectionCompleted

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -181,13 +181,6 @@ final class ProductSelectorViewModel: ObservableObject {
         configureProductSearch()
     }
 
-    private func debug_helper(product: Product) {
-        print("🍍ProductID: \(product.productID) selected. \(product.name)")
-        print("🍍initialSelectedItems \(initialSelectedItems)")
-        print("🍍selectedProductIDs \(selectedProductIDs)")
-        print("🍍selectedProductVariationIDs \(selectedProductVariationIDs)")
-    }
-
     /// Select a product to add to the order
     ///
     func selectProduct(_ productID: Int64) {
@@ -200,8 +193,6 @@ final class ProductSelectorViewModel: ObservableObject {
             if let onProductSelected = onProductSelected {
                 toggleSelection(productID: productID)
                 onProductSelected(selectedProduct)
-                // TODO: Remove
-                debug_helper(product: selectedProduct)
             }
         } else {
             // Product single-selection (legacy)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -172,16 +172,35 @@ final class ProductSelectorViewModel: ObservableObject {
         configureProductSearch()
     }
 
+    private func debug_helper(product: Product) {
+        print("🍍ProductID: \(product.productID) selected. \(product.name)")
+        print("🍍initialSelectedItems \(initialSelectedItems)")
+        print("🍍selectedProductIDs \(selectedProductIDs)")
+        print("🍍selectedProductVariationIDs \(selectedProductVariationIDs)")
+    }
+
     /// Select a product to add to the order
     ///
     func selectProduct(_ productID: Int64) {
         guard let selectedProduct = products.first(where: { $0.productID == productID }) else {
             return
         }
-        if let onProductSelected = onProductSelected {
-            onProductSelected(selectedProduct)
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
+            // Product multi-selection (new)
+            if let onProductSelected = onProductSelected {
+                toggleSelection(productID: productID)
+                onProductSelected(selectedProduct)
+                // TODO: Remove
+                debug_helper(product: selectedProduct)
+            }
         } else {
-            toggleSelection(productID: productID)
+            // Product single-selection (legacy)
+            if let onProductSelected = onProductSelected {
+                onProductSelected(selectedProduct)
+            } else {
+                toggleSelection(productID: productID)
+            }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -52,9 +52,10 @@ final class ProductSelectorViewModel: ObservableObject {
     ///
     @Published private(set) var productRows: [ProductRowViewModel] = []
 
-    /// Discerns if the `ProductSelectorViewModel` is being used within Order Creation, or not
+    /// Determines if products should be toggled on selection
+    /// `false` by default, mainly used to allow multi-seleciton on the Order Creation flow
     ///
-    let isOrderCreationViewModel: Bool
+    let shouldToggleItemOnSelection: Bool
 
     /// Closure to be invoked when a product is selected
     ///
@@ -136,13 +137,13 @@ final class ProductSelectorViewModel: ObservableObject {
          purchasableItemsOnly: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
-         isOrderCreationViewModel: Bool = false,
+         shouldToggleItemOnSelection: Bool = false,
          onProductSelected: ((Product) -> Void)? = nil,
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
-        self.isOrderCreationViewModel = isOrderCreationViewModel
+        self.shouldToggleItemOnSelection = shouldToggleItemOnSelection
         self.onProductSelected = onProductSelected
         self.onVariationSelected = onVariationSelected
         self.onMultipleSelectionCompleted = nil
@@ -162,12 +163,12 @@ final class ProductSelectorViewModel: ObservableObject {
          purchasableItemsOnly: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
-         isOrderCreationViewModel: Bool = false,
+         shouldToggleItemOnSelection: Bool = false,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
-        self.isOrderCreationViewModel = isOrderCreationViewModel
+        self.shouldToggleItemOnSelection = shouldToggleItemOnSelection
         self.onProductSelected = nil
         self.onVariationSelected = nil
         self.onMultipleSelectionCompleted = onMultipleSelectionCompleted
@@ -194,7 +195,7 @@ final class ProductSelectorViewModel: ObservableObject {
             return
         }
 
-        if isOrderCreationViewModel {
+        if shouldToggleItemOnSelection {
             // Product multi-selection (new)
             if let onProductSelected = onProductSelected {
                 toggleSelection(productID: productID)
@@ -223,7 +224,7 @@ final class ProductSelectorViewModel: ObservableObject {
                                                  product: variableProduct,
                                                  selectedProductVariationIDs: selectedItems,
                                                  purchasableItemsOnly: purchasableItemsOnly,
-                                                 isOrderCreationViewModel: isOrderCreationViewModel,
+                                                 shouldToggleItemOnSelection: shouldToggleItemOnSelection,
                                                  onVariationSelected: onVariationSelected)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -187,20 +187,16 @@ final class ProductSelectorViewModel: ObservableObject {
         guard let selectedProduct = products.first(where: { $0.productID == productID }) else {
             return
         }
-
-        if shouldToggleItemOnSelection {
-            // Product multi-selection (new)
-            if let onProductSelected = onProductSelected {
-                toggleSelection(productID: productID)
-                onProductSelected(selectedProduct)
-            }
+        
+        if shouldToggleItemOnSelection, let onProductSelected {
+            // The selector supports multiple selection. Toggles the item, and triggers the selection
+            toggleSelection(productID: productID)
+            onProductSelected(selectedProduct)
+        } else if let onProductSelected {
+            // The selector supports single selection only
+            onProductSelected(selectedProduct)
         } else {
-            // Product single-selection (legacy)
-            if let onProductSelected = onProductSelected {
-                onProductSelected(selectedProduct)
-            } else {
-                toggleSelection(productID: productID)
-            }
+            toggleSelection(productID: productID)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -54,7 +54,7 @@ final class ProductSelectorViewModel: ObservableObject {
 
     /// Determines if multiple item selection is supported.
     ///
-    let supportsMultipleSelections: Bool
+    let supportsMultipleSelection: Bool
 
     /// Determines if it is possible to toggle all variation items upon selection
     ///
@@ -140,14 +140,14 @@ final class ProductSelectorViewModel: ObservableObject {
          purchasableItemsOnly: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
-         supportsMultipleSelections: Bool = false,
+         supportsMultipleSelection: Bool = false,
          toggleAllVariationsOnSelection: Bool = true,
          onProductSelected: ((Product) -> Void)? = nil,
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
-        self.supportsMultipleSelections = supportsMultipleSelections
+        self.supportsMultipleSelection = supportsMultipleSelection
         self.toggleAllVariationsOnSelection = toggleAllVariationsOnSelection
         self.onProductSelected = onProductSelected
         self.onVariationSelected = onVariationSelected
@@ -168,13 +168,13 @@ final class ProductSelectorViewModel: ObservableObject {
          purchasableItemsOnly: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
-         supportsMultipleSelections: Bool = false,
+         supportsMultipleSelection: Bool = false,
          toggleAllVariationsOnSelection: Bool = true,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
-        self.supportsMultipleSelections = supportsMultipleSelections
+        self.supportsMultipleSelection = supportsMultipleSelection
         self.toggleAllVariationsOnSelection = toggleAllVariationsOnSelection
         self.onProductSelected = nil
         self.onVariationSelected = nil
@@ -195,14 +195,14 @@ final class ProductSelectorViewModel: ObservableObject {
             return
         }
 
-        if supportsMultipleSelections, let onProductSelected {
+        if supportsMultipleSelection, let onProductSelected {
             // The selector supports multiple selection. Toggles the item, and triggers the selection
             toggleSelection(productID: productID)
             onProductSelected(selectedProduct)
         } else if let onProductSelected {
             // The selector supports single selection only
             onProductSelected(selectedProduct)
-        } else if supportsMultipleSelections {
+        } else if supportsMultipleSelection {
             toggleSelection(productID: productID)
         }
     }
@@ -218,7 +218,7 @@ final class ProductSelectorViewModel: ObservableObject {
                                                  product: variableProduct,
                                                  selectedProductVariationIDs: selectedItems,
                                                  purchasableItemsOnly: purchasableItemsOnly,
-                                                 supportsMultipleSelections: supportsMultipleSelections,
+                                                 supportsMultipleSelection: supportsMultipleSelection,
                                                  onVariationSelected: onVariationSelected)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -223,6 +223,7 @@ final class ProductSelectorViewModel: ObservableObject {
                                                  product: variableProduct,
                                                  selectedProductVariationIDs: selectedItems,
                                                  purchasableItemsOnly: purchasableItemsOnly,
+                                                 isOrderCreationViewModel: isOrderCreationViewModel,
                                                  onVariationSelected: onVariationSelected)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -52,6 +52,10 @@ final class ProductSelectorViewModel: ObservableObject {
     ///
     @Published private(set) var productRows: [ProductRowViewModel] = []
 
+    /// Discerns if the `ProductSelectorViewModel` is being used within Order Creation, or not
+    ///
+    let isOrderCreationViewModel: Bool
+
     /// Closure to be invoked when a product is selected
     ///
     private let onProductSelected: ((Product) -> Void)?
@@ -132,11 +136,13 @@ final class ProductSelectorViewModel: ObservableObject {
          purchasableItemsOnly: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
+         isOrderCreationViewModel: Bool = false,
          onProductSelected: ((Product) -> Void)? = nil,
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
+        self.isOrderCreationViewModel = isOrderCreationViewModel
         self.onProductSelected = onProductSelected
         self.onVariationSelected = onVariationSelected
         self.onMultipleSelectionCompleted = nil
@@ -156,10 +162,12 @@ final class ProductSelectorViewModel: ObservableObject {
          purchasableItemsOnly: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
+         isOrderCreationViewModel: Bool = false,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
+        self.isOrderCreationViewModel = isOrderCreationViewModel
         self.onProductSelected = nil
         self.onVariationSelected = nil
         self.onMultipleSelectionCompleted = onMultipleSelectionCompleted
@@ -186,7 +194,7 @@ final class ProductSelectorViewModel: ObservableObject {
             return
         }
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
+        if isOrderCreationViewModel {
             // Product multi-selection (new)
             if let onProductSelected = onProductSelected {
                 toggleSelection(productID: productID)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -52,12 +52,11 @@ final class ProductSelectorViewModel: ObservableObject {
     ///
     @Published private(set) var productRows: [ProductRowViewModel] = []
 
-    /// Determines if multiple item selection is supported, `false` by default.
-    /// Mainly used to allow multi-selection on the Order Creation flow
+    /// Determines if multiple item selection is supported.
     ///
     let supportsMultipleSelections: Bool
 
-    /// Determines if is possible to toggle all variatoon items upon selection
+    /// Determines if it is possible to toggle all variation items upon selection
     ///
     let enableTogglingSelectionForAllVariations: Bool
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
@@ -137,7 +137,8 @@ struct AddProductVariationToOrder_Previews: PreviewProvider {
             productID: 2,
             productName: "Monstera Plant",
             productAttributes: [],
-            selectedProductVariationIDs: []
+            selectedProductVariationIDs: [],
+            isOrderCreationViewModel: true
         )
 
         ProductVariationSelector(isPresented: .constant(true), viewModel: viewModel, multipleSelectionsEnabled: true)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
@@ -138,7 +138,7 @@ struct AddProductVariationToOrder_Previews: PreviewProvider {
             productName: "Monstera Plant",
             productAttributes: [],
             selectedProductVariationIDs: [],
-            shouldToggleItemOnSelection: true
+            supportsMultipleSelections: true
         )
 
         ProductVariationSelector(isPresented: .constant(true), viewModel: viewModel, multipleSelectionsEnabled: true)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
@@ -138,7 +138,7 @@ struct AddProductVariationToOrder_Previews: PreviewProvider {
             productName: "Monstera Plant",
             productAttributes: [],
             selectedProductVariationIDs: [],
-            isOrderCreationViewModel: true
+            shouldToggleItemOnSelection: true
         )
 
         ProductVariationSelector(isPresented: .constant(true), viewModel: viewModel, multipleSelectionsEnabled: true)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
@@ -138,7 +138,7 @@ struct AddProductVariationToOrder_Previews: PreviewProvider {
             productName: "Monstera Plant",
             productAttributes: [],
             selectedProductVariationIDs: [],
-            supportsMultipleSelections: true
+            supportsMultipleSelection: true
         )
 
         ProductVariationSelector(isPresented: .constant(true), viewModel: viewModel, multipleSelectionsEnabled: true)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -159,10 +159,19 @@ final class ProductVariationSelectorViewModel: ObservableObject {
             return
         }
 
-        if let onVariationSelected = onVariationSelected {
-            onVariationSelected(selectedVariation, parentProduct)
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
+            // Product variation multi-selection (new)
+            if let onVariationSelected = onVariationSelected {
+                toggleSelection(productVariationID: variationID)
+                onVariationSelected(selectedVariation, parentProduct)
+            }
         } else {
-            toggleSelection(productVariationID: variationID)
+            // Product variation single-selection (legacy)
+            if let onVariationSelected = onVariationSelected {
+                onVariationSelected(selectedVariation, parentProduct)
+            } else {
+                toggleSelection(productVariationID: variationID)
+            }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -16,10 +16,10 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     ///
     private let stores: StoresManager
 
-    /// Determines if product variations should be toggled on selection
-    /// `false` by default, mainly used to allow multi-seleciton on the Order Creation flow
+    /// Determines if multiple item selection is supported, `false` by default.
+    /// Mainly used to allow multi-selection on the Order Creation flow
     ///
-    let shouldToggleItemOnSelection: Bool
+    let supportsMultipleSelections: Bool
 
     /// Store for publishers subscriptions
     ///
@@ -117,7 +117,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
          purchasableItemsOnly: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
-         shouldToggleItemOnSelection: Bool = false,
+         supportsMultipleSelections: Bool = false,
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.siteID = siteID
         self.productID = productID
@@ -125,7 +125,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         self.productAttributes = productAttributes
         self.storageManager = storageManager
         self.stores = stores
-        self.shouldToggleItemOnSelection = shouldToggleItemOnSelection
+        self.supportsMultipleSelections = supportsMultipleSelections
         self.onVariationSelected = onVariationSelected
         self.selectedProductVariationIDs = selectedProductVariationIDs
         self.purchasableItemsOnly = purchasableItemsOnly
@@ -141,7 +141,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                      purchasableItemsOnly: Bool = false,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      stores: StoresManager = ServiceLocator.stores,
-                     shouldToggleItemOnSelection: Bool = false,
+                     supportsMultipleSelections: Bool = false,
                      onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.init(siteID: siteID,
                   productID: product.productID,
@@ -151,7 +151,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                   purchasableItemsOnly: purchasableItemsOnly,
                   storageManager: storageManager,
                   stores: stores,
-                  shouldToggleItemOnSelection: shouldToggleItemOnSelection,
+                  supportsMultipleSelections: supportsMultipleSelections,
                   onVariationSelected: onVariationSelected)
     }
 
@@ -168,7 +168,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
             return
         }
 
-        if shouldToggleItemOnSelection, let onVariationSelected {
+        if supportsMultipleSelections, let onVariationSelected {
             // The selector supports multiple selection. Toggles the item, and triggers the selection
             toggleSelection(productVariationID: variationID)
             onVariationSelected(selectedVariation, parentProduct)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -16,8 +16,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     ///
     private let stores: StoresManager
 
-    /// Determines if multiple item selection is supported, `false` by default.
-    /// Mainly used to allow multi-selection on the Order Creation flow
+    /// Determines if multiple item selection is supported
     ///
     let supportsMultipleSelections: Bool
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -16,9 +16,10 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     ///
     private let stores: StoresManager
 
+    /// Determines if product variations should be toggled on selection
+    /// `false` by default, mainly used to allow multi-seleciton on the Order Creation flow
     ///
-    ///
-    let isOrderCreationViewModel: Bool
+    let shouldToggleItemOnSelection: Bool
 
     /// Store for publishers subscriptions
     ///
@@ -116,7 +117,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
          purchasableItemsOnly: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
-         isOrderCreationViewModel: Bool = false,
+         shouldToggleItemOnSelection: Bool = false,
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.siteID = siteID
         self.productID = productID
@@ -124,7 +125,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         self.productAttributes = productAttributes
         self.storageManager = storageManager
         self.stores = stores
-        self.isOrderCreationViewModel = isOrderCreationViewModel
+        self.shouldToggleItemOnSelection = shouldToggleItemOnSelection
         self.onVariationSelected = onVariationSelected
         self.selectedProductVariationIDs = selectedProductVariationIDs
         self.purchasableItemsOnly = purchasableItemsOnly
@@ -140,7 +141,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                      purchasableItemsOnly: Bool = false,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      stores: StoresManager = ServiceLocator.stores,
-                     isOrderCreationViewModel: Bool = false,
+                     shouldToggleItemOnSelection: Bool = false,
                      onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.init(siteID: siteID,
                   productID: product.productID,
@@ -150,7 +151,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                   purchasableItemsOnly: purchasableItemsOnly,
                   storageManager: storageManager,
                   stores: stores,
-                  isOrderCreationViewModel: isOrderCreationViewModel,
+                  shouldToggleItemOnSelection: shouldToggleItemOnSelection,
                   onVariationSelected: onVariationSelected)
     }
 
@@ -167,7 +168,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
             return
         }
 
-        if isOrderCreationViewModel {
+        if shouldToggleItemOnSelection {
             // Product variation multi-selection (new)
             if let onVariationSelected = onVariationSelected {
                 toggleSelection(productVariationID: variationID)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -16,6 +16,10 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     ///
     private let stores: StoresManager
 
+    ///
+    ///
+    let isOrderCreationViewModel: Bool
+
     /// Store for publishers subscriptions
     ///
     private var subscriptions = Set<AnyCancellable>()
@@ -112,6 +116,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
          purchasableItemsOnly: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
+         isOrderCreationViewModel: Bool = false,
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.siteID = siteID
         self.productID = productID
@@ -119,6 +124,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         self.productAttributes = productAttributes
         self.storageManager = storageManager
         self.stores = stores
+        self.isOrderCreationViewModel = isOrderCreationViewModel
         self.onVariationSelected = onVariationSelected
         self.selectedProductVariationIDs = selectedProductVariationIDs
         self.purchasableItemsOnly = purchasableItemsOnly
@@ -134,6 +140,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                      purchasableItemsOnly: Bool = false,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      stores: StoresManager = ServiceLocator.stores,
+                     isOrderCreationViewModel: Bool = false,
                      onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.init(siteID: siteID,
                   productID: product.productID,
@@ -143,6 +150,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                   purchasableItemsOnly: purchasableItemsOnly,
                   storageManager: storageManager,
                   stores: stores,
+                  isOrderCreationViewModel: isOrderCreationViewModel,
                   onVariationSelected: onVariationSelected)
     }
 
@@ -159,7 +167,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
             return
         }
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
+        if isOrderCreationViewModel {
             // Product variation multi-selection (new)
             if let onVariationSelected = onVariationSelected {
                 toggleSelection(productVariationID: variationID)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -18,7 +18,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
 
     /// Determines if multiple item selection is supported
     ///
-    let supportsMultipleSelections: Bool
+    let supportsMultipleSelection: Bool
 
     /// Store for publishers subscriptions
     ///
@@ -116,7 +116,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
          purchasableItemsOnly: Bool = false,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
-         supportsMultipleSelections: Bool = false,
+         supportsMultipleSelection: Bool = false,
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.siteID = siteID
         self.productID = productID
@@ -124,7 +124,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         self.productAttributes = productAttributes
         self.storageManager = storageManager
         self.stores = stores
-        self.supportsMultipleSelections = supportsMultipleSelections
+        self.supportsMultipleSelection = supportsMultipleSelection
         self.onVariationSelected = onVariationSelected
         self.selectedProductVariationIDs = selectedProductVariationIDs
         self.purchasableItemsOnly = purchasableItemsOnly
@@ -140,7 +140,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                      purchasableItemsOnly: Bool = false,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      stores: StoresManager = ServiceLocator.stores,
-                     supportsMultipleSelections: Bool = false,
+                     supportsMultipleSelection: Bool = false,
                      onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
         self.init(siteID: siteID,
                   productID: product.productID,
@@ -150,7 +150,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                   purchasableItemsOnly: purchasableItemsOnly,
                   storageManager: storageManager,
                   stores: stores,
-                  supportsMultipleSelections: supportsMultipleSelections,
+                  supportsMultipleSelection: supportsMultipleSelection,
                   onVariationSelected: onVariationSelected)
     }
 
@@ -167,7 +167,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
             return
         }
 
-        if supportsMultipleSelections, let onVariationSelected {
+        if supportsMultipleSelection, let onVariationSelected {
             // The selector supports multiple selection. Toggles the item, and triggers the selection
             toggleSelection(productVariationID: variationID)
             onVariationSelected(selectedVariation, parentProduct)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -166,17 +166,18 @@ final class ProductVariationSelectorViewModel: ObservableObject {
               let selectedVariation = productVariations.first(where: { $0.productVariationID == variationID }) else {
             return
         }
-
-        if supportsMultipleSelection, let onVariationSelected {
-            // The selector supports multiple selection. Toggles the item, and triggers the selection
+        guard let onVariationSelected else {
             toggleSelection(productVariationID: variationID)
-            onVariationSelected(selectedVariation, parentProduct)
-        } else if let onVariationSelected {
+            return
+        }
+        guard supportsMultipleSelection else {
             // The selector supports single selection only
             onVariationSelected(selectedVariation, parentProduct)
-        } else {
-            toggleSelection(productVariationID: variationID)
+            return
         }
+        // The selector supports multiple selection. Toggles the item, and triggers the selection
+        toggleSelection(productVariationID: variationID)
+        onVariationSelected(selectedVariation, parentProduct)
     }
 
     /// Unselect all items.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -168,19 +168,15 @@ final class ProductVariationSelectorViewModel: ObservableObject {
             return
         }
 
-        if shouldToggleItemOnSelection {
-            // Product variation multi-selection (new)
-            if let onVariationSelected = onVariationSelected {
-                toggleSelection(productVariationID: variationID)
-                onVariationSelected(selectedVariation, parentProduct)
-            }
+        if shouldToggleItemOnSelection, let onVariationSelected {
+            // The selector supports multiple selection. Toggles the item, and triggers the selection
+            toggleSelection(productVariationID: variationID)
+            onVariationSelected(selectedVariation, parentProduct)
+        } else if let onVariationSelected {
+            // The selector supports single selection only
+            onVariationSelected(selectedVariation, parentProduct)
         } else {
-            // Product variation single-selection (legacy)
-            if let onVariationSelected = onVariationSelected {
-                onVariationSelected(selectedVariation, parentProduct)
-            } else {
-                toggleSelection(productVariationID: variationID)
-            }
+            toggleSelection(productVariationID: variationID)
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -367,23 +367,6 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(productRow?.selectedState, .selected)
     }
 
-    func test_selecting_a_product_if_supportsMultipleSelections_is_false_and_selectProduct_is_invoked_sets_its_row_to_selected_state() {
-        // Given
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
-        insert(product)
-        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
-                                                 storageManager: storageManager,
-                                                 supportsMultipleSelections: false)
-
-        // When
-        viewModel.selectProduct(product.productID)
-
-        // Then
-        let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
-        XCTAssertNotNil(productRow)
-        XCTAssertEqual(productRow?.selectedState, .selected)
-    }
-
     func test_selecting_a_product_sets_its_row_to_notSelected_state_if_it_was_previously_selected() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
@@ -533,7 +516,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  selectedItemIDs: [],
                                                  storageManager: storageManager,
-                                                 supportsMultipleSelections: false,
+                                                 supportsMultipleSelections: true,
                                                  onMultipleSelectionCompleted: {
             selectedItems = $0
         })
@@ -599,7 +582,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
-                                                 supportsMultipleSelections: false)
+                                                 supportsMultipleSelections: true)
 
         // When
         viewModel.selectProduct(product.productID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -332,13 +332,13 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertNil(variationsViewModel)
     }
 
-    func test_selecting_a_product_sets_its_row_to_selected_state_given_shouldToggleItemOnSelection_is_false() {
+    func test_selecting_a_product_sets_its_row_to_selected_state_given_supportsMultipleSelections_is_false() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
-                                                 shouldToggleItemOnSelection: false)
+                                                 supportsMultipleSelections: false)
 
         // When
         viewModel.selectProduct(product.productID)
@@ -349,13 +349,13 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(productRow?.selectedState, .selected)
     }
 
-    func test_selecting_a_product_sets_its_row_to_selected_state_given_shouldToggleItemOnSelection_is_true() {
+    func test_selecting_a_product_sets_its_row_to_selected_state_given_supportsMultipleSelections_is_true() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
-                                                 shouldToggleItemOnSelection: true,
+                                                 supportsMultipleSelections: true,
                                                  onProductSelected: { _ in })
 
         // When
@@ -373,7 +373,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
-                                                 shouldToggleItemOnSelection: true,
+                                                 supportsMultipleSelections: true,
                                                  onProductSelected: { _ in })
 
         // When
@@ -409,7 +409,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
-                                                 shouldToggleItemOnSelection: false,
+                                                 supportsMultipleSelections: false,
                                                  onProductSelected: { _ in })
 
         // When
@@ -517,7 +517,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  selectedItemIDs: [],
                                                  storageManager: storageManager,
-                                                 shouldToggleItemOnSelection: false,
+                                                 supportsMultipleSelections: false,
                                                  onMultipleSelectionCompleted: {
             selectedItems = $0
         })
@@ -583,7 +583,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
-                                                 shouldToggleItemOnSelection: false)
+                                                 supportsMultipleSelections: false)
 
         // When
         viewModel.selectProduct(product.productID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -303,14 +303,14 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(selectedProduct, product.productID)
     }
 
-    func test_selectProduct_given_supportsMultipleSelections_is_enabled_invokes_onProductSelected_closure_for_existing_product() {
+    func test_selectProduct_given_supportsMultipleSelection_is_enabled_invokes_onProductSelected_closure_for_existing_product() {
         // Given
         var selectedProduct: Int64?
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
-                                                 supportsMultipleSelections: true,
+                                                 supportsMultipleSelection: true,
                                                  onProductSelected: { selectedProduct = $0.productID })
 
         // When
@@ -349,13 +349,13 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertNil(variationsViewModel)
     }
 
-    func test_selecting_a_product_if_supportsMultipleSelections_is_true_and_selectProduct_is_invoked_sets_its_row_to_selected_state() {
+    func test_selecting_a_product_if_supportsMultipleSelection_is_true_and_selectProduct_is_invoked_sets_its_row_to_selected_state() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
-                                                 supportsMultipleSelections: true,
+                                                 supportsMultipleSelection: true,
                                                  onProductSelected: { _ in })
 
         // When
@@ -390,7 +390,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
-                                                 supportsMultipleSelections: false,
+                                                 supportsMultipleSelection: false,
                                                  onProductSelected: { _ in })
 
         // When
@@ -409,7 +409,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
-                                                 supportsMultipleSelections: true)
+                                                 supportsMultipleSelection: true)
 
         // When
         viewModel.selectProduct(product.productID)
@@ -516,7 +516,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  selectedItemIDs: [],
                                                  storageManager: storageManager,
-                                                 supportsMultipleSelections: true,
+                                                 supportsMultipleSelection: true,
                                                  onMultipleSelectionCompleted: {
             selectedItems = $0
         })
@@ -582,7 +582,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
-                                                 supportsMultipleSelections: true)
+                                                 supportsMultipleSelection: true)
 
         // When
         viewModel.selectProduct(product.productID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -303,6 +303,23 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(selectedProduct, product.productID)
     }
 
+    func test_selectProduct_given_supportsMultipleSelections_is_enabled_invokes_onProductSelected_closure_for_existing_product() {
+        // Given
+        var selectedProduct: Int64?
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
+        insert(product)
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 storageManager: storageManager,
+                                                 supportsMultipleSelections: true,
+                                                 onProductSelected: { selectedProduct = $0.productID })
+
+        // When
+        viewModel.selectProduct(product.productID)
+
+        // Then
+        XCTAssertEqual(selectedProduct, product.productID)
+    }
+
     func test_getVariationsViewModel_returns_expected_view_model_for_variable_product() throws {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, name: "Test Product", purchasable: true, variations: [1, 2])
@@ -332,7 +349,25 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertNil(variationsViewModel)
     }
 
-    func test_selecting_a_product_sets_its_row_to_selected_state_given_supportsMultipleSelections_is_false() {
+    func test_selecting_a_product_if_supportsMultipleSelections_is_true_and_selectProduct_is_invoked_sets_its_row_to_selected_state() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
+        insert(product)
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 storageManager: storageManager,
+                                                 supportsMultipleSelections: true,
+                                                 onProductSelected: { _ in })
+
+        // When
+        viewModel.selectProduct(product.productID)
+
+        // Then
+        let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
+        XCTAssertNotNil(productRow)
+        XCTAssertEqual(productRow?.selectedState, .selected)
+    }
+
+    func test_selecting_a_product_if_supportsMultipleSelections_is_false_and_selectProduct_is_invoked_sets_its_row_to_selected_state() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
         insert(product)
@@ -347,43 +382,6 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
         XCTAssertNotNil(productRow)
         XCTAssertEqual(productRow?.selectedState, .selected)
-    }
-
-    func test_selecting_a_product_sets_its_row_to_selected_state_given_supportsMultipleSelections_is_true() {
-        // Given
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
-        insert(product)
-        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
-                                                 storageManager: storageManager,
-                                                 supportsMultipleSelections: true,
-                                                 onProductSelected: { _ in })
-
-        // When
-        viewModel.selectProduct(product.productID)
-
-        // Then
-        let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
-        XCTAssertNotNil(productRow)
-        XCTAssertEqual(productRow?.selectedState, .selected)
-    }
-
-    func test_selecting_a_product_when_onProductSelected_is_invoked_then_sets_its_row_to_selected_state() {
-        // Given
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
-        insert(product)
-        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
-                                                 storageManager: storageManager,
-                                                 supportsMultipleSelections: true,
-                                                 onProductSelected: { _ in })
-
-        // When
-        viewModel.selectProduct(product.productID)
-
-        // Then
-        let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
-        XCTAssertNotNil(productRow)
-        XCTAssertEqual(productRow?.selectedState, .selected)
-
     }
 
     func test_selecting_a_product_sets_its_row_to_notSelected_state_if_it_was_previously_selected() {
@@ -403,7 +401,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(productRow?.selectedState, .notSelected)
     }
 
-    func test_selecting_a_product_when_onProductSelected_is_invoked_then_sets_its_row_to_notSelected_state_if_it_was_previously_selected() {
+    func test_productRow_selectedState_if_supportsMultiselection_is_false_and_selectProduct_invoked_twice_then_selectedState_is_notSelected() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
         insert(product)
@@ -411,6 +409,24 @@ final class ProductSelectorViewModelTests: XCTestCase {
                                                  storageManager: storageManager,
                                                  supportsMultipleSelections: false,
                                                  onProductSelected: { _ in })
+
+        // When
+        viewModel.selectProduct(product.productID)
+        viewModel.selectProduct(product.productID)
+
+        // Then
+        let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
+        XCTAssertNotNil(productRow)
+        XCTAssertEqual(productRow?.selectedState, .notSelected)
+    }
+
+    func test_productRow_selectedState_if_supportsMultiselection_is_true_and_selectProduct_invoked_twice_then_selectedState_is_notSelected() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
+        insert(product)
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 storageManager: storageManager,
+                                                 supportsMultipleSelections: true)
 
         // When
         viewModel.selectProduct(product.productID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -332,12 +332,13 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertNil(variationsViewModel)
     }
 
-    func test_selecting_a_product_sets_its_row_to_selected_state() {
+    func test_selecting_a_product_sets_its_row_to_selected_state_given_shouldToggleItemOnSelection_is_false() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
-                                                 storageManager: storageManager)
+                                                 storageManager: storageManager,
+                                                 shouldToggleItemOnSelection: false)
 
         // When
         viewModel.selectProduct(product.productID)
@@ -345,9 +346,25 @@ final class ProductSelectorViewModelTests: XCTestCase {
         // Then
         let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
         XCTAssertNotNil(productRow)
-        if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
-            XCTAssertEqual(productRow?.selectedState, .selected)
-        }
+        XCTAssertEqual(productRow?.selectedState, .selected)
+    }
+
+    func test_selecting_a_product_sets_its_row_to_selected_state_given_shouldToggleItemOnSelection_is_true() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
+        insert(product)
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 storageManager: storageManager,
+                                                 shouldToggleItemOnSelection: true,
+                                                 onProductSelected: { _ in })
+
+        // When
+        viewModel.selectProduct(product.productID)
+
+        // Then
+        let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
+        XCTAssertNotNil(productRow)
+        XCTAssertEqual(productRow?.selectedState, .selected)
     }
 
     func test_selecting_a_product_when_onProductSelected_is_invoked_then_sets_its_row_to_selected_state() {
@@ -356,17 +373,17 @@ final class ProductSelectorViewModelTests: XCTestCase {
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
+                                                 shouldToggleItemOnSelection: true,
                                                  onProductSelected: { _ in })
 
         // When
         viewModel.selectProduct(product.productID)
 
         // Then
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
-            let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
-            XCTAssertNotNil(productRow)
-            XCTAssertEqual(productRow?.selectedState, .selected)
-        }
+        let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
+        XCTAssertNotNil(productRow)
+        XCTAssertEqual(productRow?.selectedState, .selected)
+
     }
 
     func test_selecting_a_product_sets_its_row_to_notSelected_state_if_it_was_previously_selected() {
@@ -392,6 +409,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
+                                                 shouldToggleItemOnSelection: false,
                                                  onProductSelected: { _ in })
 
         // When
@@ -399,11 +417,9 @@ final class ProductSelectorViewModelTests: XCTestCase {
         viewModel.selectProduct(product.productID)
 
         // Then
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
-            let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
-            XCTAssertNotNil(productRow)
-            XCTAssertEqual(productRow?.selectedState, .notSelected)
-        }
+        let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
+        XCTAssertNotNil(productRow)
+        XCTAssertEqual(productRow?.selectedState, .notSelected)
     }
 
     func test_selecting_a_product_variation_set_its_product_row_to_partiallySelected() {
@@ -501,6 +517,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  selectedItemIDs: [],
                                                  storageManager: storageManager,
+                                                 shouldToggleItemOnSelection: false,
                                                  onMultipleSelectionCompleted: {
             selectedItems = $0
         })
@@ -511,9 +528,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         viewModel.completeMultipleSelection()
 
         // Then
-        if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
-            XCTAssertEqual(selectedItems, [simpleProduct.productID, 12])
-        }
+        XCTAssertEqual(selectedItems, [simpleProduct.productID, 12])
     }
 
     func test_filter_button_title_shows_correct_number_of_active_filters() async throws {
@@ -567,22 +582,19 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
-                                                 storageManager: storageManager)
+                                                 storageManager: storageManager,
+                                                 shouldToggleItemOnSelection: false)
 
         // When
         viewModel.selectProduct(product.productID)
         // Confidence check
         let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
-        if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
-            XCTAssertEqual(productRow?.selectedState, .selected)
-        }
+        XCTAssertEqual(productRow?.selectedState, .selected)
         viewModel.clearSelection()
 
         // Then
         let updatedRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
-        if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
-            XCTAssertEqual(updatedRow?.selectedState, .notSelected)
-        }
+        XCTAssertEqual(updatedRow?.selectedState, .notSelected)
     }
 
     func test_clearSelection_unselects_all_initially_selected_items() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -345,7 +345,28 @@ final class ProductSelectorViewModelTests: XCTestCase {
         // Then
         let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
         XCTAssertNotNil(productRow)
-        XCTAssertEqual(productRow?.selectedState, .selected)
+        if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
+            XCTAssertEqual(productRow?.selectedState, .selected)
+        }
+    }
+
+    func test_selecting_a_product_when_onProductSelected_is_invoked_then_sets_its_row_to_selected_state() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
+        insert(product)
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 storageManager: storageManager,
+                                                 onProductSelected: { _ in })
+
+        // When
+        viewModel.selectProduct(product.productID)
+
+        // Then
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
+            let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
+            XCTAssertNotNil(productRow)
+            XCTAssertEqual(productRow?.selectedState, .selected)
+        }
     }
 
     func test_selecting_a_product_sets_its_row_to_notSelected_state_if_it_was_previously_selected() {
@@ -363,6 +384,26 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
         XCTAssertNotNil(productRow)
         XCTAssertEqual(productRow?.selectedState, .notSelected)
+    }
+
+    func test_selecting_a_product_when_onProductSelected_is_invoked_then_sets_its_row_to_notSelected_state_if_it_was_previously_selected() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
+        insert(product)
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 storageManager: storageManager,
+                                                 onProductSelected: { _ in })
+
+        // When
+        viewModel.selectProduct(product.productID)
+        viewModel.selectProduct(product.productID)
+
+        // Then
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
+            let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
+            XCTAssertNotNil(productRow)
+            XCTAssertEqual(productRow?.selectedState, .notSelected)
+        }
     }
 
     func test_selecting_a_product_variation_set_its_product_row_to_partiallySelected() {
@@ -470,7 +511,9 @@ final class ProductSelectorViewModelTests: XCTestCase {
         viewModel.completeMultipleSelection()
 
         // Then
-        XCTAssertEqual(selectedItems, [simpleProduct.productID, 12])
+        if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
+            XCTAssertEqual(selectedItems, [simpleProduct.productID, 12])
+        }
     }
 
     func test_filter_button_title_shows_correct_number_of_active_filters() async throws {
@@ -530,12 +573,16 @@ final class ProductSelectorViewModelTests: XCTestCase {
         viewModel.selectProduct(product.productID)
         // Confidence check
         let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
-        XCTAssertEqual(productRow?.selectedState, .selected)
+        if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
+            XCTAssertEqual(productRow?.selectedState, .selected)
+        }
         viewModel.clearSelection()
 
         // Then
         let updatedRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
-        XCTAssertEqual(updatedRow?.selectedState, .notSelected)
+        if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
+            XCTAssertEqual(updatedRow?.selectedState, .notSelected)
+        }
     }
 
     func test_clearSelection_unselects_all_initially_selected_items() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -430,7 +430,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
                                                  storageManager: storageManager)
 
         // When
-        viewModel.toggleSelectionForVariations(of: product.productID)
+        viewModel.toggleSelectionForAllVariations(of: product.productID)
 
         // Then
         let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
@@ -447,7 +447,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // When
         viewModel.updateSelectedVariations(productID: product.productID, selectedVariationIDs: [2])
-        viewModel.toggleSelectionForVariations(of: product.productID)
+        viewModel.toggleSelectionForAllVariations(of: product.productID)
 
         // Then
         let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
@@ -464,7 +464,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // When
         viewModel.updateSelectedVariations(productID: product.productID, selectedVariationIDs: [1, 2])
-        viewModel.toggleSelectionForVariations(of: product.productID)
+        viewModel.toggleSelectionForAllVariations(of: product.productID)
 
         // Then
         let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8920

## Description:

This PR addresses the toggle state (selected, and unselected) for `Product` and `Product variations` when product multi-selection is enabled. 

At the moment it is expected that unselecting a product **does not** remove the product from the order, this will be dealt with on a future PR. Both selecting, or unselecting, currently adds a product to the Order.

## Changes:
- `selectProduct` and `selectVariation` are the methods that are called on each view model when we tap on a Product or a Product Variation. We've duplicated the existing `toggleSelection(_:)` logic to account for the closure being called when multi-selection is enabled.
- Renamed `toggleSelectionForVariations` to `toggleSelectionForAllVariations` to reflect that tapping on that toggle will select all variations.
- Removed the call for `toggleSelectionForAllVariations` from the `ProductSelectorView`, as we do not want to select all product variations when the button is tapped.
- Adapted existing Unit Tests to account for the feature flag.
- Added additional Unit Tests to confirm the `productRow` selected state (`.selected` vs `.unselected`) is correct when the feature flag is enabled.

## Testing instructions
- Go to Orders > `+` >  `+ Add Product`
- Add Products to the order. See how the toggle/checkbox is enabled/disabled when tapping
- Go to a variable product and tap on the row. See how you can also select/unselect variable products
- Go back to the Order. Tap on Done.
- Confirm that all products are part of the Order.

| Variable products selection  | Products selection  | Order creation  |
|---|---|---|
| <img width=450 src="https://user-images.githubusercontent.com/3812076/220635012-2e917b31-678b-4743-be91-feef2ced3537.png"> | <img width=450 src="https://user-images.githubusercontent.com/3812076/220635052-c5d7a276-1b8d-44f7-8fe8-37a3992cd1f9.png"> | <img width=450 src="https://user-images.githubusercontent.com/3812076/220635107-76208151-8031-46e3-bf7e-db94150de7cb.png"> |

