### PR TITLE
Fix: password encoding in application passwords login

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 		45B204B82489095100FE6526 /* ProductCategoryMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B204B72489095100FE6526 /* ProductCategoryMapper.swift */; };
 		45B204BA24890A8C00FE6526 /* ProductCategoryMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B204B924890A8C00FE6526 /* ProductCategoryMapperTests.swift */; };
 		45B204BC24890B1200FE6526 /* category.json in Resources */ = {isa = PBXBuildFile; fileRef = 45B204BB24890B1200FE6526 /* category.json */; };
+		45C6D0E429B9F327009CE29C /* CookieNonceAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C6D0E329B9F327009CE29C /* CookieNonceAuthenticatorTests.swift */; };
 		45CCFCE227A2C9BF0012E8CB /* InboxNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CCFCE127A2C9BF0012E8CB /* InboxNote.swift */; };
 		45CCFCE427A2DC270012E8CB /* InboxAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CCFCE327A2DC270012E8CB /* InboxAction.swift */; };
 		45CCFCE627A2E3710012E8CB /* InboxNoteListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CCFCE527A2E3710012E8CB /* InboxNoteListMapper.swift */; };
@@ -1232,6 +1233,7 @@
 		45B204B72489095100FE6526 /* ProductCategoryMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryMapper.swift; sourceTree = "<group>"; };
 		45B204B924890A8C00FE6526 /* ProductCategoryMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryMapperTests.swift; sourceTree = "<group>"; };
 		45B204BB24890B1200FE6526 /* category.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = category.json; sourceTree = "<group>"; };
+		45C6D0E329B9F327009CE29C /* CookieNonceAuthenticatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieNonceAuthenticatorTests.swift; sourceTree = "<group>"; };
 		45CCFCE127A2C9BF0012E8CB /* InboxNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxNote.swift; sourceTree = "<group>"; };
 		45CCFCE327A2DC270012E8CB /* InboxAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxAction.swift; sourceTree = "<group>"; };
 		45CCFCE527A2E3710012E8CB /* InboxNoteListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxNoteListMapper.swift; sourceTree = "<group>"; };
@@ -3061,6 +3063,7 @@
 			children = (
 				EE8DE431294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift */,
 				EE76762E2962B85E000066FA /* RequestProcessorTests.swift */,
+				45C6D0E329B9F327009CE29C /* CookieNonceAuthenticatorTests.swift */,
 			);
 			path = ApplicationPassword;
 			sourceTree = "<group>";
@@ -4096,6 +4099,7 @@
 				D88D5A4D230BD010007B6E01 /* ProductReviewsRemoteTests.swift in Sources */,
 				261CF1BC255AEE290090D8D3 /* PaymentsGatewayRemoteTests.swift in Sources */,
 				453305EF2459E46100264E50 /* SitePostsRemoteTests.swift in Sources */,
+				45C6D0E429B9F327009CE29C /* CookieNonceAuthenticatorTests.swift in Sources */,
 				24F98C602502EF8200F49B68 /* FeatureFlagRemoteTests.swift in Sources */,
 				02C254D32563992900A04423 /* OrderShippingLabelListMapperTests.swift in Sources */,
 				740211E121939908002248DA /* CommentRemoteTests.swift in Sources */,

--- a/Networking/Networking/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Networking/Networking/CookieNonce/CookieNonceAuthenticator.swift
@@ -176,8 +176,8 @@ extension CookieNonceAuthenticator {
 
         /// `percentEncodedQuery` creates a validly escaped URL query component, but
         /// doesn't encode the '+'. Percent encodes '+' to avoid this ambiguity.
-        let characterSett = CharacterSet(charactersIn: "+").inverted
-        request.httpBody = components.percentEncodedQuery?.addingPercentEncoding(withAllowedCharacters: characterSett)?.data(using: .utf8)
+        let characterSet = CharacterSet(charactersIn: "+").inverted
+        request.httpBody = components.percentEncodedQuery?.addingPercentEncoding(withAllowedCharacters: characterSet)?.data(using: .utf8)
         return request
     }
 }

--- a/Networking/Networking/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Networking/Networking/CookieNonce/CookieNonceAuthenticator.swift
@@ -150,6 +150,17 @@ private extension CookieNonceAuthenticator {
         requestsToRetry.removeAll()
     }
 
