### PR TITLE
[Mobile Payments] Disconnect other readers when setting up TTP

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1057,6 +1057,16 @@ extension WooAnalyticsEvent {
             )
         }
 
+        static func cardReaderAutomaticDisconnect(cardReaderModel: String?, forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .cardReaderAutomaticDisconnect,
+                              properties: [
+                                Keys.cardReaderModel: readerModel(for: cardReaderModel),
+                                Keys.countryCode: countryCode,
+                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
+                              ]
+            )
+        }
+
         /// Tracked when card reader discovery fails
         ///
         /// - Parameters:

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1057,6 +1057,13 @@ extension WooAnalyticsEvent {
             )
         }
 
+        /// Tracked when we automatically disconnect a Built In reader, when setting up Tap to Pay
+        ///
+        /// - Parameters:
+        ///   - cardReaderModel: the model type of the card reader.
+        ///   - forGatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///   - countryCode: the country code of the store.
+        ///
         static func cardReaderAutomaticDisconnect(cardReaderModel: String?, forGatewayID: String?, countryCode: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderAutomaticDisconnect,
                               properties: [

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -260,6 +260,7 @@ public enum WooAnalyticsStat: String {
     case cardReaderConnectionSuccess = "card_reader_connection_success"
     case cardReaderDisconnectTapped = "card_reader_disconnect_tapped"
     case manageCardReadersBuiltInReaderAutoDisconnect = "manage_card_readers_automatic_disconnect_built_in_reader"
+    case cardReaderAutomaticDisconnect = "card_reader_automatic_disconnect"
 
     // MARK: Card Reader Software Update Events
     //

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
@@ -99,6 +99,13 @@ final class CardReaderConnectionAnalyticsTracker {
             .manageCardReadersBuiltInReaderAutoDisconnect(forGatewayID: gatewayID,
                                                           countryCode: configuration.countryCode))
     }
+
+    func automaticallyDisconnectedFromReader() {
+        analytics.track(event: WooAnalyticsEvent.InPersonPayments
+            .cardReaderAutomaticDisconnect(cardReaderModel: cardReaderModel,
+                                           forGatewayID: gatewayID,
+                                           countryCode: configuration.countryCode))
+    }
 }
 
 private extension CardReaderConnectionAnalyticsTracker {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -37,10 +37,11 @@ final class CardReaderSettingsSearchingViewController: UIHostingController<CardR
     }
 
     private func configureView() {
-        rootView.connectClickAction = {
-            self.searchAndConnect()
+        rootView.connectClickAction = { [weak self] in
+            self?.searchAndConnect()
         }
-        rootView.showURL = { url in
+        rootView.showURL = { [weak self] url in
+            guard let self = self else { return }
             WebviewHelper.launch(url, with: self)
         }
         rootView.learnMoreUrl = viewModel.learnMoreURL
@@ -98,7 +99,7 @@ private extension CardReaderSettingsSearchingViewController {
 //
 private extension CardReaderSettingsSearchingViewController {
     func searchAndConnect() {
-        connectionController?.searchAndConnect(from: self) {_ in
+        connectionController?.searchAndConnect(from: self) { _ in
             /// No need for logic here. Once connected, the connected reader will publish
             /// through the `cardReaderAvailableSubscription`
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -34,7 +34,8 @@ final class SetUpTapToPayInformationViewController: UIHostingController<SetUpTap
     }
 
     private func configureView() {
-        rootView.showURL = { url in
+        rootView.showURL = { [weak self] url in
+            guard let self = self else { return }
             WebviewHelper.launch(url, with: self)
         }
         rootView.learnMoreUrl = viewModel.learnMoreURL

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -60,10 +60,26 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
             guard let self = self else {
                 return
             }
+            self.disconnectFromBluetoothReader(in: readers)
             self.noConnectedReader = readers.isEmpty ? .isTrue : .isFalse
             self.reevaluateShouldShow()
         }
         stores.dispatch(connectedAction)
+    }
+
+    /// This screen is only used for setting up the Built In card reader.
+    /// If we're connected to a Bluetooth reader when the screen opens,
+    /// we should disconnect, as we can't continue with setup while connected.
+    private func disconnectFromBluetoothReader(in readers: [CardReader]) {
+        if readers.includesBluetoothReader() {
+            self.connectionAnalyticsTracker.automaticallyDisconnectedFromReader()
+            self.disconnect()
+        }
+    }
+
+    private func disconnect() {
+        let action = CardPresentPaymentAction.disconnect { _ in }
+        ServiceLocator.stores.dispatch(action)
     }
 
     private func beginConnectivityObservation() {
@@ -115,5 +131,18 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
         case .stripe:
             return WooConstants.URLs.inPersonPaymentsLearnMoreStripe.asURL()
         }
+    }
+}
+
+private extension [CardReader] {
+    func includesBluetoothReader() -> Bool {
+        return self.first(where: { reader in
+            switch reader.readerType {
+            case .appleBuiltIn:
+                return false
+            default:
+                return true
+            }
+        }) != nil
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -79,7 +79,7 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
 
     private func disconnect() {
         let action = CardPresentPaymentAction.disconnect { _ in }
-        ServiceLocator.stores.dispatch(action)
+        stores.dispatch(action)
     }
 
     private func beginConnectivityObservation() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
@@ -26,6 +26,7 @@ final class SetUpTapToPayViewModelsOrderedList: PaymentSettingsFlowPrioritizedVi
         /// Initialize dependencies for viewmodels first, then viewmodels
         ///
         cardReaderConnectionAnalyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: configuration)
+        cardReaderConnectionAnalyticsTracker.setGatewayID(gatewayID: activePaymentGateway.gatewayID)
 
         /// Instantiate and add each viewmodel related to setting up Tap to Pay on iPhone to the
         /// array. Viewmodels will be evaluated for shouldShow starting at the top

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentAlertsPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentAlertsPresenter.swift
@@ -14,17 +14,20 @@ final class CardPresentPaymentAlertsPresenter: CardPresentPaymentAlertsPresentin
     private var modalController: CardPresentPaymentsModalViewController?
     private var severalFoundController: SeveralReadersFoundViewController?
 
-    let rootViewController: UIViewController
+    /// There should not be a strong reference to the view controller, as generally the alerts presenter
+    /// will be owned (perhaps indirectly) by the view controller. Keeping a strong reference here makes
+    /// retain cycles likely/unavoidable.
+    private weak var rootViewController: UIViewController?
 
     init(rootViewController: UIViewController) {
         self.rootViewController = rootViewController
     }
 
     func present(viewModel: CardPresentPaymentsModalViewModel) {
-        setViewModelAndPresent(from: rootViewController, viewModel: viewModel)
+        setViewModelAndPresent(viewModel: viewModel)
     }
 
-    private func setViewModelAndPresent(from: UIViewController, viewModel: CardPresentPaymentsModalViewModel) {
+    private func setViewModelAndPresent(viewModel: CardPresentPaymentsModalViewModel) {
         guard modalController == nil else {
             modalController?.setViewModel(viewModel)
             return
@@ -37,7 +40,7 @@ final class CardPresentPaymentAlertsPresenter: CardPresentPaymentAlertsPresentin
 
         modalController.prepareForCardReaderModalFlow()
 
-        dismissSeveralFoundAndPresent(animated: true, from: from, present: modalController)
+        dismissSeveralFoundAndPresent(animated: true, from: rootViewController, present: modalController)
     }
 
     /// Dismisses any view controller based on `CardPresentPaymentsModalViewController`,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9010
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In previous PRs against #9010, we've added a Set up screen for Tap to Pay on iPhone.

“Setting up” TTP is just a connection to the reader. Stripe’s SDK only allow us to connect to one reader at a time, so if the merchant is already connected to a bluetooth reader, they won’t be able to set up TTP without disconnecting from the bluetooth reader first.

This is an implementation detail which isn’t very relevant to the merchant, so we can just do it automatically when we start the set up process.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a US store and an iPhone XS or newer running iOS 16.0

Navigate to `Menu > Payments > Manage card readers`
Connect to an external reader
Tap back to go to the Payments menu
Tap `Set up Tap to Pay on iPhone`
Observe that you're shown the Set up screen (not a blank or "connected" screen)
Observe that the `card_reader_automatic_disconnect` analytics event was logged with the correct card reader model
Observe that when you tap the `Set up Tap to Pay on iPhone` button on this screen, you can connect to the built in reader.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/225305681-87e7e85d-c82a-470b-93fb-be2930ed8436.mp4

<img width="873" alt="Console log of card_reader_automatic_disconnect event with STRIPE_M2 card reader" src="https://user-images.githubusercontent.com/2472348/225305866-c0d7c5ca-c1a7-4f5b-9bf9-2664c678ce72.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
