### PR TITLE
[Product Bundle] Show actual bundled products in product details

### DIFF
--- a/Networking/Networking/Model/Product/ProductBundleItem.swift
+++ b/Networking/Networking/Model/Product/ProductBundleItem.swift
@@ -71,4 +71,17 @@ public enum ProductBundleItemStockStatus: String, Codable, GeneratedFakeable {
     case inStock        = "in_stock"
     case outOfStock     = "out_of_stock"
     case onBackOrder    = "on_backorder"
+
+    /// Returns the localized text version of the Enum
+    ///
+    public var description: String {
+        switch self {
+        case .inStock:
+            return NSLocalizedString("In stock", comment: "Display label for the bundle item's inventory stock status")
+        case .outOfStock:
+            return NSLocalizedString("Out of stock", comment: "Display label for the bundle item's inventory stock status")
+        case .onBackOrder:
+            return NSLocalizedString("On back order", comment: "Display label for the bundle item's inventory stock status")
+        }
+    }
 }

--- a/Networking/Networking/Model/Product/ProductBundleItem.swift
+++ b/Networking/Networking/Model/Product/ProductBundleItem.swift
@@ -71,17 +71,4 @@ public enum ProductBundleItemStockStatus: String, Codable, GeneratedFakeable {
     case inStock        = "in_stock"
     case outOfStock     = "out_of_stock"
     case onBackOrder    = "on_backorder"
-
-    /// Returns the localized text version of the Enum
-    ///
-    public var description: String {
-        switch self {
-        case .inStock:
-            return NSLocalizedString("In stock", comment: "Display label for the bundle item's inventory stock status")
-        case .outOfStock:
-            return NSLocalizedString("Out of stock", comment: "Display label for the bundle item's inventory stock status")
-        case .onBackOrder:
-            return NSLocalizedString("On back order", comment: "Display label for the bundle item's inventory stock status")
-        }
-    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
@@ -28,20 +28,15 @@ struct BundledProductsList: View {
 
     var body: some View {
         ScrollView {
-            LazyVStack {
-                // TODO-8954: Display actual bundled items from view model
-                VStack(spacing: 0) {
-                    TitleAndSubtitleRow(title: "Beanie with Logo", subtitle: "In stock")
-                    Divider().padding(.leading)
-                    TitleAndSubtitleRow(title: "T-Shirt with Logo", subtitle: "In stock")
-                    Divider().padding(.leading)
-                    TitleAndSubtitleRow(title: "Hoodie with Logo", subtitle: "Out of stock")
+            LazyVStack(spacing: 0) {
+                ForEach(viewModel.bundledProducts) { bundledProduct in
+                    TitleAndSubtitleRow(title: bundledProduct.title, subtitle: bundledProduct.stockStatus)
                     Divider().padding(.leading)
                 }
-                .background(Color(.listForeground(modal: false)))
-
-                FooterNotice(infoText: viewModel.infoNotice)
             }
+            .background(Color(.listForeground(modal: false)))
+
+            FooterNotice(infoText: viewModel.infoNotice)
         }
         .background(
             Color(.listBackground).edgesIgnoringSafeArea(.all)
@@ -53,7 +48,11 @@ struct BundledProductsList: View {
 // MARK: Previews
 struct BundledProductsList_Previews: PreviewProvider {
 
-    static let viewModel = BundledProductsListViewModel()
+    static let viewModel = BundledProductsListViewModel(bundledProducts: [
+        .init(id: 1, title: "Beanie with Logo", stockStatus: "In stock"),
+        .init(id: 2, title: "T-Shirt with Logo", stockStatus: "In stock"),
+        .init(id: 3, title: "Hoodie with Logo", stockStatus: "Out of stock")
+    ])
 
     static var previews: some View {
         BundledProductsList(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
@@ -1,8 +1,22 @@
 import Foundation
+import Yosemite
 
 /// ViewModel for `BundledProductsList`
 ///
 final class BundledProductsListViewModel {
+
+    /// Represents a bundled product
+    ///
+    struct BundledProduct: Identifiable {
+        /// Bundled product ID
+        let id: Int64
+
+        /// Title of the bundled product
+        let title: String
+
+        /// Stock status of the bundled product
+        let stockStatus: String
+    }
 
     /// View title
     ///
@@ -11,6 +25,24 @@ final class BundledProductsListViewModel {
     /// View info notice
     ///
     let infoNotice = Localization.infoNotice
+
+    /// Bundled products
+    ///
+    let bundledProducts: [BundledProduct]
+
+    init(bundledProducts: [BundledProduct]) {
+        self.bundledProducts = bundledProducts
+    }
+}
+
+// MARK: Initializers
+extension BundledProductsListViewModel {
+    convenience init(bundledProducts: [Yosemite.ProductBundleItem]) {
+        let viewModels = bundledProducts.map {
+            BundledProduct(id: $0.bundledItemID, title: $0.title, stockStatus: $0.stockStatus.description)
+        }
+        self.init(bundledProducts: viewModels)
+    }
 }
 
 // MARK: Constants

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/ProductBundleItemStockStatus+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/ProductBundleItemStockStatus+UI.swift
@@ -1,0 +1,16 @@
+import Yosemite
+
+extension ProductBundleItemStockStatus {
+    /// Returns the localized text version of the Enum
+    ///
+    var description: String {
+        switch self {
+        case .inStock:
+            return NSLocalizedString("In stock", comment: "Display label for the bundle item's inventory stock status")
+        case .outOfStock:
+            return NSLocalizedString("Out of stock", comment: "Display label for the bundle item's inventory stock status")
+        case .onBackOrder:
+            return NSLocalizedString("On back order", comment: "Display label for the bundle item's inventory stock status")
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1686,7 +1686,7 @@ private extension ProductFormViewController {
         guard let product = product as? EditableProductModel else {
             return
         }
-        let viewModel = BundledProductsListViewModel()
+        let viewModel = BundledProductsListViewModel(bundledProducts: product.bundledItems)
         let viewController = BundledProductsListViewController(viewModel: viewModel)
         show(viewController, sender: self)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1318,7 +1318,6 @@
 		AEFF77AA29786DAA00667F7A /* PriceInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFF77A929786DAA00667F7A /* PriceInputViewModelTests.swift */; };
 		B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509112D2049E27A007D25DC /* DashboardViewController.swift */; };
 		B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED021C041DF000076A9 /* Locale+Woo.swift */; };
-		B509FED521C052D1000076A9 /* MockSupportManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED421C052D1000076A9 /* MockSupportManager.swift */; };
 		B50BB4162141828F00AF0F3C /* FooterSpinnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50BB4152141828F00AF0F3C /* FooterSpinnerView.swift */; };
 		B511ED27218A660E005787DC /* StringDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B511ED26218A660E005787DC /* StringDescriptor.swift */; };
 		B517EA18218B232700730EC4 /* StringFormatter+Notes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B517EA17218B232700730EC4 /* StringFormatter+Notes.swift */; };
@@ -1591,6 +1590,7 @@
 		CCDC49ED24000533003166BA /* TestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49EC24000533003166BA /* TestCredentials.swift */; };
 		CCE4CD172667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */; };
 		CCE4CD282669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */; };
+		CCE785CA29C1F9170003977F /* ProductBundleItemStockStatus+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE785C929C1F9170003977F /* ProductBundleItemStockStatus+UI.swift */; };
 		CCEC256A27B581E800EF9FA3 /* ProductVariationFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEC256927B581E800EF9FA3 /* ProductVariationFormatter.swift */; };
 		CCF27B35280EF69700B755E1 /* orders_3337_add_product.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF27B33280EF69600B755E1 /* orders_3337_add_product.json */; };
 		CCF27B3A280EF98F00B755E1 /* orders_3337.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF27B39280EF98F00B755E1 /* orders_3337.json */; };
@@ -3755,6 +3755,7 @@
 		CCDC49F1240060F3003166BA /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UnitTests.xctestplan; path = WooCommerceTests/UnitTests.xctestplan; sourceTree = SOURCE_ROOT; };
 		CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
 		CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsTopBanner.swift; sourceTree = "<group>"; };
