### PR TITLE
REST API: Fetch Jetpack connection status before starting the Jetpack setup flow

### DIFF
--- a/Networking/Networking/ApplicationPassword/RequestConverter.swift
+++ b/Networking/Networking/ApplicationPassword/RequestConverter.swift
@@ -6,6 +6,9 @@ struct RequestConverter {
     let credentials: Credentials?
 
     func convert(_ request: URLRequestConvertible) -> URLRequestConvertible {
+        if request is RESTRequest {
+            return request
+        }
         guard let convertibleRequest = request as? RESTRequestConvertible,
               case let .wporg(_, _, siteAddress) = credentials,
               let restRequest = convertibleRequest.asRESTRequest(with: siteAddress) else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsView.swift
@@ -95,15 +95,16 @@ struct JetpackBenefitsView: View {
 }
 
 private extension JetpackBenefitsView {
+    @MainActor
     func fetchJetpackUser() async -> Result<JetpackUser, Error> {
-        await withCheckedContinuation{ continuation in
+        await withCheckedContinuation { continuation in
             let action = JetpackConnectionAction.fetchJetpackUser { result in
                 continuation.resume(returning: result)
             }
             ServiceLocator.stores.dispatch(action)
         }
     }
-    
+
     enum Layout {
         static let topPadding = CGFloat(75)
         static let spacingBetweenTitleAndSubtitle = CGFloat(10)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsView.swift
@@ -1,17 +1,19 @@
 import SwiftUI
+import Yosemite
 
 /// Hosting controller wrapper for `JetpackBenefitsView`
 ///
 final class JetpackBenefitsHostingController: UIHostingController<JetpackBenefitsView> {
-    init() {
-        super.init(rootView: JetpackBenefitsView())
+    init(isJetpackCPSite: Bool) {
+        super.init(rootView: JetpackBenefitsView(isJetpackCPSite: isJetpackCPSite))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func setActions(installAction: @escaping () -> Void, dismissAction: @escaping () -> Void) {
+    func setActions(installAction: @escaping (Result<JetpackUser, Error>?) -> Void,
+                    dismissAction: @escaping () -> Void) {
         rootView.installAction = installAction
         rootView.dismissAction = dismissAction
     }
@@ -19,13 +21,18 @@ final class JetpackBenefitsHostingController: UIHostingController<JetpackBenefit
 
 /// Displays a list of Jetpack benefits with two CTAs to install Jetpack and dismiss the view.
 struct JetpackBenefitsView: View {
+    /// Whether the view is showing benefit for a JetpackCP site or non-Jetpack site.
+    let isJetpackCPSite: Bool
+
     /// Closure invoked when the install button is tapped
     ///
-    var installAction: () -> Void = {}
+    var installAction: (Result<JetpackUser, Error>?) -> Void = { _ in }
 
     /// Closure invoked when the "Not Now" button is tapped
     ///
     var dismissAction: () -> Void = {}
+
+    @State private var isPrimaryButtonLoading = false
 
     var body: some View {
         VStack {
@@ -65,9 +72,19 @@ struct JetpackBenefitsView: View {
             // Actions
             VStack(spacing: Layout.spacingBetweenCTAs) {
                 // Primary Button to install Jetpack
-                Button(Localization.installAction, action: installAction)
-                    .buttonStyle(PrimaryButtonStyle())
-                    .fixedSize(horizontal: false, vertical: true)
+                Button(Localization.installAction) {
+                    guard !isJetpackCPSite else {
+                        return installAction(nil)
+                    }
+                    Task { @MainActor in
+                        isPrimaryButtonLoading = true
+                        let result = await fetchJetpackUser()
+                        isPrimaryButtonLoading = false
+                        installAction(result)
+                    }
+                }
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isPrimaryButtonLoading))
+                .fixedSize(horizontal: false, vertical: true)
                 // Secondary button to dismiss
                 Button(Localization.dismissAction, action: dismissAction)
                     .buttonStyle(SecondaryButtonStyle())
@@ -78,6 +95,15 @@ struct JetpackBenefitsView: View {
 }
 
 private extension JetpackBenefitsView {
+    func fetchJetpackUser() async -> Result<JetpackUser, Error> {
+        await withCheckedContinuation{ continuation in
+            let action = JetpackConnectionAction.fetchJetpackUser { result in
+                continuation.resume(returning: result)
+            }
+            ServiceLocator.stores.dispatch(action)
+        }
+    }
+    
     enum Layout {
         static let topPadding = CGFloat(75)
         static let spacingBetweenTitleAndSubtitle = CGFloat(10)
@@ -112,10 +138,10 @@ private extension JetpackBenefitsView {
 
 struct JetpackBenefits_Previews: PreviewProvider {
     static var previews: some View {
-        JetpackBenefitsView()
+        JetpackBenefitsView(isJetpackCPSite: true)
             .preferredColorScheme(.light)
             .previewLayout(.fixed(width: 414, height: 780))
-        JetpackBenefitsView()
+        JetpackBenefitsView(isJetpackCPSite: false)
             .preferredColorScheme(.light)
             .previewLayout(.fixed(width: 800, height: 300))
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsView.swift
@@ -5,14 +5,15 @@ import Yosemite
 ///
 final class JetpackBenefitsHostingController: UIHostingController<JetpackBenefitsView> {
     init(isJetpackCPSite: Bool) {
-        super.init(rootView: JetpackBenefitsView(isJetpackCPSite: isJetpackCPSite))
+        let viewModel = JetpackBenefitsViewModel(isJetpackCPSite: isJetpackCPSite)
+        super.init(rootView: JetpackBenefitsView(viewModel: viewModel))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func setActions(installAction: @escaping (Result<JetpackUser, Error>?) -> Void,
+    func setActions(installAction: @escaping (Result<JetpackUser, Error>) -> Void,
                     dismissAction: @escaping () -> Void) {
         rootView.installAction = installAction
         rootView.dismissAction = dismissAction
@@ -21,16 +22,20 @@ final class JetpackBenefitsHostingController: UIHostingController<JetpackBenefit
 
 /// Displays a list of Jetpack benefits with two CTAs to install Jetpack and dismiss the view.
 struct JetpackBenefitsView: View {
-    /// Whether the view is showing benefit for a JetpackCP site or non-Jetpack site.
-    let isJetpackCPSite: Bool
+
+    private let viewModel: JetpackBenefitsViewModel
 
     /// Closure invoked when the install button is tapped
     ///
-    var installAction: (Result<JetpackUser, Error>?) -> Void = { _ in }
+    var installAction: (Result<JetpackUser, Error>) -> Void = { _ in }
 
     /// Closure invoked when the "Not Now" button is tapped
     ///
     var dismissAction: () -> Void = {}
+
+    init(viewModel: JetpackBenefitsViewModel) {
+        self.viewModel = viewModel
+    }
 
     @State private var isPrimaryButtonLoading = false
 
@@ -73,12 +78,9 @@ struct JetpackBenefitsView: View {
             VStack(spacing: Layout.spacingBetweenCTAs) {
                 // Primary Button to install Jetpack
                 Button(Localization.installAction) {
-                    guard !isJetpackCPSite else {
-                        return installAction(nil)
-                    }
                     Task { @MainActor in
                         isPrimaryButtonLoading = true
-                        let result = await fetchJetpackUser()
+                        let result = await viewModel.fetchJetpackUser()
                         isPrimaryButtonLoading = false
                         installAction(result)
                     }
@@ -95,15 +97,6 @@ struct JetpackBenefitsView: View {
 }
 
 private extension JetpackBenefitsView {
-    @MainActor
-    func fetchJetpackUser() async -> Result<JetpackUser, Error> {
-        await withCheckedContinuation { continuation in
-            let action = JetpackConnectionAction.fetchJetpackUser { result in
-                continuation.resume(returning: result)
-            }
-            ServiceLocator.stores.dispatch(action)
-        }
-    }
 
     enum Layout {
         static let topPadding = CGFloat(75)
@@ -139,10 +132,10 @@ private extension JetpackBenefitsView {
 
 struct JetpackBenefits_Previews: PreviewProvider {
     static var previews: some View {
-        JetpackBenefitsView(isJetpackCPSite: true)
+        JetpackBenefitsView(viewModel: .init(isJetpackCPSite: true))
             .preferredColorScheme(.light)
             .previewLayout(.fixed(width: 414, height: 780))
-        JetpackBenefitsView(isJetpackCPSite: false)
+        JetpackBenefitsView(viewModel: .init(isJetpackCPSite: false))
             .preferredColorScheme(.light)
             .previewLayout(.fixed(width: 800, height: 300))
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsViewModel.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Yosemite
+
+/// View model for `JetpackBenefitsView`
+///
+final class JetpackBenefitsViewModel {
+    /// Whether the view is showing benefits for a JetpackCP site or non-Jetpack site.
+    let isJetpackCPSite: Bool
+    private let stores: StoresManager
+
+    init(isJetpackCPSite: Bool, stores: StoresManager = ServiceLocator.stores) {
+        self.isJetpackCPSite = isJetpackCPSite
+        self.stores = stores
+    }
+
+    @MainActor
+    func fetchJetpackUser() async -> Result<JetpackUser, Error> {
+        guard !isJetpackCPSite else {
+            return .failure(FetchJetpackUserError.notSupportedForJCPSites)
+        }
+        return await withCheckedContinuation { continuation in
+            let action = JetpackConnectionAction.fetchJetpackUser { result in
+                continuation.resume(returning: result)
+            }
+            stores.dispatch(action)
+        }
+    }
+}
+
+extension JetpackBenefitsViewModel {
+    enum FetchJetpackUserError: Error {
+        case notSupportedForJCPSites
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsViewModel.swift
@@ -28,7 +28,7 @@ final class JetpackBenefitsViewModel {
 }
 
 extension JetpackBenefitsViewModel {
-    enum FetchJetpackUserError: Error {
+    enum FetchJetpackUserError: Error, Equatable {
         case notSupportedForJCPSites
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Yosemite
+import enum Alamofire.AFError
 
 /// Coordinates the Jetpack setup flow in the authenticated state.
 ///
@@ -8,7 +9,7 @@ final class JetpackSetupCoordinator {
 
     private let site: Site
     /// Whether Jetpack is installed and activated and only connection needs to be handled.
-    private var connectionOnly: Bool
+    private var requiresConnectionOnly: Bool
     private let stores: StoresManager
     private let analytics: Analytics
 
@@ -17,36 +18,72 @@ final class JetpackSetupCoordinator {
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.site = site
-        self.connectionOnly = false // to be updated later after fetching Jetpack status
+        self.requiresConnectionOnly = false // to be updated later after fetching Jetpack status
         self.navigationController = navigationController
         self.stores = stores
         self.analytics = analytics
     }
 
     func showBenefitModal() {
-        let benefitsController = JetpackBenefitsHostingController()
-        benefitsController.setActions { [weak self] in
-            self?.navigationController.dismiss(animated: true, completion: { [weak self] in
-                guard let self else { return }
-                self.analytics.track(event: .jetpackInstallButtonTapped(source: .benefitsModal))
-
-                guard !self.site.isJetpackCPConnected else {
-                    let installController = JCPJetpackInstallHostingController(siteID: self.site.siteID,
-                                                                               siteURL: self.site.url,
-                                                                               siteAdminURL: self.site.adminURL)
-
-                    installController.setDismissAction { [weak self] in
-                        self?.navigationController.dismiss(animated: true, completion: nil)
-                    }
-                    self.navigationController.present(installController, animated: true, completion: nil)
-                    return
-                }
-
-                #warning("show Jetpack setup flow for non-Jetpack sites")
-            })
-        } dismissAction: { [weak self] in
+        let benefitsController = JetpackBenefitsHostingController(isJetpackCPSite: site.isJetpackCPConnected)
+        benefitsController.setActions (installAction: { [weak self] result in
+            guard let self else { return }
+            self.analytics.track(event: .jetpackInstallButtonTapped(source: .benefitsModal))
+            if let result, self.site.isNonJetpackSite {
+                self.handleJetpackStatus(result)
+            } else {
+                self.presentJCPJetpackInstallFlow()
+            }
+        }, dismissAction: { [weak self] in
             self?.navigationController.dismiss(animated: true, completion: nil)
-        }
+        })
         navigationController.present(benefitsController, animated: true, completion: nil)
+    }
+}
+
+// MARK: - Private helpers
+//
+private extension JetpackSetupCoordinator {
+    /// Navigates to the Jetpack installation flow for JCP sites.
+    func presentJCPJetpackInstallFlow() {
+        navigationController.dismiss(animated: true, completion: { [weak self] in
+            guard let self else { return }
+            let installController = JCPJetpackInstallHostingController(siteID: self.site.siteID,
+                                                                       siteURL: self.site.url,
+                                                                       siteAdminURL: self.site.adminURL)
+
+            installController.setDismissAction { [weak self] in
+                self?.navigationController.dismiss(animated: true, completion: nil)
+            }
+            self.navigationController.present(installController, animated: true, completion: nil)
+        })
+    }
+
+    /// Checks the Jetpack connection status for non-Jetpack sites to infer the setup steps to be handled.
+    func handleJetpackStatus(_ result: Result<JetpackUser, Error>) {
+        switch result {
+        case .success(let user):
+            let connectedEmail = user.wpcomUser?.email
+            requiresConnectionOnly = !user.isConnected
+            #warning("TODO: start WPCom auth with connectedEmail")
+            DDLogInfo("✅ connected email: \(connectedEmail), isConnected: \(user.isConnected)")
+        case .failure(let error):
+            DDLogError("⛔️ Jetpack status fetched error: \(error)")
+            switch error {
+            case AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404)):
+                /// 404 error means Jetpack is not installed or activated yet.
+                requiresConnectionOnly = false
+                #warning("TODO: check user role to see if the user has permission to manage plugins")
+            case AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 403)):
+                /// 403 means the site Jetpack connection is not established yet
+                /// and the user has no permission to handle this.
+                #warning("TODO: show role error")
+                requiresConnectionOnly = true
+                break
+            default:
+                #warning("TODO: show generic error alert")
+                break
+            }
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -30,7 +30,7 @@ final class JetpackSetupCoordinator {
             guard let self else { return }
             self.analytics.track(event: .jetpackInstallButtonTapped(source: .benefitsModal))
             if self.site.isNonJetpackSite {
-                self.handleJetpackStatus(result)
+                self.checkJetpackStatus(result)
             } else {
                 self.presentJCPJetpackInstallFlow()
             }
@@ -60,7 +60,7 @@ private extension JetpackSetupCoordinator {
     }
 
     /// Checks the Jetpack connection status for non-Jetpack sites to infer the setup steps to be handled.
-    func handleJetpackStatus(_ result: Result<JetpackUser, Error>) {
+    func checkJetpackStatus(_ result: Result<JetpackUser, Error>) {
         switch result {
         case .success(let user):
             let connectedEmail = user.wpcomUser?.email

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -29,7 +29,7 @@ final class JetpackSetupCoordinator {
         benefitsController.setActions (installAction: { [weak self] result in
             guard let self else { return }
             self.analytics.track(event: .jetpackInstallButtonTapped(source: .benefitsModal))
-            if let result, self.site.isNonJetpackSite {
+            if self.site.isNonJetpackSite {
                 self.handleJetpackStatus(result)
             } else {
                 self.presentJCPJetpackInstallFlow()

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -1,0 +1,52 @@
+import UIKit
+import Yosemite
+
+/// Coordinates the Jetpack setup flow in the authenticated state.
+///
+final class JetpackSetupCoordinator {
+    let navigationController: UINavigationController
+
+    private let site: Site
+    /// Whether Jetpack is installed and activated and only connection needs to be handled.
+    private var connectionOnly: Bool
+    private let stores: StoresManager
+    private let analytics: Analytics
+
+    init(site: Site,
+         navigationController: UINavigationController,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.site = site
+        self.connectionOnly = false // to be updated later after fetching Jetpack status
+        self.navigationController = navigationController
+        self.stores = stores
+        self.analytics = analytics
+    }
+
+    func showBenefitModal() {
+        let benefitsController = JetpackBenefitsHostingController()
+        benefitsController.setActions { [weak self] in
+            self?.navigationController.dismiss(animated: true, completion: { [weak self] in
+                guard let self else { return }
+                self.analytics.track(event: .jetpackInstallButtonTapped(source: .benefitsModal))
+
+                guard !self.site.isJetpackCPConnected else {
+                    let installController = JCPJetpackInstallHostingController(siteID: self.site.siteID,
+                                                                               siteURL: self.site.url,
+                                                                               siteAdminURL: self.site.adminURL)
+
+                    installController.setDismissAction { [weak self] in
+                        self?.navigationController.dismiss(animated: true, completion: nil)
+                    }
+                    self.navigationController.present(installController, animated: true, completion: nil)
+                    return
+                }
+
+                #warning("show Jetpack setup flow for non-Jetpack sites")
+            })
+        } dismissAction: { [weak self] in
+            self?.navigationController.dismiss(animated: true, completion: nil)
+        }
+        navigationController.present(benefitsController, animated: true, completion: nil)
+    }
+}

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -99,7 +99,7 @@ class AuthenticatedState: StoresManagerState {
         } else {
             DDLogInfo("No WordPress.com auth token found. AccountStore is not initialized.")
         }
-    
+
         if case let .wporg(_, _, siteURL) = credentials {
             /// Needs Jetpack connection store to handle Jetpack setup for non-Jetpack sites.
             services.append(JetpackConnectionStore(dispatcher: dispatcher, network: network, siteURL: siteURL))

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -90,7 +90,6 @@ class AuthenticatedState: StoresManagerState {
                                storageManager: storageManager,
                                network: network,
                                fileStorage: PListFileStorage()),
-            JetpackConnectionStore(dispatcher: dispatcher),
             WordPressSiteStore(network: network, dispatcher: dispatcher),
         ]
 

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -91,7 +91,7 @@ class AuthenticatedState: StoresManagerState {
                                network: network,
                                fileStorage: PListFileStorage()),
             JetpackConnectionStore(dispatcher: dispatcher),
-            WordPressSiteStore(network: network, dispatcher: dispatcher)
+            WordPressSiteStore(network: network, dispatcher: dispatcher),
         ]
 
 
@@ -99,6 +99,11 @@ class AuthenticatedState: StoresManagerState {
             services.append(AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network, dotcomAuthToken: authToken))
         } else {
             DDLogInfo("No WordPress.com auth token found. AccountStore is not initialized.")
+        }
+    
+        if case let .wporg(_, _, siteURL) = credentials {
+            /// Needs Jetpack connection store to handle Jetpack setup for non-Jetpack sites.
+            services.append(JetpackConnectionStore(dispatcher: dispatcher, network: network, siteURL: siteURL))
         }
 
         self.services = services

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -102,10 +102,12 @@ class AuthenticatedState: StoresManagerState {
 
         if case let .wporg(_, _, siteURL) = credentials {
             /// Needs Jetpack connection store to handle Jetpack setup for non-Jetpack sites.
+            /// `AlamofireNetwork` is used here to handle requests with application password auth.
             services.append(JetpackConnectionStore(dispatcher: dispatcher, network: network, siteURL: siteURL))
         } else {
             /// When authenticated with WPCom, the store is used to handle Jetpack setup when a selected site doesn't have Jetpack.
-            /// The network for the store will be injected through the `authenticate` action before any other action is triggered.
+            /// The store will require cookie-nonce auth, which is handled by a `WordPressOrgNetwork`
+            /// injected later through the `authenticate` action before any other action is triggered.
             services.append(JetpackConnectionStore(dispatcher: dispatcher))
         }
 

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -103,6 +103,10 @@ class AuthenticatedState: StoresManagerState {
         if case let .wporg(_, _, siteURL) = credentials {
             /// Needs Jetpack connection store to handle Jetpack setup for non-Jetpack sites.
             services.append(JetpackConnectionStore(dispatcher: dispatcher, network: network, siteURL: siteURL))
+        } else {
+            /// When authenticated with WPCom, the store is used to handle Jetpack setup when a selected site doesn't have Jetpack.
+            /// The network for the store will be injected through the `authenticate` action before any other action is triggered.
+            services.append(JetpackConnectionStore(dispatcher: dispatcher))
         }
 
         self.services = services

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1938,6 +1938,7 @@
 		DEF36DE92898D3CF00178AC2 /* AuthenticatedWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE62898D3CF00178AC2 /* AuthenticatedWebViewController.swift */; };
 		DEF36DEA2898D3CF00178AC2 /* AuthenticatedWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE72898D3CF00178AC2 /* AuthenticatedWebViewModel.swift */; };
 		DEF36DEC2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */; };
+		DEF8CF0A29A71EE600800A60 /* JetpackSetupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF0929A71EE600800A60 /* JetpackSetupCoordinator.swift */; };
 		DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */; };
 		DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -4060,6 +4061,7 @@
 		DEF36DE62898D3CF00178AC2 /* AuthenticatedWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewController.swift; sourceTree = "<group>"; };
 		DEF36DE72898D3CF00178AC2 /* AuthenticatedWebViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewModel.swift; sourceTree = "<group>"; };
 		DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupWebViewModelTests.swift; sourceTree = "<group>"; };
+		DEF8CF0929A71EE600800A60 /* JetpackSetupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupCoordinator.swift; sourceTree = "<group>"; };
 		DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModel.swift; sourceTree = "<group>"; };
 		DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -7435,6 +7437,7 @@
 		B56DB3EF2049C06D00D4AA8E /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				DEF8CF0829A71ED400800A60 /* JetpackSetup */,
 				02E3B62629026C83007E0F13 /* Authentication */,
 				E1325EF928FD543B00EC9B2A /* InAppPurchases */,
 				03FBDA9B263AD47200ACE257 /* Coupons */,
@@ -9254,6 +9257,14 @@
 			path = "Print Customs Form";
 			sourceTree = "<group>";
 		};
+		DEF8CF0829A71ED400800A60 /* JetpackSetup */ = {
+			isa = PBXGroup;
+			children = (
+				DEF8CF0929A71EE600800A60 /* JetpackSetupCoordinator.swift */,
+			);
+			path = JetpackSetup;
+			sourceTree = "<group>";
+		};
 		DEFD6E5F264990DD00E51E0D /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
@@ -10281,6 +10292,7 @@
 				26E7EE6C292D894100793045 /* AnalyticsReportCardViewModel.swift in Sources */,
 				DE7B479027A153C20018742E /* CouponSearchUICommand.swift in Sources */,
 				DE50294D28BEF8F100551736 /* JetpackConnectionWebViewModel.swift in Sources */,
+				DEF8CF0A29A71EE600800A60 /* JetpackSetupCoordinator.swift in Sources */,
 				02645D8827BA2E820065DC68 /* NSAttributedString+Attributes.swift in Sources */,
 				024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */,
 				45F8C43B2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1939,6 +1939,7 @@
 		DEF36DEA2898D3CF00178AC2 /* AuthenticatedWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DE72898D3CF00178AC2 /* AuthenticatedWebViewModel.swift */; };
 		DEF36DEC2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */; };
 		DEF8CF0A29A71EE600800A60 /* JetpackSetupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF0929A71EE600800A60 /* JetpackSetupCoordinator.swift */; };
+		DEF8CF0D29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF0C29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift */; };
 		DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */; };
 		DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -4062,6 +4063,7 @@
 		DEF36DE72898D3CF00178AC2 /* AuthenticatedWebViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewModel.swift; sourceTree = "<group>"; };
 		DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupWebViewModelTests.swift; sourceTree = "<group>"; };
 		DEF8CF0929A71EE600800A60 /* JetpackSetupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupCoordinator.swift; sourceTree = "<group>"; };
+		DEF8CF0C29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupCoordinatorTests.swift; sourceTree = "<group>"; };
 		DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModel.swift; sourceTree = "<group>"; };
 		DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -8846,6 +8848,7 @@
 		D816DDBA22265D8000903E59 /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				DEF8CF0B29A76F6200800A60 /* JetpackSetup */,
 				02645D8027BA20950065DC68 /* Inbox */,
 				BAA34C1E2787494300846F3C /* Reviews */,
 				03FBDAF7263EE49300ACE257 /* Coupons */,
@@ -9261,6 +9264,14 @@
 			isa = PBXGroup;
 			children = (
 				DEF8CF0929A71EE600800A60 /* JetpackSetupCoordinator.swift */,
+			);
+			path = JetpackSetup;
+			sourceTree = "<group>";
+		};
+		DEF8CF0B29A76F6200800A60 /* JetpackSetup */ = {
+			isa = PBXGroup;
+			children = (
+				DEF8CF0C29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift */,
 			);
 			path = JetpackSetup;
 			sourceTree = "<group>";
@@ -11832,6 +11843,7 @@
 				45DB706C26161F970064A6CF /* DecimalWooTests.swift in Sources */,
 				CCE4CD172667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift in Sources */,
 				45AF9DA5265CEA89001EB794 /* ShippingLabelCarriersViewModelTests.swift in Sources */,
+				DEF8CF0D29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift in Sources */,
 				0248042D2887C92A00991319 /* MockLoggedOutAppSettings.swift in Sources */,
 				B56BBD16214820A70053A32D /* SyncCoordinatorTests.swift in Sources */,
 				02A275C023FE58F6005C560F /* MockImageCache.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1941,6 +1941,7 @@
 		DEF8CF0A29A71EE600800A60 /* JetpackSetupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF0929A71EE600800A60 /* JetpackSetupCoordinator.swift */; };
 		DEF8CF0D29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF0C29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift */; };
 		DEF8CF0F29A890E900800A60 /* JetpackBenefitsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF0E29A890E900800A60 /* JetpackBenefitsViewModel.swift */; };
+		DEF8CF1129A8933E00800A60 /* JetpackBenefitsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1029A8933E00800A60 /* JetpackBenefitsViewModelTests.swift */; };
 		DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */; };
 		DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -4066,6 +4067,7 @@
 		DEF8CF0929A71EE600800A60 /* JetpackSetupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupCoordinator.swift; sourceTree = "<group>"; };
 		DEF8CF0C29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupCoordinatorTests.swift; sourceTree = "<group>"; };
 		DEF8CF0E29A890E900800A60 /* JetpackBenefitsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsViewModel.swift; sourceTree = "<group>"; };
+		DEF8CF1029A8933E00800A60 /* JetpackBenefitsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsViewModelTests.swift; sourceTree = "<group>"; };
 		DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModel.swift; sourceTree = "<group>"; };
 		DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -9232,6 +9234,7 @@
 			isa = PBXGroup;
 			children = (
 				DEC51A9F274F9922009F3DF4 /* JCPJetpackInstallStepsViewModelTests.swift */,
+				DEF8CF1029A8933E00800A60 /* JetpackBenefitsViewModelTests.swift */,
 			);
 			path = JetpackInstall;
 			sourceTree = "<group>";
@@ -11676,6 +11679,7 @@
 				DEF13C542963ED4E0024A02B /* PostSiteCredentialLoginCheckerTests.swift in Sources */,
 				EEC2D281292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift in Sources */,
 				746FC23D2200A62B00C3096C /* DateWooTests.swift in Sources */,
+				DEF8CF1129A8933E00800A60 /* JetpackBenefitsViewModelTests.swift in Sources */,
 				31F21B5A263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift in Sources */,
 				CC3B35DF28E5BE6F0036B097 /* ReviewReplyViewModelTests.swift in Sources */,
 				02F5F80E246102240000613A /* FilterProductListViewModel+numberOfActiveFiltersTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1940,6 +1940,7 @@
 		DEF36DEC2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */; };
 		DEF8CF0A29A71EE600800A60 /* JetpackSetupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF0929A71EE600800A60 /* JetpackSetupCoordinator.swift */; };
 		DEF8CF0D29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF0C29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift */; };
+		DEF8CF0F29A890E900800A60 /* JetpackBenefitsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF0E29A890E900800A60 /* JetpackBenefitsViewModel.swift */; };
 		DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */; };
 		DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -4064,6 +4065,7 @@
 		DEF36DEB2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupWebViewModelTests.swift; sourceTree = "<group>"; };
 		DEF8CF0929A71EE600800A60 /* JetpackSetupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupCoordinator.swift; sourceTree = "<group>"; };
 		DEF8CF0C29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupCoordinatorTests.swift; sourceTree = "<group>"; };
+		DEF8CF0E29A890E900800A60 /* JetpackBenefitsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsViewModel.swift; sourceTree = "<group>"; };
 		DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModel.swift; sourceTree = "<group>"; };
 		DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -5407,6 +5409,7 @@
 			children = (
 				02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */,
 				02A9BCD32737DE0D00159C79 /* JetpackBenefitsView.swift */,
+				DEF8CF0E29A890E900800A60 /* JetpackBenefitsViewModel.swift */,
 				02A9BCD52737F73C00159C79 /* JetpackBenefitItem.swift */,
 			);
 			path = JetpackConnectionPackageSites;
@@ -11062,6 +11065,7 @@
 				B5BE75DB213F1D1E00909A14 /* OverlayMessageView.swift in Sources */,
 				31B0551E264B3C7A00134D87 /* CardPresentModalFoundReader.swift in Sources */,
 				4520A15E2722BA3E001FA573 /* OrderDateRangeFilter+Utils.swift in Sources */,
+				DEF8CF0F29A890E900800A60 /* JetpackBenefitsViewModel.swift in Sources */,
 				DEE183F1292E0ED0008818AB /* JetpackSetupInterruptedView.swift in Sources */,
 				028A465329597A91001CF6CE /* StoreCreationSellingPlatformsQuestionViewModel.swift in Sources */,
 				027CB045295D7B8B00F98F7C /* StoreCreationCountryQuestionViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
@@ -94,7 +94,7 @@ final class MockCardPresentPaymentsStoresManager: DefaultStoresManager {
         case .disconnect(let onCompletion):
             onCompletion(Result.success(()))
         default:
-            fatalError("Not available")
+            break
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/JetpackInstall/JetpackBenefitsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/JetpackInstall/JetpackBenefitsViewModelTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+@MainActor
+final class JetpackBenefitsViewModelTests: XCTestCase {
+    func test_fetchJetpackUser_returns_error_for_jcp_sites() async {
+        // Given
+        let viewModel = JetpackBenefitsViewModel(isJetpackCPSite: true)
+
+        // When
+        let result = await viewModel.fetchJetpackUser()
+
+        // Then
+        XCTAssertEqual(result.failure as? JetpackBenefitsViewModel.FetchJetpackUserError,
+                       JetpackBenefitsViewModel.FetchJetpackUserError.notSupportedForJCPSites)
+    }
+
+    func test_fetchJetpackUser_returns_result_from_jetpack_fetch_correctly() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = JetpackBenefitsViewModel(isJetpackCPSite: false, stores: stores)
+        let testUser = JetpackUser.fake().copy(username: "test")
+
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackUser(let completion):
+                completion(.success(testUser))
+            default:
+                break
+            }
+        }
+
+        // When
+        let result = await viewModel.fetchJetpackUser()
+
+        //  Then
+        XCTAssertEqual(try result.get().username, testUser.username)
+    }
+
+    func test_fetchJetpackUser_relays_error_from_jetpack_fetch() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let viewModel = JetpackBenefitsViewModel(isJetpackCPSite: false, stores: stores)
+        let testError = NSError(domain: "Test", code: 404)
+
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case .fetchJetpackUser(let completion):
+                completion(.failure(testError))
+            default:
+                break
+            }
+        }
+
+        // When
+        let result = await viewModel.fetchJetpackUser()
+
+        //  Then
+        XCTAssertEqual(result.failure as? NSError, testError)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -50,7 +50,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
             self.navigationController.presentedViewController != nil
         }
         let benefitModal = try XCTUnwrap(navigationController.presentedViewController as? JetpackBenefitsHostingController)
-        benefitModal.rootView.installAction(nil)
+        benefitModal.rootView.installAction(.failure(JetpackBenefitsViewModel.FetchJetpackUserError.notSupportedForJCPSites))
         waitUntil {
             self.navigationController.presentedViewController is JCPJetpackInstallHostingController
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -39,4 +39,20 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         XCTAssertTrue(navigationController.presentedViewController is JetpackBenefitsHostingController)
     }
 
+    func test_installation_flow_for_jcp_sites_is_presented_for_jcp_sites() throws {
+        // Given
+        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: false, isJetpackConnected: true)
+        let coordinator = JetpackSetupCoordinator(site: testSite, navigationController: navigationController)
+
+        // When
+        coordinator.showBenefitModal()
+        waitUntil {
+            self.navigationController.presentedViewController != nil
+        }
+        let benefitModal = try XCTUnwrap(navigationController.presentedViewController as? JetpackBenefitsHostingController)
+        benefitModal.rootView.installAction(nil)
+        waitUntil {
+            self.navigationController.presentedViewController is JCPJetpackInstallHostingController
+        }
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class JetpackSetupCoordinatorTests: XCTestCase {
+
+    private var stores: MockStoresManager!
+    private var navigationController: UINavigationController!
+
+    override func setUp() {
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+        navigationController = UINavigationController()
+
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = UIViewController()
+        window.makeKeyAndVisible()
+        window.rootViewController = navigationController
+        super.setUp()
+    }
+
+    override func tearDown() {
+        stores = nil
+        navigationController = nil
+        super.tearDown()
+    }
+
+    func test_benefit_modal_is_presented_correctly() {
+        // Given
+        let testSite = Site.fake()
+        let coordinator = JetpackSetupCoordinator(site: testSite, navigationController: navigationController)
+
+        // When
+        coordinator.showBenefitModal()
+        waitUntil {
+            self.navigationController.presentedViewController != nil
+        }
+
+        // Then
+        XCTAssertTrue(navigationController.presentedViewController is JetpackBenefitsHostingController)
+    }
+
+}

--- a/Yosemite/Yosemite/Stores/JetpackConnectionStore.swift
+++ b/Yosemite/Yosemite/Stores/JetpackConnectionStore.swift
@@ -12,6 +12,11 @@ public final class JetpackConnectionStore: DeauthenticatedStore {
         super.init(dispatcher: dispatcher)
     }
 
+    public convenience init(dispatcher: Dispatcher, network: Network, siteURL: String) {
+        self.init(dispatcher: dispatcher)
+        updateRemote(with: siteURL, network: network)
+    }
+
     public override func registerSupportedActions(in dispatcher: Dispatcher) {
         dispatcher.register(processor: self, for: JetpackConnectionAction.self)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8914 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the Jetpack connection check to the Jetpack setup flow for non-Jetpack sites. The logic for this connection check can be found in an internal document here: [pe5sF9-1c9-p2].

Since the logic for showing the benefit modal is currently kept in `DashboardViewController` which is not scalable, I moved this logic to a new coordinator `JetpackSetupCoordinator` which takes care of showing the modal and handling the actions for both JCP sites and non-Jetpack sites:
- For JCP sites, the logic is kept as-is: when tapping the Install Jetpack on the modal, we dismiss the modal and present the installation flow for JCP sites.
- For non-Jetpack sites: tapping the Install Jetpack button triggers fetching Jetpack connection details while showing a loading indicator on the button. When the result returns, it is sent back to the coordinator to continue the setup flow - which will be handled in subsequent PRs.

Previously, `JetpackConnectionRemote` was designed to handle requests with cookie-nonce authentication only. To make use of this remote with application password authentication,  `JetpackConnectionStore` has been updated to be initialized with `AlamofireNetwork` in `AuthenticatedState`. This makes it possible to use `JetpackSetupViewModel` later without having to switch between `JetpackConnectionStore` and `SitePluginStore`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Make sure that you have access to a site with WooCommerce and no Jetpack.
- Log out of the app or skip onboarding if needed.
- Tap "Enter your site address" on the prologue screen and proceed with the address of your test site.
- Log in with the credentials of a shop manager.
- When the login completes, tap the Jetback benefit banner at the bottom of the Dashboard screen.
- Tap Install Jetpack on the benefit modal.
- Notice in Xcode console: `⛔️ Jetpack status fetched error: responseValidationFailed(reason: Alamofire.AFError.ResponseValidationFailureReason.unacceptableStatusCode(code: 404))`
- Install and activate Jetpack to your test site on WP Admin.
- Come back to the app and tap Install Jetpack again. You should see in Xcode console: `⛔️ Jetpack status fetched error: responseValidationFailed(reason: Alamofire.AFError.ResponseValidationFailureReason.unacceptableStatusCode(code: 403))`.
- Log out and log in again to an admin account of your test site.
- Try to tap the Install Jetpack on the Jetpack benefit modal again. Notice in Xcode console: `✅ connected email: nil, isConnected: false`.
- Use your admin user to handle Jetpack connection in WP Admin.
- Try again to tap the Install Jetpack button on the app. Notice in Xcode console: `✅ connected email: Optional("<your email>"), isConnected: true`

Feel free to also test the JCP case again:
- Deactivate Jetpack plugin on your site in WP Admin.
- Install and activate WCPay on your site. Connect your WPCom account to WCPay.
- Log out of the app and log in again to your site with your WPCom account.
- Tap the Jetpack benefit banner and then the Install Jetpack button on the benefit modal. The app should navigate to the installation flow for JCP sites.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
No new UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
