### PR TITLE
[Store onboarding] Hide task list if all tasks are completed

### DIFF
--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -25,6 +25,7 @@ extension UserDefaults {
         case analyticsUsername
         case notificationsLastSeenTime
         case notificationsMarkAsReadCount
+        case completedAllStoreOnboardingTasks
     }
 }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -161,11 +161,11 @@ final class SessionManager: SessionManagerProtocol {
     ///
     func reset() {
         deleteApplicationPassword()
-        defaults[.completedAllStoreOnboardingTasks] = nil
         defaultAccount = nil
         defaultCredentials = nil
         defaultStoreID = nil
         defaultSite = nil
+        defaults[.completedAllStoreOnboardingTasks] = nil
     }
 
     /// Deletes application password

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -165,6 +165,7 @@ final class SessionManager: SessionManagerProtocol {
         defaultCredentials = nil
         defaultStoreID = nil
         defaultSite = nil
+        defaults[.completedAllStoreOnboardingTasks] = nil
     }
 
     /// Deletes application password

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -161,11 +161,11 @@ final class SessionManager: SessionManagerProtocol {
     ///
     func reset() {
         deleteApplicationPassword()
+        defaults[.completedAllStoreOnboardingTasks] = nil
         defaultAccount = nil
         defaultCredentials = nil
         defaultStoreID = nil
         defaultSite = nil
-        defaults[.completedAllStoreOnboardingTasks] = nil
     }
 
     /// Deletes application password

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -563,8 +563,7 @@ private extension DashboardViewController {
         }
 
         let hostingController = StoreOnboardingViewHostingController(viewModel: .init(isExpanded: false,
-                                                                                      siteID: site.siteID,
-                                                                                      onAllOnboardingTasksCompleted: viewModel.didCompleteAllOnboardingTasks),
+                                                                                      siteID: site.siteID),
                                                                      navigationController: navigationController,
                                                                      site: site,
                                                                      shareFeedbackAction: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -562,7 +562,9 @@ private extension DashboardViewController {
             removeOnboardingCard()
         }
 
-        let hostingController = StoreOnboardingViewHostingController(viewModel: .init(isExpanded: false, siteID: site.siteID),
+        let hostingController = StoreOnboardingViewHostingController(viewModel: .init(isExpanded: false,
+                                                                                      siteID: site.siteID,
+                                                                                      onAllOnboardingTasksCompleted: viewModel.didCompleteAllOnboardingTasks),
                                                                      navigationController: navigationController,
                                                                      site: site,
                                                                      shareFeedbackAction: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -27,16 +27,19 @@ final class DashboardViewModel {
     private let featureFlagService: FeatureFlagService
     private let analytics: Analytics
     private let justInTimeMessagesManager: JustInTimeMessagesProvider
+    private let userDefaults: UserDefaults
 
     init(stores: StoresManager = ServiceLocator.stores,
          featureFlags: FeatureFlagService = ServiceLocator.featureFlagService,
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         userDefaults: UserDefaults = .standard) {
         self.stores = stores
         self.featureFlagService = featureFlags
         self.analytics = analytics
+        self.userDefaults = userDefaults
         self.justInTimeMessagesManager = JustInTimeMessagesProvider(stores: stores, analytics: analytics)
-        // TODO: 8893 - determine if the onboarding view should be shown based on more criteria
-        self.showOnboarding = featureFlags.isFeatureFlagEnabled(.dashboardOnboarding)
+        let completedAllOnboardingTasks = userDefaults[.completedAllStoreOnboardingTasks] as? Bool ?? false
+        self.showOnboarding = featureFlags.isFeatureFlagEnabled(.dashboardOnboarding) && (completedAllOnboardingTasks == false)
     }
 
     /// Syncs store stats for dashboard UI.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -23,6 +23,12 @@ final class DashboardViewModel {
     ///
     let addProductTrigger = PassthroughSubject<Void, Never>()
 
+    /// Should be called when all the store onboarding tasks are completed
+    ///
+    func didCompleteAllOnboardingTasks() {
+        self.showOnboarding = false
+    }
+
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
     private let analytics: Analytics

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -140,7 +140,7 @@ struct StoreOnboardingView: View {
 
                 // View all button
                 viewAllButton(action: viewAllTapped, text: String(format: Localization.viewAll, viewModel.taskViewModels.count))
-                    .renderedIf(!viewModel.isExpanded)
+                    .renderedIf(!viewModel.isExpanded && !viewModel.isRedacted)
 
                 Spacer()
                     .renderedIf(viewModel.isExpanded)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -74,7 +74,9 @@ class StoreOnboardingViewModel: ObservableObject {
     func reloadTasks() async {
         await update(state: .loading)
         let tasks = try? await loadTasks()
-        await checkIfAllTasksAreCompleted()
+        if let tasks {
+            await checkIfAllTasksAreCompleted(tasks)
+        }
         await update(state: .loaded(rows: tasks ?? taskViewModels))
     }
 }
@@ -109,8 +111,12 @@ private extension StoreOnboardingViewModel {
     }
 
     @MainActor
-    func checkIfAllTasksAreCompleted() {
-        let isPendingTaskPresent = taskViewModels.contains(where: { $0.isComplete == false })
+    func checkIfAllTasksAreCompleted(_ tasksFromServer: [StoreOnboardingTaskViewModel]) {
+        guard tasksFromServer.isNotEmpty else {
+            return
+        }
+
+        let isPendingTaskPresent = tasksFromServer.contains(where: { $0.isComplete == false })
         guard isPendingTaskPresent == false else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -121,7 +121,7 @@ private extension StoreOnboardingViewModel {
             return
         }
 
-        // This will be reset to `false` when session resets
+        // This will be reset to `nil` when session resets
         defaults[.completedAllStoreOnboardingTasks] = true
         onAllOnboardingTasksCompleted?()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -49,26 +49,20 @@ class StoreOnboardingViewModel: ObservableObject {
 
     private let defaults: UserDefaults
 
-    private let onAllOnboardingTasksCompleted: (() -> Void)?
-
-    /// Initializer
     /// - Parameters:
     ///   - isExpanded: Whether the onboarding view is in the expanded state. The expanded state is shown when the view is in fullscreen.
     ///   - siteID: siteID
     ///   - stores: StoresManager
     ///   - userDefaults: UserDefaults for storing when all onboarding tasks are completed
-    ///   - onAllOnboardingTasksCompleted:Callback to fire when all onboarding tasks are completed
     init(isExpanded: Bool,
          siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
-         defaults: UserDefaults = .standard,
-         onAllOnboardingTasksCompleted: (() -> Void)? = nil) {
+         defaults: UserDefaults = .standard) {
         self.isExpanded = isExpanded
         self.siteID = siteID
         self.stores = stores
         self.state = .loading
         self.defaults = defaults
-        self.onAllOnboardingTasksCompleted = onAllOnboardingTasksCompleted
     }
 
     func reloadTasks() async {
@@ -123,7 +117,6 @@ private extension StoreOnboardingViewModel {
 
         // This will be reset to `nil` when session resets
         defaults[.completedAllStoreOnboardingTasks] = true
-        onAllOnboardingTasksCompleted?()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -67,11 +67,12 @@ class StoreOnboardingViewModel: ObservableObject {
 
     func reloadTasks() async {
         await update(state: .loading)
-        let tasks = try? await loadTasks()
-        if let tasks {
+        if let tasks = try? await loadTasks() {
             await checkIfAllTasksAreCompleted(tasks)
+            await update(state: .loaded(rows: tasks))
+        } else {
+            await update(state: .loaded(rows: taskViewModels))
         }
-        await update(state: .loaded(rows: tasks ?? taskViewModels))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -47,19 +47,34 @@ class StoreOnboardingViewModel: ObservableObject {
     private let placeholderTasks: [StoreOnboardingTaskViewModel] = Array(repeating: StoreOnboardingTaskViewModel.placeHolder(),
                                                                          count: 3)
 
-    /// - Parameter isExpanded: Whether the onboarding view is in the expanded state. The expanded state is shown when the view is in fullscreen.
+    private let defaults: UserDefaults
+
+    private let onAllOnboardingTasksCompleted: (() -> Void)?
+
+    /// Initializer
+    /// - Parameters:
+    ///   - isExpanded: Whether the onboarding view is in the expanded state. The expanded state is shown when the view is in fullscreen.
+    ///   - siteID: siteID
+    ///   - stores: StoresManager
+    ///   - userDefaults: UserDefaults for storing when all onboarding tasks are completed
+    ///   - onAllOnboardingTasksCompleted:Callback to fire when all onboarding tasks are completed
     init(isExpanded: Bool,
          siteID: Int64,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         defaults: UserDefaults = .standard,
+         onAllOnboardingTasksCompleted: (() -> Void)? = nil) {
         self.isExpanded = isExpanded
         self.siteID = siteID
         self.stores = stores
         self.state = .loading
+        self.defaults = defaults
+        self.onAllOnboardingTasksCompleted = onAllOnboardingTasksCompleted
     }
 
     func reloadTasks() async {
         await update(state: .loading)
         let tasks = try? await loadTasks()
+        await checkIfAllTasksAreCompleted()
         await update(state: .loaded(rows: tasks ?? taskViewModels))
     }
 }
@@ -91,6 +106,18 @@ private extension StoreOnboardingViewModel {
             self.taskViewModels = items
         }
         onStateChange?()
+    }
+
+    @MainActor
+    func checkIfAllTasksAreCompleted() {
+        let isPendingTaskPresent = taskViewModels.contains(where: { $0.isComplete == false })
+        guard isPendingTaskPresent == false else {
+            return
+        }
+
+        // This will be reset to `false` when session resets
+        defaults[.completedAllStoreOnboardingTasks] = true
+        onAllOnboardingTasksCompleted?()
     }
 }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -183,7 +183,6 @@ class DefaultStoresManager: StoresManager {
     ///
     func removeDefaultStore() {
         sessionManager.deleteApplicationPassword()
-        defaults[.completedAllStoreOnboardingTasks] = nil
         ServiceLocator.analytics.refreshUserData()
         ZendeskProvider.shared.reset()
         ServiceLocator.pushNotesManager.unregisterForRemoteNotifications()
@@ -222,6 +221,7 @@ class DefaultStoresManager: StoresManager {
         // Because `defaultSite` is loaded or synced asynchronously, it is reset here so that any UI that calls this does not show outdated data.
         // For example, `sessionManager.defaultSite` is used to show site name in various screens in the app.
         sessionManager.defaultSite = nil
+        defaults[.completedAllStoreOnboardingTasks] = nil
         restoreSessionSiteIfPossible()
         ServiceLocator.pushNotesManager.reloadBadgeCount()
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -23,6 +23,8 @@ class DefaultStoresManager: StoresManager {
     /// https://github.com/woocommerce/woocommerce-ios/issues/878
     private var _sessionManager: SessionManagerProtocol
 
+    private let defaults: UserDefaults
+
     /// Keychain access. Used for sharing the auth access token with the widgets extension.
     ///
     private lazy var keychain = Keychain(service: WooConstants.keychainServiceName)
@@ -110,10 +112,12 @@ class DefaultStoresManager: StoresManager {
     /// Designated Initializer
     ///
     init(sessionManager: SessionManagerProtocol,
-         notificationCenter: NotificationCenter = .default) {
+         notificationCenter: NotificationCenter = .default,
+         defaults: UserDefaults = .standard) {
         _sessionManager = sessionManager
         self.state = AuthenticatedState(sessionManager: sessionManager) ?? DeauthenticatedState()
         self.notificationCenter = notificationCenter
+        self.defaults = defaults
 
         isLoggedIn = isAuthenticated
 
@@ -179,6 +183,7 @@ class DefaultStoresManager: StoresManager {
     ///
     func removeDefaultStore() {
         sessionManager.deleteApplicationPassword()
+        defaults[.completedAllStoreOnboardingTasks] = nil
         ServiceLocator.analytics.refreshUserData()
         ZendeskProvider.shared.reset()
         ServiceLocator.pushNotesManager.unregisterForRemoteNotifications()

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -14,6 +14,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isSupportRequestEnabled: Bool
     private let isProductMultiSelectionM1Enabled: Bool
     private let isAddCouponToOrderEnabled: Bool
+    private let isDashboardStoreOnboardingEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -26,7 +27,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isDomainSettingsEnabled: Bool = false,
          isSupportRequestEnabled: Bool = false,
          isProductMultiSelectionM1Enabled: Bool = false,
-         isAddCouponToOrderEnabled: Bool = false) {
+         isAddCouponToOrderEnabled: Bool = false,
+         isDashboardStoreOnboardingEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -39,6 +41,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isSupportRequestEnabled = isSupportRequestEnabled
         self.isProductMultiSelectionM1Enabled = isProductMultiSelectionM1Enabled
         self.isAddCouponToOrderEnabled = isAddCouponToOrderEnabled
+        self.isDashboardStoreOnboardingEnabled = isDashboardStoreOnboardingEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -67,6 +70,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isProductMultiSelectionM1Enabled
         case .addCouponToOrder:
             return isAddCouponToOrderEnabled
+        case .dashboardOnboarding:
+            return isDashboardStoreOnboardingEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -109,6 +109,27 @@ class SessionManagerTests: XCTestCase {
         }
     }
 
+    /// Verifies that `completedAllStoreOnboardingTasks` is set to `nil` upon reset
+    ///
+    func test_completedAllStoreOnboardingTasks_is_set_to_nil_upon_reset() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = UserDefaults(suiteName: uuid)!
+        let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
+
+        // Then
+        defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = true
+
+        // When
+        XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? Bool))
+
+        // When
+        sut.reset()
+
+        // Then
+        XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
+    }
+
     /// Verifies that `removeDefaultCredentials` effectively nukes everything from the keychain
     ///
     func testDefaultCredentialsAreEffectivelyNuked() {
@@ -154,7 +175,6 @@ class SessionManagerTests: XCTestCase {
         XCTAssertEqual(sut.defaultCredentials, Settings.wpcomCredentials)
     }
 }
-
 
 // MARK: - Testing Constants
 //

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -114,13 +114,13 @@ class SessionManagerTests: XCTestCase {
     func test_completedAllStoreOnboardingTasks_is_set_to_nil_upon_reset() throws {
         // Given
         let uuid = UUID().uuidString
-        let defaults = UserDefaults(suiteName: uuid)!
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
 
-        // Then
+        // When
         defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = true
 
-        // When
+        // Then
         XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? Bool))
 
         // When
@@ -151,12 +151,12 @@ class SessionManagerTests: XCTestCase {
 
     /// Verifies that WPCOM credentials are returned for already installed and logged in versions which don't have type stored in user defaults
     ///
-    func test_already_installed_version_without_authentication_type_saved_returns_WPCOM_credentials() {
+    func test_already_installed_version_without_authentication_type_saved_returns_WPCOM_credentials() throws {
         // Given
         let uuid = UUID().uuidString
 
         // Prepare user defaults
-        let defaults = UserDefaults(suiteName: uuid)!
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         defaults[UserDefaults.Key.defaultUsername] = "lalala"
         defaults[UserDefaults.Key.defaultSiteAddress] = "https://example.com"
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -354,15 +354,17 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.showOnboarding)
     }
 
-    func test_showOnboarding_is_set_to_false_upon_calling_didCompleteAllOnboardingTasks() {
+    func test_showOnboarding_is_set_to_false_upon_setting_user_defaults_value_completedAllStoreOnboardingTasks_as_true() throws {
         // Given
-        let viewModel = DashboardViewModel()
-
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let viewModel = DashboardViewModel(featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
+                                           userDefaults: defaults)
         // Then
         XCTAssertTrue(viewModel.showOnboarding)
 
         // When
-        viewModel.didCompleteAllOnboardingTasks()
+        defaults[.completedAllStoreOnboardingTasks] = true
 
         // Then
         XCTAssertFalse(viewModel.showOnboarding)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -300,10 +300,10 @@ final class DashboardViewModelTests: XCTestCase {
 
     // MARK: Store onboarding
 
-    func test_showOnboarding_is_false_when_feature_flag_is_turned_off_and_completedAllStoreOnboardingTasks_is_false() async {
+    func test_showOnboarding_is_false_when_feature_flag_is_turned_off_and_completedAllStoreOnboardingTasks_is_false() async throws {
         // Given
         let uuid = UUID().uuidString
-        let defaults = UserDefaults(suiteName: uuid)!
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         defaults[.completedAllStoreOnboardingTasks] = false
         let viewModel = DashboardViewModel(featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: false),
                                            userDefaults: defaults)
@@ -311,10 +311,10 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.showOnboarding)
     }
 
-    func test_showOnboarding_is_false_when_feature_flag_is_turned_off_and_completedAllStoreOnboardingTasks_is_true() async {
+    func test_showOnboarding_is_false_when_feature_flag_is_turned_off_and_completedAllStoreOnboardingTasks_is_true() async throws {
         // Given
         let uuid = UUID().uuidString
-        let defaults = UserDefaults(suiteName: uuid)!
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         defaults[.completedAllStoreOnboardingTasks] = true
         let viewModel = DashboardViewModel(featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: false),
                                            userDefaults: defaults)
@@ -322,10 +322,10 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.showOnboarding)
     }
 
-    func test_showOnboarding_is_false_when_feature_flag_is_turned_on_and_completedAllStoreOnboardingTasks_is_true() async {
+    func test_showOnboarding_is_false_when_feature_flag_is_turned_on_and_completedAllStoreOnboardingTasks_is_true() async throws {
         // Given
         let uuid = UUID().uuidString
-        let defaults = UserDefaults(suiteName: uuid)!
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         defaults[.completedAllStoreOnboardingTasks] = true
         let viewModel = DashboardViewModel(featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
                                            userDefaults: defaults)
@@ -333,10 +333,10 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.showOnboarding)
     }
 
-    func test_showOnboarding_is_true_when_feature_flag_is_turned_on_and_completedAllStoreOnboardingTasks_is_false() async {
+    func test_showOnboarding_is_true_when_feature_flag_is_turned_on_and_completedAllStoreOnboardingTasks_is_false() async throws {
         // Given
         let uuid = UUID().uuidString
-        let defaults = UserDefaults(suiteName: uuid)!
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         defaults[.completedAllStoreOnboardingTasks] = false
         let viewModel = DashboardViewModel(featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
                                            userDefaults: defaults)
@@ -344,10 +344,10 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.showOnboarding)
     }
 
-    func test_showOnboarding_is_true_when_feature_flag_is_turned_on_and_completedAllStoreOnboardingTasks_is_not_set() async {
+    func test_showOnboarding_is_true_when_feature_flag_is_turned_on_and_completedAllStoreOnboardingTasks_is_not_set() async throws {
         // Given
         let uuid = UUID().uuidString
-        let defaults = UserDefaults(suiteName: uuid)!
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let viewModel = DashboardViewModel(featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
                                            userDefaults: defaults)
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -297,4 +297,74 @@ final class DashboardViewModelTests: XCTestCase {
         // Then
         XCTAssertNil(viewModel.announcementViewModel)
     }
+
+    // MARK: Store onboarding
+
+    func test_showOnboarding_is_false_when_feature_flag_is_turned_off_and_completedAllStoreOnboardingTasks_is_false() async {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = UserDefaults(suiteName: uuid)!
+        defaults[.completedAllStoreOnboardingTasks] = false
+        let viewModel = DashboardViewModel(featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: false),
+                                           userDefaults: defaults)
+        // Then
+        XCTAssertFalse(viewModel.showOnboarding)
+    }
+
+    func test_showOnboarding_is_false_when_feature_flag_is_turned_off_and_completedAllStoreOnboardingTasks_is_true() async {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = UserDefaults(suiteName: uuid)!
+        defaults[.completedAllStoreOnboardingTasks] = true
+        let viewModel = DashboardViewModel(featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: false),
+                                           userDefaults: defaults)
+        // Then
+        XCTAssertFalse(viewModel.showOnboarding)
+    }
+
+    func test_showOnboarding_is_false_when_feature_flag_is_turned_on_and_completedAllStoreOnboardingTasks_is_true() async {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = UserDefaults(suiteName: uuid)!
+        defaults[.completedAllStoreOnboardingTasks] = true
+        let viewModel = DashboardViewModel(featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
+                                           userDefaults: defaults)
+        // Then
+        XCTAssertFalse(viewModel.showOnboarding)
+    }
+
+    func test_showOnboarding_is_true_when_feature_flag_is_turned_on_and_completedAllStoreOnboardingTasks_is_false() async {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = UserDefaults(suiteName: uuid)!
+        defaults[.completedAllStoreOnboardingTasks] = false
+        let viewModel = DashboardViewModel(featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
+                                           userDefaults: defaults)
+        // Then
+        XCTAssertTrue(viewModel.showOnboarding)
+    }
+
+    func test_showOnboarding_is_true_when_feature_flag_is_turned_on_and_completedAllStoreOnboardingTasks_is_not_set() async {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = UserDefaults(suiteName: uuid)!
+        let viewModel = DashboardViewModel(featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
+                                           userDefaults: defaults)
+        // Then
+        XCTAssertTrue(viewModel.showOnboarding)
+    }
+
+    func test_showOnboarding_is_set_to_false_upon_calling_didCompleteAllOnboardingTasks() {
+        // Given
+        let viewModel = DashboardViewModel()
+
+        // Then
+        XCTAssertTrue(viewModel.showOnboarding)
+
+        // When
+        viewModel.didCompleteAllOnboardingTasks()
+
+        // Then
+        XCTAssertFalse(viewModel.showOnboarding)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewHostingControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewHostingControllerTests.swift
@@ -6,19 +6,21 @@ import XCTest
 /// Test cases for `StoreOnboardingViewHostingController`.
 ///
 final class StoreOnboardingViewHostingControllerTests: XCTestCase {
-    func it_reloads_tasks_when_view_loads() {
+    func test_it_reloads_tasks_when_view_loads() {
         // Given
         let mockViewModel = MockStoreOnboardingViewModel()
         let sut = StoreOnboardingViewHostingController(viewModel: mockViewModel, navigationController: .init(), site: .fake(), shareFeedbackAction: nil)
 
         // When
-        sut.loadView()
+        sut.viewDidLoad()
 
         // Then
-        XCTAssertTrue(mockViewModel.reloadTasksCalled)
+        waitUntil {
+            mockViewModel.reloadTasksCalled
+        }
     }
 
-    func it_reloads_tasks_when_view_appears() {
+    func test_it_reloads_tasks_when_view_appears() {
         // Given
         let mockViewModel = MockStoreOnboardingViewModel()
         let sut = StoreOnboardingViewHostingController(viewModel: mockViewModel, navigationController: .init(), site: .fake(), shareFeedbackAction: nil)
@@ -27,7 +29,9 @@ final class StoreOnboardingViewHostingControllerTests: XCTestCase {
         sut.viewWillAppear(true)
 
         // Then
-        XCTAssertTrue(mockViewModel.reloadTasksCalled)
+        waitUntil {
+            mockViewModel.reloadTasksCalled
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -179,19 +179,17 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         // Given
         let uuid = UUID().uuidString
         let defaults = UserDefaults(suiteName: uuid)!
-        let initialTasks: [StoreOnboardingTask] = [
+        let tasks: [StoreOnboardingTask] = [
             .init(isComplete: false, type: .addFirstProduct),
             .init(isComplete: false, type: .launchStore),
             .init(isComplete: true, type: .customizeDomains),
             .init(isComplete: false, type: .payments)
         ]
-
-        let tasks = initialTasks + [(.init(isComplete: true, type: .unsupported("")))]
         mockLoadOnboardingTasks(result: .success(tasks))
         let sut = StoreOnboardingViewModel(isExpanded: true,
                                            siteID: 0,
                                            stores: stores,
-                                           userDefaults: defaults)
+                                           defaults: defaults)
         // When
         await sut.reloadTasks()
 
@@ -203,24 +201,60 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         // Given
         let uuid = UUID().uuidString
         let defaults = UserDefaults(suiteName: uuid)!
-        let initialTasks: [StoreOnboardingTask] = [
+        let tasks: [StoreOnboardingTask] = [
             .init(isComplete: true, type: .addFirstProduct),
             .init(isComplete: true, type: .launchStore),
             .init(isComplete: true, type: .customizeDomains),
             .init(isComplete: true, type: .payments)
         ]
-
-        let tasks = initialTasks + [(.init(isComplete: true, type: .unsupported("")))]
         mockLoadOnboardingTasks(result: .success(tasks))
         let sut = StoreOnboardingViewModel(isExpanded: true,
                                            siteID: 0,
                                            stores: stores,
-                                           userDefaults: defaults)
+                                           defaults: defaults)
         // When
         await sut.reloadTasks()
 
         // Then
         XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? Bool))
+    }
+
+    func test_completedAllStoreOnboardingTasks_is_not_changed_when_tasks_request_fails() async {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = UserDefaults(suiteName: uuid)!
+        mockLoadOnboardingTasks(result: .failure(MockError()))
+        let sut = StoreOnboardingViewModel(isExpanded: true,
+                                           siteID: 0,
+                                           stores: stores,
+                                           defaults: defaults)
+        // Then
+        XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
+
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
+    }
+
+    func test_completedAllStoreOnboardingTasks_is_not_changed_when_tasks_request_returns_empty_array() async {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = UserDefaults(suiteName: uuid)!
+        mockLoadOnboardingTasks(result: .success([]))
+        let sut = StoreOnboardingViewModel(isExpanded: true,
+                                           siteID: 0,
+                                           stores: stores,
+                                           defaults: defaults)
+        // Then
+        XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
+
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -125,54 +125,6 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         XCTAssertEqual(sut.tasksForDisplay.map({ $0.task }), initialTasks)
     }
 
-    // MARK: onAllOnboardingTasksCompleted callback
-
-    func test_it_does_not_call_onAllOnboardingTasksCompleted_when_there_are_pending_tasks() async {
-        // Given
-        var onAllOnboardingTasksCompletedCalled = false
-        let tasks: [StoreOnboardingTask] = [
-            .init(isComplete: false, type: .addFirstProduct),
-            .init(isComplete: false, type: .launchStore),
-            .init(isComplete: true, type: .customizeDomains),
-            .init(isComplete: false, type: .payments)
-        ]
-        mockLoadOnboardingTasks(result: .success(tasks))
-        let sut = StoreOnboardingViewModel(isExpanded: true,
-                                           siteID: 0,
-                                           stores: stores,
-                                           onAllOnboardingTasksCompleted: {
-            onAllOnboardingTasksCompletedCalled = true
-        })
-        // When
-        await sut.reloadTasks()
-
-        // Then
-        XCTAssertFalse(onAllOnboardingTasksCompletedCalled)
-    }
-
-    func test_it_calls_onAllOnboardingTasksCompleted_when_there_are_no_pending_tasks() async {
-        // Given
-        var onAllOnboardingTasksCompletedCalled = false
-        let tasks: [StoreOnboardingTask] = [
-            .init(isComplete: true, type: .addFirstProduct),
-            .init(isComplete: true, type: .launchStore),
-            .init(isComplete: true, type: .customizeDomains),
-            .init(isComplete: true, type: .payments)
-        ]
-        mockLoadOnboardingTasks(result: .success(tasks))
-        let sut = StoreOnboardingViewModel(isExpanded: true,
-                                           siteID: 0,
-                                           stores: stores,
-                                           onAllOnboardingTasksCompleted: {
-            onAllOnboardingTasksCompletedCalled = true
-        })
-        // When
-        await sut.reloadTasks()
-
-        // Then
-        XCTAssertTrue(onAllOnboardingTasksCompletedCalled)
-    }
-
     // MARK: completedAllStoreOnboardingTasks user defaults
 
     func test_completedAllStoreOnboardingTasks_is_nil_when_there_are_pending_tasks() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -175,10 +175,10 @@ final class StoreOnboardingViewModelTests: XCTestCase {
 
     // MARK: completedAllStoreOnboardingTasks user defaults
 
-    func test_completedAllStoreOnboardingTasks_is_nil_when_there_are_pending_tasks() async {
+    func test_completedAllStoreOnboardingTasks_is_nil_when_there_are_pending_tasks() async throws {
         // Given
         let uuid = UUID().uuidString
-        let defaults = UserDefaults(suiteName: uuid)!
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let tasks: [StoreOnboardingTask] = [
             .init(isComplete: false, type: .addFirstProduct),
             .init(isComplete: false, type: .launchStore),
@@ -197,10 +197,10 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
     }
 
-    func test_completedAllStoreOnboardingTasks_is_true_when_there_are_no_pending_tasks() async {
+    func test_completedAllStoreOnboardingTasks_is_true_when_there_are_no_pending_tasks() async throws {
         // Given
         let uuid = UUID().uuidString
-        let defaults = UserDefaults(suiteName: uuid)!
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let tasks: [StoreOnboardingTask] = [
             .init(isComplete: true, type: .addFirstProduct),
             .init(isComplete: true, type: .launchStore),
@@ -219,10 +219,10 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? Bool))
     }
 
-    func test_completedAllStoreOnboardingTasks_is_not_changed_when_tasks_request_fails() async {
+    func test_completedAllStoreOnboardingTasks_is_not_changed_when_tasks_request_fails() async throws {
         // Given
         let uuid = UUID().uuidString
-        let defaults = UserDefaults(suiteName: uuid)!
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         mockLoadOnboardingTasks(result: .failure(MockError()))
         let sut = StoreOnboardingViewModel(isExpanded: true,
                                            siteID: 0,
@@ -238,10 +238,10 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
     }
 
-    func test_completedAllStoreOnboardingTasks_is_not_changed_when_tasks_request_returns_empty_array() async {
+    func test_completedAllStoreOnboardingTasks_is_not_changed_when_tasks_request_returns_empty_array() async throws {
         // Given
         let uuid = UUID().uuidString
-        let defaults = UserDefaults(suiteName: uuid)!
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         mockLoadOnboardingTasks(result: .success([]))
         let sut = StoreOnboardingViewModel(isExpanded: true,
                                            siteID: 0,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -124,6 +124,104 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.tasksForDisplay.map({ $0.task }), initialTasks)
     }
+
+    // MARK: onAllOnboardingTasksCompleted callback
+
+    func test_it_does_not_call_onAllOnboardingTasksCompleted_when_there_are_pending_tasks() async {
+        // Given
+        var onAllOnboardingTasksCompletedCalled = false
+        let tasks: [StoreOnboardingTask] = [
+            .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .launchStore),
+            .init(isComplete: true, type: .customizeDomains),
+            .init(isComplete: false, type: .payments)
+        ]
+        mockLoadOnboardingTasks(result: .success(tasks))
+        let sut = StoreOnboardingViewModel(isExpanded: true,
+                                           siteID: 0,
+                                           stores: stores,
+                                           onAllOnboardingTasksCompleted: {
+            onAllOnboardingTasksCompletedCalled = true
+        })
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertFalse(onAllOnboardingTasksCompletedCalled)
+    }
+
+    func test_it_calls_onAllOnboardingTasksCompleted_when_there_are_no_pending_tasks() async {
+        // Given
+        var onAllOnboardingTasksCompletedCalled = false
+        let tasks: [StoreOnboardingTask] = [
+            .init(isComplete: true, type: .addFirstProduct),
+            .init(isComplete: true, type: .launchStore),
+            .init(isComplete: true, type: .customizeDomains),
+            .init(isComplete: true, type: .payments)
+        ]
+        mockLoadOnboardingTasks(result: .success(tasks))
+        let sut = StoreOnboardingViewModel(isExpanded: true,
+                                           siteID: 0,
+                                           stores: stores,
+                                           onAllOnboardingTasksCompleted: {
+            onAllOnboardingTasksCompletedCalled = true
+        })
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertTrue(onAllOnboardingTasksCompletedCalled)
+    }
+
+    // MARK: completedAllStoreOnboardingTasks user defaults
+
+    func test_completedAllStoreOnboardingTasks_is_nil_when_there_are_pending_tasks() async {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = UserDefaults(suiteName: uuid)!
+        let initialTasks: [StoreOnboardingTask] = [
+            .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .launchStore),
+            .init(isComplete: true, type: .customizeDomains),
+            .init(isComplete: false, type: .payments)
+        ]
+
+        let tasks = initialTasks + [(.init(isComplete: true, type: .unsupported("")))]
+        mockLoadOnboardingTasks(result: .success(tasks))
+        let sut = StoreOnboardingViewModel(isExpanded: true,
+                                           siteID: 0,
+                                           stores: stores,
+                                           userDefaults: defaults)
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
+    }
+
+    func test_completedAllStoreOnboardingTasks_is_true_when_there_are_no_pending_tasks() async {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = UserDefaults(suiteName: uuid)!
+        let initialTasks: [StoreOnboardingTask] = [
+            .init(isComplete: true, type: .addFirstProduct),
+            .init(isComplete: true, type: .launchStore),
+            .init(isComplete: true, type: .customizeDomains),
+            .init(isComplete: true, type: .payments)
+        ]
+
+        let tasks = initialTasks + [(.init(isComplete: true, type: .unsupported("")))]
+        mockLoadOnboardingTasks(result: .success(tasks))
+        let sut = StoreOnboardingViewModel(isExpanded: true,
+                                           siteID: 0,
+                                           stores: stores,
+                                           userDefaults: defaults)
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? Bool))
+    }
 }
 
 private extension StoreOnboardingViewModelTests {

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -284,7 +284,7 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertTrue(mockSessionManager.deleteApplicationPasswordInvoked)
     }
 
-    func test_removing_default_store_sets_completedAllStoreOnboardingTasks_to_nil() throws {
+    func test_updating_default_storeID_sets_completedAllStoreOnboardingTasks_to_nil() throws {
         // Given
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
@@ -298,7 +298,7 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? Bool))
 
         // When
-        sut.removeDefaultStore()
+        sut.updateDefaultStore(storeID: 0)
 
         // Then
         XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -284,6 +284,26 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertTrue(mockSessionManager.deleteApplicationPasswordInvoked)
     }
 
+    func test_removing_default_store_sets_completedAllStoreOnboardingTasks_to_nil() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let mockSessionManager = MockSessionManager()
+        let sut = DefaultStoresManager(sessionManager: mockSessionManager, defaults: defaults)
+
+        // When
+        defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = true
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] as? Bool))
+
+        // When
+        sut.removeDefaultStore()
+
+        // Then
+        XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
+    }
+
     /// Verifies that user is logged out when application password regeneration fails
     ///
     func test_it_deauthenticates_upon_receiving_application_password_generation_failure_notification() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8893 
Closes: #9108 

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
- Don't show the store onboarding list if all tasks are completed for a store. 
- Store the info in user defaults to prevent further network requests. i.e. If the tasks are completed once we will never show the task list again. 

## Testing instructions
**Prerequisite**
1. Create 2 JN sites A and B. 
1. Complete all the onboarding tasks on site A. (I did this by adding a product and  enabling Cash on delivery option (Screenshot below))
1. Keep the tasks incomplete for site B.

Enabling Cash on delivery
<img width="2357" alt="Screenshot 2023-03-14 at 8 21 10 PM" src="https://user-images.githubusercontent.com/524475/225039714-49e0f45b-ad8c-49ad-a9ff-240260a41d88.png">


**Steps**
1. Launch and login into site B
1. Verify that you see the onboarding task list in the dashboard
1. Logout and log in using site A
1. Verify that you don't see the onboarding task list in the dashboard
1. Logout and log in using site B again and verify that the onboarding list is back again.

## Screenshots
| Pending tasks | All tasks completed |
| - | - |
| ![TasksPending](https://user-images.githubusercontent.com/524475/225049650-415474cc-ed83-4488-876d-764fadf43e8e.gif) | ![NoPendingTasks](https://user-images.githubusercontent.com/524475/225049199-06153ec1-6da5-4060-ab6e-3e2133af8c5c.gif) | 



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
