### PR TITLE
REST API: Add support tag for site credential login failure

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreTelephony
 import Yosemite
+import class WordPressAuthenticator.AuthenticatorAnalyticsTracker
 import protocol Storage.StorageManagerType
 
 /// Helper that provides general device & site zendesk metadata.
@@ -39,6 +40,12 @@ class SupportFormMetadataProvider {
     /// Common system & site  tags. Used in Zendesk Forms.
     ///
     func systemTags() -> [String] {
+        if stores.isAuthenticated == false,
+           AuthenticatorAnalyticsTracker.shared.state.lastFlow == .loginWithSiteAddress,
+           AuthenticatorAnalyticsTracker.shared.state.lastStep == .usernamePassword {
+            return [Constants.platformTag, Constants.siteCredentialLoginErrorTag]
+        }
+
         guard let site = sessionManager.defaultSite else {
             return [Constants.platformTag] + getIPPTags()
         }
@@ -233,6 +240,7 @@ private extension SupportFormMetadataProvider {
         static let platformTag = "iOS"
         static let wpComTag = "wpcom"
         static let authenticatedWithApplicationPasswordTag = "application_password_authenticated"
+        static let siteCredentialLoginErrorTag = "application_password_login_error"
         static let logFieldCharacterLimit = 64000
         static let networkWiFi = "WiFi"
         static let networkWWAN = "Mobile"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -40,9 +40,10 @@ class SupportFormMetadataProvider {
     /// Common system & site  tags. Used in Zendesk Forms.
     ///
     func systemTags() -> [String] {
+        let authenticatorAnalyticsTracker = AuthenticatorAnalyticsTracker.shared
         if stores.isAuthenticated == false,
-           AuthenticatorAnalyticsTracker.shared.state.lastFlow == .loginWithSiteAddress,
-           AuthenticatorAnalyticsTracker.shared.state.lastStep == .usernamePassword {
+           authenticatorAnalyticsTracker.state.lastFlow == .loginWithSiteAddress,
+           authenticatorAnalyticsTracker.state.lastStep == .usernamePassword {
             return [Constants.platformTag, Constants.siteCredentialLoginErrorTag]
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9146 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR does the same thing as #9150 to add the new Zendesk tag `application_password_login_error` for site credential login failure. The changes in the other PR was discarded due to a [merge conflict](https://github.com/woocommerce/woocommerce-ios/pull/9164#issuecomment-1470920472) with `trunk` since the introduction of `SupportFormMetadataProvider`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log out of the app if needed.
- Select Enter your site address.
- Enter the address of your test site and incorrect credentials.
- On the error alert, select Need more help?
- On the Contact Support form, enter content for the ticket (please note in the content that the ticket is intended for testing so that HEs can skip it).
- Submit the ticket, confirm on Zendesk that the new tag `application_password_login_error` is present.
- Please feel free to submit other support tickets from other flows and confirm that `application_password_login_error` is not present.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="284" alt="Screenshot 2023-03-15 at 17 32 42" src="https://user-images.githubusercontent.com/5533851/225497323-a06d4cb6-749f-4292-9040-c12ef6f5cb25.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
