### PR TITLE
[Product Bundles] Add bundle type to ProductType model

### DIFF
--- a/Networking/Networking/Model/Product/ProductType.swift
+++ b/Networking/Networking/Model/Product/ProductType.swift
@@ -9,6 +9,7 @@ public enum ProductType: Codable, Hashable, GeneratedFakeable {
     case affiliate
     case variable
     case subscription
+    case bundle
     case custom(String) // in case there are extensions modifying product types
 }
 
@@ -31,6 +32,8 @@ extension ProductType: RawRepresentable {
             self = .variable
         case Keys.subscription:
             self = .subscription
+        case Keys.bundle:
+            self = .bundle
         default:
             self = .custom(rawValue)
         }
@@ -45,6 +48,7 @@ extension ProductType: RawRepresentable {
         case .affiliate:            return Keys.affiliate
         case .variable:             return Keys.variable
         case .subscription:         return Keys.subscription
+        case .bundle:               return Keys.bundle
         case .custom(let payload):  return payload
         }
     }
@@ -63,6 +67,8 @@ extension ProductType: RawRepresentable {
             return NSLocalizedString("Variable", comment: "Display label for variable product type.")
         case .subscription:
             return NSLocalizedString("Subscription", comment: "Display label for subscription product type.")
+        case .bundle:
+            return NSLocalizedString("Bundle", comment: "Display label for bundle product type.")
         case .custom(let payload):
             return payload // unable to localize at runtime.
         }
@@ -78,4 +84,5 @@ private enum Keys {
     static let affiliate    = "external"
     static let variable     = "variable"
     static let subscription = "subscription"
+    static let bundle       = "bundle"
 }

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -303,6 +303,7 @@ final class ProductMapperTests: XCTestCase {
         let product = try XCTUnwrap(mapLoadProductBundleResponse())
 
         // Then
+        XCTAssertEqual(product.productType, .bundle)
         XCTAssertEqual(product.bundleLayout, .defaultLayout)
         XCTAssertEqual(product.bundleFormLocation, .defaultLocation)
         XCTAssertEqual(product.bundleItemGrouping, .parent)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
@@ -148,6 +148,9 @@ public enum BottomSheetProductType: Hashable {
             // We need to be aware of subscriptions for Payments
             // but we don't handle them in the UI yet
             self = .custom("subscription")
+        case .bundle:
+            // We do not yet support product editing or creation for bundles
+            self = .custom("bundle")
         case .custom(let string):
             self = .custom(string)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: https://github.com/woocommerce/woocommerce-ios/issues/8953
⚠️ Depends on https://github.com/woocommerce/woocommerce-ios/pull/9025
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is the last of the changes in the Networking layer to support Product Bundles (a custom product type). This adds the `bundle` type to the `ProductType` model.

It also handles the new bundle type in the `BottomSheetProductType` initializer. Since that type is used when creating a new product or changing a product type, and we don't yet support creating or editing product bundles, it's only handled as a custom case there and not fully supported.

We will use this new product type to display product bundle's properties (read-only for now) in product details.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

These new properties aren't yet used in the app, but you can confirm the product list loads as expected:

1. Build and run the app.
2. Open the Products tab and confirm your products load.
3. Select a product and confirm the product details load.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
