### PR TITLE
[Product Bundles] Add product bundle properties to Product model

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -787,7 +787,16 @@ extension Networking.Product {
             variations: .fake(),
             groupedProducts: .fake(),
             menuOrder: .fake(),
-            addOns: .fake()
+            addOns: .fake(),
+            bundleLayout: .fake(),
+            bundleFormLocation: .fake(),
+            bundleItemGrouping: .fake(),
+            bundleMinSize: .fake(),
+            bundleMaxSize: .fake(),
+            bundleEditableInCart: .fake(),
+            bundleSoldIndividuallyContext: .fake(),
+            bundleStockStatus: .fake(),
+            bundleStockQuantity: .fake()
         )
     }
 }
@@ -860,6 +869,34 @@ extension ProductBackordersSetting {
     ///
     public static func fake() -> ProductBackordersSetting {
         .allowed
+    }
+}
+extension ProductBundleFormLocation {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ProductBundleFormLocation {
+        .defaultLocation
+    }
+}
+extension ProductBundleItemGrouping {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ProductBundleItemGrouping {
+        .parent
+    }
+}
+extension ProductBundleLayout {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ProductBundleLayout {
+        .defaultLayout
+    }
+}
+extension ProductBundleSoldIndividuallyContext {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ProductBundleSoldIndividuallyContext {
+        .product
     }
 }
 extension ProductCatalogVisibility {

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -560,6 +560,7 @@
 		CC01CE5129B0DC3B004FF537 /* ProductBundleLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC01CE5029B0DC3B004FF537 /* ProductBundleLayout.swift */; };
 		CC01CE5329B0DC4C004FF537 /* ProductBundleFormLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC01CE5229B0DC4C004FF537 /* ProductBundleFormLocation.swift */; };
 		CC01CE5529B0DEE2004FF537 /* ProductBundleItemGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC01CE5429B0DEE2004FF537 /* ProductBundleItemGrouping.swift */; };
+		CC01CE5829B0EBED004FF537 /* product-bundle.json in Resources */ = {isa = PBXBuildFile; fileRef = CC01CE5729B0EBED004FF537 /* product-bundle.json */; };
 		CC07865F267799EE00BA9AC1 /* ShippingLabelPurchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */; };
 		CC0786612677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */; };
 		CC0786632678F79500BA9AC1 /* shipping-label-purchase-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */; };
@@ -1445,6 +1446,7 @@
 		CC01CE5029B0DC3B004FF537 /* ProductBundleLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleLayout.swift; sourceTree = "<group>"; };
 		CC01CE5229B0DC4C004FF537 /* ProductBundleFormLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleFormLocation.swift; sourceTree = "<group>"; };
 		CC01CE5429B0DEE2004FF537 /* ProductBundleItemGrouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleItemGrouping.swift; sourceTree = "<group>"; };
+		CC01CE5729B0EBED004FF537 /* product-bundle.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle.json"; sourceTree = "<group>"; };
 		CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchase.swift; sourceTree = "<group>"; };
 		CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchaseMapper.swift; sourceTree = "<group>"; };
 		CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-purchase-success.json"; sourceTree = "<group>"; };
@@ -2442,6 +2444,7 @@
 				DE5CA110288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json */,
 				02AAD53E250092A300BA1E26 /* product-add-or-delete.json */,
 				02698CF524C17FC1005337C4 /* product-alternative-types.json */,
+				CC01CE5729B0EBED004FF537 /* product-bundle.json */,
 				02DD6491248A3EC00082523E /* product-external.json */,
 				4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */,
 				025CA2C7238F4FF400B05C81 /* product-shipping-classes-load-all.json */,
@@ -3178,6 +3181,7 @@
 				3158FE7C26129E2100E566B9 /* wcpay-account-restricted-pending.json in Resources */,
 				DE34051B28BDF12C00CF0D97 /* jetpack-connection-url.json in Resources */,
 				D823D91422377EE600C90817 /* shipment_tracking_providers.json in Resources */,
+				CC01CE5829B0EBED004FF537 /* product-bundle.json in Resources */,
 				4599FC5C24A6276F0056157A /* product-tags-all.json in Resources */,
 				EE57C1562980F3BF00BC31E7 /* shipment_tracking_single_without_data.json in Resources */,
 				03DCB77E262738E300C8953D /* coupon.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -556,6 +556,10 @@
 		B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */; };
 		B963A5CC2853870000EFADA0 /* OrderItemRefundMetaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B963A5CB2853870000EFADA0 /* OrderItemRefundMetaData.swift */; };
 		BAB373722795A1FB00837B4A /* OrderTaxLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB373712795A1FB00837B4A /* OrderTaxLine.swift */; };
+		CC01CE4F29AFEB87004FF537 /* ProductBundleSoldIndividuallyContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC01CE4E29AFEB87004FF537 /* ProductBundleSoldIndividuallyContext.swift */; };
+		CC01CE5129B0DC3B004FF537 /* ProductBundleLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC01CE5029B0DC3B004FF537 /* ProductBundleLayout.swift */; };
+		CC01CE5329B0DC4C004FF537 /* ProductBundleFormLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC01CE5229B0DC4C004FF537 /* ProductBundleFormLocation.swift */; };
+		CC01CE5529B0DEE2004FF537 /* ProductBundleItemGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC01CE5429B0DEE2004FF537 /* ProductBundleItemGrouping.swift */; };
 		CC07865F267799EE00BA9AC1 /* ShippingLabelPurchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */; };
 		CC0786612677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */; };
 		CC0786632678F79500BA9AC1 /* shipping-label-purchase-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */; };
