### PR TITLE
[Mobile Payments] Fix Set up Tap to Pay connectivity handling

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailed.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailed.swift
@@ -37,8 +37,8 @@ final class CardPresentModalBuiltInConnectingFailed: CardPresentPaymentsModalVie
         self.cancelSearchAction = cancelSearch
 
         switch error {
-        case CardReaderServiceError.connection(let underlyingError):
-            bottomTitle = underlyingError.localizedDescription
+        case CardReaderServiceError.connection(_):
+            bottomTitle = builtInReaderDescription(for: error)
         default:
             break
         }
@@ -53,6 +53,20 @@ final class CardPresentModalBuiltInConnectingFailed: CardPresentPaymentsModalVie
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }
+}
+
+extension CardPresentModalBuiltInConnectingFailed: ReaderConnectionUnderlyingErrorDisplaying {
+    func errorDescription(underlyingError: CardReaderServiceUnderlyingError) -> String? {
+        switch underlyingError {
+        case .internalServiceError:
+            return NSLocalizedString(
+                "Sorry, we could not start Tap to Pay on iPhone. Please check your connection and try again.",
+                comment: "Error message when the built-in reader connection experiences an unexpected internal service error."
+            )
+        default:
+            return underlyingError.errorDescription
+        }
+    }
 }
 
 private extension CardPresentModalBuiltInConnectingFailed {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailedNonRetryable.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailedNonRetryable.swift
@@ -34,8 +34,8 @@ final class CardPresentModalBuiltInConnectingFailedNonRetryable: CardPresentPaym
         self.closeAction = close
 
         switch error {
-        case CardReaderServiceError.connection(let underlyingError):
-            bottomTitle = underlyingError.localizedDescription
+        case CardReaderServiceError.connection(_):
+            bottomTitle = builtInReaderDescription(for: error)
         default:
             break
         }
@@ -48,6 +48,20 @@ final class CardPresentModalBuiltInConnectingFailedNonRetryable: CardPresentPaym
     func didTapSecondaryButton(in viewController: UIViewController?) { }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }
