### PR TITLE
REST API: Password login UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -118,7 +118,7 @@ private extension JetpackSetupCoordinator {
                 displayAdminRoleRequiredError()
                 requiresConnectionOnly = true
             default:
-                showAlert(message: Localization.errorCheckingJetpack)
+                showAlert(message: prepareErrorMessage(for: error, fallback: Localization.errorCheckingJetpack))
             }
         }
     }
@@ -208,27 +208,33 @@ private extension JetpackSetupCoordinator {
     func startAuthentication(email: String, isPasswordlessAccount: Bool, onCompletion: @escaping () -> Void) {
         if isPasswordlessAccount {
             Task { @MainActor in
-                do {
-                    try await requestAuthenticationLink(email: email)
-                    onCompletion()
-                    showMagicLinkUI(email: email)
-                } catch {
-                    onCompletion()
-                    showAlert(message: Localization.errorRequestingAuthURL)
-                }
+                await requestAuthenticationLink(email: email)
+                onCompletion()
             }
         } else {
-            #warning("TODO: show password UI")
+            showPasswordUI(email: email)
             onCompletion()
         }
     }
 
-    func requestAuthenticationLink(email: String) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            accountService.requestAuthenticationLink(for: email, jetpackLogin: false, success: {
+    func requestAuthenticationLink(email: String) async {
+        await withCheckedContinuation { continuation in
+            accountService.requestAuthenticationLink(for: email, jetpackLogin: false, success: { [weak self] in
+                guard let self else {
+                    return continuation.resume()
+                }
+                DispatchQueue.main.async {
+                    self.showMagicLinkUI(email: email)
+                }
                 continuation.resume()
-            }, failure: { error in
-                continuation.resume(throwing: error)
+            }, failure: { [weak self] error in
+                guard let self else {
+                    return continuation.resume()
+                }
+                DispatchQueue.main.async {
+                    self.showAlert(message: self.prepareErrorMessage(for: error, fallback: Localization.errorRequestingAuthURL))
+                }
+                continuation.resume()
             })
         }
     }
@@ -237,11 +243,32 @@ private extension JetpackSetupCoordinator {
         let viewController = WPComMagicLinkHostingController(email: email, requiresConnectionOnly: requiresConnectionOnly)
         loginNavigationController?.pushViewController(viewController, animated: true)
     }
+
+    func showPasswordUI(email: String) {
+        let viewController = WPComPasswordLoginHostingController(
+            siteURL: site.url,
+            email: email,
+            requiresConnectionOnly: requiresConnectionOnly,
+            onSubmit: { _ in
+                #warning("TODO: handle log in")
+            },
+            onMagicLinkRequest: requestAuthenticationLink(email:))
+        loginNavigationController?.pushViewController(viewController, animated: true)
+    }
 }
 
 // MARK: - Error handling
 //
 private extension JetpackSetupCoordinator {
+    /// If a localized description is available, use it for the error alert.
+    func prepareErrorMessage(for error: Error, fallback: String) -> String {
+        let description = (error as NSError).localizedDescription
+        guard description.isNotEmpty else {
+            return fallback
+        }
+        return description
+    }
+
     /// Handles the result of `accountService`'s `isPasswordlessAccount`.
     /// The implementation follows what have been done in `WordPressAuthenticator`.
     /// Please update this when the API changes.
@@ -256,7 +283,7 @@ private extension JetpackSetupCoordinator {
             // username instead.
             #warning("TODO: handle username login")
         } else {
-            showAlert(message: Localization.errorCheckingWPComAccount)
+            showAlert(message: prepareErrorMessage(for: error, fallback: Localization.errorCheckingWPComAccount))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Screen for entering the password for a WPCom account during the Jetpack setup flow
+/// This is presented for users authenticated with WPOrg credentials.
+struct WPComPasswordLoginView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Constants.blockVerticalPadding) {
+                JetpackInstallHeaderView()
+
+                // title
+                Text("")
+                    .largeTitleStyle()
+
+                Spacer()
+            }
+            .padding(Constants.contentPadding)
+        }
+    }
+}
+
+private extension WPComPasswordLoginView {
+    enum Constants {
+        static let blockVerticalPadding: CGFloat = 32
+        static let contentVerticalSpacing: CGFloat = 8
+        static let contentPadding: CGFloat = 16
+    }
+}
+
+struct WPComPasswordLoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        WPComPasswordLoginView()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
@@ -3,7 +3,8 @@ import SwiftUI
 /// Screen for entering the password for a WPCom account during the Jetpack setup flow
 /// This is presented for users authenticated with WPOrg credentials.
 struct WPComPasswordLoginView: View {
-    private let viewModel: WPComPasswordLoginViewModel
+    @FocusState private var isPasswordFieldFocused: Bool
+    @ObservedObject private var viewModel: WPComPasswordLoginViewModel
 
     init(viewModel: WPComPasswordLoginViewModel) {
         self.viewModel = viewModel
@@ -14,9 +15,30 @@ struct WPComPasswordLoginView: View {
             VStack(alignment: .leading, spacing: Constants.blockVerticalPadding) {
                 JetpackInstallHeaderView()
 
-                // title
+                // Title
                 Text(viewModel.titleString)
                     .largeTitleStyle()
+
+                // Password field
+                AccountCreationFormFieldView(viewModel: .init(
+                    header: Localization.passwordLabel,
+                    placeholder: Localization.passwordPlaceholder,
+                    keyboardType: .default,
+                    text: $viewModel.password,
+                    isSecure: true,
+                    errorMessage: nil,
+                    isFocused: isPasswordFieldFocused
+                ))
+                .focused($isPasswordFieldFocused)
+
+                // Reset password button
+                Button {
+                    // TODO
+                } label: {
+                    Text(Localization.resetPassword)
+                        .linkStyle()
+                }
+                .buttonStyle(.plain)
 
                 Spacer()
             }
@@ -30,6 +52,21 @@ private extension WPComPasswordLoginView {
         static let blockVerticalPadding: CGFloat = 32
         static let contentVerticalSpacing: CGFloat = 8
         static let contentPadding: CGFloat = 16
+    }
+
+    enum Localization {
+        static let passwordLabel = NSLocalizedString(
+            "Enter your WordPress.com password",
+            comment: "Label for the password field on the WPCom password login screen of the Jetpack setup flow."
+        )
+        static let passwordPlaceholder = NSLocalizedString(
+            "Enter password",
+            comment: "Placeholder text for the password field on the WPCom password login screen of the Jetpack setup flow."
+        )
+        static let resetPassword = NSLocalizedString(
+            "Reset your password",
+            comment: "Button to reset password on the WPCom password login screen of the Jetpack setup flow."
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
@@ -4,8 +4,13 @@ import Kingfisher
 /// Hosting controller for `WPComPasswordLoginView`
 final class WPComPasswordLoginHostingController: UIHostingController<WPComPasswordLoginView> {
 
-    init(email: String, requiresConnectionOnly: Bool, onSubmit: @escaping (String) async -> Void) {
-        let viewModel = WPComPasswordLoginViewModel(email: email, requiresConnectionOnly: requiresConnectionOnly)
+    init(siteURL: String,
+         email: String,
+         requiresConnectionOnly: Bool,
+         onSubmit: @escaping (String) async -> Void) {
+        let viewModel = WPComPasswordLoginViewModel(siteURL: siteURL,
+                                                    email: email,
+                                                    requiresConnectionOnly: requiresConnectionOnly)
         super.init(rootView: WPComPasswordLoginView(viewModel: viewModel, onSubmit: onSubmit))
     }
 
@@ -74,7 +79,7 @@ struct WPComPasswordLoginView: View {
 
                 // Reset password button
                 Button {
-                    // TODO
+                    viewModel.resetPassword()
                 } label: {
                     Text(Localization.resetPassword)
                         .linkStyle()
@@ -145,6 +150,9 @@ private extension WPComPasswordLoginView {
 
 struct WPComPasswordLoginView_Previews: PreviewProvider {
     static var previews: some View {
-        WPComPasswordLoginView(viewModel: .init(email: "test@example.com", requiresConnectionOnly: true))
+        WPComPasswordLoginView(viewModel: .init(siteURL: "https://example.com",
+                                                email: "test@example.com",
+                                                requiresConnectionOnly: true),
+                               onSubmit: { _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
@@ -9,7 +9,7 @@ struct WPComPasswordLoginView: View {
                 JetpackInstallHeaderView()
 
                 // title
-                Text("")
+                Text(viewModel.titleString)
                     .largeTitleStyle()
 
                 Spacer()

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
@@ -3,6 +3,12 @@ import SwiftUI
 /// Screen for entering the password for a WPCom account during the Jetpack setup flow
 /// This is presented for users authenticated with WPOrg credentials.
 struct WPComPasswordLoginView: View {
+    private let viewModel: WPComPasswordLoginViewModel
+
+    init(viewModel: WPComPasswordLoginViewModel) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Constants.blockVerticalPadding) {
@@ -29,6 +35,6 @@ private extension WPComPasswordLoginView {
 
 struct WPComPasswordLoginView_Previews: PreviewProvider {
     static var previews: some View {
-        WPComPasswordLoginView()
+        WPComPasswordLoginView(viewModel: .init(username: "test@example.com", requiresConnectionOnly: true))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
@@ -62,6 +62,24 @@ struct WPComPasswordLoginView: View {
             }
             .padding(Constants.contentPadding)
         }
+        .safeAreaInset(edge: .bottom) {
+            VStack {
+                // Primary CTA
+                Button(Localization.primaryAction) {
+                    // TODO
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .disabled(viewModel.password.isEmpty)
+
+                // Secondary CTA
+                Button(Localization.secondaryAction) {
+                    // TODO
+                }
+                .buttonStyle(SecondaryButtonStyle())
+            }
+            .padding(Constants.contentPadding)
+            .background(Color(uiColor: .systemBackground))
+        }
     }
 }
 
@@ -86,6 +104,14 @@ private extension WPComPasswordLoginView {
         static let resetPassword = NSLocalizedString(
             "Reset your password",
             comment: "Button to reset password on the WPCom password login screen of the Jetpack setup flow."
+        )
+        static let primaryAction = NSLocalizedString(
+            "Continue",
+            comment: "Button to submit password on the WPCom password login screen of the Jetpack setup flow."
+        )
+        static let secondaryAction = NSLocalizedString(
+            "Or Continue using Magic Link",
+            comment: "Button to switch to magic link on the WPCom password login screen of the Jetpack setup flow."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Kingfisher
 
 /// Screen for entering the password for a WPCom account during the Jetpack setup flow
 /// This is presented for users authenticated with WPOrg credentials.
@@ -18,6 +19,23 @@ struct WPComPasswordLoginView: View {
                 // Title
                 Text(viewModel.titleString)
                     .largeTitleStyle()
+
+                // Avatar and email
+                HStack(spacing: Constants.contentPadding) {
+                    viewModel.avatarURL.map { url in
+                        KFImage(url)
+                            .resizable()
+                            .clipShape(Circle())
+                            .frame(width: Constants.avatarSize, height: Constants.avatarSize)
+                    }
+                    Text(viewModel.email)
+                    Spacer()
+                }
+                .padding(Constants.avatarPadding)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .strokeBorder(.gray, lineWidth: 1)
+                )
 
                 // Password field
                 AccountCreationFormFieldView(viewModel: .init(
@@ -52,6 +70,8 @@ private extension WPComPasswordLoginView {
         static let blockVerticalPadding: CGFloat = 32
         static let contentVerticalSpacing: CGFloat = 8
         static let contentPadding: CGFloat = 16
+        static let avatarSize: CGFloat = 32
+        static let avatarPadding: EdgeInsets = .init(top: 8, leading: 16, bottom: 8, trailing: 16)
     }
 
     enum Localization {
@@ -72,6 +92,6 @@ private extension WPComPasswordLoginView {
 
 struct WPComPasswordLoginView_Previews: PreviewProvider {
     static var previews: some View {
-        WPComPasswordLoginView(viewModel: .init(username: "test@example.com", requiresConnectionOnly: true))
+        WPComPasswordLoginView(viewModel: .init(email: "test@example.com", requiresConnectionOnly: true))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// View model for `WPComPasswordLoginView`.
+///
+final class WPComPasswordLoginViewModel {
+
+    /// Title of the view.
+    let titleString: String
+
+    /// Username/email address of the WPCom account
+    private let username: String
+
+    init(username: String, requiresConnectionOnly: Bool) {
+        self.username = username
+        self.titleString = requiresConnectionOnly ? Localization.connectJetpack : Localization.installJetpack
+    }
+}
+
+extension WPComPasswordLoginViewModel {
+    enum Localization {
+        static let installJetpack = NSLocalizedString(
+            "Install Jetpack",
+            comment: "Title for the WPCom magic link screen when Jetpack is not installed yet"
+        )
+        static let connectJetpack = NSLocalizedString(
+            "Connect Jetpack",
+            comment: "Title for the WPCom magic link screen when Jetpack is not connected yet"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
@@ -16,7 +16,7 @@ final class WPComPasswordLoginViewModel: ObservableObject {
 
     private let siteURL: String
 
-    @Published private(set) var avatarURL: URL?
+    private(set) var avatarURL: URL?
 
     private var loginFields: LoginFields {
         let loginFields = LoginFields()
@@ -45,7 +45,12 @@ private extension WPComPasswordLoginViewModel {
     /// Ref: https://en.gravatar.com/site/implement/images/
     func gravatarUrl(of email: String) -> URL? {
         let hash = gravatarHash(of: email)
-        let targetURL = String(format: "%@/%@?d=%@&s=%d&r=%@", Constants.baseGravatarURL, hash, Constants.gravatarDefaultOption, Constants.imageSize, Constants.gravatarRating)
+        let targetURL = String(format: "%@/%@?d=%@&s=%d&r=%@",
+                               Constants.baseGravatarURL,
+                               hash,
+                               Constants.gravatarDefaultOption,
+                               Constants.imageSize,
+                               Constants.gravatarRating)
         return URL(string: targetURL)
     }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
@@ -2,10 +2,13 @@ import Foundation
 
 /// View model for `WPComPasswordLoginView`.
 ///
-final class WPComPasswordLoginViewModel {
+final class WPComPasswordLoginViewModel: ObservableObject {
 
     /// Title of the view.
     let titleString: String
+
+    /// Entered password
+    @Published var password: String = ""
 
     /// Username/email address of the WPCom account
     private let username: String

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
@@ -10,16 +10,43 @@ final class WPComPasswordLoginViewModel: ObservableObject {
     /// Entered password
     @Published var password: String = ""
 
-    /// Username/email address of the WPCom account
-    private let username: String
+    /// Email address of the WPCom account
+    let email: String
 
-    init(username: String, requiresConnectionOnly: Bool) {
-        self.username = username
+    @Published private(set) var avatarURL: URL?
+
+    init(email: String, requiresConnectionOnly: Bool) {
+        self.email = email
         self.titleString = requiresConnectionOnly ? Localization.connectJetpack : Localization.installJetpack
+        avatarURL = gravatarUrl(of: email)
+    }
+}
+
+// MARK: - Helpers
+private extension WPComPasswordLoginViewModel {
+    /// Constructs Gravatar URL from an email.
+    /// Ref: https://en.gravatar.com/site/implement/images/
+    func gravatarUrl(of email: String) -> URL? {
+        let hash = gravatarHash(of: email)
+        let targetURL = String(format: "%@/%@?d=%@&s=%d&r=%@", Constants.baseGravatarURL, hash, Constants.gravatarDefaultOption, Constants.imageSize, Constants.gravatarRating)
+        return URL(string: targetURL)
+    }
+
+    func gravatarHash(of email: String) -> String {
+        return email
+            .lowercased()
+            .trimmingCharacters(in: .whitespaces)
+            .md5Hash()
     }
 }
 
 extension WPComPasswordLoginViewModel {
+    enum Constants {
+        static let imageSize = 80
+        static let baseGravatarURL = "https://gravatar.com/avatar"
+        static let gravatarRating = "g" // safest rating
+        static let gravatarDefaultOption = "mp" // a simple, cartoon-style silhouetted outline of a person
+    }
     enum Localization {
         static let installJetpack = NSLocalizedString(
             "Install Jetpack",

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressAuthenticator
 
 /// View model for `WPComPasswordLoginView`.
 ///
@@ -13,12 +14,28 @@ final class WPComPasswordLoginViewModel: ObservableObject {
     /// Email address of the WPCom account
     let email: String
 
+    private let siteURL: String
+
     @Published private(set) var avatarURL: URL?
 
-    init(email: String, requiresConnectionOnly: Bool) {
+    private var loginFields: LoginFields {
+        let loginFields = LoginFields()
+        loginFields.username = email
+        loginFields.password = password
+        loginFields.siteAddress = siteURL
+        loginFields.meta.userIsDotCom = true
+        return loginFields
+    }
+
+    init(siteURL: String, email: String, requiresConnectionOnly: Bool) {
+        self.siteURL = siteURL
         self.email = email
         self.titleString = requiresConnectionOnly ? Localization.connectJetpack : Localization.installJetpack
         avatarURL = gravatarUrl(of: email)
+    }
+
+    func resetPassword() {
+        WordPressAuthenticator.openForgotPasswordURL(loginFields)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1867,6 +1867,7 @@
 		DE4D239C29B06642003A4B5D /* WPComMagicLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D239B29B06642003A4B5D /* WPComMagicLinkView.swift */; };
 		DE4D239E29B073B1003A4B5D /* WPComMagicLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D239D29B073B1003A4B5D /* WPComMagicLinkViewModel.swift */; };
 		DE4D23A029B09D71003A4B5D /* WPComMagicLinkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D239F29B09D71003A4B5D /* WPComMagicLinkViewModelTests.swift */; };
+		DE4D23A429B0A9FA003A4B5D /* WPComPasswordLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23A329B0A9FA003A4B5D /* WPComPasswordLoginView.swift */; };
 		DE4D308928507B5B00E36ADD /* CouponCreationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D308828507B5B00E36ADD /* CouponCreationSuccess.swift */; };
 		DE4FB7732812AE96003D20D6 /* FilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4FB7722812AE96003D20D6 /* FilterListView.swift */; };
 		DE50294928BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50294828BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift */; };
@@ -4008,6 +4009,7 @@
 		DE4D239B29B06642003A4B5D /* WPComMagicLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComMagicLinkView.swift; sourceTree = "<group>"; };
 		DE4D239D29B073B1003A4B5D /* WPComMagicLinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComMagicLinkViewModel.swift; sourceTree = "<group>"; };
 		DE4D239F29B09D71003A4B5D /* WPComMagicLinkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComMagicLinkViewModelTests.swift; sourceTree = "<group>"; };
+		DE4D23A329B0A9FA003A4B5D /* WPComPasswordLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPasswordLoginView.swift; sourceTree = "<group>"; };
 		DE4D308828507B5B00E36ADD /* CouponCreationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponCreationSuccess.swift; sourceTree = "<group>"; };
 		DE4FB7722812AE96003D20D6 /* FilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListView.swift; sourceTree = "<group>"; };
 		DE50294828BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "WordPressOrgCredentials+Authenticator.swift"; path = "Classes/Authentication/WordPressOrgCredentials+Authenticator.swift"; sourceTree = SOURCE_ROOT; };
@@ -9354,6 +9356,7 @@
 				DEF8CF1E29AC870A00800A60 /* WPComEmailLoginViewModel.swift */,
 				DE4D239B29B06642003A4B5D /* WPComMagicLinkView.swift */,
 				DE4D239D29B073B1003A4B5D /* WPComMagicLinkViewModel.swift */,
+				DE4D23A329B0A9FA003A4B5D /* WPComPasswordLoginView.swift */,
 			);
 			path = WPComLogin;
 			sourceTree = "<group>";
@@ -11171,6 +11174,7 @@
 				028A465329597A91001CF6CE /* StoreCreationSellingPlatformsQuestionViewModel.swift in Sources */,
 				027CB045295D7B8B00F98F7C /* StoreCreationCountryQuestionViewModel.swift in Sources */,
 				2676F4CC2908284800C7A15B /* ProductCreationTypeCommand.swift in Sources */,
+				DE4D23A429B0A9FA003A4B5D /* WPComPasswordLoginView.swift in Sources */,
 				45A24E5F2451DF1A0050606B /* ProductMenuOrderViewController.swift in Sources */,
 				0201E4272945B01800C793C7 /* StoreCreationProfilerQuestionView.swift in Sources */,
 				2667BFE1252FA117008099D4 /* RefundItemQuantityListSelectorCommand.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1868,6 +1868,7 @@
 		DE4D239E29B073B1003A4B5D /* WPComMagicLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D239D29B073B1003A4B5D /* WPComMagicLinkViewModel.swift */; };
 		DE4D23A029B09D71003A4B5D /* WPComMagicLinkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D239F29B09D71003A4B5D /* WPComMagicLinkViewModelTests.swift */; };
 		DE4D23A429B0A9FA003A4B5D /* WPComPasswordLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23A329B0A9FA003A4B5D /* WPComPasswordLoginView.swift */; };
+		DE4D23A629B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23A529B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift */; };
 		DE4D308928507B5B00E36ADD /* CouponCreationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D308828507B5B00E36ADD /* CouponCreationSuccess.swift */; };
 		DE4FB7732812AE96003D20D6 /* FilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4FB7722812AE96003D20D6 /* FilterListView.swift */; };
 		DE50294928BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50294828BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift */; };
@@ -4010,6 +4011,7 @@
 		DE4D239D29B073B1003A4B5D /* WPComMagicLinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComMagicLinkViewModel.swift; sourceTree = "<group>"; };
 		DE4D239F29B09D71003A4B5D /* WPComMagicLinkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComMagicLinkViewModelTests.swift; sourceTree = "<group>"; };
 		DE4D23A329B0A9FA003A4B5D /* WPComPasswordLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPasswordLoginView.swift; sourceTree = "<group>"; };
+		DE4D23A529B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPasswordLoginViewModel.swift; sourceTree = "<group>"; };
 		DE4D308828507B5B00E36ADD /* CouponCreationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponCreationSuccess.swift; sourceTree = "<group>"; };
 		DE4FB7722812AE96003D20D6 /* FilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListView.swift; sourceTree = "<group>"; };
 		DE50294828BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "WordPressOrgCredentials+Authenticator.swift"; path = "Classes/Authentication/WordPressOrgCredentials+Authenticator.swift"; sourceTree = SOURCE_ROOT; };
@@ -9357,6 +9359,7 @@
 				DE4D239B29B06642003A4B5D /* WPComMagicLinkView.swift */,
 				DE4D239D29B073B1003A4B5D /* WPComMagicLinkViewModel.swift */,
 				DE4D23A329B0A9FA003A4B5D /* WPComPasswordLoginView.swift */,
+				DE4D23A529B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift */,
 			);
 			path = WPComLogin;
 			sourceTree = "<group>";
@@ -10760,6 +10763,7 @@
 				DE37517C28DC5FC6000163CB /* Authenticator.swift in Sources */,
 				AED089F227C794BC0020AE10 /* View+CurrencySymbol.swift in Sources */,
 				03BB9EA7292E50B600251E9E /* CardPresentModalSelectSearchType.swift in Sources */,
+				DE4D23A629B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift in Sources */,
 				D85806292642BA5400A8AB6C /* LegacyPaymentCaptureOrchestrator.swift in Sources */,
 				E1E636BB26FB467A00C9D0D7 /* Comparable+Woo.swift in Sources */,
 				450C2CB024CF006A00D570DD /* ProductTagsDataSource.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1869,6 +1869,7 @@
 		DE4D23A029B09D71003A4B5D /* WPComMagicLinkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D239F29B09D71003A4B5D /* WPComMagicLinkViewModelTests.swift */; };
 		DE4D23A429B0A9FA003A4B5D /* WPComPasswordLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23A329B0A9FA003A4B5D /* WPComPasswordLoginView.swift */; };
 		DE4D23A629B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23A529B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift */; };
+		DE4D23A829B0D11E003A4B5D /* WPComPasswordLoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23A729B0D11E003A4B5D /* WPComPasswordLoginViewModelTests.swift */; };
 		DE4D308928507B5B00E36ADD /* CouponCreationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D308828507B5B00E36ADD /* CouponCreationSuccess.swift */; };
 		DE4FB7732812AE96003D20D6 /* FilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4FB7722812AE96003D20D6 /* FilterListView.swift */; };
 		DE50294928BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50294828BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift */; };
@@ -4012,6 +4013,7 @@
 		DE4D239F29B09D71003A4B5D /* WPComMagicLinkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComMagicLinkViewModelTests.swift; sourceTree = "<group>"; };
 		DE4D23A329B0A9FA003A4B5D /* WPComPasswordLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPasswordLoginView.swift; sourceTree = "<group>"; };
 		DE4D23A529B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPasswordLoginViewModel.swift; sourceTree = "<group>"; };
+		DE4D23A729B0D11E003A4B5D /* WPComPasswordLoginViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPasswordLoginViewModelTests.swift; sourceTree = "<group>"; };
 		DE4D308828507B5B00E36ADD /* CouponCreationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponCreationSuccess.swift; sourceTree = "<group>"; };
 		DE4FB7722812AE96003D20D6 /* FilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListView.swift; sourceTree = "<group>"; };
 		DE50294828BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "WordPressOrgCredentials+Authenticator.swift"; path = "Classes/Authentication/WordPressOrgCredentials+Authenticator.swift"; sourceTree = SOURCE_ROOT; };
@@ -9369,6 +9371,7 @@
 			children = (
 				DEF8CF2129ACDBB100800A60 /* WPComEmailLoginViewModelTests.swift */,
 				DE4D239F29B09D71003A4B5D /* WPComMagicLinkViewModelTests.swift */,
+				DE4D23A729B0D11E003A4B5D /* WPComPasswordLoginViewModelTests.swift */,
 			);
 			path = WPComLogin;
 			sourceTree = "<group>";
@@ -11809,6 +11812,7 @@
 				D802549B265531D4001B2CC1 /* CardPresentModalConnectingToReaderTests.swift in Sources */,
 				4572641B27F1FDF2004E1F95 /* AddEditCouponViewModelTests.swift in Sources */,
 				AEE1D4FF25D1580E006A490B /* AttributeOptionListSelectorCommandTests.swift in Sources */,
+				DE4D23A829B0D11E003A4B5D /* WPComPasswordLoginViewModelTests.swift in Sources */,
 				CC5BA5F5287EDC900072F307 /* OrderCustomFieldsViewModelTests.swift in Sources */,
 				02B653AC2429F7BF00A9C839 /* MockTaxClassStoresManager.swift in Sources */,
 				0277AEA5256CAA4200F45C4A /* MockShippingLabel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModelTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import WooCommerce
+
+final class WPComPasswordLoginViewModelTests: XCTestCase {
+
+    func test_title_string_is_correct_when_requiresConnectionOnly_is_false() {
+        // Given
+        let siteURL = "https://example.com"
+        let viewModel = WPComPasswordLoginViewModel(siteURL: siteURL,
+                                                    email: "test@example.com",
+                                                    requiresConnectionOnly: false)
+
+        // When
+        let text = viewModel.titleString
+
+        // Then
+        assertEqual(WPComPasswordLoginViewModel.Localization.installJetpack, text)
+    }
+
+    func test_title_string_is_correct_when_requiresConnectionOnly_is_true() {
+        // Given
+        let siteURL = "https://example.com"
+        let viewModel = WPComPasswordLoginViewModel(siteURL: siteURL,
+                                                    email: "test@example.com",
+                                                    requiresConnectionOnly: true)
+
+        // When
+        let text = viewModel.titleString
+
+        // Then
+        assertEqual(WPComPasswordLoginViewModel.Localization.connectJetpack, text)
+    }
+
+    func test_gravatar_url_is_correct() throws {
+        // Given
+        let siteURL = "https://example.com"
+        let email = "test@example.com"
+        let viewModel = WPComPasswordLoginViewModel(siteURL: siteURL,
+                                                    email: email,
+                                                    requiresConnectionOnly: true)
+
+        // When
+        let url = try XCTUnwrap(viewModel.avatarURL)
+
+        // Then
+        assertEqual("https://gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?d=mp&s=80&r=g", url.absoluteString)
+    }
+
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8918 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR continues the custom WPCom login flow of the Jetpack setup feature by adding the UI for the password screen. Besides the UI part, some logic is also included:
- Constructing Gravatar URL based on the input email to show in the avatar view.
- Handling magic link requests and showing the magic link screen/error upon receiving responses.
- Error handling was updated by getting the `localizedDescription` to display on the alert if possible. This helps show more specific messages.
- A new button style `SecondaryLoadingButtonStyle` to show loading indicator on secondary buttons.

Flow reference: [pe5sF9-1c9-p2].

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Make sure that you have access to a site with WooCommerce and no Jetpack.
- Log out of the app or skip onboarding if needed.
- Tap "Enter your site address" on the prologue screen and proceed with the address of your test site.
- Log in with the credentials of an admin.
- When the login completes, tap the Jetback benefit banner at the bottom of the Dashboard screen.
- Tap Log In on the benefit modal.
- Enter the email address of a WPCom account with a password on the presented WPCom email login screen.
- Tap Install/Connect Jetpack. Notice that the password screen is displayed with the correct avatar.
- Tap Continue using magic link. The magic link screen should be displayed after the link is requested successfully.
- Try again with an A8C email address. Tapping Continue using magic link should fails with a message "You're not allowed to request login link for this account".

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/222445202-5aeaf7e8-e461-439f-acb9-e3c0abd961d9.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.