+    func readNonceFromAjaxAction(html: String) -> String? {
+        html.isEmpty ? nil : html
+    }
+
+    func buildNonceRequestURL(base: URL) -> URL? {
+        URL(string: "admin-ajax.php?action=rest-nonce", relativeTo: base)
+    }
+}
+
+// MARK: Public helpers
+extension CookieNonceAuthenticator {
     func authenticatedRequest() -> URLRequest {
         var request = URLRequest(url: loginURL)
 
@@ -168,13 +179,5 @@ private extension CookieNonceAuthenticator {
         let characterSett = CharacterSet(charactersIn: "+").inverted
         request.httpBody = components.percentEncodedQuery?.addingPercentEncoding(withAllowedCharacters: characterSett)?.data(using: .utf8)
         return request
-    }
-
-    func readNonceFromAjaxAction(html: String) -> String? {
-        html.isEmpty ? nil : html
-    }
-
-    func buildNonceRequestURL(base: URL) -> URL? {
-        URL(string: "admin-ajax.php?action=rest-nonce", relativeTo: base)
     }
 }

--- a/Networking/Networking/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Networking/Networking/CookieNonce/CookieNonceAuthenticator.swift
@@ -162,7 +162,11 @@ private extension CookieNonceAuthenticator {
         parameters.append(URLQueryItem(name: "rememberme", value: "true"))
         var components = URLComponents()
         components.queryItems = parameters
-        request.httpBody = components.percentEncodedQuery?.data(using: .utf8)
+
+        /// `percentEncodedQuery` creates a validly escaped URL query component, but
+        /// doesn't encode the '+'. Percent encodes '+' to avoid this ambiguity.
+        let characterSett = CharacterSet(charactersIn: "+").inverted
+        request.httpBody = components.percentEncodedQuery?.addingPercentEncoding(withAllowedCharacters: characterSett)?.data(using: .utf8)
         return request
     }
 

--- a/Networking/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
+++ b/Networking/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
@@ -9,7 +9,7 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
     private let sampleUser = "user123"
     private let samplePassword = "password *+/$&=2+é"
 
-    func test_cookie_nonce_authenticator_encode_parameters_correctly() {
+    func test_cookie_nonce_authenticator_encode_parameters_correctly() throws {
         // Given
         let config = CookieNonceAuthenticatorConfiguration(username: sampleUser,
                                                            password: samplePassword,
@@ -20,7 +20,7 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
 
         let generatedBodyAsData = try XCTUnwrap(authenticator.authenticatedRequest().urlRequest?.httpBody)
         let generatedBodyAsString = try XCTUnwrap(String(data: generatedBodyAsData, encoding: .utf8))
-        let generatedBodyParameters = generatedBodyAsString!.split(separator: Character("&"))
+        let generatedBodyParameters = generatedBodyAsString.split(separator: Character("&"))
 
         // When
         /// Expected parameters with encoded data

--- a/Networking/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
+++ b/Networking/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
@@ -18,8 +18,8 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         let authenticator = CookieNonceAuthenticator(configuration: config)
 
 
-        let generatedBodyAsData = authenticator.authenticatedRequest().urlRequest!.httpBody!
-        let generatedBodyAsString = String(data: generatedBodyAsData, encoding: .utf8)
+        let generatedBodyAsData = try XCTUnwrap(authenticator.authenticatedRequest().urlRequest?.httpBody)
+        let generatedBodyAsString = try XCTUnwrap(String(data: generatedBodyAsData, encoding: .utf8))
         let generatedBodyParameters = generatedBodyAsString!.split(separator: Character("&"))
 
         // When

--- a/Networking/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
+++ b/Networking/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
@@ -1,3 +1,4 @@
+import XCTest
 @testable import Networking
 
 final class CookieNonceAuthenticatorTests: XCTestCase {

--- a/Networking/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
+++ b/Networking/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
@@ -1,0 +1,5 @@
+@testable import Networking
+
+class CookieNonceAuthenticatorTests: XCTest {
+
+}

--- a/Networking/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
+++ b/Networking/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
@@ -1,5 +1,5 @@
 @testable import Networking
 
-class CookieNonceAuthenticatorTests: XCTest {
+class CookieNonceAuthenticatorTests: XCTestCase {
 
 }

--- a/Networking/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
+++ b/Networking/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
@@ -1,5 +1,5 @@
 @testable import Networking
 
-class CookieNonceAuthenticatorTests: XCTestCase {
+final class CookieNonceAuthenticatorTests: XCTestCase {
 
 }

--- a/Networking/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
+++ b/Networking/NetworkingTests/ApplicationPassword/CookieNonceAuthenticatorTests.swift
@@ -3,4 +3,39 @@ import XCTest
 
 final class CookieNonceAuthenticatorTests: XCTestCase {
 
+    private let loginURL = URL(string: "https://example.com/wp-login.php")!
+    private let adminURL = URL(string: "https://example.com/wp-admin/")!
+    private let apiRequest = URLRequest(url: URL(string: "https://example.com/wp-json/")!)
+    private let sampleUser = "user123"
+    private let samplePassword = "password *+/$&=2+é"
+
+    func test_cookie_nonce_authenticator_encode_parameters_correctly() {
+        // Given
+        let config = CookieNonceAuthenticatorConfiguration(username: sampleUser,
+                                                           password: samplePassword,
+                                                           loginURL: loginURL,
+                                                           adminURL: adminURL)
+        let authenticator = CookieNonceAuthenticator(configuration: config)
+
+
+        let generatedBodyAsData = authenticator.authenticatedRequest().urlRequest!.httpBody!
+        let generatedBodyAsString = String(data: generatedBodyAsData, encoding: .utf8)
+        let generatedBodyParameters = generatedBodyAsString!.split(separator: Character("&"))
+
+        // When
+        /// Expected parameters with encoded data
+        ///
+        let expectedParameters = ["log": "user123", "pwd": "password%20*%2B/$%26%3D2%2B%C3%A9", "rememberme": "true"]
+
+        // Then
+        /// Note: As of iOS 12 the parameters were being serialized at random positions. That's *why* this test is a bit extra complex!
+        ///
+        for parameter in generatedBodyParameters {
+            let components = parameter.split(separator: Character("="))
+            let key = String(components[0])
+            let value = String(components[1])
+
+            XCTAssertEqual(value, expectedParameters[key])
+        }
+    }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 12.7
 -----
+- [*] Fix: unencoded special character in password causes login issues with store credentials (application passwords login).
 - [Internal] Shipping Label: add condition checks before showing contact options [https://github.com/woocommerce/woocommerce-ios/pull/8982]
 
 12.6


### PR DESCRIPTION
Closes #9051 

## Description
A user of an agency opened an issue on Github, detailing how he could log in with the Android app but not the iOS app due to an invalid credentials error using application passwords. The issue was on the app and was able to work with the user to carry out tests. The cause of the issue was a special `+` sign in the password that was not being converted to `%2B` during the API call, which it should have been.
More here: wp-pe5sF9-1gt


## Testing instructions
1. Use a WooCommerce store without Jetpack and configure an admin user.
2. Configure a password that contains the `+` character.
3. Try to login into the app.
4. It should work as expected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
