### PR TITLE
[Product Bundles] Display product images in bundled products list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import SwiftUI
+import Kingfisher
 
 // MARK: Hosting Controller
 
@@ -26,11 +27,28 @@ struct BundledProductsList: View {
     ///
     let viewModel: BundledProductsListViewModel
 
+    /// Dynamic image width, also used for its height.
+    ///
+    @ScaledMetric private var imageWidth = Layout.standardImageWidth
+
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
                 ForEach(viewModel.bundledProducts) { bundledProduct in
-                    TitleAndSubtitleRow(title: bundledProduct.title, subtitle: bundledProduct.stockStatus)
+                    HStack {
+                        KFImage(bundledProduct.imageURL)
+                            .placeholder {
+                                Image(uiImage: .productPlaceholderImage)
+                                    .foregroundColor(Color(.listIcon))
+                            }
+                            .resizable()
+                            .frame(width: imageWidth, height: imageWidth)
+                            .cornerRadius(Layout.imageCornerRadius)
+                            .accessibilityHidden(true)
+                            .padding(.leading)
+
+                        TitleAndSubtitleRow(title: bundledProduct.title, subtitle: bundledProduct.stockStatus)
+                    }
                     Divider().padding(.leading)
                 }
             }
@@ -44,18 +62,32 @@ struct BundledProductsList: View {
     }
 }
 