@@ -1437,6 +1441,10 @@
 		BAB373712795A1FB00837B4A /* OrderTaxLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTaxLine.swift; sourceTree = "<group>"; };
 		BD9439D9B8F2C1ED2EADAA51 /* Pods-NetworkingTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C8F9A8CC6F90A8C9B5EF2EE2 /* Pods-Networking.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.release.xcconfig"; sourceTree = "<group>"; };
+		CC01CE4E29AFEB87004FF537 /* ProductBundleSoldIndividuallyContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleSoldIndividuallyContext.swift; sourceTree = "<group>"; };
+		CC01CE5029B0DC3B004FF537 /* ProductBundleLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleLayout.swift; sourceTree = "<group>"; };
+		CC01CE5229B0DC4C004FF537 /* ProductBundleFormLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleFormLocation.swift; sourceTree = "<group>"; };
+		CC01CE5429B0DEE2004FF537 /* ProductBundleItemGrouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleItemGrouping.swift; sourceTree = "<group>"; };
 		CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchase.swift; sourceTree = "<group>"; };
 		CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchaseMapper.swift; sourceTree = "<group>"; };
 		CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-purchase-success.json"; sourceTree = "<group>"; };
@@ -2865,9 +2873,21 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		CC01CE5629B0DFD5004FF537 /* ProductBundle */ = {
+			isa = PBXGroup;
+			children = (
+				CC01CE5229B0DC4C004FF537 /* ProductBundleFormLocation.swift */,
+				CC01CE5429B0DEE2004FF537 /* ProductBundleItemGrouping.swift */,
+				CC01CE5029B0DC3B004FF537 /* ProductBundleLayout.swift */,
+				CC01CE4E29AFEB87004FF537 /* ProductBundleSoldIndividuallyContext.swift */,
+			);
+			path = ProductBundle;
+			sourceTree = "<group>";
+		};
 		CE6BFEE62236CF0D005C79FB /* Product */ = {
 			isa = PBXGroup;
 			children = (
+				CC01CE5629B0DFD5004FF537 /* ProductBundle */,
 				CE6BFEE42236BF05005C79FB /* Product.swift */,
 				26650331261FFA1A0079A159 /* ProductAddOnEnvelope.swift */,
 				26650329261F41510079A159 /* ProductAddOn.swift */,
@@ -3556,6 +3576,7 @@
 				311D41302783C0E200052F64 /* StripeRemote.swift in Sources */,
 				267313312559CC930026F7EF /* PaymentGateway.swift in Sources */,
 				B58E5BEA20FFB3D0003C986E /* CodingUserInfoKey+Woo.swift in Sources */,
+				CC01CE5329B0DC4C004FF537 /* ProductBundleFormLocation.swift in Sources */,
 				EE57C10E2979277300BC31E7 /* ApplicationPasswordNameAndUUID.swift in Sources */,
 				B59325D3217E4206000B0E8E /* NoteMedia.swift in Sources */,
 				26731337255ACA850026F7EF /* PaymentGatewayListMapper.swift in Sources */,
@@ -3727,6 +3748,7 @@
 				7426CA0F21AF2C90004E9FFC /* SiteAPI.swift in Sources */,
 				D87F6151226591E10031A13B /* NullNetwork.swift in Sources */,
 				CE43A8F9229F463000A4FF29 /* ProductDownload.swift in Sources */,
+				CC01CE5529B0DEE2004FF537 /* ProductBundleItemGrouping.swift in Sources */,
 				4513382027A8227F00AE5E78 /* InboxNotesRemote.swift in Sources */,
 				B53EF5322180F21C003E146F /* Dictionary+Woo.swift in Sources */,
 				24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */,
@@ -3772,6 +3794,7 @@
 				CCB573AA268CCFE90070FBB0 /* ShippingLabelStatusPollingResponse.swift in Sources */,
 				B524193F21AC5FE400D6FC0A /* DotcomDeviceMapper.swift in Sources */,
 				021EAA5625493B3600AA8CCD /* OrderItemAttribute.swift in Sources */,
+				CC01CE4F29AFEB87004FF537 /* ProductBundleSoldIndividuallyContext.swift in Sources */,
 				77CE40602514CB3E003FF69D /* ProductDownloadDragAndDrop.swift in Sources */,
 				2685C0FE263B5D8900D9EE97 /* AddOnGroupRemote.swift in Sources */,
 				AE1950F3296DB2C2004D37D2 /* ProductsBulkUpdateMapper.swift in Sources */,
@@ -3853,6 +3876,7 @@
 				45150A9E26836A57006922EA /* CountryListMapper.swift in Sources */,
 				DE34051928BDEE6A00CF0D97 /* JetpackConnectionURLMapper.swift in Sources */,
 				CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */,
+				CC01CE5129B0DC3B004FF537 /* ProductBundleLayout.swift in Sources */,
 				077F39D426A58DE700ABEADC /* SystemStatusMapper.swift in Sources */,
 				45152811257A81730076B03C /* ProductAttributeMapper.swift in Sources */,
 				B505F6D120BEE39600BB1B69 /* AccountRemote.swift in Sources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -962,7 +962,7 @@ extension Networking.Product {
         bundleEditableInCart: NullableCopiableProp<Bool> = .copy,
         bundleSoldIndividuallyContext: NullableCopiableProp<ProductBundleSoldIndividuallyContext> = .copy,
         bundleStockStatus: NullableCopiableProp<ProductStockStatus> = .copy,
-        bundleStockQuantity: NullableCopiableProp<String> = .copy
+        bundleStockQuantity: NullableCopiableProp<Int64> = .copy
     ) -> Networking.Product {
         let siteID = siteID ?? self.siteID
         let productID = productID ?? self.productID

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -953,7 +953,16 @@ extension Networking.Product {
         variations: CopiableProp<[Int64]> = .copy,
         groupedProducts: CopiableProp<[Int64]> = .copy,
         menuOrder: CopiableProp<Int> = .copy,
-        addOns: CopiableProp<[ProductAddOn]> = .copy
+        addOns: CopiableProp<[ProductAddOn]> = .copy,
+        bundleLayout: NullableCopiableProp<ProductBundleLayout> = .copy,
+        bundleFormLocation: NullableCopiableProp<ProductBundleFormLocation> = .copy,
+        bundleItemGrouping: NullableCopiableProp<ProductBundleItemGrouping> = .copy,
+        bundleMinSize: NullableCopiableProp<Int64> = .copy,
+        bundleMaxSize: NullableCopiableProp<Int64> = .copy,
+        bundleEditableInCart: NullableCopiableProp<Bool> = .copy,
+        bundleSoldIndividuallyContext: NullableCopiableProp<ProductBundleSoldIndividuallyContext> = .copy,
+        bundleStockStatus: NullableCopiableProp<ProductStockStatus> = .copy,
+        bundleStockQuantity: NullableCopiableProp<String> = .copy
     ) -> Networking.Product {
         let siteID = siteID ?? self.siteID
         let productID = productID ?? self.productID
@@ -1018,6 +1027,15 @@ extension Networking.Product {
         let groupedProducts = groupedProducts ?? self.groupedProducts
         let menuOrder = menuOrder ?? self.menuOrder
         let addOns = addOns ?? self.addOns
+        let bundleLayout = bundleLayout ?? self.bundleLayout
+        let bundleFormLocation = bundleFormLocation ?? self.bundleFormLocation
+        let bundleItemGrouping = bundleItemGrouping ?? self.bundleItemGrouping
+        let bundleMinSize = bundleMinSize ?? self.bundleMinSize
+        let bundleMaxSize = bundleMaxSize ?? self.bundleMaxSize
+        let bundleEditableInCart = bundleEditableInCart ?? self.bundleEditableInCart
+        let bundleSoldIndividuallyContext = bundleSoldIndividuallyContext ?? self.bundleSoldIndividuallyContext
+        let bundleStockStatus = bundleStockStatus ?? self.bundleStockStatus
+        let bundleStockQuantity = bundleStockQuantity ?? self.bundleStockQuantity
 
         return Networking.Product(
             siteID: siteID,
@@ -1082,7 +1100,16 @@ extension Networking.Product {
             variations: variations,
             groupedProducts: groupedProducts,
             menuOrder: menuOrder,
-            addOns: addOns
+            addOns: addOns,
+            bundleLayout: bundleLayout,
+            bundleFormLocation: bundleFormLocation,
+            bundleItemGrouping: bundleItemGrouping,
+            bundleMinSize: bundleMinSize,
+            bundleMaxSize: bundleMaxSize,
+            bundleEditableInCart: bundleEditableInCart,
+            bundleSoldIndividuallyContext: bundleSoldIndividuallyContext,
+            bundleStockStatus: bundleStockStatus,
+            bundleStockQuantity: bundleStockQuantity
         )
     }
 }

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -449,15 +449,15 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         // https://github.com/woocommerce/woocommerce-ios/issues/4205
         let addOns = (try? container.decodeIfPresent(ProductAddOnEnvelope.self, forKey: .metadata)?.revolve()) ?? []
 
-        // Product Bundle
-        let bundleLayout = try container.decodeIfPresent(ProductBundleLayout.self, forKey: .bundleLayout)
-        let bundleFormLocation = try container.decodeIfPresent(ProductBundleFormLocation.self, forKey: .bundleFormLocation)
-        let bundleItemGrouping = try container.decodeIfPresent(ProductBundleItemGrouping.self, forKey: .bundleItemGrouping)
-        let bundleEditableInCart = try container.decodeIfPresent(Bool.self, forKey: .bundleEditableInCart)
-        let bundleSoldIndividuallyContext = try container.decodeIfPresent(ProductBundleSoldIndividuallyContext.self, forKey: .bundleSoldIndividuallyContext)
-        let bundleStockStatus = try container.decodeIfPresent(ProductStockStatus.self, forKey: .bundleStockStatus)
-        // When the bundle min size, max size, or stock quantity is not set, the API returns an empty string.
-        // In those cases, we skip decoding and set the property to `nil`
+        // Product Bundle properties
+        // Uses failsafe decoding because non-bundle product types can return unexpected value types.
+        let bundleLayout = container.failsafeDecodeIfPresent(ProductBundleLayout.self, forKey: .bundleLayout)
+        let bundleFormLocation = container.failsafeDecodeIfPresent(ProductBundleFormLocation.self, forKey: .bundleFormLocation)
+        let bundleItemGrouping = container.failsafeDecodeIfPresent(ProductBundleItemGrouping.self, forKey: .bundleItemGrouping)
+        let bundleEditableInCart = container.failsafeDecodeIfPresent(Bool.self, forKey: .bundleEditableInCart)
+        let bundleSoldIndividuallyContext = container.failsafeDecodeIfPresent(ProductBundleSoldIndividuallyContext.self, forKey: .bundleSoldIndividuallyContext)
+        let bundleStockStatus = container.failsafeDecodeIfPresent(ProductStockStatus.self, forKey: .bundleStockStatus)
+        // When the bundle min size, max size, or stock quantity is not set for a product bundle, the API returns an empty string and the value will be `nil`.
         let bundleMinSize = container.failsafeDecodeIfPresent(Int64.self, forKey: .bundleMinSize)
         let bundleMaxSize = container.failsafeDecodeIfPresent(Int64.self, forKey: .bundleMaxSize)
         let bundleStockQuantity = container.failsafeDecodeIfPresent(Int64.self, forKey: .bundleStockQuantity)

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -112,7 +112,7 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
     public let bundleStockStatus: ProductStockStatus?
 
     /// Quantity of bundles left in stock, taking bundled product quantity requirements into account. Applicable for bundle-type products only.
-    public let bundleStockQuantity: String?
+    public let bundleStockQuantity: Int64?
 
     /// Computed Properties
     ///
@@ -237,7 +237,7 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                 bundleEditableInCart: Bool?,
                 bundleSoldIndividuallyContext: ProductBundleSoldIndividuallyContext?,
                 bundleStockStatus: ProductStockStatus?,
-                bundleStockQuantity: String?) {
+                bundleStockQuantity: Int64?) {
         self.siteID = siteID
         self.productID = productID
         self.name = name
@@ -454,11 +454,13 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         let bundleFormLocation = try container.decodeIfPresent(ProductBundleFormLocation.self, forKey: .bundleFormLocation)
         let bundleItemGrouping = try container.decodeIfPresent(ProductBundleItemGrouping.self, forKey: .bundleItemGrouping)
         let bundleEditableInCart = try container.decodeIfPresent(Bool.self, forKey: .bundleEditableInCart)
-        let bundleMinSize = try container.decodeIfPresent(Int64.self, forKey: .bundleMinSize)
-        let bundleMaxSize = try container.decodeIfPresent(Int64.self, forKey: .bundleMaxSize)
         let bundleSoldIndividuallyContext = try container.decodeIfPresent(ProductBundleSoldIndividuallyContext.self, forKey: .bundleSoldIndividuallyContext)
         let bundleStockStatus = try container.decodeIfPresent(ProductStockStatus.self, forKey: .bundleStockStatus)
-        let bundleStockQuantity = try container.decodeIfPresent(String.self, forKey: .bundleStockQuantity)
+        // When the bundle min size, max size, or stock quantity is not set, the API returns an empty string.
+        // In those cases, we skip decoding and set the property to `nil`
+        let bundleMinSize = container.failsafeDecodeIfPresent(Int64.self, forKey: .bundleMinSize)
+        let bundleMaxSize = container.failsafeDecodeIfPresent(Int64.self, forKey: .bundleMaxSize)
+        let bundleStockQuantity = container.failsafeDecodeIfPresent(Int64.self, forKey: .bundleStockQuantity)
 
         self.init(siteID: siteID,
                   productID: productID,

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -85,6 +85,35 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
 
     public let addOns: [ProductAddOn]
 
+    // MARK: Product Bundle properties
+
+    /// Single-product details page layout. Applicable for bundle-type products only.
+    public let bundleLayout: ProductBundleLayout?
+
+    /// Controls the form location of the product in the single-product page. Applicable to bundle-type products.
+    public let bundleFormLocation: ProductBundleFormLocation?
+
+    /// Controls the display of bundle container/child items in cart/order templates. Applicable for bundle-type products only.
+    public let bundleItemGrouping: ProductBundleItemGrouping?
+
+    /// Min bundle size. Applicable for bundle-type products only.
+    public let bundleMinSize: Int64?
+
+    /// Max bundle size. Applicable for bundle-type products only.
+    public let bundleMaxSize: Int64?
+
+    /// Controls whether the configuration of this product can be modified from the cart page. Applicable to bundle-type products.
+    public let bundleEditableInCart: Bool?
+
+    /// Sold Individually option context. Applicable to bundle-type products.
+    public let bundleSoldIndividuallyContext: ProductBundleSoldIndividuallyContext?
+
+    /// Stock status of this bundle, taking bundled product quantity requirements and limitations into account. Applicable for bundle-type products only.
+    public let bundleStockStatus: ProductStockStatus?
+
+    /// Quantity of bundles left in stock, taking bundled product quantity requirements into account. Applicable for bundle-type products only.
+    public let bundleStockQuantity: String?
+
     /// Computed Properties
     ///
     public var productStatus: ProductStatus {
@@ -199,7 +228,16 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                 variations: [Int64],
                 groupedProducts: [Int64],
                 menuOrder: Int,
-                addOns: [ProductAddOn]) {
+                addOns: [ProductAddOn],
+                bundleLayout: ProductBundleLayout?,
+                bundleFormLocation: ProductBundleFormLocation?,
+                bundleItemGrouping: ProductBundleItemGrouping?,
+                bundleMinSize: Int64?,
+                bundleMaxSize: Int64?,
+                bundleEditableInCart: Bool?,
+                bundleSoldIndividuallyContext: ProductBundleSoldIndividuallyContext?,
+                bundleStockStatus: ProductStockStatus?,
+                bundleStockQuantity: String?) {
         self.siteID = siteID
         self.productID = productID
         self.name = name
@@ -263,6 +301,15 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         self.groupedProducts = groupedProducts
         self.menuOrder = menuOrder
         self.addOns = addOns
+        self.bundleLayout = bundleLayout
+        self.bundleFormLocation = bundleFormLocation
+        self.bundleItemGrouping = bundleItemGrouping
+        self.bundleMinSize = bundleMinSize
+        self.bundleMaxSize = bundleMaxSize
+        self.bundleEditableInCart = bundleEditableInCart
+        self.bundleStockStatus = bundleStockStatus
+        self.bundleStockQuantity = bundleStockQuantity
+        self.bundleSoldIndividuallyContext = bundleSoldIndividuallyContext
     }
 
     /// The public initializer for Product.
@@ -402,6 +449,17 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         // https://github.com/woocommerce/woocommerce-ios/issues/4205
         let addOns = (try? container.decodeIfPresent(ProductAddOnEnvelope.self, forKey: .metadata)?.revolve()) ?? []
 
+        // Product Bundle
+        let bundleLayout = try container.decodeIfPresent(ProductBundleLayout.self, forKey: .bundleLayout)
+        let bundleFormLocation = try container.decodeIfPresent(ProductBundleFormLocation.self, forKey: .bundleFormLocation)
+        let bundleItemGrouping = try container.decodeIfPresent(ProductBundleItemGrouping.self, forKey: .bundleItemGrouping)
+        let bundleEditableInCart = try container.decodeIfPresent(Bool.self, forKey: .bundleEditableInCart)
+        let bundleMinSize = try container.decodeIfPresent(Int64.self, forKey: .bundleMinSize)
+        let bundleMaxSize = try container.decodeIfPresent(Int64.self, forKey: .bundleMaxSize)
+        let bundleSoldIndividuallyContext = try container.decodeIfPresent(ProductBundleSoldIndividuallyContext.self, forKey: .bundleSoldIndividuallyContext)
+        let bundleStockStatus = try container.decodeIfPresent(ProductStockStatus.self, forKey: .bundleStockStatus)
+        let bundleStockQuantity = try container.decodeIfPresent(String.self, forKey: .bundleStockQuantity)
+
         self.init(siteID: siteID,
                   productID: productID,
                   name: name,
@@ -464,7 +522,16 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                   variations: variations,
                   groupedProducts: groupedProducts,
                   menuOrder: menuOrder,
-                  addOns: addOns)
+                  addOns: addOns,
+                  bundleLayout: bundleLayout,
+                  bundleFormLocation: bundleFormLocation,
+                  bundleItemGrouping: bundleItemGrouping,
+                  bundleMinSize: bundleMinSize,
+                  bundleMaxSize: bundleMaxSize,
+                  bundleEditableInCart: bundleEditableInCart,
+                  bundleSoldIndividuallyContext: bundleSoldIndividuallyContext,
+                  bundleStockStatus: bundleStockStatus,
+                  bundleStockQuantity: bundleStockQuantity)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -650,6 +717,16 @@ private extension Product {
         case groupedProducts    = "grouped_products"
         case menuOrder          = "menu_order"
         case metadata           = "meta_data"
+
+        case bundleLayout                   = "bundle_layout"
+        case bundleFormLocation             = "bundle_add_to_cart_form_location"
+        case bundleItemGrouping             = "bundle_item_grouping"
+        case bundleMinSize                  = "bundle_min_size"
+        case bundleMaxSize                  = "bundle_max_size"
+        case bundleEditableInCart           = "bundle_editable_in_cart"
+        case bundleSoldIndividuallyContext  = "bundle_sold_individually_context"
+        case bundleStockStatus              = "bundle_stock_status"
+        case bundleStockQuantity            = "bundle_stock_quantity"
     }
 }
 

--- a/Networking/Networking/Model/Product/ProductBundle/ProductBundleFormLocation.swift
+++ b/Networking/Networking/Model/Product/ProductBundle/ProductBundleFormLocation.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Codegen
+
+/// Represents supported "Form Location" options for products with the bundle product type.
+///
+public enum ProductBundleFormLocation: Codable, Hashable, GeneratedFakeable {
+    case defaultLocation
+    case afterSummary
+    case custom(String) // in case there are extensions modifying form location options
+}
+
+
+/// RawRepresentable Conformance
+///
+extension ProductBundleFormLocation: RawRepresentable {
+
+    /// Designated Initializer.
+    ///
+    public init(rawValue: String) {
+        switch rawValue {
+        case Keys.defaultLocation:
+            self = .defaultLocation
+        case Keys.afterSummary:
+            self = .afterSummary
+        default:
+            self = .custom(rawValue)
+        }
+    }
+
+    /// Returns the current Enum Case's Raw Value
+    ///
+    public var rawValue: String {
+        switch self {
+        case .defaultLocation:        return Keys.defaultLocation
+        case .afterSummary:              return Keys.afterSummary
+        case .custom(let payload):  return payload
+        }
+    }
+
+    /// Returns the localized text version of the Enum
+    ///
+    public var description: String {
+        switch self {
+        case .defaultLocation:
+            return NSLocalizedString("Default", comment: "Display label for the product bundle's default form location")
+        case .afterSummary:
+            return NSLocalizedString("Before Tabs",
+                                     comment: "Display label when a product bundle's add-to-cart form is displayed before the single-product tabs.")
+        case .custom(let payload):
+            return payload // unable to localize at runtime.
+        }
+    }
+}
+
+
+/// Enum containing the 'Known' Product Bundle Form Location Keys
+///
+private enum Keys {
+    static let defaultLocation  = "default"
+    static let afterSummary     = "after_summary"
+}

--- a/Networking/Networking/Model/Product/ProductBundle/ProductBundleItemGrouping.swift
+++ b/Networking/Networking/Model/Product/ProductBundle/ProductBundleItemGrouping.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Codegen
+
+/// Represents supported item grouping options for products with the bundle product type.
+///
+public enum ProductBundleItemGrouping: Codable, Hashable, GeneratedFakeable {
+    case parent
+    case noindent
+    case none
+    case custom(String) // in case there are extensions modifying item grouping options
+}
+
+
+/// RawRepresentable Conformance
+///
+extension ProductBundleItemGrouping: RawRepresentable {
+
+    /// Designated Initializer.
+    ///
+    public init(rawValue: String) {
+        switch rawValue {
+        case Keys.parent:
+            self = .parent
+        case Keys.noindent:
+            self = .noindent
+        case Keys.none:
+            self = .none
+        default:
+            self = .custom(rawValue)
+        }
+    }
+
+    /// Returns the current Enum Case's Raw Value
+    ///
+    public var rawValue: String {
+        switch self {
+        case .parent:        return Keys.parent
+        case .noindent:              return Keys.noindent
+        case .none:              return Keys.none
+        case .custom(let payload):  return payload
+        }
+    }
+
+    /// Returns the localized text version of the Enum
+    ///
+    public var description: String {
+        switch self {
+        case .parent:
+            return NSLocalizedString("Grouped", comment: "Display label for the product bundle's item grouping")
+        case .noindent:
+            return NSLocalizedString("Flat", comment: "Display label for the product bundle's item grouping")
+        case .none:
+            return NSLocalizedString("None", comment: "Display label for the product bundle's item grouping")
+        case .custom(let payload):
+            return payload // unable to localize at runtime.
+        }
+    }
+}
+
+
+/// Enum containing the 'Known' Product Bundle Form Location Keys
+///
+private enum Keys {
+    static let parent   = "parent"
+    static let noindent = "noindent"
+    static let none     = "none"
+}

--- a/Networking/Networking/Model/Product/ProductBundle/ProductBundleLayout.swift
+++ b/Networking/Networking/Model/Product/ProductBundle/ProductBundleLayout.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Codegen
+
+/// Represents all supported layouts for products with the bundle product type.
+///
+public enum ProductBundleLayout: Codable, Hashable, GeneratedFakeable {
+    case defaultLayout
+    case tabular
+    case grid
+    case custom(String) // in case there are extensions modifying layout options
+}
+
+
+/// RawRepresentable Conformance
+///
+extension ProductBundleLayout: RawRepresentable {
+
+    /// Designated Initializer.
+    ///
+    public init(rawValue: String) {
+        switch rawValue {
+        case Keys.defaultLayout:
+            self = .defaultLayout
+        case Keys.tabular:
+            self = .tabular
+        case Keys.grid:
+            self = .grid
+        default:
+            self = .custom(rawValue)
+        }
+    }
+
+    /// Returns the current Enum Case's Raw Value
+    ///
+    public var rawValue: String {
+        switch self {
+        case .defaultLayout:        return Keys.defaultLayout
+        case .tabular:              return Keys.tabular
+        case .grid:                 return Keys.grid
+        case .custom(let payload):  return payload
+        }
+    }
+
+    /// Returns the localized text version of the Enum
+    ///
+    public var description: String {
+        switch self {
+        case .defaultLayout:
+            return NSLocalizedString("Standard", comment: "Display label for the product bundle's layout")
+        case .tabular:
+            return NSLocalizedString("Tabular", comment: "Display label for the product bundle's layout")
+        case .grid:
+            return NSLocalizedString("Grid", comment: "Display label for the product bundle's layout")
+        case .custom(let payload):
+            return payload // unable to localize at runtime.
+        }
+    }
+}
+
+
+/// Enum containing the 'Known' Product Bundle Layout Keys
+///
+private enum Keys {
+    static let defaultLayout    = "default"
+    static let tabular          = "tabular"
+    static let grid             = "grid"
+}

--- a/Networking/Networking/Model/Product/ProductBundle/ProductBundleSoldIndividuallyContext.swift
+++ b/Networking/Networking/Model/Product/ProductBundle/ProductBundleSoldIndividuallyContext.swift
@@ -1,0 +1,9 @@
+import Foundation
+import Codegen
+
+/// Represents all contexts for the Sold Individually setting for products with the bundle product type.
+///
+public enum ProductBundleSoldIndividuallyContext: String, Codable, GeneratedFakeable {
+    case product
+    case configuration
+}

--- a/Networking/Networking/Model/Product/ProductStockStatus.swift
+++ b/Networking/Networking/Model/Product/ProductStockStatus.swift
@@ -7,6 +7,7 @@ public enum ProductStockStatus: Codable, Hashable, GeneratedFakeable {
     case inStock
     case outOfStock
     case onBackOrder
+    case insufficientStock // Product Bundles only
     case custom(String) // in case there are extensions modifying product stock statuses
 }
 
@@ -25,6 +26,8 @@ extension ProductStockStatus: RawRepresentable {
             self = .outOfStock
         case Keys.onBackOrder:
             self = .onBackOrder
+        case Keys.insufficientStock:
+            self = .insufficientStock
         default:
             self = .custom(rawValue)
         }
@@ -37,6 +40,7 @@ extension ProductStockStatus: RawRepresentable {
         case .inStock:              return Keys.inStock
         case .outOfStock:           return Keys.outOfStock
         case .onBackOrder:          return Keys.onBackOrder
+        case .insufficientStock:    return Keys.insufficientStock
         case .custom(let payload):  return payload
         }
     }
@@ -51,6 +55,8 @@ extension ProductStockStatus: RawRepresentable {
             return NSLocalizedString("Out of stock", comment: "Display label for the product's inventory stock status")
         case .onBackOrder:
             return NSLocalizedString("On back order", comment: "Display label for the product's inventory stock status")
+        case .insufficientStock:
+            return NSLocalizedString("Insufficient stock", comment: "Display label for the product's inventory stock status")
         case .custom(let payload):
             return payload // unable to localize at runtime.
         }
@@ -61,7 +67,8 @@ extension ProductStockStatus: RawRepresentable {
 /// Enum containing the 'Known' Product Stock Status Keys
 ///
 private enum Keys {
-    static let inStock     = "instock"
-    static let outOfStock  = "outofstock"
-    static let onBackOrder = "onbackorder"
+    static let inStock           = "instock"
+    static let outOfStock        = "outofstock"
+    static let onBackOrder       = "onbackorder"
+    static let insufficientStock = "insufficientstock"
 }

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -295,6 +295,24 @@ final class ProductMapperTests: XCTestCase {
         // Then
         XCTAssertTrue(product.variations.isEmpty)
     }
+
+    /// Test that products with the `bundle` product type are properly parsed.
+    ///
+    func test_product_bundles_are_properly_parsed() throws {
+        // Given
+        let product = try XCTUnwrap(mapLoadProductBundleResponse())
+
+        // Then
+        XCTAssertEqual(product.bundleLayout, .defaultLayout)
+        XCTAssertEqual(product.bundleFormLocation, .defaultLocation)
+        XCTAssertEqual(product.bundleItemGrouping, .parent)
+        XCTAssertEqual(product.bundleMinSize, 3)
+        XCTAssertNil(product.bundleMaxSize)
+        XCTAssertEqual(product.bundleEditableInCart, false)
+        XCTAssertEqual(product.bundleSoldIndividuallyContext, .configuration)
+        XCTAssertEqual(product.bundleStockStatus, .insufficientStock)
+        XCTAssertEqual(product.bundleStockQuantity, 0)
+    }
 }
 
 
@@ -342,5 +360,11 @@ private extension ProductMapperTests {
     ///
     func mapLoadProductWithMalformedImageAltAndVariations() -> Product? {
         return mapProduct(from: "product-malformed-variations-and-image-alt")
+    }
+
+    /// Returns the ProductMapper output upon receiving `product-bundle`
+    ///
+    func mapLoadProductBundleResponse() -> Product? {
+        return mapProduct(from: "product-bundle")
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -105,7 +105,16 @@ final class ProductsRemoteTests: XCTestCase {
                                       variations: [],
                                       groupedProducts: [],
                                       menuOrder: 0,
-                                      addOns: [])
+                                      addOns: [],
+                                      bundleLayout: nil,
+                                      bundleFormLocation: nil,
+                                      bundleItemGrouping: nil,
+                                      bundleMinSize: nil,
+                                      bundleMaxSize: nil,
+                                      bundleEditableInCart: nil,
+                                      bundleSoldIndividuallyContext: nil,
+                                      bundleStockStatus: nil,
+                                      bundleStockQuantity: nil)
         XCTAssertEqual(addedProduct, expectedProduct)
     }
 
@@ -208,7 +217,16 @@ final class ProductsRemoteTests: XCTestCase {
                                       variations: [],
                                       groupedProducts: [],
                                       menuOrder: 0,
-                                      addOns: [])
+                                      addOns: [],
+                                      bundleLayout: nil,
+                                      bundleFormLocation: nil,
+                                      bundleItemGrouping: nil,
+                                      bundleMinSize: nil,
+                                      bundleMaxSize: nil,
+                                      bundleEditableInCart: nil,
+                                      bundleSoldIndividuallyContext: nil,
+                                      bundleStockStatus: nil,
+                                      bundleStockQuantity: nil)
         XCTAssertEqual(deletedProduct, expectedProduct)
     }
 
@@ -737,7 +755,16 @@ private extension ProductsRemoteTests {
                        variations: [192, 194, 193],
                        groupedProducts: [],
                        menuOrder: 0,
-                       addOns: [])
+                       addOns: [],
+                       bundleLayout: nil,
+                       bundleFormLocation: nil,
+                       bundleItemGrouping: nil,
+                       bundleMinSize: nil,
+                       bundleMaxSize: nil,
+                       bundleEditableInCart: nil,
+                       bundleSoldIndividuallyContext: nil,
+                       bundleStockStatus: nil,
+                       bundleStockQuantity: nil)
     }
 
     func sampleDimensions() -> Networking.ProductDimensions {

--- a/Networking/NetworkingTests/Responses/product-bundle.json
+++ b/Networking/NetworkingTests/Responses/product-bundle.json
@@ -1,0 +1,431 @@
+{
+    "data": {
+            "id": 282,
+            "name": "Logo Bundle",
+            "slug": "logo-bundle",
+            "permalink": "https://example.com/product/logo-bundle/",
+            "date_created": "2019-02-19T17:33:31",
+            "date_created_gmt": "2019-02-19T17:33:31",
+            "date_modified": "2019-02-19T17:48:01",
+            "date_modified_gmt": "2019-02-19T17:48:01",
+            "type": "bundle",
+            "status": "publish",
+            "featured": false,
+            "catalog_visibility": "visible",
+            "description": "<p>A bundle of our best logo gear!</p>\n",
+            "short_description": "",
+            "sku": "",
+            "price": "59",
+            "regular_price": "59",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": "2019-10-15T21:30:00",
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": "2019-10-27T21:29:59",
+            "price_html": "Free",
+            "on_sale": false,
+            "purchasable": true,
+            "total_sales": 0,
+            "virtual": true,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": 1,
+            "download_expiry": 1,
+            "external_url": "",
+            "button_text": "",
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "sold_individually": true,
+            "weight": "213",
+            "dimensions": {
+                "length": "12",
+                "width": "33",
+                "height": "54"
+            },
+            "shipping_required": false,
+            "shipping_taxable": false,
+            "shipping_class": "",
+            "shipping_class_id": 134,
+            "reviews_allowed": true,
+            "average_rating": "4.30",
+            "rating_count": 23,
+            "related_ids": [
+                31,
+                22,
+                369,
+                414,
+                56
+            ],
+            "upsell_ids":  [
+                99,
+                1234566
+            ],
+            "cross_sell_ids":  [
+                1234,
+                234234,
+                3
+            ],
+            "parent_id": 0,
+            "purchase_note": "Thank you!",
+            "categories": [
+                {
+                    "id": 36,
+                    "name": "Events",
+                    "slug": "events"
+                }
+            ],
+            "tags": [
+                {
+                    "id": 37,
+                    "name": "room",
+                    "slug": "room"
+                },
+                {
+                    "id": 38,
+                    "name": "party room",
+                    "slug": "party-room"
+                },
+                {
+                    "id": 39,
+                    "name": "30",
+                    "slug": "30"
+                },
+                {
+                    "id": 40,
+                    "name": "20+",
+                    "slug": "20"
+                },
+                {
+                    "id": 41,
+                    "name": "meeting room",
+                    "slug": "meeting-room"
+                },
+                {
+                    "id": 42,
+                    "name": "meetings",
+                    "slug": "meetings"
+                },
+                {
+                    "id": 43,
+                    "name": "parties",
+                    "slug": "parties"
+                },
+                {
+                    "id": 44,
+                    "name": "graduation",
+                    "slug": "graduation"
+                },
+                {
+                    "id": 45,
+                    "name": "birthday party",
+                    "slug": "birthday-party"
+                }
+            ],
+            "images": [
+                {
+                    "id": 19,
+                    "date_created": "2018-01-26T21:49:45",
+                    "date_created_gmt": "2018-01-26T21:49:45",
+                    "date_modified": "2018-01-26T21:50:11",
+                    "date_modified_gmt": "2018-01-26T21:50:11",
+                    "src": "https://somewebsite.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/vneck-tee.jpg.png",
+                    "name": "Vneck Tshirt",
+                    "alt": ""
+                }
+            ],
+            "attributes": [
+                {
+                    "id": 0,
+                    "name": "Color",
+                    "position": 1,
+                    "visible": true,
+                    "variation": true,
+                    "options": [
+                        "Purple",
+                        "Yellow",
+                        "Hot Pink",
+                        "Lime Green",
+                        "Teal"
+                    ]
+                },
+                {
+                    "id": 0,
+                    "name": "Size",
+                    "position": 0,
+                    "visible": true,
+                    "variation": true,
+                    "options": [
+                        "Small",
+                        "Medium",
+                        "Large"
+                    ]
+                }
+            ],
+            "default_attributes": [
+                {
+                    "id": 0,
+                    "name": "Color",
+                    "option": "Purple"
+                },
+                {
+                    "id": 0,
+                    "name": "Size",
+                    "option": "Medium"
+                }
+            ],
+            "variations": [
+                192,
+                194,
+                193
+            ],
+            "grouped_products": [],
+            "menu_order": 0,
+            "meta_data": [
+                {
+                    "id": 6779,
+                    "key": "_wpas_done_all",
+                    "value": "1"
+                },
+                {
+                    "id": 6780,
+                    "key": "_g_feedback_shortcode_5368fb4ef32094b7055b8732bb77a337bdd9331d",
+                    "value": "[contact-field label=\"Name\" type=\"name\" required=\"1\"][contact-field label=\"Email\" type=\"email\" required=\"1\"][contact-field label=\"Phone Number\" type=\"text\" required=\"1\"][contact-field label=\"Group or Organization Name (if any)\" type=\"text\"][contact-field label=\"Special Requests / Event Notes\" type=\"textarea\"]"
+                },
+                {
+                    "id": 6781,
+                    "key": "_g_feedback_shortcode_atts_5368fb4ef32094b7055b8732bb77a337bdd9331d",
+                    "value": {
+                        "to": "thuy.copeland@automattic.com",
+                        "subject": "Booking Event",
+                        "show_subject": "no",
+                        "widget": 0,
+                        "id": 282,
+                        "submit_button_text": "Submit"
+                    }
+                },
+                {
+                    "id": 6471,
+                    "key": "_product_addons",
+                    "value": [
+                        {
+                            "description": "Pizza topping",
+                            "title_format": "label",
+                            "required": 0,
+                            "restrictions": 0,
+                            "position": 0,
+                            "display": "radiobutton",
+                            "restrictions_type": "any_text",
+                            "min": 0,
+                            "max": 0,
+                            "options": [
+                                {
+                                    "label": "Peperoni",
+                                    "price_type": "flat_fee",
+                                    "price": "3",
+                                    "image": ""
+                                },
+                                {
+                                    "label": "Extra cheese",
+                                    "price_type": "flat_fee",
+                                    "price": "4",
+                                    "image": ""
+                                },
+                                {
+                                    "label": "Salami",
+                                    "price_type": "flat_fee",
+                                    "price": "3",
+                                    "image": ""
+                                },
+                                {
+                                    "label": "Ham",
+                                    "price_type": "flat_fee",
+                                    "price": "3",
+                                    "image": ""
+                                }
+                            ],
+                            "type": "checkbox",
+                            "price": "",
+                            "price_type": "flat_fee",
+                            "adjust_price": 0,
+                            "name": "Topping",
+                            "description_enable": 1
+                        },
+                        {
+                            "description": "",
+                            "title_format": "label",
+                            "required": 0,
+                            "restrictions": 1,
+                            "position": 1,
+                            "display": "select",
+                            "restrictions_type": "any_text",
+                            "min": 0,
+                            "max": 3,
+                            "options": [
+                                {
+                                    "label": "",
+                                    "price_type": "flat_fee",
+                                    "price": "",
+                                    "image": ""
+                                }
+                            ],
+                            "type": "input_multiplier",
+                            "price": "2",
+                            "price_type": "quantity_based",
+                            "adjust_price": 1,
+                            "name": "Soda",
+                            "description_enable": 0
+                        },
+                        {
+                            "description": "",
+                            "title_format": "label",
+                            "required": 1,
+                            "restrictions": 0,
+                            "position": 2,
+                            "display": "radiobutton",
+                            "restrictions_type": "any_text",
+                            "min": 0,
+                            "max": 0,
+                            "options": [
+                                {
+                                    "label": "Yes",
+                                    "price_type": "flat_fee",
+                                    "price": "5",
+                                    "image": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "price_type": "flat_fee",
+                                    "price": "",
+                                    "image": ""
+                                }
+                            ],
+                            "type": "multiple_choice",
+                            "price": "",
+                            "price_type": "flat_fee",
+                            "adjust_price": 0,
+                            "name": "Delivery",
+                            "description_enable": 0
+                        }
+                    ]
+                },
+            ],
+            "bundled_by": [],
+            "bundle_stock_status": "insufficientstock",
+            "bundle_stock_quantity": 0,
+            "bundle_virtual": true,
+            "bundle_layout": "default",
+            "bundle_add_to_cart_form_location": "default",
+            "bundle_editable_in_cart": false,
+            "bundle_sold_individually_context": "configuration",
+            "bundle_item_grouping": "parent",
+            "bundle_min_size": 3,
+            "bundle_max_size": "",
+            "bundled_items": [
+                {
+                    "bundled_item_id": 6,
+                    "product_id": 36,
+                    "menu_order": 0,
+                    "quantity_min": 1,
+                    "quantity_max": 1,
+                    "quantity_default": 1,
+                    "priced_individually": true,
+                    "shipped_individually": false,
+                    "override_title": false,
+                    "title": "Beanie with Logo",
+                    "override_description": false,
+                    "description": "",
+                    "optional": true,
+                    "hide_thumbnail": false,
+                    "discount": "10",
+                    "override_variations": false,
+                    "allowed_variations": [],
+                    "override_default_variation_attributes": false,
+                    "default_variation_attributes": [],
+                    "single_product_visibility": "visible",
+                    "cart_visibility": "visible",
+                    "order_visibility": "visible",
+                    "single_product_price_visibility": "visible",
+                    "cart_price_visibility": "visible",
+                    "order_price_visibility": "visible",
+                    "stock_status": "in_stock"
+                },
+                {
+                    "bundled_item_id": 7,
+                    "product_id": 35,
+                    "menu_order": 1,
+                    "quantity_min": 1,
+                    "quantity_max": 1,
+                    "quantity_default": 1,
+                    "priced_individually": false,
+                    "shipped_individually": false,
+                    "override_title": false,
+                    "title": "T-Shirt with Logo",
+                    "override_description": false,
+                    "description": "",
+                    "optional": false,
+                    "hide_thumbnail": false,
+                    "discount": "",
+                    "override_variations": false,
+                    "allowed_variations": [],
+                    "override_default_variation_attributes": false,
+                    "default_variation_attributes": [],
+                    "single_product_visibility": "visible",
+                    "cart_visibility": "visible",
+                    "order_visibility": "visible",
+                    "single_product_price_visibility": "visible",
+                    "cart_price_visibility": "visible",
+                    "order_price_visibility": "visible",
+                    "stock_status": "in_stock"
+                },
+                {
+                    "bundled_item_id": 8,
+                    "product_id": 17,
+                    "menu_order": 2,
+                    "quantity_min": 1,
+                    "quantity_max": 1,
+                    "quantity_default": 1,
+                    "priced_individually": false,
+                    "shipped_individually": false,
+                    "override_title": false,
+                    "title": "Hoodie with Logo",
+                    "override_description": false,
+                    "description": "",
+                    "optional": false,
+                    "hide_thumbnail": false,
+                    "discount": "",
+                    "override_variations": false,
+                    "allowed_variations": [],
+                    "override_default_variation_attributes": false,
+                    "default_variation_attributes": [],
+                    "single_product_visibility": "visible",
+                    "cart_visibility": "visible",
+                    "order_visibility": "visible",
+                    "single_product_price_visibility": "visible",
+                    "cart_price_visibility": "visible",
+                    "order_price_visibility": "visible",
+                    "stock_status": "out_of_stock"
+                }
+            ],
+            "bundle_sell_ids": [],
+            "jetpack_publicize_connections": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products/282"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products"
+                    }
+                ]
+            }
+    }
+}
+

--- a/Networking/NetworkingTests/Responses/product.json
+++ b/Networking/NetworkingTests/Responses/product.json
@@ -331,6 +331,18 @@
                     ]
                 },
             ],
+            "bundled_by": [],
+            "bundle_stock_status": "instock",
+            "bundle_stock_quantity": null,
+            "bundle_virtual": false,
+            "bundle_layout": "",
+            "bundle_add_to_cart_form_location": "",
+            "bundle_editable_in_cart": false,
+            "bundle_sold_individually_context": "",
+            "bundle_item_grouping": "",
+            "bundle_min_size": "",
+            "bundle_max_size": "",
+            "bundled_items": [],
             "jetpack_publicize_connections": [],
             "_links": {
                 "self": [

--- a/WooCommerce/Classes/Extensions/Product+SwiftUIPreviewHelpers.swift
+++ b/WooCommerce/Classes/Extensions/Product+SwiftUIPreviewHelpers.swift
@@ -67,7 +67,16 @@ extension Product {
                 variations: [],
                 groupedProducts: [],
                 menuOrder: 0,
-                addOns: [])
+                addOns: [],
+                bundleLayout: nil,
+                bundleFormLocation: nil,
+                bundleItemGrouping: nil,
+                bundleMinSize: nil,
+                bundleMaxSize: nil,
+                bundleEditableInCart: nil,
+                bundleSoldIndividuallyContext: nil,
+                bundleStockStatus: nil,
+                bundleStockQuantity: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
@@ -94,6 +94,15 @@ private extension ProductFactory {
                 variations: [],
                 groupedProducts: [],
                 menuOrder: 0,
-                addOns: [])
+                addOns: [],
+                bundleLayout: nil,
+                bundleFormLocation: nil,
+                bundleItemGrouping: nil,
+                bundleMinSize: nil,
+                bundleMaxSize: nil,
+                bundleEditableInCart: nil,
+                bundleSoldIndividuallyContext: nil,
+                bundleStockStatus: nil,
+                bundleStockQuantity: nil)
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
@@ -118,7 +118,16 @@ extension MockReviews {
                        variations: [192, 194, 193],
                        groupedProducts: [],
                        menuOrder: 0,
-                       addOns: [])
+                       addOns: [],
+                       bundleLayout: nil,
+                       bundleFormLocation: nil,
+                       bundleItemGrouping: nil,
+                       bundleMinSize: nil,
+                       bundleMaxSize: nil,
+                       bundleEditableInCart: nil,
+                       bundleSoldIndividuallyContext: nil,
+                       bundleStockStatus: nil,
+                       bundleStockQuantity: nil)
     }
 
     func sampleDimensions() -> Networking.ProductDimensions {
@@ -264,7 +273,16 @@ extension MockReviews {
                        variations: [],
                        groupedProducts: [111, 222, 333],
                        menuOrder: 0,
-                       addOns: [])
+                       addOns: [],
+                       bundleLayout: nil,
+                       bundleFormLocation: nil,
+                       bundleItemGrouping: nil,
+                       bundleMinSize: nil,
+                       bundleMaxSize: nil,
+                       bundleEditableInCart: nil,
+                       bundleSoldIndividuallyContext: nil,
+                       bundleStockStatus: nil,
+                       bundleStockQuantity: nil)
     }
 
     func sampleDimensionsMutated() -> Networking.ProductDimensions {
@@ -385,7 +403,16 @@ extension MockReviews {
                        variations: [],
                        groupedProducts: [],
                        menuOrder: 2,
-                       addOns: [])
+                       addOns: [],
+                       bundleLayout: nil,
+                       bundleFormLocation: nil,
+                       bundleItemGrouping: nil,
+                       bundleMinSize: nil,
+                       bundleMaxSize: nil,
+                       bundleEditableInCart: nil,
+                       bundleSoldIndividuallyContext: nil,
+                       bundleStockStatus: nil,
+                       bundleStockQuantity: nil)
     }
 
     func sampleVariationTypeDimensions() -> Networking.ProductDimensions {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
@@ -164,6 +164,15 @@ private extension Product_ProductFormTests {
                        variations: [192, 194, 193],
                        groupedProducts: [],
                        menuOrder: 0,
-                       addOns: [])
+                       addOns: [],
+                       bundleLayout: nil,
+                       bundleFormLocation: nil,
+                       bundleItemGrouping: nil,
+                       bundleMinSize: nil,
+                       bundleMaxSize: nil,
+                       bundleEditableInCart: nil,
+                       bundleSoldIndividuallyContext: nil,
+                       bundleStockStatus: nil,
+                       bundleStockQuantity: nil)
     }
 }

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -307,7 +307,16 @@ extension MockObjectGraph {
             variations: [],
             groupedProducts: [],
             menuOrder: 0,
-            addOns: []
+            addOns: [],
+            bundleLayout: nil,
+            bundleFormLocation: nil,
+            bundleItemGrouping: nil,
+            bundleMinSize: nil,
+            bundleMaxSize: nil,
+            bundleEditableInCart: nil,
+            bundleSoldIndividuallyContext: nil,
+            bundleStockStatus: nil,
+            bundleStockQuantity: nil
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
@@ -162,7 +162,16 @@ extension Storage.Product: ReadOnlyConvertible {
                        variations: variations ?? [],
                        groupedProducts: groupedProducts ?? [],
                        menuOrder: Int(menuOrder),
-                       addOns: addOnsArray.map { $0.toReadOnly() })
+                       addOns: addOnsArray.map { $0.toReadOnly() },
+                       bundleLayout: nil, // TODO-8953: Convert the product bundle properties
+                       bundleFormLocation: nil,
+                       bundleItemGrouping: nil,
+                       bundleMinSize: nil,
+                       bundleMaxSize: nil,
+                       bundleEditableInCart: nil,
+                       bundleSoldIndividuallyContext: nil,
+                       bundleStockStatus: nil,
+                       bundleStockQuantity: nil)
     }
 
     // MARK: - Private Helpers

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1731,7 +1731,16 @@ private extension ProductStoreTests {
                        variations: [192, 194, 193],
                        groupedProducts: [],
                        menuOrder: 0,
-                       addOns: addOns ?? sampleAddOns())
+                       addOns: addOns ?? sampleAddOns(),
+                       bundleLayout: nil,
+                       bundleFormLocation: nil,
+                       bundleItemGrouping: nil,
+                       bundleMinSize: nil,
+                       bundleMaxSize: nil,
+                       bundleEditableInCart: nil,
+                       bundleSoldIndividuallyContext: nil,
+                       bundleStockStatus: nil,
+                       bundleStockQuantity: nil)
     }
 
     func sampleDimensions() -> Networking.ProductDimensions {
@@ -1887,7 +1896,16 @@ private extension ProductStoreTests {
                        variations: [],
                        groupedProducts: [111, 222, 333],
                        menuOrder: 0,
-                       addOns: [])
+                       addOns: [],
+                       bundleLayout: nil,
+                       bundleFormLocation: nil,
+                       bundleItemGrouping: nil,
+                       bundleMinSize: nil,
+                       bundleMaxSize: nil,
+                       bundleEditableInCart: nil,
+                       bundleSoldIndividuallyContext: nil,
+                       bundleStockStatus: nil,
+                       bundleStockQuantity: nil)
     }
 
     func sampleDimensionsMutated() -> Networking.ProductDimensions {
@@ -2017,7 +2035,16 @@ private extension ProductStoreTests {
                        variations: [],
                        groupedProducts: [],
                        menuOrder: 2,
-                       addOns: [])
+                       addOns: [],
+                       bundleLayout: nil,
+                       bundleFormLocation: nil,
+                       bundleItemGrouping: nil,
+                       bundleMinSize: nil,
+                       bundleMaxSize: nil,
+                       bundleEditableInCart: nil,
+                       bundleSoldIndividuallyContext: nil,
+                       bundleStockStatus: nil,
+                       bundleStockQuantity: nil)
     }
 
     func sampleVariationTypeDimensions() -> Networking.ProductDimensions {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8953
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds properties specific to Product Bundles (a custom product type) to the `Product` model. (This is not all of the model changes required. Another PR will add an array of bundled items to the `Product` model, including a new model for those items.)

Apologies for the size of the PR. Many of the changes are from a new JSON mock and adding the properties to the generated fakeable and copiable methods, mocks, etc.

These are the new properties:

* `bundleLayout`
   * Also adds a new type `ProductBundleLayout` for this property. Includes core options and a custom option in case the value is modified by another extension.
* `bundleFormLocation`
   * Also adds a new type `ProductBundleFormLocation` for this property. Includes core options and a custom option in case the value is modified by another extension.
* `bundleItemGrouping`
   * Also adds a new type `ProductBundleItemGrouping` for this property. Includes core options and a custom option in case the value is modified by another extension.
* `bundleMinSize`
   * This is expected to be an integer. If the property is not set the API returns an empty string, in which case we set the value to `nil`.
* `bundleMaxSize`
   * This is expected to be an integer. If the property is not set the API returns an empty string, in which case we set the value to `nil`.
* `bundleEditableInCart`
* `bundleSoldIndividuallyContext`
   * Also adds a new type `ProductBundleSoldIndividuallyContext` for this property. This only returns two possible values (not modifiable) so it is a simple `enum`.
* `bundleStockStatus`
   * Bundle stock statuses are the same as product stock statuses, with the addition of an "Insufficient stock" status. This new status is added to `ProductStockStatus` to support all possible statuses.
* `bundleStockQuantity`
   * This is expected to be an integer. If the property is not set the API returns an empty string, in which case we set the value to `nil`.

We will use these properties to display them (read-only for now) in the product details for product bundles.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

These new properties aren't yet used in the app, but you can confirm the product list loads as expected:

1. Build and run the app.
2. Open the Products tab and confirm your products load.
3. Select a product and confirm the product details load.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
