### PR TITLE
[Mobile Payments] Add cancel button on Tap to Pay set up screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/PaymentSettingsFlowHint.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/PaymentSettingsFlowHint.swift
@@ -16,7 +16,7 @@ struct PaymentSettingsFlowHint: View {
                 .padding(.leading, 16)
             Spacer()
         }
-            .padding(.horizontal, 8)
+        .padding(.horizontal, 8)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -122,7 +122,8 @@ struct SetUpTapToPayInformationView: View {
             })
             .buttonStyle(PrimaryButtonStyle())
 
-            InPersonPaymentsLearnMore()
+            InPersonPaymentsLearnMore(
+                viewModel: LearnMoreViewModel(formatText: Localization.learnMore))
                 .customOpenURL(action: { url in
                     switch url {
                     case LearnMoreViewModel.learnMoreURL:
@@ -195,8 +196,12 @@ private enum Localization {
     )
 
     static let learnMore = NSLocalizedString(
-        "Tap to learn more about accepting payments with Tap to Pay on iPhone",
-        comment: "A label prompting users to learn more about Tap to Pay on iPhone"
+        "%1$@ about accepting payments with Tap to Pay on iPhone.",
+        comment: """
+                 A label prompting users to learn more about Tap to Pay on iPhone"
+                 %1$@ is a placeholder that always replaced with \"Learn more\" string,
+                 which should be translated separately and considered part of this sentence.
+                 """
     )
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -59,7 +59,8 @@ private extension SetUpTapToPayInformationViewController {
     func searchAndConnect() {
         connectionController.searchAndConnect { _ in
             /// No need for logic here. Once connected, the connected reader will publish
-            /// through the `cardReaderAvailableSubscription`
+            /// through the `cardReaderAvailableSubscription`, so we can just
+            /// dismiss the connection flow alerts.
             self.alertsPresenter.dismiss()
         }
     }
@@ -75,9 +76,7 @@ struct SetUpTapToPayInformationView: View {
     @Environment(\.sizeCategory) private var sizeCategory
 
     var isCompact: Bool {
-        get {
-            verticalSizeClass == .compact
-        }
+        verticalSizeClass == .compact
     }
 
     var isSizeCategoryLargerThanExtraLarge: Bool {
@@ -112,9 +111,10 @@ struct SetUpTapToPayInformationView: View {
 
             Spacer()
 
-            Button(Localization.setUpButton, action: setUpButtonAction!)
-                .buttonStyle(PrimaryButtonStyle())
-                .padding(.bottom, 8)
+            Button(Localization.setUpButton, action: {
+                setUpButtonAction?()
+            })
+            .buttonStyle(PrimaryButtonStyle())
 
             InPersonPaymentsLearnMore()
                 .customOpenURL(action: { url in
@@ -128,16 +128,16 @@ struct SetUpTapToPayInformationView: View {
                     }
                 })
         }
-            .frame(
-                maxWidth: .infinity,
-                maxHeight: .infinity
-            )
-            .padding()
-            .if(isCompact || isSizeCategoryLargerThanExtraLarge) { content in
-                ScrollView(.vertical) {
-                    content
-                }
+        .frame(
+            maxWidth: .infinity,
+            maxHeight: .infinity
+        )
+        .padding()
+        .if(isCompact || isSizeCategoryLargerThanExtraLarge) { content in
+            ScrollView(.vertical) {
+                content
             }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -97,17 +97,23 @@ struct SetUpTapToPayInformationView: View {
 
             Text(Localization.setUpTapToPayOnIPhoneTitle)
                 .font(.title.weight(.semibold))
-                .padding(32)
                 .multilineTextAlignment(.center)
+                .padding([.leading, .trailing])
+                .fixedSize(horizontal: false, vertical: true)
             Image(uiImage: .setUpBuiltInReader)
                 .resizable()
                 .scaledToFit()
                 .frame(height: isCompact ? 80 : 206)
-                .padding(.bottom, isCompact ? 16 : 32)
+                .padding()
 
-            PaymentSettingsFlowHint(title: Localization.hintOneTitle, text: Localization.hintOne)
-            PaymentSettingsFlowHint(title: Localization.hintTwoTitle, text: Localization.hintTwo)
-            PaymentSettingsFlowHint(title: Localization.hintThreeTitle, text: Localization.hintThree)
+            VStack(spacing: 16) {
+                PaymentSettingsFlowHint(title: Localization.hintOneTitle, text: Localization.hintOne)
+                PaymentSettingsFlowHint(title: Localization.hintTwoTitle, text: Localization.hintTwo)
+                PaymentSettingsFlowHint(title: Localization.hintThreeTitle, text: Localization.hintThree)
+            }
+            .fixedSize(horizontal: false, vertical: true)
+            .layoutPriority(1)
+            .padding([.top, .bottom])
 
             Spacer()
 
@@ -166,7 +172,7 @@ private enum Localization {
     )
 
     static let hintTwo = NSLocalizedString(
-        "Accept the Terms of Service during set up",
+        "Accept the Terms of Service during set up.",
         comment: "Settings > Set up Tap to Pay on iPhone > Information > Hint to accept the " +
         "Terms of Service from Apple"
     )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -38,6 +38,9 @@ final class SetUpTapToPayInformationViewController: UIHostingController<SetUpTap
             WebviewHelper.launch(url, with: self)
         }
         rootView.learnMoreUrl = viewModel.learnMoreURL
+        rootView.dismiss = { [weak self] in
+            self?.dismiss(animated: true)
+        }
     }
 
     required init?(coder: NSCoder) {
@@ -66,6 +69,7 @@ struct SetUpTapToPayInformationView: View {
     var setUpButtonAction: (() -> Void)? = nil
     var showURL: ((URL) -> Void)? = nil
     var learnMoreUrl: URL? = nil
+    var dismiss: (() -> Void)? = nil
 
     @Environment(\.verticalSizeClass) var verticalSizeClass
     @Environment(\.sizeCategory) private var sizeCategory
@@ -82,6 +86,14 @@ struct SetUpTapToPayInformationView: View {
 
     var body: some View {
         VStack {
+            HStack {
+                Button("Cancel", action: {
+                    dismiss?()
+                })
+                Spacer()
+            }
+            .padding(.top)
+
             Spacer()
 
             Text(Localization.setUpTapToPayOnIPhoneTitle)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsLearnMore.swift
@@ -35,27 +35,6 @@ private enum Constants {
     static let verticalPadding: CGFloat = 8
 }
 
-private enum Localization {
-    static let unavailable = NSLocalizedString(
-        "In-Person Payments is currently unavailable",
-        comment: "Title for the error screen when In-Person Payments is unavailable"
-    )
-
-    static let acceptCash = NSLocalizedString(
-        "You can still accept in-person cash payments by enabling the “Cash on Delivery” payment method on your store.",
-        comment: "Generic error message when In-Person Payments is unavailable"
-    )
-
-    static let learnMoreText = NSLocalizedString(
-        "%1$@ about accepting payments with your mobile device and ordering card readers",
-        comment: """
-                 A label prompting users to learn more about card readers"
-                 %1$@ is a placeholder that always replaced with \"Learn more\" string,
-                 which should be translated separately and considered part of this sentence.
-                 """
-    )
-}
-
 struct InPersonPaymentsLearnMore_Previews: PreviewProvider {
     static var previews: some View {
         InPersonPaymentsLearnMore()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9010
Based on #9015 (merge that first)
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds the cancel button required for the Set up Tap to Pay on iPhone screen, and tweaks the layout to match the design, including fixes for truncation on smaller screens.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using an iPhone XS or newer on iOS 16+, with a US-based WCPay/Stripe store, and a local Xcode build:

Preferably a small phone or simulator should be used

1. Navigate to `Menu > Payments`
2. Wait for `Manage card reader` to be enabled (resolve any onboarding issues if required)
3. Tap the `Set up Tap to Pay on iPhone` row
4. Observe that you see the new screen, and the design matches the current Figma designs pecCkj-pc-p2
5. Try different text sizes, and landscape.
6. Tap the `Learn More` link and observe that for a WCPay store, you are taken to a TTP-specific set up page (Stripe docs are still pending)
7. Tap the `Cancel` button
8. Observe that the screen is dismissed

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![setup ttp](https://user-images.githubusercontent.com/2472348/222758324-5edfe8d1-8dab-4b11-8caa-26b3c0a9a8b6.jpg)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
