### PR TITLE
[Store onboarding] Add "PRIVATE" label to launch store task.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -53,7 +53,6 @@ struct StoreOnboardingTaskView: View {
                                     .font(.caption)
                                     .fontWeight(.bold)
                                     .foregroundColor(Color(.wooCommercePurple(.shade60)))
-                                    .multilineTextAlignment(.leading)
                                     .padding(Layout.PrivateLabel.padding)
                                     .background(Color(.wooCommercePurple(.shade0)))
                                     .cornerRadius(Layout.PrivateLabel.cornerRadius)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -52,10 +52,10 @@ struct StoreOnboardingTaskView: View {
                                 Text(Localization.privateLabel)
                                     .font(.caption)
                                     .fontWeight(.bold)
-                                    .foregroundColor(Color(uiColor: .accent))
+                                    .foregroundColor(Color(.wooCommercePurple(.shade60)))
                                     .multilineTextAlignment(.leading)
                                     .padding(Layout.PrivateLabel.padding)
-                                    .background(Color(uiColor: .selectableSecondaryButtonSelectedBackground))
+                                    .background(Color(.wooCommercePurple(.shade0)))
                                     .cornerRadius(Layout.PrivateLabel.cornerRadius)
                                     .renderedIf(!isRedacted && viewModel.task.type == .launchStore)
                             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -40,11 +40,25 @@ struct StoreOnboardingTaskView: View {
                         // Task labels
                         VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
                             Spacer().frame(height: Layout.spacerHeight)
-                            // Task title.
-                            Text(viewModel.title)
-                                .headlineStyle()
-                                .multilineTextAlignment(.leading)
-                                .redacted(reason: isRedacted ? .placeholder : [])
+
+                            HStack {
+                                // Task title.
+                                Text(viewModel.title)
+                                    .headlineStyle()
+                                    .multilineTextAlignment(.leading)
+                                    .redacted(reason: isRedacted ? .placeholder : [])
+
+                                // PRIVATE label.
+                                Text(Localization.privateLabel)
+                                    .font(.caption)
+                                    .fontWeight(.bold)
+                                    .foregroundColor(Color(uiColor: .accent))
+                                    .multilineTextAlignment(.leading)
+                                    .padding(Layout.PrivateLabel.padding)
+                                    .background(Color(uiColor: .selectableSecondaryButtonSelectedBackground))
+                                    .cornerRadius(Layout.PrivateLabel.cornerRadius)
+                                    .renderedIf(!isRedacted && viewModel.task.type == .launchStore)
+                            }
 
                             // Task subtitle.
                             Text(viewModel.subtitle)
@@ -70,11 +84,19 @@ struct StoreOnboardingTaskView: View {
 }
 
 private extension StoreOnboardingTaskView {
+    enum Localization {
+        static let privateLabel = NSLocalizedString("PRIVATE", comment: "Label shown on the launch store task.")
+    }
     enum Layout {
         static let horizontalSpacing: CGFloat = 16
         static let verticalSpacing: CGFloat = 4
         static let spacerHeight: CGFloat = 12
         static let imageDimension: CGFloat = 24
+
+        enum PrivateLabel {
+            static let padding: EdgeInsets = .init(top: 4, leading: 6, bottom: 4, trailing: 6)
+            static let cornerRadius: CGFloat = 6
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -49,7 +49,7 @@ struct StoreOnboardingTaskView: View {
                                     .redacted(reason: isRedacted ? .placeholder : [])
 
                                 // PRIVATE label.
-                                Text(Localization.privateLabel)
+                                Text(Localization.privateLabel.uppercased())
                                     .font(.caption)
                                     .fontWeight(.bold)
                                     .foregroundColor(Color(.wooCommercePurple(.shade60)))
@@ -84,7 +84,7 @@ struct StoreOnboardingTaskView: View {
 
 private extension StoreOnboardingTaskView {
     enum Localization {
-        static let privateLabel = NSLocalizedString("PRIVATE", comment: "Label shown on the launch store task.")
+        static let privateLabel = NSLocalizedString("private", comment: "Label shown on the launch store task.")
     }
     enum Layout {
         static let horizontalSpacing: CGFloat = 16


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8907 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Add a "PRIVATE" label to launch store task view.

## Testing instructions
- Launch app and login using a staging WPCOM store
- Verify that you see the "PRIVATE" label on the launch store task

## Screenshots
| Light | Dark |
| - | - |
| ![Light](https://user-images.githubusercontent.com/524475/225284687-725a3419-d845-41c9-9db3-c89badb9ee50.png) | ![Dark](https://user-images.githubusercontent.com/524475/225284660-18af0471-3808-40fd-a514-b48279f222f7.png) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
