### PR TITLE
REST API: Update Jetpack benefit modal for non-Jetpack sites

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsView.swift
@@ -64,9 +64,16 @@ struct JetpackBenefitsView: View {
                     JetpackBenefitItem(title: Localization.analyticsBenefitTitle,
                                        subtitle: Localization.analyticsBenefitSubtitle,
                                        icon: .analyticsImage)
-                    JetpackBenefitItem(title: Localization.userProfilesBenefitTitle,
-                                       subtitle: Localization.userProfilesBenefitSubtitle,
-                                       icon: .multipleUsersImage)
+                    if viewModel.isJetpackCPSite {
+                        JetpackBenefitItem(title: Localization.userProfilesBenefitTitle,
+                                           subtitle: Localization.userProfilesBenefitSubtitle,
+                                           icon: .multipleUsersImage)
+                    } else {
+                        #warning("TODO-8912: update icon for multiple stores")
+                        JetpackBenefitItem(title: Localization.multiStoresBenefitTitle,
+                                           subtitle: Localization.multiStoresBenefitSubtitle,
+                                           icon: .multipleUsersImage)
+                    }
                 }.padding([.leading, .trailing], insets: Layout.horizontalPaddingInBenefitList)
 
                 Spacer().frame(height: Layout.verticalSpacing)
@@ -77,7 +84,7 @@ struct JetpackBenefitsView: View {
             // Actions
             VStack(spacing: Layout.spacingBetweenCTAs) {
                 // Primary Button to install Jetpack
-                Button(Localization.installAction) {
+                Button(viewModel.isJetpackCPSite ? Localization.installAction : Localization.loginAction) {
                     Task { @MainActor in
                         isPrimaryButtonLoading = true
                         let result = await viewModel.fetchJetpackUser()
@@ -127,6 +134,11 @@ private extension JetpackBenefitsView {
         static let userProfilesBenefitSubtitle =
         NSLocalizedString("Allow multiple users to access WooCommerce Mobile.",
                           comment: "Subtitle of user profiles as part of Jetpack benefits.")
+        static let multiStoresBenefitTitle = NSLocalizedString("Multiple Stores", comment: "Title of multiple stores as part of Jetpack benefits.")
+        static let multiStoresBenefitSubtitle =
+        NSLocalizedString("Get access to all of your WooCommerce stores.",
+                          comment: "Subtitle of multiple stores as part of Jetpack benefits.")
+        static let loginAction = NSLocalizedString("Log In to Continue", comment: "Button to start the WPCom login flow from the Jetpack benefits screen.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -41,6 +41,8 @@ final class SettingsViewController: UIViewController {
 
     private let stores: StoresManager
 
+    private var jetpackSetupCoordinator: JetpackSetupCoordinator?
+
     init(viewModel: ViewModel = SettingsViewModel(), stores: StoresManager = ServiceLocator.stores) {
         self.viewModel = viewModel
         self.stores = stores
@@ -368,9 +370,11 @@ private extension SettingsViewController {
 
         ServiceLocator.analytics.track(event: .jetpackInstallButtonTapped(source: .settings))
 
-        if site.isNonJetpackSite {
-            #warning("TODO: handle jetpack setup with application password")
-            return
+        if site.isNonJetpackSite, let navigationController {
+            let coordinator = JetpackSetupCoordinator(site: site,
+                                                      navigationController: navigationController)
+            self.jetpackSetupCoordinator = coordinator
+            return coordinator.showBenefitModal()
         }
         let installJetpackController = JCPJetpackInstallHostingController(siteID: site.siteID, siteURL: site.url, siteAdminURL: site.adminURL)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8912 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the wording for the Jetpack benefit modal to make it suitable for non-Jetpack sites:
- The last benefit "User Profiles" has been updated to "Multiple Stores".
- The primary CTA has been updated to "Log in to Continue".

Also, as discussed in a thread [pe5sF9-19y-p2#comment-1765] - we decided to show the Jetpack benefit banner from the entry point in the Settings screen as well. This PR updates that part for non-Jetpack sites.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Make sure that you have access to a site with WooCommerce and no Jetpack.
- Log out of the app or skip onboarding if needed.
- Tap "Enter your site address" on the prologue screen and proceed with the address of your test site.
- Log in with the credentials of a shop manager or admin user.
- When the login completes, tap the Jetback benefit banner at the bottom of the Dashboard screen.
- The Jetpack benefit modal should have the correct wording like the mockup in pe5sF9-1c9-p2. The icon will need to be updated later when we get the design for it.
- Switch to Menu tap and select the Settings CTA.
- Select Install Jetpack row, the Jetpack benefit modal should be presented.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| JCP sites | Non-Jetpack sites |
| ----- | ----- | 
| <img src="https://user-images.githubusercontent.com/5533851/221117887-cd6fa7ac-0ee6-472d-8de3-82c960294bba.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/221117969-0d04c637-615e-42c3-b6b2-1ffbd054e4e4.png" width=320 /> |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.