### PR TITLE
[Store Onboarding] Feedback for store setup

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -81,6 +81,8 @@ extension WooAnalyticsEvent {
         case inPersonPaymentsFirstTransactionBanner
         /// Shown in IPP banner for eligible merchants with a significant number of IPP transactions.
         case inPersonPaymentsPowerUsersBanner
+        /// Shown in store setup task list
+        case storeSetup = "store_setup"
     }
 
     /// The action performed on the survey screen.

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -185,7 +185,6 @@ extension WooConstants {
 
         /// URL for the store setup feedback survey
         ///
-        ///
 #if DEBUG
         case storeSetupFeedback = "https://automattic.survey.fm/testing-debug-woo-mobile-–-store-setup-survey-2022"
 #else

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -183,6 +183,15 @@ extension WooConstants {
         ///
         case productsFeedback = "https://automattic.survey.fm/woo-app-feature-feedback-products"
 
+        /// URL for the store setup feedback survey
+        ///
+        ///
+#if DEBUG
+        case storeSetupFeedback = "https://automattic.survey.fm/testing-debug-woo-mobile-–-store-setup-survey-2022"
+#else
+        case storeSetupFeedback = "https://automattic.survey.fm/woo-mobile-–-store-setup-survey-2022"
+#endif
+
         /// URL for the shipping labels M3 feedback survey
         ///
 #if DEBUG

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -541,8 +541,12 @@ private extension DashboardViewController {
             coordinator.start(task: task)
         },
                                                                                                    viewAllTapped: { [weak self] in
-            guard let self, let navigationController = self.navigationController else { return }
-            let coordinator = StoreOnboardingCoordinator(navigationController: navigationController)
+            guard let self,
+                  let navigationController = self.navigationController,
+                  let site = ServiceLocator.stores.sessionManager.defaultSite else {
+                return
+            }
+            let coordinator = StoreOnboardingCoordinator(navigationController: navigationController, site: site)
             self.onboardingCoordinator = coordinator
             coordinator.start()
         },

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -539,7 +539,19 @@ private extension DashboardViewController {
             let coordinator = StoreOnboardingCoordinator(navigationController: navigationController, site: site)
             self.onboardingCoordinator = coordinator
             coordinator.start(task: task)
+        },
+                                                                                                   viewAllTapped: { [weak self] in
+            guard let self, let navigationController = self.navigationController else { return }
+            let coordinator = StoreOnboardingCoordinator(navigationController: navigationController)
+            self.onboardingCoordinator = coordinator
+            coordinator.start()
+        },
+                                                                                                   shareFeedbackAction: { [weak self] in
+            // Present survey
+            let navigationController = SurveyCoordinatingController(survey: .storeSetup)
+            self?.present(navigationController, animated: true, completion: nil)
         })
+
         guard let uiView = hostingController.view else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -7,11 +7,13 @@ final class StoreOnboardingViewHostingController: UIHostingController<StoreOnboa
 
     init(viewModel: StoreOnboardingViewModel,
          taskTapped: @escaping (StoreOnboardingTask) -> Void,
-         viewAllTapped: (() -> Void)? = nil) {
+         viewAllTapped: (() -> Void)? = nil,
+         shareFeedbackAction: (() -> Void)? = nil) {
         self.viewModel = viewModel
         super.init(rootView: StoreOnboardingView(viewModel: viewModel,
                                                  taskTapped: taskTapped,
-                                                 viewAllTapped: viewAllTapped))
+                                                 viewAllTapped: viewAllTapped,
+                                                 shareFeedbackAction: shareFeedbackAction))
     }
 
     @available(*, unavailable)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -46,13 +46,16 @@ struct StoreOnboardingView: View {
     private let viewModel: StoreOnboardingViewModel
     private let taskTapped: (StoreOnboardingTask) -> Void
     private let viewAllTapped: (() -> Void)?
+    private let shareFeedbackAction: (() -> Void)?
 
     init(viewModel: StoreOnboardingViewModel,
          taskTapped: @escaping (StoreOnboardingTask) -> Void,
-         viewAllTapped: (() -> Void)? = nil) {
+         viewAllTapped: (() -> Void)? = nil,
+         shareFeedbackAction: (() -> Void)? = nil) {
         self.viewModel = viewModel
         self.taskTapped = taskTapped
         self.viewAllTapped = viewAllTapped
+        self.shareFeedbackAction = shareFeedbackAction
     }
 
     var body: some View {
@@ -76,7 +79,8 @@ struct StoreOnboardingView: View {
                 // Progress view
                 StoreSetupProgressView(isExpanded: viewModel.isExpanded,
                                        totalNumberOfTasks: viewModel.taskViewModels.count,
-                                       numberOfTasksCompleted: viewModel.numberOfTasksCompleted)
+                                       numberOfTasksCompleted: viewModel.numberOfTasksCompleted,
+                                       shareFeedbackAction: shareFeedbackAction)
 
                 // Task list
                 VStack(alignment: .leading, spacing: Layout.verticalSpacingBetweenTasks) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreSetupProgressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreSetupProgressView.swift
@@ -7,6 +7,10 @@ struct StoreSetupProgressView: View {
 
     let numberOfTasksCompleted: Int
 
+    let shareFeedbackAction: (() -> Void)?
+
+    @State private var showingActionSheet = false
+
     var body: some View {
         HStack(alignment: .top) {
             VStack(alignment: isExpanded ? .center : .leading, spacing: Layout.verticalSpacing) {
@@ -35,13 +39,18 @@ struct StoreSetupProgressView: View {
 
             // More button
             Button {
-                // TODO: Show the popup with feedback button
+                showingActionSheet = true
             } label: {
                 Image(uiImage: .ellipsisImage)
                     .flipsForRightToLeftLayoutDirection(true)
                     .foregroundColor(Color(.textTertiary))
             }
             .renderedIf(!isExpanded)
+        }
+        .confirmationDialog(Localization.title, isPresented: $showingActionSheet) {
+            Button(Localization.shareFeedbackButton) {
+                shareFeedbackAction?()
+            }
         }
     }
 }
@@ -79,14 +88,19 @@ private extension StoreSetupProgressView {
                 "This text is displayed when the store setup task list is presented in full-screen/expanded mode."
             )
         }
+
+        static let shareFeedbackButton = NSLocalizedString(
+            "Share feedback",
+            comment: "Title of the feedback button in the action sheet."
+        )
     }
 }
 
 
 struct StoreSetupProgressView_Previews: PreviewProvider {
     static var previews: some View {
-        StoreSetupProgressView(isExpanded: false, totalNumberOfTasks: 5, numberOfTasksCompleted: 1)
+        StoreSetupProgressView(isExpanded: false, totalNumberOfTasks: 5, numberOfTasksCompleted: 1, shareFeedbackAction: nil)
 
-        StoreSetupProgressView(isExpanded: true, totalNumberOfTasks: 5, numberOfTasksCompleted: 1)
+        StoreSetupProgressView(isExpanded: true, totalNumberOfTasks: 5, numberOfTasksCompleted: 1, shareFeedbackAction: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -71,6 +71,7 @@ extension SurveyViewController {
         case inPersonPaymentsCashOnDelivery
         case inPersonPaymentsFirstTransaction
         case inPersonPaymentsPowerUsers
+        case storeSetup
 
         fileprivate var url: URL {
             switch self {
@@ -120,6 +121,11 @@ extension SurveyViewController {
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
+            case .storeSetup:
+                return WooConstants.URLs.storeSetupFeedback
+                    .asURL()
+                    .tagPlatform("ios")
+                    .tagAppVersion(Bundle.main.bundleVersion())
             }
         }
 
@@ -127,7 +133,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback, .inPersonPaymentsCashOnDelivery, .inPersonPaymentsFirstTransaction, .inPersonPaymentsPowerUsers:
                 return Localization.title
-            case .productsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement:
+            case .productsFeedback, .shippingLabelsRelease3Feedback, .addOnsI1, .orderCreation, .couponManagement, .storeSetup:
                 return Localization.giveFeedback
             }
         }
@@ -153,6 +159,8 @@ extension SurveyViewController {
                 return .inPersonPaymentsFirstTransactionBanner
             case .inPersonPaymentsPowerUsers:
                 return .inPersonPaymentsPowerUsersBanner
+            case .storeSetup:
+                return .storeSetup
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -53,6 +53,22 @@ final class SurveyViewControllerTests: XCTestCase {
                         .tagAppVersion(Bundle.main.bundleVersion()))
     }
 
+    func test_it_loads_the_correct_store_setup_survey() throws {
+        // Given
+        let viewController = SurveyViewController(survey: .storeSetup, onCompletion: {})
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let mirror = try self.mirror(of: viewController)
+
+        // Then
+        XCTAssertTrue(mirror.webView.isLoading)
+        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.storeSetupFeedback
+                        .asURL()
+                        .tagPlatform("ios")
+                        .tagAppVersion(Bundle.main.bundleVersion()))
+    }
+
     func test_it_completes_after_receiving_a_form_submitted_completed_callback_request() throws {
         // Given
         var surveyCompleted = false


### PR DESCRIPTION
Closes: #8970 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Adds an option to share feedback for the store setup task list.

## Testing instructions
- Launch the app and login if needed
- Tap the ellipsis button (`...`) from the onboarding check list
- Tap on "Share feedback" and ensure that the store setup survey is launched

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![Simulator Screen Recording - iPhone 14 - 2023-02-28 at 17 46 03](https://user-images.githubusercontent.com/524475/221851963-8b206368-8663-460a-af03-5d3e104686ee.gif)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