+private enum Layout {
+    static let standardImageWidth: CGFloat = 48.0
+    static let imageCornerRadius: CGFloat = 4.0
+}
+
 
 // MARK: Previews
 struct BundledProductsList_Previews: PreviewProvider {
 
     static let viewModel = BundledProductsListViewModel(bundledProducts: [
-        .init(id: 1, title: "Beanie with Logo", stockStatus: "In stock"),
-        .init(id: 2, title: "T-Shirt with Logo", stockStatus: "In stock"),
-        .init(id: 3, title: "Hoodie with Logo", stockStatus: "Out of stock")
+        .init(id: 1, title: "Beanie with Logo", stockStatus: "In stock", imageURL: nil),
+        .init(id: 2, title: "T-Shirt with Logo", stockStatus: "In stock", imageURL: nil),
+        .init(id: 3, title: "Hoodie with Logo", stockStatus: "Out of stock", imageURL: nil)
     ])
 
     static var previews: some View {
         BundledProductsList(viewModel: viewModel)
             .environment(\.colorScheme, .light)
+            .previewDisplayName("Light")
+
+        BundledProductsList(viewModel: viewModel)
+            .environment(\.colorScheme, .dark)
+            .previewDisplayName("Dark")
+
+        BundledProductsList(viewModel: viewModel)
+            .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+            .previewDisplayName("Large Font")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import protocol Storage.StorageManagerType
 
 /// ViewModel for `BundledProductsList`
 ///
@@ -40,8 +41,8 @@ final class BundledProductsListViewModel {
 
 // MARK: Initializers
 extension BundledProductsListViewModel {
-    convenience init(siteID: Int64, bundledProducts: [Yosemite.ProductBundleItem]) {
-        let products = BundledProductsListViewModel.fetchProducts(for: siteID, including: bundledProducts.map { $0.productID })
+    convenience init(siteID: Int64, bundledProducts: [Yosemite.ProductBundleItem], storageManager: StorageManagerType = ServiceLocator.storageManager) {
+        let products = BundledProductsListViewModel.fetchProducts(for: siteID, including: bundledProducts.map { $0.productID }, storageManager: storageManager)
         let viewModels = bundledProducts.map { bundledProduct in
             BundledProduct(id: bundledProduct.bundledItemID,
                            title: bundledProduct.title,
@@ -54,8 +55,7 @@ extension BundledProductsListViewModel {
 
 // MARK: Private helpers
 private extension BundledProductsListViewModel {
-    static func fetchProducts(for siteID: Int64, including productIDs: [Int64]) -> [Product] {
-        let storageManager = ServiceLocator.storageManager
+    static func fetchProducts(for siteID: Int64, including productIDs: [Int64], storageManager: StorageManagerType) -> [Product] {
         let predicate = NSPredicate(format: "siteID == %lld AND productID IN %@", siteID, productIDs)
         let controller = ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortedBy: [])
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
@@ -16,6 +16,9 @@ final class BundledProductsListViewModel {
 
         /// Stock status of the bundled product
         let stockStatus: String
+
+        /// URL of the bundled product's image, if any
+        let imageURL: URL?
     }
 
     /// View title
@@ -37,11 +40,32 @@ final class BundledProductsListViewModel {
 
 // MARK: Initializers
 extension BundledProductsListViewModel {
-    convenience init(bundledProducts: [Yosemite.ProductBundleItem]) {
-        let viewModels = bundledProducts.map {
-            BundledProduct(id: $0.bundledItemID, title: $0.title, stockStatus: $0.stockStatus.description)
+    convenience init(siteID: Int64, bundledProducts: [Yosemite.ProductBundleItem]) {
+        let products = BundledProductsListViewModel.fetchProducts(for: siteID, including: bundledProducts.map { $0.productID })
+        let viewModels = bundledProducts.map { bundledProduct in
+            BundledProduct(id: bundledProduct.bundledItemID,
+                           title: bundledProduct.title,
+                           stockStatus: bundledProduct.stockStatus.description,
+                           imageURL: products.first(where: { $0.productID == bundledProduct.productID })?.imageURL) // URL for bundled product's first image
         }
         self.init(bundledProducts: viewModels)
+    }
+}
+
+// MARK: Private helpers
+private extension BundledProductsListViewModel {
+    static func fetchProducts(for siteID: Int64, including productIDs: [Int64]) -> [Product] {
+        let storageManager = ServiceLocator.storageManager
+        let predicate = NSPredicate(format: "siteID == %lld AND productID IN %@", siteID, productIDs)
+        let controller = ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortedBy: [])
+
+        do {
+            try controller.performFetch()
+        } catch {
+            DDLogError("⛔️ Unable to fetch products for Bundled Products list: \(error)")
+        }
+
+        return controller.fetchedObjects
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1686,7 +1686,7 @@ private extension ProductFormViewController {
         guard let product = product as? EditableProductModel else {
             return
         }
-        let viewModel = BundledProductsListViewModel(bundledProducts: product.bundledItems)
+        let viewModel = BundledProductsListViewModel(siteID: product.siteID, bundledProducts: product.bundledItems)
         let viewController = BundledProductsListViewController(viewModel: viewModel)
         show(viewController, sender: self)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1318,7 +1318,6 @@
 		AEFF77AA29786DAA00667F7A /* PriceInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFF77A929786DAA00667F7A /* PriceInputViewModelTests.swift */; };
 		B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509112D2049E27A007D25DC /* DashboardViewController.swift */; };
 		B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED021C041DF000076A9 /* Locale+Woo.swift */; };
-		B509FED521C052D1000076A9 /* MockSupportManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B509FED421C052D1000076A9 /* MockSupportManager.swift */; };
 		B50BB4162141828F00AF0F3C /* FooterSpinnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50BB4152141828F00AF0F3C /* FooterSpinnerView.swift */; };
 		B511ED27218A660E005787DC /* StringDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B511ED26218A660E005787DC /* StringDescriptor.swift */; };
 		B517EA18218B232700730EC4 /* StringFormatter+Notes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B517EA17218B232700730EC4 /* StringFormatter+Notes.swift */; };
@@ -1591,6 +1590,7 @@
 		CCDC49ED24000533003166BA /* TestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49EC24000533003166BA /* TestCredentials.swift */; };
 		CCE4CD172667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */; };
 		CCE4CD282669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */; };
+		CCE785C829C1E8280003977F /* BundledProductsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE785C729C1E8280003977F /* BundledProductsListViewModelTests.swift */; };
 		CCEC256A27B581E800EF9FA3 /* ProductVariationFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEC256927B581E800EF9FA3 /* ProductVariationFormatter.swift */; };
 		CCF27B35280EF69700B755E1 /* orders_3337_add_product.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF27B33280EF69600B755E1 /* orders_3337_add_product.json */; };
 		CCF27B3A280EF98F00B755E1 /* orders_3337.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF27B39280EF98F00B755E1 /* orders_3337.json */; };
@@ -3755,6 +3755,7 @@
 		CCDC49F1240060F3003166BA /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UnitTests.xctestplan; path = WooCommerceTests/UnitTests.xctestplan; sourceTree = SOURCE_ROOT; };
 		CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
 		CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsTopBanner.swift; sourceTree = "<group>"; };
