### PR TITLE
Store onboarding > launch store: Networking & Yosemite layer changes

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -53,6 +53,9 @@
 		026CF624237D839B009563D4 /* product-variations-load-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 026CF623237D839A009563D4 /* product-variations-load-all.json */; };
 		0272E3F5254AA48F00436277 /* order-with-line-item-attributes.json in Resources */ = {isa = PBXBuildFile; fileRef = 0272E3F4254AA48F00436277 /* order-with-line-item-attributes.json */; };
 		0272E3FB254AABB800436277 /* order-with-line-item-attributes-before-API-support.json in Resources */ = {isa = PBXBuildFile; fileRef = 0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */; };
+		027EB57429C07524003CE551 /* site-launch-error-unauthorized.json in Resources */ = {isa = PBXBuildFile; fileRef = 027EB57129C07524003CE551 /* site-launch-error-unauthorized.json */; };
+		027EB57529C07524003CE551 /* site-launch-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 027EB57229C07524003CE551 /* site-launch-success.json */; };
+		027EB57629C07524003CE551 /* site-launch-error-already-launched.json in Resources */ = {isa = PBXBuildFile; fileRef = 027EB57329C07524003CE551 /* site-launch-error-already-launched.json */; };
 		028296F7237D588700E84012 /* ProductVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296F6237D588700E84012 /* ProductVariation.swift */; };
 		0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */ = {isa = PBXBuildFile; fileRef = 0282DD90233A120A006A5FDB /* products-search-photo.json */; };
 		028CB716290223CB00331C09 /* create-account-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 028CB712290223CB00331C09 /* create-account-success.json */; };
@@ -947,6 +950,9 @@
 		026CF623237D839A009563D4 /* product-variations-load-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variations-load-all.json"; sourceTree = "<group>"; };
 		0272E3F4254AA48F00436277 /* order-with-line-item-attributes.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-with-line-item-attributes.json"; sourceTree = "<group>"; };
 		0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-with-line-item-attributes-before-API-support.json"; sourceTree = "<group>"; };
+		027EB57129C07524003CE551 /* site-launch-error-unauthorized.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-launch-error-unauthorized.json"; sourceTree = "<group>"; };
+		027EB57229C07524003CE551 /* site-launch-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-launch-success.json"; sourceTree = "<group>"; };
+		027EB57329C07524003CE551 /* site-launch-error-already-launched.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-launch-error-already-launched.json"; sourceTree = "<group>"; };
 		028296F6237D588700E84012 /* ProductVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariation.swift; sourceTree = "<group>"; };
 		0282DD90233A120A006A5FDB /* products-search-photo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-search-photo.json"; sourceTree = "<group>"; };
 		028CB712290223CB00331C09 /* create-account-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "create-account-success.json"; sourceTree = "<group>"; };
@@ -2368,6 +2374,9 @@
 				02B41A93296C04BC00FE3311 /* load-site-plans-no-current-plan.json */,
 				EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */,
 				02B41A8F296BC85800FE3311 /* site-domains.json */,
+				027EB57329C07524003CE551 /* site-launch-error-already-launched.json */,
+				027EB57129C07524003CE551 /* site-launch-error-unauthorized.json */,
+				027EB57229C07524003CE551 /* site-launch-success.json */,
 				D865CE6D278CC19A002C8520 /* stripe-location-error.json */,
 				D865CE6C278CC19A002C8520 /* stripe-location.json */,
 				D865CE6A278CA266002C8520 /* stripe-payment-intent-error.json */,
@@ -3353,6 +3362,7 @@
 				DE4F2A442975684900B0701C /* site-api-without-data.json in Resources */,
 				DE42F96B296BC23800D514C2 /* customer-without-data.json in Resources */,
 				EE80A24729547F8B003591E4 /* coupons-all-without-data.json in Resources */,
+				027EB57629C07524003CE551 /* site-launch-error-already-launched.json in Resources */,
 				7412A8F021B6E416005D182A /* report-orders.json in Resources */,
 				CCF4346A2906C9C300B4475A /* products-ids-only-empty.json in Resources */,
 				DEF13C5E296686AB0024A02B /* orders-load-all-without-data.json in Resources */,
