### PR TITLE
REST API: UI for the custom WPCom email login screen of the Jetpack Setup flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -104,12 +104,7 @@ private extension JetpackSetupCoordinator {
         }, onSuccess: { [weak self] in
             guard let self else { return }
             self.benefitsController?.dismiss(animated: true) {
-                // only start WPCom email login immediately if Jetpack installation is required.
-                // otherwise force the user to tap the Install Jetpack button again
-                // to fetch the connected email.
-                if !self.requiresConnectionOnly {
-                    self.showWPComEmailLogin()
-                }
+                self.showWPComEmailLogin()
             }
         })
         benefitsController?.present(UINavigationController(rootViewController: viewController), animated: true)

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -117,7 +117,7 @@ private extension JetpackSetupCoordinator {
     }
 
     func showWPComEmailLogin() {
-        let emailLoginController = WPComEmailLoginHostingController { email in
+        let emailLoginController = WPComEmailLoginHostingController(siteURL: site.url) { email in
             #warning("TODO: start the password screen")
         }
         let loginNavigationController = UINavigationController(rootViewController: emailLoginController)

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -69,12 +69,11 @@ private extension JetpackSetupCoordinator {
         case .success(let user):
             let connectedEmail = user.wpcomUser?.email
             requiresConnectionOnly = !user.isConnected
-            if requiresConnectionOnly {
-                #warning("TODO: start WPCom password with connectedEmail")
+            if let connectedEmail {
+                #warning("TODO-8918: check if account is passwordless and show the next screen")
             } else {
                 showWPComEmailLogin()
             }
-            DDLogInfo("✅ connected email: \(connectedEmail), isConnected: \(user.isConnected)")
         case .failure(let error):
             DDLogError("⛔️ Jetpack status fetched error: \(error)")
             switch error {
@@ -117,8 +116,8 @@ private extension JetpackSetupCoordinator {
     }
 
     func showWPComEmailLogin() {
-        let emailLoginController = WPComEmailLoginHostingController(siteURL: site.url) { email in
-            #warning("TODO: start the password screen")
+        let emailLoginController = WPComEmailLoginHostingController(siteURL: site.url, requiresConnectionOnly: requiresConnectionOnly) { email in
+            #warning("TODO-8918: check if account is passwordless and show the next screen")
         }
         let loginNavigationController = UINavigationController(rootViewController: emailLoginController)
         navigationController.dismiss(animated: true) {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
@@ -121,7 +121,7 @@ private extension WPComEmailLoginView {
 
 struct WPComEmailLoginView_Previews: PreviewProvider {
     static var previews: some View {
-        WPComEmailLoginView(viewModel: .init(siteURL: "https://test.com",
+        WPComEmailLoginView(viewModel: .init(siteURL: "https://example.com",
                                              requiresConnectionOnly: true),
                             onSubmit: { _ in })
     }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
@@ -8,8 +8,9 @@ final class WPComEmailLoginHostingController: UIHostingController<WPComEmailLogi
         return noticePresenter
     }()
 
-    init(onSubmit: @escaping (String) -> Void) {
-        super.init(rootView: WPComEmailLoginView(viewModel: .init(onSubmit: onSubmit)))
+    init(siteURL: String, onSubmit: @escaping (String) -> Void) {
+        super.init(rootView: WPComEmailLoginView(viewModel: .init(siteURL: siteURL,
+                                                                  onSubmit: onSubmit)))
     }
 
     @available(*, unavailable)
@@ -73,7 +74,7 @@ struct WPComEmailLoginView: View {
 
                 Spacer()
             }
-            .padding(Constants.contentHorizontalPadding)
+            .padding(Constants.contentPadding)
         }
         .safeAreaInset(edge: .bottom) {
             VStack {
@@ -83,7 +84,11 @@ struct WPComEmailLoginView: View {
                 }
                 .buttonStyle(PrimaryButtonStyle())
                 .disabled(viewModel.emailAddress.isEmpty)
+
+                // Terms label
+                AttributedText(viewModel.termsAttributedString)
             }
+            .padding(Constants.contentPadding)
             .background(Color(uiColor: .systemBackground))
         }
     }
@@ -93,7 +98,7 @@ private extension WPComEmailLoginView {
     enum Constants {
         static let blockVerticalPadding: CGFloat = 32
         static let contentVerticalSpacing: CGFloat = 8
-        static let contentHorizontalPadding: CGFloat = 16
+        static let contentPadding: CGFloat = 16
     }
 
     enum Localization {
@@ -105,14 +110,21 @@ private extension WPComEmailLoginView {
             "Log in with your WordPress.com account to install Jetpack",
             comment: "Subtitle for the WPCom email login screen when Jetpack is not installed yet"
         )
-        static let emailLabel = NSLocalizedString("Email address", comment: "Label for the email field on the WPCom email login screen of the Jetpack setup flow.")
-        static let enterEmail = NSLocalizedString("Enter email", comment: "Placeholder text for the email field on the WPCom email login screen of the Jetpack setup flow.")
+        static let emailLabel = NSLocalizedString(
+            "Email address",
+            comment: "Label for the email field on the WPCom email login screen of the Jetpack setup flow."
+        )
+        static let enterEmail = NSLocalizedString(
+            "Enter email",
+            comment: "Placeholder text for the email field on the WPCom email login screen of the Jetpack setup flow."
+        )
     }
 }
 
 
 struct WPComEmailLoginView_Previews: PreviewProvider {
     static var previews: some View {
-        WPComEmailLoginView(viewModel: .init(onSubmit: { _ in }))
+        WPComEmailLoginView(viewModel: .init(siteURL: "https://test.com",
+                                             onSubmit: { _ in }))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
@@ -1,5 +1,41 @@
 import SwiftUI
 
+/// Hosting controller for `WPComEmailLoginView`
+final class WPComEmailLoginHostingController: UIHostingController<WPComEmailLoginView> {
+    private lazy var noticePresenter: DefaultNoticePresenter = {
+        let noticePresenter = DefaultNoticePresenter()
+        noticePresenter.presentingViewController = self
+        return noticePresenter
+    }()
+
+    init(onSubmit: @escaping (String) -> Void) {
+        super.init(rootView: WPComEmailLoginView(viewModel: .init(onSubmit: onSubmit)))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTransparentNavigationBar()
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Localization.cancel, style: .plain, target: self, action: #selector(dismissView))
+    }
+
+    @objc
+    private func dismissView() {
+        dismiss(animated: true)
+    }
+}
+
+private extension WPComEmailLoginHostingController {
+    enum Localization {
+        static let cancel = NSLocalizedString("Cancel", comment: "Button to dismiss the site credential login screen")
+    }
+}
+
+
 /// Screen for logging in to a WPCom account during the Jetpack setup flow
 /// This is presented for users authenticated with WPOrg credentials.
 struct WPComEmailLoginView: View {
@@ -10,20 +46,17 @@ struct WPComEmailLoginView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: Constants.blockVerticalPadding) {
-                JetpackInstallHeaderView()
-                
-                // title and description
-                VStack(alignment: .leading, spacing: Constants.contentVerticalSpacing) {
-                    Text(Localization.installJetpack)
-                        .largeTitleStyle()
-                    Text(Localization.loginToInstall)
-                        .subheadlineStyle()
-                }
-    
-                Spacer()
+        ScrollableVStack(alignment: .leading, padding: Constants.contentHorizontalPadding, spacing: Constants.blockVerticalPadding) {
+            JetpackInstallHeaderView()
+
+            // title and description
+            VStack(alignment: .leading, spacing: Constants.contentVerticalSpacing) {
+                Text(Localization.installJetpack)
+                    .largeTitleStyle()
+                Text(Localization.loginToInstall)
+                    .subheadlineStyle()
             }
+            Spacer()
         }
     }
 }
@@ -32,6 +65,7 @@ private extension WPComEmailLoginView {
     enum Constants {
         static let blockVerticalPadding: CGFloat = 32
         static let contentVerticalSpacing: CGFloat = 8
+        static let contentHorizontalPadding: CGFloat = 16
     }
 
     enum Localization {
@@ -49,6 +83,6 @@ private extension WPComEmailLoginView {
 
 struct WPComEmailLoginView_Previews: PreviewProvider {
     static var previews: some View {
-        WPComEmailLoginView()
+        WPComEmailLoginView(viewModel: .init(onSubmit: { _ in }))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
@@ -39,24 +39,52 @@ private extension WPComEmailLoginHostingController {
 /// Screen for logging in to a WPCom account during the Jetpack setup flow
 /// This is presented for users authenticated with WPOrg credentials.
 struct WPComEmailLoginView: View {
-    private let viewModel: WPComEmailLoginViewModel
+    @ObservedObject private var viewModel: WPComEmailLoginViewModel
+    @FocusState private var isEmailFieldFocused: Bool
 
     init(viewModel: WPComEmailLoginViewModel) {
         self.viewModel = viewModel
     }
 
     var body: some View {
-        ScrollableVStack(alignment: .leading, padding: Constants.contentHorizontalPadding, spacing: Constants.blockVerticalPadding) {
-            JetpackInstallHeaderView()
+        ScrollView {
+            VStack(alignment: .leading, spacing: Constants.blockVerticalPadding) {
+                JetpackInstallHeaderView()
 
-            // title and description
-            VStack(alignment: .leading, spacing: Constants.contentVerticalSpacing) {
-                Text(Localization.installJetpack)
-                    .largeTitleStyle()
-                Text(Localization.loginToInstall)
-                    .subheadlineStyle()
+                // title and description
+                VStack(alignment: .leading, spacing: Constants.contentVerticalSpacing) {
+                    Text(Localization.installJetpack)
+                        .largeTitleStyle()
+                    Text(Localization.loginToInstall)
+                        .subheadlineStyle()
+                }
+
+                // Email field
+                AccountCreationFormFieldView(viewModel: .init(
+                    header: Localization.emailLabel,
+                    placeholder: Localization.enterEmail,
+                    keyboardType: .emailAddress,
+                    text: $viewModel.emailAddress,
+                    isSecure: false,
+                    errorMessage: nil,
+                    isFocused: isEmailFieldFocused
+                ))
+                .focused($isEmailFieldFocused)
+
+                Spacer()
             }
-            Spacer()
+            .padding(Constants.contentHorizontalPadding)
+        }
+        .safeAreaInset(edge: .bottom) {
+            VStack {
+                // Primary CTA
+                Button(Localization.installJetpack) {
+                    viewModel.handleSubmission()
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .disabled(viewModel.emailAddress.isEmpty)
+            }
+            .background(Color(uiColor: .systemBackground))
         }
     }
 }
@@ -77,6 +105,8 @@ private extension WPComEmailLoginView {
             "Log in with your WordPress.com account to install Jetpack",
             comment: "Subtitle for the WPCom email login screen when Jetpack is not installed yet"
         )
+        static let emailLabel = NSLocalizedString("Email address", comment: "Label for the email field on the WPCom email login screen of the Jetpack setup flow.")
+        static let enterEmail = NSLocalizedString("Enter email", comment: "Placeholder text for the email field on the WPCom email login screen of the Jetpack setup flow.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// Screen for logging in to a WPCom account during the Jetpack setup flow
+/// This is presented for users authenticated with WPOrg credentials.
+struct WPComEmailLoginView: View {
+    private let viewModel: WPComEmailLoginViewModel
+
+    init(viewModel: WPComEmailLoginViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Constants.blockVerticalPadding) {
+                JetpackInstallHeaderView()
+                
+                // title and description
+                VStack(alignment: .leading, spacing: Constants.contentVerticalSpacing) {
+                    Text(Localization.installJetpack)
+                        .largeTitleStyle()
+                    Text(Localization.loginToInstall)
+                        .subheadlineStyle()
+                }
+    
+                Spacer()
+            }
+        }
+    }
+}
+
+private extension WPComEmailLoginView {
+    enum Constants {
+        static let blockVerticalPadding: CGFloat = 32
+        static let contentVerticalSpacing: CGFloat = 8
+    }
+
+    enum Localization {
+        static let installJetpack = NSLocalizedString(
+            "Install Jetpack",
+            comment: "Title for the WPCom email login screen when Jetpack is not installed yet"
+        )
+        static let loginToInstall = NSLocalizedString(
+            "Log in with your WordPress.com account to install Jetpack",
+            comment: "Subtitle for the WPCom email login screen when Jetpack is not installed yet"
+        )
+    }
+}
+
+
+struct WPComEmailLoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        WPComEmailLoginView()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
@@ -8,8 +8,9 @@ final class WPComEmailLoginHostingController: UIHostingController<WPComEmailLogi
         return noticePresenter
     }()
 
-    init(siteURL: String, onSubmit: @escaping (String) -> Void) {
-        super.init(rootView: WPComEmailLoginView(viewModel: .init(siteURL: siteURL), onSubmit: onSubmit))
+    init(siteURL: String, requiresConnectionOnly: Bool, onSubmit: @escaping (String) -> Void) {
+        let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: requiresConnectionOnly)
+        super.init(rootView: WPComEmailLoginView(viewModel: viewModel, onSubmit: onSubmit))
     }
 
     @available(*, unavailable)
@@ -45,7 +46,8 @@ struct WPComEmailLoginView: View {
     /// The closure to be triggered when the Install Jetpack button is tapped.
     private let onSubmit: (String) -> Void
 
-    init(viewModel: WPComEmailLoginViewModel, onSubmit: @escaping (String) -> Void) {
+    init(viewModel: WPComEmailLoginViewModel,
+         onSubmit: @escaping (String) -> Void) {
         self.viewModel = viewModel
         self.onSubmit = onSubmit
     }
@@ -57,9 +59,9 @@ struct WPComEmailLoginView: View {
 
                 // title and description
                 VStack(alignment: .leading, spacing: Constants.contentVerticalSpacing) {
-                    Text(Localization.installJetpack)
+                    Text(viewModel.titleString)
                         .largeTitleStyle()
-                    Text(Localization.loginToInstall)
+                    Text(viewModel.subtitleString)
                         .subheadlineStyle()
                 }
 
@@ -82,7 +84,7 @@ struct WPComEmailLoginView: View {
         .safeAreaInset(edge: .bottom) {
             VStack {
                 // Primary CTA
-                Button(Localization.installJetpack) {
+                Button(viewModel.titleString) {
                     onSubmit(viewModel.emailAddress)
                 }
                 .buttonStyle(PrimaryButtonStyle())
@@ -105,14 +107,6 @@ private extension WPComEmailLoginView {
     }
 
     enum Localization {
-        static let installJetpack = NSLocalizedString(
-            "Install Jetpack",
-            comment: "Title for the WPCom email login screen when Jetpack is not installed yet"
-        )
-        static let loginToInstall = NSLocalizedString(
-            "Log in with your WordPress.com account to install Jetpack",
-            comment: "Subtitle for the WPCom email login screen when Jetpack is not installed yet"
-        )
         static let emailLabel = NSLocalizedString(
             "Email address",
             comment: "Label for the email field on the WPCom email login screen of the Jetpack setup flow."
@@ -127,7 +121,8 @@ private extension WPComEmailLoginView {
 
 struct WPComEmailLoginView_Previews: PreviewProvider {
     static var previews: some View {
-        WPComEmailLoginView(viewModel: .init(siteURL: "https://test.com"),
+        WPComEmailLoginView(viewModel: .init(siteURL: "https://test.com",
+                                             requiresConnectionOnly: true),
                             onSubmit: { _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
@@ -9,8 +9,7 @@ final class WPComEmailLoginHostingController: UIHostingController<WPComEmailLogi
     }()
 
     init(siteURL: String, onSubmit: @escaping (String) -> Void) {
-        super.init(rootView: WPComEmailLoginView(viewModel: .init(siteURL: siteURL,
-                                                                  onSubmit: onSubmit)))
+        super.init(rootView: WPComEmailLoginView(viewModel: .init(siteURL: siteURL), onSubmit: onSubmit))
     }
 
     @available(*, unavailable)
@@ -43,8 +42,12 @@ struct WPComEmailLoginView: View {
     @ObservedObject private var viewModel: WPComEmailLoginViewModel
     @FocusState private var isEmailFieldFocused: Bool
 
-    init(viewModel: WPComEmailLoginViewModel) {
+    /// The closure to be triggered when the Install Jetpack button is tapped.
+    private let onSubmit: (String) -> Void
+
+    init(viewModel: WPComEmailLoginViewModel, onSubmit: @escaping (String) -> Void) {
         self.viewModel = viewModel
+        self.onSubmit = onSubmit
     }
 
     var body: some View {
@@ -80,10 +83,10 @@ struct WPComEmailLoginView: View {
             VStack {
                 // Primary CTA
                 Button(Localization.installJetpack) {
-                    viewModel.handleSubmission()
+                    onSubmit(viewModel.emailAddress)
                 }
                 .buttonStyle(PrimaryButtonStyle())
-                .disabled(viewModel.emailAddress.isEmpty)
+                .disabled(!viewModel.isEmailValid)
 
                 // Terms label
                 AttributedText(viewModel.termsAttributedString)
@@ -124,7 +127,7 @@ private extension WPComEmailLoginView {
 
 struct WPComEmailLoginView_Previews: PreviewProvider {
     static var previews: some View {
-        WPComEmailLoginView(viewModel: .init(siteURL: "https://test.com",
-                                             onSubmit: { _ in }))
+        WPComEmailLoginView(viewModel: .init(siteURL: "https://test.com"),
+                            onSubmit: { _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModel.swift
@@ -3,4 +3,11 @@ import Foundation
 /// View model for `WPComEmailLoginView`
 final class WPComEmailLoginViewModel {
     @Published var emailAddress: String = ""
+
+    /// The closure to be triggered when the Install Jetpack button is tapped.
+    private let onSubmit: (String) -> Void
+
+    init(onSubmit: @escaping (String) -> Void) {
+        self.onSubmit = onSubmit
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// View model for `WPComEmailLoginView`
-final class WPComEmailLoginViewModel {
+final class WPComEmailLoginViewModel: ObservableObject {
     @Published var emailAddress: String = ""
 
     /// The closure to be triggered when the Install Jetpack button is tapped.
@@ -9,5 +9,9 @@ final class WPComEmailLoginViewModel {
 
     init(onSubmit: @escaping (String) -> Void) {
         self.onSubmit = onSubmit
+    }
+
+    func handleSubmission() {
+        // TODO
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModel.swift
@@ -1,17 +1,60 @@
 import Foundation
+import UIKit
 
 /// View model for `WPComEmailLoginView`
 final class WPComEmailLoginViewModel: ObservableObject {
     @Published var emailAddress: String = ""
 
+    let termsAttributedString: NSAttributedString
+
     /// The closure to be triggered when the Install Jetpack button is tapped.
     private let onSubmit: (String) -> Void
 
-    init(onSubmit: @escaping (String) -> Void) {
+    init(siteURL: String, onSubmit: @escaping (String) -> Void) {
         self.onSubmit = onSubmit
+        self.termsAttributedString = {
+            let content = String.localizedStringWithFormat(Localization.termsContent, Localization.termsOfService, Localization.shareDetails)
+            let paragraph = NSMutableParagraphStyle()
+            paragraph.alignment = .center
+
+            let mutableAttributedText = NSMutableAttributedString(
+                string: content,
+                attributes: [.font: UIFont.footnote,
+                             .foregroundColor: UIColor.secondaryLabel,
+                             .paragraphStyle: paragraph]
+            )
+
+            mutableAttributedText.setAsLink(textToFind: Localization.termsOfService,
+                                            linkURL: Constants.jetpackTermsURL + siteURL)
+            mutableAttributedText.setAsLink(textToFind: Localization.shareDetails,
+                                            linkURL: Constants.jetpackShareDetailsURL + siteURL)
+            return mutableAttributedText
+        }()
     }
 
     func handleSubmission() {
         // TODO
+    }
+}
+
+private extension WPComEmailLoginViewModel {
+    enum Constants {
+        static let jetpackTermsURL = "https://jetpack.com/redirect/?source=wpcom-tos&site="
+        static let jetpackShareDetailsURL = "https://jetpack.com/redirect/?source=jetpack-support-what-data-does-jetpack-sync&site="
+    }
+
+    enum Localization {
+        static let termsContent = NSLocalizedString(
+            "By tapping the Install Jetpack button, you agree to our %1$@ and to %2$@ with WordPress.com.",
+            comment: "Content of the label at the end of the Wrong Account screen. " +
+            "Reads like: By tapping the Connect Jetpack button, you agree to our Terms of Service and to share details with WordPress.com.")
+        static let termsOfService = NSLocalizedString(
+            "Terms of Service",
+            comment: "The terms to be agreed upon when tapping the Connect Jetpack button on the Wrong Account screen."
+        )
+        static let shareDetails = NSLocalizedString(
+            "share details",
+            comment: "The action to be agreed upon when tapping the Connect Jetpack button on the Wrong Account screen."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModel.swift
@@ -4,6 +4,9 @@ import WordPressShared
 
 /// View model for `WPComEmailLoginView`
 final class WPComEmailLoginViewModel: ObservableObject {
+    let titleString: String
+    let subtitleString: String
+
     @Published var emailAddress: String = ""
     /// Local validation on the email field.
     @Published private(set) var isEmailValid: Bool = false
@@ -13,7 +16,10 @@ final class WPComEmailLoginViewModel: ObservableObject {
     private var emailFieldSubscription: AnyCancellable?
 
     init(siteURL: String,
+         requiresConnectionOnly: Bool,
          debounceDuration: Double = Constants.fieldDebounceDuration) {
+        self.titleString = requiresConnectionOnly ? Localization.connectJetpack : Localization.installJetpack
+        self.subtitleString = requiresConnectionOnly ? Localization.loginToConnect : Localization.loginToInstall
         self.termsAttributedString = {
             let content = String.localizedStringWithFormat(Localization.termsContent, Localization.termsOfService, Localization.shareDetails)
             let paragraph = NSMutableParagraphStyle()
@@ -51,14 +57,30 @@ private extension WPComEmailLoginViewModel {
     }
 }
 
-private extension WPComEmailLoginViewModel {
-    enum Constants {
+extension WPComEmailLoginViewModel {
+    private enum Constants {
         static let fieldDebounceDuration = 0.3
         static let jetpackTermsURL = "https://jetpack.com/redirect/?source=wpcom-tos&site="
         static let jetpackShareDetailsURL = "https://jetpack.com/redirect/?source=jetpack-support-what-data-does-jetpack-sync&site="
     }
 
     enum Localization {
+        static let installJetpack = NSLocalizedString(
+            "Install Jetpack",
+            comment: "Title for the WPCom email login screen when Jetpack is not installed yet"
+        )
+        static let loginToInstall = NSLocalizedString(
+            "Log in with your WordPress.com account to install Jetpack",
+            comment: "Subtitle for the WPCom email login screen when Jetpack is not installed yet"
+        )
+        static let connectJetpack = NSLocalizedString(
+            "Connect Jetpack",
+            comment: "Title for the WPCom email login screen when Jetpack is not connected yet"
+        )
+        static let loginToConnect = NSLocalizedString(
+            "Log in with your WordPress.com account to connect Jetpack",
+            comment: "Subtitle for the WPCom email login screen when Jetpack is not connected yet"
+        )
         static let termsContent = NSLocalizedString(
             "By tapping the Install Jetpack button, you agree to our %1$@ and to %2$@ with WordPress.com.",
             comment: "Content of the label at the end of the Wrong Account screen. " +

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModel.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// View model for `WPComEmailLoginView`
+final class WPComEmailLoginViewModel {
+    @Published var emailAddress: String = ""
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1945,6 +1945,8 @@
 		DEF8CF1629A8C2EB00800A60 /* AdminRoleRequiredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1529A8C2EB00800A60 /* AdminRoleRequiredView.swift */; };
 		DEF8CF1829A8C39600800A60 /* AdminRoleRequiredViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1729A8C39600800A60 /* AdminRoleRequiredViewModel.swift */; };
 		DEF8CF1A29AC6E5900800A60 /* AdminRoleRequiredViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1929AC6E5900800A60 /* AdminRoleRequiredViewModelTests.swift */; };
+		DEF8CF1D29AC84BC00800A60 /* WPComEmailLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1C29AC84BC00800A60 /* WPComEmailLoginView.swift */; };
+		DEF8CF1F29AC870A00800A60 /* WPComEmailLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1E29AC870A00800A60 /* WPComEmailLoginViewModel.swift */; };
 		DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */; };
 		DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -4074,6 +4076,8 @@
 		DEF8CF1529A8C2EB00800A60 /* AdminRoleRequiredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminRoleRequiredView.swift; sourceTree = "<group>"; };
 		DEF8CF1729A8C39600800A60 /* AdminRoleRequiredViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminRoleRequiredViewModel.swift; sourceTree = "<group>"; };
 		DEF8CF1929AC6E5900800A60 /* AdminRoleRequiredViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminRoleRequiredViewModelTests.swift; sourceTree = "<group>"; };
+		DEF8CF1C29AC84BC00800A60 /* WPComEmailLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComEmailLoginView.swift; sourceTree = "<group>"; };
+		DEF8CF1E29AC870A00800A60 /* WPComEmailLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComEmailLoginViewModel.swift; sourceTree = "<group>"; };
 		DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModel.swift; sourceTree = "<group>"; };
 		DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -9275,6 +9279,7 @@
 		DEF8CF0829A71ED400800A60 /* JetpackSetup */ = {
 			isa = PBXGroup;
 			children = (
+				DEF8CF1B29AC83AC00800A60 /* WPComLogin */,
 				DEF8CF1429A8C2D000800A60 /* AdminRole */,
 				DEF8CF0929A71EE600800A60 /* JetpackSetupCoordinator.swift */,
 			);
@@ -9297,6 +9302,15 @@
 				DEF8CF1729A8C39600800A60 /* AdminRoleRequiredViewModel.swift */,
 			);
 			path = AdminRole;
+			sourceTree = "<group>";
+		};
+		DEF8CF1B29AC83AC00800A60 /* WPComLogin */ = {
+			isa = PBXGroup;
+			children = (
+				DEF8CF1C29AC84BC00800A60 /* WPComEmailLoginView.swift */,
+				DEF8CF1E29AC870A00800A60 /* WPComEmailLoginViewModel.swift */,
+			);
+			path = WPComLogin;
 			sourceTree = "<group>";
 		};
 		DEFD6E5F264990DD00E51E0D /* Plugins */ = {
@@ -11031,6 +11045,7 @@
 				CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */,
 				DE4B3B5826A7041800EEF2D8 /* EdgeInsets+Woo.swift in Sources */,
 				02CE4304276993DA0006EAEF /* CaptureDevicePermissionChecker.swift in Sources */,
+				DEF8CF1F29AC870A00800A60 /* WPComEmailLoginViewModel.swift in Sources */,
 				74A33D8021C3F234009E25DE /* LicensesViewController.swift in Sources */,
 				02EEA9282923338100D05F47 /* StoreCreationPlanView.swift in Sources */,
 				454453CA27566CDE00464AC5 /* HubMenuViewModel.swift in Sources */,
@@ -11323,6 +11338,7 @@
 				CC254F3826C43B52005F3C82 /* ShippingLabelCustomPackageFormViewModel.swift in Sources */,
 				02F49ADC23BF3A0100FA0BFA /* ErrorSectionHeaderView.swift in Sources */,
 				3178C1F726409216000D771A /* BluetoothCardReaderSettingsConnectedViewModel.swift in Sources */,
+				DEF8CF1D29AC84BC00800A60 /* WPComEmailLoginView.swift in Sources */,
 				CC6923AC26010D8D002FB669 /* LoginProloguePageViewController.swift in Sources */,
 				4515C88D25D6BE540099C8E3 /* ShippingLabelAddressFormViewController.swift in Sources */,
 				CE5F462A23AACA0A006B1A5C /* RefundDetailsDataSource.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1947,6 +1947,7 @@
 		DEF8CF1A29AC6E5900800A60 /* AdminRoleRequiredViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1929AC6E5900800A60 /* AdminRoleRequiredViewModelTests.swift */; };
 		DEF8CF1D29AC84BC00800A60 /* WPComEmailLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1C29AC84BC00800A60 /* WPComEmailLoginView.swift */; };
 		DEF8CF1F29AC870A00800A60 /* WPComEmailLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF1E29AC870A00800A60 /* WPComEmailLoginViewModel.swift */; };
+		DEF8CF2229ACDBB100800A60 /* WPComEmailLoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF8CF2129ACDBB100800A60 /* WPComEmailLoginViewModelTests.swift */; };
 		DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */; };
 		DEFB3011289904E300A620B3 /* WooSetupWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */; };
 		DEFD6E61264990FB00E51E0D /* SitePluginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */; };
@@ -4078,6 +4079,7 @@
 		DEF8CF1929AC6E5900800A60 /* AdminRoleRequiredViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminRoleRequiredViewModelTests.swift; sourceTree = "<group>"; };
 		DEF8CF1C29AC84BC00800A60 /* WPComEmailLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComEmailLoginView.swift; sourceTree = "<group>"; };
 		DEF8CF1E29AC870A00800A60 /* WPComEmailLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComEmailLoginViewModel.swift; sourceTree = "<group>"; };
+		DEF8CF2129ACDBB100800A60 /* WPComEmailLoginViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComEmailLoginViewModelTests.swift; sourceTree = "<group>"; };
 		DEFA3D922897D8930076FAE1 /* NoWooErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModel.swift; sourceTree = "<group>"; };
 		DEFB3010289904E300A620B3 /* WooSetupWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooSetupWebViewModel.swift; sourceTree = "<group>"; };
 		DEFD6E60264990FB00E51E0D /* SitePluginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -9289,6 +9291,7 @@
 		DEF8CF0B29A76F6200800A60 /* JetpackSetup */ = {
 			isa = PBXGroup;
 			children = (
+				DEF8CF2029ACDB9C00800A60 /* WPComLogin */,
 				DEF8CF0C29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift */,
 				DEF8CF1929AC6E5900800A60 /* AdminRoleRequiredViewModelTests.swift */,
 			);
@@ -9309,6 +9312,14 @@
 			children = (
 				DEF8CF1C29AC84BC00800A60 /* WPComEmailLoginView.swift */,
 				DEF8CF1E29AC870A00800A60 /* WPComEmailLoginViewModel.swift */,
+			);
+			path = WPComLogin;
+			sourceTree = "<group>";
+		};
+		DEF8CF2029ACDB9C00800A60 /* WPComLogin */ = {
+			isa = PBXGroup;
+			children = (
+				DEF8CF2129ACDBB100800A60 /* WPComEmailLoginViewModelTests.swift */,
 			);
 			path = WPComLogin;
 			sourceTree = "<group>";
@@ -11923,6 +11934,7 @@
 				0290E27E238E5B5C00B5C466 /* ProductStockStatusListSelectorCommandTests.swift in Sources */,
 				028A4655295AD2DA001CF6CE /* StoreCreationSellingStatusQuestionViewModelTests.swift in Sources */,
 				EE81B1382865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift in Sources */,
+				DEF8CF2229ACDBB100800A60 /* WPComEmailLoginViewModelTests.swift in Sources */,
 				7E7C5F8B2719AEDA00315B61 /* EditProductCategoryListViewModelTests.swift in Sources */,
 				0247F510286E7D26009C177E /* ProductVariationFormViewModel+ImageUploaderTests.swift in Sources */,
 				020B2F9123BDD71500BD79AD /* IntegerInputFormatterTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModelTests.swift
@@ -5,7 +5,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
 
     func test_title_string_is_correct_when_requiresConnectionOnly_is_false() {
         // Given
-        let siteURL = "https://test.com"
+        let siteURL = "https://example.com"
         let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: false)
 
         // When
@@ -17,7 +17,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
 
     func test_title_string_is_correct_when_requiresConnectionOnly_is_true() {
         // Given
-        let siteURL = "https://test.com"
+        let siteURL = "https://example.com"
         let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: true)
 
         // When
@@ -29,7 +29,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
 
     func test_subtitle_string_is_correct_when_requiresConnectionOnly_is_false() {
         // Given
-        let siteURL = "https://test.com"
+        let siteURL = "https://example.com"
         let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: false)
 
         // When
@@ -41,7 +41,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
 
     func test_subtitle_string_is_correct_when_requiresConnectionOnly_is_true() {
         // Given
-        let siteURL = "https://test.com"
+        let siteURL = "https://example.com"
         let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: true)
 
         // When
@@ -53,7 +53,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
 
     func test_terms_string_is_correct() {
         // Given
-        let siteURL = "https://test.com"
+        let siteURL = "https://example.com"
         let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: true)
 
         // When
@@ -68,7 +68,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
 
     func test_isEmailValid_is_false_for_invalid_email() {
         // Given
-        let siteURL = "https://test.com"
+        let siteURL = "https://example.com"
         let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: true, debounceDuration: 0)
 
         // When
@@ -86,7 +86,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
         let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: true, debounceDuration: 0)
 
         // When
-        viewModel.emailAddress = "random@mail.com"
+        viewModel.emailAddress = "random@example.com"
 
         // Then
         waitUntil {

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModelTests.swift
@@ -3,23 +3,73 @@ import XCTest
 
 final class WPComEmailLoginViewModelTests: XCTestCase {
 
+    func test_title_string_is_correct_when_requiresConnectionOnly_is_false() {
+        // Given
+        let siteURL = "https://test.com"
+        let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: false)
+
+        // When
+        let text = viewModel.titleString
+
+        // Then
+        assertEqual(WPComEmailLoginViewModel.Localization.installJetpack, text)
+    }
+
+    func test_title_string_is_correct_when_requiresConnectionOnly_is_true() {
+        // Given
+        let siteURL = "https://test.com"
+        let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: true)
+
+        // When
+        let text = viewModel.titleString
+
+        // Then
+        assertEqual(WPComEmailLoginViewModel.Localization.connectJetpack, text)
+    }
+
+    func test_subtitle_string_is_correct_when_requiresConnectionOnly_is_false() {
+        // Given
+        let siteURL = "https://test.com"
+        let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: false)
+
+        // When
+        let text = viewModel.subtitleString
+
+        // Then
+        assertEqual(WPComEmailLoginViewModel.Localization.loginToInstall, text)
+    }
+
+    func test_subtitle_string_is_correct_when_requiresConnectionOnly_is_true() {
+        // Given
+        let siteURL = "https://test.com"
+        let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: true)
+
+        // When
+        let text = viewModel.subtitleString
+
+        // Then
+        assertEqual(WPComEmailLoginViewModel.Localization.loginToConnect, text)
+    }
+
     func test_terms_string_is_correct() {
         // Given
         let siteURL = "https://test.com"
-        let viewModel = WPComEmailLoginViewModel(siteURL: siteURL)
+        let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: true)
 
         // When
         let text = viewModel.termsAttributedString.string
 
         // Then
-        let expectedString = String(format: Expectations.termsContent, Expectations.termsOfService, Expectations.shareDetails)
+        let expectedString = String(format: WPComEmailLoginViewModel.Localization.termsContent,
+                                    WPComEmailLoginViewModel.Localization.termsOfService,
+                                    WPComEmailLoginViewModel.Localization.shareDetails)
         assertEqual(text, expectedString)
     }
 
     func test_isEmailValid_is_false_for_invalid_email() {
         // Given
         let siteURL = "https://test.com"
-        let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, debounceDuration: 0)
+        let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: true, debounceDuration: 0)
 
         // When
         viewModel.emailAddress = "random@mail."
@@ -33,7 +83,7 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
     func test_isEmailValid_is_true_for_valid_email() {
         // Given
         let siteURL = "https://test.com"
-        let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, debounceDuration: 0)
+        let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, requiresConnectionOnly: true, debounceDuration: 0)
 
         // When
         viewModel.emailAddress = "random@mail.com"
@@ -42,22 +92,5 @@ final class WPComEmailLoginViewModelTests: XCTestCase {
         waitUntil {
             viewModel.isEmailValid == true
         }
-    }
-}
-
-private extension WPComEmailLoginViewModelTests {
-    enum Expectations {
-        static let termsContent = NSLocalizedString(
-            "By tapping the Install Jetpack button, you agree to our %1$@ and to %2$@ with WordPress.com.",
-            comment: "Content of the label at the end of the Wrong Account screen. " +
-            "Reads like: By tapping the Connect Jetpack button, you agree to our Terms of Service and to share details with WordPress.com.")
-        static let termsOfService = NSLocalizedString(
-            "Terms of Service",
-            comment: "The terms to be agreed upon when tapping the Connect Jetpack button on the Wrong Account screen."
-        )
-        static let shareDetails = NSLocalizedString(
-            "share details",
-            comment: "The action to be agreed upon when tapping the Connect Jetpack button on the Wrong Account screen."
-        )
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModelTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import WooCommerce
+
+final class WPComEmailLoginViewModelTests: XCTestCase {
+
+    func test_terms_string_is_correct() {
+        // Given
+        let siteURL = "https://test.com"
+        let viewModel = WPComEmailLoginViewModel(siteURL: siteURL)
+
+        // When
+        let text = viewModel.termsAttributedString.string
+
+        // Then
+        let expectedString = String(format: Expectations.termsContent, Expectations.termsOfService, Expectations.shareDetails)
+        assertEqual(text, expectedString)
+    }
+
+    func test_isEmailValid_is_false_for_invalid_email() {
+        // Given
+        let siteURL = "https://test.com"
+        let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, debounceDuration: 0)
+
+        // When
+        viewModel.emailAddress = "random@mail."
+
+        // Then
+        waitUntil {
+            viewModel.isEmailValid == false
+        }
+    }
+
+    func test_isEmailValid_is_true_for_valid_email() {
+        // Given
+        let siteURL = "https://test.com"
+        let viewModel = WPComEmailLoginViewModel(siteURL: siteURL, debounceDuration: 0)
+
+        // When
+        viewModel.emailAddress = "random@mail.com"
+
+        // Then
+        waitUntil {
+            viewModel.isEmailValid == true
+        }
+    }
+}
+
+private extension WPComEmailLoginViewModelTests {
+    enum Expectations {
+        static let termsContent = NSLocalizedString(
+            "By tapping the Install Jetpack button, you agree to our %1$@ and to %2$@ with WordPress.com.",
+            comment: "Content of the label at the end of the Wrong Account screen. " +
+            "Reads like: By tapping the Connect Jetpack button, you agree to our Terms of Service and to share details with WordPress.com.")
+        static let termsOfService = NSLocalizedString(
+            "Terms of Service",
+            comment: "The terms to be agreed upon when tapping the Connect Jetpack button on the Wrong Account screen."
+        )
+        static let shareDetails = NSLocalizedString(
+            "share details",
+            comment: "The action to be agreed upon when tapping the Connect Jetpack button on the Wrong Account screen."
+        )
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8918 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the UI for the custom WPCom email login screen of the Jetpack setup flow. Only local validation for the email field is available for now, integration will be added in a future PR.

Reference for the flow: [pe5sF9-1c9-p2]
Figma file: [ERGtCFLyiC9CFpHsw1XIid-fi-1516%3A41678]

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Make sure that you have access to a site with WooCommerce and no Jetpack.
- Log out of the app or skip onboarding if needed.
- Tap "Enter your site address" on the prologue screen and proceed with the address of your test site.
- Log in with the credentials of an admin account.
- When the login completes, tap the Jetback benefit banner at the bottom of the Dashboard screen.
- Tap Install Jetpack on the benefit modal.
- The WPCom email login screen should be displayed. The Install Jetpack button on this screen should be enabled only when you type a valid email address. The screen's title, subtitle, and CTA should mention "Install Jetpack".
- Log out of the app and log in again to your test site with another account (either admin or shop manager).
- Install, activate and connect Jetpack for your test site using your main account on WP Admin.
- On the app, tap the Jetpack benefit banner and Install Jetpack on the modal.
- The WPCom email login screen should be displayed with the title, subtitle, and CTA mentioning "Connect Jetpack".

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Needs installation | Connection only |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/221568969-c0a71923-7d8b-4de0-8596-f6792cdfb320.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/221575671-b4920811-615b-401b-aa29-4a23364e0d5c.png" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.