### PR TITLE
[Product Bundles] Add and navigate to a Bundled Products list view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Addons/ProductAddOnsListViewController.swift
@@ -32,30 +32,12 @@ struct ProductAddOnsList: View {
                 ForEach(viewModel.addOns) { addOn in
                     ProductAddOn(viewModel: addOn)
                 }
-                AddOnListNotice(updateText: viewModel.infoNotice)
+                FooterNotice(infoText: viewModel.infoNotice)
             }
         }
         .background(
             Color(.listBackground).edgesIgnoringSafeArea(.all)
         )
-    }
-}
-
-/// Renders a info notice with an icon
-///
-private struct AddOnListNotice: View {
-
-    /// Content to be rendered next to the info icon.
-    ///
-    let updateText: String
-
-    var body: some View {
-        HStack {
-            Image(uiImage: .infoOutlineImage)
-            Text(updateText)
-        }
-        .footnoteStyle()
-        .padding([.leading, .trailing]).padding(.top, 4)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
@@ -40,30 +40,12 @@ struct BundledProductsList: View {
                 }
                 .background(Color(.listForeground(modal: false)))
 
-                BundledProductsListNotice(infoText: viewModel.infoNotice)
+                FooterNotice(infoText: viewModel.infoNotice)
             }
         }
         .background(
             Color(.listBackground).edgesIgnoringSafeArea(.all)
         )