+}
+
+extension CardPresentModalBuiltInConnectingFailedNonRetryable: ReaderConnectionUnderlyingErrorDisplaying {
+    func errorDescription(underlyingError: CardReaderServiceUnderlyingError) -> String? {
+        switch underlyingError {
+        case .internalServiceError:
+            return NSLocalizedString(
+                "Sorry, we could not start Tap to Pay on iPhone. Please check your connection and try again.",
+                comment: "Error message when the built-in reader connection experiences an unexpected internal service error."
+            )
+        default:
+            return underlyingError.errorDescription
+        }
+    }
 }
 
 private extension CardPresentModalBuiltInConnectingFailedNonRetryable {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReaderConnectionUnderlyingErrorDisplaying.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReaderConnectionUnderlyingErrorDisplaying.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Yosemite
+
+protocol ReaderConnectionUnderlyingErrorDisplaying {
+    func errorDescription(underlyingError: CardReaderServiceUnderlyingError) -> String?
+}
+
+extension ReaderConnectionUnderlyingErrorDisplaying {
+    func builtInReaderDescription(for error: Error) -> String? {
+        if let error = error as? CardReaderServiceError {
+            switch error {
+            case .connection(let underlyingError),
+                    .discovery(let underlyingError):
+                return errorDescription(underlyingError: underlyingError)
+            default:
+                return error.errorDescription
+            }
+        } else {
+            return error.localizedDescription
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/PaymentSettingsFlowPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/PaymentSettingsFlowPresentingViewController.swift
@@ -54,6 +54,10 @@ final class PaymentSettingsFlowPresentingViewController: UIViewController {
         view.pinSubviewToAllEdges(childViewController.view)
         childViewController.didMove(toParent: self)
     }
+
+    override var shouldShowOfflineBanner: Bool {
+        true
+    }
 }
 
 // MARK: - View Configuration

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -26,7 +26,7 @@ final class SetUpTapToPayInformationViewController: UIHostingController<SetUpTap
         }
         self.viewModel = viewModel
 
-        super.init(rootView: SetUpTapToPayInformationView())
+        super.init(rootView: SetUpTapToPayInformationView(viewModel: viewModel))
         configureView()
     }
 
@@ -67,6 +67,7 @@ private extension SetUpTapToPayInformationViewController {
 }
 
 struct SetUpTapToPayInformationView: View {
+    @ObservedObject var viewModel: SetUpTapToPayInformationViewModel
     var setUpButtonAction: (() -> Void)? = nil
     var showURL: ((URL) -> Void)? = nil
     var learnMoreUrl: URL? = nil
@@ -120,6 +121,7 @@ struct SetUpTapToPayInformationView: View {
                     setUpButtonAction?()
                 })
                 .buttonStyle(PrimaryButtonStyle())
+                .disabled(!viewModel.enableSetup)
 
                 InPersonPaymentsLearnMore(
                     viewModel: LearnMoreViewModel(formatText: Localization.learnMore))
@@ -216,6 +218,14 @@ private enum Localization {
 
 struct SetUpTapToPayInformationView_Previews: PreviewProvider {
     static var previews: some View {
-        SetUpTapToPayInformationView(setUpButtonAction: {})
+        let config = CardPresentConfigurationLoader().configuration
+        let viewModel = SetUpTapToPayInformationViewModel(
+            siteID: 0,
+            configuration: config,
+            didChangeShouldShow: nil,
+            activePaymentGateway: .wcPay,
+            connectionAnalyticsTracker: .init(configuration: config))
+        SetUpTapToPayInformationView(viewModel: viewModel,
+                                     setUpButtonAction: {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -66,7 +66,7 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
             guard let self = self else { return }
             switch (status, self.enableSetup) {
             case (.notReachable, true),
-                (.reachable(_), false):
+                (.reachable, false):
                 self.enableSetup.toggle()
             default:
                 break

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -2,16 +2,19 @@ import Foundation
 import Combine
 import Yosemite
 
-final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewModel {
+final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewModel, ObservableObject {
     private(set) var shouldShow: CardReaderSettingsTriState = .isUnknown
     var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?
     var didUpdate: (() -> Void)?
     let learnMoreURL: URL
     private let stores: StoresManager
 
+    @Published var enableSetup: Bool = true
+
     let siteID: Int64
     let configuration: CardPresentPaymentsConfiguration
     let connectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker
+    let connectivityObserver: ConnectivityObserver
 
     private(set) var noConnectedReader: CardReaderSettingsTriState = .isUnknown {
         didSet {
@@ -26,15 +29,18 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
          didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?,
          activePaymentGateway: CardPresentPaymentsPlugin,
          connectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker,
+         connectivityObserver: ConnectivityObserver = ServiceLocator.connectivityObserver,
          stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.configuration = configuration
         self.didChangeShouldShow = didChangeShouldShow
         self.stores = stores
         self.connectionAnalyticsTracker = connectionAnalyticsTracker
+        self.connectivityObserver = connectivityObserver
         self.learnMoreURL = Self.learnMoreURL(for: activePaymentGateway)
 
         beginConnectedReaderObservation()
+        beginConnectivityObservation()
     }
 
     deinit {
@@ -53,6 +59,20 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
             self.reevaluateShouldShow()
         }
         stores.dispatch(connectedAction)
+    }
+
+    private func beginConnectivityObservation() {
+        connectivityObserver.statusPublisher.sink { [weak self] status in
+            guard let self = self else { return }
+            switch (status, self.enableSetup) {
+            case (.notReachable, true),
+                (.reachable(_), false):
+                self.enableSetup.toggle()
+            default:
+                break
+            }
+        }
+        .store(in: &subscriptions)
     }
 
     /// Updates whether the view this viewModel is associated with should be shown or not

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -411,7 +411,9 @@ extension InPersonPaymentsMenuViewController {
                                                                     configuration: viewModel.cardPresentPaymentsConfiguration,
                                                                     activePaymentGateway: activePaymentGateway)
         let setUpTapToPayViewController = PaymentSettingsFlowPresentingViewController(viewModelsAndViews: viewModelsAndViews)
-        navigationController?.present(setUpTapToPayViewController, animated: true)
+        let controller = WooNavigationController(rootViewController: setUpTapToPayViewController)
+        controller.navigationBar.isHidden = true
+        navigationController?.present(controller, animated: true)
     }
 
     func navigateToInPersonPaymentsSelectPluginView() {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -503,6 +503,7 @@
 		02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */; };
 		02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
+		0300201029C0EBA400B09777 /* ReaderConnectionUnderlyingErrorDisplaying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0300200F29C0EBA400B09777 /* ReaderConnectionUnderlyingErrorDisplaying.swift */; };
 		0304E35E28BDC86D00A80191 /* LearnMoreViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0304E35D28BDC86D00A80191 /* LearnMoreViewModel.swift */; };
 		0304E36428BE1EDE00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0304E36328BE1EDE00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.xib */; };
 		0304E36628BE1EED00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0304E36528BE1EED00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.swift */; };
@@ -1318,7 +1319,6 @@
 		AEFF77AA29786DAA00667F7A /* PriceInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFF77A929786DAA00667F7A /* PriceInputViewModelTests.swift */; };
 		B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509112D2049E27A007D25DC /* DashboardViewController.swift */; };
 		B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED021C041DF000076A9 /* Locale+Woo.swift */; };
-		B509FED521C052D1000076A9 /* MockSupportManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED421C052D1000076A9 /* MockSupportManager.swift */; };
 		B50BB4162141828F00AF0F3C /* FooterSpinnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50BB4152141828F00AF0F3C /* FooterSpinnerView.swift */; };
 		B511ED27218A660E005787DC /* StringDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B511ED26218A660E005787DC /* StringDescriptor.swift */; };
 		B517EA18218B232700730EC4 /* StringFormatter+Notes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B517EA17218B232700730EC4 /* StringFormatter+Notes.swift */; };
