### PR TITLE
[Support Request] Decouple ZendeskManager from support request metada

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -9,13 +9,25 @@ struct SupportFormMetadataProvider {
     private let sessionManager: SessionManager
     private let connectivityObserver: ConnectivityObserver
 
+
+    func systemFields() -> [Int64: String] {
+        [
+            ZendeskFieldsIDs.appVersion: Bundle.main.version,
+            ZendeskFieldsIDs.deviceFreeSpace: getDeviceFreeSpace(),
+            ZendeskFieldsIDs.networkInformation: getNetworkInformation(),
+            ZendeskFieldsIDs.logs: getLogFile(),
+            //ZendeskFieldsIDs.legacyLogs: systemStatusReport, // TODO: Migrate SSR
+            ZendeskFieldsIDs.currentSite: getCurrentSiteDescription(),
+            ZendeskFieldsIDs.sourcePlatform: Constants.sourcePlatform,
+            ZendeskFieldsIDs.appLanguage: Locale.preferredLanguage,
+        ]
+    }
 }
 
 
 // MARK: Helpers
 //
 private extension SupportFormMetadataProvider {
-
     /// Get the device free space: EG `56.34 GB`
     ///
     func getDeviceFreeSpace() -> String {
@@ -99,6 +111,26 @@ private extension SupportFormMetadataProvider {
 // MARK: Definitions
 //
 private extension SupportFormMetadataProvider {
+
+    enum ZendeskFieldsIDs {
+//        static let form: Int64 = 360000010286
+//        static let paymentsForm: Int64 = 189946
+//        static let paymentsGroup: Int64 = 27709263
+        static let appVersion: Int64 = 360000086866
+//        static let allBlogs: Int64 = 360000087183
+        static let deviceFreeSpace: Int64 = 360000089123
+        static let networkInformation: Int64 = 360000086966
+        static let legacyLogs: Int64 = 22871957
+        static let logs: Int64 = 10901699622036
+        static let currentSite: Int64 = 360000103103
+        static let sourcePlatform: Int64 = 360009311651
+        static let appLanguage: Int64 = 360008583691
+//        static let category: Int64 = 25176003
+//        static let subcategory: Int64 = 25176023
+//        static let product: Int64 = 25254766
+//        static let productArea: Int64 = 360025069951
+    }
+
     enum Constants {
         static let unknownValue = "unknown"
 //        static let noValue = "none"
@@ -125,7 +157,7 @@ private extension SupportFormMetadataProvider {
 //        static let profileNameKey = "name"
 //        static let unreadNotificationsKey = "wc_zendesk_unread_notifications"
 //        static let nameFieldCharacterLimit = 50
-//        static let sourcePlatform = "mobile_-_woo_ios"
+        static let sourcePlatform = "mobile_-_woo_ios"
 //        static let subcategory = "WooCommerce Mobile Apps"
 //        static let paymentsCategory = "support"
 //        static let paymentsSubcategory = "payment"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -1,0 +1,135 @@
+import Foundation
+import CoreTelephony
+
+/// Helper that provides general device & site zendesk metadata.
+///
+struct SupportFormMetadataProvider {
+
+    private let fileLogger: Logs
+    private let sessionManager: SessionManager
+    private let connectivityObserver: ConnectivityObserver
+
+}
+
+
+// MARK: Helpers
+//
+private extension SupportFormMetadataProvider {
+
+    /// Get the device free space: EG `56.34 GB`
+    ///
+    func getDeviceFreeSpace() -> String {
+        guard let resourceValues = try? URL(fileURLWithPath: "/").resourceValues(forKeys: [.volumeAvailableCapacityKey]),
+              let capacityBytes = resourceValues.volumeAvailableCapacity else {
+            return Constants.unknownValue
+        }
+
+        // format string using human readable units. ex: 1.5 GB
+        // Since ByteCountFormatter.string translates the string and has no locale setting,
+        // do the byte conversion manually so the Free Space is in English.
+        let sizeAbbreviations = ["bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+        var sizeAbbreviationsIndex = 0
+        var capacity = Double(capacityBytes)
+
+        while capacity > 1024 {
+            capacity /= 1024
+            sizeAbbreviationsIndex += 1
+        }
+
+        let formattedCapacity = String(format: "%4.2f", capacity)
+        let sizeAbbreviation = sizeAbbreviations[sizeAbbreviationsIndex]
+        return "\(formattedCapacity) \(sizeAbbreviation)"
+    }
+
+    /// Gets the content of the main/first log file. Trimmed with a character limit.
+    ///
+    func getLogFile() -> String {
+        guard let logFileInformation = fileLogger.logFileManager.sortedLogFileInfos.first,
+              let logData = try? Data(contentsOf: URL(fileURLWithPath: logFileInformation.filePath)),
+              let logText = String(data: logData, encoding: .utf8) else {
+            return ""
+        }
+
+        // Truncates the log text so it fits in the ticket field.
+        if logText.count > Constants.logFieldCharacterLimit {
+            return String(logText.suffix(Constants.logFieldCharacterLimit))
+        }
+
+        return logText
+    }
+
+    /// Gets the current site description (site url + site description).
+    ///
+    func getCurrentSiteDescription() -> String {
+        guard let site = sessionManager.defaultSite else {
+            return ""
+        }
+
+        return "\(site.url) (\(site.description))"
+    }
+
+    /// Gets the current device network information. Network type, Carrier, and Country Code
+    ///
+    func getNetworkInformation() -> String {
+        let networkType: String = {
+            switch connectivityObserver.currentStatus {
+            case .reachable(let type) where type == .ethernetOrWiFi:
+                return Constants.networkWiFi
+            case .reachable(let type) where type == .cellular:
+                return Constants.networkWWAN
+            default:
+                return Constants.unknownValue
+            }
+        }()
+
+        let networkCarrier = CTTelephonyNetworkInfo().serviceSubscriberCellularProviders?.first?.value
+        let carrierName = networkCarrier?.carrierName ?? Constants.unknownValue
+        let carrierCountryCode = networkCarrier?.isoCountryCode ?? Constants.unknownValue
+
+        let networkInformation = [
+            "\(Constants.networkTypeLabel) \(networkType)",
+            "\(Constants.networkCarrierLabel) \(carrierName)",
+            "\(Constants.networkCountryCodeLabel) \(carrierCountryCode)"
+        ]
+
+        return networkInformation.joined(separator: "\n")
+    }
+}
+
+// MARK: Definitions
+//
+private extension SupportFormMetadataProvider {
+    enum Constants {
+        static let unknownValue = "unknown"
+//        static let noValue = "none"
+//        static let mobileCategoryID: UInt64 = 360000041586
+//        static let articleLabel = "iOS"
+//        static let platformTag = "iOS"
+//        static let sdkTag = "woo-mobile-sdk"
+//        static let ticketSubject = NSLocalizedString(
+//            "WooCommerce for iOS Support",
+//            comment: "Subject of new Zendesk ticket."
+//        )
+//        static let blogSeperator = "\n----------\n"
+//        static let jetpackTag = "jetpack"
+//        static let wpComTag = "wpcom"
+//        static let authenticatedWithApplicationPasswordTag = "application_password_authenticated"
+        static let logFieldCharacterLimit = 64000
+        static let networkWiFi = "WiFi"
+        static let networkWWAN = "Mobile"
+        static let networkTypeLabel = "Network Type:"
+        static let networkCarrierLabel = "Carrier:"
+        static let networkCountryCodeLabel = "Country Code:"
+//        static let zendeskProfileUDKey = "wc_zendesk_profile"
+//        static let profileEmailKey = "email"
+//        static let profileNameKey = "name"
+//        static let unreadNotificationsKey = "wc_zendesk_unread_notifications"
+//        static let nameFieldCharacterLimit = 50
+//        static let sourcePlatform = "mobile_-_woo_ios"
+//        static let subcategory = "WooCommerce Mobile Apps"
+//        static let paymentsCategory = "support"
+//        static let paymentsSubcategory = "payment"
+//        static let paymentsProduct = "woocommerce_payments"
+//        static let paymentsProductArea = "product_area_woo_payment_gateway"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -7,6 +7,7 @@ import protocol Storage.StorageManagerType
 ///
 struct SupportFormMetadataProvider {
 
+    /// Dependencies
     private let fileLogger: Logs
     private let stores: StoresManager
     private let sessionManager: SessionManagerProtocol
@@ -53,7 +54,7 @@ struct SupportFormMetadataProvider {
             ZendeskFieldsIDs.deviceFreeSpace: getDeviceFreeSpace(),
             ZendeskFieldsIDs.networkInformation: getNetworkInformation(),
             ZendeskFieldsIDs.logs: getLogFile(),
-            //ZendeskFieldsIDs.legacyLogs: systemStatusReport, // TODO: Migrate SSR
+            //ZendeskFieldsIDs.legacyLogs: systemStatusReport, // TODO: Migrate SSR. We need it to be async so it needs a further refactor
             ZendeskFieldsIDs.currentSite: getCurrentSiteDescription(),
             ZendeskFieldsIDs.sourcePlatform: Constants.sourcePlatform,
             ZendeskFieldsIDs.appLanguage: Locale.preferredLanguage,
@@ -199,13 +200,10 @@ private extension SupportFormMetadataProvider {
 // MARK: Definitions
 //
 private extension SupportFormMetadataProvider {
-
+    /// Zendesk Form IDs
+    ///
     enum ZendeskFieldsIDs {
-//        static let form: Int64 = 360000010286
-//        static let paymentsForm: Int64 = 189946
-//        static let paymentsGroup: Int64 = 27709263
         static let appVersion: Int64 = 360000086866
-//        static let allBlogs: Int64 = 360000087183
         static let deviceFreeSpace: Int64 = 360000089123
         static let networkInformation: Int64 = 360000086966
         static let legacyLogs: Int64 = 22871957
@@ -213,25 +211,13 @@ private extension SupportFormMetadataProvider {
         static let currentSite: Int64 = 360000103103
         static let sourcePlatform: Int64 = 360009311651
         static let appLanguage: Int64 = 360008583691
-//        static let category: Int64 = 25176003
-//        static let subcategory: Int64 = 25176023
-//        static let product: Int64 = 25254766
-//        static let productArea: Int64 = 360025069951
     }
 
+    /// General Tags & Values used for Zendesk
+    ///
     enum Constants {
         static let unknownValue = "unknown"
-//        static let noValue = "none"
-//        static let mobileCategoryID: UInt64 = 360000041586
-//        static let articleLabel = "iOS"
         static let platformTag = "iOS"
-//        static let sdkTag = "woo-mobile-sdk"
-//        static let ticketSubject = NSLocalizedString(
-//            "WooCommerce for iOS Support",
-//            comment: "Subject of new Zendesk ticket."
-//        )
-//        static let blogSeperator = "\n----------\n"
-//        static let jetpackTag = "jetpack"
         static let wpComTag = "wpcom"
         static let authenticatedWithApplicationPasswordTag = "application_password_authenticated"
         static let logFieldCharacterLimit = 64000
@@ -240,23 +226,18 @@ private extension SupportFormMetadataProvider {
         static let networkTypeLabel = "Network Type:"
         static let networkCarrierLabel = "Carrier:"
         static let networkCountryCodeLabel = "Country Code:"
-//        static let zendeskProfileUDKey = "wc_zendesk_profile"
-//        static let profileEmailKey = "email"
-//        static let profileNameKey = "name"
-//        static let unreadNotificationsKey = "wc_zendesk_unread_notifications"
-//        static let nameFieldCharacterLimit = 50
         static let sourcePlatform = "mobile_-_woo_ios"
-//        static let subcategory = "WooCommerce Mobile Apps"
-//        static let paymentsCategory = "support"
-//        static let paymentsSubcategory = "payment"
-//        static let paymentsProduct = "woocommerce_payments"
-//        static let paymentsProductArea = "product_area_woo_payment_gateway"
     }
 
+    /// Payments extensions Slugs
+    ///
     enum PluginSlug {
         static let stripe = "woocommerce-gateway-stripe/woocommerce-gateway-stripe"
         static let wcpay = "woocommerce-payments/woocommerce-payments"
     }
+
+    /// iPP Zendesk tags
+    ///
     enum PluginStatus: String {
         case stripeNotInstalled = "woo_mobile_stripe_not_installed"
         case stripeInstalledAndActivated = "woo_mobile_stripe_installed_and_activated"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -54,7 +54,7 @@ struct SupportFormMetadataProvider {
             ZendeskFieldsIDs.deviceFreeSpace: getDeviceFreeSpace(),
             ZendeskFieldsIDs.networkInformation: getNetworkInformation(),
             ZendeskFieldsIDs.logs: getLogFile(),
-            //ZendeskFieldsIDs.legacyLogs: systemStatusReport, // TODO: Migrate SSR. We need it to be async so it needs a further refactor
+            ZendeskFieldsIDs.legacyLogs: "", //systemStatusReport, TODO: Migrate SSR. We need it to be async so it needs a further refactor
             ZendeskFieldsIDs.currentSite: getCurrentSiteDescription(),
             ZendeskFieldsIDs.sourcePlatform: Constants.sourcePlatform,
             ZendeskFieldsIDs.appLanguage: Locale.preferredLanguage,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -160,12 +160,13 @@ private extension SupportFormViewModel {
     /// Default Woo Support Areas
     ///
     static func wooSupportAreas() -> [Area] {
-        [
-            .init(title: Localization.mobileApp, datasource: MobileAppSupportDataSource()),
-            .init(title: Localization.ipp, datasource: IPPSupportDataSource()),
-            .init(title: Localization.wcPayments, datasource: WCPaySupportDataSource()),
-            .init(title: Localization.wcPlugin, datasource: WCPluginsSupportDataSource()),
-            .init(title: Localization.otherPlugin, datasource: OtherPluginsSupportDataSource())
+        let metadataProvider = SupportFormMetadataProvider()
+        return [
+            .init(title: Localization.mobileApp, datasource: MobileAppSupportDataSource(metadataProvider: metadataProvider)),
+            .init(title: Localization.ipp, datasource: IPPSupportDataSource(metadataProvider: metadataProvider)),
+            .init(title: Localization.wcPayments, datasource: WCPaySupportDataSource(metadataProvider: metadataProvider)),
+            .init(title: Localization.wcPlugin, datasource: WCPluginsSupportDataSource(metadataProvider: metadataProvider)),
+            .init(title: Localization.otherPlugin, datasource: OtherPluginsSupportDataSource(metadataProvider: metadataProvider))
         ]
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 struct MobileAppSupportDataSource: SupportFormMetaDataSource {
     var formID: Int64 {
-        ZendeskProvider.shared.formID()
+        ZendeskForms.IDs.mobileForm
     }
 
     var tags: [String] {
@@ -22,7 +22,7 @@ struct MobileAppSupportDataSource: SupportFormMetaDataSource {
 ///
 struct IPPSupportDataSource: SupportFormMetaDataSource {
     var formID: Int64 {
-        ZendeskProvider.shared.formID()
+        ZendeskForms.IDs.mobileForm
     }
 
     var tags: [String] {
@@ -40,7 +40,7 @@ struct IPPSupportDataSource: SupportFormMetaDataSource {
 ///
 struct WCPluginsSupportDataSource: SupportFormMetaDataSource {
     var formID: Int64 {
-        ZendeskProvider.shared.wcPayFormID()
+        ZendeskForms.IDs.wooForm
     }
 
     var tags: [String] {
@@ -58,7 +58,7 @@ struct WCPluginsSupportDataSource: SupportFormMetaDataSource {
 ///
 struct WCPaySupportDataSource: SupportFormMetaDataSource {
     var formID: Int64 {
-        ZendeskProvider.shared.wcPayFormID()
+        ZendeskForms.IDs.wooForm
     }
 
     var tags: [String] {
@@ -74,7 +74,7 @@ struct WCPaySupportDataSource: SupportFormMetaDataSource {
 ///
 struct OtherPluginsSupportDataSource: SupportFormMetaDataSource {
     var formID: Int64 {
-        ZendeskProvider.shared.wcPayFormID()
+        ZendeskForms.IDs.wooForm
     }
 
     var tags: [String] {
@@ -98,6 +98,8 @@ private enum ZendeskForms {
     /// Custom Field IDs
     ///
     enum IDs {
+        static let mobileForm: Int64 = 360000010286
+        static let wooForm: Int64 = 189946
         static let category: Int64 = 25176003
         static let subCategory: Int64 = 25176023
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
@@ -8,7 +8,7 @@ struct MobileAppSupportDataSource: SupportFormMetaDataSource {
     }
 
     var tags: [String] {
-        ZendeskProvider.shared.generalTags() + [ZendeskForms.Tags.wcMobileApps, ZendeskForms.Tags.jetpack]
+        SupportFormMetadataProvider().systemTags() + [ZendeskForms.Tags.wcMobileApps, ZendeskForms.Tags.jetpack]
     }
 
     var customFields: [Int64: String] {
@@ -26,7 +26,7 @@ struct IPPSupportDataSource: SupportFormMetaDataSource {
     }
 
     var tags: [String] {
-        ZendeskProvider.shared.generalTags() + [ZendeskForms.Tags.wcMobileApps, ZendeskForms.Tags.productAreaIPP, ZendeskForms.Tags.wcPayments]
+        SupportFormMetadataProvider().systemTags() + [ZendeskForms.Tags.wcMobileApps, ZendeskForms.Tags.productAreaIPP, ZendeskForms.Tags.wcPayments]
     }
 
     var customFields: [Int64: String] {
@@ -44,7 +44,7 @@ struct WCPluginsSupportDataSource: SupportFormMetaDataSource {
     }
 
     var tags: [String] {
-        ZendeskProvider.shared.generalTags() + [ZendeskForms.Tags.wcCore, ZendeskForms.Tags.appTransfer, ZendeskForms.Tags.support]
+        SupportFormMetadataProvider().systemTags() + [ZendeskForms.Tags.wcCore, ZendeskForms.Tags.appTransfer, ZendeskForms.Tags.support]
     }
 
     var customFields: [Int64: String] {
@@ -62,7 +62,11 @@ struct WCPaySupportDataSource: SupportFormMetaDataSource {
     }
 
     var tags: [String] {
-        ZendeskProvider.shared.wcPayTags() + [ZendeskForms.Tags.appTransfer]
+        SupportFormMetadataProvider().systemTags() + [ZendeskForms.Tags.appTransfer,
+                                                      ZendeskForms.Tags.wcPayments,
+                                                      ZendeskForms.Tags.payment,
+                                                      ZendeskForms.Tags.support,
+                                                      ZendeskForms.Tags.productAreaWCPayments]
     }
 
     var customFields: [Int64: String] {
@@ -78,10 +82,10 @@ struct OtherPluginsSupportDataSource: SupportFormMetaDataSource {
     }
 
     var tags: [String] {
-        ZendeskProvider.shared.generalTags() + [ZendeskForms.Tags.productAreaWooExtensions,
-                                                ZendeskForms.Tags.appTransfer,
-                                                ZendeskForms.Tags.support,
-                                                ZendeskForms.Tags.store]
+        SupportFormMetadataProvider().systemTags() + [ZendeskForms.Tags.productAreaWooExtensions,
+                                                      ZendeskForms.Tags.appTransfer,
+                                                      ZendeskForms.Tags.support,
+                                                      ZendeskForms.Tags.store]
     }
 
     var customFields: [Int64: String] {
@@ -118,11 +122,13 @@ private enum ZendeskForms {
         static let support = Fields.support
         static let store = Fields.store
         static let jetpack = "jetpack"
+        static let payment = "payment"
         static let wcCore = "woocommerce_core"
         static let wcPayments = "woocommerce_payments"
         static let appTransfer = "mobile_app_woo_transfer"
         static let wcMobileApps = "woocommerce_mobile_apps"
         static let productAreaIPP = "product_area_apps_in_person_payments"
         static let productAreaWooExtensions = "product_area_woo_extensions"
+        static let productAreaWCPayments = "product_area_woo_payment_gateway"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
@@ -12,7 +12,7 @@ struct MobileAppSupportDataSource: SupportFormMetaDataSource {
     }
 
     var customFields: [Int64: String] {
-        var generalFields = ZendeskProvider.shared.generalCustomFields()
+        var generalFields = SupportFormMetadataProvider().systemFields()
         generalFields[ZendeskForms.IDs.subCategory] = ZendeskForms.Fields.wooMobileApps
         return generalFields
     }
@@ -30,7 +30,7 @@ struct IPPSupportDataSource: SupportFormMetaDataSource {
     }
 
     var customFields: [Int64: String] {
-        var generalFields = ZendeskProvider.shared.generalCustomFields()
+        var generalFields = SupportFormMetadataProvider().systemFields()
         generalFields[ZendeskForms.IDs.subCategory] = ZendeskForms.Fields.wooMobileApps
         return generalFields
     }
@@ -48,7 +48,7 @@ struct WCPluginsSupportDataSource: SupportFormMetaDataSource {
     }
 
     var customFields: [Int64: String] {
-        var generalFields = ZendeskProvider.shared.generalCustomFields()
+        var generalFields = SupportFormMetadataProvider().systemFields()
         generalFields[ZendeskForms.IDs.category] = ZendeskForms.Fields.support
         return generalFields
     }
@@ -70,7 +70,10 @@ struct WCPaySupportDataSource: SupportFormMetaDataSource {
     }
 
     var customFields: [Int64: String] {
-        ZendeskProvider.shared.wcPayCustomFields()
+        var generalFields = SupportFormMetadataProvider().systemFields()
+        generalFields[ZendeskForms.IDs.category] = ZendeskForms.Fields.support
+        generalFields[ZendeskForms.IDs.subCategory] = ZendeskForms.Fields.payment
+        return generalFields
     }
 }
 
@@ -89,7 +92,7 @@ struct OtherPluginsSupportDataSource: SupportFormMetaDataSource {
     }
 
     var customFields: [Int64: String] {
-        var generalFields = ZendeskProvider.shared.generalCustomFields()
+        var generalFields = SupportFormMetadataProvider().systemFields()
         generalFields[ZendeskForms.IDs.category] = ZendeskForms.Fields.support
         generalFields[ZendeskForms.IDs.subCategory] = ZendeskForms.Fields.store
         return generalFields
@@ -114,6 +117,7 @@ private enum ZendeskForms {
         static let wooMobileApps = "WooCommerce Mobile Apps"
         static let support = "support"
         static let store = "store"
+        static let payment = "payment"
     }
 
     /// Common Tags
@@ -121,8 +125,8 @@ private enum ZendeskForms {
     enum Tags {
         static let support = Fields.support
         static let store = Fields.store
+        static let payment = Fields.payment
         static let jetpack = "jetpack"
-        static let payment = "payment"
         static let wcCore = "woocommerce_core"
         static let wcPayments = "woocommerce_payments"
         static let appTransfer = "mobile_app_woo_transfer"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
@@ -71,10 +71,10 @@ struct WCPaySupportDataSource: SupportFormMetaDataSource {
 
     var tags: [String] {
         metadataProvider.systemTags() + [ZendeskForms.Tags.appTransfer,
-                                                      ZendeskForms.Tags.wcPayments,
-                                                      ZendeskForms.Tags.payment,
-                                                      ZendeskForms.Tags.support,
-                                                      ZendeskForms.Tags.productAreaWCPayments]
+                                         ZendeskForms.Tags.wcPayments,
+                                         ZendeskForms.Tags.payment,
+                                         ZendeskForms.Tags.support,
+                                         ZendeskForms.Tags.productAreaWCPayments]
     }
 
     var customFields: [Int64: String] {
@@ -96,9 +96,9 @@ struct OtherPluginsSupportDataSource: SupportFormMetaDataSource {
 
     var tags: [String] {
         metadataProvider.systemTags() + [ZendeskForms.Tags.productAreaWooExtensions,
-                                                      ZendeskForms.Tags.appTransfer,
-                                                      ZendeskForms.Tags.support,
-                                                      ZendeskForms.Tags.store]
+                                         ZendeskForms.Tags.appTransfer,
+                                         ZendeskForms.Tags.support,
+                                         ZendeskForms.Tags.store]
     }
 
     var customFields: [Int64: String] {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
@@ -3,16 +3,18 @@ import Foundation
 /// Provides Mobile App Zendesk metadata.
 ///
 struct MobileAppSupportDataSource: SupportFormMetaDataSource {
+    let metadataProvider: SupportFormMetadataProvider
+
     var formID: Int64 {
         ZendeskForms.IDs.mobileForm
     }
 
     var tags: [String] {
-        SupportFormMetadataProvider().systemTags() + [ZendeskForms.Tags.wcMobileApps, ZendeskForms.Tags.jetpack]
+        metadataProvider.systemTags() + [ZendeskForms.Tags.wcMobileApps, ZendeskForms.Tags.jetpack]
     }
 
     var customFields: [Int64: String] {
-        var generalFields = SupportFormMetadataProvider().systemFields()
+        var generalFields = metadataProvider.systemFields()
         generalFields[ZendeskForms.IDs.subCategory] = ZendeskForms.Fields.wooMobileApps
         return generalFields
     }
@@ -21,16 +23,18 @@ struct MobileAppSupportDataSource: SupportFormMetaDataSource {
 /// Provides IPP Zendesk metadata.
 ///
 struct IPPSupportDataSource: SupportFormMetaDataSource {
+    let metadataProvider: SupportFormMetadataProvider
+
     var formID: Int64 {
         ZendeskForms.IDs.mobileForm
     }
 
     var tags: [String] {
-        SupportFormMetadataProvider().systemTags() + [ZendeskForms.Tags.wcMobileApps, ZendeskForms.Tags.productAreaIPP, ZendeskForms.Tags.wcPayments]
+        metadataProvider.systemTags() + [ZendeskForms.Tags.wcMobileApps, ZendeskForms.Tags.productAreaIPP, ZendeskForms.Tags.wcPayments]
     }
 
     var customFields: [Int64: String] {
-        var generalFields = SupportFormMetadataProvider().systemFields()
+        var generalFields = metadataProvider.systemFields()
         generalFields[ZendeskForms.IDs.subCategory] = ZendeskForms.Fields.wooMobileApps
         return generalFields
     }
@@ -39,16 +43,18 @@ struct IPPSupportDataSource: SupportFormMetaDataSource {
 /// Provides WC Plugins Zendesk metadata.
 ///
 struct WCPluginsSupportDataSource: SupportFormMetaDataSource {
+    let metadataProvider: SupportFormMetadataProvider
+
     var formID: Int64 {
         ZendeskForms.IDs.wooForm
     }
 
     var tags: [String] {
-        SupportFormMetadataProvider().systemTags() + [ZendeskForms.Tags.wcCore, ZendeskForms.Tags.appTransfer, ZendeskForms.Tags.support]
+        metadataProvider.systemTags() + [ZendeskForms.Tags.wcCore, ZendeskForms.Tags.appTransfer, ZendeskForms.Tags.support]
     }
 
     var customFields: [Int64: String] {
-        var generalFields = SupportFormMetadataProvider().systemFields()
+        var generalFields = metadataProvider.systemFields()
         generalFields[ZendeskForms.IDs.category] = ZendeskForms.Fields.support
         return generalFields
     }
@@ -57,12 +63,14 @@ struct WCPluginsSupportDataSource: SupportFormMetaDataSource {
 /// Provides WC Payments Zendesk metadata.
 ///
 struct WCPaySupportDataSource: SupportFormMetaDataSource {
+    let metadataProvider: SupportFormMetadataProvider
+
     var formID: Int64 {
         ZendeskForms.IDs.wooForm
     }
 
     var tags: [String] {
-        SupportFormMetadataProvider().systemTags() + [ZendeskForms.Tags.appTransfer,
+        metadataProvider.systemTags() + [ZendeskForms.Tags.appTransfer,
                                                       ZendeskForms.Tags.wcPayments,
                                                       ZendeskForms.Tags.payment,
                                                       ZendeskForms.Tags.support,
@@ -70,7 +78,7 @@ struct WCPaySupportDataSource: SupportFormMetaDataSource {
     }
 
     var customFields: [Int64: String] {
-        var generalFields = SupportFormMetadataProvider().systemFields()
+        var generalFields = metadataProvider.systemFields()
         generalFields[ZendeskForms.IDs.category] = ZendeskForms.Fields.support
         generalFields[ZendeskForms.IDs.subCategory] = ZendeskForms.Fields.payment
         return generalFields
@@ -80,19 +88,21 @@ struct WCPaySupportDataSource: SupportFormMetaDataSource {
 /// Provides Other Plugins Zendesk metadata.
 ///
 struct OtherPluginsSupportDataSource: SupportFormMetaDataSource {
+    let metadataProvider: SupportFormMetadataProvider
+
     var formID: Int64 {
         ZendeskForms.IDs.wooForm
     }
 
     var tags: [String] {
-        SupportFormMetadataProvider().systemTags() + [ZendeskForms.Tags.productAreaWooExtensions,
+        metadataProvider.systemTags() + [ZendeskForms.Tags.productAreaWooExtensions,
                                                       ZendeskForms.Tags.appTransfer,
                                                       ZendeskForms.Tags.support,
                                                       ZendeskForms.Tags.store]
     }
 
     var customFields: [Int64: String] {
-        var generalFields = SupportFormMetadataProvider().systemFields()
+        var generalFields = metadataProvider.systemFields()
         generalFields[ZendeskForms.IDs.category] = ZendeskForms.Fields.support
         generalFields[ZendeskForms.IDs.subCategory] = ZendeskForms.Fields.store
         return generalFields

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -625,6 +625,7 @@
 		261AA309275178FA009530FE /* PaymentMethodsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA308275178FA009530FE /* PaymentMethodsView.swift */; };
 		261AA30C2753119E009530FE /* PaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30B2753119E009530FE /* PaymentMethodsViewModel.swift */; };
 		261AA30E275506DE009530FE /* PaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30D275506DE009530FE /* PaymentMethodsViewModelTests.swift */; };
+		261B526E29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */; };
 		26281776278F0B0100C836D3 /* View+NoticesModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26281775278F0B0100C836D3 /* View+NoticesModifier.swift */; };
 		262A098B2628C51D0033AD20 /* OrderAddOnListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */; };
 		262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */; };
@@ -2765,6 +2766,7 @@
 		261AA308275178FA009530FE /* PaymentMethodsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsView.swift; sourceTree = "<group>"; };
 		261AA30B2753119E009530FE /* PaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsViewModel.swift; sourceTree = "<group>"; };
 		261AA30D275506DE009530FE /* PaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
+		261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportFormMetadataProvider.swift; sourceTree = "<group>"; };
 		26281775278F0B0100C836D3 /* View+NoticesModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+NoticesModifier.swift"; sourceTree = "<group>"; };
 		262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListViewModel.swift; sourceTree = "<group>"; };
 		262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListI1Tests.swift; sourceTree = "<group>"; };
@@ -5712,6 +5714,7 @@
 				2677B558299F322300862180 /* SupportForm+Presentation.swift */,
 				262EB5AD298C70EF009DCC36 /* SupportFormViewModel.swift */,
 				262EB5AF298C7C3A009DCC36 /* SupportFormsDataSources.swift */,
+				261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */,
 			);
 			path = SupportForm;
 			sourceTree = "<group>";
@@ -11272,6 +11275,7 @@
 				CC4A4FF126557D0E00B75DCD /* TitleAndToggleRow.swift in Sources */,
 				029B0F57234197B80010C1F3 /* ProductSearchUICommand.swift in Sources */,
 				DE19BB0C26C2688B00AB70D9 /* SelectionList.swift in Sources */,
+				261B526E29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift in Sources */,
 				45DB705A26124C710064A6CF /* TitleAndTextFieldRow.swift in Sources */,
 				DE19BB1226C3811100AB70D9 /* LearnMoreRow.swift in Sources */,
 				DEF36DE82898D3CF00178AC2 /* JetpackSetupWebViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportDataSourcesTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportDataSourcesTests.swift
@@ -9,13 +9,13 @@ final class SupportDataSourcesTests: XCTestCase {
     }
 
     func test_mobile_app_formID_has_correct_value() {
-        let dataSource = MobileAppSupportDataSource()
+        let dataSource = MobileAppSupportDataSource(metadataProvider: SupportFormMetadataProvider())
         XCTAssertEqual(dataSource.formID, 360000010286)
     }
 
     func test_mobile_app_tags_have_correct_values() {
         // Given
-        let dataSource = MobileAppSupportDataSource()
+        let dataSource = MobileAppSupportDataSource(metadataProvider: SupportFormMetadataProvider())
         let tagsSet = Set(dataSource.tags)
         let expectedSet = Set(["iOS", "jetpack", "woocommerce_mobile_apps"])
 
@@ -24,7 +24,7 @@ final class SupportDataSourcesTests: XCTestCase {
     }
 
     func test_mobile_app_fields_have_correct_ids() {
-        let dataSource = MobileAppSupportDataSource()
+        let dataSource = MobileAppSupportDataSource(metadataProvider: SupportFormMetadataProvider())
         let customFieldsKeys = dataSource.customFields.keys.sorted()
         XCTAssertEqual(customFieldsKeys, [
             360008583691, // App Language
@@ -40,13 +40,13 @@ final class SupportDataSourcesTests: XCTestCase {
     }
 
     func test_ipp_formID_has_correct_value() {
-        let dataSource = IPPSupportDataSource()
+        let dataSource = IPPSupportDataSource(metadataProvider: SupportFormMetadataProvider())
         XCTAssertEqual(dataSource.formID, 360000010286)
     }
 
     func test_ipp_tags_have_correct_values() {
         // Given
-        let dataSource = IPPSupportDataSource()
+        let dataSource = IPPSupportDataSource(metadataProvider: SupportFormMetadataProvider())
         let tagsSet = Set(dataSource.tags)
         let expectedSet = Set(["iOS", "woocommerce_payments", "woocommerce_mobile_apps", "product_area_apps_in_person_payments"])
 
@@ -55,7 +55,7 @@ final class SupportDataSourcesTests: XCTestCase {
     }
 
     func test_ipp_fields_have_correct_ids() {
-        let dataSource = IPPSupportDataSource()
+        let dataSource = IPPSupportDataSource(metadataProvider: SupportFormMetadataProvider())
         let customFieldsKeys = dataSource.customFields.keys.sorted()
         XCTAssertEqual(customFieldsKeys, [
             360008583691, // App Language
@@ -71,13 +71,13 @@ final class SupportDataSourcesTests: XCTestCase {
     }
 
     func test_wc_plugins_formID_has_correct_value() {
-        let dataSource = WCPluginsSupportDataSource()
+        let dataSource = WCPluginsSupportDataSource(metadataProvider: SupportFormMetadataProvider())
         XCTAssertEqual(dataSource.formID, 189946)
     }
 
     func test_wc_plugins_tags_have_correct_values() {
         // Given
-        let dataSource = WCPluginsSupportDataSource()
+        let dataSource = WCPluginsSupportDataSource(metadataProvider: SupportFormMetadataProvider())
         let tagsSet = Set(dataSource.tags)
         let expectedSet = Set(["iOS", "mobile_app_woo_transfer", "woocommerce_core", "support"])
 
@@ -86,7 +86,7 @@ final class SupportDataSourcesTests: XCTestCase {
     }
 
     func test_wc_plugins_fields_have_correct_ids() {
-        let dataSource = WCPluginsSupportDataSource()
+        let dataSource = WCPluginsSupportDataSource(metadataProvider: SupportFormMetadataProvider())
         let customFieldsKeys = dataSource.customFields.keys.sorted()
         XCTAssertEqual(customFieldsKeys, [
             360008583691, // App Language
@@ -102,12 +102,12 @@ final class SupportDataSourcesTests: XCTestCase {
     }
 
     func test_wcpay_formID_has_correctValue() {
-        let dataSource = WCPaySupportDataSource()
+        let dataSource = WCPaySupportDataSource(metadataProvider: SupportFormMetadataProvider())
         XCTAssertEqual(dataSource.formID, 189946)
     }
 
     func test_wcpay_tags_have_correct_values() {
-        let dataSource = WCPaySupportDataSource()
+        let dataSource = WCPaySupportDataSource(metadataProvider: SupportFormMetadataProvider())
         let tagsSet = Set(dataSource.tags)
         let expectedSet = Set(["iOS", "mobile_app_woo_transfer", "woocommerce_payments", "support", "payment", "product_area_woo_payment_gateway"])
 
@@ -116,7 +116,7 @@ final class SupportDataSourcesTests: XCTestCase {
     }
 
     func test_wcpay_custom_fields_have_correct_values() {
-        let dataSource = WCPaySupportDataSource()
+        let dataSource = WCPaySupportDataSource(metadataProvider: SupportFormMetadataProvider())
         let customFieldsKeys = dataSource.customFields.keys.sorted()
         XCTAssertEqual(customFieldsKeys, [
             360008583691, // App Language
@@ -133,12 +133,12 @@ final class SupportDataSourcesTests: XCTestCase {
     }
 
     func test_other_plugins_formID_has_correctValue() {
-        let dataSource = OtherPluginsSupportDataSource()
+        let dataSource = OtherPluginsSupportDataSource(metadataProvider: SupportFormMetadataProvider())
         XCTAssertEqual(dataSource.formID, 189946)
     }
 
     func test_other_plugins_tags_have_correct_values() {
-        let dataSource = OtherPluginsSupportDataSource()
+        let dataSource = OtherPluginsSupportDataSource(metadataProvider: SupportFormMetadataProvider())
         let tagsSet = Set(dataSource.tags)
         let expectedSet = Set(["iOS", "product_area_woo_extensions", "mobile_app_woo_transfer", "support", "store"])
 
@@ -147,7 +147,7 @@ final class SupportDataSourcesTests: XCTestCase {
     }
 
     func test_other_plugins_custom_fields_have_correct_values() {
-        let dataSource = OtherPluginsSupportDataSource()
+        let dataSource = OtherPluginsSupportDataSource(metadataProvider: SupportFormMetadataProvider())
         let customFieldsKeys = dataSource.customFields.keys.sorted()
         XCTAssertEqual(customFieldsKeys, [
             360008583691, // App Language


### PR DESCRIPTION
Part of #8795 

#  Why

This PR migrates all the tags & custom fields logic from the `ZendeskManager` to its own `SupportFormMetadataProvider` type. This new type is now used to feed each individual `SupportFormDataSource`.

The reason for this change is to decouple `ZendeskManager` from the specific woo logic to be able to reuse it later in other modules or applications.

# How

Logic has been copied from `ZendeskManager`. No new significant logic has been added.

# Testing Steps

Existing unit tests should make sure that tickets are sent with the correct tags and custom fields.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
