### PR TITLE
Only authenticate wp-admin if site is wpcom or if logged in with site credentials

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -91,7 +91,7 @@ struct HubMenu: View {
             .sheet(isPresented: $showingWooCommerceAdmin, onDismiss: enableMenuItemTaps) {
                 WebViewSheet(viewModel: WebViewSheetViewModel(url: viewModel.woocommerceAdminURL,
                                                               navigationTitle: HubMenuViewModel.Localization.woocommerceAdmin,
-                                                              authenticated: true)) {
+                                                              authenticated: viewModel.shouldAuthenticateAdminPage)) {
                     showingWooCommerceAdmin = false
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -45,6 +45,8 @@ final class HubMenuViewModel: ObservableObject {
 
     @Published var showingReviewDetail = false
 
+    @Published var shouldAuthenticateAdminPage = false
+
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
     private let generalAppSettings: GeneralAppSettingsStorage
@@ -151,6 +153,21 @@ final class HubMenuViewModel: ObservableObject {
                 return url
             }
             .assign(to: &$woocommerceAdminURL)
+
+        stores.site
+            .map { [weak self] site in
+                guard let self, let site else {
+                    return false
+                }
+                /// If the site is self-hosted and user is authenticated with WPCom,
+                /// `AuthenticatedWebView` will attempt to authenticate and redirect to the admin page and fails.
+                /// This should be prevented 💀⛔️
+                guard site.isWordPressComStore || self.stores.isAuthenticatedWithoutWPCom else {
+                    return false
+                }
+                return true
+            }
+            .assign(to: &$shouldAuthenticateAdminPage)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -289,7 +289,7 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.switchStoreEnabled)
     }
 
-    func test_switchStoreEnabled_returns_false_when_logged_in_with_wpcom() {
+    func test_switchStoreEnabled_returns_false_when_logged_in_without_wpcom() {
         // Given
         let sampleStoreURL = "https://testshop.com"
         let sampleAdminURL = ""
@@ -304,6 +304,57 @@ final class HubMenuViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.switchStoreEnabled)
+    }
+
+    func test_shouldAuthenticateAdminPage_returns_true_when_logged_in_with_wpcom_to_wpcom_site() {
+        // Given
+        let sampleStoreURL = "https://testshop.com"
+        let sampleAdminURL = ""
+        let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: true)
+        let site = Site.fake().copy(url: sampleStoreURL, adminURL: sampleAdminURL, isWordPressComStore: true)
+        sessionManager.defaultSite = site
+        let stores = MockStoresManager(sessionManager: sessionManager)
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: site.siteID,
+                                         stores: stores)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldAuthenticateAdminPage)
+    }
+
+    func test_shouldAuthenticateAdminPage_returns_true_when_logged_in_without_wpcom_to_self_hosted_site() {
+        // Given
+        let sampleStoreURL = "https://testshop.com"
+        let sampleAdminURL = ""
+        let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: false)
+        let site = Site.fake().copy(url: sampleStoreURL, adminURL: sampleAdminURL, isWordPressComStore: false)
+        sessionManager.defaultSite = site
+        let stores = MockStoresManager(sessionManager: sessionManager)
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: site.siteID,
+                                         stores: stores)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldAuthenticateAdminPage)
+    }
+
+    func test_shouldAuthenticateAdminPage_returns_false_when_logged_in_with_wpcom_to_self_hosted_site() {
+        // Given
+        let sampleStoreURL = "https://testshop.com"
+        let sampleAdminURL = ""
+        let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: true)
+        let site = Site.fake().copy(url: sampleStoreURL, adminURL: sampleAdminURL, isWordPressComStore: false)
+        sessionManager.defaultSite = site
+        let stores = MockStoresManager(sessionManager: sessionManager)
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: site.siteID,
+                                         stores: stores)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldAuthenticateAdminPage)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9048 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The last update in #8822 caused an issue to the WP Admin button in Hub menu when the user is logged in with WPCom to a self-hosted site. The `AuthenticatedWebView` attempts to authenticate the user and then redirect to the admin page, but these credentials don't work for the page so the user is redirected to WordPress.com instead.

This PR fixes this by checking to authenticate the web view only if the site is WPCom or if the user is authenticated with site credentials only. These are the cases where the authentication on the web view will work.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log out of the app and log in to a self-hosted site with Jetpack. 
- Log in with your WPCom credentials.
- Navigate to Menu tab and select WP-Admin button. The admin page displayed on the web view should require logging in with site credentials.
- Log out of the app and log in to a WPCom site. Try the WP-admin button again, the admin page should be authenticated automatically.
- Log out of the app and log in again to a self-hosted site without Jetpack and site credentials. Try the WP-admin button again, the admin page should be authenticated automatically.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
