### PR TITLE
Store onboarding > launch store: present a modal with a no-op CTA to publish store

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -10,6 +10,7 @@ final class StoreOnboardingCoordinator: Coordinator {
 
     private var addProductCoordinator: AddProductCoordinator?
     private var domainSettingsCoordinator: DomainSettingsCoordinator?
+    private var launchStoreCoordinator: StoreOnboardingLaunchStoreCoordinator?
 
     private let site: Site
 
@@ -38,6 +39,8 @@ final class StoreOnboardingCoordinator: Coordinator {
             addProduct()
         case .customizeDomains:
             showCustomDomains()
+        case .launchStore:
+            launchStore()
         default:
             #warning("TODO: handle navigation for each onboarding task")
             start()
@@ -60,6 +63,17 @@ private extension StoreOnboardingCoordinator {
     func showCustomDomains() {
         let coordinator = DomainSettingsCoordinator(source: .dashboardOnboarding, site: site, navigationController: navigationController)
         self.domainSettingsCoordinator = coordinator
+        coordinator.start()
+    }
+
+    @MainActor
+    func launchStore() {
+        guard let siteURL = URL(string: site.url) else {
+            assertionFailure("The site does not have a valid URL to launch from store onboarding: \(site).")
+            return
+        }
+        let coordinator = StoreOnboardingLaunchStoreCoordinator(siteURL: siteURL, navigationController: navigationController)
+        self.launchStoreCoordinator = coordinator
         coordinator.start()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreCoordinator.swift
@@ -11,7 +11,7 @@ final class StoreOnboardingLaunchStoreCoordinator: Coordinator {
     }
 
     func start() {
-        let launchStoreController = UIHostingController(rootView: StoreOnboardingLaunchStoreView(viewModel: .init(siteURL: siteURL)))
-        navigationController.show(launchStoreController, sender: nil)
+        let launchStoreController = StoreOnboardingLaunchStoreHostingController(viewModel: .init(siteURL: siteURL))
+        navigationController.present(WooNavigationController(rootViewController: launchStoreController), animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreCoordinator.swift
@@ -1,0 +1,17 @@
+import UIKit
+import SwiftUI
+
+final class StoreOnboardingLaunchStoreCoordinator: Coordinator {
+    let navigationController: UINavigationController
+    private let siteURL: URL
+
+    init(siteURL: URL, navigationController: UINavigationController) {
+        self.siteURL = siteURL
+        self.navigationController = navigationController
+    }
+
+    func start() {
+        let launchStoreController = UIHostingController(rootView: StoreOnboardingLaunchStoreView(viewModel: .init(siteURL: siteURL)))
+        navigationController.show(launchStoreController, sender: nil)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreCoordinator.swift
@@ -1,6 +1,7 @@
 import UIKit
 import SwiftUI
 
+/// Coordinates navigation of the launch store action from store onboarding.
 final class StoreOnboardingLaunchStoreCoordinator: Coordinator {
     let navigationController: UINavigationController
     private let siteURL: URL

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
@@ -43,7 +43,6 @@ struct StoreOnboardingLaunchStoreView: View {
                 Divider()
                     .dividerStyle()
 
-
                 // Launch store button.
                 Button(Localization.launchStoreButton) {
                     Task { @MainActor in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct StoreOnboardingLaunchStoreView: View {
+    // Tracks the scale of the view due to accessibility changes.
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    @ObservedObject private var viewModel: StoreOnboardingLaunchStoreViewModel
+
+    init(viewModel: StoreOnboardingLaunchStoreViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        ScrollView {
+            #warning("TODO: 9122 - show upsell banner when the launch store action requires an upgraded plan")
+
+            // Readonly webview for the new site.
+            WebView(isPresented: .constant(true), url: viewModel.siteURL)
+                .frame(height: 400 * scale)
+                .disabled(true)
+        }
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: 0) {
+                Divider()
+                    .frame(height: 1)
+                    .foregroundColor(Color(.separator))
+
+                VStack(spacing: 16) {
+                    // Launch store button.
+                    Button(Localization.launchStoreButton) {
+                        Task { @MainActor in
+                            try await viewModel.launchStore()
+                        }
+                    }
+                    .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLaunchingStore))
+                }
+                .padding(insets: Layout.buttonContainerPadding)
+            }
+            .background(Color(.systemBackground))
+        }
+    }
+}
+
+private extension StoreOnboardingLaunchStoreView {
+    enum Layout {
+        static let contentPadding: EdgeInsets = .init(top: 38, leading: 16, bottom: 16, trailing: 16)
+        static let buttonContainerPadding: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+        static let webviewHorizontalPadding: EdgeInsets = .init(top: 0, leading: 44, bottom: 0, trailing: 44)
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Preview",
+            comment: "Title of the store onboarding > launch store screen."
+        )
+        static let launchStoreButton = NSLocalizedString(
+            "Publish My Store",
+            comment: "Title of the primary button on the store onboarding > launch store screen to publish a store."
+        )
+    }
+}
+
+struct StoreOnboardingLaunchStoreView_Previews: PreviewProvider {
+    static var previews: some View {
+        StoreOnboardingLaunchStoreView(viewModel: .init(siteURL: .init(string: "https://woocommerce.com")!))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
@@ -1,5 +1,24 @@
 import SwiftUI
 
+/// Hosting controller that wraps the `StoreOnboardingLaunchStoreView`.
+final class StoreOnboardingLaunchStoreHostingController: UIHostingController<StoreOnboardingLaunchStoreView> {
+    init(viewModel: StoreOnboardingLaunchStoreViewModel) {
+        super.init(rootView: StoreOnboardingLaunchStoreView(viewModel: viewModel))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureTransparentNavigationBar()
+    }
+}
+
+/// Shows a preview of the site with a CTA to launch store if applicable.
 struct StoreOnboardingLaunchStoreView: View {
     // Tracks the scale of the view due to accessibility changes.
     @ScaledMetric private var scale: CGFloat = 1.0
@@ -38,6 +57,7 @@ struct StoreOnboardingLaunchStoreView: View {
             }
             .background(Color(.systemBackground))
         }
+        .navigationTitle(Localization.title)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
@@ -33,26 +33,24 @@ struct StoreOnboardingLaunchStoreView: View {
         ScrollView {
             #warning("TODO: 9122 - show upsell banner when the launch store action requires an upgraded plan")
 
-            // Readonly webview for the new site.
+            // Readonly webview for the site.
             WebView(isPresented: .constant(true), url: viewModel.siteURL)
-                .frame(height: 400 * scale)
+                .frame(height: Layout.webviewHeight * scale)
                 .disabled(true)
         }
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 0) {
                 Divider()
-                    .frame(height: 1)
-                    .foregroundColor(Color(.separator))
+                    .dividerStyle()
 
-                VStack(spacing: 16) {
-                    // Launch store button.
-                    Button(Localization.launchStoreButton) {
-                        Task { @MainActor in
-                            try await viewModel.launchStore()
-                        }
+
+                // Launch store button.
+                Button(Localization.launchStoreButton) {
+                    Task { @MainActor in
+                        try await viewModel.launchStore()
                     }
-                    .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLaunchingStore))
                 }
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLaunchingStore))
                 .padding(insets: Layout.buttonContainerPadding)
             }
             .background(Color(.systemBackground))
@@ -63,9 +61,8 @@ struct StoreOnboardingLaunchStoreView: View {
 
 private extension StoreOnboardingLaunchStoreView {
     enum Layout {
-        static let contentPadding: EdgeInsets = .init(top: 38, leading: 16, bottom: 16, trailing: 16)
+        static let webviewHeight: CGFloat = 400
         static let buttonContainerPadding: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
-        static let webviewHorizontalPadding: EdgeInsets = .init(top: 0, leading: 44, bottom: 0, trailing: 44)
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Yosemite
 
+/// View model for `StoreOnboardingLaunchStoreView`.
 final class StoreOnboardingLaunchStoreViewModel: ObservableObject {
     let siteURL: URL
 
@@ -13,7 +14,5 @@ final class StoreOnboardingLaunchStoreViewModel: ObservableObject {
     func launchStore() async throws {
         isLaunchingStore = true
         #warning("TODO: 9122 - launch store action")
-        throw StoreCreationError.invalidCompletionPath
-        isLaunchingStore = false
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import Yosemite
+
+final class StoreOnboardingLaunchStoreViewModel: ObservableObject {
+    let siteURL: URL
+
+    @Published private(set) var isLaunchingStore: Bool = false
+
+    init(siteURL: URL) {
+        self.siteURL = siteURL
+    }
+
+    func launchStore() async throws {
+        isLaunchingStore = true
+        #warning("TODO: 9122 - launch store action")
+        throw StoreCreationError.invalidCompletionPath
+        isLaunchingStore = false
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
@@ -11,6 +11,7 @@ final class StoreOnboardingLaunchStoreViewModel: ObservableObject {
         self.siteURL = siteURL
     }
 
+    @MainActor
     func launchStore() async throws {
         isLaunchingStore = true
         #warning("TODO: 9122 - launch store action")

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -301,6 +301,9 @@
 		027D4A8D2526FD1800108626 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027D4A8B2526FD1700108626 /* SettingsViewController.swift */; };
 		027D4A8E2526FD1800108626 /* SettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 027D4A8C2526FD1700108626 /* SettingsViewController.xib */; };
 		027D67D1245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027D67D0245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift */; };
+		027EB56C29C05F4B003CE551 /* StoreOnboardingLaunchStoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027EB56B29C05F4A003CE551 /* StoreOnboardingLaunchStoreView.swift */; };
+		027EB56E29C0602D003CE551 /* StoreOnboardingLaunchStoreViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027EB56D29C0602D003CE551 /* StoreOnboardingLaunchStoreViewModel.swift */; };
+		027EB57029C062DD003CE551 /* StoreOnboardingLaunchStoreCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027EB56F29C062DD003CE551 /* StoreOnboardingLaunchStoreCoordinator.swift */; };
 		027F240C258371150021DB06 /* RefundShippingLabelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027F240B258371150021DB06 /* RefundShippingLabelViewModelTests.swift */; };
 		027F83ED29B046D2002688C6 /* DashboardTopPerformersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027F83EC29B046D2002688C6 /* DashboardTopPerformersViewModel.swift */; };
 		027F83EF29B048E2002688C6 /* DashboardTopPerformersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027F83EE29B048E2002688C6 /* DashboardTopPerformersViewModelTests.swift */; };
@@ -1318,7 +1321,6 @@
 		AEFF77AA29786DAA00667F7A /* PriceInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFF77A929786DAA00667F7A /* PriceInputViewModelTests.swift */; };
 		B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509112D2049E27A007D25DC /* DashboardViewController.swift */; };
 		B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED021C041DF000076A9 /* Locale+Woo.swift */; };
-		B509FED521C052D1000076A9 /* MockSupportManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED421C052D1000076A9 /* MockSupportManager.swift */; };
 		B50BB4162141828F00AF0F3C /* FooterSpinnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50BB4152141828F00AF0F3C /* FooterSpinnerView.swift */; };
 		B511ED27218A660E005787DC /* StringDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B511ED26218A660E005787DC /* StringDescriptor.swift */; };
 		B517EA18218B232700730EC4 /* StringFormatter+Notes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B517EA17218B232700730EC4 /* StringFormatter+Notes.swift */; };