-    }
-}
-
-/// Renders a info notice with an icon
-///
-private struct BundledProductsListNotice: View {
-
-    /// Content to be rendered next to the info icon.
-    ///
-    let infoText: String
-
-    var body: some View {
-        HStack {
-            Image(uiImage: .infoOutlineImage)
-            Text(infoText)
-        }
-        .footnoteStyle()
-        .padding([.leading, .trailing]).padding(.top, 4)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
@@ -28,18 +28,42 @@ struct BundledProductsList: View {
 
     var body: some View {
         ScrollView {
-            Group {
-                TitleAndSubtitleRow(title: "Beanie with Logo", subtitle: "In stock")
-                Divider().padding(.leading)
-                TitleAndSubtitleRow(title: "T-Shirt with Logo", subtitle: "In stock")
-                Divider().padding(.leading)
-                TitleAndSubtitleRow(title: "Hoodie with Logo", subtitle: "Out of stock")
-                Divider().padding(.leading)
-            }.background(Color(.listForeground(modal: false)))
+            LazyVStack {
+                // TODO-8954: Display actual bundled items from view model
+                VStack(spacing: 0) {
+                    TitleAndSubtitleRow(title: "Beanie with Logo", subtitle: "In stock")
+                    Divider().padding(.leading)
+                    TitleAndSubtitleRow(title: "T-Shirt with Logo", subtitle: "In stock")
+                    Divider().padding(.leading)
+                    TitleAndSubtitleRow(title: "Hoodie with Logo", subtitle: "Out of stock")
+                    Divider().padding(.leading)
+                }
+                .background(Color(.listForeground(modal: false)))
+
+                BundledProductsListNotice(infoText: viewModel.infoNotice)
+            }
         }
         .background(
             Color(.listBackground).edgesIgnoringSafeArea(.all)
         )
+    }
+}
+
+/// Renders a info notice with an icon
+///
+private struct BundledProductsListNotice: View {
+
+    /// Content to be rendered next to the info icon.
+    ///
+    let infoText: String
+
+    var body: some View {
+        HStack {
+            Image(uiImage: .infoOutlineImage)
+            Text(infoText)
+        }
+        .footnoteStyle()
+        .padding([.leading, .trailing]).padding(.top, 4)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
@@ -1,0 +1,56 @@
+import UIKit
+import SwiftUI
+
+// MARK: Hosting Controller
+
+/// Hosting controller that wraps a `BundledProductsList` view.
+///
+final class BundledProductsListViewController: UIHostingController<BundledProductsList> {
+    init(viewModel: BundledProductsListViewModel) {
+        super.init(rootView: BundledProductsList(viewModel: viewModel))
+        title = viewModel.title
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: Views
+
+/// Renders a list of bundled products in a product bundle
+///
+struct BundledProductsList: View {
+
+    /// View model that directs the view content.
+    ///
+    let viewModel: BundledProductsListViewModel
+
+    var body: some View {
+        ScrollView {
+            Group {
+                TitleAndSubtitleRow(title: "Beanie with Logo", subtitle: "In stock")
+                Divider().padding(.leading)
+                TitleAndSubtitleRow(title: "T-Shirt with Logo", subtitle: "In stock")
+                Divider().padding(.leading)
+                TitleAndSubtitleRow(title: "Hoodie with Logo", subtitle: "Out of stock")
+                Divider().padding(.leading)
+            }.background(Color(.listForeground(modal: false)))
+        }
+        .background(
+            Color(.listBackground).edgesIgnoringSafeArea(.all)
+        )
+    }
+}
+
+
+// MARK: Previews
+struct BundledProductsList_Previews: PreviewProvider {
+
+    static let viewModel = BundledProductsListViewModel()
+
+    static var previews: some View {
+        BundledProductsList(viewModel: viewModel)
+            .environment(\.colorScheme, .light)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// ViewModel for `BundledProductsList`
+///
+final class BundledProductsListViewModel {
+
+    /// View title
+    ///
+    let title = Localization.title
+}
+
+// MARK: Constants
+extension BundledProductsListViewModel {
+    enum Localization {
+        static let title = NSLocalizedString("Bundled Products", comment: "Title for the bundled products screen")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
@@ -7,11 +7,17 @@ final class BundledProductsListViewModel {
     /// View title
     ///
     let title = Localization.title
+
+    /// View info notice
+    ///
+    let infoNotice = Localization.infoNotice
 }
 
 // MARK: Constants
 extension BundledProductsListViewModel {
     enum Localization {
         static let title = NSLocalizedString("Bundled Products", comment: "Title for the bundled products screen")
+        static let infoNotice = NSLocalizedString("You can edit bundled products in the web dashboard.",
+                                                  comment: "Info notice at the bottom of the bundled products screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -520,8 +520,7 @@ private extension DefaultProductFormTableViewModel {
 
         return ProductFormSection.SettingsRow.ViewModel(icon: icon,
                                                         title: title,
-                                                        details: details,
-                                                        isActionable: false) // TODO-8954: Make actionable once bundled products screen is ready
+                                                        details: details)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -445,7 +445,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 break
             case .bundledProducts:
                 // TODO-8954: Add tracking
-                // TODO-8954: Add action to show bundled products settings screen
+                showBundledProducts()
                 return
             }
         case .optionsCTA(let rows):
@@ -1673,6 +1673,19 @@ private extension ProductFormViewController {
             viewModel.updateProductVariations(from: updatedProduct)
         }
         show(variationsViewController, sender: self)
+    }
+}
+
+// MARK: Action - Show Bundled Products
+//
+private extension ProductFormViewController {
+    func showBundledProducts() {
+        guard let product = product as? EditableProductModel else {
+            return
+        }
+        let viewModel = BundledProductsListViewModel()
+        let viewController = BundledProductsListViewController(viewModel: viewModel)
+        show(viewController, sender: self)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FooterNotice.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FooterNotice.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// Renders a info notice with an icon
+///
+struct FooterNotice: View {
+
+    /// Content to be rendered next to the info icon.
+    ///
+    let infoText: String
+
+    var body: some View {
+        HStack {
+            Image(uiImage: .infoOutlineImage)
+            Text(infoText)
+        }
+        .footnoteStyle()
+        .padding([.leading, .trailing]).padding(.top, 4)
+    }
+}
+
+struct FooterNotice_Previews: PreviewProvider {
+    static var previews: some View {
+        FooterNotice(infoText: "This is a notice")
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1561,6 +1561,7 @@
 		CC8413E523F5C49100EFC277 /* start.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011023E9E3F400157A78 /* start.sh */; };
 		CC857C7129B23A6C00E19D1E /* BundledProductsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC857C7029B23A6C00E19D1E /* BundledProductsListViewController.swift */; };
 		CC857C7529B23AE100E19D1E /* BundledProductsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC857C7429B23AE100E19D1E /* BundledProductsListViewModel.swift */; };
+		CC857C7729B25FAF00E19D1E /* FooterNotice.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC857C7629B25FAF00E19D1E /* FooterNotice.swift */; };
 		CC923A1D2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC923A1C2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift */; };
 		CCA1D5FE293F537400B40560 /* DeltaPercentage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA1D5FD293F537400B40560 /* DeltaPercentage.swift */; };
 		CCA1D6022943636100B40560 /* AnalyticsReportCardCurrentPeriodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA1D6012943636100B40560 /* AnalyticsReportCardCurrentPeriodViewModel.swift */; };
@@ -3700,6 +3701,7 @@
 		CC77488D2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressTopBannerFactoryTests.swift; sourceTree = "<group>"; };
 		CC857C7029B23A6C00E19D1E /* BundledProductsListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledProductsListViewController.swift; sourceTree = "<group>"; };
 		CC857C7429B23AE100E19D1E /* BundledProductsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledProductsListViewModel.swift; sourceTree = "<group>"; };
+		CC857C7629B25FAF00E19D1E /* FooterNotice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FooterNotice.swift; sourceTree = "<group>"; };
 		CC923A1C2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderStatusListViewModelTests.swift; sourceTree = "<group>"; };
 		CCA1D5FD293F537400B40560 /* DeltaPercentage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeltaPercentage.swift; sourceTree = "<group>"; };
 		CCA1D6012943636100B40560 /* AnalyticsReportCardCurrentPeriodViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportCardCurrentPeriodViewModel.swift; sourceTree = "<group>"; };
@@ -6595,6 +6597,7 @@
 				AEE9A87F293A3E5500227C92 /* RefreshablePlainList.swift */,
 				26B71DB5293FE490004D8052 /* RangedDatePicker.swift */,
 				020ACF87299A809000B3638B /* LearnMoreAttributedText.swift */,
+				CC857C7629B25FAF00E19D1E /* FooterNotice.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -10860,7 +10863,7 @@
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,
 				31EF399C26430C6D0093C6F6 /* PaymentSettingsFlowPrioritizedViewModelsProvider.swift in Sources */,
 				CC857C7129B23A6C00E19D1E /* BundledProductsListViewController.swift in Sources */,
-				31EF399C26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift in Sources */,
+				31EF399C26430C6D0093C6F6 /* PaymentSettingsFlowPrioritizedViewModelsProvider.swift in Sources */,
 				D85136C1231E09C300DD0539 /* ReviewsDataSourceProtocol.swift in Sources */,
 				CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */,
 				45968545254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift in Sources */,
@@ -11078,6 +11081,7 @@
 				02C887712450285100E4470F /* BottomButtonContainerView.swift in Sources */,
 				0235BFD9246E959500778909 /* ProductFormActionsFactory.swift in Sources */,
 				024EFA6923FCC10B00F36918 /* Product+Media.swift in Sources */,
+				CC857C7729B25FAF00E19D1E /* FooterNotice.swift in Sources */,
 				0202B68D23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift in Sources */,
 				2677B559299F322300862180 /* SupportForm+Presentation.swift in Sources */,
 				D8B4D5F426C30E7C00F34E94 /* InPersonPaymentsStripeRejectedView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1559,6 +1559,8 @@
 		CC77488E2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC77488D2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift */; };
 		CC8413E423F5C48E00EFC277 /* stop.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011123E9E40B00157A78 /* stop.sh */; };
 		CC8413E523F5C49100EFC277 /* start.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011023E9E3F400157A78 /* start.sh */; };
+		CC857C7129B23A6C00E19D1E /* BundledProductsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC857C7029B23A6C00E19D1E /* BundledProductsListViewController.swift */; };
+		CC857C7529B23AE100E19D1E /* BundledProductsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC857C7429B23AE100E19D1E /* BundledProductsListViewModel.swift */; };
 		CC923A1D2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC923A1C2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift */; };
 		CCA1D5FE293F537400B40560 /* DeltaPercentage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA1D5FD293F537400B40560 /* DeltaPercentage.swift */; };
 		CCA1D6022943636100B40560 /* AnalyticsReportCardCurrentPeriodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA1D6012943636100B40560 /* AnalyticsReportCardCurrentPeriodViewModel.swift */; };
