### PR TITLE
[Mobile Payments] Show cancel on TTP Setup for all screen sizes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -73,14 +73,13 @@ struct SetUpTapToPayInformationView: View {
     var dismiss: (() -> Void)? = nil
 
     @Environment(\.verticalSizeClass) var verticalSizeClass
-    @Environment(\.sizeCategory) private var sizeCategory
 
     var isCompact: Bool {
         verticalSizeClass == .compact
     }
 
-    var isSizeCategoryLargerThanExtraLarge: Bool {
-        sizeCategory >= .accessibilityMedium
+    var imageMaxHeight: CGFloat {
+        isCompact ? Constants.maxCompactImageHeight : Constants.maxImageHeight
     }
 
     var body: some View {
@@ -94,36 +93,36 @@ struct SetUpTapToPayInformationView: View {
             .padding(.top)
 
             Spacer()
+            VStack {
+                Text(Localization.setUpTapToPayOnIPhoneTitle)
+                    .font(.title.weight(.semibold))
+                    .multilineTextAlignment(.center)
+                    .padding([.leading, .trailing])
+                    .fixedSize(horizontal: false, vertical: true)
+                Image(uiImage: .setUpBuiltInReader)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxHeight: imageMaxHeight)
+                    .padding()
 
-            Text(Localization.setUpTapToPayOnIPhoneTitle)
-                .font(.title.weight(.semibold))
-                .multilineTextAlignment(.center)
-                .padding([.leading, .trailing])
+                VStack(spacing: Constants.hintSpacing) {
+                    PaymentSettingsFlowHint(title: Localization.hintOneTitle, text: Localization.hintOne)
+                    PaymentSettingsFlowHint(title: Localization.hintTwoTitle, text: Localization.hintTwo)
+                    PaymentSettingsFlowHint(title: Localization.hintThreeTitle, text: Localization.hintThree)
+                }
                 .fixedSize(horizontal: false, vertical: true)
-            Image(uiImage: .setUpBuiltInReader)
-                .resizable()
-                .scaledToFit()
-                .frame(height: isCompact ? 80 : 206)
-                .padding()
+                .layoutPriority(1)
+                .padding([.top, .bottom])
 
-            VStack(spacing: 16) {
-                PaymentSettingsFlowHint(title: Localization.hintOneTitle, text: Localization.hintOne)
-                PaymentSettingsFlowHint(title: Localization.hintTwoTitle, text: Localization.hintTwo)
-                PaymentSettingsFlowHint(title: Localization.hintThreeTitle, text: Localization.hintThree)
-            }
-            .fixedSize(horizontal: false, vertical: true)
-            .layoutPriority(1)
-            .padding([.top, .bottom])
+                Spacer()
 
-            Spacer()
+                Button(Localization.setUpButton, action: {
+                    setUpButtonAction?()
+                })
+                .buttonStyle(PrimaryButtonStyle())
 
-            Button(Localization.setUpButton, action: {
-                setUpButtonAction?()
-            })
-            .buttonStyle(PrimaryButtonStyle())
-
-            InPersonPaymentsLearnMore(
-                viewModel: LearnMoreViewModel(formatText: Localization.learnMore))
+                InPersonPaymentsLearnMore(
+                    viewModel: LearnMoreViewModel(formatText: Localization.learnMore))
                 .customOpenURL(action: { url in
                     switch url {
                     case LearnMoreViewModel.learnMoreURL:
@@ -134,17 +133,27 @@ struct SetUpTapToPayInformationView: View {
                         showURL?(url)
                     }
                 })
-        }
-        .frame(
-            maxWidth: .infinity,
-            maxHeight: .infinity
-        )
-        .padding()
-        .if(isCompact || isSizeCategoryLargerThanExtraLarge) { content in
-            ScrollView(.vertical) {
-                content
             }
+            .scrollVerticallyIfNeeded()
         }
+        .padding()
+    }
+}
+
+private enum Constants {
+    // maxHeight should be 208, but that hides the button on iPhone SE
+    // TODO: make this 208, or proportional to screen height for small screens
+    // https://github.com/woocommerce/woocommerce-ios/issues/9134
+    static let maxImageHeight: CGFloat = 180
+    static let maxCompactImageHeight: CGFloat = 80
+    static let hintSpacing: CGFloat = 16
+}
+
+private struct ViewSizeKey: PreferenceKey {
+    static var defaultValue: CGSize = .zero
+
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        value = nextValue()
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9052
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The Cancel button was hidden on some phones, with certain dynamic type sizes. It was hidden on the iPhone SE simulator at the default text size.

This changes the scrollview to be shown whenever it's required, and reduces the size of the image to avoid the button being hidden on iPhone SE. It also moves the `Cancel` button outside the scrollview so it behaves more like a toolbar item, and is always visible.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

On an iPhone SE, or iPhone XS with dynamic type set to 110%, go to:
Menu > Payments > Set up Tap to Pay on iPhone
Observe that you can see and use the cancel button

On any phone:
On the same screen, observe that you can set dynamic type to any size and still use the screen, if you scroll.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/225079751-ed0884d9-c0cc-45eb-9f4a-a0c5653a9304.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