@@ -2461,6 +2463,9 @@
 		027D4A8B2526FD1700108626 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		027D4A8C2526FD1700108626 /* SettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsViewController.xib; sourceTree = "<group>"; };
 		027D67D0245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterTypeViewModel+Helpers.swift"; sourceTree = "<group>"; };
+		027EB56B29C05F4A003CE551 /* StoreOnboardingLaunchStoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingLaunchStoreView.swift; sourceTree = "<group>"; };
+		027EB56D29C0602D003CE551 /* StoreOnboardingLaunchStoreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingLaunchStoreViewModel.swift; sourceTree = "<group>"; };
+		027EB56F29C062DD003CE551 /* StoreOnboardingLaunchStoreCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingLaunchStoreCoordinator.swift; sourceTree = "<group>"; };
 		027F240B258371150021DB06 /* RefundShippingLabelViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingLabelViewModelTests.swift; sourceTree = "<group>"; };
 		027F83EC29B046D2002688C6 /* DashboardTopPerformersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTopPerformersViewModel.swift; sourceTree = "<group>"; };
 		027F83EE29B048E2002688C6 /* DashboardTopPerformersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTopPerformersViewModelTests.swift; sourceTree = "<group>"; };
@@ -5297,6 +5302,9 @@
 				02BBD6EA29A316FB00243BE2 /* StoreOnboardingCoordinator.swift */,
 				EEC5E01029A70CC300416CAC /* StoreSetupProgressView.swift */,
 				EEB4E2D429B205F400371C3C /* StoreOnboardingTaskViewModel.swift */,
