### PR TITLE
Track `signed_in` event during site credentials login

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -804,6 +804,10 @@ private extension AuthenticationManager {
         let checker = PostSiteCredentialLoginChecker(applicationPasswordUseCase: useCase)
         checker.checkEligibility(for: siteURL, from: navigationController) { [weak self] in
             guard let self else { return }
+            // Tracking `signedIn` after the user logged in using site creds & application password is created
+            // to ensure that we are measuring only the users who can actually start using the app
+            WordPressAuthenticator.track(.signedIn)
+
             // clear scheduled local notifications
             if self.featureFlagService.isFeatureFlagEnabled(.loginErrorNotifications) {
                 ServiceLocator.pushNotesManager.cancelLocalNotification(scenarios: LocalNotification.Scenario.allCases)


### PR DESCRIPTION
## Description
This PR starts tracking the `signed_in` tracks event when the client handles the site credential login. 


## Testing instructions

Prerequiste - Create a JN site without Jetpack and with WooCommerce

- Install and launch the app 
- Tap "Enter Your Store Address" and enter the JN site
- Tap Continue and enter your wp-admin credentials in the next screen
- You should land in the dashboard screen
- From the Xcode console, ensure that the following events are tracked in the same order
```
Tracked application_passwords_new_password_created, properties: [AnyHashable("scenario"): "generation"]
Tracked signed_in
```

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