@@ -3696,6 +3698,8 @@
 		CC72BB6327BD842500837876 /* DisclosureIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisclosureIndicator.swift; sourceTree = "<group>"; };
 		CC770C8927B1497700CE6ABC /* SearchHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHeader.swift; sourceTree = "<group>"; };
 		CC77488D2719A07D0043CDD7 /* ShippingLabelAddressTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddressTopBannerFactoryTests.swift; sourceTree = "<group>"; };
+		CC857C7029B23A6C00E19D1E /* BundledProductsListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledProductsListViewController.swift; sourceTree = "<group>"; };
+		CC857C7429B23AE100E19D1E /* BundledProductsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledProductsListViewModel.swift; sourceTree = "<group>"; };
 		CC923A1C2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderStatusListViewModelTests.swift; sourceTree = "<group>"; };
 		CCA1D5FD293F537400B40560 /* DeltaPercentage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeltaPercentage.swift; sourceTree = "<group>"; };
 		CCA1D6012943636100B40560 /* AnalyticsReportCardCurrentPeriodViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportCardCurrentPeriodViewModel.swift; sourceTree = "<group>"; };
@@ -4515,6 +4519,7 @@
 				265BCA032430E5EA004E53EE /* Edit Categories */,
 				4592A54824BF58A200BC3DE0 /* Edit Tags */,
 				45E9A6E124DAE18E00A600E8 /* Reviews */,
