### PR TITLE
REST API: 2FA UI and WPCom login integration

### DIFF
--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginView.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginView.swift
@@ -100,7 +100,7 @@ struct SiteCredentialLoginView: View {
                 // text fields
                 VStack(alignment: .leading, spacing: Constants.fieldVerticalSpacing) {
                     // Username field.
-                    AccountCreationFormFieldView(viewModel: .init(header: Localization.usernameFieldTitle,
+                    AuthenticationFormFieldView(viewModel: .init(header: Localization.usernameFieldTitle,
                                                                   placeholder: Localization.enterUsername,
                                                                   keyboardType: .default,
                                                                   text: $viewModel.username,
@@ -111,7 +111,7 @@ struct SiteCredentialLoginView: View {
                     .disabled(viewModel.isLoggingIn)
 
                     // Password field.
-                    AccountCreationFormFieldView(viewModel: .init(header: Localization.passwordFieldTitle,
+                    AuthenticationFormFieldView(viewModel: .init(header: Localization.passwordFieldTitle,
                                                                   placeholder: Localization.enterPassword,
                                                                   keyboardType: .default,
                                                                   text: $viewModel.password,

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -89,7 +89,7 @@ struct AccountCreationForm: View {
                 // Form fields.
                 VStack(spacing: Layout.verticalSpacingBetweenFields) {
                     // Email field.
-                    AccountCreationFormFieldView(viewModel: .init(header: Localization.emailFieldTitle,
+                    AuthenticationFormFieldView(viewModel: .init(header: Localization.emailFieldTitle,
                                                                   placeholder: Localization.emailFieldPlaceholder,
                                                                   keyboardType: .emailAddress,
                                                                   text: $viewModel.email,
@@ -100,7 +100,7 @@ struct AccountCreationForm: View {
                     .disabled(isPerformingTask)
 
                     // Password field.
-                    AccountCreationFormFieldView(viewModel: .init(header: Localization.passwordFieldTitle,
+                    AuthenticationFormFieldView(viewModel: .init(header: Localization.passwordFieldTitle,
                                                                   placeholder: Localization.passwordFieldPlaceholder,
                                                                   keyboardType: .default,
                                                                   text: $viewModel.password,

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationFormFieldView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Necessary data for the account creation form field.
 struct AccountCreationFormFieldViewModel {
     /// Title of the field.
-    let header: String
+    let header: String?
     /// Placeholder of the text field.
     let placeholder: String
     /// The type of keyboard.
@@ -36,9 +36,11 @@ struct AccountCreationFormFieldView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
-            Text(viewModel.header)
-                .foregroundColor(Color(.label))
-                .subheadlineStyle()
+            viewModel.header.map { header in
+                Text(header)
+                    .foregroundColor(Color(.label))
+                    .subheadlineStyle()
+            }
             if viewModel.isSecure {
                 ZStack(alignment: .trailing) {
                     // Text field based on the `isTextFieldSecure` state.

--- a/WooCommerce/Classes/ViewRelated/Authentication/AuthenticationFormFieldView.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AuthenticationFormFieldView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
-/// Necessary data for the account creation form field.
-struct AccountCreationFormFieldViewModel {
+/// Necessary data for the account creation / authentication form field.
+struct AuthenticationFormFieldViewModel {
     /// Title of the field.
     let header: String?
     /// Placeholder of the text field.
@@ -18,9 +18,10 @@ struct AccountCreationFormFieldViewModel {
     let isFocused: Bool
 }
 
-/// A field in the account creation form. Currently, there are two fields - email and password.
-struct AccountCreationFormFieldView: View {
-    private let viewModel: AccountCreationFormFieldViewModel
+/// A field in the account creation / authentication form.
+/// Currently, there are two fields - email and password.
+struct AuthenticationFormFieldView: View {
+    private let viewModel: AuthenticationFormFieldViewModel
 
     /// Whether the text field is *shown* as secure.
     /// When the field is secure, there is a button to show/hide the text field input.
@@ -29,7 +30,7 @@ struct AccountCreationFormFieldView: View {
     // Tracks the scale of the view due to accessibility changes.
     @ScaledMetric private var scale: CGFloat = 1.0
 
-    init(viewModel: AccountCreationFormFieldViewModel) {
+    init(viewModel: AuthenticationFormFieldViewModel) {
         self.viewModel = viewModel
         self.showsSecureInput = viewModel.isSecure
     }
@@ -88,7 +89,7 @@ struct AccountCreationFormFieldView: View {
     }
 }
 
-private extension AccountCreationFormFieldView {
+private extension AuthenticationFormFieldView {
     enum Layout {
         static let verticalSpacing: CGFloat = 8
         static let secureFieldRevealButtonHorizontalPadding: CGFloat = 16
@@ -98,7 +99,7 @@ private extension AccountCreationFormFieldView {
 
 struct AccountCreationFormField_Previews: PreviewProvider {
     static var previews: some View {
-        AccountCreationFormFieldView(viewModel: .init(header: "Your email address",
+        AuthenticationFormFieldView(viewModel: .init(header: "Your email address",
                                                       placeholder: "Email address",
                                                       keyboardType: .emailAddress,
                                                       text: .constant(""),
@@ -106,7 +107,7 @@ struct AccountCreationFormField_Previews: PreviewProvider {
                                                       errorMessage: nil,
                                                       isFocused: true))
         VStack {
-            AccountCreationFormFieldView(viewModel: .init(header: "Choose a password",
+            AuthenticationFormFieldView(viewModel: .init(header: "Choose a password",
                                                           placeholder: "Password",
                                                           keyboardType: .default,
                                                           text: .constant("wwwwwwwwwwwwwwwwwwwwwwww"),
@@ -115,7 +116,7 @@ struct AccountCreationFormField_Previews: PreviewProvider {
                                                           isFocused: false))
             .environment(\.sizeCategory, .medium)
 
-            AccountCreationFormFieldView(viewModel: .init(header: "Choose a password",
+            AuthenticationFormFieldView(viewModel: .init(header: "Choose a password",
                                                           placeholder: "Password",
                                                           keyboardType: .default,
                                                           text: .constant("wwwwwwwwwwwwwwwwwwwwwwww"),

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -346,16 +346,20 @@ extension JetpackSetupCoordinator: LoginFacadeDelegate {
     }
 
     func displayRemoteError(_ error: Error) {
-        // TODO: show error alert
+        let message = prepareErrorMessage(for: error, fallback: Localization.errorRequestingAuthURL)
+        showAlert(message: message)
+        loginCompletionHandler?()
     }
 
     func finishedLogin(withAuthToken authToken: String, requiredMultifactorCode: Bool) {
         loginCompletionHandler?()
+        DDLogInfo("✅ Ready for Jetpack setup - connection only: \(requiresConnectionOnly)")
         // TODO: prepare for Jetpack setup
     }
 
     func finishedLogin(withNonceAuthToken authToken: String) {
         loginCompletionHandler?()
+        DDLogInfo("✅ Ready for Jetpack setup - connection only: \(requiresConnectionOnly)")
         // TODO: prepare for Jetpack setup
     }
 }
@@ -386,6 +390,10 @@ private extension JetpackSetupCoordinator {
         static let pleaseWait = NSLocalizedString(
             "Please wait",
             comment: "Message on the loading view displayed when the magic link authentication for Jetpack setup is in progress"
+        )
+        static let errorLoggingIn = NSLocalizedString(
+            "Login failed. Please try again.",
+            comment: "Generic message shown on the error alert displayed when the WPCom login for the Jetpack setup flow fails"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -334,7 +334,15 @@ private extension JetpackSetupCoordinator {
 //
 extension JetpackSetupCoordinator: LoginFacadeDelegate {
     func needsMultifactorCode() {
-        // TODO: show 2FA UI
+        let viewController = WPCom2FALoginHostingController(
+            requiresConnectionOnly: requiresConnectionOnly,
+            onSubmit: { code in
+            // TODO: request 2FA code
+        },
+            onSMSRequest: {
+            // TODO: request SMS
+        })
+        loginNavigationController?.pushViewController(viewController, animated: true)
     }
 
     func displayRemoteError(_ error: Error) {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -180,7 +180,10 @@ private extension JetpackSetupCoordinator {
     func showWPComEmailLogin() {
         let emailLoginController = WPComEmailLoginHostingController(siteURL: site.url,
                                                                     requiresConnectionOnly: requiresConnectionOnly,
-                                                                    onSubmit: checkWordPressComAccount(email:))
+                                                                    onSubmit: { [weak self] email in
+            guard let self else { return }
+            await self.checkWordPressComAccount(email: email)
+        })
         let loginNavigationController = LoginNavigationController(rootViewController: emailLoginController)
         rootViewController.dismiss(animated: true) {
             self.rootViewController.present(loginNavigationController, animated: true)
@@ -258,7 +261,10 @@ private extension JetpackSetupCoordinator {
             onLoginSuccess: { _ in
                 DDLogInfo("✅ Ready for Jetpack setup")
             })
-        let viewController = WPComPasswordLoginHostingController(viewModel: viewModel, onMagicLinkRequest: requestAuthenticationLink(email:))
+        let viewController = WPComPasswordLoginHostingController(viewModel: viewModel, onMagicLinkRequest: { [weak self] email in
+            guard let self else { return }
+            await self.requestAuthenticationLink(email: email)
+        })
         loginNavigationController?.pushViewController(viewController, animated: true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -2,10 +2,11 @@ import UIKit
 import Yosemite
 import enum Alamofire.AFError
 import WordPressAuthenticator
+import class Networking.UserAgent
 
 /// Coordinates the Jetpack setup flow in the authenticated state.
 ///
-final class JetpackSetupCoordinator {
+final class JetpackSetupCoordinator: NSObject {
     let rootViewController: UIViewController
 
     private let site: Site
@@ -15,6 +16,7 @@ final class JetpackSetupCoordinator {
     private let analytics: Analytics
     private let accountService: WordPressComAccountService
     private let dotcomAuthScheme: String
+    private let loginFacade: LoginFacade
 
     private var benefitsController: JetpackBenefitsHostingController?
     private var loginNavigationController: LoginNavigationController?
@@ -35,6 +37,11 @@ final class JetpackSetupCoordinator {
         /// to be used for requesting authentication link and handle login later.
         WordPressAuthenticator.initializeWithCustomConfigs(dotcomAuthScheme: dotcomAuthScheme)
         self.accountService = WordPressComAccountService()
+        self.loginFacade = LoginFacade(dotcomClientID: ApiCredentials.dotcomAppId,
+                                       dotcomSecret: ApiCredentials.dotcomSecret,
+                                       userAgent: UserAgent.defaultUserAgent)
+        super.init()
+        loginFacade.delegate = self
     }
 
     func showBenefitModal() {
@@ -303,6 +310,26 @@ private extension JetpackSetupCoordinator {
         let cancelAction = UIAlertAction(title: Localization.cancelButton, style: .cancel)
         alert.addAction(cancelAction)
         rootViewController.topmostPresentedViewController.present(alert, animated: true)
+    }
+}
+
+// MARK: - LoginFacadeDelegate conformance
+//
+extension JetpackSetupCoordinator: LoginFacadeDelegate {
+    func needsMultifactorCode() {
+        // TODO: show 2FA UI
+    }
+
+    func displayRemoteError(_ error: Error) {
+        // TODO: show error alert
+    }
+
+    func finishedLogin(withAuthToken authToken: String, requiredMultifactorCode: Bool) {
+        // TODO: prepare for Jetpack setup
+    }
+
+    func finishedLogin(withNonceAuthToken authToken: String) {
+        // TODO: prepare for Jetpack setup
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -252,21 +252,22 @@ private extension JetpackSetupCoordinator {
     }
 
     func showPasswordUI(email: String) {
-        let viewController = WPComPasswordLoginHostingController(
+        let viewModel = WPComPasswordLoginViewModel(
             siteURL: site.url,
             email: email,
             requiresConnectionOnly: requiresConnectionOnly,
-            onSubmit: { [weak self] password in
-                await withCheckedContinuation { continuation in
-                    guard let self else {
-                        return continuation.resume()
-                    }
-                    self.handleLogin(email: email, password: password, onCompletion: {
-                        continuation.resume()
-                    })
-                }
+            onMultifactorCodeRequest: {
+                // TODO
             },
-            onMagicLinkRequest: requestAuthenticationLink(email:))
+            onLoginFailure: { [weak self] error in
+                guard let self else { return }
+                let message = self.prepareErrorMessage(for: error, fallback: Localization.errorRequestingAuthURL)
+                self.showAlert(message: message)
+            },
+            onLoginSuccess: { _ in
+                DDLogInfo("✅ Ready for Jetpack setup")
+            })
+        let viewController = WPComPasswordLoginHostingController(viewModel: viewModel, onMagicLinkRequest: requestAuthenticationLink(email:))
         loginNavigationController?.pushViewController(viewController, animated: true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
@@ -42,7 +42,7 @@ struct WPCom2FALoginView: View {
                 }
 
                 // Verification field
-                AccountCreationFormFieldView(viewModel: .init(
+                AuthenticationFormFieldView(viewModel: .init(
                     header: nil,
                     placeholder: Localization.verificationCode,
                     keyboardType: .asciiCapableNumberPad,

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
@@ -47,7 +47,7 @@ struct WPCom2FALoginView: View {
                     placeholder: Localization.verificationCode,
                     keyboardType: .asciiCapableNumberPad,
                     text: $viewModel.verificationCode,
-                    isSecure: true,
+                    isSecure: false,
                     errorMessage: nil,
                     isFocused: isFieldFocused
                 ))

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
@@ -92,12 +92,12 @@ struct WPCom2FALoginView: View {
                 Button(viewModel.titleString) {
                     Task { @MainActor in
                         isPrimaryButtonLoading = true
-                        await onSubmit(viewModel.verificationCode)
+                        await onSubmit(viewModel.strippedCode)
                         isPrimaryButtonLoading = false
                     }
                 }
                 .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isPrimaryButtonLoading))
-                .disabled(viewModel.verificationCode.isEmpty)
+                .disabled(viewModel.isValidCode)
             }
             .padding(Constants.contentPadding)
             .background(Color(uiColor: .systemBackground))

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+/// View for 2FA login screen of the custom WPCom login flow for Jetpack setup.
+struct WPCom2FALoginView: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct WPCom2FALoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        WPCom2FALoginView()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
@@ -1,5 +1,26 @@
 import SwiftUI
 
+/// Hosting controller for `WPCom2FALoginView`
+final class WPCom2FALoginHostingController: UIHostingController<WPCom2FALoginView> {
+
+    init(siteURL: String, requiresConnectionOnly: Bool,
+         onSubmit: @escaping (String) async -> Void,
+         onSMSRequest: @escaping () async -> Void) {
+        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: requiresConnectionOnly)
+        super.init(rootView: WPCom2FALoginView(viewModel: viewModel, onSubmit: onSubmit, onSMSRequest: onSMSRequest))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTransparentNavigationBar()
+    }
+}
+
 /// View for 2FA login screen of the custom WPCom login flow for Jetpack setup.
 struct WPCom2FALoginView: View {
     @ObservedObject private var viewModel: WPCom2FALoginViewModel
@@ -46,6 +67,7 @@ struct WPCom2FALoginView: View {
                 ))
                 .focused($isFieldFocused)
 
+                // Text me a code button
                 Button(action: {
                     Task { @MainActor in
                         isSMSRequestInProgress = true
@@ -109,6 +131,6 @@ struct WPCom2FALoginView_Previews: PreviewProvider {
     static var previews: some View {
         WPCom2FALoginView(viewModel: .init(requiresConnectionOnly: true),
                           onSubmit: { _ in },
-                           onSMSRequest: {})
+                          onSMSRequest: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
@@ -107,7 +107,7 @@ struct WPCom2FALoginView: View {
 
 private extension WPCom2FALoginView {
     enum Constants {
-        static let blockVerticalPadding: CGFloat = 16
+        static let blockVerticalPadding: CGFloat = 24
         static let contentVerticalSpacing: CGFloat = 8
         static let contentPadding: CGFloat = 16
     }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Hosting controller for `WPCom2FALoginView`
 final class WPCom2FALoginHostingController: UIHostingController<WPCom2FALoginView> {
 
-    init(siteURL: String, requiresConnectionOnly: Bool,
+    init(requiresConnectionOnly: Bool,
          onSubmit: @escaping (String) async -> Void,
          onSMSRequest: @escaping () async -> Void) {
         let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: requiresConnectionOnly)

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
@@ -57,7 +57,7 @@ struct WPCom2FALoginView: View {
 
                 // Verification field
                 AccountCreationFormFieldView(viewModel: .init(
-                    header: "",
+                    header: nil,
                     placeholder: Localization.verificationCode,
                     keyboardType: .asciiCapableNumberPad,
                     text: $viewModel.verificationCode,
@@ -107,7 +107,7 @@ struct WPCom2FALoginView: View {
 
 private extension WPCom2FALoginView {
     enum Constants {
-        static let blockVerticalPadding: CGFloat = 32
+        static let blockVerticalPadding: CGFloat = 16
         static let contentVerticalSpacing: CGFloat = 8
         static let contentPadding: CGFloat = 16
     }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
@@ -2,13 +2,113 @@ import SwiftUI
 
 /// View for 2FA login screen of the custom WPCom login flow for Jetpack setup.
 struct WPCom2FALoginView: View {
+    @ObservedObject private var viewModel: WPCom2FALoginViewModel
+    @FocusState private var isFieldFocused: Bool
+    @State private var isPrimaryButtonLoading = false
+    @State private var isSMSRequestInProgress = false
+
+    /// The closure to be triggered when the Install Jetpack button is tapped.
+    private let onSubmit: (String) async -> Void
+
+    /// The closure to be triggered when the Text me a code button is tapped.
+    private let onSMSRequest: () async -> Void
+
+    init(viewModel: WPCom2FALoginViewModel,
+         onSubmit: @escaping (String) async -> Void,
+         onSMSRequest: @escaping () async -> Void) {
+        self.viewModel = viewModel
+        self.onSubmit = onSubmit
+        self.onSMSRequest = onSMSRequest
+    }
+
     var body: some View {
-        Text("Hello, World!")
+        ScrollView {
+            VStack(alignment: .leading, spacing: Constants.blockVerticalPadding) {
+                JetpackInstallHeaderView()
+
+                // title and description
+                VStack(alignment: .leading, spacing: Constants.contentVerticalSpacing) {
+                    Text(viewModel.titleString)
+                        .largeTitleStyle()
+                    Text(Localization.subtitleString)
+                        .subheadlineStyle()
+                }
+
+                // Verification field
+                AccountCreationFormFieldView(viewModel: .init(
+                    header: "",
+                    placeholder: Localization.verificationCode,
+                    keyboardType: .asciiCapableNumberPad,
+                    text: $viewModel.verificationCode,
+                    isSecure: true,
+                    errorMessage: nil,
+                    isFocused: isFieldFocused
+                ))
+                .focused($isFieldFocused)
+
+                Button(action: {
+                    Task { @MainActor in
+                        isSMSRequestInProgress = true
+                        await onSMSRequest()
+                        isSMSRequestInProgress = false
+                    }
+                }, label: {
+                    if isSMSRequestInProgress {
+                        ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                    } else {
+                        Text(Localization.textMeACode)
+                            .linkStyle()
+                    }
+                })
+                Spacer()
+            }
+            .padding(Constants.contentPadding)
+        }
+        .safeAreaInset(edge: .bottom) {
+            VStack {
+                // Primary CTA
+                Button(viewModel.titleString) {
+                    Task { @MainActor in
+                        isPrimaryButtonLoading = true
+                        await onSubmit(viewModel.verificationCode)
+                        isPrimaryButtonLoading = false
+                    }
+                }
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isPrimaryButtonLoading))
+                .disabled(viewModel.verificationCode.isEmpty)
+            }
+            .padding(Constants.contentPadding)
+            .background(Color(uiColor: .systemBackground))
+        }
+    }
+}
+
+private extension WPCom2FALoginView {
+    enum Constants {
+        static let blockVerticalPadding: CGFloat = 32
+        static let contentVerticalSpacing: CGFloat = 8
+        static let contentPadding: CGFloat = 16
+    }
+
+    enum Localization {
+        static let subtitleString = NSLocalizedString(
+            "Almost there! Please enter the verification code from your Authentication app",
+            comment: "Instruction on the WPCom 2FA login screen of the Jetpack setup flow")
+        static let verificationCode = NSLocalizedString(
+            "Verification code",
+            comment: "Placeholder for the 2FA code field on the WPCom 2FA login screen of the Jetpack setup flow."
+        )
+        static let textMeACode = NSLocalizedString(
+            "Text me a code instead",
+            comment: "Button to request 2FA code via SMS on the WPCom 2FA login screen of the Jetpack setup flow."
+        )
     }
 }
 
 struct WPCom2FALoginView_Previews: PreviewProvider {
     static var previews: some View {
-        WPCom2FALoginView()
+        WPCom2FALoginView(viewModel: .init(requiresConnectionOnly: true),
+                          onSubmit: { _ in },
+                           onSMSRequest: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
@@ -97,7 +97,7 @@ struct WPCom2FALoginView: View {
                     }
                 }
                 .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isPrimaryButtonLoading))
-                .disabled(viewModel.isValidCode)
+                .disabled(!viewModel.isValidCode)
             }
             .padding(Constants.contentPadding)
             .background(Color(uiColor: .systemBackground))

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModel.swift
@@ -28,7 +28,8 @@ final class WPCom2FALoginViewModel: NSObject, ObservableObject {
         return false
     }
 
-    private let loginFields: LoginFields
+    // set to non-private for testing purpose
+    let loginFields: LoginFields
     private let loginFacade: LoginFacade
     private let onLoginFailure: (Error) -> Void
     private let onLoginSuccess: (String) -> Void

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModel.swift
@@ -2,7 +2,25 @@ import Foundation
 
 /// View model for `WPCom2FALoginView`.
 final class WPCom2FALoginViewModel: ObservableObject {
-    @Published var otp: String
+    @Published var verificationCode: String = ""
 
-    init(requiresConnectionOnly: Bool) {}
+    /// Title for the view
+    let titleString: String
+
+    init(requiresConnectionOnly: Bool) {
+        self.titleString = requiresConnectionOnly ? Localization.connectJetpack : Localization.installJetpack
+    }
+}
+
+extension WPCom2FALoginViewModel {
+    enum Localization {
+        static let installJetpack = NSLocalizedString(
+            "Install Jetpack",
+            comment: "Title for the WPCom 2FA login screen when Jetpack is not installed yet"
+        )
+        static let connectJetpack = NSLocalizedString(
+            "Connect Jetpack",
+            comment: "Title for the WPCom 2FA login screen when Jetpack is not connected yet"
+        )
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModel.swift
@@ -29,8 +29,7 @@ final class WPCom2FALoginViewModel: NSObject, ObservableObject {
         return false
     }
 
-    // set to non-private for testing purpose
-    let loginFields: LoginFields
+    private let loginFields: LoginFields
     private let loginFacade: LoginFacade
     private let onLoginFailure: (Error) -> Void
     private let onLoginSuccess: (String) -> Void

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModel.swift
@@ -86,6 +86,9 @@ extension WPCom2FALoginViewModel: LoginFacadeDelegate {
 extension WPCom2FALoginViewModel {
     enum Constants {
         // Following the implementation in WordPressAuthenticator
+        // swiftlint:disable line_length
+        // https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/c0d16065c5b5a8e54dbb54cc31c7b3cf28f584f9/WordPressAuthenticator/Signin/Login2FAViewController.swift#L218
+        // swiftlint:enable line_length
         static let maximumCodeLength = 8
     }
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModel.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// View model for `WPCom2FALoginView`.
+final class WPCom2FALoginViewModel: ObservableObject {
+    @Published var otp: String
+
+    init(requiresConnectionOnly: Bool) {}
+}

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModel.swift
@@ -12,6 +12,7 @@ final class WPCom2FALoginViewModel: NSObject, ObservableObject {
     let titleString: String
 
     /// In case the code is entered by pasting from the clipboard, we need to remove all white spaces.
+    /// kept non-private for testing purposes.
     var strippedCode: String {
         verificationCode.components(separatedBy: .whitespacesAndNewlines).joined()
     }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModel.swift
@@ -7,12 +7,33 @@ final class WPCom2FALoginViewModel: ObservableObject {
     /// Title for the view
     let titleString: String
 
+    /// In case the code is entered by pasting from the clipboard, we need to remove all white spaces.
+    var strippedCode: String {
+        verificationCode.components(separatedBy: .whitespacesAndNewlines).joined()
+    }
+
+    var isValidCode: Bool {
+        let allowedCharacters = CharacterSet.decimalDigits
+        let resultCharacterSet = CharacterSet(charactersIn: strippedCode)
+        let isOnlyNumbers = allowedCharacters.isSuperset(of: resultCharacterSet)
+        let isValidLength = strippedCode.count <= Constants.maximumCodeLength && strippedCode.isNotEmpty
+
+        if isOnlyNumbers && isValidLength {
+            return true
+        }
+        return false
+    }
+
     init(requiresConnectionOnly: Bool) {
         self.titleString = requiresConnectionOnly ? Localization.connectJetpack : Localization.installJetpack
     }
 }
 
 extension WPCom2FALoginViewModel {
+    enum Constants {
+        // Following the implementation in WordPressAuthenticator
+        static let maximumCodeLength = 8
+    }
     enum Localization {
         static let installJetpack = NSLocalizedString(
             "Install Jetpack",

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
@@ -67,7 +67,7 @@ struct WPComEmailLoginView: View {
                 }
 
                 // Email field
-                AccountCreationFormFieldView(viewModel: .init(
+                AuthenticationFormFieldView(viewModel: .init(
                     header: Localization.emailLabel,
                     placeholder: Localization.enterEmail,
                     keyboardType: .emailAddress,

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
@@ -4,16 +4,9 @@ import Kingfisher
 /// Hosting controller for `WPComPasswordLoginView`
 final class WPComPasswordLoginHostingController: UIHostingController<WPComPasswordLoginView> {
 
-    init(siteURL: String,
-         email: String,
-         requiresConnectionOnly: Bool,
-         onSubmit: @escaping (String) async -> Void,
+    init(viewModel: WPComPasswordLoginViewModel,
          onMagicLinkRequest: @escaping (String) async -> Void) {
-        let viewModel = WPComPasswordLoginViewModel(siteURL: siteURL,
-                                                    email: email,
-                                                    requiresConnectionOnly: requiresConnectionOnly)
         super.init(rootView: WPComPasswordLoginView(viewModel: viewModel,
-                                                    onSubmit: onSubmit,
                                                     onMagicLinkRequest: onMagicLinkRequest))
     }
 
@@ -31,19 +24,15 @@ final class WPComPasswordLoginHostingController: UIHostingController<WPComPasswo
 /// Screen for entering the password for a WPCom account during the Jetpack setup flow
 /// This is presented for users authenticated with WPOrg credentials.
 struct WPComPasswordLoginView: View {
-    @State private var isPrimaryButtonLoading = false
     @State private var isSecondaryButtonLoading = false
     @FocusState private var isPasswordFieldFocused: Bool
     @ObservedObject private var viewModel: WPComPasswordLoginViewModel
 
-    private let onSubmit: (String) async -> Void
     private let onMagicLinkRequest: (String) async -> Void
 
     init(viewModel: WPComPasswordLoginViewModel,
-         onSubmit: @escaping (String) async -> Void,
          onMagicLinkRequest: @escaping (String) async -> Void) {
         self.viewModel = viewModel
-        self.onSubmit = onSubmit
         self.onMagicLinkRequest = onMagicLinkRequest
     }
 
@@ -102,13 +91,9 @@ struct WPComPasswordLoginView: View {
             VStack {
                 // Primary CTA
                 Button(Localization.primaryAction) {
-                    Task { @MainActor in
-                        isPrimaryButtonLoading = true
-                        await onSubmit(viewModel.password)
-                        isPrimaryButtonLoading = false
-                    }
+                    viewModel.handleLogin()
                 }
-                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isPrimaryButtonLoading))
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLoggingIn))
                 .disabled(viewModel.password.isEmpty)
 
                 // Secondary CTA
@@ -164,8 +149,10 @@ struct WPComPasswordLoginView_Previews: PreviewProvider {
     static var previews: some View {
         WPComPasswordLoginView(viewModel: .init(siteURL: "https://example.com",
                                                 email: "test@example.com",
-                                                requiresConnectionOnly: true),
-                               onSubmit: { _ in },
+                                                requiresConnectionOnly: true,
+                                                onMultifactorCodeRequest: {},
+                                                onLoginFailure: { _ in },
+                                                onLoginSuccess: { _ in }),
                                onMagicLinkRequest: { _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
@@ -150,7 +150,7 @@ struct WPComPasswordLoginView_Previews: PreviewProvider {
         WPComPasswordLoginView(viewModel: .init(siteURL: "https://example.com",
                                                 email: "test@example.com",
                                                 requiresConnectionOnly: true,
-                                                onMultifactorCodeRequest: {},
+                                                onMultifactorCodeRequest: { _ in },
                                                 onLoginFailure: { _ in },
                                                 onLoginSuccess: { _ in }),
                                onMagicLinkRequest: { _ in })

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
@@ -63,7 +63,7 @@ struct WPComPasswordLoginView: View {
                 )
 
                 // Password field
-                AccountCreationFormFieldView(viewModel: .init(
+                AuthenticationFormFieldView(viewModel: .init(
                     header: Localization.passwordLabel,
                     placeholder: Localization.passwordPlaceholder,
                     keyboardType: .default,

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
@@ -18,7 +18,7 @@ final class WPComPasswordLoginViewModel: NSObject, ObservableObject {
 
     private let siteURL: String
     private let loginFacade: LoginFacade
-    private let onMultifactorCodeRequest: () -> Void
+    private let onMultifactorCodeRequest: (LoginFields) -> Void
     private let onLoginFailure: (Error) -> Void
     private let onLoginSuccess: (String) -> Void
 
@@ -36,7 +36,7 @@ final class WPComPasswordLoginViewModel: NSObject, ObservableObject {
     init(siteURL: String,
          email: String,
          requiresConnectionOnly: Bool,
-         onMultifactorCodeRequest: @escaping () -> Void,
+         onMultifactorCodeRequest: @escaping (LoginFields) -> Void,
          onLoginFailure: @escaping (Error) -> Void,
          onLoginSuccess: @escaping (String) -> Void) {
         self.siteURL = siteURL
@@ -89,7 +89,7 @@ private extension WPComPasswordLoginViewModel {
 extension WPComPasswordLoginViewModel: LoginFacadeDelegate {
     func needsMultifactorCode() {
         isLoggingIn = false
-        onMultifactorCodeRequest()
+        onMultifactorCodeRequest(loginFields)
     }
 
     func displayRemoteError(_ error: Error) {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModel.swift
@@ -1,20 +1,26 @@
 import Foundation
 import WordPressAuthenticator
+import class Networking.UserAgent
 
 /// View model for `WPComPasswordLoginView`.
 ///
-final class WPComPasswordLoginViewModel: ObservableObject {
+final class WPComPasswordLoginViewModel: NSObject, ObservableObject {
 
     /// Title of the view.
     let titleString: String
 
     /// Entered password
     @Published var password: String = ""
+    @Published private(set) var isLoggingIn = false
 
     /// Email address of the WPCom account
     let email: String
 
     private let siteURL: String
+    private let loginFacade: LoginFacade
+    private let onMultifactorCodeRequest: () -> Void
+    private let onLoginFailure: (Error) -> Void
+    private let onLoginSuccess: (String) -> Void
 
     private(set) var avatarURL: URL?
 
@@ -27,15 +33,33 @@ final class WPComPasswordLoginViewModel: ObservableObject {
         return loginFields
     }
 
-    init(siteURL: String, email: String, requiresConnectionOnly: Bool) {
+    init(siteURL: String,
+         email: String,
+         requiresConnectionOnly: Bool,
+         onMultifactorCodeRequest: @escaping () -> Void,
+         onLoginFailure: @escaping (Error) -> Void,
+         onLoginSuccess: @escaping (String) -> Void) {
         self.siteURL = siteURL
         self.email = email
         self.titleString = requiresConnectionOnly ? Localization.connectJetpack : Localization.installJetpack
+        self.loginFacade = LoginFacade(dotcomClientID: ApiCredentials.dotcomAppId,
+                                       dotcomSecret: ApiCredentials.dotcomSecret,
+                                       userAgent: UserAgent.defaultUserAgent)
+        self.onMultifactorCodeRequest = onMultifactorCodeRequest
+        self.onLoginFailure = onLoginFailure
+        self.onLoginSuccess = onLoginSuccess
+        super.init()
+        loginFacade.delegate = self
         avatarURL = gravatarUrl(of: email)
     }
 
     func resetPassword() {
         WordPressAuthenticator.openForgotPasswordURL(loginFields)
+    }
+
+    func handleLogin() {
+        isLoggingIn = true
+        loginFacade.signIn(with: loginFields)
     }
 }
 
@@ -59,6 +83,23 @@ private extension WPComPasswordLoginViewModel {
             .lowercased()
             .trimmingCharacters(in: .whitespaces)
             .md5Hash()
+    }
+}
+
+extension WPComPasswordLoginViewModel: LoginFacadeDelegate {
+    func needsMultifactorCode() {
+        isLoggingIn = false
+        onMultifactorCodeRequest()
+    }
+
+    func displayRemoteError(_ error: Error) {
+        isLoggingIn = false
+        onLoginFailure(error)
+    }
+
+    func finishedLogin(withAuthToken authToken: String, requiredMultifactorCode: Bool) {
+        isLoggingIn = false
+        onLoginSuccess(authToken)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1877,6 +1877,7 @@
 		DE4D23A829B0D11E003A4B5D /* WPComPasswordLoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23A729B0D11E003A4B5D /* WPComPasswordLoginViewModelTests.swift */; };
 		DE4D23AA29B1B0CA003A4B5D /* WPCom2FALoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23A929B1B0CA003A4B5D /* WPCom2FALoginView.swift */; };
 		DE4D23AE29B1B0EF003A4B5D /* WPCom2FALoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23AD29B1B0EF003A4B5D /* WPCom2FALoginViewModel.swift */; };
+		DE4D23B029B1D02A003A4B5D /* WPCom2FALoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23AF29B1D02A003A4B5D /* WPCom2FALoginViewModelTests.swift */; };
 		DE4D308928507B5B00E36ADD /* CouponCreationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D308828507B5B00E36ADD /* CouponCreationSuccess.swift */; };
 		DE4FB7732812AE96003D20D6 /* FilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4FB7722812AE96003D20D6 /* FilterListView.swift */; };
 		DE50294928BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50294828BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift */; };
@@ -4028,6 +4029,7 @@
 		DE4D23A729B0D11E003A4B5D /* WPComPasswordLoginViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPasswordLoginViewModelTests.swift; sourceTree = "<group>"; };
 		DE4D23A929B1B0CA003A4B5D /* WPCom2FALoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPCom2FALoginView.swift; sourceTree = "<group>"; };
 		DE4D23AD29B1B0EF003A4B5D /* WPCom2FALoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPCom2FALoginViewModel.swift; sourceTree = "<group>"; };
+		DE4D23AF29B1D02A003A4B5D /* WPCom2FALoginViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPCom2FALoginViewModelTests.swift; sourceTree = "<group>"; };
 		DE4D308828507B5B00E36ADD /* CouponCreationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponCreationSuccess.swift; sourceTree = "<group>"; };
 		DE4FB7722812AE96003D20D6 /* FilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListView.swift; sourceTree = "<group>"; };
 		DE50294828BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "WordPressOrgCredentials+Authenticator.swift"; path = "Classes/Authentication/WordPressOrgCredentials+Authenticator.swift"; sourceTree = SOURCE_ROOT; };
@@ -9393,6 +9395,7 @@
 				DEF8CF2129ACDBB100800A60 /* WPComEmailLoginViewModelTests.swift */,
 				DE4D239F29B09D71003A4B5D /* WPComMagicLinkViewModelTests.swift */,
 				DE4D23A729B0D11E003A4B5D /* WPComPasswordLoginViewModelTests.swift */,
+				DE4D23AF29B1D02A003A4B5D /* WPCom2FALoginViewModelTests.swift */,
 			);
 			path = WPComLogin;
 			sourceTree = "<group>";
@@ -11660,6 +11663,7 @@
 				B555531321B57E8800449E71 /* MockUserNotificationsCenterAdapter.swift in Sources */,
 				682210ED2909666600814E14 /* CustomerSearchUICommandTests.swift in Sources */,
 				4590B652261C8D1E00A6FCE0 /* WeightFormatterTests.swift in Sources */,
+				DE4D23B029B1D02A003A4B5D /* WPCom2FALoginViewModelTests.swift in Sources */,
 				D8C11A6022E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift in Sources */,
 				B622BC74289CF19400B10CEC /* WaitingTimeTrackerTests.swift in Sources */,
 				023EC2E224DA8BAB0021DA91 /* MockProductSKUValidationStoresManager.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1875,6 +1875,8 @@
 		DE4D23A429B0A9FA003A4B5D /* WPComPasswordLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23A329B0A9FA003A4B5D /* WPComPasswordLoginView.swift */; };
 		DE4D23A629B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23A529B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift */; };
 		DE4D23A829B0D11E003A4B5D /* WPComPasswordLoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23A729B0D11E003A4B5D /* WPComPasswordLoginViewModelTests.swift */; };
+		DE4D23AA29B1B0CA003A4B5D /* WPCom2FALoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23A929B1B0CA003A4B5D /* WPCom2FALoginView.swift */; };
+		DE4D23AE29B1B0EF003A4B5D /* WPCom2FALoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D23AD29B1B0EF003A4B5D /* WPCom2FALoginViewModel.swift */; };
 		DE4D308928507B5B00E36ADD /* CouponCreationSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D308828507B5B00E36ADD /* CouponCreationSuccess.swift */; };
 		DE4FB7732812AE96003D20D6 /* FilterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4FB7722812AE96003D20D6 /* FilterListView.swift */; };
 		DE50294928BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50294828BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift */; };
@@ -4024,6 +4026,8 @@
 		DE4D23A329B0A9FA003A4B5D /* WPComPasswordLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPasswordLoginView.swift; sourceTree = "<group>"; };
 		DE4D23A529B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPasswordLoginViewModel.swift; sourceTree = "<group>"; };
 		DE4D23A729B0D11E003A4B5D /* WPComPasswordLoginViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPasswordLoginViewModelTests.swift; sourceTree = "<group>"; };
+		DE4D23A929B1B0CA003A4B5D /* WPCom2FALoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPCom2FALoginView.swift; sourceTree = "<group>"; };
+		DE4D23AD29B1B0EF003A4B5D /* WPCom2FALoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPCom2FALoginViewModel.swift; sourceTree = "<group>"; };
 		DE4D308828507B5B00E36ADD /* CouponCreationSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponCreationSuccess.swift; sourceTree = "<group>"; };
 		DE4FB7722812AE96003D20D6 /* FilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListView.swift; sourceTree = "<group>"; };
 		DE50294828BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "WordPressOrgCredentials+Authenticator.swift"; path = "Classes/Authentication/WordPressOrgCredentials+Authenticator.swift"; sourceTree = SOURCE_ROOT; };
@@ -9377,6 +9381,8 @@
 				DE4D239D29B073B1003A4B5D /* WPComMagicLinkViewModel.swift */,
 				DE4D23A329B0A9FA003A4B5D /* WPComPasswordLoginView.swift */,
 				DE4D23A529B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift */,
+				DE4D23A929B1B0CA003A4B5D /* WPCom2FALoginView.swift */,
+				DE4D23AD29B1B0EF003A4B5D /* WPCom2FALoginViewModel.swift */,
 			);
 			path = WPComLogin;
 			sourceTree = "<group>";
@@ -10944,6 +10950,7 @@
 				DEC2962326BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift in Sources */,
 				E1E649EB28461EDF0070B194 /* BetaFeaturesConfiguration.swift in Sources */,
 				26309F17277D0AEA0012797F /* SafeAreaInsetsKey.swift in Sources */,
+				DE4D23AA29B1B0CA003A4B5D /* WPCom2FALoginView.swift in Sources */,
 				023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */,
 				0206483A23FA4160008441BB /* OrdersRootViewController.swift in Sources */,
 				022BF7FD23B9D708000A1DFB /* InProgressViewController.swift in Sources */,
@@ -11458,6 +11465,7 @@
 				D8D15F85230A18AB00D48B3F /* Analytics.swift in Sources */,
 				B582F95920FFCEAA0060934A /* UITableViewHeaderFooterView+Helpers.swift in Sources */,
 				57532CAC24BFF4DA0032B84E /* MessageComposerPresenter.swift in Sources */,
+				DE4D23AE29B1B0EF003A4B5D /* WPCom2FALoginViewModel.swift in Sources */,
 				0270F47824D006F60005210A /* ProductFormPresentationStyle.swift in Sources */,
 				EECB7EE62864647F0028C888 /* ProductImagesProductIDUpdater.swift in Sources */,
 				FE28F7182684EE6A004465C7 /* RoleErrorViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 		02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift */; };
 		02E3B62829026C8F007E0F13 /* AccountCreationForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B62729026C8F007E0F13 /* AccountCreationForm.swift */; };
 		02E3B62D290631B3007E0F13 /* AccountCreationFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B62C290631B3007E0F13 /* AccountCreationFormViewModel.swift */; };
-		02E3B62F2906322B007E0F13 /* AccountCreationFormFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B62E2906322B007E0F13 /* AccountCreationFormFieldView.swift */; };
+		02E3B62F2906322B007E0F13 /* AuthenticationFormFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B62E2906322B007E0F13 /* AuthenticationFormFieldView.swift */; };
 		02E3B63129066858007E0F13 /* StoreCreationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B63029066858007E0F13 /* StoreCreationCoordinator.swift */; };
 		02E4908929AE49B9005942AE /* TopPerformersEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4908829AE49B9005942AE /* TopPerformersEmptyView.swift */; };
 		02E4908D29AF216E005942AE /* DashboardTopPerformersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4908C29AF216E005942AE /* DashboardTopPerformersView.swift */; };
@@ -2592,7 +2592,7 @@
 		02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatusListSelectorCommand.swift; sourceTree = "<group>"; };
 		02E3B62729026C8F007E0F13 /* AccountCreationForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationForm.swift; sourceTree = "<group>"; };
 		02E3B62C290631B3007E0F13 /* AccountCreationFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationFormViewModel.swift; sourceTree = "<group>"; };
-		02E3B62E2906322B007E0F13 /* AccountCreationFormFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationFormFieldView.swift; sourceTree = "<group>"; };
+		02E3B62E2906322B007E0F13 /* AuthenticationFormFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationFormFieldView.swift; sourceTree = "<group>"; };
 		02E3B63029066858007E0F13 /* StoreCreationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCoordinator.swift; sourceTree = "<group>"; };
 		02E4908829AE49B9005942AE /* TopPerformersEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPerformersEmptyView.swift; sourceTree = "<group>"; };
 		02E4908C29AF216E005942AE /* DashboardTopPerformersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTopPerformersView.swift; sourceTree = "<group>"; };
@@ -5393,7 +5393,7 @@
 			isa = PBXGroup;
 			children = (
 				02E3B62729026C8F007E0F13 /* AccountCreationForm.swift */,
-				02E3B62E2906322B007E0F13 /* AccountCreationFormFieldView.swift */,
+				02E3B62E2906322B007E0F13 /* AuthenticationFormFieldView.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -11476,7 +11476,7 @@
 				03E471C8293A3076001A58AD /* CardPresentModalBuiltInConnectingToReader.swift in Sources */,
 				0365986529AF942700F297D3 /* PaymentSettingsFlowHint.swift in Sources */,
 				CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */,
-				02E3B62F2906322B007E0F13 /* AccountCreationFormFieldView.swift in Sources */,
+				02E3B62F2906322B007E0F13 /* AuthenticationFormFieldView.swift in Sources */,
 				03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */,
 				DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModelTests.swift
@@ -1,11 +1,15 @@
 import XCTest
 @testable import WooCommerce
+import class WordPressAuthenticator.LoginFields
 
 final class WPCom2FALoginViewModelTests: XCTestCase {
 
     func test_title_string_is_correct_when_requiresConnectionOnly_is_false() {
         // Given
-        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: false)
+        let viewModel = WPCom2FALoginViewModel(loginFields: LoginFields(),
+                                               requiresConnectionOnly: false,
+                                               onLoginFailure: { _ in },
+                                               onLoginSuccess: { _ in })
 
         // When
         let text = viewModel.titleString
@@ -16,7 +20,10 @@ final class WPCom2FALoginViewModelTests: XCTestCase {
 
     func test_title_string_is_correct_when_requiresConnectionOnly_is_true() {
         // Given
-        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: true)
+        let viewModel = WPCom2FALoginViewModel(loginFields: LoginFields(),
+                                               requiresConnectionOnly: true,
+                                               onLoginFailure: { _ in },
+                                               onLoginSuccess: { _ in })
 
         // When
         let text = viewModel.titleString
@@ -27,7 +34,10 @@ final class WPCom2FALoginViewModelTests: XCTestCase {
 
     func test_strippedCode_removes_all_white_spaces_from_verification_code() {
         // Given
-        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: true)
+        let viewModel = WPCom2FALoginViewModel(loginFields: LoginFields(),
+                                               requiresConnectionOnly: false,
+                                               onLoginFailure: { _ in },
+                                               onLoginSuccess: { _ in })
 
         // When
         viewModel.verificationCode = "43 99 92"
@@ -38,7 +48,10 @@ final class WPCom2FALoginViewModelTests: XCTestCase {
 
     func test_isValidCode_returns_false_when_verification_code_contains_non_digits() {
         // Given
-        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: true)
+        let viewModel = WPCom2FALoginViewModel(loginFields: LoginFields(),
+                                               requiresConnectionOnly: false,
+                                               onLoginFailure: { _ in },
+                                               onLoginSuccess: { _ in })
 
         // When
         viewModel.verificationCode = "43gd35"
@@ -49,7 +62,10 @@ final class WPCom2FALoginViewModelTests: XCTestCase {
 
     func test_isValidCode_returns_false_when_verification_code_is_empty() {
         // Given
-        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: true)
+        let viewModel = WPCom2FALoginViewModel(loginFields: LoginFields(),
+                                               requiresConnectionOnly: false,
+                                               onLoginFailure: { _ in },
+                                               onLoginSuccess: { _ in })
 
         // When
         viewModel.verificationCode = ""
@@ -60,7 +76,10 @@ final class WPCom2FALoginViewModelTests: XCTestCase {
 
     func test_isValidCode_returns_false_when_verification_code_is_too_long() {
         // Given
-        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: true)
+        let viewModel = WPCom2FALoginViewModel(loginFields: LoginFields(),
+                                               requiresConnectionOnly: false,
+                                               onLoginFailure: { _ in },
+                                               onLoginSuccess: { _ in })
 
         // When
         viewModel.verificationCode = "185787878"
@@ -71,7 +90,10 @@ final class WPCom2FALoginViewModelTests: XCTestCase {
 
     func test_isValidCode_returns_true_when_verification_has_acceptable_length() {
         // Given
-        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: true)
+        let viewModel = WPCom2FALoginViewModel(loginFields: LoginFields(),
+                                               requiresConnectionOnly: false,
+                                               onLoginFailure: { _ in },
+                                               onLoginSuccess: { _ in })
 
         // When
         viewModel.verificationCode = "185787"

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModelTests.swift
@@ -25,4 +25,58 @@ final class WPCom2FALoginViewModelTests: XCTestCase {
         assertEqual(WPCom2FALoginViewModel.Localization.connectJetpack, text)
     }
 
+    func test_strippedCode_removes_all_white_spaces_from_verification_code() {
+        // Given
+        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: true)
+
+        // When
+        viewModel.verificationCode = "43 99 92"
+
+        // Then
+        assertEqual("439992", "439992")
+    }
+
+    func test_isValidCode_returns_false_when_verification_code_contains_non_digits() {
+        // Given
+        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: true)
+
+        // When
+        viewModel.verificationCode = "43gd35"
+
+        //  Then
+        XCTAssertFalse(viewModel.isValidCode)
+    }
+
+    func test_isValidCode_returns_false_when_verification_code_is_empty() {
+        // Given
+        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: true)
+
+        // When
+        viewModel.verificationCode = ""
+
+        //  Then
+        XCTAssertFalse(viewModel.isValidCode)
+    }
+
+    func test_isValidCode_returns_false_when_verification_code_is_too_long() {
+        // Given
+        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: true)
+
+        // When
+        viewModel.verificationCode = "185787878"
+
+        //  Then
+        XCTAssertFalse(viewModel.isValidCode)
+    }
+
+    func test_isValidCode_returns_true_when_verification_has_acceptable_length() {
+        // Given
+        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: true)
+
+        // When
+        viewModel.verificationCode = "185787"
+
+        //  Then
+        XCTAssertTrue(viewModel.isValidCode)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModelTests.swift
@@ -5,8 +5,8 @@ import WordPressAuthenticator
 final class WPCom2FALoginViewModelTests: XCTestCase {
 
     override func setUp() {
-        WordPressAuthenticator.initializeAuthenticator()
         super.setUp()
+        WordPressAuthenticator.initializeAuthenticator()
     }
 
     func test_title_string_is_correct_when_requiresConnectionOnly_is_false() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModelTests.swift
@@ -107,21 +107,6 @@ final class WPCom2FALoginViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isValidCode)
     }
 
-    func test_handleLogin_updates_loginFields_correctly() {
-        // Given
-        let viewModel = WPCom2FALoginViewModel(loginFields: LoginFields(),
-                                               requiresConnectionOnly: false,
-                                               onLoginFailure: { _ in },
-                                               onLoginSuccess: { _ in })
-
-        // When
-        viewModel.verificationCode = "113 567"
-        viewModel.handleLogin()
-
-        // Then
-        assertEqual(viewModel.strippedCode, viewModel.loginFields.multifactorCode)
-    }
-
     func test_isLoggingIn_is_updated_correctly_and_onLoginFailure_is_triggered_when_login_fails() {
         // Given
         var errorCaught: Error? = nil

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModelTests.swift
@@ -48,7 +48,7 @@ final class WPCom2FALoginViewModelTests: XCTestCase {
         viewModel.verificationCode = "43 99 92"
 
         // Then
-        assertEqual("439992", "439992")
+        assertEqual("439992", viewModel.strippedCode)
     }
 
     func test_isValidCode_returns_false_when_verification_code_contains_non_digits() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginViewModelTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import WooCommerce
+
+final class WPCom2FALoginViewModelTests: XCTestCase {
+
+    func test_title_string_is_correct_when_requiresConnectionOnly_is_false() {
+        // Given
+        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: false)
+
+        // When
+        let text = viewModel.titleString
+
+        // Then
+        assertEqual(WPCom2FALoginViewModel.Localization.installJetpack, text)
+    }
+
+    func test_title_string_is_correct_when_requiresConnectionOnly_is_true() {
+        // Given
+        let viewModel = WPCom2FALoginViewModel(requiresConnectionOnly: true)
+
+        // When
+        let text = viewModel.titleString
+
+        // Then
+        assertEqual(WPCom2FALoginViewModel.Localization.connectJetpack, text)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModelTests.swift
@@ -9,7 +9,7 @@ final class WPComPasswordLoginViewModelTests: XCTestCase {
         let viewModel = WPComPasswordLoginViewModel(siteURL: siteURL,
                                                     email: "test@example.com",
                                                     requiresConnectionOnly: false,
-                                                    onMultifactorCodeRequest: {},
+                                                    onMultifactorCodeRequest: { _ in },
                                                     onLoginFailure: { _ in },
                                                     onLoginSuccess: { _ in })
 
@@ -26,7 +26,7 @@ final class WPComPasswordLoginViewModelTests: XCTestCase {
         let viewModel = WPComPasswordLoginViewModel(siteURL: siteURL,
                                                     email: "test@example.com",
                                                     requiresConnectionOnly: true,
-                                                    onMultifactorCodeRequest: {},
+                                                    onMultifactorCodeRequest: { _ in },
                                                     onLoginFailure: { _ in },
                                                     onLoginSuccess: { _ in })
 
@@ -44,7 +44,7 @@ final class WPComPasswordLoginViewModelTests: XCTestCase {
         let viewModel = WPComPasswordLoginViewModel(siteURL: siteURL,
                                                     email: email,
                                                     requiresConnectionOnly: true,
-                                                    onMultifactorCodeRequest: {},
+                                                    onMultifactorCodeRequest: { _ in },
                                                     onLoginFailure: { _ in },
                                                     onLoginSuccess: { _ in })
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModelTests.swift
@@ -5,8 +5,8 @@ import WordPressAuthenticator
 final class WPComPasswordLoginViewModelTests: XCTestCase {
 
     override func setUp() {
-        WordPressAuthenticator.initializeAuthenticator()
         super.setUp()
+        WordPressAuthenticator.initializeAuthenticator()
     }
 
     func test_title_string_is_correct_when_requiresConnectionOnly_is_false() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModelTests.swift
@@ -8,7 +8,10 @@ final class WPComPasswordLoginViewModelTests: XCTestCase {
         let siteURL = "https://example.com"
         let viewModel = WPComPasswordLoginViewModel(siteURL: siteURL,
                                                     email: "test@example.com",
-                                                    requiresConnectionOnly: false)
+                                                    requiresConnectionOnly: false,
+                                                    onMultifactorCodeRequest: {},
+                                                    onLoginFailure: { _ in },
+                                                    onLoginSuccess: { _ in })
 
         // When
         let text = viewModel.titleString
@@ -22,7 +25,10 @@ final class WPComPasswordLoginViewModelTests: XCTestCase {
         let siteURL = "https://example.com"
         let viewModel = WPComPasswordLoginViewModel(siteURL: siteURL,
                                                     email: "test@example.com",
-                                                    requiresConnectionOnly: true)
+                                                    requiresConnectionOnly: true,
+                                                    onMultifactorCodeRequest: {},
+                                                    onLoginFailure: { _ in },
+                                                    onLoginSuccess: { _ in })
 
         // When
         let text = viewModel.titleString
@@ -37,7 +43,10 @@ final class WPComPasswordLoginViewModelTests: XCTestCase {
         let email = "test@example.com"
         let viewModel = WPComPasswordLoginViewModel(siteURL: siteURL,
                                                     email: email,
-                                                    requiresConnectionOnly: true)
+                                                    requiresConnectionOnly: true,
+                                                    onMultifactorCodeRequest: {},
+                                                    onLoginFailure: { _ in },
+                                                    onLoginSuccess: { _ in })
 
         // When
         let url = try XCTUnwrap(viewModel.avatarURL)

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModelTests.swift
@@ -1,7 +1,13 @@
 import XCTest
 @testable import WooCommerce
+import WordPressAuthenticator
 
 final class WPComPasswordLoginViewModelTests: XCTestCase {
+
+    override func setUp() {
+        WordPressAuthenticator.initializeAuthenticator()
+        super.setUp()
+    }
 
     func test_title_string_is_correct_when_requiresConnectionOnly_is_false() {
         // Given
@@ -55,4 +61,76 @@ final class WPComPasswordLoginViewModelTests: XCTestCase {
         assertEqual("https://gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?d=mp&s=80&r=g", url.absoluteString)
     }
 
+    func test_isLoggingIn_is_updated_correctly_and_onMultifactorCodeRequest_is_triggered_when_2FA_code_is_required() {
+        // Given
+        let siteURL = "https://example.com"
+        let email = "test@example.com"
+        let password = "secret"
+        var loginFields: LoginFields? = nil
+
+        let viewModel = WPComPasswordLoginViewModel(siteURL: siteURL,
+                                                    email: email,
+                                                    requiresConnectionOnly: true,
+                                                    onMultifactorCodeRequest: { loginFields = $0 },
+                                                    onLoginFailure: { _ in },
+                                                    onLoginSuccess: { _ in })
+
+        // When
+        viewModel.password = password
+        viewModel.handleLogin()
+        XCTAssertTrue(viewModel.isLoggingIn)
+        viewModel.needsMultifactorCode()
+
+        // Then
+        XCTAssertFalse(viewModel.isLoggingIn)
+        assertEqual(email, loginFields?.username)
+        assertEqual(password, loginFields?.password)
+        assertEqual(siteURL, loginFields?.siteAddress)
+        assertEqual(true, loginFields?.meta.userIsDotCom)
+    }
+
+    func test_isLoggingIn_is_updated_correctly_and_onLoginFailure_is_triggered_when_login_fails() {
+        // Given
+        let siteURL = "https://example.com"
+        let email = "test@example.com"
+        var errorCaught: Error? = nil
+        let expectedError = NSError(domain: "Test", code: 400)
+        let viewModel = WPComPasswordLoginViewModel(siteURL: siteURL,
+                                                    email: email,
+                                                    requiresConnectionOnly: true,
+                                                    onMultifactorCodeRequest: { _ in },
+                                                    onLoginFailure: { errorCaught = $0 },
+                                                    onLoginSuccess: { _ in })
+
+        // When
+        viewModel.handleLogin()
+        XCTAssertTrue(viewModel.isLoggingIn)
+        viewModel.displayRemoteError(expectedError)
+
+        // Then
+        XCTAssertFalse(viewModel.isLoggingIn)
+        assertEqual(expectedError, errorCaught as? NSError)
+    }
+
+    func test_isLoggingIn_is_updated_correctly_and_onLoginSuccess_is_triggered_when_login_succeeds() {
+        // Given
+        let siteURL = "https://example.com"
+        let email = "test@example.com"
+        var token: String? = nil
+        let expectedToken = "secret"
+        let viewModel = WPComPasswordLoginViewModel(siteURL: siteURL,
+                                                    email: email,
+                                                    requiresConnectionOnly: true,
+                                                    onMultifactorCodeRequest: { _ in },
+                                                    onLoginFailure: { _ in },
+                                                    onLoginSuccess: { token = $0 })
+        // When
+        viewModel.handleLogin()
+        XCTAssertTrue(viewModel.isLoggingIn)
+        viewModel.finishedLogin(withAuthToken: expectedToken, requiredMultifactorCode: false)
+
+        // Then
+        XCTAssertFalse(viewModel.isLoggingIn)
+        assertEqual(token, expectedToken)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8918 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR continues the custom WPCom login flow for the Jetpack setup feature:
- New UI for the 2FA login screen.
- Integrated `LoginFacade` from `WordPressAuthenticator` to handle login with email, password, and 2FA code.
- Handled requesting SMS OTP code.
- Also: updated `AccountCreationFormFieldView` to accept the header label to be nil.

Flow reference: [pe5sF9-1er-p2]
## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Make sure that you have access to a site with WooCommerce and no Jetpack.
- Log out of the app or skip onboarding if needed.
- Tap "Enter your site address" on the prologue screen and proceed with the address of your test site.
- Log in with the credentials of an admin.
- When the login completes, tap the Jetback benefit banner at the bottom of the Dashboard screen.
- Tap Log In on the benefit modal.
- Enter the email address of a WPCom account with a password and no 2FA setup yet on the presented WPCom email login screen.
- Tap Install/Connect Jetpack. Enter an incorrect password and notice that an error alert is displayed for incorrect credentials.
- Enter the correct password, notice in Xcode console: `✅ Ready for Jetpack setup`.
- Tap back and try again with the email address of a WPCom account with password and 2FA setup.
- Enter the correct password, notice that a new screen is displayed for the 2FA code.
- Enter an incorrect code, and an error alert should be displayed.
- Enter the correct code, notice in Xcode console: `✅ Ready for Jetpack setup`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/222676360-efa2e269-837a-4f42-b35a-e0ac8c5137c0.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.