### PR TITLE
[Product Bundles] Add ProductBundleItem model for items in a product bundle

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -796,7 +796,8 @@ extension Networking.Product {
             bundleEditableInCart: .fake(),
             bundleSoldIndividuallyContext: .fake(),
             bundleStockStatus: .fake(),
-            bundleStockQuantity: .fake()
+            bundleStockQuantity: .fake(),
+            bundledItems: .fake()
         )
     }
 }
@@ -878,11 +879,59 @@ extension ProductBundleFormLocation {
         .defaultLocation
     }
 }
+extension Networking.ProductBundleItem {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.ProductBundleItem {
+        .init(
+            bundledItemID: .fake(),
+            productID: .fake(),
+            menuOrder: .fake(),
+            quantityMin: .fake(),
+            quantityMax: .fake(),
+            quantityDefault: .fake(),
+            pricedIndividually: .fake(),
+            shippedIndividually: .fake(),
+            overrideTitle: .fake(),
+            title: .fake(),
+            overrideDescription: .fake(),
+            description: .fake(),
+            optional: .fake(),
+            hideThumbnail: .fake(),
+            discount: .fake(),
+            overrideVariations: .fake(),
+            allowedVariations: .fake(),
+            overrideDefaultVariationAttributes: .fake(),
+            defaultVariationAttributes: .fake(),
+            singleProductVisibility: .fake(),
+            cartVisibility: .fake(),
+            orderVisibility: .fake(),
+            singleProductPriceVisibility: .fake(),
+            cartPriceVisibility: .fake(),
+            orderPriceVisibility: .fake(),
+            stockStatus: .fake()
+        )
+    }
+}
 extension ProductBundleItemGrouping {
     /// Returns a "ready to use" type filled with fake values.
     ///
     public static func fake() -> ProductBundleItemGrouping {
         .parent
+    }
+}
+extension ProductBundleItemStockStatus {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ProductBundleItemStockStatus {
+        .inStock
+    }
+}
+extension ProductBundleItemVisibility {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> ProductBundleItemVisibility {
+        .visible
     }
 }
 extension ProductBundleLayout {

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -561,6 +561,7 @@
 		CC01CE5329B0DC4C004FF537 /* ProductBundleFormLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC01CE5229B0DC4C004FF537 /* ProductBundleFormLocation.swift */; };
 		CC01CE5529B0DEE2004FF537 /* ProductBundleItemGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC01CE5429B0DEE2004FF537 /* ProductBundleItemGrouping.swift */; };
 		CC01CE5829B0EBED004FF537 /* product-bundle.json in Resources */ = {isa = PBXBuildFile; fileRef = CC01CE5729B0EBED004FF537 /* product-bundle.json */; };
+		CC01CE5A29B0FD61004FF537 /* ProductBundleItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC01CE5929B0FD61004FF537 /* ProductBundleItem.swift */; };
 		CC07865F267799EE00BA9AC1 /* ShippingLabelPurchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */; };
 		CC0786612677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */; };
 		CC0786632678F79500BA9AC1 /* shipping-label-purchase-success.json in Resources */ = {isa = PBXBuildFile; fileRef = CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */; };
@@ -1447,6 +1448,7 @@
 		CC01CE5229B0DC4C004FF537 /* ProductBundleFormLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleFormLocation.swift; sourceTree = "<group>"; };
 		CC01CE5429B0DEE2004FF537 /* ProductBundleItemGrouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleItemGrouping.swift; sourceTree = "<group>"; };
 		CC01CE5729B0EBED004FF537 /* product-bundle.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle.json"; sourceTree = "<group>"; };
+		CC01CE5929B0FD61004FF537 /* ProductBundleItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleItem.swift; sourceTree = "<group>"; };
 		CC07865E267799EE00BA9AC1 /* ShippingLabelPurchase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchase.swift; sourceTree = "<group>"; };
 		CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPurchaseMapper.swift; sourceTree = "<group>"; };
 		CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-purchase-success.json"; sourceTree = "<group>"; };
@@ -2883,6 +2885,7 @@
 				CC01CE5429B0DEE2004FF537 /* ProductBundleItemGrouping.swift */,
 				CC01CE5029B0DC3B004FF537 /* ProductBundleLayout.swift */,
 				CC01CE4E29AFEB87004FF537 /* ProductBundleSoldIndividuallyContext.swift */,
+				CC01CE5929B0FD61004FF537 /* ProductBundleItem.swift */,
 			);
 			path = ProductBundle;
 			sourceTree = "<group>";