+				027EB56B29C05F4A003CE551 /* StoreOnboardingLaunchStoreView.swift */,
+				027EB56D29C0602D003CE551 /* StoreOnboardingLaunchStoreViewModel.swift */,
+				027EB56F29C062DD003CE551 /* StoreOnboardingLaunchStoreCoordinator.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -10629,6 +10637,7 @@
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
 				45BBFBC5274FDCE900213001 /* HubMenu.swift in Sources */,
 				02A9BCD62737F73C00159C79 /* JetpackBenefitItem.swift in Sources */,
+				027EB56E29C0602D003CE551 /* StoreOnboardingLaunchStoreViewModel.swift in Sources */,
 				26C6439327B5DBE900DD00D1 /* OrderSynchronizer.swift in Sources */,
 				CE0F17D222A8308900964A63 /* FancyAlertController+PurchaseNote.swift in Sources */,
 				684AB83A2870677F003DFDD1 /* CardReaderManualsView.swift in Sources */,
@@ -10749,6 +10758,7 @@
 				2602A63F27BD880A00B347F1 /* NewOrderInitialStatusResolver.swift in Sources */,
 				0201E42B2946151100C793C7 /* StoreCreationCategoryQuestionViewModel.swift in Sources */,
 				E120F63826C26B550005A029 /* InPersonPaymentsLoadingView.swift in Sources */,
