### PR TITLE
[Orders] Track analytics event when orders list fails to load

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -155,6 +155,10 @@ extension WooAnalyticsEvent {
             "date_range": filters?.dateRange?.analyticsDescription ?? String()
         ])
     }
+
+    static func ordersListLoadError(_ error: Error) -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .ordersListLoadError, properties: [:], error: error)
+    }
 }
 
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -341,6 +341,7 @@ public enum WooAnalyticsStat: String {
     case ordersListFilter = "orders_list_filter"
     case ordersListSearch = "orders_list_search"
     case ordersListLoaded = "orders_list_loaded"
+    case ordersListLoadError = "orders_list_load_error"
     case orderProductAdd = "order_product_add"
     case orderProductQuantityChange = "order_product_quantity_change"
     case orderProductRemove = "order_product_remove"

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -368,7 +368,7 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
                 }
 
                 if let error = error {
-                    ServiceLocator.analytics.track(.ordersListLoadError, withError: error)
+                    ServiceLocator.analytics.track(event: .ordersListLoadError(error))
                     DDLogError("⛔️ Error synchronizing orders: \(error)")
                     self.viewModel.hasErrorLoadingData = true
                 } else {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -368,6 +368,7 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
                 }
 
                 if let error = error {
+                    ServiceLocator.analytics.track(.ordersListLoadError, withError: error)
                     DDLogError("⛔️ Error synchronizing orders: \(error)")
                     self.viewModel.hasErrorLoadingData = true
                 } else {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9084
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds a new analytics event when the orders list fails to load:

* `woocommerceios_orders_list_load_error` with custom props `error_domain`, `error_code`, and `error_description`. (Tracks registration: 1447-gh-tracks-events-registration)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Build and run the app.
2. Disable your network connection to trigger a network error.
3. Open the Orders tab to try to load the orders list.
4. Confirm that when the list fails to load, the corresponding event is tracked.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
