### PR TITLE
[Simple Payment] Dismiss Take Payment popup after sharing the payment link to another app

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 12.7
 -----
 - [Internal] Shipping Label: add condition checks before showing contact options [https://github.com/woocommerce/woocommerce-ios/pull/8982]
+- [*] Fix: Dismiss Take Payment popup after sharing the payment link to another app. [https://github.com/woocommerce/woocommerce-ios/pull/9042]
 
 12.6
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -569,6 +569,7 @@ private extension OrderDetailsViewController {
 
     private func collectPayment() {
         let paymentMethodsViewController = PaymentMethodsHostingController(viewModel: viewModel.paymentMethodsViewModel)
+        paymentMethodsViewController.parentController = self
         let paymentMethodsNavigationController = WooNavigationController(rootViewController: paymentMethodsViewController)
         present(paymentMethodsNavigationController, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsHostingController.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 
 final class PaymentMethodsHostingController: UIHostingController<HostedPaymentMethodsView> {
+
+    /// The parent controller that shows the Collect Payment screen.
+    /// We need this to call its `dismiss` method to dismiss all child views, including the share sheet.
+    ///
     weak var parentController: UIViewController?
 
     init(viewModel: PaymentMethodsViewModel) {
@@ -8,7 +12,6 @@ final class PaymentMethodsHostingController: UIHostingController<HostedPaymentMe
 
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
         rootView.dismiss = { [weak self] in
-            self?.dismiss(animated: true, completion: nil)
             self?.parentController?.dismiss(animated: true, completion: nil)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsHostingController.swift
@@ -1,12 +1,15 @@
 import SwiftUI
 
 final class PaymentMethodsHostingController: UIHostingController<HostedPaymentMethodsView> {
+    weak var parentController: UIViewController?
+
     init(viewModel: PaymentMethodsViewModel) {
         super.init(rootView: HostedPaymentMethodsView(viewModel: viewModel))
 
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
         rootView.dismiss = { [weak self] in
             self?.dismiss(animated: true, completion: nil)
+            self?.parentController?.dismiss(animated: true, completion: nil)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -130,7 +130,8 @@ struct PaymentMethodsView: View {
             ShareSheet(activityItems: [viewModel.paymentLink].compactMap { $0 } ) { _, completed, _, _ in
                 if completed {
                     dismiss()
-                    viewModel.performLinkSharedTasks()                }
+                    viewModel.performLinkSharedTasks()
+                }
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -131,6 +131,7 @@ struct PaymentMethodsView: View {
                 if completed {
                     dismiss()
                     viewModel.performLinkSharedTasks()
+                    dismiss()
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -130,9 +130,7 @@ struct PaymentMethodsView: View {
             ShareSheet(activityItems: [viewModel.paymentLink].compactMap { $0 } ) { _, completed, _, _ in
                 if completed {
                     dismiss()
-                    viewModel.performLinkSharedTasks()
-                    dismiss()
-                }
+                    viewModel.performLinkSharedTasks()                }
             }
         }
     }


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: #6712
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

When sharing a payment link to another app (e.g., iMessage), the Take Payment popup stays on the screen. While choosing the "Copy" option on the share sheet will dismiss the Take Payment popup and returns the user to the order details screen.

This PR adds another `dismiss()` action to bring users back to the order details screen after sharing the payment link to another app.

## Testing instructions

Note: I don't have the ability to send messages in the Xcode Simulator. I tested the flow by sharing the link to the Reminders app.

1. Open an order with status = `On Hold` in the app
2. Tap the "Collect Payment" button
3. Tap the "Share Payment Link" option
4. Select the "Copy" option
5. Make sure the app returns to the order details screen
6. Tap the "Collect Payment" button again
7. Tap the "Share Payment Link" option
8. Select the "Messages" app and send the link as an iMessage/SMS
9. Make sure the app returns to the order details screen after the message is sent.

## Screen recording


https://user-images.githubusercontent.com/40906847/222949345-5a645770-bd24-45b6-b636-85d98f4fb5cc.mp4


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
