### PR TITLE
[Product Multi-selection] Adapt UI tests for `test_create_new_order`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -72,6 +72,7 @@ struct ProductSelectorView: View {
                             ForEach(viewModel.productRows) { rowViewModel in
                                 createProductRow(rowViewModel: rowViewModel)
                                     .padding(Constants.defaultPadding)
+                                    .accessibilityIdentifier(Constants.productRowAccessibilityIdentifier)
                                 Divider().frame(height: Constants.dividerHeight)
                                     .padding(.leading, Constants.defaultPadding)
                             }
@@ -196,6 +197,7 @@ private extension ProductSelectorView {
         static let dividerHeight: CGFloat = 1
         static let defaultPadding: CGFloat = 16
         static let doneButtonAccessibilityIdentifier: String = "product-multiple-selection-done-button"
+        static let productRowAccessibilityIdentifier: String = "product-item"
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -83,6 +83,7 @@ struct ProductSelectorView: View {
                             }
                             .buttonStyle(PrimaryButtonStyle())
                             .padding(Constants.defaultPadding)
+                            .accessibilityIdentifier(Constants.doneButtonAccessibilityIdentifier)
                         }
                         if let variationListViewModel = variationListViewModel {
                             LazyNavigationLink(destination: ProductVariationSelector(
@@ -194,6 +195,7 @@ private extension ProductSelectorView {
     enum Constants {
         static let dividerHeight: CGFloat = 1
         static let defaultPadding: CGFloat = 16
+        static let doneButtonAccessibilityIdentifier: String = "product-multiple-selection-done-button"
     }
 
     enum Localization {

--- a/WooCommerce/UITestsFoundation/Screens/Orders/AddProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/AddProductScreen.swift
@@ -33,7 +33,7 @@ public final class AddProductScreen: ScreenObject {
     @discardableResult
     public func selectMultipleProducts(byName names: [String]) throws -> UnifiedOrderScreen {
         app.buttons.staticTexts[names[0]].tap()
-        // TODO: Add a wait, and a second product
+        // TODO: Add further scenarios in next iterations: https://github.com/woocommerce/woocommerce-ios/issues/8997
         if doneButton.exists {
             doneButton.tap()
         }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/AddProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/AddProductScreen.swift
@@ -31,9 +31,11 @@ public final class AddProductScreen: ScreenObject {
     /// Selects multiple products from the list.
     /// - Returns: Unified Order screen object.
     @discardableResult
-    public func selectMultipleProducts(byName names: [String]) throws -> UnifiedOrderScreen {
-        app.buttons.staticTexts[names[0]].tap()
-        // TODO: Add further scenarios in next iterations: https://github.com/woocommerce/woocommerce-ios/issues/8997
+    public func selectMultipleProducts(numberOfProductsToAdd: Int) throws -> UnifiedOrderScreen {
+        for product in 0..<numberOfProductsToAdd {
+            let products = app.buttons.matching(identifier: "product-item")
+            products.element(boundBy: product).tap()
+        }
         if doneButton.exists {
             doneButton.tap()
         }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/AddProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/AddProductScreen.swift
@@ -7,9 +7,15 @@ public final class AddProductScreen: ScreenObject {
         $0.searchFields["product-selector-search-bar"]
     }
 
+    private let doneButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["product-multiple-selection-done-button"]
+    }
+
+    private var doneButton: XCUIElement { doneButtonGetter(app) }
+
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [ searchBarGetter ],
+            expectedElementGetters: [ searchBarGetter, doneButtonGetter ],
             app: app
         )
     }
@@ -19,6 +25,18 @@ public final class AddProductScreen: ScreenObject {
     @discardableResult
     public func selectProduct(byName name: String) throws -> UnifiedOrderScreen {
         app.buttons.staticTexts[name].tap()
+        return try UnifiedOrderScreen()
+    }
+
+    /// Selects multiple products from the list.
+    /// - Returns: Unified Order screen object.
+    @discardableResult
+    public func selectMultipleProducts(byName names: [String]) throws -> UnifiedOrderScreen {
+        app.buttons.staticTexts[names[0]].tap()
+        // TODO: Add a wait, and a second product
+        if doneButton.exists {
+            doneButton.tap()
+        }
         return try UnifiedOrderScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -167,9 +167,9 @@ public final class UnifiedOrderScreen: ScreenObject {
 
     /// Select the first product from the addProductScreen
     /// - Returns: Unified Order screen object.
-    public func addProducts(byName names: [String]) throws -> UnifiedOrderScreen {
+    public func addProducts(numberOfProductsToAdd numberOfProducts: Int) throws -> UnifiedOrderScreen {
         return try openAddProductScreen()
-            .selectMultipleProducts(byName: [names[0]])
+            .selectMultipleProducts(numberOfProductsToAdd: numberOfProducts)
     }
 
     /// Adds minimal customer details on the Customer Details screen

--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -165,6 +165,13 @@ public final class UnifiedOrderScreen: ScreenObject {
             .selectProduct(byName: name)
     }
 
+    /// Select the first and second products from the addProductScreen
+    /// - Returns: Unified Order screen object.
+    public func addProducts(byName names: [String]) throws -> UnifiedOrderScreen {
+        return try openAddProductScreen()
+            .selectMultipleProducts(byName: [names[0], names[1]])
+    }
+
     /// Adds minimal customer details on the Customer Details screen
     /// - Returns: Unified Order screen object.
     public func addCustomerDetails(name: String) throws -> UnifiedOrderScreen {

--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -165,11 +165,11 @@ public final class UnifiedOrderScreen: ScreenObject {
             .selectProduct(byName: name)
     }
 
-    /// Select the first and second products from the addProductScreen
+    /// Select the first product from the addProductScreen
     /// - Returns: Unified Order screen object.
     public func addProducts(byName names: [String]) throws -> UnifiedOrderScreen {
         return try openAddProductScreen()
-            .selectMultipleProducts(byName: [names[0], names[1]])
+            .selectMultipleProducts(byName: [names[0]])
     }
 
     /// Adds minimal customer details on the Customer Details screen

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -32,7 +32,7 @@ final class OrdersTests: XCTestCase {
         try TabNavComponent().goToOrdersScreen()
             .startOrderCreation()
             .editOrderStatus()
-            .addProducts(byName: [products[0].name])
+            .addProducts(numberOfProductsToAdd: 1)
             .addCustomerDetails(name: order.billing.first_name)
             .addShipping(amount: order.shipping_lines[0].total, name: order.shipping_lines[0].method_title)
             .addFee(amount: order.fee_lines[0].amount)

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -32,7 +32,7 @@ final class OrdersTests: XCTestCase {
         try TabNavComponent().goToOrdersScreen()
             .startOrderCreation()
             .editOrderStatus()
-            .addProducts(byName: [products[0].name, products[1].name])
+            .addProducts(byName: [products[0].name])
             .addCustomerDetails(name: order.billing.first_name)
             .addShipping(amount: order.shipping_lines[0].total, name: order.shipping_lines[0].method_title)
             .addFee(amount: order.fee_lines[0].amount)

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -32,7 +32,7 @@ final class OrdersTests: XCTestCase {
         try TabNavComponent().goToOrdersScreen()
             .startOrderCreation()
             .editOrderStatus()
-            .addProduct(byName: products[0].name)
+            .addProducts(byName: [products[0].name, products[1].name])
             .addCustomerDetails(name: order.billing.first_name)
             .addShipping(amount: order.shipping_lines[0].total, name: order.shipping_lines[0].method_title)
             .addFee(amount: order.fee_lines[0].amount)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8932 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
As part of Speedy IPP' Product Multi-selection project (pdfdoF-2lX-p2) we're changing the UI related to adding products to an order, to accept multiple products rather than a single product. This change will make the `test_create_new_order` fail as now we're not immediately returning `UnifiedOrderScreen` after a product is selected, but we need to tap on a "Done" button to complete the product selection.

This PR modifies the UI test the bare minimum to make it pass with the new UI changes, we'll iterate over the flow in future UI tests as necessary.

| Before  | After |
|---|---|
| <img width=450 src="https://user-images.githubusercontent.com/3812076/221470424-dd7d216a-b3f1-4033-a736-6e7ea25ffe49.png"> | <img width=450 src="https://user-images.githubusercontent.com/3812076/221470595-ada52a48-0776-4fbe-b6bd-f8cd004f0500.png"> |

## Changes
- Added an accessibility identifier to the "Done" button that appears when we enable product multi-selection. This allows us to target the button element during UI tests.
- Added a new `selectMultipleProducts()` method to `AddProductScreen`, which selects multiple products from the list, and then taps the Done button
- Changed the OrderTests `addProduct()` for `addProducts()`, which accepts one or multiple inputs.

## Testing instructions
- CI should pass
- Switch the `productMultiSelectionM1` feature flag temporarily to `true`
- Run `rake mocks` in terminal
- In Xcode, switch to the `Test Plan: UITests`
- Search for `test_create_new_order` and run it. Test should pass.
- Try again with the `productMultiSelectionM1` feature flag switched to `false`, to confirm that works for single-selection as well.
