### PR TITLE
Replace "No ratings" with "No (approved) reviews" in Product Detail

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -555,7 +555,7 @@ private extension DefaultProductFormTableViewModel {
                                                     comment: "Format of the sale period on the Price Settings row until a certain date")
 
         // Reviews
-        static let emptyReviews = NSLocalizedString("No ratings",
+        static let emptyReviews = NSLocalizedString("No (approved) reviews",
                                                     comment: "Placeholder for empty product ratings")
         static let singularReviewFormat = NSLocalizedString("rated once",
                                                             comment: "Format of the number of product ratings in singular form")


### PR DESCRIPTION
Fixes #7984 

## Description
In the product detail screen, for a product with no reviews, we were showing `No ratings`.
This wording might give a perception that the product has reviews, but these reviews have no star ratings (which is not possible to do). Android uses `No approved reviews` for that case.
I used the suggestion of @pachlava and edited the text to `No (approved) reviews`

## Testing instructions
1. Open a product with no reviews.
2. You should see the cell with the title `No (approved) reviews`.



## Screenshots
<img src="https://user-images.githubusercontent.com/495617/223156370-b2fa1423-5374-4750-9ab0-ce1f37ef7271.png" width=300 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
