### PR TITLE
Products: using `context=edit` parameter to load products for editing to enable updates with shortcodes in description

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -100,7 +100,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     /// - Parameters:
     ///     - siteID: Site for which we'll fetch remote products.
     ///     - context: view or edit. Scope under which the request is made;
-    ///                determines fields present in response. Default is view.
+    ///                determines fields present in response. Default is `edit`.
     ///     - pageNumber: Number of page that should be retrieved.
     ///     - pageSize: Number of products to be retrieved per page.
     ///     - stockStatus: Optional stock status filtering. Default to nil (no filtering).
@@ -177,6 +177,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.include: stringOfProductIDs,
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
+            ParameterKey.contextKey: Default.context
         ]
         let path = Path.products
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
@@ -236,7 +237,8 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
             ParameterKey.search: keyword,
-            ParameterKey.exclude: stringOfExcludedProductIDs
+            ParameterKey.exclude: stringOfExcludedProductIDs,
+            ParameterKey.contextKey: Default.context
         ].merging(filterParameters, uniquingKeysWith: { (first, _) in first })
 
         let path = Path.products
@@ -262,7 +264,8 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.sku: keyword,
             ParameterKey.partialSKUSearch: keyword,
             ParameterKey.page: String(pageNumber),
-            ParameterKey.perPage: String(pageSize)
+            ParameterKey.perPage: String(pageSize),
+            ParameterKey.contextKey: Default.context
         ]
         let path = Path.products
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
@@ -417,7 +420,7 @@ public extension ProductsRemote {
     enum Default {
         public static let pageSize: Int   = 25
         public static let pageNumber: Int = Remote.Default.firstPageNumber
-        public static let context: String = "view"
+        public static let context: String = "edit"
     }
 
     private enum Path {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9044 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

Previously, we had a merchant writing in about an issue where a shortcode from a third-party extension was gone after saving the product with unrelated changes in the app. This issue didn't happen when they did the same in core. After checking with core p1677738632061289/1677732494.104509-slack-C7U3Y3VMY, description fields are rendered in HTML when the `context` parameter is `view` (the default) and we should be using  `context=edit` when loading products for editing.

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In `ProductsRemote`, the default `context` parameter was updated from `view` to `edit`. The parameter is also added to other `wc/v3/products` GET requests. I compared the API response for the two parameter values, there are some new fields only when `context=edit` and a slight difference in `related_ids` but this is a [read-only field in the API](https://woocommerce.github.io/woocommerce-rest-api-docs/#product-properties) and is likely generated with some randomness.

🗒️ I expected variations endpoint to work the same, but passing a `context=edit` parameter doesn't have the same effect for `products/id/variations`. I asked in p1678413143713519/1677732494.104509-slack-C7U3Y3VMY

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has a product with a shortcode in the **description** and **short description** (please set this in core), you can use a core one like `[sale_products]`

### Product list

- Go to the products tab
- Tap on the product in the prerequisite --> the product description and short description should include the shortcode (not the HTML version)
- Change any property of the product (except for images and password) like name, price, inventory, or shipping
- Tap `Save` to save the product remotely --> the product description and short description should stay the same with the shortcode after the save

### Product search

- Go to the products tab
- Tap search 🔍 
- Search for the product in the prerequisite
- Tap on the product in the prerequisite --> the product description and short description should include the shortcode (not the HTML version)
- Change any property of the product (except for images and password) like name, price, inventory, or shipping
- Tap `Save` to save the product remotely --> the product description and short description should stay the same with the shortcode after the save

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after
-- | --
![Simulator Screen Shot - iPhone 14 - 2023-03-10 at 09 20 21](https://user-images.githubusercontent.com/1945542/224225072-3faa7e9b-229f-4d11-b221-08706475f062.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-10 at 09 20 20](https://user-images.githubusercontent.com/1945542/224225079-599adde4-f84e-449a-af61-64318516f638.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.