### PR TITLE
[Free trial] Fetch site plan details.

### DIFF
--- a/Networking/NetworkingTests/Remote/PaymentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/PaymentRemoteTests.swift
@@ -70,7 +70,9 @@ final class PaymentRemoteTests: XCTestCase {
         let plan = try await remote.loadSiteCurrentPlan(siteID: 134)
 
         // Then
-        XCTAssertEqual(plan, .init(hasDomainCredit: false))
+        XCTAssertEqual(plan, .init(id: "1008",
+                                   hasDomainCredit: false,
+                                   expiryDate: DateFormatter.Defaults.iso8601.date(from: "2025-01-01T00:00:00+00:00")))
     }
 
     func test_loadSiteCurrentPlan_returns_noCurrentPlan_error_when_response_has_no_current_plan() async throws {

--- a/WooCommerce/Classes/Model/WPComSitePlan+FreeTrial.swift
+++ b/WooCommerce/Classes/Model/WPComSitePlan+FreeTrial.swift
@@ -1,0 +1,18 @@
+import Foundation
+import struct Yosemite.WPComSitePlan
+
+/// Extension to determine if a WPComPlan is a free trial plan.
+///
+extension WPComSitePlan {
+
+    /// WooCommerce Core Free Trial ID.
+    ///
+    private static let freeTrialID = "1052"
+
+    /// Determines if a plan is a free trial plan.
+    /// Note: It doesn't take into account if the trial has expired or not.
+    ///
+    var isFreeTrial: Bool {
+        id == Self.freeTrialID && expiryDate != nil
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -158,6 +158,8 @@ final class DashboardViewController: UIViewController {
         observeAddProductTrigger()
         observeOnboardingVisibility()
 
+        viewModel.syncFreeTrialBanner(siteID: siteID)
+
         Task { @MainActor in
             await viewModel.syncAnnouncements(for: siteID)
             await reloadDashboardUIStatsVersion(forced: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -159,6 +159,21 @@ final class DashboardViewModel {
         }
     }
 
+    /// Fetches the current site plan.
+    ///
+    func syncFreeTrialBanner(siteID: Int64) {
+        let action = PaymentAction.loadSiteCurrentPlan(siteID: siteID) { [weak self] result in
+            //guard let self = self else { return }
+            switch result {
+            case .success(let plan):
+                print(plan)
+            case .failure(let error):
+                DDLogError("⛔️ Error fetching the current site's plan information: \(error)")
+            }
+        }
+        stores.dispatch(action)
+    }
+
     /// Checks if a store is eligible for products onboarding -returning error otherwise- and prepares the onboarding announcement if needed.
     ///
     private func syncProductsOnboarding(for siteID: Int64) async throws {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -162,11 +162,24 @@ final class DashboardViewModel {
     /// Fetches the current site plan.
     ///
     func syncFreeTrialBanner(siteID: Int64) {
-        let action = PaymentAction.loadSiteCurrentPlan(siteID: siteID) { [weak self] result in
-            //guard let self = self else { return }
+        // Only fetch free trial information when the local feature flag is enabled.
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.freeTrial) else {
+            return
+        }
+
+        // Only fetch free trial information is the site is a WPCom site.
+        guard stores.sessionManager.defaultSite?.isWordPressComStore == true else {
+            return DDLogInfo("⚠️ Site is not a WPCOM site.")
+        }
+
+        let action = PaymentAction.loadSiteCurrentPlan(siteID: siteID) { result in
             switch result {
             case .success(let plan):
-                print(plan)
+                if plan.isFreeTrial {
+                    print("*****************************")
+                    print("****** FREE TRIAL PLAN ******")
+                    print("*****************************")
+                }
             case .failure(let error):
                 DDLogError("⛔️ Error fetching the current site's plan information: \(error)")
             }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -729,6 +729,7 @@
 		26C6E8E626E6B5F500C7BB0F /* StateSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */; };
 		26C6E8EA26E8FD3900C7BB0F /* LazyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E926E8FD3900C7BB0F /* LazyView.swift */; };
 		26C6E8EC26E8FF4800C7BB0F /* LazyNavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */; };
+		26C98F9829C1247000F96503 /* WPComSitePlan+FreeTrial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C98F9729C1246F00F96503 /* WPComSitePlan+FreeTrial.swift */; };
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26CFDB2727357E8000AB940B /* SimplePaymentsSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */; };
@@ -1318,7 +1319,6 @@
 		AEFF77AA29786DAA00667F7A /* PriceInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFF77A929786DAA00667F7A /* PriceInputViewModelTests.swift */; };
 		B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509112D2049E27A007D25DC /* DashboardViewController.swift */; };
 		B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED021C041DF000076A9 /* Locale+Woo.swift */; };
-		B509FED521C052D1000076A9 /* MockSupportManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED421C052D1000076A9 /* MockSupportManager.swift */; };
 		B50BB4162141828F00AF0F3C /* FooterSpinnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50BB4152141828F00AF0F3C /* FooterSpinnerView.swift */; };
 		B511ED27218A660E005787DC /* StringDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B511ED26218A660E005787DC /* StringDescriptor.swift */; };
 		B517EA18218B232700730EC4 /* StringFormatter+Notes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B517EA17218B232700730EC4 /* StringFormatter+Notes.swift */; };
