### PR TITLE
Top performers SwiftUI views for the upcoming changes in dashboard

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/DashboardTopPerformersView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/DashboardTopPerformersView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// Shows top performing products for a site in a given time range on the dashboard.
+struct DashboardTopPerformersView: View {
+    @ObservedObject private var viewModel: DashboardTopPerformersViewModel
+
+    init(viewModel: DashboardTopPerformersViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        if viewModel.rows.isNotEmpty {
+            TopPerformersView(itemTitle: Localization.productsTitle,
+                              valueTitle: Localization.itemsSoldTitle,
+                              rows: viewModel.rows,
+                              isRedacted: viewModel.isRedacted)
+            .padding(Layout.padding)
+            .redacted(reason: viewModel.isRedacted ? .placeholder : [])
+            .shimmering(active: viewModel.isRedacted)
+        } else {
+            TopPerformersEmptyView()
+        }
+    }
+}
+
+private extension DashboardTopPerformersView {
+    enum Localization {
+        static let productsTitle = NSLocalizedString(
+            "Products",
+            comment: "Title for the products card at the top of the top performers section in dashboard stats."
+        )
+        static let itemsSoldTitle = NSLocalizedString(
+            "Items Sold",
+            comment: "Title for the products card at the top of the top performers section in dashboard stats."
+        )
+    }
+
+    enum Layout {
+        static let padding: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+    }
+}
+
+struct DashboardTopPerformersView_Previews: PreviewProvider {
+    static var previews: some View {
+        DashboardTopPerformersView(viewModel: .init(state: .loading, onTap: { _ in }))
+        DashboardTopPerformersView(viewModel: .init(state: .loaded(rows: [.init(productID: 12,
+                                                                                productName: "Fun product",
+                                                                                quantity: 6,
+                                                                                price: 12.8,
+                                                                                total: 16.8,
+                                                                                currency: "USD",
+                                                                                imageUrl: nil)]), onTap: { _ in }))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/DashboardTopPerformersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/DashboardTopPerformersViewModel.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import struct Yosemite.TopEarnerStatsItem
+
+/// View model for `DashboardTopPerformersView`.
+final class DashboardTopPerformersViewModel: ObservableObject {
+    /// UI state of the dashboard top performers.
+    enum State {
+        /// Shows placeholder rows.
+        case loading
+        /// Shows either an empty view or a list of top performing rows.
+        case loaded(rows: [TopEarnerStatsItem])
+    }
+
+    @Published private(set) var isRedacted: Bool = false
+    @Published private(set) var rows: [TopPerformersRow.Data] = []
+
+    private var state: State
+    private var onTap: (_ item: TopEarnerStatsItem) -> Void
+
+    private let placeholderRows: [TopPerformersRow.Data] = [
+        .init(imageURL: nil, name: "Placeholder", details: "", value: "Value"),
+        .init(imageURL: nil, name: "Placeholder", details: "", value: "Value"),
+        .init(imageURL: nil, name: "Placeholder", details: "", value: "Value")
+    ]
+
+    init(state: State, onTap: @escaping (_ item: TopEarnerStatsItem) -> Void) {
+        self.state = state
+        self.onTap = onTap
+        update(state: state)
+    }
+
+    /// Updates the state based on the data loading status.
+    func update(state: State) {
+        switch state {
+        case .loading:
+            isRedacted = true
+            rows = placeholderRows
+        case .loaded(let items):
+            isRedacted = false
+            let rows = items.map { item in
+                TopPerformersRow.Data(imageURL: URL(string: item.imageUrl ?? ""),
+                                      name: item.productName ?? "",
+                                      details: Localization.netSales(value: item.totalString),
+                                      value: "\(item.quantity)",
+                                      tapHandler: { [weak self] in
+                    self?.onTap(item)
+                })
+            }
+            self.rows = rows
+        }
+    }
+}
+
+private extension DashboardTopPerformersViewModel {
+    enum Localization {
+        static func netSales(value: String) -> String {
+            String.localizedStringWithFormat(NSLocalizedString("Net sales: %@", comment: "Label for the total sales of a product in the Analytics Hub"),
+                                             value)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/DashboardTopPerformersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/DashboardTopPerformersViewModel.swift
@@ -17,11 +17,11 @@ final class DashboardTopPerformersViewModel: ObservableObject {
     private var state: State
     private var onTap: (_ item: TopEarnerStatsItem) -> Void
 
-    private let placeholderRows: [TopPerformersRow.Data] = [
-        .init(imageURL: nil, name: "Placeholder", details: "", value: "Value"),
-        .init(imageURL: nil, name: "Placeholder", details: "", value: "Value"),
-        .init(imageURL: nil, name: "Placeholder", details: "", value: "Value")
-    ]
+    private let placeholderRows: [TopPerformersRow.Data] = Array(repeating: .init(imageURL: nil,
+                                                                                  name: "        ",
+                                                                                  details: "",
+                                                                                  value: "     "),
+                                                                 count: 3)
 
     init(state: State, onTap: @escaping (_ item: TopEarnerStatsItem) -> Void) {
         self.state = state

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersEmptyView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersEmptyView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Shown when the site doesn't have any top performers for a time range.
+/// Contains a placeholder image and text.
+struct TopPerformersEmptyView: View {
+    var body: some View {
+        VStack(alignment: .center, spacing: Layout.defaultSpacing) {
+            Image(uiImage: .noStoreImage)
+            Text(Localization.text)
+                .subheadlineStyle()
+        }
+        .padding(Layout.padding)
+    }
+}
+
+private extension TopPerformersEmptyView {
+    enum Localization {
+        static let text = NSLocalizedString(
+            "No activity this period",
+            comment: "Default text for Top Performers section when no data exists for a given period."
+        )
+    }
+
+    enum Layout {
+        static let defaultSpacing: CGFloat = 10
+        static let padding: EdgeInsets = .init(top: 0, leading: defaultSpacing, bottom: defaultSpacing, trailing: defaultSpacing)
+    }
+}
+
+struct TopPerformersEmptyView_Previews: PreviewProvider {
+    static var previews: some View {
+        TopPerformersEmptyView()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersView.swift
@@ -42,9 +42,13 @@ struct TopPerformersView: View {
 
             // Rows
             ForEach(rows.indexed(), id: \.0.self) { index, row in
-
-                // Do not render the divider for the last row.
-                TopPerformersRow(data: row, showDivider: index < rows.count - 1)
+                Button {
+                    row.tapHandler?()
+                } label: {
+                    // Do not render the divider for the last row.
+                    TopPerformersRow(data: row, showDivider: index < rows.count - 1)
+                }
+                .disabled(row.tapHandler == nil)
             }
             .redacted(reason: isRedacted ? .placeholder : [])
             .shimmering(active: isRedacted)
@@ -82,6 +86,17 @@ struct TopPerformersRow: View {
         /// Item Value
         ///
         let value: String
+
+        /// Handles the tap action if the row is tappable. If the row is not tappable, `nil` is set.
+        let tapHandler: (() -> Void)?
+
+        init(imageURL: URL? = nil, name: String, details: String, value: String, tapHandler: (() -> Void)? = nil) {
+            self.imageURL = imageURL
+            self.name = name
+            self.details = details
+            self.value = value
+            self.tapHandler = tapHandler
+        }
     }
 
     /// Row  information to display.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 		027D67D1245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027D67D0245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift */; };
 		027F240C258371150021DB06 /* RefundShippingLabelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027F240B258371150021DB06 /* RefundShippingLabelViewModelTests.swift */; };
 		027F83ED29B046D2002688C6 /* DashboardTopPerformersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027F83EC29B046D2002688C6 /* DashboardTopPerformersViewModel.swift */; };
+		027F83EF29B048E2002688C6 /* DashboardTopPerformersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027F83EE29B048E2002688C6 /* DashboardTopPerformersViewModelTests.swift */; };
 		02817B39242B34560050AD8B /* ToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02817B38242B34560050AD8B /* ToolbarView.swift */; };
 		028203CF297662A200217369 /* DomainSelectorDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028203CE297662A200217369 /* DomainSelectorDataProvider.swift */; };
 		02820F3422C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift */; };
@@ -2428,6 +2429,7 @@
 		027D67D0245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterTypeViewModel+Helpers.swift"; sourceTree = "<group>"; };
 		027F240B258371150021DB06 /* RefundShippingLabelViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingLabelViewModelTests.swift; sourceTree = "<group>"; };
 		027F83EC29B046D2002688C6 /* DashboardTopPerformersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTopPerformersViewModel.swift; sourceTree = "<group>"; };
+		027F83EE29B048E2002688C6 /* DashboardTopPerformersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTopPerformersViewModelTests.swift; sourceTree = "<group>"; };
 		02817B38242B34560050AD8B /* ToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarView.swift; sourceTree = "<group>"; };
 		028203CE297662A200217369 /* DomainSelectorDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSelectorDataProvider.swift; sourceTree = "<group>"; };
 		02820F3322C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+HeaderFooterHelpers.swift"; sourceTree = "<group>"; };
@@ -5400,6 +5402,7 @@
 				0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */,
 				02AB40812784297C00929CF3 /* ProductTableViewCellViewModelTests.swift */,
 				028E1F712833E954001F8829 /* DashboardViewModelTests.swift */,
+				027F83EE29B048E2002688C6 /* DashboardTopPerformersViewModelTests.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -11748,6 +11751,7 @@
 				D85136CD231E15B800DD0539 /* MockReviews.swift in Sources */,
 				E181CDCC291BB2E1002DA3C6 /* InAppPurchaseStoreTests.swift in Sources */,
 				2655905B27863D1300BB8457 /* MockCollectOrderPaymentUseCase.swift in Sources */,
+				027F83EF29B048E2002688C6 /* DashboardTopPerformersViewModelTests.swift in Sources */,
 				D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */,
 				A650BE862578E76600C655E0 /* MockStorageManager+Sample.swift in Sources */,
 				5791FB4224EC834300117FD6 /* MainTabViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -300,6 +300,7 @@
 		027D4A8E2526FD1800108626 /* SettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 027D4A8C2526FD1700108626 /* SettingsViewController.xib */; };
 		027D67D1245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027D67D0245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift */; };
 		027F240C258371150021DB06 /* RefundShippingLabelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027F240B258371150021DB06 /* RefundShippingLabelViewModelTests.swift */; };
+		027F83ED29B046D2002688C6 /* DashboardTopPerformersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027F83EC29B046D2002688C6 /* DashboardTopPerformersViewModel.swift */; };
 		02817B39242B34560050AD8B /* ToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02817B38242B34560050AD8B /* ToolbarView.swift */; };
 		028203CF297662A200217369 /* DomainSelectorDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028203CE297662A200217369 /* DomainSelectorDataProvider.swift */; };
 		02820F3422C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift */; };
