### PR TITLE
Fix issues preventing app building under Catalyst

### DIFF
--- a/Hardware/Hardware.xcodeproj/project.pbxproj
+++ b/Hardware/Hardware.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		030338102705F7D400764131 /* ReceiptTotalLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0303380F2705F7D400764131 /* ReceiptTotalLine.swift */; };
 		035DBA3929251ED6003E5125 /* CardReaderInputOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035DBA3829251ED6003E5125 /* CardReaderInputOptions.swift */; };
 		035DBA41292BBEB2003E5125 /* CardReaderDiscoveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035DBA40292BBEB2003E5125 /* CardReaderDiscoveryMethod.swift */; };
+		0365986D29B60AA000F297D3 /* CardReaderDiscoveryMethod+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0365986C29B60AA000F297D3 /* CardReaderDiscoveryMethod+Stripe.swift */; };
 		039D948B2760C0660044EF38 /* NoOpCardReaderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948A2760C0660044EF38 /* NoOpCardReaderService.swift */; };
 		03B440AA2754DFC400759429 /* UnderlyingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B440A92754DFC400759429 /* UnderlyingError.swift */; };
 		03CF78D327C6710C00523706 /* interac.svg in Resources */ = {isa = PBXBuildFile; fileRef = 03CF78D227C6710B00523706 /* interac.svg */; };
@@ -157,6 +158,7 @@
 		0303380F2705F7D400764131 /* ReceiptTotalLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptTotalLine.swift; sourceTree = "<group>"; };
 		035DBA3829251ED6003E5125 /* CardReaderInputOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderInputOptions.swift; sourceTree = "<group>"; };
 		035DBA40292BBEB2003E5125 /* CardReaderDiscoveryMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderDiscoveryMethod.swift; sourceTree = "<group>"; };
+		0365986C29B60AA000F297D3 /* CardReaderDiscoveryMethod+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardReaderDiscoveryMethod+Stripe.swift"; sourceTree = "<group>"; };
 		039D948A2760C0660044EF38 /* NoOpCardReaderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoOpCardReaderService.swift; sourceTree = "<group>"; };
 		03B440A92754DFC400759429 /* UnderlyingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnderlyingError.swift; sourceTree = "<group>"; };
 		03CF78D227C6710B00523706 /* interac.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = interac.svg; sourceTree = "<group>"; };
@@ -442,6 +444,7 @@
 			children = (
 				D88FDB3625DD21BE00CB0DBD /* StripeCardReader */,
 				D88FDB2725DD21B000CB0DBD /* CardReader.swift */,
+				035DBA40292BBEB2003E5125 /* CardReaderDiscoveryMethod.swift */,
 				D88FDB2425DD21B000CB0DBD /* CardReaderEvent.swift */,
 				035DBA3829251ED6003E5125 /* CardReaderInputOptions.swift */,
 				D88FDB2625DD21B000CB0DBD /* CardReaderService.swift */,
@@ -480,7 +483,7 @@
 				D845BDCB262D9B7700A3E40F /* CardBrand+Stripe.swift */,
 				D845BDC5262D9A4200A3E40F /* CardPresentDetails+Stripe.swift */,
 				D8DF5F4925DD9F7A008AFE25 /* CardReader+Stripe.swift */,
-				035DBA40292BBEB2003E5125 /* CardReaderDiscoveryMethod.swift */,
+				0365986C29B60AA000F297D3 /* CardReaderDiscoveryMethod+Stripe.swift */,
 				D865C61D261CE001006717B8 /* CardReaderEvent+Stripe.swift */,
 				D8DF5F4D25DD9F91008AFE25 /* CardReaderType+Stripe.swift */,
 				D89B8F1125DDCBCD0001C726 /* Charge+Stripe.swift */,
@@ -827,6 +830,7 @@
 				D89B8F0825DDC8F60001C726 /* Charge.swift in Sources */,
 				D845BDCC262D9B7700A3E40F /* CardBrand+Stripe.swift in Sources */,
 				D88FDB2E25DD21B000CB0DBD /* CardReaderEvent.swift in Sources */,
+				0365986D29B60AA000F297D3 /* CardReaderDiscoveryMethod+Stripe.swift in Sources */,
 				D80409A625FBE42B006F9BDA /* PaymentIntentParameters+Stripe.swift in Sources */,
 				D845BDC2262D98C400A3E40F /* CardBrand.swift in Sources */,
 				D845BE54262ED7CC00A3E40F /* PrinterService.swift in Sources */,

--- a/Hardware/Hardware/CardReader/CardReaderDiscoveryMethod.swift
+++ b/Hardware/Hardware/CardReader/CardReaderDiscoveryMethod.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum CardReaderDiscoveryMethod {
+    case localMobile
+    case bluetoothScan
+}

--- a/Hardware/Hardware/CardReader/StripeCardReader/CardReaderDiscoveryMethod+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/CardReaderDiscoveryMethod+Stripe.swift
@@ -1,11 +1,7 @@
 #if !targetEnvironment(macCatalyst)
-import Foundation
 import StripeTerminal
 
-public enum CardReaderDiscoveryMethod {
-    case localMobile
-    case bluetoothScan
-
+public extension CardReaderDiscoveryMethod {
     func toStripe() -> DiscoveryMethod {
         switch self {
         case .localMobile:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In a previous HACK week, I updated bits of the app to allow us to turn on Catalyst builds. We don't habitually build for Catalyst, so it's easy for things to slip through and break the build when we turn it back on. This PR fixes some of those issues, but does not turn on Catalyst builds because... we don't want to do that without resolving all the issues, if ever.

StripeTerminal and ZendeskSDK don't work in Catalyst, so some of their code is excluded from Catalyst builds.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Unit tests, 
Launch the app on a phone and take an IPP payment
Open the help and support views.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
