### PR TITLE
[Mobile Payments] Block setup button when in progress

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -27,13 +27,13 @@ final class SetUpTapToPayInformationViewController: UIHostingController<SetUpTap
         self.viewModel = viewModel
 
         super.init(rootView: SetUpTapToPayInformationView(viewModel: viewModel))
+
+        viewModel.alertsPresenter = alertsPresenter
+        viewModel.connectionController = connectionController
         configureView()
     }
 
     private func configureView() {
-        rootView.setUpButtonAction = { [weak self] in
-            self?.searchAndConnect()
-        }
         rootView.showURL = { url in
             WebviewHelper.launch(url, with: self)
         }
@@ -50,19 +50,6 @@ final class SetUpTapToPayInformationViewController: UIHostingController<SetUpTap
     override func viewWillDisappear(_ animated: Bool) {
         viewModel.didUpdate = nil
         super.viewWillDisappear(animated)
-    }
-}
-
-// MARK: - Convenience Methods
-//
-private extension SetUpTapToPayInformationViewController {
-    func searchAndConnect() {
-        connectionController.searchAndConnect { _ in
-            /// No need for logic here. Once connected, the connected reader will publish
-            /// through the `cardReaderAvailableSubscription`, so we can just
-            /// dismiss the connection flow alerts.
-            self.alertsPresenter.dismiss()
-        }
     }
 }
 
@@ -118,7 +105,7 @@ struct SetUpTapToPayInformationView: View {
                 Spacer()
 
                 Button(Localization.setUpButton, action: {
-                    setUpButtonAction?()
+                    viewModel.setUpTapped()
                 })
                 .buttonStyle(PrimaryButtonStyle())
                 .disabled(!viewModel.enableSetup)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -107,7 +107,7 @@ struct SetUpTapToPayInformationView: View {
                 Button(Localization.setUpButton, action: {
                     viewModel.setUpTapped()
                 })
-                .buttonStyle(PrimaryButtonStyle())
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.setUpInProgress))
                 .disabled(!viewModel.enableSetup)
 
                 InPersonPaymentsLearnMore(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -10,6 +10,7 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
     private let stores: StoresManager
 
     @Published var enableSetup: Bool = true
+    @Published var setUpInProgress: Bool = false
 
     let siteID: Int64
     let configuration: CardPresentPaymentsConfiguration
@@ -80,11 +81,13 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
     }
 
     func setUpTapped() {
+        setUpInProgress = true
         connectionController?.searchAndConnect { _ in
             /// No need for logic here. Once connected, the connected reader will publish
             /// through the `cardReaderAvailableSubscription`, so we can just
             /// dismiss the connection flow alerts.
             self.alertsPresenter?.dismiss()
+            self.setUpInProgress = false
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -16,6 +16,10 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
     let connectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker
     let connectivityObserver: ConnectivityObserver
 
+
+    var connectionController: BuiltInCardReaderConnectionController? = nil
+    var alertsPresenter: CardPresentPaymentAlertsPresenting? = nil
+
     private(set) var noConnectedReader: CardReaderSettingsTriState = .isUnknown {
         didSet {
             didUpdate?()
@@ -73,6 +77,15 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
             }
         }
         .store(in: &subscriptions)
+    }
+
+    func setUpTapped() {
+        connectionController?.searchAndConnect { _ in
+            /// No need for logic here. Once connected, the connected reader will publish
+            /// through the `cardReaderAvailableSubscription`, so we can just
+            /// dismiss the connection flow alerts.
+            self.alertsPresenter?.dismiss()
+        }
     }
 
     /// Updates whether the view this viewModel is associated with should be shown or not

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -9,8 +9,8 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
     let learnMoreURL: URL
     private let stores: StoresManager
 
-    @Published var enableSetup: Bool = true
-    @Published var setUpInProgress: Bool = false
+    @Published private(set) var enableSetup: Bool = true
+    @Published private(set) var setUpInProgress: Bool = false
 
     let siteID: Int64
     let configuration: CardPresentPaymentsConfiguration


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9010
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In the new Set up Tap to Pay on iPhone screen, there can be a small gap between tapping the `Set up` button and showing any change in the UI. This is because PaymentGatewayAccounts are fetched from the network before any alert is shown by the ConnectionController. 

In this PR, we add a spinner to the button, so when it’s pressed the user sees that the app is loading from the network. The button is returned to its original state when the ConnectionController completes, success or failure.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Set a breakpoint
To test this effectively, you may need to be able to slow down the network or the move into the connection alerts. You can do that using a breakpoint to pause proceedings.

Set a network breakpoint (using Proxyman or Charles) on the appropriate `PaymentGatewayAccount` endpoint for the gateway you're using.
Stripe: `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/*/rest-api/?json=true&path=/wc/v3/wc_stripe/account/summary%26_method%3Dget*`
WCPay: `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/*/rest-api/?json=true&path=/wc/v3/payments/accounts%26_method%3Dget*

(* is a wildcard: substitute the first for your site ID if it doesn't work)

Alternatively, find another way to make your network connection really slow 😊 

### Testing the change
Using a US store and an iPhone on iOS 16 or above:

#### Happy path

1. Navigate to Menu > Payments > Set up Tap to Pay on iPhone (wait for the spinner before you tap the row)
2. Tap the `Set up Tap to Pay on iPhone` button
3. Observe that a spinner is shown
4. Press run on your breakpoint
5. Observe that the alerts are shown, and then that the connection completes (blank screen shown.)


#### Error shown
Repeat the steps above, and as soon as the alerts are shown...:

1. Enable Airplane Mode
2. Dismiss the error that shows in the app
3. Observe that the set up screen shows the button disabled, without a spinner
4. Disable Airplane Mode
5. Observe that the button is enabled again
6. Tap the button once more
7. Press run on your breakpoint
8. Observe that the reader connection completes as expected

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/2472348/225285918-041f5b6e-1e4b-4744-acae-6af355b5bcd8.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
