### PR TITLE
SPE: Remove downloadable setting from product settings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -261,14 +261,15 @@ private extension DefaultProductFormTableViewModel {
         let title = Localization.productTypeTitle
 
         let details: String
+        let hideDownloadableProductType = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing)
         switch product.productType {
         case .simple:
-            switch (product.downloadable, product.virtual) {
-            case (true, _):
+            switch (product.downloadable, product.virtual, hideDownloadableProductType) {
+            case (true, _, false):
                 details = Localization.downloadableProductType
-            case (false, true):
+            case (_, true, _):
                 details = Localization.virtualProductType
-            case (false, false):
+            case (_, false, _):
                 details = Localization.physicalProductType
             }
         case .custom(let customProductType):

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -51,14 +51,15 @@ enum ProductSettingsRows {
             }
 
             let details: String
+            let hideDownloadableProductType = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing)
             switch settings.productType {
             case .simple:
-                switch (settings.downloadable, settings.virtual) {
-                case (true, _):
+                switch (settings.downloadable, settings.virtual, hideDownloadableProductType) {
+                case (true, _, false):
                     details = Localization.downloadableProductType
-                case (false, true):
+                case (_, true, _):
                     details = Localization.virtualProductType
-                case (false, false):
+                case (_, false, _):
                     details = Localization.physicalProductType
                 }
             case .custom(let customProductType):

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -8,7 +8,7 @@ protocol ProductSettingsSectionMediator {
     var title: String { get }
     var rows: [ProductSettingsRowMediator] { get }
 
-    init(_ settings: ProductSettings)
+    init(_ settings: ProductSettings, isDownloadableSettingEnabled: Bool)
 }
 
 // MARK: - Sections declaration for Product Settings
@@ -20,7 +20,7 @@ enum ProductSettingsSections {
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings) {
+        init(_ settings: ProductSettings, isDownloadableSettingEnabled: Bool = false) {
             rows = [ProductSettingsRows.ProductType(settings)]
         }
     }
@@ -31,13 +31,13 @@ enum ProductSettingsSections {
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings) {
+        init(_ settings: ProductSettings, isDownloadableSettingEnabled: Bool) {
             if settings.productType == .simple {
                 let tempRows: [ProductSettingsRowMediator?] = [ProductSettingsRows.Status(settings),
                         ProductSettingsRows.Visibility(settings),
                         ProductSettingsRows.CatalogVisibility(settings),
                         ProductSettingsRows.VirtualProduct(settings),
-                        ProductSettingsRows.DownloadableProduct(settings)
+                        isDownloadableSettingEnabled ? ProductSettingsRows.DownloadableProduct(settings) : nil
                 ]
                 rows = tempRows.compactMap { $0 }
             } else {
@@ -54,7 +54,7 @@ enum ProductSettingsSections {
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings) {
+        init(_ settings: ProductSettings, isDownloadableSettingEnabled: Bool = false) {
             rows = [ProductSettingsRows.ReviewsAllowed(settings),
             ProductSettingsRows.Slug(settings),
             ProductSettingsRows.PurchaseNote(settings),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
@@ -21,7 +21,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
                                        downloadable: false)
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings)
+        let section = ProductSettingsSections.PublishSettings(settings, isDownloadableSettingEnabled: true)
 
         // Then
         XCTAssertNil(section.rows.first(where: {
@@ -44,7 +44,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
                                        downloadable: false)
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings)
+        let section = ProductSettingsSections.PublishSettings(settings, isDownloadableSettingEnabled: true)
 
         // Then
         XCTAssertNotNil(section.rows.first(where: {
@@ -67,7 +67,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
                                         downloadable: false)
 
           // When
-         let section = ProductSettingsSections.PublishSettings(settings)
+        let section = ProductSettingsSections.PublishSettings(settings, isDownloadableSettingEnabled: true)
 
           // Then
          XCTAssertNil(section.rows.first(where: {
@@ -90,11 +90,34 @@ final class ProductSettingsSectionsTests: XCTestCase {
                                         downloadable: false)
 
           // When
-         let section = ProductSettingsSections.PublishSettings(settings)
+          let section = ProductSettingsSections.PublishSettings(settings, isDownloadableSettingEnabled: true)
 
           // Then
          XCTAssertNotNil(section.rows.first(where: {
              $0 is ProductSettingsRows.DownloadableProduct
          }))
      }
+
+    func test_given_a_simple_product_then_it_does_not_show_the_downloadable_product_option_when_it_is_disabled() {
+       // Given
+       let settings = ProductSettings(productType: .simple,
+                                      status: .draft,
+                                      featured: false,
+                                      password: nil,
+                                      catalogVisibility: .catalog,
+                                      virtual: false,
+                                      reviewsAllowed: false,
+                                      slug: "",
+                                      purchaseNote: nil,
+                                      menuOrder: 0,
+                                      downloadable: false)
+
+        // When
+        let section = ProductSettingsSections.PublishSettings(settings, isDownloadableSettingEnabled: false)
+
+        // Then
+       XCTAssertNil(section.rows.first(where: {
+           $0 is ProductSettingsRows.DownloadableProduct
+       }))
+   }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8936
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The is the **first** of two PRs to update how downloadable files work in Simplified Product Editing. This PR makes the following changes to Product Settings:

* Removes the “Downloadable product” setting in Product Settings. (The product's `downloadable` property will depend instead on whether it has downloadable files.)
* Simple products always have a “Physical” or “Virtual” product type. (Previously the product type changed to "Downloadable" when the downloadable setting was enabled.)

The next PR will complete the changes, updating the behavior for the "Downloadable files" section in product details.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Go to products and create or edit a product.
3. Open the product settings and confirm no "Downloadable product" setting appears.
4. Go back to the product list and select a product with downloadable files.
5. Open the product settings and confirm the product type is "Physical" or "Virtual" (not "Downloadable").

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-24 at 17 02 12](https://user-images.githubusercontent.com/8658164/221241653-f0d95058-7d0b-4c8b-827e-c561f6d844a6.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-24 at 16 59 30](https://user-images.githubusercontent.com/8658164/221241625-48d92b59-6836-4ae7-8928-b382cfa539ae.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
