### PR TITLE
Separate `NavigationView` from `ProductSelectorView` to `ProductSelectorNavigationView`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -297,9 +297,9 @@ struct AddEditCoupon: View {
                 }
             }
             .sheet(isPresented: $showingSelectProducts) {
-                ProductSelectorView(configuration: ProductSelectorView.Configuration.productsForCoupons,
-                                isPresented: $showingSelectProducts,
-                                viewModel: viewModel.productSelectorViewModel)
+                ProductSelectorNavigationView(configuration: .productsForCoupons,
+                                              isPresented: $showingSelectProducts,
+                                              viewModel: viewModel.productSelectorViewModel)
                     .onDisappear {
                         viewModel.productSelectorViewModel.clearSearchAndFilters()
                     }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
@@ -154,9 +154,9 @@ struct CouponRestrictions: View {
             .background(Color(.listForeground(modal: false)))
             .ignoresSafeArea(.container, edges: [.horizontal])
             .sheet(isPresented: $showingExcludeProducts) {
-                ProductSelectorView(configuration: ProductSelectorView.Configuration.excludedProductsForCoupons,
-                                isPresented: $showingExcludeProducts,
-                                viewModel: viewModel.productSelectorViewModel)
+                ProductSelectorNavigationView(configuration: .excludedProductsForCoupons,
+                                              isPresented: $showingExcludeProducts,
+                                              viewModel: viewModel.productSelectorViewModel)
                     .onDisappear {
                         viewModel.productSelectorViewModel.clearSearchAndFilters()
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -278,9 +278,9 @@ private struct ProductsSection: View {
                 .sheet(isPresented: $showAddProduct, onDismiss: {
                     scroll.scrollTo(addProductButton)
                 }, content: {
-                    ProductSelectorView(configuration: ProductSelectorView.Configuration.addProductToOrder,
-                                    isPresented: $showAddProduct,
-                                    viewModel: viewModel.addProductViewModel)
+                    ProductSelectorNavigationView(configuration: .addProductToOrder,
+                                                  isPresented: $showAddProduct,
+                                                  viewModel: viewModel.addProductViewModel)
                         .onDisappear {
                             viewModel.addProductViewModel.clearSearchAndFilters()
                             navigationButtonID = UUID()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorNavigationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorNavigationView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// `ProductSelectorView` wrapped in a SwiftUI navigation view.
+struct ProductSelectorNavigationView: View {
+    private let configuration: ProductSelectorView.Configuration
+    @Binding private var isPresented: Bool
+    private let viewModel: ProductSelectorViewModel
+
+    init(configuration: ProductSelectorView.Configuration,
+         isPresented: Binding<Bool>,
+         viewModel: ProductSelectorViewModel) {
+        self.configuration = configuration
+        self._isPresented = isPresented
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        NavigationView {
+            ProductSelectorView(configuration: configuration,
+                                isPresented: $isPresented,
+                                viewModel: viewModel)
+        }
+        .navigationViewStyle(.stack)
+        .wooNavigationBarStyle()
+    }
+}
+
+struct ProductSelectorNavigationView_Previews: PreviewProvider {
+    static var previews: some View {
+        let viewModel = ProductSelectorViewModel(siteID: 123)
+        let configuration = ProductSelectorView.Configuration(
+            showsFilters: true,
+            multipleSelectionsEnabled: true,
+            title: "Add Product",
+            cancelButtonTitle: "Close",
+            productRowAccessibilityHint: "Add product to order",
+            variableProductRowAccessibilityHint: "Open variation list")
+        ProductSelectorNavigationView(configuration: configuration, isPresented: .constant(true), viewModel: viewModel)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -40,110 +40,108 @@ struct ProductSelectorView: View {
     }
 
     var body: some View {
-        NavigationView {
-            VStack(spacing: 0) {
-                SearchHeader(text: $viewModel.searchTerm, placeholder: Localization.searchPlaceholder)
-                    .padding(.horizontal, insets: safeAreaInsets)
-                    .accessibilityIdentifier("product-selector-search-bar")
-                HStack {
-                        Button(Localization.clearSelection) {
-                            viewModel.clearSelection()
-                        }
-                        .buttonStyle(LinkButtonStyle())
-                        .fixedSize()
-                        .renderedIf(configuration.clearSelectionEnabled && viewModel.totalSelectedItemsCount > 0 && viewModel.syncStatus == .results)
-                    Spacer()
-
-                    Button(viewModel.filterButtonTitle) {
-                        showingFilters.toggle()
-                    }
-                    .buttonStyle(LinkButtonStyle())
-                    .fixedSize()
-                    .renderedIf(configuration.showsFilters)
-                }
+        VStack(spacing: 0) {
+            SearchHeader(text: $viewModel.searchTerm, placeholder: Localization.searchPlaceholder)
                 .padding(.horizontal, insets: safeAreaInsets)
+                .accessibilityIdentifier("product-selector-search-bar")
+            HStack {
+                Button(Localization.clearSelection) {
+                    viewModel.clearSelection()
+                }
+                .buttonStyle(LinkButtonStyle())
+                .fixedSize()
+                .renderedIf(configuration.clearSelectionEnabled && viewModel.totalSelectedItemsCount > 0 && viewModel.syncStatus == .results)
+                Spacer()
 
-                switch viewModel.syncStatus {
-                case .results:
-                    VStack(spacing: 0) {
-                        InfiniteScrollList(isLoading: viewModel.shouldShowScrollIndicator,
-                                           loadAction: viewModel.syncNextPage) {
-                            ForEach(viewModel.productRows) { rowViewModel in
-                                createProductRow(rowViewModel: rowViewModel)
-                                    .padding(Constants.defaultPadding)
-                                    .accessibilityIdentifier(Constants.productRowAccessibilityIdentifier)
-                                Divider().frame(height: Constants.dividerHeight)
-                                    .padding(.leading, Constants.defaultPadding)
-                            }
+                Button(viewModel.filterButtonTitle) {
+                    showingFilters.toggle()
+                }
+                .buttonStyle(LinkButtonStyle())
+                .fixedSize()
+                .renderedIf(configuration.showsFilters)
+            }
+            .padding(.horizontal, insets: safeAreaInsets)
+
+            switch viewModel.syncStatus {
+            case .results:
+                VStack(spacing: 0) {
+                    InfiniteScrollList(isLoading: viewModel.shouldShowScrollIndicator,
+                                       loadAction: viewModel.syncNextPage) {
+                        ForEach(viewModel.productRows) { rowViewModel in
+                            createProductRow(rowViewModel: rowViewModel)
+                                .padding(Constants.defaultPadding)
+                                .accessibilityIdentifier(Constants.productRowAccessibilityIdentifier)
+                            Divider().frame(height: Constants.dividerHeight)
+                                .padding(.leading, Constants.defaultPadding)
                         }
-                        if configuration.multipleSelectionsEnabled {
-                            Button(doneButtonTitle) {
-                                viewModel.completeMultipleSelection()
-                                isPresented.toggle()
-                            }
-                            .buttonStyle(PrimaryButtonStyle())
-                            .padding(Constants.defaultPadding)
-                            .accessibilityIdentifier(Constants.doneButtonAccessibilityIdentifier)
+                    }
+                    if configuration.multipleSelectionsEnabled {
+                        Button(doneButtonTitle) {
+                            viewModel.completeMultipleSelection()
+                            isPresented.toggle()
                         }
-                        if let variationListViewModel = variationListViewModel {
-                            LazyNavigationLink(destination: ProductVariationSelector(
-                                isPresented: $isPresented,
-                                viewModel: variationListViewModel,
-                                multipleSelectionsEnabled: configuration.multipleSelectionsEnabled,
-                                onMultipleSelections: { selectedIDs in
-                                    viewModel.updateSelectedVariations(productID: variationListViewModel.productID, selectedVariationIDs: selectedIDs)
-                                }), isActive: $isShowingVariationList) {
+                        .buttonStyle(PrimaryButtonStyle())
+                        .padding(Constants.defaultPadding)
+                        .accessibilityIdentifier(Constants.doneButtonAccessibilityIdentifier)
+                    }
+                    if let variationListViewModel = variationListViewModel {
+                        LazyNavigationLink(destination: ProductVariationSelector(
+                            isPresented: $isPresented,
+                            viewModel: variationListViewModel,
+                            multipleSelectionsEnabled: configuration.multipleSelectionsEnabled,
+                            onMultipleSelections: { selectedIDs in
+                                viewModel.updateSelectedVariations(productID: variationListViewModel.productID, selectedVariationIDs: selectedIDs)
+                            }), isActive: $isShowingVariationList) {
                                 EmptyView()
                             }
-                        }
                     }
-                    .padding(.horizontal, insets: safeAreaInsets)
-                    .background(Color(.listForeground(modal: false)).ignoresSafeArea())
-
-                case .empty:
-                    EmptyState(title: Localization.emptyStateMessage, image: .emptyProductsTabImage)
-                        .frame(maxHeight: .infinity)
-                case .firstPageSync:
-                    List(viewModel.ghostRows) { rowViewModel in
-                        ProductRow(viewModel: rowViewModel)
-                            .redacted(reason: .placeholder)
-                            .accessibilityRemoveTraits(.isButton)
-                            .accessibilityLabel(Localization.loadingRowsAccessibilityLabel)
-                            .shimmering()
-                    }
-                    .padding(.horizontal, insets: safeAreaInsets)
-                    .listStyle(PlainListStyle())
-                default:
-                    EmptyView()
                 }
+                .padding(.horizontal, insets: safeAreaInsets)
+                .background(Color(.listForeground(modal: false)).ignoresSafeArea())
+
+            case .empty:
+                EmptyState(title: Localization.emptyStateMessage, image: .emptyProductsTabImage)
+                    .frame(maxHeight: .infinity)
+            case .firstPageSync:
+                List(viewModel.ghostRows) { rowViewModel in
+                    ProductRow(viewModel: rowViewModel)
+                        .redacted(reason: .placeholder)
+                        .accessibilityRemoveTraits(.isButton)
+                        .accessibilityLabel(Localization.loadingRowsAccessibilityLabel)
+                        .shimmering()
+                }
+                .padding(.horizontal, insets: safeAreaInsets)
+                .listStyle(PlainListStyle())
+            default:
+                EmptyView()
             }
-            .background(Color(configuration.searchHeaderBackgroundColor).ignoresSafeArea())
-            .ignoresSafeArea(.container, edges: .horizontal)
-            .navigationTitle(configuration.title)
-            .navigationBarTitleDisplayMode(configuration.prefersLargeTitle ? .large : .inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(configuration.cancelButtonTitle) {
+        }
+        .background(Color(configuration.searchHeaderBackgroundColor).ignoresSafeArea())
+        .ignoresSafeArea(.container, edges: .horizontal)
+        .navigationTitle(configuration.title)
+        .navigationBarTitleDisplayMode(configuration.prefersLargeTitle ? .large : .inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                if let cancelButtonTitle = configuration.cancelButtonTitle {
+                    Button(cancelButtonTitle) {
                         isPresented.toggle()
                     }
                 }
             }
-            .onAppear {
-                viewModel.onLoadTrigger.send()
-            }
-            .notice($viewModel.notice, autoDismiss: false)
-            .sheet(isPresented: $showingFilters) {
-                FilterListView(viewModel: viewModel.filterListViewModel) { filters in
-                    viewModel.filters = filters
-                } onClearAction: {
-                    // no-op
-                } onDismissAction: {
-                    // no-op
-                }
+        }
+        .onAppear {
+            viewModel.onLoadTrigger.send()
+        }
+        .notice($viewModel.notice, autoDismiss: false)
+        .sheet(isPresented: $showingFilters) {
+            FilterListView(viewModel: viewModel.filterListViewModel) { filters in
+                viewModel.filters = filters
+            } onClearAction: {
+                // no-op
+            } onDismissAction: {
+                // no-op
             }
         }
-        .navigationViewStyle(.stack)
-        .wooNavigationBarStyle()
     }
 
     /// Creates the `ProductRow` for a product, depending on whether the product is variable.
@@ -189,7 +187,7 @@ extension ProductSelectorView {
         var doneButtonTitleSingularFormat: String = ""
         var doneButtonTitlePluralFormat: String = ""
         let title: String
-        let cancelButtonTitle: String
+        let cancelButtonTitle: String?
         let productRowAccessibilityHint: String
         let variableProductRowAccessibilityHint: String
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		022C658C2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022C658B2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift */; };
 		022C7D7729793ABE0036568D /* PaidDomainSelectorDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022C7D7629793ABE0036568D /* PaidDomainSelectorDataProviderTests.swift */; };
 		022C7D792979778E0036568D /* DomainSettingsDomainCreditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022C7D782979778E0036568D /* DomainSettingsDomainCreditView.swift */; };
+		022CE91A29BB143000F210E0 /* ProductSelectorNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022CE91929BB143000F210E0 /* ProductSelectorNavigationView.swift */; };
 		022F2FA6295E77F4003A0A46 /* StoreCreationCountrySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F2FA5295E77F4003A0A46 /* StoreCreationCountrySectionView.swift */; };
 		022F2FA8295E7A14003A0A46 /* StoreCreationCountryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F2FA7295E7A14003A0A46 /* StoreCreationCountryButton.swift */; };
 		022F2FAA295E8241003A0A46 /* StoreCreationCountryQuestionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F2FA9295E8241003A0A46 /* StoreCreationCountryQuestionViewModelTests.swift */; };
@@ -2276,6 +2277,7 @@
 		022C658B2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewController+ProductImageUploaderTests.swift"; sourceTree = "<group>"; };
 		022C7D7629793ABE0036568D /* PaidDomainSelectorDataProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaidDomainSelectorDataProviderTests.swift; sourceTree = "<group>"; };
 		022C7D782979778E0036568D /* DomainSettingsDomainCreditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSettingsDomainCreditView.swift; sourceTree = "<group>"; };
+		022CE91929BB143000F210E0 /* ProductSelectorNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSelectorNavigationView.swift; sourceTree = "<group>"; };
 		022F2FA5295E77F4003A0A46 /* StoreCreationCountrySectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCountrySectionView.swift; sourceTree = "<group>"; };
 		022F2FA7295E7A14003A0A46 /* StoreCreationCountryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCountryButton.swift; sourceTree = "<group>"; };
 		022F2FA9295E8241003A0A46 /* StoreCreationCountryQuestionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationCountryQuestionViewModelTests.swift; sourceTree = "<group>"; };
@@ -9309,6 +9311,7 @@
 			children = (
 				CC53FB372755213900C4CA4F /* ProductSelectorView.swift */,
 				CC53FB3B2757EC7200C4CA4F /* ProductSelectorViewModel.swift */,
+				022CE91929BB143000F210E0 /* ProductSelectorNavigationView.swift */,
 				CCF87BBF2790582400461C43 /* ProductVariationSelector.swift */,
 				CC13C0CA278E021300C0B5B5 /* ProductVariationSelectorViewModel.swift */,
 				CC53FB3427551A6E00C4CA4F /* ProductRow.swift */,
@@ -10670,6 +10673,7 @@
 				31579028273EE2B1008CA3AF /* VersionHelpers.swift in Sources */,
 				CCD2F51C26D697860010E679 /* ShippingLabelServicePackageListViewModel.swift in Sources */,
 				03076D38290C223E008EE839 /* WooNavigationSheet.swift in Sources */,
+				022CE91A29BB143000F210E0 /* ProductSelectorNavigationView.swift in Sources */,
 				E107FCE326C13A0D00BAF51B /* InPersonPaymentsSupportLink.swift in Sources */,
 				2662D90626E1571900E25611 /* ListSelector.swift in Sources */,
 				74D0A5302139CF1300E2919F /* String+Helpers.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #2407 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For inventory scanner feature #2407, I'd like to show a product selector with our SwiftUI implementation `ProductSelectorView` instead of the legacy UIKit version `ProductListSelectorViewController`. However, I encountered an issue when two navigation bars are shown when embedding `ProductSelectorView` in a `UIHostingController` because `ProductSelectorView` also has a `NavigationView` for its content. This PR created a separate `ProductSelectorNavigationView` to move the `NavigationView` out of `ProductSelectorView`. All existing use cases should remain the same.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please do a confidence check on the affected use cases to ensure their UX stays the same.

### Order form

- Log in if needed
- Go to the Orders tab
- Tap `+`
- Tap `+ Add Product` --> the product selector should behave the same as in production. you can try searching for products and variations

### Coupon form > products

- Go to the Menu tab
- Tap Settings > Experimental Features, enable `Coupon Management`
- Go back to the root of the Menu tab
- Tap `Coupons`
- Tap `+` to add a coupon and select a type
- Tap `All Products` --> the product selector is shown with all products shown and should behave the same as in production
- Enter some search query --> the results should be updated accordingly
- Tap `Filters` and add some filters --> the results should be updated accordingly (please note this known issue if you try the filters before changing the search query https://github.com/woocommerce/woocommerce-ios/issues/9098)
- Select some products and tap `Select * Products` at the bottom --> the selected products should be shown on the coupon form
- Tap `Usage Restrictions` > `Exclude Products` --> the product selector is shown with all products shown and should behave the same as in production, including the filters and clear selection action

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

order form | coupon form > products | coupon form > usage restrictions > excluded products
-- | -- | --
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-10 at 16 11 32](https://user-images.githubusercontent.com/1945542/224260923-63fcd604-fa2d-4257-a12f-13e8080fa339.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-10 at 16 16 03](https://user-images.githubusercontent.com/1945542/224260932-6f51eee4-01f7-4988-a885-b3dd0a8cbcc8.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-10 at 16 16 11](https://user-images.githubusercontent.com/1945542/224260937-c13ba045-9373-4385-897e-1deae4cc3f3b.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
