### PR TITLE
[Product Bundles] Track when the Bundled Products row is tapped

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -388,6 +388,12 @@ extension WooAnalyticsEvent {
         static func previewFailed(statusCode: Int) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productDetailPreviewFailed, properties: ["status_code": Int64(statusCode)])
         }
+
+        /// Tracks when the merchant taps the Bundled Products row (applicable for bundle-type products only).
+        ///
+        static func bundledProductsTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDetailViewBundledProductsTapped, properties: [:])
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -547,6 +547,7 @@ public enum WooAnalyticsStat: String {
     case productInventorySettingsSKUScanned = "product_inventory_settings_sku_scanned"
     case productDetailPreviewTapped = "product_detail_preview_tapped"
     case productDetailPreviewFailed = "product_detail_preview_failed"
+    case productDetailViewBundledProductsTapped = "product_detail_view_bundled_products_tapped"
 
     // MARK: Edit Product Variation Events
     //

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -447,7 +447,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 guard isActionable else {
                     return
                 }
-                // TODO-9128: Add tracking
+                ServiceLocator.analytics.track(event: .ProductDetail.bundledProductsTapped())
                 showBundledProducts()
                 return
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9128
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds a new event to track when the "Bundled products" row is tapped in product details (for a product bundle):

* `product_detail_view_bundled_products_tapped` (Event registration: 1455-gh-tracks-events-registration)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Prerequisites

1. Install and activate the [Product Bundles extension](https://woocommerce.com/products/product-bundles/) on your store.
2. Create a product with the Product Bundle type, and add at least one bundled product to it.

### To test

1. Build and run the app.
2. Open the Products tab and select a product bundle.
3. Tap the "Bundled products" row in the product details. Confirm the new event is triggered.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