@@ -3395,6 +3405,7 @@
 				268B68FD24C87E37007EBF1D /* leaderboards-year-alt.json in Resources */,
 				74A1D264211898F000931DFA /* site-visits-week.json in Resources */,
 				EE57C127297F8E5E00BC31E7 /* product-attribute-terms-without-data.json in Resources */,
+				027EB57429C07524003CE551 /* site-launch-error-unauthorized.json in Resources */,
 				B53EF53621813681003E146F /* generic_success.json in Resources */,
 				31054718262E2F5E00C5C02B /* wcpay-payment-intent-requires-confirmation.json in Resources */,
 				DE66C5672977CEB800DAA978 /* shipping-label-status-success-without-data.json in Resources */,
@@ -3470,6 +3481,7 @@
 				2676F4D0290B0EC800C7A15B /* product-id-only.json in Resources */,
 				31D27C8F2602B553002EDB1D /* plugins.json in Resources */,
 				DE66C55D2977C35A00DAA978 /* shipping-label-packages-success-without-data.json in Resources */,
+				027EB57529C07524003CE551 /* site-launch-success.json in Resources */,
 				261CF1B4255AD6B30090D8D3 /* payment-gateway-list.json in Resources */,
 				268B68FB24C87384007EBF1D /* leaderboards-products.json in Resources */,
 				0359EA2527AAF7D60048DE2D /* wcpay-charge-card.json in Resources */,

--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -8,6 +8,10 @@ public protocol SiteRemoteProtocol {
     ///   - domain: The domain selected for the site.
     /// - Returns: The response with the site creation.
     func createSite(name: String, domain: String) async throws -> SiteCreationResponse
+
+    /// Launches a site publicly through WPCOM.
+    /// - Parameter siteID: Remote WPCOM ID of the site.
+    func launchSite(siteID: Int64) async throws
 }
 
 /// Site: Remote Endpoints
@@ -51,6 +55,12 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
         ]
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters)
 
+        return try await enqueue(request)
+    }
+
+    public func launchSite(siteID: Int64) async throws {
+        let path = "sites/\(siteID)/launch"
+        let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: path)
         return try await enqueue(request)
     }
 }

--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -59,7 +59,7 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
     }
 
     public func launchSite(siteID: Int64) async throws {
-        let path = "sites/\(siteID)/launch"
+        let path = Path.siteLaunch(siteID: siteID)
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: path)
         return try await enqueue(request)
     }
@@ -103,5 +103,8 @@ public extension SiteCreationResponse {
 private extension SiteRemote {
     enum Path {
         static let siteCreation = "sites/new"
+        static func siteLaunch(siteID: Int64) -> String {
+            "sites/\(siteID)/launch"
+        }
     }
 }

--- a/Networking/NetworkingTests/Responses/site-launch-error-already-launched.json
+++ b/Networking/NetworkingTests/Responses/site-launch-error-already-launched.json
@@ -1,0 +1,5 @@
+{
+    "code": "already-launched",
+    "message": "This site has already been launched",
+    "data": null
+}

--- a/Networking/NetworkingTests/Responses/site-launch-error-unauthorized.json
+++ b/Networking/NetworkingTests/Responses/site-launch-error-unauthorized.json
@@ -1,0 +1,7 @@
+{
+    "code": "unauthorized",
+    "message": "You do not have permission to launch this site.",
+    "data": {
+        "status": 403
+    }
+}

--- a/Networking/NetworkingTests/Responses/site-launch-success.json
+++ b/Networking/NetworkingTests/Responses/site-launch-success.json
@@ -1,0 +1,3 @@
+{
+    "status_launched": "launched"
+}

--- a/Yosemite/Yosemite/Actions/SiteAction.swift
+++ b/Yosemite/Yosemite/Actions/SiteAction.swift
@@ -11,6 +11,12 @@ public enum SiteAction: Action {
     case createSite(name: String,
                     domain: String,
                     completion: (Result<SiteCreationResult, SiteCreationError>) -> Void)
+
+    /// Launches a site publicly through WPCOM.
+    /// - Parameter:
+    ///   - siteID: ID of the site to launch.
+    ///   - completion: Called when the result of site launch is available.
+    case launchSite(siteID: Int64, completion: (Result<Void, SiteLaunchError>) -> Void)
 }
 
 /// The result of site creation including necessary site information.

--- a/Yosemite/Yosemite/Stores/SiteStore.swift
+++ b/Yosemite/Yosemite/Stores/SiteStore.swift
@@ -42,6 +42,8 @@ public final class SiteStore: Store {
         switch action {
         case .createSite(let name, let domain, let completion):
             createSite(name: name, domain: domain, completion: completion)
+        case let .launchSite(siteID, completion):
+            launchSite(siteID: siteID, completion: completion)
         }
     }
 }