@@ -455,6 +456,8 @@
 		02E3B62D290631B3007E0F13 /* AccountCreationFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B62C290631B3007E0F13 /* AccountCreationFormViewModel.swift */; };
 		02E3B62F2906322B007E0F13 /* AccountCreationFormFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B62E2906322B007E0F13 /* AccountCreationFormFieldView.swift */; };
 		02E3B63129066858007E0F13 /* StoreCreationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B63029066858007E0F13 /* StoreCreationCoordinator.swift */; };
+		02E4908929AE49B9005942AE /* TopPerformersEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4908829AE49B9005942AE /* TopPerformersEmptyView.swift */; };
+		02E4908D29AF216E005942AE /* DashboardTopPerformersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4908C29AF216E005942AE /* DashboardTopPerformersView.swift */; };
 		02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */; };
 		02E4AF7126FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4AF7026FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift */; };
 		02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */; };
@@ -2424,6 +2427,7 @@
 		027D4A8C2526FD1700108626 /* SettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsViewController.xib; sourceTree = "<group>"; };
 		027D67D0245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterTypeViewModel+Helpers.swift"; sourceTree = "<group>"; };
 		027F240B258371150021DB06 /* RefundShippingLabelViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingLabelViewModelTests.swift; sourceTree = "<group>"; };
+		027F83EC29B046D2002688C6 /* DashboardTopPerformersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTopPerformersViewModel.swift; sourceTree = "<group>"; };
 		02817B38242B34560050AD8B /* ToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarView.swift; sourceTree = "<group>"; };
 		028203CE297662A200217369 /* DomainSelectorDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSelectorDataProvider.swift; sourceTree = "<group>"; };
 		02820F3322C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+HeaderFooterHelpers.swift"; sourceTree = "<group>"; };
@@ -2578,6 +2582,8 @@
 		02E3B62C290631B3007E0F13 /* AccountCreationFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationFormViewModel.swift; sourceTree = "<group>"; };
 		02E3B62E2906322B007E0F13 /* AccountCreationFormFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationFormFieldView.swift; sourceTree = "<group>"; };
 		02E3B63029066858007E0F13 /* StoreCreationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCoordinator.swift; sourceTree = "<group>"; };
+		02E4908829AE49B9005942AE /* TopPerformersEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPerformersEmptyView.swift; sourceTree = "<group>"; };
+		02E4908C29AF216E005942AE /* DashboardTopPerformersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTopPerformersView.swift; sourceTree = "<group>"; };
 		02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		02E4AF7026FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewFromNoteParcelFactory.swift; sourceTree = "<group>"; };
 		02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Chart.swift"; sourceTree = "<group>"; };
@@ -6854,6 +6860,9 @@
 				748D34E02148291E00E21A2F /* TopPerformerDataViewController.swift */,
 				748D34DC214828DC00E21A2F /* TopPerformerDataViewController.xib */,
 				26E7EE7329365F0700793045 /* TopPerformersView.swift */,