@@ -3663,6 +3666,7 @@
 				3178A49F2703E5CF00A8B4CA /* RemoteReaderLocationMapper.swift in Sources */,
 				45D685F823D0BC78005F87D0 /* ProductSkuMapper.swift in Sources */,
 				7412A8EA21B6E192005D182A /* ReportRemote.swift in Sources */,
+				CC01CE5A29B0FD61004FF537 /* ProductBundleItem.swift in Sources */,
 				B5A2417D217F9ECC00595DEF /* MetaContainer.swift in Sources */,
 				025CA2C4238EBC4300B05C81 /* ProductShippingClassRemote.swift in Sources */,
 				D88D5A4B230BCF0A007B6E01 /* ProductReviewListMapper.swift in Sources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1231,7 +1231,7 @@ extension Networking.ProductBundleItem {
         productID: CopiableProp<Int64> = .copy,
         menuOrder: CopiableProp<Int64> = .copy,
         quantityMin: CopiableProp<Int64> = .copy,
-        quantityMax: CopiableProp<Int64> = .copy,
+        quantityMax: NullableCopiableProp<Int64> = .copy,
         quantityDefault: CopiableProp<Int64> = .copy,
         pricedIndividually: CopiableProp<Bool> = .copy,
         shippedIndividually: CopiableProp<Bool> = .copy,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -962,7 +962,8 @@ extension Networking.Product {
         bundleEditableInCart: NullableCopiableProp<Bool> = .copy,
         bundleSoldIndividuallyContext: NullableCopiableProp<ProductBundleSoldIndividuallyContext> = .copy,
         bundleStockStatus: NullableCopiableProp<ProductStockStatus> = .copy,
-        bundleStockQuantity: NullableCopiableProp<Int64> = .copy
+        bundleStockQuantity: NullableCopiableProp<Int64> = .copy,
+        bundledItems: CopiableProp<[ProductBundleItem]> = .copy
     ) -> Networking.Product {
         let siteID = siteID ?? self.siteID
         let productID = productID ?? self.productID
@@ -1036,6 +1037,7 @@ extension Networking.Product {
         let bundleSoldIndividuallyContext = bundleSoldIndividuallyContext ?? self.bundleSoldIndividuallyContext
         let bundleStockStatus = bundleStockStatus ?? self.bundleStockStatus
         let bundleStockQuantity = bundleStockQuantity ?? self.bundleStockQuantity
+        let bundledItems = bundledItems ?? self.bundledItems
 
         return Networking.Product(
             siteID: siteID,
@@ -1109,7 +1111,8 @@ extension Networking.Product {
             bundleEditableInCart: bundleEditableInCart,
             bundleSoldIndividuallyContext: bundleSoldIndividuallyContext,
             bundleStockStatus: bundleStockStatus,
-            bundleStockQuantity: bundleStockQuantity
+            bundleStockQuantity: bundleStockQuantity,
+            bundledItems: bundledItems
         )
     }
 }
@@ -1218,6 +1221,93 @@ extension Networking.ProductAttribute {
             visible: visible,
             variation: variation,
             options: options
+        )
+    }
+}
+
+extension Networking.ProductBundleItem {
+    public func copy(
+        bundledItemID: CopiableProp<Int64> = .copy,
+        productID: CopiableProp<Int64> = .copy,
+        menuOrder: CopiableProp<Int64> = .copy,
+        quantityMin: CopiableProp<Int64> = .copy,
+        quantityMax: CopiableProp<Int64> = .copy,
+        quantityDefault: CopiableProp<Int64> = .copy,
+        pricedIndividually: CopiableProp<Bool> = .copy,
+        shippedIndividually: CopiableProp<Bool> = .copy,
+        overrideTitle: CopiableProp<Bool> = .copy,
+        title: CopiableProp<String> = .copy,
+        overrideDescription: CopiableProp<Bool> = .copy,
+        description: CopiableProp<String> = .copy,
+        optional: CopiableProp<Bool> = .copy,
+        hideThumbnail: CopiableProp<Bool> = .copy,
+        discount: CopiableProp<String> = .copy,
+        overrideVariations: CopiableProp<Bool> = .copy,
+        allowedVariations: CopiableProp<[Int64]> = .copy,
+        overrideDefaultVariationAttributes: CopiableProp<Bool> = .copy,
+        defaultVariationAttributes: CopiableProp<[ProductVariationAttribute]> = .copy,
+        singleProductVisibility: CopiableProp<ProductBundleItemVisibility> = .copy,
+        cartVisibility: CopiableProp<ProductBundleItemVisibility> = .copy,
+        orderVisibility: CopiableProp<ProductBundleItemVisibility> = .copy,
+        singleProductPriceVisibility: CopiableProp<ProductBundleItemVisibility> = .copy,
+        cartPriceVisibility: CopiableProp<ProductBundleItemVisibility> = .copy,
+        orderPriceVisibility: CopiableProp<ProductBundleItemVisibility> = .copy,
+        stockStatus: CopiableProp<ProductBundleItemStockStatus> = .copy
+    ) -> Networking.ProductBundleItem {
+        let bundledItemID = bundledItemID ?? self.bundledItemID
+        let productID = productID ?? self.productID
+        let menuOrder = menuOrder ?? self.menuOrder
+        let quantityMin = quantityMin ?? self.quantityMin
+        let quantityMax = quantityMax ?? self.quantityMax
+        let quantityDefault = quantityDefault ?? self.quantityDefault
+        let pricedIndividually = pricedIndividually ?? self.pricedIndividually
+        let shippedIndividually = shippedIndividually ?? self.shippedIndividually
+        let overrideTitle = overrideTitle ?? self.overrideTitle
+        let title = title ?? self.title
+        let overrideDescription = overrideDescription ?? self.overrideDescription
+        let description = description ?? self.description
+        let optional = optional ?? self.optional
+        let hideThumbnail = hideThumbnail ?? self.hideThumbnail
+        let discount = discount ?? self.discount
+        let overrideVariations = overrideVariations ?? self.overrideVariations
+        let allowedVariations = allowedVariations ?? self.allowedVariations
+        let overrideDefaultVariationAttributes = overrideDefaultVariationAttributes ?? self.overrideDefaultVariationAttributes
+        let defaultVariationAttributes = defaultVariationAttributes ?? self.defaultVariationAttributes
+        let singleProductVisibility = singleProductVisibility ?? self.singleProductVisibility
+        let cartVisibility = cartVisibility ?? self.cartVisibility
+        let orderVisibility = orderVisibility ?? self.orderVisibility
+        let singleProductPriceVisibility = singleProductPriceVisibility ?? self.singleProductPriceVisibility
+        let cartPriceVisibility = cartPriceVisibility ?? self.cartPriceVisibility
+        let orderPriceVisibility = orderPriceVisibility ?? self.orderPriceVisibility
+        let stockStatus = stockStatus ?? self.stockStatus
+
+        return Networking.ProductBundleItem(
+            bundledItemID: bundledItemID,
+            productID: productID,
+            menuOrder: menuOrder,
+            quantityMin: quantityMin,
+            quantityMax: quantityMax,
+            quantityDefault: quantityDefault,
+            pricedIndividually: pricedIndividually,
+            shippedIndividually: shippedIndividually,
+            overrideTitle: overrideTitle,
+            title: title,
+            overrideDescription: overrideDescription,
+            description: description,
+            optional: optional,
+            hideThumbnail: hideThumbnail,
+            discount: discount,
+            overrideVariations: overrideVariations,
+            allowedVariations: allowedVariations,
+            overrideDefaultVariationAttributes: overrideDefaultVariationAttributes,
+            defaultVariationAttributes: defaultVariationAttributes,
+            singleProductVisibility: singleProductVisibility,
+            cartVisibility: cartVisibility,
+            orderVisibility: orderVisibility,
+            singleProductPriceVisibility: singleProductPriceVisibility,
+            cartPriceVisibility: cartPriceVisibility,
+            orderPriceVisibility: orderPriceVisibility,
+            stockStatus: stockStatus
         )
     }
 }

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -114,6 +114,9 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
     /// Quantity of bundles left in stock, taking bundled product quantity requirements into account. Applicable for bundle-type products only.
     public let bundleStockQuantity: Int64?
 
+    /// List of bundled item data contained in this product.
+    public let bundledItems: [ProductBundleItem]
+
     /// Computed Properties
     ///
     public var productStatus: ProductStatus {
@@ -237,7 +240,8 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                 bundleEditableInCart: Bool?,
                 bundleSoldIndividuallyContext: ProductBundleSoldIndividuallyContext?,
                 bundleStockStatus: ProductStockStatus?,
-                bundleStockQuantity: Int64?) {
+                bundleStockQuantity: Int64?,
+                bundledItems: [ProductBundleItem]) {
         self.siteID = siteID
         self.productID = productID
         self.name = name
@@ -310,6 +314,7 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         self.bundleStockStatus = bundleStockStatus
         self.bundleStockQuantity = bundleStockQuantity
         self.bundleSoldIndividuallyContext = bundleSoldIndividuallyContext
+        self.bundledItems = bundledItems
     }
 
     /// The public initializer for Product.
@@ -461,6 +466,7 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         let bundleMinSize = container.failsafeDecodeIfPresent(Int64.self, forKey: .bundleMinSize)
         let bundleMaxSize = container.failsafeDecodeIfPresent(Int64.self, forKey: .bundleMaxSize)
         let bundleStockQuantity = container.failsafeDecodeIfPresent(Int64.self, forKey: .bundleStockQuantity)
+        let bundledItems = try container.decodeIfPresent([ProductBundleItem].self, forKey: .bundledItems) ?? []
 
         self.init(siteID: siteID,
                   productID: productID,
@@ -533,7 +539,8 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                   bundleEditableInCart: bundleEditableInCart,
                   bundleSoldIndividuallyContext: bundleSoldIndividuallyContext,
                   bundleStockStatus: bundleStockStatus,
-                  bundleStockQuantity: bundleStockQuantity)
+                  bundleStockQuantity: bundleStockQuantity,
+                  bundledItems: bundledItems)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -729,6 +736,7 @@ private extension Product {
         case bundleSoldIndividuallyContext  = "bundle_sold_individually_context"
         case bundleStockStatus              = "bundle_stock_status"
         case bundleStockQuantity            = "bundle_stock_quantity"
+        case bundledItems                   = "bundled_items"
     }
 }
 

--- a/Networking/Networking/Model/Product/ProductBundle/ProductBundleItem.swift
+++ b/Networking/Networking/Model/Product/ProductBundle/ProductBundleItem.swift
@@ -17,7 +17,7 @@ public struct ProductBundleItem: Codable, Equatable, GeneratedCopiable, Generate
     public let quantityMin: Int64
 
     /// Maximum bundled item quantity.
-    public let quantityMax: Int64
+    public let quantityMax: Int64?
 
     /// Default bundled item quantity.
     public let quantityDefault: Int64
@@ -88,7 +88,7 @@ public struct ProductBundleItem: Codable, Equatable, GeneratedCopiable, Generate
                 productID: Int64,
                 menuOrder: Int64,
                 quantityMin: Int64,
-                quantityMax: Int64,
+                quantityMax: Int64?,
                 quantityDefault: Int64,
                 pricedIndividually: Bool,
                 shippedIndividually: Bool,
@@ -136,6 +136,68 @@ public struct ProductBundleItem: Codable, Equatable, GeneratedCopiable, Generate
         self.cartPriceVisibility = cartPriceVisibility
         self.orderPriceVisibility = orderPriceVisibility
         self.stockStatus = stockStatus
+    }
+
+    /// The public initializer for ProductBundleItem.
+    ///
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let bundledItemID = try container.decode(Int64.self, forKey: .bundledItemID)
+        let productID = try container.decode(Int64.self, forKey: .productID)
+        let menuOrder = try container.decode(Int64.self, forKey: .menuOrder)
+        let quantityMin = try container.decode(Int64.self, forKey: .quantityMin)
+        // When the quantity max is not set, the API returns an empty string.
+        // In that case, we skip decoding and set the property to `nil`.
+        let quantityMax = container.failsafeDecodeIfPresent(Int64.self, forKey: .quantityMax)
+        let quantityDefault = try container.decode(Int64.self, forKey: .quantityDefault)
+        let pricedIndividually = try container.decode(Bool.self, forKey: .pricedIndividually)
+        let shippedIndividually = try container.decode(Bool.self, forKey: .shippedIndividually)
+        let overrideTitle = try container.decode(Bool.self, forKey: .overrideTitle)
+        let title = try container.decode(String.self, forKey: .title)
+        let overrideDescription = try container.decode(Bool.self, forKey: .overrideDescription)
+        let description = try container.decode(String.self, forKey: .description)
+        let optional = try container.decode(Bool.self, forKey: .optional)
+        let hideThumbnail = try container.decode(Bool.self, forKey: .hideThumbnail)
+        let discount = try container.decode(String.self, forKey: .discount)
+        let overrideVariations = try container.decode(Bool.self, forKey: .overrideVariations)
+        let allowedVariations = try container.decode([Int64].self, forKey: .allowedVariations)
+        let overrideDefaultVariationAttributes = try container.decode(Bool.self, forKey: .overrideDefaultVariationAttributes)
+        let defaultVariationAttributes = try container.decode([ProductVariationAttribute].self, forKey: .defaultVariationAttributes)
+        let singleProductVisibility = try container.decode(ProductBundleItemVisibility.self, forKey: .singleProductVisibility)
+        let cartVisibility = try container.decode(ProductBundleItemVisibility.self, forKey: .cartVisibility)
+        let orderVisibility = try container.decode(ProductBundleItemVisibility.self, forKey: .orderVisibility)
+        let singleProductPriceVisibility = try container.decode(ProductBundleItemVisibility.self, forKey: .singleProductPriceVisibility)
+        let cartPriceVisibility = try container.decode(ProductBundleItemVisibility.self, forKey: .cartPriceVisibility)
+        let orderPriceVisibility = try container.decode(ProductBundleItemVisibility.self, forKey: .orderPriceVisibility)
+        let stockStatus = try container.decode(ProductBundleItemStockStatus.self, forKey: .stockStatus)
+
+        self.init(bundledItemID: bundledItemID,
+                  productID: productID,
+                  menuOrder: menuOrder,
+                  quantityMin: quantityMin,
+                  quantityMax: quantityMax,
+                  quantityDefault: quantityDefault,
+                  pricedIndividually: pricedIndividually,
+                  shippedIndividually: shippedIndividually,
+                  overrideTitle: overrideTitle,
+                  title: title,
+                  overrideDescription: overrideDescription,
+                  description: description,
+                  optional: optional,
+                  hideThumbnail: hideThumbnail,
+                  discount: discount,
+                  overrideVariations: overrideVariations,
+                  allowedVariations: allowedVariations,
+                  overrideDefaultVariationAttributes: overrideDefaultVariationAttributes,
+                  defaultVariationAttributes: defaultVariationAttributes,
+                  singleProductVisibility: singleProductVisibility,
+                  cartVisibility: cartVisibility,
+                  orderVisibility: orderVisibility,
+                  singleProductPriceVisibility: singleProductPriceVisibility,
+                  cartPriceVisibility: cartPriceVisibility,
+                  orderPriceVisibility: orderPriceVisibility,
+                  stockStatus: stockStatus)
     }
 }
 

--- a/Networking/Networking/Model/Product/ProductBundle/ProductBundleItem.swift
+++ b/Networking/Networking/Model/Product/ProductBundle/ProductBundleItem.swift
@@ -1,0 +1,189 @@
+import Foundation
+import Codegen
+
+/// Represents an item in a Product Bundle
+///
+public struct ProductBundleItem: Codable, Equatable, GeneratedCopiable, GeneratedFakeable {
+    /// Bundled item ID
+    public let bundledItemID: Int64
+
+    /// Bundled product ID
+    public let productID: Int64
+
+    /// Bundled item menu order
+    public let menuOrder: Int64
+
+    /// Minimum bundled item quantity.
+    public let quantityMin: Int64
+
+    /// Maximum bundled item quantity.
+    public let quantityMax: Int64
+
+    /// Default bundled item quantity.
+    public let quantityDefault: Int64
+
+    /// Indicates whether the price of this bundled item is added to the base price of the bundle.
+    public let pricedIndividually: Bool
+
+    /// Indicates whether the bundled product is shipped separately from the bundle.
+    public let shippedIndividually: Bool
+
+    /// Indicates whether the title of the bundled product is overridden in front-end and e-mail templates.
+    public let overrideTitle: Bool
+
+    /// Title of the bundled product to display instead of the original product title, if overridden.
+    public let title: String
+
+    /// Indicates whether the short description of the bundled product is overridden in front-end templates.
+    public let overrideDescription: Bool
+
+    /// Short description of the bundled product to display instead of the original product short description, if overridden.
+    public let description: String
+
+    /// Indicates whether the bundled item is optional.
+    public let optional: Bool
+
+    /// Indicates whether the bundled product thumbnail is hidden in the single-product template.
+    public let hideThumbnail: Bool
+
+    /// Discount applied to the bundled product, applicable when the Priced Individually option is enabled.
+    public let discount: String
+
+    /// Indicates whether variations filtering is active, applicable for variable bundled products only.
+    public let overrideVariations: Bool
+
+    /// List of enabled variation IDs, applicable when variations filtering is active.
+    public let allowedVariations: [Int64]
+
+    /// Indicates whether the default variation attribute values are overridden, applicable for variable bundled products only.
+    public let overrideDefaultVariationAttributes: Bool
+
+    /// Overridden default variation attribute values, if applicable.
+    public let defaultVariationAttributes: [ProductVariationAttribute]
+
+    /// Indicates whether the bundled product is visible in the single-product template.
+    public let singleProductVisibility: ProductBundleItemVisibility
+
+    /// Indicates whether the bundled product is visible in cart templates.
+    public let cartVisibility: ProductBundleItemVisibility
+
+    /// Indicates whether the bundled product is visible in order/e-mail templates.
+    public let orderVisibility: ProductBundleItemVisibility
+
+    /// Indicates whether the bundled product price is visible in the single-product template. Applicable when the Priced Individually option is enabled.
+    public let singleProductPriceVisibility: ProductBundleItemVisibility
+
+    /// Indicates whether the bundled product price is visible in cart templates. Applicable when the Priced Individually option is enabled.
+    public let cartPriceVisibility: ProductBundleItemVisibility
+
+    /// Indicates whether the bundled product price is visible in order/e-mail templates. Applicable when the Priced Individually option is enabled.
+    public let orderPriceVisibility: ProductBundleItemVisibility
+
+    /// Stock status of the bundled item, taking minimum quantity into account.
+    public let stockStatus: ProductBundleItemStockStatus
+
+    /// ProductBundleItem struct initializer
+    ///
+    public init(bundledItemID: Int64,
+                productID: Int64,
+                menuOrder: Int64,
+                quantityMin: Int64,
+                quantityMax: Int64,
+                quantityDefault: Int64,
+                pricedIndividually: Bool,
+                shippedIndividually: Bool,
+                overrideTitle: Bool,
+                title: String,
+                overrideDescription: Bool,
+                description: String,
+                optional: Bool,
+                hideThumbnail: Bool,
+                discount: String,
+                overrideVariations: Bool,
+                allowedVariations: [Int64],
+                overrideDefaultVariationAttributes: Bool,
+                defaultVariationAttributes: [ProductVariationAttribute],
+                singleProductVisibility: ProductBundleItemVisibility,
+                cartVisibility: ProductBundleItemVisibility,
+                orderVisibility: ProductBundleItemVisibility,
+                singleProductPriceVisibility: ProductBundleItemVisibility,
+                cartPriceVisibility: ProductBundleItemVisibility,
+                orderPriceVisibility: ProductBundleItemVisibility,
+                stockStatus: ProductBundleItemStockStatus) {
+        self.bundledItemID = bundledItemID
+        self.productID = productID
+        self.menuOrder = menuOrder
+        self.quantityMin = quantityMin
+        self.quantityMax = quantityMax
+        self.quantityDefault = quantityDefault
+        self.pricedIndividually = pricedIndividually
+        self.shippedIndividually = shippedIndividually
+        self.overrideTitle = overrideTitle
+        self.title = title
+        self.overrideDescription = overrideDescription
+        self.description = description
+        self.optional = optional
+        self.hideThumbnail = hideThumbnail
+        self.discount = discount
+        self.overrideVariations = overrideVariations
+        self.allowedVariations = allowedVariations
+        self.overrideDefaultVariationAttributes = overrideDefaultVariationAttributes
+        self.defaultVariationAttributes = defaultVariationAttributes
+        self.singleProductVisibility = singleProductVisibility
+        self.cartVisibility = cartVisibility
+        self.orderVisibility = orderVisibility
+        self.singleProductPriceVisibility = singleProductPriceVisibility
+        self.cartPriceVisibility = cartPriceVisibility
+        self.orderPriceVisibility = orderPriceVisibility
+        self.stockStatus = stockStatus
+    }
+}
+
+/// Defines all of the ProductBundleItem CodingKeys
+///
+private extension ProductBundleItem {
+
+    enum CodingKeys: String, CodingKey {
+        case bundledItemID                      = "bundled_item_id"
+        case productID                          = "product_id"
+        case menuOrder                          = "menu_order"
+        case quantityMin                        = "quantity_min"
+        case quantityMax                        = "quantity_max"
+        case quantityDefault                    = "quantity_default"
+        case pricedIndividually                 = "priced_individually"
+        case shippedIndividually                = "shipped_individually"
+        case overrideTitle                      = "override_title"
+        case title
+        case overrideDescription                = "override_description"
+        case description
+        case optional
+        case hideThumbnail                      = "hide_thumbnail"
+        case discount
+        case overrideVariations                 = "override_variations"
+        case allowedVariations                  = "allowed_variations"
+        case overrideDefaultVariationAttributes = "override_default_variation_attributes"
+        case defaultVariationAttributes         = "default_variation_attributes"
+        case singleProductVisibility            = "single_product_visibility"
+        case cartVisibility                     = "cart_visibility"
+        case orderVisibility                    = "order_visibility"
+        case singleProductPriceVisibility       = "single_product_price_visibility"
+        case cartPriceVisibility                = "cart_price_visibility"
+        case orderPriceVisibility               = "order_price_visibility"
+        case stockStatus                        = "stock_status"
+    }
+}
+
+/// Represents all visibility options for ProductBundleItem settings.
+///
+public enum ProductBundleItemVisibility: String, Codable, GeneratedFakeable {
+    case visible
+    case hidden
+}
+
+/// Represents all ProductBundleItem stock statuses
+///
+public enum ProductBundleItemStockStatus: String, Codable, GeneratedFakeable {
+    case inStock        = "in_stock"
+    case outOfStock     = "out_of_stock"
+    case onBackOrder    = "on_backorder"
+}

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -313,6 +313,42 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(product.bundleStockStatus, .insufficientStock)
         XCTAssertEqual(product.bundleStockQuantity, 0)
     }
+
+    /// Test that products with bundled items product type are properly parsed.
+    ///
+    func test_product_bundled_items_are_properly_parsed() throws {
+        // Given
+        let product = try XCTUnwrap(mapLoadProductBundleResponse())
+        let bundledItem = try XCTUnwrap(product.bundledItems.first)
+
+        // Then
+        XCTAssertEqual(product.bundledItems.count, 3)
+        XCTAssertEqual(bundledItem.bundledItemID, 6)
+        XCTAssertEqual(bundledItem.productID, 36)
+        XCTAssertEqual(bundledItem.menuOrder, 0)
+        XCTAssertEqual(bundledItem.quantityMin, 1)
+        XCTAssertNil(bundledItem.quantityMax)
+        XCTAssertTrue(bundledItem.pricedIndividually)
+        XCTAssertFalse(bundledItem.shippedIndividually)
+        XCTAssertFalse(bundledItem.overrideTitle)
+        XCTAssertEqual(bundledItem.title, "Beanie with Logo")
+        XCTAssertFalse(bundledItem.overrideDescription)
+        XCTAssertEqual(bundledItem.description, "")
+        XCTAssertTrue(bundledItem.optional)
+        XCTAssertFalse(bundledItem.hideThumbnail)
+        XCTAssertEqual(bundledItem.discount, "10")
+        XCTAssertFalse(bundledItem.overrideVariations)
+        XCTAssertEqual(bundledItem.allowedVariations.count, 3)
+        XCTAssertFalse(bundledItem.overrideDefaultVariationAttributes)
+        XCTAssertEqual(bundledItem.defaultVariationAttributes.count, 2)
+        XCTAssertEqual(bundledItem.singleProductVisibility, .visible)
+        XCTAssertEqual(bundledItem.cartVisibility, .visible)
+        XCTAssertEqual(bundledItem.orderVisibility, .visible)
+        XCTAssertEqual(bundledItem.singleProductPriceVisibility, .visible)
+        XCTAssertEqual(bundledItem.cartPriceVisibility, .visible)
+        XCTAssertEqual(bundledItem.orderPriceVisibility, .visible)
+        XCTAssertEqual(bundledItem.stockStatus, .inStock)
+    }
 }
 
 

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -114,7 +114,8 @@ final class ProductsRemoteTests: XCTestCase {
                                       bundleEditableInCart: nil,
                                       bundleSoldIndividuallyContext: nil,
                                       bundleStockStatus: nil,
-                                      bundleStockQuantity: nil)
+                                      bundleStockQuantity: nil,
+                                      bundledItems: [])
         XCTAssertEqual(addedProduct, expectedProduct)
     }
 
@@ -226,7 +227,8 @@ final class ProductsRemoteTests: XCTestCase {
                                       bundleEditableInCart: nil,
                                       bundleSoldIndividuallyContext: nil,
                                       bundleStockStatus: nil,
-                                      bundleStockQuantity: nil)
+                                      bundleStockQuantity: nil,
+                                      bundledItems: [])
         XCTAssertEqual(deletedProduct, expectedProduct)
     }
 
@@ -764,7 +766,8 @@ private extension ProductsRemoteTests {
                        bundleEditableInCart: nil,
                        bundleSoldIndividuallyContext: nil,
                        bundleStockStatus: nil,
-                       bundleStockQuantity: nil)
+                       bundleStockQuantity: nil,
+                       bundledItems: [])
     }
 
     func sampleDimensions() -> Networking.ProductDimensions {

--- a/Networking/NetworkingTests/Responses/product-bundle.json
+++ b/Networking/NetworkingTests/Responses/product-bundle.json
@@ -332,7 +332,7 @@
                     "product_id": 36,
                     "menu_order": 0,
                     "quantity_min": 1,
-                    "quantity_max": 1,
+                    "quantity_max": "",
                     "quantity_default": 1,
                     "priced_individually": true,
                     "shipped_individually": false,
@@ -344,9 +344,24 @@
                     "hide_thumbnail": false,
                     "discount": "10",
                     "override_variations": false,
-                    "allowed_variations": [],
+                    "allowed_variations": [
+                        39,
+                        32,
+                        33
+                    ],
                     "override_default_variation_attributes": false,
-                    "default_variation_attributes": [],
+                    "default_variation_attributes": [
+                        {
+                            "id": 1,
+                            "name": "Color",
+                            "option": "blue"
+                        },
+                        {
+                            "id": 0,
+                            "name": "Logo",
+                            "option": "Yes"
+                        }
+                    ],
                     "single_product_visibility": "visible",
                     "cart_visibility": "visible",
                     "order_visibility": "visible",

--- a/WooCommerce/Classes/Extensions/Product+SwiftUIPreviewHelpers.swift
+++ b/WooCommerce/Classes/Extensions/Product+SwiftUIPreviewHelpers.swift
@@ -76,7 +76,8 @@ extension Product {
                 bundleEditableInCart: nil,
                 bundleSoldIndividuallyContext: nil,
                 bundleStockStatus: nil,
-                bundleStockQuantity: nil)
+                bundleStockQuantity: nil,
+                bundledItems: [])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
@@ -103,6 +103,7 @@ private extension ProductFactory {
                 bundleEditableInCart: nil,
                 bundleSoldIndividuallyContext: nil,
                 bundleStockStatus: nil,
-                bundleStockQuantity: nil)
+                bundleStockQuantity: nil,
+                bundledItems: [])
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
@@ -127,7 +127,8 @@ extension MockReviews {
                        bundleEditableInCart: nil,
                        bundleSoldIndividuallyContext: nil,
                        bundleStockStatus: nil,
-                       bundleStockQuantity: nil)
+                       bundleStockQuantity: nil,
+                       bundledItems: [])
     }
 
     func sampleDimensions() -> Networking.ProductDimensions {
@@ -282,7 +283,8 @@ extension MockReviews {
                        bundleEditableInCart: nil,
                        bundleSoldIndividuallyContext: nil,
                        bundleStockStatus: nil,
-                       bundleStockQuantity: nil)
+                       bundleStockQuantity: nil,
+                       bundledItems: [])
     }
 
     func sampleDimensionsMutated() -> Networking.ProductDimensions {
@@ -412,7 +414,8 @@ extension MockReviews {
                        bundleEditableInCart: nil,
                        bundleSoldIndividuallyContext: nil,
                        bundleStockStatus: nil,
-                       bundleStockQuantity: nil)
+                       bundleStockQuantity: nil,
+                       bundledItems: [])
     }
 
     func sampleVariationTypeDimensions() -> Networking.ProductDimensions {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
@@ -173,6 +173,7 @@ private extension Product_ProductFormTests {
                        bundleEditableInCart: nil,
                        bundleSoldIndividuallyContext: nil,
                        bundleStockStatus: nil,
-                       bundleStockQuantity: nil)
+                       bundleStockQuantity: nil,
+                       bundledItems: [])
     }
 }

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -316,7 +316,8 @@ extension MockObjectGraph {
             bundleEditableInCart: nil,
             bundleSoldIndividuallyContext: nil,
             bundleStockStatus: nil,
-            bundleStockQuantity: nil
+            bundleStockQuantity: nil,
+            bundledItems: []
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
@@ -171,7 +171,8 @@ extension Storage.Product: ReadOnlyConvertible {
                        bundleEditableInCart: nil,
                        bundleSoldIndividuallyContext: nil,
                        bundleStockStatus: nil,
-                       bundleStockQuantity: nil)
+                       bundleStockQuantity: nil,
+                       bundledItems: [])
     }
 
     // MARK: - Private Helpers

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1740,7 +1740,8 @@ private extension ProductStoreTests {
                        bundleEditableInCart: nil,
                        bundleSoldIndividuallyContext: nil,
                        bundleStockStatus: nil,
-                       bundleStockQuantity: nil)
+                       bundleStockQuantity: nil,
+                       bundledItems: [])
     }
 
     func sampleDimensions() -> Networking.ProductDimensions {
@@ -1905,7 +1906,8 @@ private extension ProductStoreTests {
                        bundleEditableInCart: nil,
                        bundleSoldIndividuallyContext: nil,
                        bundleStockStatus: nil,
-                       bundleStockQuantity: nil)
+                       bundleStockQuantity: nil,
+                       bundledItems: [])
     }
 
     func sampleDimensionsMutated() -> Networking.ProductDimensions {
@@ -2044,7 +2046,8 @@ private extension ProductStoreTests {
                        bundleEditableInCart: nil,
                        bundleSoldIndividuallyContext: nil,
                        bundleStockStatus: nil,
-                       bundleStockQuantity: nil)
+                       bundleStockQuantity: nil,
+                       bundledItems: [])
     }
 
     func sampleVariationTypeDimensions() -> Networking.ProductDimensions {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8953
⚠️ Depends on #9024
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a new model `ProductBundleItem` for items in a Product Bundle (a custom product type). It also adds a new property in the `Product` model to track bundled items in a product.

We will use these `ProductBundleItem` properties to display the bundled item settings (read-only for now) in the product details.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

These new properties aren't yet used in the app, but you can confirm the product list loads as expected:

1. Build and run the app.
2. Open the Products tab and confirm your products load.
3. Select a product and confirm the product details load.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
