### PR TITLE
Beta Fix: Disable Support Request Feature

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -62,7 +62,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .domainSettings:
             return true
         case .supportRequests:
-            return true
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .simplifyProductEditing:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,7 +11,6 @@
 - [Internal] A new tag has been added for Zendesk for users authenticated with application password. [https://github.com/woocommerce/woocommerce-ios/pull/8850]
 - [Internal] Failures in the logged-out state are now tracked with anonymous ID. [https://github.com/woocommerce/woocommerce-ios/pull/8861]
 - [*] Fix: Fixed a crash when switching away from the Products tab. [https://github.com/woocommerce/woocommerce-ios/pull/8874]
-- [**] Support Requests: We have added a new way of Contacting Support with an improved UX. [https://github.com/woocommerce/woocommerce-ios/pull/8886]
 
 12.3
 -----


### PR DESCRIPTION
## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is a fix for the 12.4 release, to disable the "Support Request" feature (reverting the changes from https://github.com/woocommerce/woocommerce-ios/pull/8886).

Internal ref: pe5pgL-2dS-p2#comment-1850 / p5T066-3SZ-p2

cc @spencertransier @Ecarrion 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.