+				02E4908829AE49B9005942AE /* TopPerformersEmptyView.swift */,
+				02E4908C29AF216E005942AE /* DashboardTopPerformersView.swift */,
+				027F83EC29B046D2002688C6 /* DashboardTopPerformersViewModel.swift */,
 			);
 			path = MyStore;
 			sourceTree = "<group>";
@@ -10381,6 +10390,7 @@
 				B5F571A421BEC90D0010D1B8 /* NoteDetailsHeaderPlainTableViewCell.swift in Sources */,
 				EE57C11F297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift in Sources */,
 				AEA3F91127BEC08800B9F555 /* PriceFieldFormatter.swift in Sources */,
+				02E4908929AE49B9005942AE /* TopPerformersEmptyView.swift in Sources */,
 				4592A54B24BF58DD00BC3DE0 /* ProductTagsViewController.swift in Sources */,
 				D817585E22BB5E8700289CFE /* OrderEmailComposer.swift in Sources */,
 				D8815ADF26383EE700EDAD62 /* CardPresentPaymentsModalViewController.swift in Sources */,
@@ -10810,6 +10820,7 @@
 				DE50294928BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift in Sources */,
 				02E8B17E23E2C8D900A43403 /* ProductImageActionHandler.swift in Sources */,
 				03076D3A290C22BE008EE839 /* WebView.swift in Sources */,
