### PR TITLE
Store onboarding > launch store: show launched store UI

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Installations/StoreCreationSuccessView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Installations/StoreCreationSuccessView.swift
@@ -48,9 +48,6 @@ struct StoreCreationSuccessView: View {
     /// URL of the newly created site.
     let siteURL: URL
 
-    // Tracks the scale of the view due to accessibility changes.
-    @ScaledMetric private var scale: CGFloat = 1.0
-
     @State private var isPresentingWebview: Bool = false
 
     var body: some View {
@@ -62,13 +59,7 @@ struct StoreCreationSuccessView: View {
                     .titleStyle()
 
                 // Readonly webview for the new site.
-                WebView(isPresented: .constant(true), url: siteURL)
-                    .frame(height: 400 * scale)
-                    .disabled(true)
-                    .border(Color(.systemBackground), width: 8)
-                    .cornerRadius(8)
-                    .shadow(color: Color(.secondaryLabel), radius: 26)
-                    .padding(.horizontal, insets: Layout.webviewHorizontalPadding)
+                SitePreviewView(siteURL: siteURL)
             }
             .padding(Layout.contentPadding)
         }
@@ -104,7 +95,6 @@ private extension StoreCreationSuccessView {
     enum Layout {
         static let contentPadding: EdgeInsets = .init(top: 38, leading: 16, bottom: 16, trailing: 16)
         static let buttonContainerPadding: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
-        static let webviewHorizontalPadding: EdgeInsets = .init(top: 0, leading: 44, bottom: 0, trailing: 44)
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -40,7 +40,7 @@ final class StoreOnboardingCoordinator: Coordinator {
         case .customizeDomains:
             showCustomDomains()
         case .launchStore:
-            launchStore()
+            launchStore(task: task)
         default:
             #warning("TODO: handle navigation for each onboarding task")
             start()
@@ -67,8 +67,8 @@ private extension StoreOnboardingCoordinator {
     }
 
     @MainActor
-    func launchStore() {
-        let coordinator = StoreOnboardingLaunchStoreCoordinator(site: site, navigationController: navigationController)
+    func launchStore(task: StoreOnboardingTask) {
+        let coordinator = StoreOnboardingLaunchStoreCoordinator(site: site, isLaunched: task.isComplete, navigationController: navigationController)
         self.launchStoreCoordinator = coordinator
         coordinator.start()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreCoordinator.swift
@@ -6,9 +6,15 @@ import struct Yosemite.Site
 final class StoreOnboardingLaunchStoreCoordinator: Coordinator {
     let navigationController: UINavigationController
     private let site: Site
+    private let isLaunched: Bool
 
-    init(site: Site, navigationController: UINavigationController) {
+    /// - Parameters:
+    ///   - site: The site for the launch store onboarding task.
+    ///   - isLaunched: Whether the site has already been launched.
+    ///   - navigationController: The navigation controller that presents the launch store flow.
+    init(site: Site, isLaunched: Bool, navigationController: UINavigationController) {
         self.site = site
+        self.isLaunched = isLaunched
         self.navigationController = navigationController
     }
 
@@ -17,15 +23,46 @@ final class StoreOnboardingLaunchStoreCoordinator: Coordinator {
             assertionFailure("The site does not have a valid URL to launch from store onboarding: \(site).")
             return
         }
-        let launchStoreController = StoreOnboardingLaunchStoreHostingController(viewModel: .init(siteURL: siteURL, siteID: site.siteID) { [weak self] in
-            self?.showLaunchedView()
-        })
-        navigationController.present(WooNavigationController(rootViewController: launchStoreController), animated: true)
+
+        // Navigation controller for the launch store flow.
+        let modalNavigationController = WooNavigationController()
+        if isLaunched {
+            presentLaunchedView(siteURL: siteURL, in: modalNavigationController)
+        } else {
+            presentLaunchStoreView(siteURL: siteURL, in: modalNavigationController)
+        }
     }
 }
 
 private extension StoreOnboardingLaunchStoreCoordinator {
-    func showLaunchedView() {
-        print("🚀 site launched")
+    func presentLaunchStoreView(siteURL: URL, in modalNavigationController: UINavigationController) {
+        let launchStoreController = StoreOnboardingLaunchStoreHostingController(viewModel: .init(siteURL: siteURL, siteID: site.siteID) { [weak self] in
+            self?.showLaunchedView(siteURL: siteURL, in: modalNavigationController)
+        })
+        modalNavigationController.pushViewController(launchStoreController, animated: false)
+        navigationController.present(modalNavigationController, animated: true)
+    }
+
+    func presentLaunchedView(siteURL: URL, in modalNavigationController: UINavigationController) {
+        let launchedStoreController = createLaunchedStoreController(siteURL: siteURL)
+        modalNavigationController.pushViewController(launchedStoreController, animated: false)
+        navigationController.present(modalNavigationController, animated: true)
+    }
+
+    func showLaunchedView(siteURL: URL, in modalNavigationController: UINavigationController) {
+        let launchedStoreController = createLaunchedStoreController(siteURL: siteURL)
+        modalNavigationController.pushViewController(launchedStoreController, animated: true)
+    }
+
+    func dismiss() {
+        navigationController.dismiss(animated: true)
+    }
+}
+
+private extension StoreOnboardingLaunchStoreCoordinator {
+    func createLaunchedStoreController(siteURL: URL) -> UIViewController {
+        StoreOnboardingStoreLaunchedHostingController(siteURL: siteURL) { [weak self] in
+            self?.dismiss()
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingStoreLaunchedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingStoreLaunchedView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+/// Hosting controller that wraps the `StoreOnboardingStoreLaunchedView`.
+final class StoreOnboardingStoreLaunchedHostingController: UIHostingController<StoreOnboardingStoreLaunchedView> {
+    init(siteURL: URL, onContinue: @escaping () -> Void) {
+        super.init(rootView: StoreOnboardingStoreLaunchedView(siteURL: siteURL))
+        rootView.onContinue = onContinue
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// Shows a preview of a launched store from store onboarding with a CTA to share the URL.
+struct StoreOnboardingStoreLaunchedView: View {
+    /// Set in the hosting controller.
+    var onContinue: () -> Void = {}
+
+    /// URL of the launched site.
+    let siteURL: URL
+
+    @State private var showsShareSheet: Bool = false
+
+    // Tracks the scale of the view due to accessibility changes.
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .center, spacing: Layout.textAndPreviewSpacing) {
+                VStack(alignment: .center, spacing: Layout.defaultSpacing) {
+                    // Title label.
+                    HStack(alignment: .center, spacing: Layout.titleAndCircleSpacing) {
+                        Circle()
+                            .fill(Color.green)
+                            .frame(width: Layout.circleDimension * scale, height: Layout.circleDimension * scale)
+                        Text(Localization.title)
+                            .fontWeight(.bold)
+                            .titleStyle()
+                    }
+
+                    // URL label.
+                    Text(siteURL.absoluteString)
+                        .underline()
+                        .foregroundColor(.init(.textSubtle))
+                        .captionStyle()
+                }
+
+                // Readonly webview for the launched site.
+                SitePreviewView(siteURL: siteURL)
+            }
+            .padding(Layout.contentPadding)
+        }
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: 0) {
+                Divider()
+                    .dividerStyle()
+
+                VStack(spacing: Layout.defaultSpacing) {
+                    // Share button.
+                    Button(Localization.shareButtonTitle) {
+                        showsShareSheet = true
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+
+                    // Continue button.
+                    Button(Localization.continueButtonTitle) {
+                        onContinue()
+                    }
+                    .buttonStyle(SecondaryButtonStyle())
+                }
+                .padding(insets: Layout.buttonContainerPadding)
+            }
+            .background(Color(.systemBackground))
+        }
+        .shareSheet(isPresented: $showsShareSheet) {
+            ShareSheet(activityItems: [siteURL])
+        }
+        .navigationBarHidden(true)
+    }
+}
+
+private extension StoreOnboardingStoreLaunchedView {
+    enum Layout {
+        static let contentPadding: EdgeInsets = .init(top: 38, leading: 16, bottom: 16, trailing: 16)
+        static let buttonContainerPadding: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+        static let defaultSpacing: CGFloat = 16
+        static let textAndPreviewSpacing: CGFloat = 33
+        static let titleAndCircleSpacing: CGFloat = 14
+        static let circleDimension: CGFloat = 12
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Your store is live!",
+            comment: "Title of the store onboarding launched store screen."
+        )
+        static let shareButtonTitle = NSLocalizedString(
+            "Share URL",
+            comment: "Title of the primary button on the store onboarding launched store screen."
+        )
+        static let continueButtonTitle = NSLocalizedString(
+            "Back to My Store",
+            comment: "Title of the secondary button on the store onboarding launched store screen."
+        )
+    }
+}
+
+struct StoreOnboardingStoreLaunchedView_Previews: PreviewProvider {
+    static var previews: some View {
+        StoreOnboardingStoreLaunchedView(siteURL: URL(string: "https://woocommerce.com")!)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SitePreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SitePreviewView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// Previews a site in a web view with a border, shadow, and a default height.
+struct SitePreviewView: View {
+    /// URL of the site.
+    let siteURL: URL
+
+    // Tracks the scale of the view due to accessibility changes.
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    var body: some View {
+        // Readonly webview for the new site.
+        WebView(isPresented: .constant(true), url: siteURL)
+            .frame(height: 400 * scale)
+            .disabled(true)
+            .border(Color(.systemBackground), width: 8)
+            .cornerRadius(8)
+            .shadow(color: Color(.secondaryLabel), radius: 26)
+            .padding(.horizontal, insets: Layout.webviewHorizontalPadding)
+    }
+}
+
+private extension SitePreviewView {
+    enum Layout {
+        static let webviewHorizontalPadding: EdgeInsets = .init(top: 0, leading: 44, bottom: 0, trailing: 44)
+    }
+}
+
+struct SitePreviewView_Previews: PreviewProvider {
+    static var previews: some View {
+        SitePreviewView(siteURL: URL(string: "https://woocommerce.com")!)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		020B2F8F23BD9F1F00BD79AD /* IntegerInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */; };
 		020B2F9123BDD71500BD79AD /* IntegerInputFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F9023BDD71500BD79AD /* IntegerInputFormatterTests.swift */; };
 		020B2F9423BDDBDC00BD79AD /* ProductUpdateError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F9323BDDBDC00BD79AD /* ProductUpdateError+UI.swift */; };
+		020B640F29C194CF001C5BD9 /* StoreOnboardingStoreLaunchedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B640E29C194CF001C5BD9 /* StoreOnboardingStoreLaunchedView.swift */; };
 		020BE74823B05CF2007FE54C /* ProductInventoryEditableData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE74723B05CF2007FE54C /* ProductInventoryEditableData.swift */; };
 		020BE74D23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE74B23B1F5EA007FE54C /* TitleAndTextFieldTableViewCell.swift */; };
 		020BE74E23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 020BE74C23B1F5EA007FE54C /* TitleAndTextFieldTableViewCell.xib */; };
@@ -2215,6 +2216,7 @@
 		020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerInputFormatter.swift; sourceTree = "<group>"; };
 		020B2F9023BDD71500BD79AD /* IntegerInputFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerInputFormatterTests.swift; sourceTree = "<group>"; };
 		020B2F9323BDDBDC00BD79AD /* ProductUpdateError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductUpdateError+UI.swift"; sourceTree = "<group>"; };
+		020B640E29C194CF001C5BD9 /* StoreOnboardingStoreLaunchedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingStoreLaunchedView.swift; sourceTree = "<group>"; };
 		020BE74723B05CF2007FE54C /* ProductInventoryEditableData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInventoryEditableData.swift; sourceTree = "<group>"; };
 		020BE74B23B1F5EA007FE54C /* TitleAndTextFieldTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndTextFieldTableViewCell.swift; sourceTree = "<group>"; };
 		020BE74C23B1F5EA007FE54C /* TitleAndTextFieldTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleAndTextFieldTableViewCell.xib; sourceTree = "<group>"; };
@@ -5315,6 +5317,7 @@
 				027EB56B29C05F4A003CE551 /* StoreOnboardingLaunchStoreView.swift */,
 				027EB56D29C0602D003CE551 /* StoreOnboardingLaunchStoreViewModel.swift */,
 				027EB56F29C062DD003CE551 /* StoreOnboardingLaunchStoreCoordinator.swift */,
+				020B640E29C194CF001C5BD9 /* StoreOnboardingStoreLaunchedView.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -11664,6 +11667,7 @@
 				02F843DA273646A30017FE12 /* JetpackBenefitsBanner.swift in Sources */,
 				027D4A8D2526FD1800108626 /* SettingsViewController.swift in Sources */,
 				02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift in Sources */,
+				020B640F29C194CF001C5BD9 /* StoreOnboardingStoreLaunchedView.swift in Sources */,
 				26B3EC642745916F0075EAE6 /* BindableTextField.swift in Sources */,
 				CE2A9FC823C3D2D4002BEC1C /* RefundedProductsDataSource.swift in Sources */,
 				5783FB3F25D7369F00B9984B /* WooAnalyticsEventPropertyType.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -412,6 +412,7 @@
 		02BC5AA524D27F8900C43326 /* ProductVariationFormViewModel+UpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BC5AA224D27F8800C43326 /* ProductVariationFormViewModel+UpdatesTests.swift */; };
 		02BC5AA624D27F8900C43326 /* ProductVariationFormViewModel+ChangesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BC5AA324D27F8800C43326 /* ProductVariationFormViewModel+ChangesTests.swift */; };
 		02BC5AA824D2802B00C43326 /* MockProductVariationStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BC5AA724D2802B00C43326 /* MockProductVariationStoresManager.swift */; };
