### PR TITLE
Disable profiler questions feature flag to reduce friction in the store creation flow

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -48,7 +48,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .storeCreationM2WithInAppPurchasesEnabled:
             return false
         case .storeCreationM3Profiler:
-            return true
+            return false
         case .justInTimeMessagesOnDashboard:
             return true
         case .systemStatusReportInSupportRequest:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8968 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

From pe5sF9-1cC-p2:

> Given that the new profiler endpoint will be worked on early March, we have decided to remove the user profiler questions from the store creation flow (just because it adds a friction point to users and the user would need to complete these questions again from the web to mark this task as completed)

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR disabled the profiler questions feature flag to hide the 3 profiler steps, since we can't use these data to configure the store without the API.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in if needed
- Go to the Menu tab, and tap `Switch store`
- On the store picker, tap `+ Add a store`
- Tap `Create a new store` --> the domain selector should be shown with a placeholder image
- Enter some store name and tap `Continue` --> the domain selector should be shown instead of the profiler questions

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

store name --> | domain selector
-- | --
<img src="https://user-images.githubusercontent.com/1945542/221071688-284a70de-c7f2-49db-83f1-30cd244e9f00.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1945542/221071693-ef2b115c-e2d5-417a-96ab-d4b580ae8c7f.png" width="300" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
