### PR TITLE
Widget: Load revenue and orders when logged in with site credentials

### DIFF
--- a/WooCommerce/Classes/Authentication/Keychain+Entries.swift
+++ b/WooCommerce/Classes/Authentication/Keychain+Entries.swift
@@ -19,4 +19,11 @@ extension Keychain {
         get { self[WooConstants.authToken] }
         set { self[WooConstants.authToken] = newValue }
     }
+
+    /// Site credential password of the logged-in user
+    ///
+    var siteCredentialPassword: String? {
+        get { self[WooConstants.siteCredentialPassword] }
+        set { self[WooConstants.siteCredentialPassword] = newValue }
+    }
 }

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -29,6 +29,10 @@ enum WooConstants {
     ///
     static let authToken = "authToken"
 
+    /// Keychain Access's Key for the current site credential password
+    ///
+    static let siteCredentialPassword = "siteCredentialPassword"
+
     /// Shared UsersDefaults Suite Name
     ///
     static let sharedUserDefaultsSuiteName = "group.com.automattic.woocommerce"

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -578,9 +578,10 @@ private extension DefaultStoresManager {
         switch sessionManager.defaultCredentials {
         case let .wpcom(_, authToken, _):
             keychain.currentAuthToken = authToken
-        case let .wporg(username, password, _):
+        case let .wporg(username, password, siteAddress):
             keychain.siteCredentialPassword = password
             UserDefaults.group?[.defaultUsername] = username
+            UserDefaults.group?[.defaultSiteAddress] = siteAddress
         default:
             break
         }
@@ -588,7 +589,6 @@ private extension DefaultStoresManager {
         // Non-critical store info
         UserDefaults.group?[.defaultStoreID] = siteID
         UserDefaults.group?[.defaultStoreName] = sessionManager.defaultSite?.name
-        UserDefaults.group?[.defaultSiteAddress] = sessionManager.defaultStoreURL
 
         // Currency Settings are stored in `SelectedSiteSettings.defaultStoreCurrencySettings`
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -568,7 +568,7 @@ private extension DefaultStoresManager {
         dispatch(action)
     }
 
-    /// Updates the neccesary dependencies for the widget to function correctly.
+    /// Updates the necessary dependencies for the widget to function correctly.
     /// Reloads widgets timelines.
     ///
     func updateAndReloadWidgetInformation(with siteID: Int64?) {

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -528,6 +528,7 @@ private extension DefaultStoresManager {
             switch result {
             case .success(let site):
                 self.sessionManager.defaultSite = site
+                self.updateAndReloadWidgetInformation(with: site.siteID)
                 /// Trigger the `v1.1/connect/site-info` API to get information about
                 /// the site's Jetpack status and whether it's a WPCom site.
                 WordPressAuthenticator.fetchSiteInfo(for: url) { [weak self] result in
@@ -538,6 +539,7 @@ private extension DefaultStoresManager {
                                                     isJetpackConnected: info.isJetpackConnected,
                                                     isWordPressComStore: info.isWPCom)
                         self.sessionManager.defaultSite = updatedSite
+                        self.updateAndReloadWidgetInformation(with: site.siteID)
                     case .failure(let error):
                         DDLogError("⛔️ Cannot fetch generic site info: \(error)")
                     }
@@ -566,18 +568,27 @@ private extension DefaultStoresManager {
         dispatch(action)
     }
 
-    /// Updates the necesary dependencies for the widget to function correctly.
+    /// Updates the neccesary dependencies for the widget to function correctly.
     /// Reloads widgets timelines.
     ///
     func updateAndReloadWidgetInformation(with siteID: Int64?) {
-        // Token to fire network requests
-        if case let .wpcom(_, authToken, _) = sessionManager.defaultCredentials {
+        // Token/password to fire network requests
+        keychain.currentAuthToken = nil
+        keychain.siteCredentialPassword = nil
+        switch sessionManager.defaultCredentials {
+        case let .wpcom(_, authToken, _):
             keychain.currentAuthToken = authToken
+        case let .wporg(username, password, _):
+            keychain.siteCredentialPassword = password
+            UserDefaults.group?[.defaultUsername] = username
+        default:
+            break
         }
 
         // Non-critical store info
         UserDefaults.group?[.defaultStoreID] = siteID
         UserDefaults.group?[.defaultStoreName] = sessionManager.defaultSite?.name
+        UserDefaults.group?[.defaultSiteAddress] = sessionManager.defaultStoreURL
 
         // Currency Settings are stored in `SelectedSiteSettings.defaultStoreCurrencySettings`
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9067 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the issue of loading the store widget when logged in with site credentials.

Previously we fetched stats on the widget with WPCom credentials only. Since we now support site credential login, we need to save and update the credential with the widget. The widget then detects if the user is authenticated with site credentials only - if so, only revenue and orders are fetched; site visits and conversion are displayed with the placeholder "-".

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log out of the app and log in again to a self-hosted site without Jetpack.
- On the device, add the store widget extension to the home screen. If you're testing on the simulator, switch to the StoreWidgetsExtension scheme and run it.
- Confirm that the widget works properly and the visitor/conversion stats are displayed with the placeholder "-".

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/5533851/223383261-6baedf5d-3011-4713-9fa2-0f54dc03c2de.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
