### PR TITLE
SPE: Present product form modally with feature flag enabled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -258,9 +258,15 @@ private extension AddProductCoordinator {
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,
                                                        presentationStyle: .navigationStack)
-        // Since the Add Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
-        viewController.hidesBottomBarWhenPushed = true
-        navigationController.pushViewController(viewController, animated: true)
+        if isSimplifiedBottomSheetEnabled {
+            viewController.addCloseNavigationBarButton(title: NSLocalizedString("Cancel", comment: "Button to dismiss the new product form"))
+            let productFormNavController = WooNavigationController(rootViewController: viewController)
+            navigationController.present(productFormNavController, animated: true)
+        } else {
+            // Since the Add Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
+            viewController.hidesBottomBarWhenPushed = true
+            navigationController.pushViewController(viewController, animated: true)
+        }
     }
 
     /// Converts a `BottomSheetProductType` type to a `ProductsRemote.TemplateType` template type.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8837
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is the **first** of 3 PRs to update how the new product screen is presented in the Simplified Product Editing experience. In this PR:

* The new product screen is presented modally when the feature flag is enabled, with a "Cancel" button to close the modal without saving anything.

The next PRs will update the experience after the modal is presented.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Go to the Products tab to add a new product.
3. Select a product type.
4. Confirm the new product screen is presented modally.
5. Tap the "Cancel" button and confirm the modal is closed without saving the new product.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-23 at 22 10 49](https://user-images.githubusercontent.com/8658164/221042164-0ed9f775-5256-4741-8aea-70726632e47b.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-23 at 22 00 39](https://user-images.githubusercontent.com/8658164/221040572-be86632b-664b-4351-97bd-bfae275bec2e.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