+		02BE9CC029C05CFD00292333 /* SitePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BE9CBF29C05CFD00292333 /* SitePreviewView.swift */; };
 		02BF9BAF2851E7EA008CE2DD /* MockAppleIDCredentialChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BF9BAE2851E7EA008CE2DD /* MockAppleIDCredentialChecker.swift */; };
 		02C0CD2A23B5BB1C00F880B1 /* ImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0CD2923B5BB1C00F880B1 /* ImageService.swift */; };
 		02C0CD2C23B5BC9600F880B1 /* DefaultImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0CD2B23B5BC9600F880B1 /* DefaultImageService.swift */; };
@@ -2577,6 +2578,7 @@
 		02BC5AA224D27F8800C43326 /* ProductVariationFormViewModel+UpdatesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductVariationFormViewModel+UpdatesTests.swift"; sourceTree = "<group>"; };
 		02BC5AA324D27F8800C43326 /* ProductVariationFormViewModel+ChangesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductVariationFormViewModel+ChangesTests.swift"; sourceTree = "<group>"; };
 		02BC5AA724D2802B00C43326 /* MockProductVariationStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductVariationStoresManager.swift; sourceTree = "<group>"; };
+		02BE9CBF29C05CFD00292333 /* SitePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePreviewView.swift; sourceTree = "<group>"; };
 		02BF9BAE2851E7EA008CE2DD /* MockAppleIDCredentialChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppleIDCredentialChecker.swift; sourceTree = "<group>"; };
 		02C0CD2923B5BB1C00F880B1 /* ImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageService.swift; sourceTree = "<group>"; };
 		02C0CD2B23B5BC9600F880B1 /* DefaultImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageService.swift; sourceTree = "<group>"; };
@@ -6665,6 +6667,7 @@
 				26B71DB5293FE490004D8052 /* RangedDatePicker.swift */,
 				020ACF87299A809000B3638B /* LearnMoreAttributedText.swift */,
 				CC857C7629B25FAF00E19D1E /* FooterNotice.swift */,
