### PR TITLE
[Mobile Payments] Enable Tap to Pay for all users

### DIFF
--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -75,6 +75,8 @@ public enum FeatureFlag: Int {
     case inAppPurchases
 
     /// Enables Tap to Pay on iPhone flow in In-Person Payments, on eligible devices.
+    /// This flag needs to be retained, as we cannot enable TTPoI on the Enterprise certificate,
+    /// so `.alpha` builds must be excluded.
     ///
     case tapToPayOnIPhone
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Fix: When a product's details can be edited, they display a disclosure indicator (chevron). [https://github.com/woocommerce/woocommerce-ios/pull/8980]
 - [*] Payments: fixed a bug where enabled rows in the Payments Menu were sometimes incorrectly shown as disabled [https://github.com/woocommerce/woocommerce-ios/pull/8983]
 - [Internal] Mobile Payments: fixed logic on display of IPP feedback banner on Order List [https://github.com/woocommerce/woocommerce-ios/pull/8994]
+- [***] Mobile Payments: Tap to Pay on iPhone enabled for all US merchants [https://github.com/woocommerce/woocommerce-ios/pull/9023]
 
 12.5
 -----

--- a/WooCommerce/Classes/Model/BetaFeature.swift
+++ b/WooCommerce/Classes/Model/BetaFeature.swift
@@ -5,7 +5,6 @@ enum BetaFeature: String, CaseIterable {
     case productSKUScanner
     case couponManagement
     case inAppPurchases
-    case tapToPayOnIPhone
 }
 
 extension BetaFeature {
@@ -19,8 +18,6 @@ extension BetaFeature {
             return Localization.couponManagementTitle
         case .inAppPurchases:
             return Localization.inAppPurchasesManagementTitle
-        case .tapToPayOnIPhone:
-            return Localization.tapToPayOnIPhoneTitle
         }
     }
 
@@ -34,8 +31,6 @@ extension BetaFeature {
             return Localization.couponManagementDescription
         case .inAppPurchases:
             return Localization.inAppPurchasesManagementDescription
-        case .tapToPayOnIPhone:
-            return Localization.tapToPayOnIPhoneDescription
         }
     }
 
@@ -49,8 +44,6 @@ extension BetaFeature {
             return \.isCouponManagementSwitchEnabled
         case .inAppPurchases:
             return \.isInAppPurchasesSwitchEnabled
-        case .tapToPayOnIPhone:
-            return \.isTapToPayOnIPhoneSwitchEnabled
         }
     }
 
@@ -69,21 +62,9 @@ extension BetaFeature {
         switch self {
         case .inAppPurchases:
             return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.inAppPurchases)
-        case .tapToPayOnIPhone:
-            return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhone) && deviceMaySupportTTP
         default:
             return true
         }
-    }
-
-    // Full checking for support of TTP requires a more complicated call.
-    // This is sufficient for whether the feature toggle should be shown, as full support checks
-    // are done when a payment is started. This is a temporary measure until full release.
-    private var deviceMaySupportTTP: Bool {
-        guard #available(iOS 16, *) else {
-            return false
-        }
-        return !UIDevice.isPad()
     }
 
     static var availableFeatures: [Self] {
@@ -157,15 +138,6 @@ private extension BetaFeature {
             comment: "Cell title on beta features screen to enable in-app purchases")
         static let inAppPurchasesManagementDescription = NSLocalizedString(
             "Test out in-app purchases as we get ready to launch",
-            comment: "Cell description on beta features screen to enable in-app purchases")
-
-        static let tapToPayOnIPhoneTitle = NSLocalizedString(
-            "Tap to Pay on iPhone",
-            comment: "Cell tytle on beta features screen to enable Tap to Pay on iPhone: card payments with the " +
-            "phone's built in reader")
-        static let tapToPayOnIPhoneDescription = NSLocalizedString(
-            "Test out In-Person Payments using your phone's built-in card reader, as we get ready to launch. " +
-            "Supported on iPhone XS and newer phones, running iOS 16 or above, for US-based stores.",
             comment: "Cell description on beta features screen to enable in-app purchases")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -200,7 +200,7 @@ private extension InPersonPaymentsMenuViewController {
 
     var tapToPayOnIPhoneSection: Section? {
         guard featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhoneSetupFlow),
-              ServiceLocator.generalAppSettings.betaFeatureEnabled(.tapToPayOnIPhone) else {
+              featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhone) else {
             return nil
         }
         return Section(header: nil, rows: [.tapToPayOnIPhone])

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -148,7 +148,7 @@ final class PaymentMethodsViewModel: ObservableObject {
          paymentLink: URL? = nil,
          formattedTotal: String,
          flow: WooAnalyticsEvent.PaymentsFlow.Flow,
-         isTapToPayOnIPhoneEnabled: Bool = ServiceLocator.generalAppSettings.settings.isTapToPayOnIPhoneSwitchEnabled,
+         isTapToPayOnIPhoneEnabled: Bool = true,
          dependencies: Dependencies = Dependencies()) {
         self.siteID = siteID
         self.orderID = orderID


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8774 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
During development and initial release, we kept TTP behind an Experimental feature toggle. This PR turns Tap to Pay on iPhone on for all merchants. See pdfdoF-2s7-p2 for full context.

We still check for device support using the method which Stripe expose, called from `CardPresentPaymentPreflightController` using `CardPresentPaymentAction.checkDeviceSupport`. This checks for iOS 16+ and the required hardware, and we only show the selection modal if it returns `true`.

This change deliberately leaves the legacy code in place, because of other ongoing work combined with the chance that we may revert this in the 12.6 beta period. Leaving the legacy code in makes that potential reversion more straightforward. We will remove it once 12.6 is released.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Shown on supported devices
Using a US store on an iPhone XS or newer, running iOS16+

1. Delete the app if it's already installed, to clear localStorage for the toggle setting
2. Launch the app and collect a payment
3. Observe that you are asked to choose between the built-in reader and a bluetooth reader, as if you had the feature toggled on.

### Not shown on unsupported devices
Using a US store on a (physical) iPhone which doesn't support TTP – iPhone X or older, and/or running iOS 15.x

1. Delete the app if it's already installed, to clear localStorage for the toggle setting
2. Launch the app and collect a payment
3. Observe that you are **not** asked to choose between the built-in reader and a bluetooth reader, and the bluetooth connection process starts immediately.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
