### PR TITLE
[Product Multi-selection] Adapt "done" button configuration for multiple products selection

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -355,6 +355,8 @@ private extension ProductSelectorView.Configuration {
         .init(multipleSelectionsEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1),
               searchHeaderBackgroundColor: .listBackground,
               prefersLargeTitle: false,
+              doneButtonTitleSingularFormat: Localization.doneButtonSingular,
+              doneButtonTitlePluralFormat: Localization.doneButtonPlural, 
               title: Localization.title,
               cancelButtonTitle: Localization.close,
               productRowAccessibilityHint: Localization.productRowAccessibilityHint,
@@ -363,6 +365,11 @@ private extension ProductSelectorView.Configuration {
     enum Localization {
         static let title = NSLocalizedString("Add Product", comment: "Title for the screen to add a product to an order")
         static let close = NSLocalizedString("Close", comment: "Text for the close button in the Add Product screen")
+        static let doneButtonSingular = NSLocalizedString("1 Product selected",
+                                                          comment: "Title of the action button at the bottom of the Select Products screen when one product is selected")
+        static let doneButtonPlural = NSLocalizedString("%1$d Products selected",
+                                                        comment: "Title of the action button at the bottom of the Select Products screen " +
+                                                        "when more than 1 item is selected, reads like: 5 Products selected")
         static let productRowAccessibilityHint = NSLocalizedString("Adds product to order.",
                                                                    comment: "Accessibility hint for selecting a product in the Add Product screen")
         static let variableProductRowAccessibilityHint = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -356,7 +356,7 @@ private extension ProductSelectorView.Configuration {
               searchHeaderBackgroundColor: .listBackground,
               prefersLargeTitle: false,
               doneButtonTitleSingularFormat: Localization.doneButtonSingular,
-              doneButtonTitlePluralFormat: Localization.doneButtonPlural, 
+              doneButtonTitlePluralFormat: Localization.doneButtonPlural,
               title: Localization.title,
               cancelButtonTitle: Localization.close,
               productRowAccessibilityHint: Localization.productRowAccessibilityHint,
@@ -366,7 +366,8 @@ private extension ProductSelectorView.Configuration {
         static let title = NSLocalizedString("Add Product", comment: "Title for the screen to add a product to an order")
         static let close = NSLocalizedString("Close", comment: "Text for the close button in the Add Product screen")
         static let doneButtonSingular = NSLocalizedString("1 Product selected",
-                                                          comment: "Title of the action button at the bottom of the Select Products screen when one product is selected")
+                                                          comment: "Title of the action button at the bottom of the Select Products screen " +
+                                                          "when one product is selected")
         static let doneButtonPlural = NSLocalizedString("%1$d Products selected",
                                                         comment: "Title of the action button at the bottom of the Select Products screen " +
                                                         "when more than 1 item is selected, reads like: 5 Products selected")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8938 

## Description:
This PR takes care of updating the "Done" button when product multi-selection is active, so reflects how many products a merchant has selected.

## Changes:
We add the existing `doneButtonTitleSingularFormat` and `doneButtonTitlePluralFormat` properties to the `OrderForm` configuration initializer

| Before | After |
|---|---|
<img width=450 src="https://user-images.githubusercontent.com/3812076/220635052-c5d7a276-1b8d-44f7-8fe8-37a3992cd1f9.png"> | <img width=450 src="https://user-images.githubusercontent.com/3812076/221359674-1984cf0e-0ee5-4567-9c62-9ff88ae46421.png"> |

## Testing instructions
- Go to Orders > `+` >  + `Add Product`
- Select various products
- See how the button updates from Done to `X Products selected`