### PR TITLE
SPE: Save new product as draft

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -209,7 +209,9 @@ private extension AddProductCoordinator {
 
             switch result {
             case .success(let product):
-                let newProduct = ProductFactory().newProduct(from: product) // Transforms the auto-draft product into a new product ready to be used.
+                // Transforms the auto-draft product into a new product ready to be used.
+                let newProduct = ProductFactory().newProduct(from: product,
+                                                             status: self.isSimplifiedBottomSheetEnabled ? .draft : .published)
                 self.presentProduct(newProduct) // We need to strongly capture `self` because no one is retaining `AddProductCoordinator`.
 
             case .failure(let error):
@@ -231,7 +233,8 @@ private extension AddProductCoordinator {
     func presentProductForm(bottomSheetProductType: BottomSheetProductType) {
         guard let product = ProductFactory().createNewProduct(type: bottomSheetProductType.productType,
                                                               isVirtual: bottomSheetProductType.isVirtual,
-                                                              siteID: siteID) else {
+                                                              siteID: siteID,
+                                                              status: isSimplifiedBottomSheetEnabled ? .draft : .published) else {
             assertionFailure("Unable to create product of type: \(bottomSheetProductType)")
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
@@ -7,11 +7,13 @@ struct ProductFactory {
     ///
     /// - Parameters:
     ///   - type: The type of the product.
+    ///   - isVirtual: Whether the product is virtual (for simple products).
     ///   - siteID: The site ID where the product is added to.
-    func createNewProduct(type: ProductType, isVirtual: Bool, siteID: Int64) -> Product? {
+    ///   - status: The status of the new product.
+    func createNewProduct(type: ProductType, isVirtual: Bool, siteID: Int64, status: ProductStatus = .published) -> Product? {
         switch type {
         case .simple, .grouped, .variable, .affiliate:
-            return createEmptyProduct(type: type, isVirtual: isVirtual, siteID: siteID)
+            return createEmptyProduct(type: type, isVirtual: isVirtual, siteID: siteID, status: status)
         default:
             return nil
         }
@@ -20,13 +22,16 @@ struct ProductFactory {
     /// Copies a product by cleaning properties like `id, name, statusKey, and groupedProducts` to their default state.
     /// This is useful to turn an existing (on core) `auto-draft` product into a new app-product ready to be saved.
     ///
-    func newProduct(from existingProduct: Product) -> Product {
-        existingProduct.copy(productID: 0, name: "", statusKey: ProductStatus.published.rawValue, groupedProducts: [])
+    /// - Parameters:
+    ///   - existingProduct: The product to copy.
+    ///   - status: The status of the new product.
+    func newProduct(from existingProduct: Product, status: ProductStatus = .published) -> Product {
+        return existingProduct.copy(productID: 0, name: "", statusKey: status.rawValue, groupedProducts: [])
     }
 }
 
 private extension ProductFactory {
-    func createEmptyProduct(type: ProductType, isVirtual: Bool, siteID: Int64) -> Product {
+    func createEmptyProduct(type: ProductType, isVirtual: Bool, siteID: Int64, status: ProductStatus) -> Product {
         Product(siteID: siteID,
                 productID: 0,
                 name: "",
@@ -38,7 +43,7 @@ private extension ProductFactory {
                 dateOnSaleStart: nil,
                 dateOnSaleEnd: nil,
                 productTypeKey: type.rawValue,
-                statusKey: ProductStatus.published.rawValue,
+                statusKey: status.rawValue,
                 featured: false,
                 catalogVisibilityKey: ProductCatalogVisibility.visible.rawValue,
                 fullDescription: "",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -187,7 +187,11 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
     /// Additionally we don't take dates into consideration as we don't control their value when creating a product.
     ///
     func isEmpty() -> Bool {
-        guard let emptyProduct = ProductFactory().createNewProduct(type: productType, isVirtual: virtual, siteID: siteID) else {
+        let simplifiedEditingEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing)
+        guard let emptyProduct = ProductFactory().createNewProduct(type: productType,
+                                                                   isVirtual: virtual,
+                                                                   siteID: siteID,
+                                                                   status: simplifiedEditingEnabled ? .draft : .published) else {
             return false
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -1,5 +1,4 @@
 import Combine
-import protocol Experiments.FeatureFlagService
 import Yosemite
 
 import protocol Storage.StorageManagerType
@@ -125,32 +124,45 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     var actionButtons: [ActionButtonType] {
         // Figure out main action button first
         var buttons: [ActionButtonType] = {
-            switch (formType, originalProductModel.status, productModel.status, originalProduct.product.existsRemotely, hasUnsavedChanges()) {
-            case (.add, .published, .published, false, _): // New product with publish status
-                return [.publish]
-
-            case (.add, .published, _, false, _): // New product with a different status
-                return [.save] // And publish in more
-
-            case (.edit, .published, _, true, true): // Existing published product with changes
+            switch (formType,
+                    originalProductModel.status,
+                    productModel.status,
+                    originalProduct.product.existsRemotely,
+                    hasUnsavedChanges(),
+                    simplifiedProductEditingEnabled) {
+            case (.add, _, _, _, _, true): // New product with simplified editing enabled
                 return [.save]
 
-            case (.edit, .published, _, true, false): // Existing published product with no changes
-                return []
-
-            case (.edit, _, _, true, true): // Any other existing product with changes
-                return [.save] // And publish in more
-
-            case (.edit, _, _, true, false): // Any other existing product with no changes
+            case (.add, .published, .published, false, _, _): // New product with publish status
                 return [.publish]
 
-            case (.readonly, _, _, _, _): // Any product on readonly mode
+            case (.add, .published, _, false, _, _): // New product with a different status
+                return [.save] // And publish in more
+
+            case (.edit, .published, _, true, true, _): // Existing published product with changes
+                return [.save]
+
+            case (.edit, .published, _, true, false, _): // Existing published product with no changes
+                return []
+
+            case (.edit, _, _, true, true, _): // Any other existing product with changes
+                return [.save] // And publish in more
+
+            case (.edit, _, _, true, false, _): // Any other existing product with no changes
+                return [.publish]
+
+            case (.readonly, _, _, _, _, _): // Any product on readonly mode
                  return []
 
             default: // Impossible cases
                 return []
             }
         }()
+
+        // When simplified editing is enabled, only show the "Save" button on the new product form
+        if simplifiedProductEditingEnabled, formType == .add {
+            return buttons
+        }
 
         // The `frame_nonce` value must be stored for the preview to be displayed
         if let site = stores.sessionManager.defaultSite,
@@ -179,7 +191,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     private let analytics: Analytics
 
-    private let featureFlagService: FeatureFlagService
+    private let simplifiedProductEditingEnabled: Bool
 
     /// Assign this closure to be notified when a new product is saved remotely
     ///
@@ -192,7 +204,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          productImagesUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
          analytics: Analytics = ServiceLocator.analytics,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+         simplifiedProductEditingEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing)) {
         self.formType = formType
         self.productImageActionHandler = productImageActionHandler
         self.originalProduct = product
@@ -202,7 +214,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         self.storageManager = storageManager
         self.productImagesUploader = productImagesUploader
         self.analytics = analytics
-        self.featureFlagService = featureFlagService
+        self.simplifiedProductEditingEnabled = simplifiedProductEditingEnabled
 
         self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
             guard let self = self else { return }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/ProductFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/ProductFactoryTests.swift
@@ -7,10 +7,11 @@ final class ProductFactoryTests: XCTestCase {
     private let siteID: Int64 = 134
 
     func test_created_simple_physical_product_has_expected_fields() throws {
-        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: siteID))
+        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: siteID, status: .draft))
         XCTAssertEqual(product.productType, .simple)
         XCTAssertEqual(product.virtual, false)
         XCTAssertEqual(product.siteID, siteID)
+        XCTAssertEqual(product.statusKey, ProductStatus.draft.rawValue)
     }
 
     func test_created_simple_virtual_product_has_expected_fields() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -346,10 +346,10 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertEqual(actionButtons, [.save])
     }
 
-    func test_action_buttons_for_existing_product_with_simplified_editing_enabled() throws {
+    func test_action_buttons_for_existing_draft_product_and_no_pending_changes_with_simplified_editing_enabled() {
         // Given
         sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
-        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: 123))
+        let product = Product.fake().copy(productID: 123, statusKey: ProductStatus.draft.rawValue)
         let viewModel = createViewModel(product: product, formType: .edit, stores: stores, simplifiedProductEditingEnabled: true)
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -3,7 +3,6 @@ import XCTest
 @testable import WooCommerce
 import Yosemite
 import TestKit
-import protocol Experiments.FeatureFlagService
 
 final class ProductFormViewModelTests: XCTestCase {
 
@@ -334,6 +333,32 @@ final class ProductFormViewModelTests: XCTestCase {
         XCTAssertEqual(actionButtons, [.save, .more])
     }
 
+    func test_action_buttons_for_new_product_with_simplified_editing_enabled() throws {
+        // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
+        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: 123))
+        let viewModel = createViewModel(product: product, formType: .add, stores: stores, simplifiedProductEditingEnabled: true)
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [.save])
+    }
+
+    func test_action_buttons_for_existing_product_with_simplified_editing_enabled() throws {
+        // Given
+        sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
+        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: 123))
+        let viewModel = createViewModel(product: product, formType: .edit, stores: stores, simplifiedProductEditingEnabled: true)
+
+        // When
+        let actionButtons = viewModel.actionButtons
+
+        // Then
+        XCTAssertEqual(actionButtons, [.preview, .publish, .more])
+    }
+
     func test_action_buttons_for_existing_published_product_and_pending_changes() {
         // Given
         sessionManager.defaultSite = Site.fake().copy(frameNonce: "abc123")
@@ -610,7 +635,7 @@ private extension ProductFormViewModelTests {
                          formType: ProductFormType,
                          stores: StoresManager = ServiceLocator.stores,
                          analytics: Analytics = ServiceLocator.analytics,
-                         featureFlagService: FeatureFlagService = MockFeatureFlagService()) -> ProductFormViewModel {
+                         simplifiedProductEditingEnabled: Bool = false) -> ProductFormViewModel {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         return ProductFormViewModel(product: model,
@@ -618,6 +643,6 @@ private extension ProductFormViewModelTests {
                                     productImageActionHandler: productImageActionHandler,
                                     stores: stores,
                                     analytics: analytics,
-                                    featureFlagService: featureFlagService)
+                                    simplifiedProductEditingEnabled: simplifiedProductEditingEnabled)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8837
⚠️ Depends on #8964 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is the **second** of 3 PRs to update how the new product screen is presented in the Simplified Product Editing experience. In this PR:

* When a new product is created, the status is set to `draft` (instead of `publish`).
* The navigation bar shows only a "Save" button for the new product (until it is saved).

The last PR will update what happens after the new product is saved.

### Changes

There are two significant parts to these changes:

* The `ProductFactory` methods for preparing new products now accept a `status` argument, to support creating new products as a draft when the feature flag is enabled.
* `ProductFormViewModel.actionButtons` is updated to always return a "Save" button (and only a save button) when the feature flag is enabled while adding new products.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Go to the Products tab to add a new product.
3. Select a product type.
4. In the new product screen, confirm you see only "Cancel" and "Save" buttons in the navigation bar.
5. Tap "Save" and confirm the product is saved as a draft.
6. Once the product is saved remotely, confirm you see Preview and Publish buttons and the "more" menu in the navigation bar.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-23 at 22 00 39](https://user-images.githubusercontent.com/8658164/221042520-65f30093-87db-4e27-8a34-4ebaa371ad4d.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-23 at 22 14 13](https://user-images.githubusercontent.com/8658164/221042805-63208fdc-b353-44b1-982f-5591f5bb2ef0.png)


https://user-images.githubusercontent.com/8658164/221042842-dea7d55d-6f40-4f5e-be71-46e3dfc4a99a.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
