### PR TITLE
[Mobile Payments] Update StripeTerminal to 2.18

### DIFF
--- a/Hardware/Hardware/CardReader/Charge.swift
+++ b/Hardware/Hardware/CardReader/Charge.swift
@@ -18,7 +18,7 @@ public struct Charge: Identifiable, GeneratedCopiable, GeneratedFakeable {
     public let description: String?
 
     /// Metadata associated with the charge.
-    public let metadata: [AnyHashable: Any]?
+    public let metadata: [String: String]?
 
     /// The payment method associated with the charge.
     public let paymentMethod: PaymentMethod?
@@ -28,7 +28,7 @@ public struct Charge: Identifiable, GeneratedCopiable, GeneratedFakeable {
                 currency: String,
                 status: ChargeStatus,
                 description: String?,
-                metadata: [AnyHashable: Any]?,
+                metadata: [String: String]?,
                 paymentMethod: PaymentMethod?) {
         self.id = id
         self.amount = amount

--- a/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
+++ b/Hardware/Hardware/CardReader/PaymentIntentParameters.swift
@@ -39,7 +39,7 @@ public struct PaymentIntentParameters {
 
     /// Set of key-value pairs that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
-    public let metadata: [AnyHashable: Any]?
+    public let metadata: [String: String]?
 
     /// Supported payment methods for this intent.
     ///
@@ -55,7 +55,7 @@ public struct PaymentIntentParameters {
                 statementDescription: String? = nil,
                 receiptEmail: String? = nil,
                 paymentMethodTypes: [String] = [],
-                metadata: [AnyHashable: Any]? = nil) {
+                metadata: [String: String]? = nil) {
         self.amount = amount
         self.currency = currency
         self.stripeSmallestCurrencyUnitMultiplier = stripeSmallestCurrencyUnitMultiplier

--- a/Hardware/Hardware/CardReader/StripeCardReader/Charge+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/Charge+Stripe.swift
@@ -27,7 +27,7 @@ protocol StripeCharge {
     var currency: String { get }
     var status: StripeTerminal.ChargeStatus { get }
     var stripeDescription: String? { get }
-    var metadata: [AnyHashable: Any] { get }
+    var metadata: [String: String] { get }
     var paymentMethodDetails: StripeTerminal.PaymentMethodDetails? { get }
 }
 

--- a/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntent+Stripe.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/PaymentIntent+Stripe.swift
@@ -11,7 +11,7 @@ extension PaymentIntent {
         self.created = intent.created
         self.amount = intent.amount
         self.currency = intent.currency
-        self.metadata = intent.metadata as? [String: String]
+        self.metadata = intent.metadata
         self.charges = intent.charges.map { .init(charge: $0) }
     }
 }
@@ -28,7 +28,7 @@ protocol StripePaymentIntent {
     var status: StripeTerminal.PaymentIntentStatus { get }
     var amount: UInt { get }
     var currency: String { get }
-    var metadata: [AnyHashable: Any]? { get }
+    var metadata: [String: String]? { get }
     var charges: [StripeTerminal.Charge] { get }
 }
 

--- a/Hardware/Hardware/Model/Copiable/Models+Copiable.generated.swift
+++ b/Hardware/Hardware/Model/Copiable/Models+Copiable.generated.swift
@@ -41,7 +41,7 @@ extension Hardware.Charge {
         currency: CopiableProp<String> = .copy,
         status: CopiableProp<ChargeStatus> = .copy,
         description: NullableCopiableProp<String> = .copy,
-        metadata: NullableCopiableProp<[AnyHashable: Any]> = .copy,
+        metadata: NullableCopiableProp<[String: String]> = .copy,
         paymentMethod: NullableCopiableProp<PaymentMethod> = .copy
     ) -> Hardware.Charge {
         let id = id ?? self.id

--- a/Hardware/HardwareTests/ChargeTests.swift
+++ b/Hardware/HardwareTests/ChargeTests.swift
@@ -43,7 +43,6 @@ final class ChargeTests: XCTestCase {
         let charge = Charge(charge: mockCharge)
 
         XCTAssertNotNil(charge.metadata)
-        // Asserting keys only, as the metadata is types as [Hashable: Any]
-        XCTAssertEqual(charge.metadata?.keys, mockCharge.metadata.keys)
+        XCTAssertEqual(charge.metadata, mockCharge.metadata)
     }
 }

--- a/Hardware/HardwareTests/Mocks/MockStripeCharge.swift
+++ b/Hardware/HardwareTests/Mocks/MockStripeCharge.swift
@@ -9,7 +9,7 @@ struct MockStripeCharge {
     let currency: String
     let status: StripeTerminal.ChargeStatus
     let stripeDescription: String?
-    let metadata: [AnyHashable: Any]
+    let metadata: [String: String]
     let paymentMethodDetails: StripeTerminal.PaymentMethodDetails?
 }
 

--- a/Hardware/HardwareTests/Mocks/MockStripePaymentIntent.swift
+++ b/Hardware/HardwareTests/Mocks/MockStripePaymentIntent.swift
@@ -9,7 +9,7 @@ struct MockStripePaymentIntent {
     let status: StripeTerminal.PaymentIntentStatus
     let amount: UInt
     let currency: String
-    let metadata: [AnyHashable: Any]?
+    let metadata: [String: String]?
     let charges: [StripeTerminal.Charge]
 }
 

--- a/Podfile
+++ b/Podfile
@@ -51,7 +51,7 @@ def cocoa_lumberjack
 end
 
 def stripe_terminal
-  pod 'StripeTerminal', '~> 2.14'
+  pod 'StripeTerminal', '~> 2.18'
 end
 
 def networking_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,7 +33,7 @@ PODS:
   - Sentry/Core (7.31.5)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
-  - StripeTerminal (2.14.0)
+  - StripeTerminal (2.18.0)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (2.2.0)
   - WordPress-Aztec-iOS (1.11.0)
@@ -82,7 +82,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 4.2.2)
   - Kingfisher (~> 7.6.2)
   - Sourcery (~> 1.0.3)
-  - StripeTerminal (~> 2.14)
+  - StripeTerminal (~> 2.18)
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (~> 5.5)
   - WordPressShared (~> 2.0)
@@ -147,7 +147,7 @@ SPEC CHECKSUMS:
   Sentry: 4c9babff9034785067c896fd580b1f7de44da020
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
-  StripeTerminal: 9bb367c9efa7bcddf2602cc29f8962390d87b6a6
+  StripeTerminal: 2259c7f6a304d13d016a8bd3aae82beeb79bf305
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
@@ -168,6 +168,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 98bcf5fe146d2c2309a4fa0fb01a864d3608f4ab
+PODFILE CHECKSUM: 83cd8f88a8c42eb28a50c4856af876bed7cc43eb
 
 COCOAPODS: 1.11.3

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 12.8
 -----
 - [Internal] Dashboard: the UI layer had a major refactoring to allow scrolling for content more than stats for the onboarding project. The main design change is on the refresh control, where it was moved from each stats tab to below the navigation bar. Other design changes are not expected. [https://github.com/woocommerce/woocommerce-ios/pull/9031]
+- [Internal] Mobile Payments: Updated StripeTerminal to 2.18 [https://github.com/woocommerce/woocommerce-ios/pull/9118]
 
 12.7
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Stripe have updated their SDK a few times recently. This moves us from 2.14 to 2.18.

### Relevant release notes from Stripe
> 2.18: Fixed bug where the SDK may have not called [reader:didReportReaderEvent:info:](https://stripe.dev/stripe-terminal-ios/docs/Protocols/SCPBluetoothReaderDelegate.html#/c:objc(pl)SCPBluetoothReaderDelegate(im)reader:didReportReaderEvent:info:) or [reader:didRequestReaderInput:](https://stripe.dev/stripe-terminal-ios/docs/Protocols/SCPBluetoothReaderDelegate.html#/c:objc(pl)SCPBluetoothReaderDelegate(im)reader:didRequestReaderInput:) when it should have.
>
> Fixed an issue where faulty readers may fail processPayment with "You passed an empty string for 'payment_method_data[card_present][emv_data]'". These readers will now fail collectPaymentMethod with error code SCPErrorMissingEMVData
>
> 2.17.1: Fixes an issue where the SDK may report a failure during processPayment if a reader error or disconnect is received while process is in-progress but the /confirm request was successful. The SDK will now wait for the /confirm API response and will report success if the PaymentIntent status moved to requires_capture or succeeded.
>
> 2.17: Added missing type annotations of <NSString *, NSString *> to all metadata dictionaries.
>
> Fixes https://github.com/stripe/stripe-terminal-ios/issues/184: SCPAppleBuiltInReaderErrorCodeNotAllowed is now returned more consistently when attempting to discover Tap to Pay on iPhone readers on apps with a missing entitlement.
>
> Fixes https://github.com/stripe/stripe-terminal-ios/issues/199: deviceSoftwareVersion on Reader could start returning fw-config-ksid instead of the reader's correct software version.
>
> 2.16: Fixes https://github.com/stripe/stripe-terminal-ios/issues/189 by adding -no-serialize-debugging-options to Swift flags.
>
> 2.15: Fixes an issue where processRefund and confirmSetupIntent were returning error SCPErrorUnexpectedSdkError instead of SCPErrorBusy or SCPErrorNotConnectedToReader for those error cases.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Take payments using the following readers:
- Tap to Pay on iPhone (USA)
- M2 (USA)
- WisePad 3 (Canada)

Refund an Interac payment using a Canadian store

Observe that payments and client-side refunds work as expected.

Connect to an external reader using Menu > Payments > Manage Card Reader: observe that the software version number is displayed.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
