### PR TITLE
SPE: Update placeholder when no product category selected

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -590,7 +590,7 @@ private extension DefaultProductFormTableViewModel {
                                                                    comment: "Placeholder of the Product Short Description row on Product main screen")
 
         // Categories
-        static let categoriesPlaceholder = NSLocalizedString("Uncategorized",
+        static let categoriesPlaceholder = NSLocalizedString("No category selected",
                                                              comment: "Placeholder of the Product Categories row on Product main screen")
         // Tags
         static let tagsPlaceholder = NSLocalizedString("No tags",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8947
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This updates the Categories placeholder in the product detail screen for Simplified Product Editing. When no categories are selected, it displays "No category selected" instead of "Uncategorized."

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Go to the Products tab and add a new product.
3. In the product detail screen, confirm the "Categories" row has the subtitle "No category selected."

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![image](https://user-images.githubusercontent.com/8658164/221158074-14f68a0c-a330-407e-bf6f-6da92d8a0c1e.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-24 at 10 33 40](https://user-images.githubusercontent.com/8658164/221158163-c07eb137-0ce3-4a6f-9861-a77674d65bda.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
