### PR TITLE
SPE: Clean up grouped product created from template

### DIFF
--- a/Networking/Networking/Model/Product/ProductStatus.swift
+++ b/Networking/Networking/Model/Product/ProductStatus.swift
@@ -9,6 +9,7 @@ public enum ProductStatus: Codable, Hashable, GeneratedFakeable {
     case pending
     case privateStatus  // `private` is a reserved keyword
     case autoDraft
+    case importing      // used for placeholder products from a product import or template
     case custom(String) // in case there are extensions modifying product statuses
 }
 
@@ -31,6 +32,8 @@ extension ProductStatus: RawRepresentable {
             self = .privateStatus
         case Keys.autoDraft:
             self = .autoDraft
+        case Keys.importing:
+            self = .importing
         default:
             self = .custom(rawValue)
         }
@@ -45,6 +48,7 @@ extension ProductStatus: RawRepresentable {
         case .pending:              return Keys.pending
         case .privateStatus:        return Keys.privateStatus
         case .autoDraft:            return Keys.autoDraft
+        case .importing:            return Keys.importing
         case .custom(let payload):  return payload
         }
     }
@@ -63,6 +67,8 @@ extension ProductStatus: RawRepresentable {
             return NSLocalizedString("Privately published", comment: "Display label for the product's private status")
         case .autoDraft:
             return "Auto Draft" // We don't need to localize this now.
+        case .importing:
+            return "Importing" // We don't need to localize this now.
         case .custom(let payload):
             return payload // unable to localize at runtime.
         }
@@ -78,4 +84,5 @@ private enum Keys {
     static let pending       = "pending"
     static let privateStatus = "private"
     static let autoDraft     = "auto-draft"
+    static let importing     = "importing"
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
@@ -17,11 +17,11 @@ struct ProductFactory {
         }
     }
 
-    /// Copies a product by cleaning properties like `id, name, and statusKey` to their default state.
-    /// This is usefult to turn an existing(on core) `auto-draft` product into a new app-product ready to be saved.
+    /// Copies a product by cleaning properties like `id, name, statusKey, and groupedProducts` to their default state.
+    /// This is useful to turn an existing (on core) `auto-draft` product into a new app-product ready to be saved.
     ///
     func newProduct(from existingProduct: Product) -> Product {
-        existingProduct.copy(productID: 0, name: "", statusKey: ProductStatus.published.rawValue)
+        existingProduct.copy(productID: 0, name: "", statusKey: ProductStatus.published.rawValue, groupedProducts: [])
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/ProductFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/ProductFactoryTests.swift
@@ -45,7 +45,7 @@ final class ProductFactoryTests: XCTestCase {
 
     func test_creating_new_product_removes_expected_fields() {
         // Given
-        let product = Product.fake().copy(siteID: 123, productID: 1234, name: "Test Product", statusKey: ProductStatus.autoDraft.rawValue, price: "20.00")
+        let product = Product.fake().copy(siteID: 123, productID: 1234, name: "Test Product", statusKey: ProductStatus.autoDraft.rawValue, price: "20.00", groupedProducts: [11, 12, 13])
 
         // When
         let newProduct = ProductFactory().newProduct(from: product)
@@ -60,5 +60,6 @@ final class ProductFactoryTests: XCTestCase {
         XCTAssertEqual(newProduct.productID, 0)
         XCTAssertEqual(newProduct.name, "")
         XCTAssertEqual(newProduct.statusKey, ProductStatus.published.rawValue)
+        XCTAssertEqual(newProduct.groupedProducts, [])
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/ProductFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/ProductFactoryTests.swift
@@ -45,7 +45,12 @@ final class ProductFactoryTests: XCTestCase {
 
     func test_creating_new_product_removes_expected_fields() {
         // Given
-        let product = Product.fake().copy(siteID: 123, productID: 1234, name: "Test Product", statusKey: ProductStatus.autoDraft.rawValue, price: "20.00", groupedProducts: [11, 12, 13])
+        let product = Product.fake().copy(siteID: 123,
+                                          productID: 1234,
+                                          name: "Test Product",
+                                          statusKey: ProductStatus.autoDraft.rawValue,
+                                          price: "20.00",
+                                          groupedProducts: [11, 12, 13])
 
         // When
         let newProduct = ProductFactory().newProduct(from: product)

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -495,6 +495,10 @@ extension ProductStore {
     ///
     func upsertStoredProducts(readOnlyProducts: [Networking.Product], in storage: StorageType) {
         for readOnlyProduct in readOnlyProducts {
+            // The "importing" status is only used for product import placeholders and should not be stored.
+            guard readOnlyProduct.productStatus != .importing else {
+                continue
+            }
             let storageProduct = storage.loadProduct(siteID: readOnlyProduct.siteID, productID: readOnlyProduct.productID) ??
                 storage.insertNewObject(ofType: Storage.Product.self)
 

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -936,6 +936,21 @@ final class ProductStoreTests: XCTestCase {
         wait(for: [backgroundSaveExpectation], timeout: Constants.expectationTimeout)
     }
 
+    /// Verifies that `ProductStore.upsertStoredProduct` does not store products with the `importing` product status.
+    ///
+    func test_upsertStoredProduct_does_not_store_import_placeholder_products() {
+        // Given
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let product = Product.fake().copy(statusKey: "importing")
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Product.self), 0)
+
+        // When
+        productStore.upsertStoredProduct(readOnlyProduct: product, in: viewStorage)
+
+        // Then
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Product.self), 0)
+    }
+
     // MARK: - ProductAction.searchProducts
 
     /// Verifies that `ProductAction.searchProducts` effectively persists the retrieved products.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8836
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As described in https://github.com/woocommerce/woocommerce-ios/issues/8836#issuecomment-1440048492, creating a grouped product from a template also imports several placeholder products to the store. (These import placeholder products can be identified by their `importing` product status.) This is not ideal and our intention is for only the parent grouped product to be created with the template.

This PR cleans up the grouped product creation:

* Removes any child products from the grouped product in `ProductFactory.newProduct`.
* Skips import placeholders (products with the `importing` product status) when products are upserted into storage in `ProductStore`.

This matches the wp-admin experience, where these placeholders don't appear in the product list.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Select a store with at least one product.
3. Go to the Products tab and tap "+" to create a new product.
4. Select "Grouped product" and confirm a new product is created from the template.
5. Confirm the product details show "Add products to the group" and there are no products already added when you open that section.
6. Go back to the product list and pull to refresh. Confirm no placeholder products (with the name "Import placeholder ...") appear.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before:

https://user-images.githubusercontent.com/8658164/220638575-084bad2e-11a1-42b3-94b0-ee0be7efad8e.mp4

After:

https://user-images.githubusercontent.com/8658164/220704895-6d8e3ab4-db59-491f-ac1e-207be276e37f.mp4




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
