### PR TITLE
[Free Trial] Adds feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -87,6 +87,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return ( buildConfig == .localDeveloper || buildConfig == .alpha ) && !isUITesting
         case .productBundles:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .freeTrial:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -175,4 +175,8 @@ public enum FeatureFlag: Int {
     /// Whether to enable product bundle settings in product details
     ///
     case productBundles
+
+    /// Enables conditional behaviour when a site has a free trial plan.
+    ///
+    case freeTrial
 }


### PR DESCRIPTION
Closes: #9055

# Why

This PR just adds the `freeTrial` feature flag definition in order to kick off development!

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
