### PR TITLE
SPE: Always include Downloadable Files action for simple products

### DIFF
--- a/Fakes/Fakes/Products/ProductFactory.swift
+++ b/Fakes/Fakes/Products/ProductFactory.swift
@@ -33,6 +33,7 @@ public enum ProductFactory {
                             regularPrice: "10.0",
                             salePrice: "5.0",
                             downloadable: true,
+                            downloads: [.fake()],
                             downloadLimit: 100,
                             downloadExpiry: 200,
                             taxStatusKey: ProductTaxStatus.taxable.rawValue,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetAction.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetAction.swift
@@ -11,6 +11,7 @@ enum ProductFormBottomSheetAction {
     case editSKU
     case editLinkedProducts
     case editReviews
+    case editDownloadableFiles
     case convertToVariable
 
     init?(productFormAction: ProductFormEditAction) {
@@ -31,6 +32,8 @@ enum ProductFormBottomSheetAction {
             self = .editLinkedProducts
         case .reviews:
             self = .editReviews
+        case .downloadableFiles:
+            self = .editDownloadableFiles
         case .convertToVariable:
             self = .convertToVariable
         default:
@@ -66,6 +69,9 @@ extension ProductFormBottomSheetAction {
         case .editReviews:
             return NSLocalizedString("Reviews",
                                      comment: "Title of the product form bottom sheet action for reviews.")
+        case .editDownloadableFiles:
+            return NSLocalizedString("Downloadable files",
+                                     comment: "Title of the product form bottom sheet action for editing downloadable files.")
         case .convertToVariable:
             return NSLocalizedString("Add product variations",
                                      comment: "Title of the product form bottom sheet action for switching to variable product type.")
@@ -98,6 +104,9 @@ extension ProductFormBottomSheetAction {
         case .editReviews:
             return NSLocalizedString("Get your first reviews",
                                      comment: "Subtitle of the product form bottom sheet action for reviews.")
+        case .editDownloadableFiles:
+            return NSLocalizedString("Include downloadable files with purchases",
+                                     comment: "Subtitle of the product form bottom sheet action for editing downloadable files.")
         case .convertToVariable:
             return NSLocalizedString("Add sizes, colors, or other options",
                                      comment: "Subtitle of the product form bottom sheet action for switching to variable product type.")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -63,6 +63,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
     private let isEmptyReviewsOptionHidden: Bool
     private let isProductTypeActionEnabled: Bool
     private let isCategoriesActionAlwaysEnabled: Bool
+    private let isDownloadableFilesSettingBased: Bool
 
     // TODO: Remove default parameter
     init(product: EditableProductModel,
@@ -74,6 +75,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
          isEmptyReviewsOptionHidden: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing),
          isProductTypeActionEnabled: Bool = !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing),
          isCategoriesActionAlwaysEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing),
+         isDownloadableFilesSettingBased: Bool = !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing),
          variationsPrice: VariationsPrice = .unknown) {
         self.product = product
         self.formType = formType
@@ -86,6 +88,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         self.isEmptyReviewsOptionHidden = isEmptyReviewsOptionHidden
         self.isProductTypeActionEnabled = isProductTypeActionEnabled
         self.isCategoriesActionAlwaysEnabled = isCategoriesActionAlwaysEnabled
+        self.isDownloadableFilesSettingBased = isDownloadableFilesSettingBased
     }
 
     /// Returns an array of actions that are visible in the product form primary section.
@@ -152,7 +155,7 @@ private extension ProductFormActionsFactory {
         let shouldShowReviewsRow = product.reviewsAllowed
         let canEditProductType = formType != .add && editable
         let shouldShowShippingSettingsRow = product.isShippingEnabled()
-        let shouldShowDownloadableProduct = product.downloadable
+        let shouldShowDownloadableProduct = isDownloadableFilesSettingBased ? product.downloadable : true
         let canEditInventorySettingsRow = editable && product.hasIntegerStockQuantity
 
         let actions: [ProductFormEditAction?] = [
@@ -297,7 +300,11 @@ private extension ProductFormActionsFactory {
             return (product.upsellIDs.count > 0 || product.crossSellIDs.count > 0)
         // Downloadable files. Only core product types for downloadable files are able to handle downloadable files.
         case .downloadableFiles:
-            return product.downloadable
+            if isDownloadableFilesSettingBased {
+                return product.downloadable
+            } else {
+                return product.downloadableFiles.isNotEmpty
+            }
         case .shortDescription:
             return product.shortDescription.isNilOrEmpty == false
         // Affiliate products only.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -787,6 +787,9 @@ private extension ProductFormViewController {
                                                                         case .editReviews:
                                                                             ServiceLocator.analytics.track(.productDetailViewReviewsTapped)
                                                                             self?.showReviews()
+                                                                        case .editDownloadableFiles:
+                                                                            ServiceLocator.analytics.track(.productDetailViewDownloadableFilesTapped)
+                                                                            self?.showDownloadableFiles()
                                                                         case .convertToVariable:
                                                                             self?.convertToVariableType()
                                                                         }
@@ -1547,7 +1550,8 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
     func showDownloadableFiles() {
-        guard let product = product as? EditableProductModel, product.downloadable  else {
+        let isDownloadableFilesActionEnabled = product.downloadable || ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing)
+        guard let product = product as? EditableProductModel, isDownloadableFilesActionEnabled  else {
             return
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -11,7 +11,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isConvertToVariableOptionEnabled: false, isEmptyReviewsOptionHidden: false)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -38,7 +38,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isConvertToVariableOptionEnabled: false, isEmptyReviewsOptionHidden: false)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -65,7 +65,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isConvertToVariableOptionEnabled: false)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -91,7 +91,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isConvertToVariableOptionEnabled: false)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -116,7 +116,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isConvertToVariableOptionEnabled: false, isEmptyReviewsOptionHidden: false)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -143,7 +143,60 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isConvertToVariableOptionEnabled: false, isEmptyReviewsOptionHidden: false)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
+                                                                       .reviews,
+                                                                       .inventorySettings(editable: true),
+                                                                       .categories(editable: true),
+                                                                       .tags(editable: true),
+                                                                       .downloadableFiles(editable: true),
+                                                                       .shortDescription(editable: true),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: true)]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
+        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
+    }
+
+    func test_view_model_for_simple_product_with_downloadable_files_action_not_setting_based_and_has_no_files() {
+        // Arrange
+        let product = Fixtures.virtualSimpleProduct
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isDownloadableFilesSettingBased: false)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
+                                                                       .reviews,
+                                                                       .inventorySettings(editable: true),
+                                                                       .categories(editable: true),
+                                                                       .tags(editable: true),
+                                                                       .shortDescription(editable: true),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: true)]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editDownloadableFiles]
+        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
+    }
+
+    func test_view_model_for_simple_product_with_downloadable_files_action_not_setting_based_and_has_files() {
+        // Arrange
+        let product = Fixtures.virtualSimpleProduct.copy(downloadable: true, downloads: [.fake()])
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isDownloadableFilesSettingBased: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -170,7 +223,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isConvertToVariableOptionEnabled: false, isEmptyReviewsOptionHidden: false)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -196,7 +249,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isEmptyReviewsOptionHidden: false, isCategoriesActionAlwaysEnabled: false)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -219,7 +272,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isEmptyReviewsOptionHidden: false, isCategoriesActionAlwaysEnabled: false)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -241,7 +294,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isEmptyReviewsOptionHidden: false, isCategoriesActionAlwaysEnabled: false)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -267,7 +320,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isEmptyReviewsOptionHidden: false, isCategoriesActionAlwaysEnabled: false)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -294,7 +347,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isEmptyReviewsOptionHidden: false, isCategoriesActionAlwaysEnabled: false)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -316,7 +369,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = ProductFormActionsFactory(product: model, formType: .edit, isEmptyReviewsOptionHidden: false, isCategoriesActionAlwaysEnabled: false)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
@@ -602,5 +655,30 @@ private extension ProductFormActionsFactoryTests {
 
         // Non-core product, missing short description/categories/tags
         static let nonCoreProductWithPrice = nonCoreProductWithoutPrice.copy(regularPrice: "2")
+
+        // Factory with default feature settings
+        static func actionsFactory(product: EditableProductModel,
+                                   formType: ProductFormType,
+                                   addOnsFeatureEnabled: Bool = false,
+                                   isLinkedProductsPromoEnabled: Bool = false,
+                                   isAddOptionsButtonEnabled: Bool = false,
+                                   isConvertToVariableOptionEnabled: Bool = false,
+                                   isEmptyReviewsOptionHidden: Bool = false,
+                                   isProductTypeActionEnabled: Bool = true,
+                                   isCategoriesActionAlwaysEnabled: Bool = false,
+                                   isDownloadableFilesSettingBased: Bool = true,
+                                   variationsPrice: ProductFormActionsFactory.VariationsPrice = .unknown) -> ProductFormActionsFactory {
+            ProductFormActionsFactory(product: product,
+                                      formType: formType,
+                                      addOnsFeatureEnabled: addOnsFeatureEnabled,
+                                      isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
+                                      isAddOptionsButtonEnabled: isAddOptionsButtonEnabled,
+                                      isConvertToVariableOptionEnabled: isConvertToVariableOptionEnabled,
+                                      isEmptyReviewsOptionHidden: isEmptyReviewsOptionHidden,
+                                      isProductTypeActionEnabled: isProductTypeActionEnabled,
+                                      isCategoriesActionAlwaysEnabled: isCategoriesActionAlwaysEnabled,
+                                      isDownloadableFilesSettingBased: isDownloadableFilesSettingBased,
+                                      variationsPrice: variationsPrice)
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -603,6 +603,42 @@ final class ProductFormViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(isCallbackCalled)
     }
+
+    func test_updateDownloadableFiles_does_not_change_downloadable_when_not_simplifiedProductEditingEnabled() {
+        // Given
+        let product = Product.fake().copy(downloadable: true, downloads: [.fake()])
+        let viewModel = createViewModel(product: product, formType: .edit, simplifiedProductEditingEnabled: false)
+
+        // When
+        viewModel.updateDownloadableFiles(downloadableFiles: [], downloadLimit: 0, downloadExpiry: 0)
+
+        // Then
+        XCTAssertTrue(viewModel.productModel.downloadable)
+    }
+
+    func test_updateDownloadableFiles_sets_downloadable_to_true_when_downloadable_files_added_and_simplifiedProductEditingEnabled() {
+        // Given
+        let product = Product.fake().copy(downloadable: false, downloads: [])
+        let viewModel = createViewModel(product: product, formType: .edit, simplifiedProductEditingEnabled: true)
+
+        // When
+        viewModel.updateDownloadableFiles(downloadableFiles: [.fake()], downloadLimit: 0, downloadExpiry: 0)
+
+        // Then
+        XCTAssertTrue(viewModel.productModel.downloadable)
+    }
+
+    func test_updateDownloadableFiles_sets_downloadable_to_false_when_downloadable_files_removed_and_simplifiedProductEditingEnabled() {
+        // Given
+        let product = Product.fake().copy(downloadable: false, downloads: [.fake()])
+        let viewModel = createViewModel(product: product, formType: .edit, simplifiedProductEditingEnabled: true)
+
+        // When
+        viewModel.updateDownloadableFiles(downloadableFiles: [], downloadLimit: 0, downloadExpiry: 0)
+
+        // Then
+        XCTAssertFalse(viewModel.productModel.downloadable)
+    }
 }
 
 private extension ProductFormViewModelTests {
@@ -610,7 +646,7 @@ private extension ProductFormViewModelTests {
                          formType: ProductFormType,
                          stores: StoresManager = ServiceLocator.stores,
                          analytics: Analytics = ServiceLocator.analytics,
-                         featureFlagService: FeatureFlagService = MockFeatureFlagService()) -> ProductFormViewModel {
+                         simplifiedProductEditingEnabled: Bool = false) -> ProductFormViewModel {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         return ProductFormViewModel(product: model,
@@ -618,6 +654,6 @@ private extension ProductFormViewModelTests {
                                     productImageActionHandler: productImageActionHandler,
                                     stores: stores,
                                     analytics: analytics,
-                                    featureFlagService: featureFlagService)
+                                    simplifiedProductEditingEnabled: simplifiedProductEditingEnabled)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8936
⚠️ Depends on #8984 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The is the **second** of two PRs to update how downloadable files work in Simplified Product Editing. This PR makes the following changes to Product Details:

* Simple products always have a “Downloadable files” action available:
   * If the product has no downloadable files, "Downloadable files" is in the “Add more details” menu.
   * If the product has downloadable files, "Downloadable files" appears in the product details.
   * In the background (product properties) the `downloadable` property is updated according to whether the product has any downloadable files.

Previously (and still when the feature flag is disabled) the "Downloadable files" action is always and only available when the product is marked as "Downloadable" in Product Settings.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Go to products and create or edit a simple product.
3. Select "Add more details" and confirm you see a "Downloadable files" option.
4. Select "Downloadable files" and upload one or more files.
5. Tap "Done" and confirm the "Downloadable files" section appears in product details.
6. Delete the files you uploaded and confirm the "Downloadable files" section is removed and shows in the "Add more details" menu again.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### New behavior:

https://user-images.githubusercontent.com/8658164/221237882-375e6fef-fab5-46be-a85a-5a2974bcd0f1.mp4

### With feature flag disabled:

https://user-images.githubusercontent.com/8658164/221237988-027e211a-6054-4950-ad68-a1223cdf5d64.mp4




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