+				02E4908D29AF216E005942AE /* DashboardTopPerformersView.swift in Sources */,
 				023D877925EC8BCB00625963 /* UIScrollView+LargeTitleWorkaround.swift in Sources */,
 				2664210326F40FB1001FC5B4 /* View+ScrollModifiers.swift in Sources */,
 				02695770237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift in Sources */,
@@ -11320,6 +11331,7 @@
 				DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */,
 				035DBA45292D0164003E5125 /* CollectOrderPaymentUseCase.swift in Sources */,
 				0282DD96233C960C006A5FDB /* SearchResultCell.swift in Sources */,
+				027F83ED29B046D2002688C6 /* DashboardTopPerformersViewModel.swift in Sources */,
 				260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */,
 				2678897C270E6E8B00BD249E /* SimplePaymentsAmount.swift in Sources */,
 				09F5DE5D27CF948000E5A4D2 /* BulkUpdateOptionsModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardTopPerformersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardTopPerformersViewModelTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import WooCommerce
+
+final class DashboardTopPerformersViewModelTests: XCTestCase {
+    // MARK: - Initializer in different states
+
+    func test_init_with_loading_state_sets_isRedacted_and_placeholder_rows() throws {
+        // Given
+        let viewModel = DashboardTopPerformersViewModel(state: .loading, onTap: { _ in })
+
+        // Then
+        XCTAssertTrue(viewModel.isRedacted)
+        XCTAssertEqual(viewModel.rows.count, 3)
+    }
+
+    func test_init_with_loaded_state_and_empty_rows_sets_isRedacted_and_empty_rows() throws {
+        // Given
+        let viewModel = DashboardTopPerformersViewModel(state: .loaded(rows: []), onTap: { _ in })
+
+        // Then
+        XCTAssertFalse(viewModel.isRedacted)
+        XCTAssertEqual(viewModel.rows.count, 0)
+    }
+
+    func test_init_with_loaded_state_and_nonempty_rows_sets_isRedacted_and_rows() throws {
+        // Given
+        let viewModel = DashboardTopPerformersViewModel(state: .loaded(rows: [.fake()]), onTap: { _ in })
+
+        // Then
+        XCTAssertFalse(viewModel.isRedacted)
+        XCTAssertEqual(viewModel.rows.count, 1)
+    }
+
+    // MARK: - `update(state:)`
+
+    func test_updateState_with_loading_state_sets_isRedacted_and_placeholder_rows() throws {
+        // Given
+        let viewModel = DashboardTopPerformersViewModel(state: .loaded(rows: [.fake()]), onTap: { _ in })
+
+        // When
+        viewModel.update(state: .loading)
+
+        // Then
+        XCTAssertTrue(viewModel.isRedacted)
+        XCTAssertEqual(viewModel.rows.count, 3)
+    }
+
+    func test_updateState_with_loaded_state_sets_isRedacted_and_rows() throws {
+        // Given
+        let viewModel = DashboardTopPerformersViewModel(state: .loading, onTap: { _ in })
+
+        // When
+        viewModel.update(state: .loaded(rows: [.fake()]))
+
+        // Then
+        XCTAssertFalse(viewModel.isRedacted)
+        XCTAssertEqual(viewModel.rows.count, 1)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Prerequisite of #8911 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

The ultimate goal of #8911 is to refactor the dashboard to have one single scroll view so that both the header (announcements, onboarding checklist) and the stats are scrollable altogether. We want to avoid nested scroll views, as it can result in unexpected scrolling behavior. Right now, there is one nested scroll view where the current top performers' UI is implemented in a `UITableView` (a subclass of `UIScrollView`) with an empty state in `NoPeriodDataTableViewCell.xib`. In order to replace this table view, we actually already have a SwiftUI version `TopPerformersView` used in the analytics hub. To make the `TopPerformersView` SwiftUI view work for the dashboard use case like supporting tap action, some changes are made to `TopPerformersView` with backward compatibility. New SwiftUI views are also created to replace the empty state `NoPeriodDataTableViewCell.xib` later and wrap the `TopPerformersView` to match the design.

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Changes to the existing `TopPerformersView`: added an optional `tapHandler` so that the top performer row can be tappable if the action handler is implemented. The row is updated to a button that is disabled when the action handler is `nil` (not tappable) for the existing analytics hub use case
- Created `TopPerformersEmptyView` for the empty state to replace `NoPeriodDataTableViewCell.xib` in a future PR
- Created `DashboardTopPerformersView` as a wrapper that either shows `TopPerformersEmptyView` or `TopPerformersView` based on its view model's state

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

For `TopPerformersEmptyView` and `DashboardTopPerformersView`, you can check the SwiftUI previews.

To test the existing analytics use case:

- Log in if needed
- In the My store tab, tap `See More` below the store stats chart --> the `PRODUCTS` section should look the same as before

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

- `TopPerformersEmptyView`:

<img width="831" alt="Screenshot 2023-03-02 at 10 51 17 AM" src="https://user-images.githubusercontent.com/1945542/222326799-3840d81b-2b6e-43ef-b304-622c8eeeca2e.png">

- `DashboardTopPerformersView`:

loading state | loaded state
-- | --
<img width="346" alt="Screenshot 2023-03-02 at 11 08 42 AM" src="https://user-images.githubusercontent.com/1945542/222326807-052deaaa-0800-430a-905d-ab5ec346499d.png"> | <img width="347" alt="Screenshot 2023-03-02 at 11 09 03 AM" src="https://user-images.githubusercontent.com/1945542/222326863-a3deb345-bed4-4979-a114-24d3ea260ed9.png">

- (no changes are expected) analytics hub:

<img src="https://user-images.githubusercontent.com/1945542/222326921-67490cd7-2f33-408b-b122-ecfa1aa864b3.png" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
