### PR TITLE
[Support Request] Remove `systemStatusReportInSupportRequest` feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -51,8 +51,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return false
         case .justInTimeMessagesOnDashboard:
             return true
-        case .systemStatusReportInSupportRequest:
-            return true
         case .IPPInAppFeedbackBanner:
             return true
         case .performanceMonitoring,

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -105,10 +105,6 @@ public enum FeatureFlag: Int {
     ///
     case justInTimeMessagesOnDashboard
 
-    /// Adds the System Status Report to support requests
-    ///
-    case systemStatusReportInSupportRequest
-
     /// IPP in-app feedback banner
     ///
     case IPPInAppFeedbackBanner

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -220,8 +220,6 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     private let stores = ServiceLocator.stores
     private let storageManager = ServiceLocator.storageManager
 
-    private let isSSRFeatureFlagEnabled = DefaultFeatureFlagService().isFeatureFlagEnabled(.systemStatusReportInSupportRequest)
-
     /// Controller for fetching site plugins from Storage
     ///
     private lazy var pluginResultsController: ResultsController<StorageSitePlugin> = createPluginResultsController()
@@ -830,25 +828,14 @@ private extension ZendeskManager {
     /// Without it, the tickets won't appear in the correct view(s) in the web portal and they won't contain all the metadata needed to solve a ticket.
     ///
     func createRequest(supportSourceTag: String?) -> RequestUiConfiguration {
-
-        var logsFieldID: Int64 = TicketFieldIDs.legacyLogs
-        var systemStatusReportFieldID: Int64 = 0
-        if isSSRFeatureFlagEnabled {
-            /// If the feature flag is enabled, `legacyLogs` Field ID is used to send the SSR logs,
-            /// and `logs` Field ID is used to send the logs.
-            ///
-            logsFieldID = TicketFieldIDs.logs
-            systemStatusReportFieldID = TicketFieldIDs.legacyLogs
-        }
-
         // Only add the subcategory field when the SupportRequests feature is disabled to maintain the legacy behaviour.
         let isNewSupportRequestDisabled = !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.supportRequests)
         let ticketFields = [
             CustomField(fieldId: TicketFieldIDs.appVersion, value: Bundle.main.version),
             CustomField(fieldId: TicketFieldIDs.deviceFreeSpace, value: getDeviceFreeSpace()),
             CustomField(fieldId: TicketFieldIDs.networkInformation, value: getNetworkInformation()),
-            CustomField(fieldId: logsFieldID, value: getLogFile()),
-            CustomField(fieldId: systemStatusReportFieldID, value: systemStatusReport),
+            CustomField(fieldId: TicketFieldIDs.logs, value: getLogFile()),
+            CustomField(fieldId: TicketFieldIDs.legacyLogs, value: systemStatusReport),
             CustomField(fieldId: TicketFieldIDs.currentSite, value: getCurrentSiteDescription()),
             CustomField(fieldId: TicketFieldIDs.sourcePlatform, value: Constants.sourcePlatform),
             CustomField(fieldId: TicketFieldIDs.appLanguage, value: Locale.preferredLanguage),
@@ -862,24 +849,13 @@ private extension ZendeskManager {
     }
 
     func createWCPayRequest(supportSourceTag: String?) -> RequestUiConfiguration {
-
-        var logsFieldID: Int64 = TicketFieldIDs.legacyLogs
-        var systemStatusReportFieldID: Int64 = 0
-        if isSSRFeatureFlagEnabled {
-            /// If the feature flag is enabled, `legacyLogs` Field ID is used to send the SSR logs,
-            /// and `logs` Field ID is used to send the logs.
-            ///
-            logsFieldID = TicketFieldIDs.logs
-            systemStatusReportFieldID = TicketFieldIDs.legacyLogs
-        }
-
         // Set form field values
         let ticketFields = [
             CustomField(fieldId: TicketFieldIDs.appVersion, value: Bundle.main.version),
             CustomField(fieldId: TicketFieldIDs.deviceFreeSpace, value: getDeviceFreeSpace()),
             CustomField(fieldId: TicketFieldIDs.networkInformation, value: getNetworkInformation()),
-            CustomField(fieldId: logsFieldID, value: getLogFile()),
-            CustomField(fieldId: systemStatusReportFieldID, value: systemStatusReport),
+            CustomField(fieldId: TicketFieldIDs.logs, value: getLogFile()),
+            CustomField(fieldId: TicketFieldIDs.legacyLogs, value: systemStatusReport),
             CustomField(fieldId: TicketFieldIDs.currentSite, value: getCurrentSiteDescription()),
             CustomField(fieldId: TicketFieldIDs.sourcePlatform, value: Constants.sourcePlatform),
             CustomField(fieldId: TicketFieldIDs.appLanguage, value: Locale.preferredLanguage),


### PR DESCRIPTION
Part of #8795

# Why

In preparation for some `ZendeskManager` refactoring, this PR removes the`systemStatusReportInSupportRequest ` feature flag as it has been enabled for a while and we don't need to maintain the legacy behavior anymore.

Confirmed by @iamgabrielma 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
