### PR TITLE
Update all instances of bash-cache to ci-toolkit

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -7,7 +7,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.8.0
+    - automattic/a8c-ci-toolkit#2.13.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         # This is not necessarily the actual name of the repo or the GitHub organization

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.12.0
+    - automattic/a8c-ci-toolkit#2.13.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         # This is not necessarily the actual name of the repo or the GitHub organization

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,7 +4,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.8.0
+    - automattic/a8c-ci-toolkit#2.13.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         # This is not necessarily the actual name of the repo or the GitHub organization


### PR DESCRIPTION
While I was at it, I also updated the version to the latest, 2.13.0.

This was done via:

```
find . -type f -name "*.yml" -exec sed -i '' 's/automattic\/bash-cache#[0-9.]\{1,\}/automattic\/a8c-ci-toolkit#2.13.0/g' {} +
```

## To test

If CI is green, we're good to merge.

Internal reference: paaHJt-4z0-p2


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

(Copied from @mokagio's [PR description in Pocket Casts iOS](https://github.com/Automattic/pocket-casts-ios/pull/754) 🙏)