+		CCE785C729C1E8280003977F /* BundledProductsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledProductsListViewModelTests.swift; sourceTree = "<group>"; };
 		CCEC256927B581E800EF9FA3 /* ProductVariationFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormatter.swift; sourceTree = "<group>"; };
 		CCF27B33280EF69600B755E1 /* orders_3337_add_product.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = orders_3337_add_product.json; sourceTree = "<group>"; };
 		CCF27B39280EF98F00B755E1 /* orders_3337.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = orders_3337.json; sourceTree = "<group>"; };
@@ -4458,6 +4459,7 @@
 		020B2F9723BDF2D000BD79AD /* Edit Product */ = {
 			isa = PBXGroup;
 			children = (
+				CCE785C629C1E80D0003977F /* Bundled Products */,
 				455208592582907C001CF873 /* Add Product Variation */,
 				AEB73C1525CD8E3100A8454A /* Edit Product Variation */,
 				45A0E4D12566BF0800D4E8C3 /* Linked Products */,
@@ -8229,6 +8231,14 @@
 			path = MyStore;
 			sourceTree = "<group>";
 		};
+		CCE785C629C1E80D0003977F /* Bundled Products */ = {
+			isa = PBXGroup;
+			children = (
+				CCE785C729C1E8280003977F /* BundledProductsListViewModelTests.swift */,
+			);
+			path = "Bundled Products";
+			sourceTree = "<group>";
+		};
 		CCFC00B623E9BD5500157A78 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
@@ -11940,6 +11950,7 @@
 				77307809251EA07100178696 /* ProductDownloadSettingsViewModelTests.swift in Sources */,
 				02EA6BFC2435EC3500FFF90A /* MockImageDownloader.swift in Sources */,
 				57C9A8FC24C21BFB001E1C2F /* ReviewsCoordinatorTests.swift in Sources */,
+				CCE785C829C1E8280003977F /* BundledProductsListViewModelTests.swift in Sources */,
 				45B9C64523A945C0007FC4C5 /* PriceInputFormatterTests.swift in Sources */,
 				262EB5B3298D66FE009DCC36 /* SupportDataSourcesTests.swift in Sources */,
 				AEA3F91327BEC40A00B9F555 /* ShippingLineDetailsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Bundled Products/BundledProductsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Bundled Products/BundledProductsListViewModelTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+@testable import Storage
+
+final class BundledProductsListViewModelTests: XCTestCase {
+
+    private let sampleSiteID: Int64 = 12345
+    private var storageManager: StorageManagerType!
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+    private let stores = MockStoresManager(sessionManager: .testingInstance)
+
+    override func setUp() {
+        super.setUp()
+        storageManager = MockStorageManager()
+        stores.reset()
+    }
+
+    override func tearDown() {
+        storageManager = nil
+        super.tearDown()
+    }
+
+    func test_view_model_prefills_bundle_item_data_correctly() throws {
+        // Given
+        let bundleItem = ProductBundleItem.fake().copy(bundledItemID: 1, title: "Hoodie", stockStatus: .outOfStock)
+
+        // When
+        let viewModel = BundledProductsListViewModel(siteID: sampleSiteID, bundledProducts: [bundleItem])
+        let bundledProduct = try XCTUnwrap(viewModel.bundledProducts.first)
+
+        // Then
+        XCTAssertEqual(bundledProduct.id, bundleItem.bundledItemID)
+        XCTAssertEqual(bundledProduct.title, bundleItem.title)
+        XCTAssertEqual(bundledProduct.stockStatus, bundleItem.stockStatus.description)
+    }
+
+    func test_view_model_fetches_expected_image_URL_for_bundle_item() throws {
+        // Given
+        let bundleItem = ProductBundleItem.fake().copy(productID: 12)
+        let imageURL = URL(string: "https://woocommerce.com/woo.jpg")
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 12, images: [.fake().copy(src: imageURL?.absoluteString)])
+        insert(product)
+
+        // When
+        let viewModel = BundledProductsListViewModel(siteID: sampleSiteID, bundledProducts: [bundleItem], storageManager: storageManager)
+        let bundledProduct = try XCTUnwrap(viewModel.bundledProducts.first)
+
+        // Then
+        XCTAssertEqual(bundledProduct.imageURL, imageURL)
+    }
+}
+
+// MARK: - Utils
+private extension BundledProductsListViewModelTests {
+    /// Insert a `Product` into storage.
+    func insert(_ readOnlyProduct: Yosemite.Product) {
+        let product = storage.insertNewObject(ofType: StorageProduct.self)
+        product.update(with: readOnlyProduct)
+
+        for readOnlyImage in readOnlyProduct.images {
+            let productImage = storage.insertNewObject(ofType: StorageProductImage.self)
+            productImage.update(with: readOnlyImage)
+            productImage.product = product
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9127
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds product images to the Bundled Products list in product details (for product bundles).

The bundle item data (`ProductBundleItem`) doesn't include any image data. However, every bundle item is also a product on the store, so we can fetch the image from the product details for the corresponding product (based on the product ID).

### Changes

* When `BundledProductsListViewModel` is initialized from a list of `ProductBundleItem`, we fetch the products matching those items from storage and get the product image URL.
* `BundledProductsList` now shows each item's image in the list.
* Adds unit tests for `BundledProductsListViewModel`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Prerequisites

1. Install and activate the [Product Bundles extension](https://woocommerce.com/products/product-bundles/) on your store.
2. Create a product with the Product Bundle type, and add bundled products that have product images.

### To test

1. Build and run the app.
2. Go to the Products tab and select your product bundle.
3. Select "Bundled products" in product details.
4. Confirm the product images appear in the Bundled Products list.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-14 at 15 08 19](https://user-images.githubusercontent.com/8658164/225320733-191ff52e-be73-44bc-b6eb-b7e55e62440b.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-15 at 11 45 21](https://user-images.githubusercontent.com/8658164/225320706-e487e0d9-4f00-4be5-a734-bdd3daf04d9a.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
