### PR TITLE
[Store onboarding] Pull to refresh store onboarding list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -709,6 +709,9 @@ private extension DashboardViewController {
             group.addTask { [weak self] in
                 await self?.reloadDashboardUIStatsVersion(forced: true)
             }
+            group.addTask { [weak self] in
+                await self?.onboardingHostingController?.reloadTasks()
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -701,8 +701,15 @@ private extension DashboardViewController {
 
     func onPullToRefresh() async {
         ServiceLocator.analytics.track(.dashboardPulledToRefresh)
-        await viewModel.syncAnnouncements(for: siteID)
-        await reloadDashboardUIStatsVersion(forced: true)
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { [weak self] in
+                guard let self = self else { return }
+                await self.viewModel.syncAnnouncements(for: self.siteID)
+            }
+            group.addTask { [weak self] in
+                await self?.reloadDashboardUIStatsVersion(forced: true)
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -703,7 +703,7 @@ private extension DashboardViewController {
         ServiceLocator.analytics.track(.dashboardPulledToRefresh)
         await withTaskGroup(of: Void.self) { group in
             group.addTask { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 await self.viewModel.syncAnnouncements(for: self.siteID)
             }
             group.addTask { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -39,8 +39,9 @@ final class StoreOnboardingViewHostingController: UIHostingController<StoreOnboa
         }
     }
 
-   func reloadTasks() async {
-       await viewModel.reloadTasks()
+    @MainActor
+    func reloadTasks() async {
+        await viewModel.reloadTasks()
     }
 
     /// Shows a transparent navigation bar without a bottom border.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -26,19 +26,21 @@ final class StoreOnboardingViewHostingController: UIHostingController<StoreOnboa
         super.viewDidLoad()
 
         configureNavigationBarAppearance()
-        reloadTasks()
+        Task {
+            await reloadTasks()
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        reloadTasks()
+        Task {
+            await reloadTasks()
+        }
     }
 
-    private func reloadTasks() {
-        Task {
-            await viewModel.reloadTasks()
-        }
+   func reloadTasks() async {
+       await viewModel.reloadTasks()
     }
 
     /// Shows a transparent navigation bar without a bottom border.


### PR DESCRIPTION
Closes: #8892
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
- Reload the store onboarding list upon performing a pull to refresh in Dashboard screen.
- Parallel load the dashboard screen-related requests using a Task Group. 

## Testing instructions
- Launch and login if needed
- Scroll down from the "My Store" tab, and you should see the store onboarding task list.
- Pull to refresh from the "My Store" tab
- Validate that the onboarding list is reloaded along with other modules on the dashboard

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![PullToRefresh](https://user-images.githubusercontent.com/524475/224707081-faa566d5-bb7b-4e38-b97c-5c0c42588529.gif)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
