### PR TITLE
[HACK Week] Spotlight activities tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Spotlight.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Spotlight.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+extension WooActivityType {
+    var trackingValue: String {
+        let screen: String
+        switch self {
+        case .products:
+            screen = "products"
+        case .dashboard:
+            screen = "dashboard"
+        case .orders:
+            screen = "orders"
+        case .payments:
+            screen = "payments"
+        }
+
+        return screen + "_screen"
+    }
+}
+
+extension WooAnalyticsEvent {
+    enum Spotlight {
+        private enum Key {
+            static let type = "type"
+        }
+
+        static func activityWasOpened(with type: WooActivityType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .spotlightActivityOpened,
+                              properties: [Key.type: type.trackingValue])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -818,6 +818,9 @@ public enum WooAnalyticsStat: String {
     case universalLinkOpened = "universal_link_opened"
     case universalLinkFailed = "universal_link_failed"
 
+    // MARK: Spotlight
+    case spotlightActivityOpened = "spotlight_activity_opened"
+
     // MARK: Login Jetpack Connection
     case loginJetpackConnectionErrorShown = "login_jetpack_connection_error_shown"
     case loginJetpackConnectButtonTapped = "login_jetpack_connect_button_tapped"

--- a/WooCommerce/Classes/Spotlight/SpotlightManager.swift
+++ b/WooCommerce/Classes/Spotlight/SpotlightManager.swift
@@ -3,17 +3,32 @@ import Foundation
 
 struct SpotlightManager {
     static func handleUserActivity(_ userActivity: NSUserActivity) {
+        var type: WooActivityType?
         switch userActivity.activityType {
         case WooActivityType.dashboard.rawValue:
             MainTabBarController.switchToMyStoreTab()
+            type = WooActivityType.dashboard
         case WooActivityType.orders.rawValue:
             MainTabBarController.switchToOrdersTab()
+            type = WooActivityType.orders
         case WooActivityType.products.rawValue:
             MainTabBarController.switchToProductsTab()
+            type = WooActivityType.products
         case WooActivityType.payments.rawValue:
             MainTabBarController.presentPayments()
+            type = WooActivityType.payments
         default:
             break
         }
+
+        trackActivityBeingOpenedIfNecessary(with: type)
+    }
+
+    private static func trackActivityBeingOpenedIfNecessary(with type: WooActivityType?) {
+        guard let type = type else {
+            return
+        }
+
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Spotlight.activityWasOpened(with: type))
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1480,6 +1480,7 @@
 		B946881229B8DD41000646B0 /* DashboardViewController+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B946881129B8DD41000646B0 /* DashboardViewController+Activity.swift */; };
 		B946881429B8DD6A000646B0 /* OrderListViewController+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B946881329B8DD6A000646B0 /* OrderListViewController+Activity.swift */; };
 		B946881829B8DDC2000646B0 /* ProductsViewController+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B946881729B8DDC2000646B0 /* ProductsViewController+Activity.swift */; };
+		B946881A29BA2AC6000646B0 /* WooAnalyticsEvent+Spotlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = B946881929BA2AC6000646B0 /* WooAnalyticsEvent+Spotlight.swift */; };
 		B95112DA28BF79CA00D9578D /* PaymentsRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95112D928BF79CA00D9578D /* PaymentsRoute.swift */; };
 		B958A7C728B3D44A00823EEF /* UniversalLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958A7C628B3D44A00823EEF /* UniversalLinkRouter.swift */; };
 		B958A7C928B3D47B00823EEF /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = B958A7C828B3D47B00823EEF /* Route.swift */; };
@@ -3629,6 +3630,7 @@
 		B946881129B8DD41000646B0 /* DashboardViewController+Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DashboardViewController+Activity.swift"; sourceTree = "<group>"; };
 		B946881329B8DD6A000646B0 /* OrderListViewController+Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderListViewController+Activity.swift"; sourceTree = "<group>"; };
 		B946881729B8DDC2000646B0 /* ProductsViewController+Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductsViewController+Activity.swift"; sourceTree = "<group>"; };
+		B946881929BA2AC6000646B0 /* WooAnalyticsEvent+Spotlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+Spotlight.swift"; sourceTree = "<group>"; };
 		B95112D928BF79CA00D9578D /* PaymentsRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsRoute.swift; sourceTree = "<group>"; };
 		B958A7C628B3D44A00823EEF /* UniversalLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalLinkRouter.swift; sourceTree = "<group>"; };
 		B958A7C828B3D47B00823EEF /* Route.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
@@ -7018,6 +7020,7 @@
 				0263E3BA290BB21800E5F88F /* WooAnalyticsEvent+StoreCreation.swift */,
 				EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */,
 				0206E295299CD2C900C061C1 /* WooAnalyticsEvent+DomainSettings.swift */,
+				B946881929BA2AC6000646B0 /* WooAnalyticsEvent+Spotlight.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -11118,6 +11121,7 @@
 				DE7842ED26F061650030C792 /* NumberFormatter+Localized.swift in Sources */,
 				748D34E12148291E00E21A2F /* TopPerformerDataViewController.swift in Sources */,
 				02C887712450285100E4470F /* BottomButtonContainerView.swift in Sources */,
+				B946881A29BA2AC6000646B0 /* WooAnalyticsEvent+Spotlight.swift in Sources */,
 				0235BFD9246E959500778909 /* ProductFormActionsFactory.swift in Sources */,
 				024EFA6923FCC10B00F36918 /* Product+Media.swift in Sources */,
 				CC857C7729B25FAF00E19D1E /* FooterNotice.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add tracking for the spotlight activity screens merged in https://github.com/woocommerce/woocommerce-ios/pull/9082

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Open these screens through Spotlight. Ensure that the events are tracked by checking these strings in the Xcode console:

- Dashboard:
`🔵 Tracked spotlight_activity_opened, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 214354650, AnyHashable("type"): "dashboard_screen"] `
- Orders:
`🔵 Tracked spotlight_activity_opened, properties: [AnyHashable("blog_id"): 214354650, AnyHashable("is_wpcom_store"): true, AnyHashable("type"): "orders_screen"]`
- Products:
`🔵 Tracked spotlight_activity_opened, properties: [AnyHashable("blog_id"): 214354650, AnyHashable("is_wpcom_store"): true, AnyHashable("type"): "products_screen"]`
- Payments:
`🔵 Tracked spotlight_activity_opened, properties: [AnyHashable("type"): "payments_screen", AnyHashable("blog_id"): 214354650, AnyHashable("is_wpcom_store"): true]`


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
