### PR TITLE
[Product Multi-selection] Redirect to variations view on checkbox toggle tap

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -153,6 +153,10 @@ struct ProductSelectorView: View {
                            viewModel: rowViewModel,
                            onCheckboxSelected: {
                     viewModel.toggleSelectionForAllVariations(of: rowViewModel.productOrVariationID)
+                    if !viewModel.toggleAllVariationsOnSelection {
+                        isShowingVariationList.toggle()
+                        self.variationListViewModel = variationListViewModel
+                    }
                 })
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .onTapGesture {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9120 , based on https://github.com/woocommerce/woocommerce-ios/pull/8943 , that PR should be merged first.

## Description
This PR takes care of opening the `ProductVariationSelector` view if product multi-selection is enabled, when we tap on the `ProductSelector` view checkbox that represents the product.

## Testing instructions
- Go to Menu > Settings > Experimental features > Switch the Product Multi-Selection feature on.
- On a store with product variations > Go to Orders > `+` > `+ Add Product`
- Tap on the checkbox for your product variations
- See how you're redirected to the ProductVariationSelector view

## Screenshots
<img width=450 src="https://user-images.githubusercontent.com/3812076/225222873-4de69bb2-bc08-4459-aca1-3f65194fcee5.jpg">


---


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