+		CCE785C929C1F9170003977F /* ProductBundleItemStockStatus+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductBundleItemStockStatus+UI.swift"; sourceTree = "<group>"; };
 		CCEC256927B581E800EF9FA3 /* ProductVariationFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormatter.swift; sourceTree = "<group>"; };
 		CCF27B33280EF69600B755E1 /* orders_3337_add_product.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = orders_3337_add_product.json; sourceTree = "<group>"; };
 		CCF27B39280EF98F00B755E1 /* orders_3337.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = orders_3337.json; sourceTree = "<group>"; };
@@ -8085,6 +8086,7 @@
 			children = (
 				CC857C7029B23A6C00E19D1E /* BundledProductsListViewController.swift */,
 				CC857C7429B23AE100E19D1E /* BundledProductsListViewModel.swift */,
+				CCE785C929C1F9170003977F /* ProductBundleItemStockStatus+UI.swift */,
 			);
 			path = "Bundled Product List";
 			sourceTree = "<group>";
@@ -10854,6 +10856,7 @@
 				02EA6BF82435E80600FFF90A /* ImageDownloader.swift in Sources */,
 				CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */,
 				B53B3F39219C817800DF1EB6 /* UIStoryboard+Woo.swift in Sources */,
+				CCE785CA29C1F9170003977F /* ProductBundleItemStockStatus+UI.swift in Sources */,
 				021E2A1723A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift in Sources */,
 				02490D1A284DE664002096EF /* ProductImagesSaver.swift in Sources */,
 				0215320B24231D5A003F2BBD /* UIStackView+Subviews.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -70,6 +70,7 @@ public typealias ProductAddOn = Networking.ProductAddOn
 public typealias ProductAddOnOption = Networking.ProductAddOnOption
 public typealias ProductBackordersSetting = Networking.ProductBackordersSetting
 public typealias ProductBundleItem = Networking.ProductBundleItem
+public typealias ProductBundleItemStockStatus = Networking.ProductBundleItemStockStatus
 public typealias ProductReview = Networking.ProductReview
 public typealias ProductReviewStatus = Networking.ProductReviewStatus
 public typealias ProductShippingClass = Networking.ProductShippingClass


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8954
⚠️ Depends on #9131
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This integrates real data in the UI layer to display the actual bundled products in a product bundle:

* Adds a `description` to `ProductBundleItemStockStatus`, to provide localized strings for the bundled product stock status.
* Updates `BundledProductsListViewModel` to hold data about the bundled products.
* Updates `BundledProductList` to show the bundled product data from the view model.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Prerequisites

1. Install and activate the [Product Bundles extension](https://woocommerce.com/products/product-bundles/) on your store.
2. Create at least one product with the Product Bundle type.

### To test

1. Build and run the app.
2. Go to the Products tab.
3. Open a Product Bundle and tap the "Bundled products" row.
4. Confirm you see a list of the actual bundled products, with the expected title and stock status.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/8658164/225064834-95325095-bfab-4442-a368-8fd0b8cf936f.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
