### PR TITLE
[Free Trial] Add Free Trial Banner UI

### DIFF
--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -119,9 +119,9 @@ private extension WooNavigationControllerDelegate {
     ///
     func setOfflineBannerWhenNoConnection(for viewController: UIViewController, status: ConnectivityStatus) {
         // We can only show it when we are sure we can't reach the internet
-//        guard status == .notReachable else {
-//            return removeOfflineBanner(for: viewController)
-//        }
+        guard status == .notReachable else {
+            return removeOfflineBanner(for: viewController)
+        }
 
         // Only add banner view if it's not already added.
         guard let navigationController = viewController.navigationController,

--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -119,9 +119,9 @@ private extension WooNavigationControllerDelegate {
     ///
     func setOfflineBannerWhenNoConnection(for viewController: UIViewController, status: ConnectivityStatus) {
         // We can only show it when we are sure we can't reach the internet
-        guard status == .notReachable else {
-            return removeOfflineBanner(for: viewController)
-        }
+//        guard status == .notReachable else {
+//            return removeOfflineBanner(for: viewController)
+//        }
 
         // Only add banner view if it's not already added.
         guard let navigationController = viewController.navigationController,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -345,7 +345,7 @@ private extension DashboardViewController {
     /// Adds a Free Trial bar at the bottom of the screen.
     ///
     func addFreeTrialBar(contentText: String) {
-        let freeTrialViewController = FreeTrialBannerHostingViewController(mainText: "Your trial has ended.") {
+        let freeTrialViewController = FreeTrialBannerHostingViewController(mainText: contentText) {
             print("Upgrade now tapped!!")
         }
         freeTrialViewController.view.translatesAutoresizingMaskIntoConstraints = false

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -160,23 +160,6 @@ final class DashboardViewController: UIViewController {
 
         viewModel.syncFreeTrialBanner(siteID: siteID)
 
-        DispatchQueue.main.async {
-            let freeTrial = FreeTrialBannerHostingViewController()
-            freeTrial.view.translatesAutoresizingMaskIntoConstraints = false
-
-            self.stackView.addSubview(freeTrial.view)
-            NSLayoutConstraint.activate([
-                freeTrial.view.leadingAnchor.constraint(equalTo: self.stackView.leadingAnchor),
-                freeTrial.view.trailingAnchor.constraint(equalTo: self.stackView.trailingAnchor),
-                freeTrial.view.bottomAnchor.constraint(equalTo: self.stackView.bottomAnchor)
-
-            ])
-
-            DispatchQueue.main.async {
-                self.containerView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: freeTrial.view.frame.size.height, right: 0)
-            }
-        }
-
         Task { @MainActor in
             await viewModel.syncAnnouncements(for: siteID)
             await reloadDashboardUIStatsVersion(forced: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -342,6 +342,28 @@ private extension DashboardViewController {
         view.pinSubviewToSafeArea(stackView)
     }
 
+    /// Adds a Free Trial bar at the bottom of the screen.
+    ///
+    func addFreeTrialBar(contentText: String) {
+        let freeTrialViewController = FreeTrialBannerHostingViewController(mainText: "Your trial has ended.") {
+            print("Upgrade now tapped!!")
+        }
+        freeTrialViewController.view.translatesAutoresizingMaskIntoConstraints = false
+
+        self.stackView.addSubview(freeTrialViewController.view)
+        NSLayoutConstraint.activate([
+            freeTrialViewController.view.leadingAnchor.constraint(equalTo: self.stackView.leadingAnchor),
+            freeTrialViewController.view.trailingAnchor.constraint(equalTo: self.stackView.trailingAnchor),
+            freeTrialViewController.view.bottomAnchor.constraint(equalTo: self.stackView.bottomAnchor)
+
+        ])
+
+        // Adjust the main container content inset to prevent it from being hidden by the `freeTrialViewController`
+        DispatchQueue.main.async {
+            self.containerView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: freeTrialViewController.view.frame.size.height, right: 0)
+        }
+    }
+
     func configureDashboardUIContainer() {
         containerView.delegate = self
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -160,6 +160,23 @@ final class DashboardViewController: UIViewController {
 
         viewModel.syncFreeTrialBanner(siteID: siteID)
 
+        DispatchQueue.main.async {
+            let freeTrial = FreeTrialBannerHostingViewController()
+            freeTrial.view.translatesAutoresizingMaskIntoConstraints = false
+
+            self.stackView.addSubview(freeTrial.view)
+            NSLayoutConstraint.activate([
+                freeTrial.view.leadingAnchor.constraint(equalTo: self.stackView.leadingAnchor),
+                freeTrial.view.trailingAnchor.constraint(equalTo: self.stackView.trailingAnchor),
+                freeTrial.view.bottomAnchor.constraint(equalTo: self.stackView.bottomAnchor)
+
+            ])
+
+            DispatchQueue.main.async {
+                self.containerView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: freeTrial.view.frame.size.height, right: 0)
+            }
+        }
+
         Task { @MainActor in
             await viewModel.syncAnnouncements(for: siteID)
             await reloadDashboardUIStatsVersion(forced: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
@@ -3,11 +3,10 @@ import SwiftUI
 /// Hosting controller for `FreeTrialBanner`.
 ///
 final class FreeTrialBannerHostingViewController: UIHostingController<FreeTrialBanner> {
-
     /// Designated initializer.
     ///
-    init() {
-        super.init(rootView: FreeTrialBanner())
+    init(mainText: String, onUpgradeNowTapped: @escaping () -> Void) {
+        super.init(rootView: FreeTrialBanner(mainText: mainText, onUpgradeNowTapped: onUpgradeNowTapped))
         self.view.backgroundColor = .wooCommercePurple(.shade5)
     }
 
@@ -22,20 +21,26 @@ final class FreeTrialBannerHostingViewController: UIHostingController<FreeTrialB
 ///
 struct FreeTrialBanner: View {
 
+    /// Text to be rendered next to the info image.
+    ///
+    let mainText: String
+
+    /// Closure invoked when the merchants taps on the `Upgrade Now` button.
+    ///
+    let onUpgradeNowTapped: () -> Void
+
     var body: some View {
         HStack {
             Image(uiImage: .infoOutlineImage)
 
             HStack(spacing: 6) {
-                Text("Your trial has ended.")
+                Text(mainText)
                     .bodyStyle()
 
-                Text("Upgrade Now")
+                Text(Localization.upgradeNow)
                     .underline(true)
                     .linkStyle()
-                    .onTapGesture {
-                        print("Upgrade Now Pressed")
-                    }
+                    .onTapGesture(perform: onUpgradeNowTapped)
             }
         }
         .padding()
@@ -44,9 +49,16 @@ struct FreeTrialBanner: View {
     }
 }
 
+// MARK: Definitions
+extension FreeTrialBanner {
+    enum Localization {
+        static let upgradeNow = NSLocalizedString("Upgrade Now", comment: "Title on the button to upgrade a free trial plan.")
+    }
+}
+
 struct FreeTrial_Preview: PreviewProvider {
     static var previews: some View {
-        FreeTrialBanner()
+        FreeTrialBanner(mainText: "Your Free trial has ended", onUpgradeNowTapped: { })
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
@@ -29,27 +29,37 @@ struct FreeTrialBanner: View {
     let onUpgradeNowTapped: () -> Void
 
     var body: some View {
-        HStack {
-            Image(uiImage: .infoOutlineImage)
+        VStack(spacing: .zero) {
+            Divider()
 
-            HStack(spacing: 6) {
-                Text(mainText)
-                    .bodyStyle()
+            HStack(alignment: .center) {
+                Image(uiImage: .infoOutlineImage)
 
-                Text(Localization.upgradeNow)
-                    .underline(true)
-                    .linkStyle()
-                    .onTapGesture(perform: onUpgradeNowTapped)
+                AdaptiveStack(verticalAlignment: .center, spacing: Layout.spacing) {
+                    Text(mainText)
+                        .bodyStyle()
+
+                    Text(Localization.upgradeNow)
+                        .underline(true)
+                        .linkStyle()
+                        .onTapGesture(perform: onUpgradeNowTapped)
+                }
             }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Divider()
         }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(.wooCommercePurple(.shade5)))
+        .background(Color(.bannerBackground))
     }
 }
 
 // MARK: Definitions
 extension FreeTrialBanner {
+    enum Layout {
+        static let spacing: CGFloat = 6.0
+    }
+
     enum Localization {
         static let upgradeNow = NSLocalizedString("Upgrade Now", comment: "Title on the button to upgrade a free trial plan.")
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
@@ -8,6 +8,7 @@ final class FreeTrialBannerHostingViewController: UIHostingController<FreeTrialB
     ///
     init() {
         super.init(rootView: FreeTrialBanner())
+        self.view.backgroundColor = .wooCommercePurple(.shade5)
     }
 
     /// Needed for protocol conformance.
@@ -39,6 +40,7 @@ struct FreeTrialBanner: View {
         }
         .padding()
         .background(Color(.wooCommercePurple(.shade5)))
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
@@ -5,7 +5,23 @@ import SwiftUI
 struct FreeTrialBanner: View {
 
     var body: some View {
-        Text("Free Trial")
+        HStack {
+            Image(uiImage: .infoOutlineImage)
+
+            HStack(spacing: 6) {
+                Text("Your trial has ended.")
+                    .bodyStyle()
+
+                Text("Upgrade Now")
+                    .underline(true)
+                    .linkStyle()
+                    .onTapGesture {
+                        print("Upgrade Now Pressed")
+                    }
+            }
+        }
+        .padding()
+        .background(Color(.wooCommercePurple(.shade5)))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
@@ -7,7 +7,6 @@ final class FreeTrialBannerHostingViewController: UIHostingController<FreeTrialB
     ///
     init(mainText: String, onUpgradeNowTapped: @escaping () -> Void) {
         super.init(rootView: FreeTrialBanner(mainText: mainText, onUpgradeNowTapped: onUpgradeNowTapped))
-        self.view.backgroundColor = .wooCommercePurple(.shade5)
     }
 
     /// Needed for protocol conformance.
@@ -44,8 +43,8 @@ struct FreeTrialBanner: View {
             }
         }
         .padding()
-        .background(Color(.wooCommercePurple(.shade5)))
         .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.wooCommercePurple(.shade5)))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+/// Free Trial Banner. To be used inside the Dashboard.
+///
+struct FreeTrialBanner: View {
+
+    var body: some View {
+        Text("Free Trial")
+    }
+}
+
+struct FreeTrial_Preview: PreviewProvider {
+    static var previews: some View {
+        FreeTrialBanner()
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
@@ -1,5 +1,22 @@
 import SwiftUI
 
+/// Hosting controller for `FreeTrialBanner`.
+///
+final class FreeTrialBannerHostingViewController: UIHostingController<FreeTrialBanner> {
+
+    /// Designated initializer.
+    ///
+    init() {
+        super.init(rootView: FreeTrialBanner())
+    }
+
+    /// Needed for protocol conformance.
+    ///
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 /// Free Trial Banner. To be used inside the Dashboard.
 ///
 struct FreeTrialBanner: View {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -733,6 +733,7 @@
 		26C6E8EA26E8FD3900C7BB0F /* LazyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8E926E8FD3900C7BB0F /* LazyView.swift */; };
 		26C6E8EC26E8FF4800C7BB0F /* LazyNavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */; };
 		26C98F9829C1247000F96503 /* WPComSitePlan+FreeTrial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C98F9729C1246F00F96503 /* WPComSitePlan+FreeTrial.swift */; };
+		26C98F9B29C18ACE00F96503 /* FreeTrialBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C98F9A29C18ACE00F96503 /* FreeTrialBanner.swift */; };
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26CFDB2727357E8000AB940B /* SimplePaymentsSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */; };
@@ -2893,6 +2894,7 @@
 		26C6E8E926E8FD3900C7BB0F /* LazyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyView.swift; sourceTree = "<group>"; };
 		26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyNavigationLink.swift; sourceTree = "<group>"; };
 		26C98F9729C1246F00F96503 /* WPComSitePlan+FreeTrial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPComSitePlan+FreeTrial.swift"; sourceTree = "<group>"; };
+		26C98F9A29C18ACE00F96503 /* FreeTrialBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBanner.swift; sourceTree = "<group>"; };
 		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummary.swift; sourceTree = "<group>"; };
@@ -6007,6 +6009,14 @@
 			path = CountrySelector;
 			sourceTree = "<group>";
 		};
+		26C98F9929C18ABF00F96503 /* Free Trial */ = {
+			isa = PBXGroup;
+			children = (
+				26C98F9A29C18ACE00F96503 /* FreeTrialBanner.swift */,
+			);
+			path = "Free Trial";
+			sourceTree = "<group>";
+		};
 		26DB7E3228636CF200506173 /* Order Edition */ = {
 			isa = PBXGroup;
 			children = (
@@ -8788,6 +8798,7 @@
 				029D444722F13F5C00DEFA8A /* Factories */,
 				74036CBE211B87FD00E462C2 /* MyStore */,
 				CE85FD5820F7A59E0080B73E /* Settings */,
+				26C98F9929C18ABF00F96503 /* Free Trial */,
 				CE85FD5220F677770080B73E /* Dashboard.storyboard */,
 				B509112D2049E27A007D25DC /* DashboardViewController.swift */,
 				028E1F6F2833DD0A001F8829 /* DashboardViewModel.swift */,
@@ -11566,6 +11577,7 @@
 				575472812452185300A94C3C /* PushNotification.swift in Sources */,
 				0396CFAD2981476900E91436 /* CardPresentModalBuiltInConnectingFailed.swift in Sources */,
 				02C1853B27FF0D9C00ABD764 /* RefundSubmissionUseCase.swift in Sources */,
+				26C98F9B29C18ACE00F96503 /* FreeTrialBanner.swift in Sources */,
 				E10BD16D27CF890800CE6449 /* InPersonPaymentsCountryNotSupportedStripe.swift in Sources */,
 				26F94E26267A559300DB6CCF /* ProductAddOn.swift in Sources */,
 				4541D88A270718F6005A9E30 /* ShippingLabelCarriersSectionViewModel.swift in Sources */,

--- a/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
+++ b/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
@@ -360,6 +360,13 @@ public extension UIColor {
     static var jetpackGreen: UIColor {
         .withColorStudio(.jetpackGreen, shade: .shade20)
     }
+
+    /// Free Trial Banner Background.
+    ///
+    static var bannerBackground: UIColor {
+        .init(light: .withColorStudio(.wooCommercePurple, shade: .shade0),
+              dark: .withColorStudio(.wooCommercePurple, shade: .shade90))
+    }
 }
 
 // MARK: - UI elements.


### PR DESCRIPTION
Closes: #9065 

# Why

This PR adds the UI for the Free Trial Banner. The UI is not yet attached to the dashboard. It will be attached on the next PR with logic handling.


# Screenshots

Light | Dark | Big Font
---- | ---- | ----
![light](https://user-images.githubusercontent.com/562080/225454508-63a7e243-007f-4aa5-903f-f8a3b16f93a5.png) | ![dark](https://user-images.githubusercontent.com/562080/225454511-4e51fa03-ec16-4567-af51-6122ebbdf404.png) | ![big-font](https://user-images.githubusercontent.com/562080/225454514-61650f7d-66d4-4d70-b24a-85e35f4d096a.png)

# Testing

The UI is not yet attached, so just look at the screenshots :-)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
