### PR TITLE
[Product Multi-Selection] Update plural for OrderForm’s `Add Product` string

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -269,7 +269,7 @@ private struct ProductsSection: View {
                     Divider()
                 }
 
-                Button(OrderForm.Localization.addProduct) {
+                Button(OrderForm.Localization.addProductsButtonTitle) {
                     showAddProduct.toggle()
                 }
                 .id(addProductButton)
@@ -310,8 +310,13 @@ private extension OrderForm {
         static let cancelButton = NSLocalizedString("Cancel", comment: "Button to cancel the creation of an order on the New Order screen")
         static let products = NSLocalizedString("Products", comment: "Title text of the section that shows the Products when creating or editing an order")
         static let addProduct = NSLocalizedString("Add Product", comment: "Title text of the button that adds a product when creating or editing an order")
+        static let addProducts = NSLocalizedString("Add Products",
+                                                   comment: "Title text of the button that allows to add multiple products when creating or editing an order")
         static let productRowAccessibilityHint = NSLocalizedString("Opens product detail.",
                                                                    comment: "Accessibility hint for selecting a product in an order form")
+
+        static let addProductsButtonTitle = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) ?
+        Localization.addProducts : Localization.addProduct
     }
 
     enum Accessibility {


### PR DESCRIPTION
Feel free to leave this review to post-HACK week 👍 

Closes: #9018 

## Description
This PR updates the "Add Product" text within Order creation to show "Add Products" (plural) when product multi-selection is enabled.

## Testing instructions
- Run the app
- Go to Orders >  tap `+` > See `Add Product` (singular) text
- Switch the `productMultiSelectionM1` feature flag to `true`
- Run the app
- Go to Orders > tap `+` > See `Add Products` (plural) text
