### PR TITLE
[Mobile Payments] Fix IPP feedback survey banner display logic

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 12.6
 -----
-
+- [Internal] Mobile Payments: fixed logic on display of IPP feedback banner on Order List [https://github.com/woocommerce/woocommerce-ios/pull/8994]
 
 12.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -254,8 +254,7 @@ private extension OrderListViewController {
                 case .orderCreation:
                     self.setOrderCreationTopBanner()
                 case .inPersonPaymentsFeedback(let survey):
-                    guard let survey = survey,
-                          self.inPersonPaymentsSurveyVariation != survey else {
+                    guard self.inPersonPaymentsSurveyVariation != survey else {
                         return
                     }
                     self.inPersonPaymentsSurveyVariation = survey

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -173,6 +173,8 @@ final class OrderListViewController: UIViewController, GhostableViewController {
         //
         // We can remove this once we've replaced XLPagerTabStrip.
         tableView.reloadData()
+
+        viewModel.updateBannerVisibility()
     }
 
     override func viewDidLayoutSubviews() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -159,11 +159,10 @@ final class OrderListViewController: UIViewController, GhostableViewController {
         configureSyncingCoordinator()
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
-            viewModel.feedbackBannerSurveySource(onCompletion: { survey in
-                // Only assign the survey once we're sure the data is fetched from storage
-                inPersonPaymentsSurveyVariation = survey
-                viewModel.trackInPersonPaymentsFeedbackBannerShown(for: survey)
-            })
+            let survey = viewModel.feedbackBannerSurveySource()
+            // Only assign the survey once we're sure the data is fetched from storage
+            inPersonPaymentsSurveyVariation = survey
+            viewModel.trackInPersonPaymentsFeedbackBannerShown(for: survey)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -254,12 +254,10 @@ private extension OrderListViewController {
                 case .orderCreation:
                     self.setOrderCreationTopBanner()
                 case .inPersonPaymentsFeedback(let survey):
-                    guard self.inPersonPaymentsSurveyVariation != survey else {
-                        return
+                    if self.inPersonPaymentsSurveyVariation != survey {
+                        self.inPersonPaymentsSurveyVariation = survey
+                        self.viewModel.trackInPersonPaymentsFeedbackBannerShown(for: survey)
                     }
-                    self.inPersonPaymentsSurveyVariation = survey
-                    self.viewModel.trackInPersonPaymentsFeedbackBannerShown(for: survey)
-
                     self.setIPPFeedbackTopBanner(survey: survey)
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -157,13 +157,6 @@ final class OrderListViewController: UIViewController, GhostableViewController {
 
         configureViewModel()
         configureSyncingCoordinator()
-
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner) {
-            let survey = viewModel.feedbackBannerSurveySource()
-            // Only assign the survey once we're sure the data is fetched from storage
-            inPersonPaymentsSurveyVariation = survey
-            viewModel.trackInPersonPaymentsFeedbackBannerShown(for: survey)
-        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -258,10 +251,14 @@ private extension OrderListViewController {
                     self.setErrorTopBanner()
                 case .orderCreation:
                     self.setOrderCreationTopBanner()
-                case .IPPFeedback:
-                    guard let survey = self.inPersonPaymentsSurveyVariation else {
+                case .inPersonPaymentsFeedback(let survey):
+                    guard let survey = survey,
+                          self.inPersonPaymentsSurveyVariation != survey else {
                         return
                     }
+                    self.inPersonPaymentsSurveyVariation = survey
+                    self.viewModel.trackInPersonPaymentsFeedbackBannerShown(for: survey)
+
                     self.setIPPFeedbackTopBanner(survey: survey)
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -572,7 +572,6 @@ extension OrderListViewModel {
 private extension OrderListViewModel {
     enum Constants {
         static let wcpayPaymentMethodID = "woocommerce_payments"
-        static let paymentMethodTitle = "WooCommerce In-Person Payments"
         static let receiptURLKey = "receipt_url"
         static let numberOfTransactions = 10
         static let remindIPPBannerDismissalAfterDays = 7

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -312,7 +312,6 @@ final class OrderListViewModel {
 
             let hasWCPayResults = WCPayOrdersResultsController.fetchedObjects.isEmpty ? false : true
             let WCPayResultsCount = WCPayOrdersResultsController.fetchedObjects.count
-            let hasOneOrMoreWCPayTransactions = (WCPayResultsCount >= 1) ? true : false
 
             /// In order to filter WCPay transactions processed through IPP within the last 30 days,
             /// we check if these contain `receipt_url` in their metadata, unlike those processed through a website,
@@ -329,8 +328,8 @@ final class OrderListViewModel {
                 }
                 // Case 1: No WCPay transactions
                 return onCompletion(.inPersonPaymentsCashOnDelivery)
-            } else if hasOneOrMoreWCPayTransactions && (recentWCPayResultsCount < Constants.numberOfTransactions) {
                 // Case 2: One or more WCPay transactions, but less than 10 within latest 30 days
+            } else if recentWCPayResultsCount < Constants.numberOfTransactions {
                 return onCompletion(.inPersonPaymentsFirstTransaction)
             } else if WCPayResultsCount >= Constants.numberOfTransactions {
                 // Case 3: More than 10 WCPay transactions

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -502,7 +502,8 @@ extension OrderListViewModel {
                     return .error
                 }
 
-                guard hasDismissedIPPFeedbackBanner else {
+                if !hasDismissedIPPFeedbackBanner,
+                   let inPersonPaymentsSurvey = inPersonPaymentsSurvey {
                     return .inPersonPaymentsFeedback(inPersonPaymentsSurvey)
                 }
 
@@ -549,7 +550,7 @@ extension OrderListViewModel {
     enum TopBanner: Equatable {
         case error
         case orderCreation
-        case inPersonPaymentsFeedback(SurveyViewController.Source?)
+        case inPersonPaymentsFeedback(SurveyViewController.Source)
         case none
 
         static func ==(lhs: TopBanner, rhs: TopBanner) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -278,7 +278,7 @@ final class OrderListViewModel {
         }
     }
 
-    func trackInPersonPaymentsFeedbackBannerShown(for surveySource: SurveyViewController.Source) {
+    func trackInPersonPaymentsFeedbackBannerShown(for surveySource: SurveyViewController.Source?) {
         var campaign: FeatureAnnouncementCampaign? = nil
 
         switch surveySource {
@@ -303,7 +303,7 @@ final class OrderListViewModel {
         )
     }
 
-    func feedbackBannerSurveySource(onCompletion: (SurveyViewController.Source) -> Void) {
+    func feedbackBannerSurveySource(onCompletion: (SurveyViewController.Source?) -> Void) {
         if isCODEnabled && isIPPSupportedCountry {
             fetchIPPTransactions()
 
@@ -322,15 +322,16 @@ final class OrderListViewModel {
 
             if !hasWCPayResults {
                 // Case 1: No WCPay transactions
-                onCompletion(.inPersonPaymentsCashOnDelivery)
+                return onCompletion(.inPersonPaymentsCashOnDelivery)
             } else if hasOneOrMoreWCPayTransactions && (recentWCPayResultsCount < Constants.numberOfTransactions) {
                 // Case 2: One or more WCPay transactions, but less than 10 within latest 30 days
-                onCompletion(.inPersonPaymentsFirstTransaction)
+                return onCompletion(.inPersonPaymentsFirstTransaction)
             } else if WCPayResultsCount >= Constants.numberOfTransactions {
                 // Case 3: More than 10 WCPay transactions
-                onCompletion(.inPersonPaymentsPowerUsers)
+                return onCompletion(.inPersonPaymentsPowerUsers)
             }
         }
+        onCompletion(.none)
     }
 
     private func createQuery() -> FetchResultSnapshotsProvider<StorageOrder>.Query {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -316,20 +316,21 @@ final class OrderListViewModel {
     func feedbackBannerSurveySource() -> SurveyViewController.Source? {
         if isIPPSupportedCountry {
             fetchIPPTransactions()
-            let hasWCPayResults = wcPayIPPOrdersResultsController.fetchedObjects.isEmpty ? false : true
-            let wcPayResultsCount = wcPayIPPOrdersResultsController.fetchedObjects.count
-            let recentWCPayResultsCount = recentWCPayIPPResultsController.fetchedObjects.count
+            let hasWCPayIPPResults = wcPayIPPOrdersResultsController.fetchedObjects.isNotEmpty
+            let wcPayIPPResultsCount = wcPayIPPOrdersResultsController.fetchedObjects.count
+            let hasRecentWCPayIPPResults = recentWCPayIPPResultsController.fetchedObjects.isNotEmpty
+            let recentWCPayIPPResultsCount = recentWCPayIPPResultsController.fetchedObjects.count
 
-            if !hasWCPayResults {
+            if !hasWCPayIPPResults {
                 guard isCODEnabled else {
                     return .none
                 }
                 // Case 1: No WCPay IPP transactions
                 return .inPersonPaymentsCashOnDelivery
-            } else if recentWCPayResultsCount < Constants.numberOfTransactions {
+            } else if hasRecentWCPayIPPResults && recentWCPayIPPResultsCount < Constants.numberOfTransactions {
                 // Case 2: One or more WCPay IPP transactions, but fewer than 10 within the last 30 days
                 return .inPersonPaymentsFirstTransaction
-            } else if wcPayResultsCount >= Constants.numberOfTransactions {
+            } else if wcPayIPPResultsCount >= Constants.numberOfTransactions {
                 // Case 3: More than 10 WCPay IPP transactions
                 return .inPersonPaymentsPowerUsers
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -310,7 +310,7 @@ final class OrderListViewModel {
         )
     }
 
-    func feedbackBannerSurveySource(onCompletion: (SurveyViewController.Source?) -> Void) {
+    func feedbackBannerSurveySource() -> SurveyViewController.Source? {
         if isIPPSupportedCountry {
             fetchIPPTransactions()
 
@@ -320,19 +320,19 @@ final class OrderListViewModel {
 
             if !hasWCPayResults {
                 guard isCODEnabled else {
-                    return onCompletion(.none)
+                    return .none
                 }
                 // Case 1: No WCPay IPP transactions
-                return onCompletion(.inPersonPaymentsCashOnDelivery)
+                return .inPersonPaymentsCashOnDelivery
             } else if recentWCPayResultsCount < Constants.numberOfTransactions {
                 // Case 2: One or more WCPay IPP transactions, but fewer than 10 within the last 30 days
-                return onCompletion(.inPersonPaymentsFirstTransaction)
+                return .inPersonPaymentsFirstTransaction
             } else if wcPayResultsCount >= Constants.numberOfTransactions {
                 // Case 3: More than 10 WCPay IPP transactions
-                return onCompletion(.inPersonPaymentsPowerUsers)
+                return .inPersonPaymentsPowerUsers
             }
         }
-        onCompletion(.none)
+        return .none
     }
 
     private func createQuery() -> FetchResultSnapshotsProvider<StorageOrder>.Query {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -24,6 +24,7 @@ final class OrderListViewModel {
     private let analytics: Analytics
     private let pushNotificationsManager: PushNotesManager
     private let notificationCenter: NotificationCenter
+    private let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
 
     /// Used for cancelling the observer for Remote Notifications when `self` is deallocated.
     ///
@@ -62,7 +63,7 @@ final class OrderListViewModel {
     }
 
     private var isIPPSupportedCountry: Bool {
-        CardPresentConfigurationLoader().configuration.isSupportedCountry
+        cardPresentPaymentsConfiguration.isSupportedCountry
     }
 
     /// Results controller that fetches any WooCommerce Payments In-Person Payments transactions
@@ -138,6 +139,7 @@ final class OrderListViewModel {
     @Published var hideIPPFeedbackBanner: Bool = true
 
     init(siteID: Int64,
+         cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics,
@@ -145,6 +147,7 @@ final class OrderListViewModel {
          notificationCenter: NotificationCenter = .default,
          filters: FilterOrderListViewModel.Filters?) {
         self.siteID = siteID
+        self.cardPresentPaymentsConfiguration = cardPresentPaymentsConfiguration
         self.stores = stores
         self.storageManager = storageManager
         self.analytics = analytics

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -7,17 +7,6 @@ import protocol Storage.StorageManagerType
 ///
 /// This is an incremental WIP. Eventually, we should move all the data loading in here.
 ///
-/// Important: The `OrdersViewController` **owned** by `OrdersTabbedViewController` currently
-/// does not get deallocated when switching sites. This `ViewModel` should consider that and not
-/// keep site-specific information as much as possible. For example, we shouldn't keep `siteID`
-/// in here but grab it from the `SessionManager` when we need it. Hopefully, we will be able to
-/// fix this in the future.
-///
-/// ## Work In Progress
-///
-/// This does not do anything at the moment. We will integrate `FetchResultsSnapshotsProvider`
-/// in here next.
-///
 final class OrderListViewModel {
     private let stores: StoresManager
     private let storageManager: StorageManagerType

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -307,7 +307,7 @@ final class OrderListViewModel {
     }
 
     func feedbackBannerSurveySource(onCompletion: (SurveyViewController.Source?) -> Void) {
-        if isCODEnabled && isIPPSupportedCountry {
+        if isIPPSupportedCountry {
             fetchIPPTransactions()
 
             let hasWCPayResults = WCPayOrdersResultsController.fetchedObjects.isEmpty ? false : true
@@ -324,6 +324,9 @@ final class OrderListViewModel {
             let recentWCPayResultsCount = recentIPPWCPayTransactionsFound.count
 
             if !hasWCPayResults {
+                guard isCODEnabled else {
+                    return onCompletion(.none)
+                }
                 // Case 1: No WCPay transactions
                 return onCompletion(.inPersonPaymentsCashOnDelivery)
             } else if hasOneOrMoreWCPayTransactions && (recentWCPayResultsCount < Constants.numberOfTransactions) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -549,6 +549,7 @@ final class OrderListViewModelTests: XCTestCase {
             id: 123,
             status: .completed,
             dateCreated: Date(),
+            datePaid: Date(),
             customFields: [OrderMetaData.init(metadataID: 1, key: "receipt_url", value: "https://example.com/receipts/1902384")]
         )
 
@@ -579,6 +580,7 @@ final class OrderListViewModelTests: XCTestCase {
             id: 123,
             status: .completed,
             dateCreated: Date(),
+            datePaid: Date(),
             customFields: [OrderMetaData.init(metadataID: 1, key: "receipt_url", value: "https://example.com/receipts/1902384")]
         )
 
@@ -611,6 +613,7 @@ final class OrderListViewModelTests: XCTestCase {
             id: 123,
             status: .completed,
             dateCreated: Date(),
+            datePaid: Date(),
             customFields: [OrderMetaData.init(metadataID: 1, key: "receipt_url", value: "https://example.com/receipts/1902384")]
         )
 
@@ -643,6 +646,7 @@ final class OrderListViewModelTests: XCTestCase {
             id: 123,
             status: .completed,
             dateCreated: Date(),
+            datePaid: Date(),
             customFields: [],
             paymentMethodID: "woocommerce_payments"
         )
@@ -683,6 +687,7 @@ final class OrderListViewModelTests: XCTestCase {
                 id: Int64(orderID),
                 status: .completed,
                 dateCreated: Date(),
+                datePaid: Date(),
                 customFields: [OrderMetaData.init(metadataID: metaDataID, key: "receipt_url", value: "https://example.com/receipts/\(orderID)")],
                 paymentMethodID: "woocommerce_payments"
             )
@@ -714,6 +719,7 @@ final class OrderListViewModelTests: XCTestCase {
                 id: Int64(orderID),
                 status: .completed,
                 dateCreated: Date(),
+                datePaid: Date(),
                 customFields: [OrderMetaData.init(metadataID: metaDataID, key: "receipt_url", value: "https://example.com/receipts/\(orderID)")],
                 paymentMethodID: "woocommerce_payments"
             )
@@ -889,12 +895,14 @@ private extension OrderListViewModelTests {
     func insertOrder(id orderID: Int64,
                      status: OrderStatusEnum,
                      dateCreated: Date = Date(),
+                     datePaid: Date? = nil,
                      customFields: [Yosemite.OrderMetaData] = [],
                      paymentMethodID: String? = nil) -> Yosemite.Order {
         let readonlyOrder = MockOrders().empty().copy(siteID: siteID,
                                                       orderID: orderID,
                                                       status: status,
                                                       dateCreated: dateCreated,
+                                                      datePaid: datePaid,
                                                       paymentMethodID: paymentMethodID,
                                                       customFields: customFields)
         let storageOrder = storage.insertNewObject(ofType: StorageOrder.self)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -34,13 +34,6 @@ final class OrderListViewModelTests: XCTestCase {
     }
 
     override func tearDown() {
-        ServiceLocator.setSelectedSiteSettings(SelectedSiteSettings())
-        storageManager.reset()
-        storageManager = nil
-        stores = nil
-        analyticsProvider = nil
-        analytics = nil
-
         cancellables.forEach {
             $0.cancel()
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -703,7 +703,7 @@ final class OrderListViewModelTests: XCTestCase {
         })
     }
 
-    func test_feedbackBannerSurveySource_when_there_more_than_ten_wcpay_orders_then_assigns_inPersonPaymentsPowerUsers_survey() {
+    func test_feedbackBannerSurveySource_when_there_are_more_than_ten_wcpay_orders_then_assigns_inPersonPaymentsPowerUsers_survey() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID,
                                            cardPresentPaymentsConfiguration: .init(country: "CA"),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -266,7 +266,12 @@ final class OrderListViewModelTests: XCTestCase {
 
     func test_when_having_no_error_and_IPP_banner_should_be_shown_shows_IPP_banner() {
         // Given
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
+        insertCODPaymentGateway()
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                           cardPresentPaymentsConfiguration: .init(country: "US"),
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           filters: nil)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case let .loadFeedbackVisibility(.inPersonPayments, onCompletion):
@@ -284,7 +289,7 @@ final class OrderListViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.topBanner == .inPersonPaymentsFeedback(.none)
+            viewModel.topBanner == .inPersonPaymentsFeedback(.inPersonPaymentsCashOnDelivery)
         }
     }
 
@@ -313,8 +318,13 @@ final class OrderListViewModelTests: XCTestCase {
 
     func test_when_having_no_error_and_orders_banner_or_IPP_banner_should_be_shown_shows_correct_banner() {
         // Given
+        insertCODPaymentGateway()
         let isIPPFeatureFlagEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPInAppFeedbackBanner)
-        let viewModel = OrderListViewModel(siteID: siteID, stores: stores, filters: nil)
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                           cardPresentPaymentsConfiguration: .init(country: "US"),
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           filters: nil)
 
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
@@ -333,7 +343,7 @@ final class OrderListViewModelTests: XCTestCase {
         if isIPPFeatureFlagEnabled {
             viewModel.hideIPPFeedbackBanner = false
             waitUntil {
-                viewModel.topBanner == .inPersonPaymentsFeedback(.none)
+                viewModel.topBanner == .inPersonPaymentsFeedback(.inPersonPaymentsCashOnDelivery)
             }
         } else {
             waitUntil {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -607,16 +607,20 @@ final class OrderListViewModelTests: XCTestCase {
 
     func test_feedbackBannerSurveySource_when_there_are_less_than_ten_wcpay_orders_then_assigns_inPersonPaymentsFirstTransaction_survey() {
         // Given
-        let viewModel = OrderListViewModel(siteID: siteID, analytics: analytics, filters: nil)
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                           cardPresentPaymentsConfiguration: .init(country: "CA"),
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           filters: nil)
         var expectedSurvey: SurveyViewController.Source?
 
         // When
         let _ = (0..<9).map { orderID in
             insertOrder(
-                id: orderID ,
+                id: orderID,
                 status: .completed,
                 dateCreated: Date(),
-                customFields: [],
+                customFields: [OrderMetaData.init(metadataID: 1, key: "receipt_url", value: "https://example.com/receipts/\(orderID)")],
                 paymentMethodID: "woocommerce_payments"
             )
         }
@@ -633,15 +637,20 @@ final class OrderListViewModelTests: XCTestCase {
 
     func test_feedbackBannerSurveySource_when_there_more_than_ten_wcpay_orders_then_assigns_inPersonPaymentsPowerUsers_survey() {
         // Given
-        let viewModel = OrderListViewModel(siteID: siteID, analytics: analytics, filters: nil)
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                           cardPresentPaymentsConfiguration: .init(country: "CA"),
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           filters: nil)
         var expectedSurvey: SurveyViewController.Source?
 
         // When
         let _ = (0..<15).map { orderID in
             insertOrder(
-                id: orderID ,
+                id: orderID,
                 status: .completed,
                 dateCreated: Date(),
+                customFields: [OrderMetaData.init(metadataID: 1, key: "receipt_url", value: "https://example.com/receipts/\(orderID)")],
                 paymentMethodID: "woocommerce_payments"
             )
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -685,6 +685,37 @@ final class OrderListViewModelTests: XCTestCase {
         assertEqual(.inPersonPaymentsFirstTransaction, survey)
     }
 
+    func test_feedbackBannerSurveySource_when_there_are_less_than_ten_wcpay_orders_all_order_than_30_days_then_no_survey() {
+        // Given
+        let viewModel = OrderListViewModel(siteID: siteID,
+                                           cardPresentPaymentsConfiguration: .init(country: "CA"),
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           filters: nil)
+
+        let thirtyOneDaysAgo = Date().adding(days: -31) ?? Date()
+        let _ = (0..<9).map { orderID in
+            let metaDataID = Int64(orderID + 100)
+            return insertOrder(
+                id: Int64(orderID),
+                status: .completed,
+                dateCreated: thirtyOneDaysAgo,
+                datePaid: thirtyOneDaysAgo,
+                customFields: [OrderMetaData.init(metadataID: metaDataID, key: "receipt_url", value: "https://example.com/receipts/\(orderID)")],
+                paymentMethodID: "woocommerce_payments"
+            )
+        }
+
+        // Confidence check
+        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 9)
+
+        // When
+        let survey = viewModel.feedbackBannerSurveySource()
+
+        // Then
+        assertEqual(.none, survey)
+    }
+
     func test_feedbackBannerSurveySource_when_there_are_more_than_ten_wcpay_orders_then_assigns_inPersonPaymentsPowerUsers_survey() {
         // Given
         let viewModel = OrderListViewModel(siteID: siteID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -678,11 +678,12 @@ final class OrderListViewModelTests: XCTestCase {
 
         // When
         let _ = (0..<9).map { orderID in
-            insertOrder(
-                id: orderID,
+            let metaDataID = Int64(orderID + 100)
+            return insertOrder(
+                id: Int64(orderID),
                 status: .completed,
                 dateCreated: Date(),
-                customFields: [OrderMetaData.init(metadataID: 1, key: "receipt_url", value: "https://example.com/receipts/\(orderID)")],
+                customFields: [OrderMetaData.init(metadataID: metaDataID, key: "receipt_url", value: "https://example.com/receipts/\(orderID)")],
                 paymentMethodID: "woocommerce_payments"
             )
         }
@@ -708,11 +709,12 @@ final class OrderListViewModelTests: XCTestCase {
 
         // When
         let _ = (0..<15).map { orderID in
-            insertOrder(
-                id: orderID,
+            let metaDataID = Int64(orderID + 100)
+            return insertOrder(
+                id: Int64(orderID),
                 status: .completed,
                 dateCreated: Date(),
-                customFields: [OrderMetaData.init(metadataID: 1, key: "receipt_url", value: "https://example.com/receipts/\(orderID)")],
+                customFields: [OrderMetaData.init(metadataID: metaDataID, key: "receipt_url", value: "https://example.com/receipts/\(orderID)")],
                 paymentMethodID: "woocommerce_payments"
             )
         }
@@ -897,6 +899,12 @@ private extension OrderListViewModelTests {
                                                       customFields: customFields)
         let storageOrder = storage.insertNewObject(ofType: StorageOrder.self)
         storageOrder.update(with: readonlyOrder)
+
+        for field in customFields {
+            let storageMetaData = storage.insertNewObject(ofType: Storage.OrderMetaData.self)
+            storageMetaData.update(with: field)
+            storageOrder.addToCustomFields(storageMetaData)
+        }
 
         return readonlyOrder
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -284,7 +284,7 @@ final class OrderListViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.topBanner == .IPPFeedback
+            viewModel.topBanner == .inPersonPaymentsFeedback(.none)
         }
     }
 
@@ -333,7 +333,7 @@ final class OrderListViewModelTests: XCTestCase {
         if isIPPFeatureFlagEnabled {
             viewModel.hideIPPFeedbackBanner = false
             waitUntil {
-                viewModel.topBanner == .IPPFeedback
+                viewModel.topBanner == .inPersonPaymentsFeedback(.none)
             }
         } else {
             waitUntil {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListViewModelTests.swift
@@ -563,11 +563,7 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 1)
 
         // When
-        let survey = waitFor { promise in
-            viewModel.feedbackBannerSurveySource(onCompletion: { survey in
-                promise(survey)
-            })
-        }
+        let survey = viewModel.feedbackBannerSurveySource()
 
         // Then
         assertEqual(.inPersonPaymentsCashOnDelivery, survey)
@@ -594,11 +590,7 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 1)
 
         // When
-        let survey = waitFor { promise in
-            viewModel.feedbackBannerSurveySource(onCompletion: { survey in
-                promise(survey)
-            })
-        }
+        let survey = viewModel.feedbackBannerSurveySource()
 
         // Then
         assertEqual(.none, survey)
@@ -627,11 +619,7 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 1)
 
         // When
-        let survey = waitFor { promise in
-            viewModel.feedbackBannerSurveySource(onCompletion: { survey in
-                promise(survey)
-            })
-        }
+        let survey = viewModel.feedbackBannerSurveySource()
 
         // Then
         assertEqual(.none, survey)
@@ -661,11 +649,7 @@ final class OrderListViewModelTests: XCTestCase {
         XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 1)
 
         // When
-        let survey = waitFor { promise in
-            viewModel.feedbackBannerSurveySource(onCompletion: { survey in
-                promise(survey)
-            })
-        }
+        let survey = viewModel.feedbackBannerSurveySource()
 
         // Then
         assertEqual(.inPersonPaymentsCashOnDelivery, survey)
@@ -678,9 +662,7 @@ final class OrderListViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            filters: nil)
-        var expectedSurvey: SurveyViewController.Source?
 
-        // When
         let _ = (0..<9).map { orderID in
             let metaDataID = Int64(orderID + 100)
             return insertOrder(
@@ -696,11 +678,11 @@ final class OrderListViewModelTests: XCTestCase {
         // Confidence check
         XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 9)
 
+        // When
+        let survey = viewModel.feedbackBannerSurveySource()
+
         // Then
-        viewModel.feedbackBannerSurveySource(onCompletion: { survey in
-            expectedSurvey = survey
-            XCTAssertEqual(expectedSurvey, .inPersonPaymentsFirstTransaction)
-        })
+        assertEqual(.inPersonPaymentsFirstTransaction, survey)
     }
 
     func test_feedbackBannerSurveySource_when_there_are_more_than_ten_wcpay_orders_then_assigns_inPersonPaymentsPowerUsers_survey() {
@@ -710,9 +692,7 @@ final class OrderListViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            filters: nil)
-        var expectedSurvey: SurveyViewController.Source?
 
-        // When
         let _ = (0..<15).map { orderID in
             let metaDataID = Int64(orderID + 100)
             return insertOrder(
@@ -728,11 +708,11 @@ final class OrderListViewModelTests: XCTestCase {
         // Confidence check
         XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), 15)
 
+        // When
+        let survey = viewModel.feedbackBannerSurveySource()
+
         // Then
-        viewModel.feedbackBannerSurveySource(onCompletion: { survey in
-            expectedSurvey = survey
-            XCTAssertEqual(expectedSurvey, .inPersonPaymentsPowerUsers)
-        })
+        assertEqual(.inPersonPaymentsPowerUsers, survey)
     }
 
     func test_IPPFeedbackBannerWasSubmitted_hides_banner_after_being_called() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8992
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes various issues in the logic that determines if, and which, In Person Payments feedback survey banner to show the user. Full context: pdfdoF-2pO-p2

To fix these issues and show the correct banners, we've decided to patch up the iOS implementation to make it work as intended by:

1. Remove COD requirement for surveys 2 and 3.
2. Use Orders filtered to IPP-only for surveys 2 and 3 (instead of all WCPay Orders.)
3. Replace the filter which uses a server-localized string, `paymentMethodTitle` to use `paymentMethodID` instead, to avoid potential clashes with other plugins. (N.B. `paymentMethodID` is the same for IPP and web, so this isn’t sufficient to identify IPP transactions alone, but we use it in combination with the presence of receiptUrl, which is only set for IPP transactions within WCPay)

This PR is a step-by-step refactor, starting by fixing the tests and then progressively addressing the issues. A commit-by-commit review shouldn't be required, but there's some extra context in the commit messages if you choose to view it that way.

## Known issues
1. Locally stored orders are used, which means that getting the correct response requires the relevant orders to be loaded. In practice, this will often mean that the relevant orders must be in the first page (25) of orders.
2. Not all data is fetched from the same place, or at the same time. We constantly try to display the correct banner, so that results, in some cases, in one banner briefly being shown before the correct banner is shown. In practice, this seems very rare and I don't have any repro steps.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Testing fully requires several stores, but the steps are simple:

1. Open the Order list
2. Observe the correct banner is shown

### Scenarios worth testing:

**Using a US or CA based store**
No WCPay IPP orders (web orders are fine)
With COD enabled
Shows banner with text "Share your own experience or how you collect in-person payments."

Same store with COD turned off (you can toggle it in the Payments menu of the app)
Doesn't show a banner

Using a US or CA based store with 1-9 WCPay IPP payments in the last 30 days
With COD enabled or disabled
Shows banner with text "Rate your first in-person payment experience."

Using a US or CA based store with 10 or more WCPay IPP payments
With COD enabled or disabled
Shows banner with text "Tell us all about your experience with in-person payments."

Using a US or CA based store with 1-9 WCPay IPP payments, all more than 30 days old
With COD enabled or disabled
Doesn't show a banner

**Using another country based store**
Using one of the above banner-displaying stores, temporarily switched to a non-US in wc-admin
Doesn't show a banner

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