@@ -2665,6 +2665,7 @@
 		02F843D9273646A30017FE12 /* JetpackBenefitsBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBenefitsBanner.swift; sourceTree = "<group>"; };
 		02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingViewController.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
+		0300200F29C0EBA400B09777 /* ReaderConnectionUnderlyingErrorDisplaying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderConnectionUnderlyingErrorDisplaying.swift; sourceTree = "<group>"; };
 		0304E35D28BDC86D00A80191 /* LearnMoreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnMoreViewModel.swift; sourceTree = "<group>"; };
 		0304E36328BE1EDE00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LeftImageTitleSubtitleToggleTableViewCell.xib; sourceTree = "<group>"; };
 		0304E36528BE1EED00A80191 /* LeftImageTitleSubtitleToggleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftImageTitleSubtitleToggleTableViewCell.swift; sourceTree = "<group>"; };
@@ -9138,6 +9139,7 @@
 				D8815AE626383FD600EDAD62 /* CardPresentPaymentsModalViewModel.swift */,
 				0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */,
 				032E481C2982996E00469D92 /* CardPresentModalBuiltInConnectingFailedNonRetryable.swift */,
+				0300200F29C0EBA400B09777 /* ReaderConnectionUnderlyingErrorDisplaying.swift */,
 				03E471C5293A2E95001A58AD /* CardPresentModalBuiltInReaderCheckingDeviceSupport.swift */,
 				03E471C9293E0A2F001A58AD /* CardPresentModalBuiltInConfigurationProgress.swift */,
 				03E471CB293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift */,
@@ -11243,6 +11245,7 @@
 				DE4FB7732812AE96003D20D6 /* FilterListView.swift in Sources */,
 				02521E11243DC3C400DC7810 /* CancellableMedia.swift in Sources */,
 				CCCC29E325E576810046B96F /* RenameAttributesViewController.swift in Sources */,
+				0300201029C0EBA400B09777 /* ReaderConnectionUnderlyingErrorDisplaying.swift in Sources */,
 				EEB4E2DA29B5F8FC00371C3C /* CouponLineDetailsViewModel.swift in Sources */,
 				B6C78B8E293BAE68008934A1 /* AnalyticsHubLastMonthRangeData.swift in Sources */,
 				B517EA18218B232700730EC4 /* StringFormatter+Notes.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9136
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In the new Tap to Pay on iPhone set up screen, we didn't have any handling for no network connectivity, and if connectivity was lost after the set up reader connection) process began, we would show an error which mentions a failed payment, out of context.

This PR adds a banner when the user is not online, and disables the Set up button. If the network connection is lost during the set up process, we now show an error message which does not mention a payment:

> Sorry, we could not start Tap to Pay on iPhone. Please check your connection and try again.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using an iPhone XS or newer on a US store

1. Open the app and navigate to `Menu > Payments > Set up Tap to Pay on iPhone` (known issue: wait until the spinner stops before you tap this!)
2. Turn on Airplane Mode, and disable wifi if required
3. Observe that the Offline mode banner is displayed, and the set up button is disabled.
4. Turn off Airplane Mode, and/or enable wifi if required
5. Observe that the banner is cleared and the set up button is enabled
6. Tap `Set up Tap to Pay on iPhone`
7. Observe that the connection proceeds – quickly enable Airplane Mode again
8. Observe that the error displayed does not mention payments.
9. Disable Airplane Mode and tap retry
10. Observe that the retried connection continues and succeeds (blank screen shows)



## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/225100639-ce31b9fc-8f7c-49e8-8de1-2198d5de38aa.mp4



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
