### PR TITLE
[App Intents] Add a constant to reuse the same value for the navigation delay.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -401,8 +401,8 @@ extension MainTabBarController {
                 guard storeIsShown else {
                     return
                 }
-                // We give some time to the orders tab transition to finish, otherwise it might prevent the second navigation from happening
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+         
+                DispatchQueue.main.asyncAfter(deadline: .now() + Constants.screenTransitionsDelay) {
                     presentDetails(for: orderID, siteID: siteID)
                 }
             }
@@ -444,8 +444,7 @@ extension MainTabBarController {
     static func presentCollectPayment() {
         let viewController = presentPayments()
 
-        // Wait a second until the payments screen is presented. Suboptimal but works.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.screenTransitionsDelay) {
             viewController?.openSimplePaymentsAmountFlow()
         }
     }
@@ -688,6 +687,15 @@ private extension MainTabBarController {
                                                                 forceReadOnly: false)
         let productNavController = WooNavigationController(rootViewController: productViewController)
         productsNavigationController.present(productNavController, animated: true)
+    }
+}
+
+private extension MainTabBarController {
+    enum Constants {
+        // Used to delay a second navigation after the previous one is called,
+        // to ensure that the first transition is finished. Without this delay
+        // the second one might not happen.
+        static let screenTransitionsDelay = 0.3
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -401,7 +401,7 @@ extension MainTabBarController {
                 guard storeIsShown else {
                     return
                 }
-         
+
                 DispatchQueue.main.asyncAfter(deadline: .now() + Constants.screenTransitionsDelay) {
                     presentDetails(for: orderID, siteID: siteID)
                 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we unify the value of the delay when two navigations are happening, by adding a constant and using it in both places.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Check that the Collect Payment shortcut navigates to the collect payment screen:


https://user-images.githubusercontent.com/1864060/225308094-3e8f360f-17ac-42fa-bc70-478aeb4a635a.MP4


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
