### PR TITLE
SPE: Dismiss modal and navigate to product details after new product is saved

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -430,7 +430,7 @@ private extension DashboardViewController {
     private func startAddProductFlow() {
         guard let announcementView, let navigationController else { return }
         let coordinator = AddProductCoordinator(siteID: siteID, sourceView: announcementView, sourceNavigationController: navigationController)
-        coordinator.onProductCreated = { [weak self] in
+        coordinator.onProductCreated = { [weak self] _ in
             guard let self else { return }
             self.viewModel.announcementViewModel = nil // Remove the products onboarding banner
             Task {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -31,7 +31,7 @@ final class AddProductCoordinator: Coordinator {
 
     /// Assign this closure to be notified when a new product is saved remotely
     ///
-    var onProductCreated: () -> Void = {}
+    var onProductCreated: (Product) -> Void = { _ in }
 
     init(siteID: Int64,
          sourceBarButtonItem: UIBarButtonItem,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -473,10 +473,10 @@ extension ProductFormViewModel {
                     }
                     self.resetProduct(data.product)
                     self.resetPassword(data.password)
-                    onCompletion(.success(data.product))
                     self.replaceProductID(productIDBeforeSave: productIDBeforeSave)
                     self.saveProductImagesWhenNoneIsPendingUploadAnymore()
                     self.onProductCreated(data.product.product)
+                    onCompletion(.success(data.product))
                 }
             }
         case .edit:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -195,7 +195,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     /// Assign this closure to be notified when a new product is saved remotely
     ///
-    var onProductCreated: () -> Void = {}
+    var onProductCreated: (Product) -> Void = { _ in }
 
     init(product: EditableProductModel,
          formType: ProductFormType,
@@ -476,7 +476,7 @@ extension ProductFormViewModel {
                     onCompletion(.success(data.product))
                     self.replaceProductID(productIDBeforeSave: productIDBeforeSave)
                     self.saveProductImagesWhenNoneIsPendingUploadAnymore()
-                    self.onProductCreated()
+                    self.onProductCreated(data.product.product)
                 }
             }
         case .edit:

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -282,6 +282,15 @@ private extension ProductsViewController {
         } else {
             fatalError("No source view for adding a product")
         }
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing) {
+            coordinatingController.onProductCreated = { [weak self] product in
+                navigationController.dismiss(animated: true) {
+                    self?.didSelectProduct(product: product)
+                }
+            }
+        }
+
         coordinatingController.start()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -284,8 +284,8 @@ private extension ProductsViewController {
         }
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing) {
-            coordinatingController.onProductCreated = { [weak self] product in
-                navigationController.dismiss(animated: true) {
+            coordinatingController.onProductCreated = { product in
+                navigationController.dismiss(animated: true) { [weak self] in
                     self?.didSelectProduct(product: product)
                 }
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -610,7 +610,7 @@ final class ProductFormViewModelTests: XCTestCase {
         var isCallbackCalled = false
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let viewModel = createViewModel(product: Product.fake(), formType: .add, stores: stores)
-        viewModel.onProductCreated = {
+        viewModel.onProductCreated = { _ in
             isCallbackCalled = true
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8837
⚠️ Depends on #8964, #8965 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is the **last** of 3 PRs to update how the new product screen is presented in the Simplified Product Editing experience. In this PR:

* After the new product is saved, it dismisses the modal and navigates to product details to edit/publish the product.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Go to the Products tab and add a new product.
3. Save the new product. Confirm the modal is automatically dismissed and you are navigated to the product details, where you can edit or publish the product as normal.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

iPhone:

https://user-images.githubusercontent.com/8658164/221053939-fb0b79b3-2ee2-4932-b3bc-26afbaa60e55.mp4



iPad:


https://user-images.githubusercontent.com/8658164/221053532-270df01a-c2d3-46db-afc9-5df61d0d249c.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
