### PR TITLE
REST API: Add support tag for application password login error

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 - [*] Fix: Dismiss Take Payment popup after sharing the payment link to another app. [https://github.com/woocommerce/woocommerce-ios/pull/9042]
 - [*] Site credential login: Catch invalid cookie nonce [https://github.com/woocommerce/woocommerce-ios/pull/9102]
 - [*] Better error messages for site credential login failures [https://github.com/woocommerce/woocommerce-ios/pull/9125]
+- [Internal] New Zendesk tag for site credential login errors [https://github.com/woocommerce/woocommerce-ios/pull/9150]
 
 12.6
 -----

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressAuthenticator
 #if !targetEnvironment(macCatalyst)
 import SupportSDK
 import ZendeskCoreSDK
@@ -581,6 +582,11 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
 
     func decorateTags(tags: [String], supportSourceTag: String?) -> [String] {
         guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
+            if ServiceLocator.stores.isAuthenticated == false,
+               AuthenticatorAnalyticsTracker.shared.state.lastFlow == .loginWithSiteAddress,
+               AuthenticatorAnalyticsTracker.shared.state.lastStep == .usernamePassword {
+                return tags + [Constants.siteCredentialLoginErrorTag]
+            }
             return tags
         }
 
@@ -1288,6 +1294,7 @@ private extension ZendeskManager {
         static let jetpackTag = "jetpack"
         static let wpComTag = "wpcom"
         static let authenticatedWithApplicationPasswordTag = "application_password_authenticated"
+        static let siteCredentialLoginErrorTag = "application_password_login_error"
         static let logFieldCharacterLimit = 64000
         static let networkWiFi = "WiFi"
         static let networkWWAN = "Mobile"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9146 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new support tag for site credential login failure. The tag is added when the user creates a support ticket from the unauthenticated state, and the last step they were experiencing is `username_password`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log out of the app if needed.
- Select Enter your site address.
- Enter the address of your test site and incorrect credentials.
- On the error alert, select Need more help?
- On the Contact Support form, enter content for the ticket (please note in the content that the ticket is intended for testing so that HEs can skip it).
- Submit the ticket, confirm on Zendesk that the new tag `application_password_login_error` is present.
- Please feel free to submit other support tickets from other flows and confirm that `application_password_login_error` is not present.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="284" alt="Screenshot 2023-03-15 at 17 32 42" src="https://user-images.githubusercontent.com/5533851/225284423-41946f51-2464-4697-8209-d8de91d45917.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