+				027EB57029C062DD003CE551 /* StoreOnboardingLaunchStoreCoordinator.swift in Sources */,
 				456417F4247D5434001203F6 /* UITableView+Helpers.swift in Sources */,
 				E15FC74326BC1D2700CF83E6 /* SafariSheet.swift in Sources */,
 				459DB7D52673721300E2CAD2 /* TopLoaderView.swift in Sources */,
@@ -11506,6 +11516,7 @@
 				0371C3682875E47B00277E2C /* FeatureAnnouncementCardViewModel.swift in Sources */,
 				03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */,
 				B946881029B8DD01000646B0 /* InPersonPaymentsMenuViewController+Activity.swift in Sources */,
+				027EB56C29C05F4B003CE551 /* StoreOnboardingLaunchStoreView.swift in Sources */,
 				09EA565527C8ACEE00407D40 /* BulkUpdateViewController.swift in Sources */,
 				2602A64627BDBEBA00B347F1 /* ProductInputTransformer.swift in Sources */,
 				02BBD6E929A3024400243BE2 /* StoreOnboardingTaskView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9122 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implemented the first step of the onboarding > launch store flow to show a modal of the site preview with a CTA to publish the store. The action is currently a no-op, and the API call will be in a separate follow-up subtask. You can see all the subtasks in #9122.

A new SwiftUI view `StoreOnboardingLaunchStoreView` was created, along with its view model, hosting controller, and a coordinator `StoreOnboardingLaunchStoreCoordinator` to coordinate the navigation later on.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the site is hosted on WPCOM

- Log in to the site in the prerequisite --> on the My store, there should be an onboarding task called `Launch your store`. If you don't see this, tap `View all (#)` and it should be listed
- Tap `Launch your store` --> a modal should be presented with a webview of the site preview and a CTA to publish the store
- Tap `Publish My Store` --> a spinner should be shown in the CTA (as a placeholder)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light | light - publishing
-- | -- | --
![Simulator Screen Shot - iPhone 14 - 2023-03-14 at 16 40 13](https://user-images.githubusercontent.com/1945542/224952393-8efb728e-be29-4d79-a0b5-486cdafb62fb.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-14 at 16 40 28](https://user-images.githubusercontent.com/1945542/224952398-a7b92c65-db20-4b8e-a89d-5f1d0195bc1d.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-14 at 16 40 31](https://user-images.githubusercontent.com/1945542/224952399-f342a97f-b65c-4c93-b269-ebafc3f0c0d4.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
