### PR TITLE
[Product Bundles] Show actual bundled product count in product details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -515,8 +515,16 @@ private extension DefaultProductFormTableViewModel {
     func bundledProductsRow(product: ProductFormDataModel) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.widgetsImage
         let title = Localization.bundledProductsTitle
+        let details: String
 
-        let details = "3 products" // TODO-8954: Display actual bundled product count (localized)
+        switch product.bundledItems.count {
+        case 1:
+            details = .localizedStringWithFormat(Localization.singularBundledProductFormat, product.bundledItems.count)
+        case 2...:
+            details = .localizedStringWithFormat(Localization.pluralBundledProductsFormat, product.bundledItems.count)
+        default:
+            details = ""
+        }
 
         return ProductFormSection.SettingsRow.ViewModel(icon: icon,
                                                         title: title,
@@ -717,5 +725,9 @@ private extension DefaultProductFormTableViewModel {
 
         // Bundled products
         static let bundledProductsTitle = NSLocalizedString("Bundled products", comment: "Title for Bundled Products row in the product form screen.")
+        static let singularBundledProductFormat = NSLocalizedString("%ld product",
+                                                                    comment: "Format of the number of bundled products in singular form")
+        static let pluralBundledProductsFormat = NSLocalizedString("%ld products",
+                                                                   comment: "Format of the number of bundled products in plural form")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -112,8 +112,8 @@ private extension DefaultProductFormTableViewModel {
                 return .noPriceWarning(viewModel: noPriceWarningRow(isActionable: true))
             case .attributes(let editable):
                 return .attributes(viewModel: productVariationsAttributesRow(product: product.product, isEditable: editable), isEditable: editable)
-            case .bundledProducts:
-                return .bundledProducts(viewModel: bundledProductsRow(product: product))
+            case .bundledProducts(let actionable):
+                return .bundledProducts(viewModel: bundledProductsRow(product: product, isActionable: actionable), isActionable: actionable)
             default:
                 assertionFailure("Unexpected action in the settings section: \(action)")
                 return nil
@@ -512,7 +512,7 @@ private extension DefaultProductFormTableViewModel {
 
     // MARK: Bundle products only
 
-    func bundledProductsRow(product: ProductFormDataModel) -> ProductFormSection.SettingsRow.ViewModel {
+    func bundledProductsRow(product: ProductFormDataModel, isActionable: Bool) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.widgetsImage
         let title = Localization.bundledProductsTitle
         let details: String
@@ -528,7 +528,8 @@ private extension DefaultProductFormTableViewModel {
 
         return ProductFormSection.SettingsRow.ViewModel(icon: icon,
                                                         title: title,
-                                                        details: details)
+                                                        details: details,
+                                                        isActionable: isActionable)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -159,6 +159,10 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
         product.addOns.isNotEmpty
     }
 
+    var bundledItems: [ProductBundleItem] {
+        product.bundledItems
+    }
+
     func isStockStatusEnabled() -> Bool {
         // Only a variable product's stock status is not editable.
         productType != .variable

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -170,6 +170,10 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
         false
     }
 
+    var bundledItems: [ProductBundleItem] {
+        []
+    }
+
     // Visibility logic
 
     func allowsMultipleImages() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -34,7 +34,7 @@ enum ProductFormEditAction: Equatable {
     // Downloadable products only
     case downloadableFiles(editable: Bool)
     // Bundle products only
-    case bundledProducts
+    case bundledProducts(actionable: Bool)
 }
 
 /// Creates actions for different sections/UI on the product form.
@@ -252,11 +252,12 @@ private extension ProductFormActionsFactory {
 
     func allSettingsSectionActionsForBundleProduct() -> [ProductFormEditAction] {
         let shouldShowBundledProductsRow = isBundledProductsEnabled
+        let canOpenBundledProducts = product.bundledItems.isNotEmpty
         let shouldShowPriceSettingsRow = product.regularPrice.isNilOrEmpty == false
         let shouldShowReviewsRow = product.reviewsAllowed
 
         let actions: [ProductFormEditAction?] = [
-            shouldShowBundledProductsRow ? .bundledProducts : nil,
+            shouldShowBundledProductsRow ? .bundledProducts(actionable: canOpenBundledProducts) : nil,
             shouldShowPriceSettingsRow ? .priceSettings(editable: false, hideSeparator: false): nil,
             shouldShowReviewsRow ? .reviews: nil,
             .inventorySettings(editable: false),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -68,6 +68,9 @@ protocol ProductFormDataModel {
 
     var hasAddOns: Bool { get }
 
+    // Product Bundles
+    var bundledItems: [ProductBundleItem] { get }
+
     /// True if a product has been saved remotely.
     var existsRemotely: Bool { get }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -257,7 +257,7 @@ private extension ProductFormTableViewDataSource {
              .linkedProducts(let viewModel, _),
              .variations(let viewModel),
              .attributes(let viewModel, _),
-             .bundledProducts(let viewModel):
+             .bundledProducts(let viewModel, _):
             configureSettings(cell: cell, viewModel: viewModel)
         case .reviews(let viewModel, let ratingCount, let averageRating):
             configureReviews(cell: cell, viewModel: viewModel, ratingCount: ratingCount, averageRating: averageRating)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -44,7 +44,7 @@ enum ProductFormSection: Equatable {
         case status(viewModel: SwitchableViewModel, isEditable: Bool)
         case linkedProducts(viewModel: ViewModel, isEditable: Bool)
         case attributes(viewModel: ViewModel, isEditable: Bool)
-        case bundledProducts(viewModel: ViewModel)
+        case bundledProducts(viewModel: ViewModel, isActionable: Bool)
 
         struct ViewModel {
             let icon: UIImage

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -443,7 +443,10 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 editAttributes()
             case .status:
                 break
-            case .bundledProducts:
+            case .bundledProducts(_, let isActionable):
+                guard isActionable else {
+                    return
+                }
                 // TODO-8954: Add tracking
                 showBundledProducts()
                 return

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -447,7 +447,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 guard isActionable else {
                     return
                 }
-                // TODO-8954: Add tracking
+                // TODO-9128: Add tracking
                 showBundledProducts()
                 return
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -626,7 +626,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
     }
 
-    func test_view_model_for_bundle_product_without_price_with_feature_flag_enabled() {
+    func test_view_model_for_bundle_product_without_price_or_bundled_items_with_feature_flag_enabled() {
         // Arrange
         let product = Fixtures.bundleProduct
         let model = EditableProductModel(product: product)
@@ -638,7 +638,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
         assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.bundledProducts,
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.bundledProducts(actionable: false),
                                                                        .reviews,
                                                                        .inventorySettings(editable: false),
                                                                        .linkedProducts(editable: true),
@@ -649,9 +649,9 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
     }
 
-    func test_view_model_for_bundle_product_with_price_with_feature_flag_enabled() {
+    func test_view_model_for_bundle_product_with_price_and_bundled_items_with_feature_flag_enabled() {
         // Arrange
-        let product = Fixtures.bundleProduct.copy(regularPrice: "2")
+        let product = Fixtures.bundleProduct.copy(regularPrice: "2", bundledItems: [.fake()])
         let model = EditableProductModel(product: product)
 
         // Action
@@ -661,7 +661,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
         assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.bundledProducts,
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.bundledProducts(actionable: true),
                                                                        .priceSettings(editable: false, hideSeparator: false),
                                                                        .reviews,
                                                                        .inventorySettings(editable: false),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8954
⚠️ Depends on #9124
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This integrates real data in the UI layer to display how many bundled products are in a product bundle:

* Updates the product details to show an actual product count in the "Bundled products" row.
* Updates the "Bundled products" row to only be actionable (open the list) if there are bundled products to show.

This does **not** make any changes to the list of bundled products, or the stock status/quantity displayed for the product bundle (parent product). Those will be handled in separate PRs.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Prerequisites

1. Install and activate the [Product Bundles extension](https://woocommerce.com/products/product-bundles/) on your store.
2. Create at least one product with the Product Bundle type.

### To test

1. Build and run the app.
2. Go to the Products tab.
3. Open a Product Bundle and confirm the "Bundled products" row shows the correct bundled product count.
4. Tap the "Bundled products" row and confirm it is only actionable (opens the bundled product list) if there are bundled products. (Note: the bundled product list view is still showing fake data.)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

No bundled products|1 bundled product|Multiple bundled products
-|-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-14 at 15 47 05](https://user-images.githubusercontent.com/8658164/225057871-b6cbecb3-7b58-4e98-a20e-579990f7a37b.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-14 at 15 47 01](https://user-images.githubusercontent.com/8658164/225057870-549d4ff1-26ff-4ae2-a2c7-97aa7d98bcd9.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-14 at 15 47 08](https://user-images.githubusercontent.com/8658164/225057900-bc7a0276-4f3f-4fbc-ac44-54197747650e.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
