### PR TITLE
[Store onboarding] Use Menu instead of action sheet to match UI design.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreSetupProgressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreSetupProgressView.swift
@@ -9,8 +9,6 @@ struct StoreSetupProgressView: View {
 
     let shareFeedbackAction: (() -> Void)?
 
-    @State private var showingActionSheet = false
-
     let isRedacted: Bool
 
     var body: some View {
@@ -43,19 +41,16 @@ struct StoreSetupProgressView: View {
                 .renderedIf(!isExpanded)
 
             // More button
-            Button {
-                showingActionSheet = true
+            Menu {
+                Button(Localization.shareFeedbackButton) {
+                    shareFeedbackAction?()
+                }
             } label: {
                 Image(uiImage: .ellipsisImage)
                     .flipsForRightToLeftLayoutDirection(true)
                     .foregroundColor(Color(.textTertiary))
             }
             .renderedIf(!isExpanded)
-        }
-        .confirmationDialog(Localization.title, isPresented: $showingActionSheet) {
-            Button(Localization.shareFeedbackButton) {
-                shareFeedbackAction?()
-            }
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8907
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Use `Menu` instead of action sheet to match UI design. 
VyLr7LvKodHE4kINfBE7Lw-fi-1644:82305

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Launch the app and login if needed
- Navigate to the "My Store" tab
- Tap on the `...` button from the store onboarding task list
- Ensure that you see a Menu with an option to Share feedback. (Previously an action sheet was displayed)

## Screenshots
![Menu](https://user-images.githubusercontent.com/524475/224716786-89524a6f-5a14-41d5-997d-bee5abdf0863.gif)

| Before | After |
| - |  - | 
| ![Simulator Screen Shot - iPhone 14 - 2023-03-13 at 19 12 05](https://user-images.githubusercontent.com/524475/224719349-eb5278bb-8468-4fbf-a3df-48a42fc36343.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-13 at 19 09 50](https://user-images.githubusercontent.com/524475/224719337-d13fb76d-e4fe-47c8-aa19-51b82c8d77af.png) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.