### PR TITLE
Switch off feature flag for `productMultiSelectionM1` temporarily

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -34,7 +34,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .loginMagicLinkEmphasisM2:
             return true
         case .productMultiSelectionM1:
-            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
+            return false
         case .promptToEnableCodInIppOnboarding:
             return true
         case .searchProductsBySKU:


### PR DESCRIPTION
Part of: #8888
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Switches off the current work in progress for `productMultiSelectionM1` to avoid friction while UI work is done separately.

## Testing instructions
- Going to Orders > + > "+ Add Product" should show the default single-selection product UI

<img width=400 src="https://user-images.githubusercontent.com/3812076/221139790-3eb558dd-09dc-4f5e-9c1a-40c23111c885.png">
