### PR TITLE
Site credential login: catch invalid cookie nonce

### DIFF
--- a/Networking/Networking/Network/NetworkError.swift
+++ b/Networking/Networking/Network/NetworkError.swift
@@ -18,6 +18,9 @@ public enum NetworkError: Error, Equatable {
     case unacceptableStatusCode(statusCode: Int)
 
     case invalidURL
+
+    /// Error for REST API requests with invalid cookie nonce
+    case invalidCookieNonce
 }
 
 

--- a/Networking/Networking/Network/WordPressOrgNetwork.swift
+++ b/Networking/Networking/Network/WordPressOrgNetwork.swift
@@ -192,7 +192,7 @@ private extension WordPressOrgNetwork {
     struct ErrorResponse: Decodable {
         /// Error code
         let code: String
-        
+
         /// Error message
         let message: String
     }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Main screens are now accessible through the Home Screen Spotlight Search [https://github.com/woocommerce/woocommerce-ios/pull/9082]
 - [*] Stats: Fixed a crash when order stats use a date and time matching the start of Daylight Saving Time. [https://github.com/woocommerce/woocommerce-ios/pull/9083]
 - [*] Fix: Dismiss Take Payment popup after sharing the payment link to another app. [https://github.com/woocommerce/woocommerce-ios/pull/9042]
+- [*] Site credential login: Catch invalid cookie nonce [https://github.com/woocommerce/woocommerce-ios/pull/9102]
 
 12.6
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9101 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Currently during site credential login, we are using the Jetpack plugin request to check the authentication. We bypass the 403 error since this is the error code for users without sufficient role to manage plugins.

However, there is another case that the Jetpack plugin endpoint may also return 403 - when the cookie nonce is invalid. We need to block this case since it's apparently a failed login attempt. This PR handles this block by validating the response data in `WordPressOrgNetwork` and returning an invalid nonce error if needed.

Changes:
- A new `NetworkError` case for `invalidCookieNonce`.
- Validation in `WordPressOrgNetwork` to check for error code `rest_cookie_invalid_nonce`.
- `SiteCredentialLoginUseCase` update to catch the invalid nonce error.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log out of the app or skip onboarding if needed.
- On the prologue screen select Enter your site address and proceed with the address of a site with custom response for `wp-login.php`. If you don't have access to one, try this [p1678258552518089/1678174641.255659-slack-C03URUK5C].
- Enter any random credentials.
- Notice an error alert displayed for the login, and no request for application password should be executed afterwards.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
We may need a better UI for the login error, but that is out of this PR scope.

<img src="https://user-images.githubusercontent.com/5533851/224302768-50c880fe-d263-4702-9ef0-edfd736cf2cb.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.