@@ -2885,6 +2885,7 @@
 		26C6E8E526E6B5F500C7BB0F /* StateSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSelectorViewModel.swift; sourceTree = "<group>"; };
 		26C6E8E926E8FD3900C7BB0F /* LazyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyView.swift; sourceTree = "<group>"; };
 		26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyNavigationLink.swift; sourceTree = "<group>"; };
+		26C98F9729C1246F00F96503 /* WPComSitePlan+FreeTrial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPComSitePlan+FreeTrial.swift"; sourceTree = "<group>"; };
 		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummary.swift; sourceTree = "<group>"; };
@@ -7699,6 +7700,7 @@
 				DECE13FF279A595200816ECD /* Coupon+Woo.swift */,
 				E1E649E82846188C0070B194 /* BetaFeature.swift */,
 				EE0EE7A528B7415200F6061E /* CustomHelpCenterContent.swift */,
+				26C98F9729C1246F00F96503 /* WPComSitePlan+FreeTrial.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -11602,6 +11604,7 @@
 				0211254125778BDF0075AD2A /* ShippingLabelDetailsViewController.swift in Sources */,
 				020DD49123239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift in Sources */,
 				0202B6952387AD1B00F3EBE0 /* UITabBar+Order.swift in Sources */,
+				26C98F9829C1247000F96503 /* WPComSitePlan+FreeTrial.swift in Sources */,
 				3120491726DD807900A4EC4F /* LabelAndButtonTableViewCell.swift in Sources */,
 				024DF31423742B7A006658FE /* AztecUnderlineFormatBarCommand.swift in Sources */,
 				CE32B10D20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift in Sources */,


### PR DESCRIPTION
closes #9060 

# Why

This PR makes sure that we fetch the current site subscription plan, to determine if it is a free trial. The next PRs will add a banner indicating the free trial status to the merchant.

# How

- Update `WPComSitePlan` to parse the `id` and `expiry` properties.
- Add an extension to determine if a site plan is a free trial plan.  We consider a plan a free trial plan if it's id is `"1052"` and has an `expiry` date.
- Fetch the current site plan when the dashboard loads

# Testing

- Load the dashboard of a free trial site.
- See that we print `FREE TRIAL PLAN` in the console.

<img width="998" alt="Screenshot 2023-03-14 at 6 20 47 PM" src="https://user-images.githubusercontent.com/562080/225163599-88318425-be2c-46f8-b8a7-b3b99ae53b71.png">



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