@@ -66,6 +68,17 @@ private extension SiteStore {
                                           siteSlug: response.site.siteSlug)))
             } catch {
                 completion(.failure(SiteCreationError(remoteError: error)))
+            }
+        }
+    }
+
+    func launchSite(siteID: Int64, completion: @escaping (Result<Void, SiteLaunchError>) -> Void) {
+        Task { @MainActor in
+            do {
+                try await remote.launchSite(siteID: siteID)
+                completion(.success(()))
+            } catch {
+                completion(.failure(SiteLaunchError(remoteError: error)))
             }
         }
     }
@@ -109,6 +122,30 @@ public enum SiteCreationError: Error, Equatable {
             }
         default:
             self = .unknown(description: remoteError.localizedDescription)
+        }
+    }
+}
+
+public enum SiteLaunchError: Error, Equatable {
+    case alreadyLaunched
+    case unexpected(description: String)
+
+    init(remoteError: Error) {
+        switch remoteError {
+        case let remoteError as WordPressApiError:
+            switch remoteError {
+            case let .unknown(code, _):
+                switch code {
+                case "already-launched":
+                    self = .alreadyLaunched
+                default:
+                    self = .unexpected(description: remoteError.localizedDescription)
+                }
+            default:
+                self = .unexpected(description: remoteError.localizedDescription)
+            }
+        default:
+            self = .unexpected(description: remoteError.localizedDescription)
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/SiteStore.swift
+++ b/Yosemite/Yosemite/Stores/SiteStore.swift
@@ -131,21 +131,12 @@ public enum SiteLaunchError: Error, Equatable {
     case unexpected(description: String)
 
     init(remoteError: Error) {
-        switch remoteError {
-        case let remoteError as WordPressApiError:
-            switch remoteError {
-            case let .unknown(code, _):
-                switch code {
-                case "already-launched":
-                    self = .alreadyLaunched
-                default:
-                    self = .unexpected(description: remoteError.localizedDescription)
-                }
-            default:
-                self = .unexpected(description: remoteError.localizedDescription)
-            }
-        default:
+        guard let error = remoteError as? WordPressApiError,
+              case let .unknown(code, _) = error,
+              code == "already-launched" else {
             self = .unexpected(description: remoteError.localizedDescription)
+            return
         }
+        self = .alreadyLaunched
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
@@ -7,9 +7,17 @@ final class MockSiteRemote {
     /// The results to return in `createSite`.
     private var createSiteResult: Result<SiteCreationResponse, Error>?
 
+    /// The results to return in `launchSite`.
+    private var launchSiteResult: Result<Void, Error>?
+
     /// Returns the value when `createSite` is called.
     func whenCreatingSite(thenReturn result: Result<SiteCreationResponse, Error>) {
         createSiteResult = result
+    }
+
+    /// Returns the value when `launchSite` is called.
+    func whenLaunchingSite(thenReturn result: Result<Void, Error>) {
+        launchSiteResult = result
     }
 }
 
@@ -17,6 +25,15 @@ extension MockSiteRemote: SiteRemoteProtocol {
     func createSite(name: String, domain: String) async throws -> SiteCreationResponse {
         guard let result = createSiteResult else {
             XCTFail("Could not find result for creating a site.")
+            throw NetworkError.notFound
+        }
+
+        return try result.get()
+    }
+
+    func launchSite(siteID: Int64) async throws {
+        guard let result = launchSiteResult else {
+            XCTFail("Could not find result for launching a site.")
             throw NetworkError.notFound
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9122 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implemented the new action to launch a store through WPCOM, the UI integration will be in a separate PR to it easier for review:
- Networking layer: new async function `SiteRemote.launchSite(siteID:)`
- Yosemite layer: new action `SiteAction.launchSite(siteID:completion:)`

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just CI is sufficient, as the new action isn't used in the app yet.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
