### PR TITLE
REST API: Check user role and show error modal if needed

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2068,6 +2068,39 @@ extension Networking.TopEarnerStatsItem {
     }
 }
 
+extension Networking.User {
+    public func copy(
+        localID: CopiableProp<Int64> = .copy,
+        siteID: CopiableProp<Int64> = .copy,
+        email: CopiableProp<String> = .copy,
+        username: CopiableProp<String> = .copy,
+        firstName: CopiableProp<String> = .copy,
+        lastName: CopiableProp<String> = .copy,
+        nickname: CopiableProp<String> = .copy,
+        roles: CopiableProp<[String]> = .copy
+    ) -> Networking.User {
+        let localID = localID ?? self.localID
+        let siteID = siteID ?? self.siteID
+        let email = email ?? self.email
+        let username = username ?? self.username
+        let firstName = firstName ?? self.firstName
+        let lastName = lastName ?? self.lastName
+        let nickname = nickname ?? self.nickname
+        let roles = roles ?? self.roles
+
+        return Networking.User(
+            localID: localID,
+            siteID: siteID,
+            email: email,
+            username: username,
+            firstName: firstName,
+            lastName: lastName,
+            nickname: nickname,
+            roles: roles
+        )
+    }
+}
+
 extension Networking.WCAnalyticsCustomer {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/User.swift
+++ b/Networking/Networking/Model/User.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Site-specific User representation
 ///
-public struct User: Decodable, GeneratedFakeable {
+public struct User: Decodable, GeneratedFakeable, GeneratedCopiable {
     /// Local ID of the account on the user's site
     ///
     public let localID: Int64

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+/// Hosting controller that wraps the `AdminRoleRequiredView`.
+final class AdminRoleRequiredHostingController: UIHostingController<AdminRoleRequiredView> {
+    init(onClose: @escaping () -> Void) {
+        super.init(rootView: AdminRoleRequiredView(viewModel: .init(), onClose: onClose))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTransparentNavigationBar()
+    }
+}
+
+/// Error view displayed when a user without admin role tries to install Jetpack.
+struct AdminRoleRequiredView: View {
+    let onClose: () -> Void
+
+    private let viewModel: AdminRoleRequiredViewModel
+
+    /// Provides the URL destination when the link button is tapped
+    private let linkDestinationURL = WooConstants.URLs.rolesAndPermissionsInfo.asURL()
+
+    @State private var showingLinkContent = false
+
+    init(viewModel: AdminRoleRequiredViewModel, onClose: @escaping () -> Void) {
+        self.viewModel = viewModel
+        self.onClose = onClose
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            // Username and role
+            VStack(spacing: 3) {
+                Text(viewModel.username)
+                    .font(.headline)
+                Text(viewModel.roleName)
+                    .font(.footnote)
+                    .foregroundColor(Color(uiColor: .textSubtle))
+            }
+            // Error image
+            Image(uiImage: .incorrectRoleError)
+                .padding(.vertical, Layout.imageVerticalPadding)
+
+            // Message
+            Text(Localization.description)
+                .multilineTextAlignment(.center)
+                .bodyStyle()
+
+            // Link button
+            Button(Localization.learnMore) {
+                showingLinkContent = true
+            }
+            .buttonStyle(LinkButtonStyle())
+            .padding(.top, Layout.linkTopPadding)
+
+            Spacer()
+            Button(Localization.retryAction) {
+                viewModel.reloadRoles()
+            }
+            .buttonStyle(PrimaryButtonStyle())
+        }
+        .padding(.horizontal, Layout.horizontalPadding)
+        .safariSheet(isPresented: $showingLinkContent, url: linkDestinationURL)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(Localization.cancelAction) {
+                    onClose()
+                }
+                .buttonStyle(TextButtonStyle())
+            }
+        }
+
+    }
+}
+
+extension AdminRoleRequiredView {
+    enum Layout {
+        static let horizontalPadding: CGFloat = 16
+        static let imageVerticalPadding: CGFloat = 16
+        static let linkTopPadding: CGFloat = 16
+    }
+    enum Localization {
+        static let description = NSLocalizedString(
+            "It looks like your user role doesn't allow you to install Jetpack.\n" +
+            "Please contact your administrator for help.",
+            comment: "Message on the error modal when a user without admin role tries to install Jetpack"
+        )
+        static let learnMore = NSLocalizedString(
+            "Learn more about roles and permissions",
+            comment: "Link on the error modal when a user without admin role tries to install Jetpack"
+        )
+        static let retryAction = NSLocalizedString(
+            "Retry",
+            comment: "Button to reload user role on the error modal when a user without admin role tries to install Jetpack"
+        )
+        static let cancelAction = NSLocalizedString(
+            "Cancel",
+            comment: "Button to dismiss the error modal when a user without admin role tries to install Jetpack"
+        )
+    }
+}
+
+struct AdminRoleRequiredView_Previews: PreviewProvider {
+    static var previews: some View {
+        AdminRoleRequiredView(viewModel: .init()) {}
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredView.swift
@@ -89,7 +89,7 @@ struct AdminRoleRequiredView: View {
                 Task { @MainActor in
                     isReloadingRoles = true
                     do {
-                        let gotSufficientRole = try await viewModel.reloadRoles()
+                        let gotSufficientRole = try await viewModel.checkIfUserGotSufficientRole()
                         if gotSufficientRole {
                             onSuccess()
                         } else {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredView.swift
@@ -59,7 +59,7 @@ struct AdminRoleRequiredView: View {
     }
 
     var body: some View {
-        VStack(spacing: 16) {
+        ScrollableVStack(padding: Layout.horizontalPadding, spacing: 16) {
             // Username and role
             VStack(spacing: 3) {
                 Text(viewModel.username)
@@ -103,7 +103,6 @@ struct AdminRoleRequiredView: View {
             }
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isReloadingRoles))
         }
-        .padding(.horizontal, Layout.horizontalPadding)
         .safariSheet(isPresented: $showingLinkContent, url: linkDestinationURL)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
@@ -113,7 +112,6 @@ struct AdminRoleRequiredView: View {
                 .buttonStyle(TextButtonStyle())
             }
         }
-        .scrollVerticallyIfNeeded()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredView.swift
@@ -113,6 +113,7 @@ struct AdminRoleRequiredView: View {
                 .buttonStyle(TextButtonStyle())
             }
         }
+        .scrollVerticallyIfNeeded()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredView.swift
@@ -2,8 +2,19 @@ import SwiftUI
 
 /// Hosting controller that wraps the `AdminRoleRequiredView`.
 final class AdminRoleRequiredHostingController: UIHostingController<AdminRoleRequiredView> {
-    init(onClose: @escaping () -> Void) {
-        super.init(rootView: AdminRoleRequiredView(viewModel: .init(), onClose: onClose))
+    private lazy var noticePresenter: DefaultNoticePresenter = {
+        let noticePresenter = DefaultNoticePresenter()
+        noticePresenter.presentingViewController = self
+        return noticePresenter
+    }()
+
+    init(siteID: Int64, onClose: @escaping () -> Void, onSuccess: @escaping () -> Void) {
+        super.init(rootView: AdminRoleRequiredView(viewModel: .init(siteID: siteID),
+                                                   onClose: onClose,
+                                                   onSuccess: onSuccess))
+        rootView.onShowingNotice = { [weak self] message in
+            self?.displayNotice(message: message)
+        }
     }
 
     @available(*, unavailable)
@@ -15,11 +26,21 @@ final class AdminRoleRequiredHostingController: UIHostingController<AdminRoleReq
         super.viewDidLoad()
         configureTransparentNavigationBar()
     }
+
+    private func displayNotice(message: String) {
+        let notice = Notice(title: message)
+        noticePresenter.enqueue(notice: notice)
+    }
 }
 
 /// Error view displayed when a user without admin role tries to install Jetpack.
 struct AdminRoleRequiredView: View {
+    /// Triggered when the user taps Cancel.
     let onClose: () -> Void
+    /// Triggered when the user taps Retry and their role is updated with the admin role.
+    let onSuccess: () -> Void
+    /// Triggered when an error needs to be displayed.
+    var onShowingNotice: (String) -> Void = { _ in }
 
     private let viewModel: AdminRoleRequiredViewModel
 
@@ -27,10 +48,14 @@ struct AdminRoleRequiredView: View {
     private let linkDestinationURL = WooConstants.URLs.rolesAndPermissionsInfo.asURL()
 
     @State private var showingLinkContent = false
+    @State private var isReloadingRoles = false
 
-    init(viewModel: AdminRoleRequiredViewModel, onClose: @escaping () -> Void) {
+    init(viewModel: AdminRoleRequiredViewModel,
+         onClose: @escaping () -> Void,
+         onSuccess: @escaping () -> Void) {
         self.viewModel = viewModel
         self.onClose = onClose
+        self.onSuccess = onSuccess
     }
 
     var body: some View {
@@ -61,9 +86,22 @@ struct AdminRoleRequiredView: View {
 
             Spacer()
             Button(Localization.retryAction) {
-                viewModel.reloadRoles()
+                Task { @MainActor in
+                    isReloadingRoles = true
+                    do {
+                        let gotSufficientRole = try await viewModel.reloadRoles()
+                        if gotSufficientRole {
+                            onSuccess()
+                        } else {
+                            onShowingNotice(Localization.insufficientRoleMessage)
+                        }
+                    } catch {
+                        onShowingNotice(Localization.retrieveErrorMessage)
+                    }
+                    isReloadingRoles = false
+                }
             }
-            .buttonStyle(PrimaryButtonStyle())
+            .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isReloadingRoles))
         }
         .padding(.horizontal, Layout.horizontalPadding)
         .safariSheet(isPresented: $showingLinkContent, url: linkDestinationURL)
@@ -75,7 +113,6 @@ struct AdminRoleRequiredView: View {
                 .buttonStyle(TextButtonStyle())
             }
         }
-
     }
 }
 
@@ -103,11 +140,22 @@ extension AdminRoleRequiredView {
             "Cancel",
             comment: "Button to dismiss the error modal when a user without admin role tries to install Jetpack"
         )
+        static let retrieveErrorMessage = NSLocalizedString(
+            "Unable to retrieve user roles.",
+            comment: "An error message shown when failing to retrieve information about user roles"
+        )
+        static let insufficientRoleMessage = NSLocalizedString(
+            "You are not authorized to install Jetpack",
+            comment: "An error message shown after the user retried checking their roles " +
+            "but they still don't have enough permission to install Jetpack"
+        )
     }
 }
 
 struct AdminRoleRequiredView_Previews: PreviewProvider {
     static var previews: some View {
-        AdminRoleRequiredView(viewModel: .init()) {}
+        AdminRoleRequiredView(viewModel: .init(siteID: 123),
+                              onClose: {},
+                              onSuccess: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredViewModel.swift
@@ -23,11 +23,10 @@ final class AdminRoleRequiredViewModel {
     func reloadRoles() async throws -> Bool {
         try await withCheckedThrowingContinuation { continuation in
             let action = UserAction.retrieveUser(siteID: siteID) { [weak self] result in
-                guard let self = self else { return }
                 switch result {
                 case .success(let user):
                     let roles = user.roles.compactMap { User.Role(rawValue: $0) }
-                    self.stores.updateDefaultRoles(roles)
+                    self?.stores.updateDefaultRoles(roles)
                     if roles.contains(.administrator) {
                         continuation.resume(returning: true)
                     } else {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredViewModel.swift
@@ -20,7 +20,7 @@ final class AdminRoleRequiredViewModel {
     }
 
     @MainActor
-    func reloadRoles() async throws -> Bool {
+    func checkIfUserGotSufficientRole() async throws -> Bool {
         try await withCheckedThrowingContinuation { continuation in
             let action = UserAction.retrieveUser(siteID: siteID) { [weak self] result in
                 switch result {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredViewModel.swift
@@ -7,8 +7,11 @@ final class AdminRoleRequiredViewModel {
     let username: String
     let roleName: String
 
+    private let siteID: Int64
+
     private let stores: StoresManager
-    init(stores: StoresManager = ServiceLocator.stores) {
+    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
         self.stores = stores
         self.username = stores.sessionManager.defaultCredentials?.username ?? ""
         self.roleName = stores.sessionManager.defaultRoles
@@ -16,7 +19,25 @@ final class AdminRoleRequiredViewModel {
             .joined(separator: ", ")
     }
 
-    func reloadRoles() {
-        // TODO
+    @MainActor
+    func reloadRoles() async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
+            let action = UserAction.retrieveUser(siteID: siteID) { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .success(let user):
+                    let roles = user.roles.compactMap { User.Role(rawValue: $0) }
+                    self.stores.updateDefaultRoles(roles)
+                    if roles.contains(.administrator) {
+                        continuation.resume(returning: true)
+                    } else {
+                        continuation.resume(returning: false)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+            stores.dispatch(action)
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/AdminRole/AdminRoleRequiredViewModel.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Yosemite
+
+/// View model for `AdminRoleRequiredView`
+///
+final class AdminRoleRequiredViewModel {
+    let username: String
+    let roleName: String
+
+    private let stores: StoresManager
+    init(stores: StoresManager = ServiceLocator.stores) {
+        self.stores = stores
+        self.username = stores.sessionManager.defaultCredentials?.username ?? ""
+        self.roleName = stores.sessionManager.defaultRoles
+            .map { $0.displayString() }
+            .joined(separator: ", ")
+    }
+
+    func reloadRoles() {
+        // TODO
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -73,17 +73,27 @@ private extension JetpackSetupCoordinator {
             case AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404)):
                 /// 404 error means Jetpack is not installed or activated yet.
                 requiresConnectionOnly = false
-                #warning("TODO: check user role to see if the user has permission to manage plugins")
+                let roles = stores.sessionManager.defaultRoles
+                if roles.contains(.administrator) {
+                    #warning("TODO: start WPCom auth")
+                } else {
+                    displayAdminRoleRequiredError()
+                }
             case AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 403)):
                 /// 403 means the site Jetpack connection is not established yet
                 /// and the user has no permission to handle this.
-                #warning("TODO: show role error")
-                requiresConnectionOnly = true
-                break
+                displayAdminRoleRequiredError()
             default:
                 #warning("TODO: show generic error alert")
                 break
             }
         }
+    }
+
+    func displayAdminRoleRequiredError() {
+        let viewController = AdminRoleRequiredHostingController { [weak self] in
+            self?.navigationController.dismiss(animated: true)
+        }
+        navigationController.presentedViewController?.present(UINavigationController(rootViewController: viewController), animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -13,6 +13,8 @@ final class JetpackSetupCoordinator {
     private let stores: StoresManager
     private let analytics: Analytics
 
+    private var benefitsController: JetpackBenefitsHostingController?
+
     init(site: Site,
          navigationController: UINavigationController,
          stores: StoresManager = ServiceLocator.stores,
@@ -38,6 +40,7 @@ final class JetpackSetupCoordinator {
             self?.navigationController.dismiss(animated: true, completion: nil)
         })
         navigationController.present(benefitsController, animated: true, completion: nil)
+        self.benefitsController = benefitsController
     }
 }
 
@@ -91,9 +94,12 @@ private extension JetpackSetupCoordinator {
     }
 
     func displayAdminRoleRequiredError() {
-        let viewController = AdminRoleRequiredHostingController { [weak self] in
+        let viewController = AdminRoleRequiredHostingController(siteID: site.siteID, onClose: { [weak self] in
             self?.navigationController.dismiss(animated: true)
-        }
-        navigationController.presentedViewController?.present(UINavigationController(rootViewController: viewController), animated: true)
+        }, onSuccess: { [weak self] in
+            self?.benefitsController?.dismiss(animated: true)
+            #warning("TODO: start WPCom auth")
+        })
+        benefitsController?.present(UINavigationController(rootViewController: viewController), animated: true)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1944,6 +1944,7 @@
 		DEF8CF1129A8933E00800A60 /* JetpackBenefitsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1029A8933E00800A60 /* JetpackBenefitsViewModelTests.swift */; };
 		DEF8CF1629A8C2EB00800A60 /* AdminRoleRequiredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1529A8C2EB00800A60 /* AdminRoleRequiredView.swift */; };
 		DEF8CF1829A8C39600800A60 /* AdminRoleRequiredViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1729A8C39600800A60 /* AdminRoleRequiredViewModel.swift */; };
+		DEF8CF1A29AC6E5900800A60 /* AdminRoleRequiredViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1929AC6E5900800A60 /* AdminRoleRequiredViewModelTests.swift */; };
 		DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */; };
 		DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -4072,6 +4073,7 @@
 		DEF8CF1029A8933E00800A60 /* JetpackBenefitsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsViewModelTests.swift; sourceTree = "<group>"; };
 		DEF8CF1529A8C2EB00800A60 /* AdminRoleRequiredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminRoleRequiredView.swift; sourceTree = "<group>"; };
 		DEF8CF1729A8C39600800A60 /* AdminRoleRequiredViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminRoleRequiredViewModel.swift; sourceTree = "<group>"; };
+		DEF8CF1929AC6E5900800A60 /* AdminRoleRequiredViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminRoleRequiredViewModelTests.swift; sourceTree = "<group>"; };
 		DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModel.swift; sourceTree = "<group>"; };
 		DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -9283,6 +9285,7 @@
 			isa = PBXGroup;
 			children = (
 				DEF8CF0C29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift */,
+				DEF8CF1929AC6E5900800A60 /* AdminRoleRequiredViewModelTests.swift */,
 			);
 			path = JetpackSetup;
 			sourceTree = "<group>";
@@ -11703,6 +11706,7 @@
 				024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */,
 				B541B2132189E7FD008FE7C1 /* ScannerWooTests.swift in Sources */,
 				CC4B252D27CFE443008D2E6E /* OrderTotalsCalculatorTests.swift in Sources */,
+				DEF8CF1A29AC6E5900800A60 /* AdminRoleRequiredViewModelTests.swift in Sources */,
 				B57C5C9A21B80E7100FF82B2 /* DataWooTests.swift in Sources */,
 				B53A56A42112483E000776C9 /* Constants.swift in Sources */,
 				2667BFE72530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1942,6 +1942,8 @@
 		DEF8CF0D29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF0C29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift */; };
 		DEF8CF0F29A890E900800A60 /* JetpackBenefitsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF0E29A890E900800A60 /* JetpackBenefitsViewModel.swift */; };
 		DEF8CF1129A8933E00800A60 /* JetpackBenefitsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1029A8933E00800A60 /* JetpackBenefitsViewModelTests.swift */; };
+		DEF8CF1629A8C2EB00800A60 /* AdminRoleRequiredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1529A8C2EB00800A60 /* AdminRoleRequiredView.swift */; };
+		DEF8CF1829A8C39600800A60 /* AdminRoleRequiredViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1729A8C39600800A60 /* AdminRoleRequiredViewModel.swift */; };
 		DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */; };
 		DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -4068,6 +4070,8 @@
 		DEF8CF0C29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupCoordinatorTests.swift; sourceTree = "<group>"; };
 		DEF8CF0E29A890E900800A60 /* JetpackBenefitsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsViewModel.swift; sourceTree = "<group>"; };
 		DEF8CF1029A8933E00800A60 /* JetpackBenefitsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsViewModelTests.swift; sourceTree = "<group>"; };
+		DEF8CF1529A8C2EB00800A60 /* AdminRoleRequiredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminRoleRequiredView.swift; sourceTree = "<group>"; };
+		DEF8CF1729A8C39600800A60 /* AdminRoleRequiredViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminRoleRequiredViewModel.swift; sourceTree = "<group>"; };
 		DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModel.swift; sourceTree = "<group>"; };
 		DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -9269,6 +9273,7 @@
 		DEF8CF0829A71ED400800A60 /* JetpackSetup */ = {
 			isa = PBXGroup;
 			children = (
+				DEF8CF1429A8C2D000800A60 /* AdminRole */,
 				DEF8CF0929A71EE600800A60 /* JetpackSetupCoordinator.swift */,
 			);
 			path = JetpackSetup;
@@ -9280,6 +9285,15 @@
 				DEF8CF0C29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift */,
 			);
 			path = JetpackSetup;
+			sourceTree = "<group>";
+		};
+		DEF8CF1429A8C2D000800A60 /* AdminRole */ = {
+			isa = PBXGroup;
+			children = (
+				DEF8CF1529A8C2EB00800A60 /* AdminRoleRequiredView.swift */,
+				DEF8CF1729A8C39600800A60 /* AdminRoleRequiredViewModel.swift */,
+			);
+			path = AdminRole;
 			sourceTree = "<group>";
 		};
 		DEFD6E5F264990DD00E51E0D /* Plugins */ = {
@@ -10381,6 +10395,7 @@
 				B651474527D644FF00C9C4E6 /* CustomerNoteSection.swift in Sources */,
 				0375799B28227EDE0083F2E1 /* CardPresentPaymentsOnboardingPresenter.swift in Sources */,
 				AE3AA890290C313600BE422D /* NavigationTitleView.swift in Sources */,
+				DEF8CF1829A8C39600800A60 /* AdminRoleRequiredViewModel.swift in Sources */,
 				029F29FC24D94106004751CA /* EditableProductVariationModel.swift in Sources */,
 				0218B4EC242E06F00083A847 /* MediaType+WPMediaType.swift in Sources */,
 				D85A3C5026C153A500C0E026 /* InPersonPaymentsPluginNotActivatedView.swift in Sources */,
@@ -10631,6 +10646,7 @@
 				024DF3052372ADCD006658FE /* KeyboardScrollable.swift in Sources */,
 				BAE4F8432734325C00871344 /* SettingsViewModel.swift in Sources */,
 				0212276324498CDC0042161F /* ProductFormBottomSheetAction.swift in Sources */,
+				DEF8CF1629A8C2EB00800A60 /* AdminRoleRequiredView.swift in Sources */,
 				DE69C54D27BB719A000BB888 /* CouponRestrictions.swift in Sources */,
 				E1D4E84426776A6B00256B83 /* HeadlineTableViewCell.swift in Sources */,
 				B555530F21B57DE700449E71 /* ApplicationAdapter.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/AdminRoleRequiredViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/AdminRoleRequiredViewModelTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class AdminRoleRequiredViewModelTests: XCTestCase {
+
+    func test_username_is_correct() {
+        // Given
+        let testUsername = "Test"
+        let sessionManager = MockSessionManager()
+        sessionManager.defaultCredentials = .wporg(username: testUsername, password: "secret", siteAddress: "https://test.com")
+        let stores = DefaultStoresManager(sessionManager: sessionManager)
+        let viewModel = AdminRoleRequiredViewModel(siteID: 123, stores: stores)
+
+        // When
+        let username = viewModel.username
+
+        // Then
+        assertEqual(testUsername, username)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/AdminRoleRequiredViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/AdminRoleRequiredViewModelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import WooCommerce
 @testable import Yosemite
 
+@MainActor
 final class AdminRoleRequiredViewModelTests: XCTestCase {
 
     func test_username_is_correct() {
@@ -31,5 +32,67 @@ final class AdminRoleRequiredViewModelTests: XCTestCase {
 
         // Then
         assertEqual(NSLocalizedString("Shop Manager", comment: "User's Shop Manager role."), roleName)
+    }
+
+    func test_reloadRoles_returns_true_if_user_has_admin_role() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+        stores.whenReceivingAction(ofType: UserAction.self) { action in
+            switch action {
+            case .retrieveUser(_, let onCompletion):
+                let user = User.fake().copy(roles: [User.Role.administrator.rawValue])
+                onCompletion(.success(user))
+            }
+        }
+        let viewModel = AdminRoleRequiredViewModel(siteID: 123, stores: stores)
+
+        // When
+        let result = try await viewModel.reloadRoles()
+
+        // Then
+        XCTAssertTrue(result)
+    }
+
+    func test_reloadRoles_returns_false_if_user_does_not_have_admin_role() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+        stores.whenReceivingAction(ofType: UserAction.self) { action in
+            switch action {
+            case .retrieveUser(_, let onCompletion):
+                let user = User.fake().copy(roles: [User.Role.shopManager.rawValue])
+                onCompletion(.success(user))
+            }
+        }
+        let viewModel = AdminRoleRequiredViewModel(siteID: 123, stores: stores)
+
+        // When
+        let result = try await viewModel.reloadRoles()
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    func test_reloadRoles_relays_error_if_the_fetch_fails() async {
+        // Given
+        let expectedError = NSError(domain: "Test", code: 500, userInfo: nil)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+        stores.whenReceivingAction(ofType: UserAction.self) { action in
+            switch action {
+            case .retrieveUser(_, let onCompletion):
+                onCompletion(.failure(expectedError))
+            }
+        }
+        let viewModel = AdminRoleRequiredViewModel(siteID: 123, stores: stores)
+
+        // When
+        var caughtError: NSError?
+        do {
+            _ = try await viewModel.reloadRoles()
+        } catch {
+            caughtError = error as NSError
+        }
+
+        // Then
+        assertEqual(expectedError, caughtError)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/AdminRoleRequiredViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/AdminRoleRequiredViewModelTests.swift
@@ -34,7 +34,7 @@ final class AdminRoleRequiredViewModelTests: XCTestCase {
         assertEqual(NSLocalizedString("Shop Manager", comment: "User's Shop Manager role."), roleName)
     }
 
-    func test_reloadRoles_returns_true_if_user_has_admin_role() async throws {
+    func test_checkIfUserGotSufficientRole_returns_true_if_user_has_admin_role() async throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
         stores.whenReceivingAction(ofType: UserAction.self) { action in
@@ -47,13 +47,13 @@ final class AdminRoleRequiredViewModelTests: XCTestCase {
         let viewModel = AdminRoleRequiredViewModel(siteID: 123, stores: stores)
 
         // When
-        let result = try await viewModel.reloadRoles()
+        let result = try await viewModel.checkIfUserGotSufficientRole()
 
         // Then
         XCTAssertTrue(result)
     }
 
-    func test_reloadRoles_returns_false_if_user_does_not_have_admin_role() async throws {
+    func test_checkIfUserGotSufficientRole_returns_false_if_user_does_not_have_admin_role() async throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
         stores.whenReceivingAction(ofType: UserAction.self) { action in
@@ -66,13 +66,13 @@ final class AdminRoleRequiredViewModelTests: XCTestCase {
         let viewModel = AdminRoleRequiredViewModel(siteID: 123, stores: stores)
 
         // When
-        let result = try await viewModel.reloadRoles()
+        let result = try await viewModel.checkIfUserGotSufficientRole()
 
         // Then
         XCTAssertFalse(result)
     }
 
-    func test_reloadRoles_relays_error_if_the_fetch_fails() async {
+    func test_checkIfUserGotSufficientRole_relays_error_if_the_fetch_fails() async {
         // Given
         let expectedError = NSError(domain: "Test", code: 500, userInfo: nil)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
@@ -87,7 +87,7 @@ final class AdminRoleRequiredViewModelTests: XCTestCase {
         // When
         var caughtError: NSError?
         do {
-            _ = try await viewModel.reloadRoles()
+            _ = try await viewModel.checkIfUserGotSufficientRole()
         } catch {
             caughtError = error as NSError
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/AdminRoleRequiredViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/AdminRoleRequiredViewModelTests.swift
@@ -19,4 +19,17 @@ final class AdminRoleRequiredViewModelTests: XCTestCase {
         assertEqual(testUsername, username)
     }
 
+    func test_roleName_is_correct() {
+        // Given
+        let sessionManager = MockSessionManager()
+        sessionManager.defaultRoles = [.shopManager]
+        let stores = DefaultStoresManager(sessionManager: sessionManager)
+        let viewModel = AdminRoleRequiredViewModel(siteID: 123, stores: stores)
+
+        // When
+        let roleName = viewModel.roleName
+
+        // Then
+        assertEqual(NSLocalizedString("Shop Manager", comment: "User's Shop Manager role."), roleName)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8913
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR handles the check for user role and showing the error modal if the user tries to install Jetpack without admin role:
- When the Jetpack check returns 404 error, the site doesn't have Jetpack. The app then checks for the user role, if it doesn't contain an admin role, it shows an error modal.
- When the Jetpack check returns 403 error, the site has Jetpack installed and activated but the site connection is not established yet and the user doesn't have permission to handle that. The app then show the error modal for the admin role requirement.

The admin role required modal has a Retry button to fetch the user info again - if the user role is updated with an admin role, they can proceed to the Jetpack setup flow.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Make sure that you have access to a site with WooCommerce and no Jetpack.
- Log out of the app or skip onboarding if needed.
- Tap "Enter your site address" on the prologue screen and proceed with the address of your test site.
- Log in with the credentials of a shop manager.
- When the login completes, tap the Jetback benefit banner at the bottom of the Dashboard screen.
- Tap Install Jetpack on the benefit modal.
- Notice that an error modal is presented for the admin role requirement.
- Tap the Retry button, notice that a message is displayed saying the user isn't authorized to install Jetpack.
- In WP Admin, update the user role to admin.
- Tap the Retry button again, the error modal should the be dismissed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/221476155-fe864dee-5232-446a-96ac-59b2b72e0269.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
