### PR TITLE
Set woocommerce-payment tag for IPP tickets

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
@@ -26,7 +26,7 @@ struct IPPSupportDataSource: SupportFormMetaDataSource {
     }
 
     var tags: [String] {
-        ZendeskProvider.shared.generalTags() + [ZendeskForms.Tags.wcMobileApps, ZendeskForms.Tags.productAreaIPP, ZendeskForms.Tags.jetpack]
+        ZendeskProvider.shared.generalTags() + [ZendeskForms.Tags.wcMobileApps, ZendeskForms.Tags.productAreaIPP, ZendeskForms.Tags.wcPayments]
     }
 
     var customFields: [Int64: String] {
@@ -117,6 +117,7 @@ private enum ZendeskForms {
         static let store = Fields.store
         static let jetpack = "jetpack"
         static let wcCore = "woocommerce_core"
+        static let wcPayments = "woocommerce_payments"
         static let appTransfer = "mobile_app_woo_transfer"
         static let wcMobileApps = "woocommerce_mobile_apps"
         static let productAreaIPP = "product_area_apps_in_person_payments"

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportDataSourcesTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportDataSourcesTests.swift
@@ -48,7 +48,7 @@ final class SupportDataSourcesTests: XCTestCase {
         // Given
         let dataSource = IPPSupportDataSource()
         let tagsSet = Set(dataSource.tags)
-        let expectedSet = Set(["iOS", "jetpack", "woocommerce_mobile_apps", "product_area_apps_in_person_payments"])
+        let expectedSet = Set(["iOS", "woocommerce_payments", "woocommerce_mobile_apps", "product_area_apps_in_person_payments"])
 
         // When & Then
         XCTAssertTrue(expectedSet.isSubset(of: tagsSet))


### PR DESCRIPTION
# Why

There was a warning that iPP tickets were not correctly being prioritized.  After digging a bit, the problem is that we were not setting the correct product tag for Card Reader / IPP tickets.

To fix this problem we need to send the  `woocommerce_payments` tag instead of the `jetpack` tag.

# Testing 

Confirmed by Rebecca

<img width="730" alt="Screenshot 2023-03-03 at 4 19 11 PM" src="https://user-images.githubusercontent.com/562080/222831808-bb8a0b01-58a0-4339-ad14-c5ee4c307222.png">
 
---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