+				02BE9CBF29C05CFD00292333 /* SitePreviewView.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -11711,6 +11714,7 @@
 				B94403C9289ABB4D00323FC2 /* SimplePaymentsAmountFlowOpener.swift in Sources */,
 				7E7C5F872719A93C00315B61 /* ProductCategoryListViewController.swift in Sources */,
 				DEC51B06276B3F3C009F3DF4 /* Int64+Helpers.swift in Sources */,
+				02BE9CC029C05CFD00292333 /* SitePreviewView.swift in Sources */,
 				D8B4D5EE26C2C26C00F34E94 /* InPersonPaymentsStripeAcountReviewView.swift in Sources */,
 				CC593A6B26EA640800EF0E04 /* PackageCreationError+UI.swift in Sources */,
 				CE1F512920697F0100C6C810 /* UIFont+Helpers.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9122 
⚠️ Please review the base PR https://github.com/woocommerce/woocommerce-ios/pull/9145 first
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

This PR implemented a new screen that is shown after a site is launched, or when tapping on the launch store onboarding task when the task is already complete (site already launched). This screen shows a site preview (it can look different after it's been launched depending on the theme), with a CTA to share the URL.

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The new screen is a new SwiftUI view `StoreOnboardingStoreLaunchedView`, and the site preview is a new SwiftUI component `SitePreviewView` extracted from the store creation success screen since they share the same design. When handling the launch store task tap action, `StoreOnboardingCoordinator` passes the task completion state to the child coordinator `StoreOnboardingLaunchStoreCoordinator` so that it either presents the **launched store screen** or the **launch store screen** when the task is complete or incomplete, respectively. When a site is launched from the launch store flow, the launched store screen is also pushed to the navigation stack.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: a site with an eCommerce or Business WPCOM plan that hasn't been launched yet

- Log in to the site in the prerequisite
- In the My store tab, tap on the `Launch your store` task --> the launch store screen should be presented
- Tap `Publish My Store` --> a spinner should be shown, and a new screen for the launched store should be shown with the site URL
- Tap `Share URL` --> a share sheet should be shown (unfortunately it's fullscreen in SwiftUI)
- Dismiss the share sheet
- Tap `Back to My Store` --> it should go back to the My store tab
- In the My store tab, pull down to refresh --> the `Launch your store` task should now be complete
- Tap on `View all (#)`, then tap `Launch your store` task again --> the launch store screen should be presented
- Tap `Publish My Store` --> a spinner should be shown, and an error alert should be shown that says the site is already published

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light
-- | --
![Simulator Screen Shot - iPhone 14 - 2023-03-15 at 16 41 23](https://user-images.githubusercontent.com/1945542/225256855-cfc29665-d306-4517-9752-b3aded177405.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-15 at 16 41 31](https://user-images.githubusercontent.com/1945542/225256859-da5f24fa-f586-40af-8d01-d3094d254d75.png)


https://user-images.githubusercontent.com/1945542/225254759-ad307415-a22e-4e32-8c2a-4753c19bc50c.mov




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
