### PR TITLE
[Store onboarding] Order tasks to match UI designs

### DIFF
--- a/Networking/Networking/Model/StoreOnboardingTask.swift
+++ b/Networking/Networking/Model/StoreOnboardingTask.swift
@@ -44,3 +44,26 @@ public extension StoreOnboardingTask {
         }
     }
 }
+
+private extension StoreOnboardingTask.TaskType {
+    var sortOrder: Int {
+        switch self {
+        case .addFirstProduct:
+            return 0
+        case .launchStore:
+            return 1
+        case .customizeDomains:
+            return 2
+        case .payments, .woocommercePayments:
+            return 3
+        case .unsupported:
+            return 4
+        }
+    }
+}
+
+extension StoreOnboardingTask: Comparable {
+    public static func < (lhs: StoreOnboardingTask, rhs: StoreOnboardingTask) -> Bool {
+        lhs.type.sortOrder < rhs.type.sortOrder
+    }
+}

--- a/Yosemite/Yosemite/Stores/StoreOnboardingTasksStore.swift
+++ b/Yosemite/Yosemite/Stores/StoreOnboardingTasksStore.swift
@@ -51,7 +51,7 @@ public final class StoreOnboardingTasksStore: Store {
 private extension StoreOnboardingTasksStore {
     func loadOnboardingTasks(siteID: Int64, completion: @escaping (Result<[StoreOnboardingTask], Error>) -> Void) {
         Task { @MainActor in
-            let result = await Result { try await remote.loadOnboardingTasks(siteID: siteID) }
+            let result = await Result { try await remote.loadOnboardingTasks(siteID: siteID).sorted() }
             completion(result)
         }
     }


### PR DESCRIPTION

Closes: #9107

## Description
Sort the store onboarding task list to match the UI design.

## Testing instructions

- Launch and login using a WPCOM store
- Verify that the store onboarding tasks list is in the same order as the UI design.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
WPCOM store 
| Before | After |
| - | - |
| ![Before](https://user-images.githubusercontent.com/524475/225250465-fe101317-80c3-4fc8-af83-cbbf4f3b445a.png) | ![After](https://user-images.githubusercontent.com/524475/225250616-a7ac6677-69e8-4ea7-bbbb-77b43f737a6e.png) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