+				CC01CE5B29B2342E004FF537 /* Bundled Products */,
 				02162724237963AF000208D2 /* ProductFormViewController.swift */,
 				02162725237963AF000208D2 /* ProductFormViewController.xib */,
 				45912FE22526642200982948 /* ProductFormViewController+Helpers.swift */,
@@ -8002,6 +8007,39 @@
 			path = data;
 			sourceTree = "<group>";
 		};
+		CC01CE5B29B2342E004FF537 /* Bundled Products */ = {
+			isa = PBXGroup;
+			children = (
+				CC01CE5D29B23610004FF537 /* Settings */,
+				CC01CE5C29B23606004FF537 /* Bundled Product List */,
+				CC01CE5E29B23622004FF537 /* Product Settings */,
+			);
+			path = "Bundled Products";
+			sourceTree = "<group>";
+		};
+		CC01CE5C29B23606004FF537 /* Bundled Product List */ = {
+			isa = PBXGroup;
+			children = (
+				CC857C7029B23A6C00E19D1E /* BundledProductsListViewController.swift */,
+				CC857C7429B23AE100E19D1E /* BundledProductsListViewModel.swift */,
+			);
+			path = "Bundled Product List";
+			sourceTree = "<group>";
+		};
+		CC01CE5D29B23610004FF537 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		CC01CE5E29B23622004FF537 /* Product Settings */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "Product Settings";
+			sourceTree = "<group>";
+		};
 		CC200BAF27847D9300EC5884 /* PaymentSection */ = {
 			isa = PBXGroup;
 			children = (
@@ -10821,6 +10859,8 @@
 				02E19B9C284743A40010B254 /* ProductImageUploader.swift in Sources */,
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,
 				31EF399C26430C6D0093C6F6 /* PaymentSettingsFlowPrioritizedViewModelsProvider.swift in Sources */,
+				CC857C7129B23A6C00E19D1E /* BundledProductsListViewController.swift in Sources */,
+				31EF399C26430C6D0093C6F6 /* CardReaderSettingsPrioritizedViewModelsProvider.swift in Sources */,
 				D85136C1231E09C300DD0539 /* ReviewsDataSourceProtocol.swift in Sources */,
 				CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */,
 				45968545254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift in Sources */,
@@ -10843,6 +10883,7 @@
 				451A04F02386F7B500E368C9 /* ProductImageCollectionViewCell.swift in Sources */,
 				AEACCB6D2785FF4A000D01F0 /* NavigationRow.swift in Sources */,
 				DE50294928BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift in Sources */,
+				CC857C7529B23AE100E19D1E /* BundledProductsListViewModel.swift in Sources */,
 				02E8B17E23E2C8D900A43403 /* ProductImageActionHandler.swift in Sources */,
 				03076D3A290C22BE008EE839 /* WebView.swift in Sources */,
 				02E4908D29AF216E005942AE /* DashboardTopPerformersView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8954
⚠️ Depends on https://github.com/woocommerce/woocommerce-ios/pull/9035
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds a "Bundled Products" view to display a list of bundled products in a product bundle. For now, the view uses fake, static data for the list. This will be replaced with real data once the work is done in the other layers.

### Changes

* Adds `BundledProductsList` (SwiftUI view) with `BundledProductsListViewController` wrapper to display the list.
* Adds a view model `BundledProductsListViewModel` to power the view.
* Adds a reusable `FooterNotice` (based on the notice in `ProductAddOnsList`).
* Updates `ProductFormViewController` to navigate to the new view.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Prerequisites

1. Install and activate the [Product Bundles extension](https://woocommerce.com/products/product-bundles/) on your store.
2. Create at least one product with the Product Bundle type.

### To test

1. Build and run the app.
2. Go to the Products tab.
3. Open a Product Bundle and tap the "Bundled products" row.
4. Confirm the new Bundled Products view appears as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Product Details|Bundled Products
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-03 at 16 57 37](https://user-images.githubusercontent.com/8658164/222792687-b947fbfe-27a5-440b-b935-e7ec8aea204b.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-03 at 16 57 39](https://user-images.githubusercontent.com/8658164/222792703-c9989d25-c583-4d19-bb9d-e2943a5c0e63.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
