### PR TITLE
[Store onboarding] "View all" button visibility and task tap action

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -140,7 +140,7 @@ struct StoreOnboardingView: View {
 
                 // View all button
                 viewAllButton(action: viewAllTapped, text: String(format: Localization.viewAll, viewModel.taskViewModels.count))
-                    .renderedIf(!viewModel.isExpanded && !viewModel.isRedacted)
+                    .renderedIf(!viewModel.isExpanded && !viewModel.isRedacted && viewModel.taskViewModels.count > 2)
 
                 Spacer()
                     .renderedIf(viewModel.isExpanded)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -143,7 +143,7 @@ struct StoreOnboardingView: View {
 
                 // View all button
                 viewAllButton(action: viewAllTapped, text: String(format: Localization.viewAll, viewModel.taskViewModels.count))
-                    .renderedIf(!viewModel.isExpanded && !viewModel.isRedacted && viewModel.taskViewModels.count > 2)
+                    .renderedIf(!viewModel.isExpanded && !viewModel.isRedacted && !(viewModel.taskViewModels.count < 3))
 
                 Spacer()
                     .renderedIf(viewModel.isExpanded)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -27,7 +27,10 @@ final class StoreOnboardingViewHostingController: SelfSizingHostingController<St
         }
 
         rootView.taskTapped = { [weak self] task in
-            guard let self else { return }
+            guard let self,
+                  !task.isComplete else {
+                return
+            }
             self.coordinator.start(task: task)
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9142
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
- Hide the "View all" button if the total number of store onboarding tasks are less than 3.
- Start the task using coordinator only if the task is not already complete. 

## Testing instructions

**View all button**
- Launch and login using a self-hosted site.
- On the "My Store" tab ensure that the "View all" button is hidden when the tasks are less than 3.  

**Tapping already completed task**
- Complete a task if needed.
- Tap on an already completed task and ensure that no screen is launched. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
View all button visibility
| Self-hosted site with less than 3 tasks | More than 3 tasks | 
| - | - |
| ![View all button](https://user-images.githubusercontent.com/524475/225292407-27425f42-bd48-44cf-bb28-eec9aa0fad9b.png) | ![MoreThan3](https://user-images.githubusercontent.com/524475/225292806-9e1ea94b-1593-4b27-be16-a4cae804e50b.png) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
