### PR TITLE
[Support Request] Add site URL request in support form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -228,7 +228,7 @@ private extension SupportForm {
         static let title = NSLocalizedString("Contact Support", comment: "Title of the view for contacting support.")
         static let iNeedHelp = NSLocalizedString("I need help with", comment: "Text on the support form to refer to what area the user has problem with.")
         static let letsGetItSorted = NSLocalizedString("Let’s get this sorted", comment: "Title to let the user know what do we want on the support screen.")
-        static let tellUsInfo = NSLocalizedString("Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon.",
+        static let tellUsInfo = NSLocalizedString("Tell us much as you can about the problem, and we will be in touch soon.",
                                                   comment: "Message info on the support screen.")
         static let subject = NSLocalizedString("Subject", comment: "Subject title on the support form")
         static let message = NSLocalizedString("Message", comment: "Message on the support form")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -228,7 +228,8 @@ private extension SupportForm {
         static let title = NSLocalizedString("Contact Support", comment: "Title of the view for contacting support.")
         static let iNeedHelp = NSLocalizedString("I need help with", comment: "Text on the support form to refer to what area the user has problem with.")
         static let letsGetItSorted = NSLocalizedString("Let’s get this sorted", comment: "Title to let the user know what do we want on the support screen.")
-        static let tellUsInfo = NSLocalizedString("Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon.",
+        static let tellUsInfo = NSLocalizedString(["Let us know your site address (URL) and tell us as much as you can about the problem,",
+                                                  " and we will be in touch soon."].joined(),
                                                   comment: "Message info on the support screen.")
         static let subject = NSLocalizedString("Subject", comment: "Subject title on the support form")
         static let message = NSLocalizedString("Message", comment: "Message on the support form")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -228,7 +228,7 @@ private extension SupportForm {
         static let title = NSLocalizedString("Contact Support", comment: "Title of the view for contacting support.")
         static let iNeedHelp = NSLocalizedString("I need help with", comment: "Text on the support form to refer to what area the user has problem with.")
         static let letsGetItSorted = NSLocalizedString("Let’s get this sorted", comment: "Title to let the user know what do we want on the support screen.")
-        static let tellUsInfo = NSLocalizedString("Tell us much as you can about the problem, and we will be in touch soon.",
+        static let tellUsInfo = NSLocalizedString("Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon.",
                                                   comment: "Message info on the support screen.")
         static let subject = NSLocalizedString("Subject", comment: "Subject title on the support form")
         static let message = NSLocalizedString("Message", comment: "Message on the support form")

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -6893,7 +6893,7 @@ This part is the link to the website, and forms part of a longer sentence which 
 "Tell us more about %1$@..." = "Tell us more about %1$@...";
 
 /* Message info on the support screen. */
-"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon.";
+"Tell us much as you can about the problem, and we will be in touch soon." = "Tell us much as you can about the problem, and we will be in touch soon.";
 
 /* Terms of service link on the account creation form.
    The terms to be agreed upon when tapping the Connect Jetpack button on the Jetpack setup required screen.

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -6893,7 +6893,7 @@ This part is the link to the website, and forms part of a longer sentence which 
 "Tell us more about %1$@..." = "Tell us more about %1$@...";
 
 /* Message info on the support screen. */
-"Tell us much as you can about the problem, and we will be in touch soon." = "Tell us much as you can about the problem, and we will be in touch soon.";
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon.";
 
 /* Terms of service link on the account creation form.
    The terms to be agreed upon when tapping the Connect Jetpack button on the Jetpack setup required screen.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9007 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Currently, the app's support contact form says, `Tell us much as you can about the problem, and we will be in touch soon.`  when requesting information from the user.

Sometimes, merchants may have multiple sites connected to their accounts, so it might be helpful to ask them about the site URL to reduce the back and forth.

## Testing instructions

1. Go to Menu > Settings > Help & Support > Contact Support
2. Check that the text under the `Let's get this sorted` title say `Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon.`

## Screenshots

<img src="https://user-images.githubusercontent.com/40906847/222069274-bbbbc9e4-5fc1-4c9d-a9cb-d0c4ac0ea4e5.png" width=300 />

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
