### PR TITLE
[Free Trial] Populate Free Trial Banner

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -163,8 +163,6 @@ final class DashboardViewController: UIViewController {
         observeOnboardingVisibility()
         observeFreeTrialBannerVisibility()
 
-        viewModel.syncFreeTrialBanner(siteID: siteID)
-
         Task { @MainActor in
             await viewModel.syncAnnouncements(for: siteID)
             await reloadDashboardUIStatsVersion(forced: true)
@@ -175,6 +173,9 @@ final class DashboardViewController: UIViewController {
         super.viewWillAppear(animated)
         // Reset title to prevent it from being empty right after login
         configureTitle()
+
+        // Proactively update the free trial banner every time we navigate to the dashboard.
+        viewModel.syncFreeTrialBanner(siteID: siteID)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -181,6 +181,8 @@ final class DashboardViewModel {
             case .success(let plan):
                 if plan.isFreeTrial {
                     self?.freeTrialBannerViewModel = FreeTrialBannerViewModel(sitePlan: plan)
+                } else {
+                    self?.freeTrialBannerViewModel = nil
                 }
             case .failure(let error):
                 DDLogError("⛔️ Error fetching the current site's plan information: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -19,6 +19,8 @@ final class DashboardViewModel {
 
     @Published private(set) var showOnboarding: Bool = false
 
+    @Published private(set) var freeTrialBannerViewModel: FreeTrialBannerViewModel? = nil
+
     /// Trigger to start the Add Product flow
     ///
     let addProductTrigger = PassthroughSubject<Void, Never>()
@@ -174,13 +176,11 @@ final class DashboardViewModel {
             return DDLogInfo("⚠️ Site is not a WPCOM site.")
         }
 
-        let action = PaymentAction.loadSiteCurrentPlan(siteID: siteID) { result in
+        let action = PaymentAction.loadSiteCurrentPlan(siteID: siteID) { [weak self] result in
             switch result {
             case .success(let plan):
                 if plan.isFreeTrial {
-                    print("*****************************")
-                    print("****** FREE TRIAL PLAN ******")
-                    print("*****************************")
+                    self?.freeTrialBannerViewModel = FreeTrialBannerViewModel(sitePlan: plan)
                 }
             case .failure(let error):
                 DDLogError("⛔️ Error fetching the current site's plan information: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBannerViewModel.swift
@@ -1,0 +1,32 @@
+import Yosemite
+
+/// ViewModel to format the text that goes into the Free Trial Banner.
+///
+struct FreeTrialBannerViewModel {
+
+    /// Free Trial banner message.
+    ///
+    let message: String
+
+    init(sitePlan: WPComSitePlan) {
+
+        // Normalize dates in the same timezone.
+        let today = Date().startOfDay(timezone: .current)
+        guard let expiryDate = sitePlan.expiryDate?.startOfDay(timezone: .current) else {
+            message = ""
+            return
+        }
+
+        let daysLeft = Calendar.current.dateComponents([.day], from: today, to: expiryDate).day ?? 0
+        switch daysLeft {
+        case 1:
+            message = NSLocalizedString("1 day left in your trial.", comment: "Message of the free trial banner when there is 1 day left")
+        case (2...):
+            let format = NSLocalizedString("%d days left in your trial.", comment: "Message of the free trial banner when there is more than 1 day left")
+            message = String.localizedStringWithFormat(format, daysLeft)
+        default:
+            message = NSLocalizedString("Your trial has ended.", comment: "Message of the free trial banner when there are no days left")
+
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -631,6 +631,8 @@
 		261AA30C2753119E009530FE /* PaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30B2753119E009530FE /* PaymentMethodsViewModel.swift */; };
 		261AA30E275506DE009530FE /* PaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30D275506DE009530FE /* PaymentMethodsViewModelTests.swift */; };
 		261B526E29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */; };
+		261F1A7929C2AB2E001D9861 /* FreeTrialBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */; };
+		261F1A7C29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */; };
 		26281776278F0B0100C836D3 /* View+NoticesModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26281775278F0B0100C836D3 /* View+NoticesModifier.swift */; };
 		262A098B2628C51D0033AD20 /* OrderAddOnListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */; };
 		262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */; };
@@ -2798,6 +2800,8 @@
 		261AA30B2753119E009530FE /* PaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsViewModel.swift; sourceTree = "<group>"; };
 		261AA30D275506DE009530FE /* PaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
 		261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportFormMetadataProvider.swift; sourceTree = "<group>"; };
+		261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModel.swift; sourceTree = "<group>"; };
+		261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModelTests.swift; sourceTree = "<group>"; };
 		26281775278F0B0100C836D3 /* View+NoticesModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+NoticesModifier.swift"; sourceTree = "<group>"; };
 		262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListViewModel.swift; sourceTree = "<group>"; };
 		262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListI1Tests.swift; sourceTree = "<group>"; };
@@ -5484,6 +5488,7 @@
 				DEFD6E5F264990DD00E51E0D /* Plugins */,
 				576D9F2724DB81BF007B48F4 /* Stats V4 */,
 				CCCFFC5B2934F089006130AF /* Factories */,
+				261F1A7A29C2B081001D9861 /* Free Trial */,
 				02E4FD802306AA890049610C /* StatsTimeRangeBarViewModelTests.swift */,
 				0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */,
 				02AB40812784297C00929CF3 /* ProductTableViewCellViewModelTests.swift */,
@@ -5735,6 +5740,14 @@
 			);
 			name = "Add Attributes";
 			path = "Variations/Add Attributes";
+			sourceTree = "<group>";
+		};
+		261F1A7A29C2B081001D9861 /* Free Trial */ = {
+			isa = PBXGroup;
+			children = (
+				261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */,
+			);
+			path = "Free Trial";
 			sourceTree = "<group>";
 		};
 		262A097F2628A8BF0033AD20 /* View Modifiers */ = {
@@ -6013,6 +6026,7 @@
 			isa = PBXGroup;
 			children = (
 				26C98F9A29C18ACE00F96503 /* FreeTrialBanner.swift */,
+				261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */,
 			);
 			path = "Free Trial";
 			sourceTree = "<group>";
@@ -10811,6 +10825,7 @@
 				0211259F2578DE310075AD2A /* ShippingLabelPrintingStepView.swift in Sources */,
 				B58B4AB22108F01700076FDD /* NoticeView.swift in Sources */,
 				74B5713621CD7604008F9B8E /* SharingHelper.swift in Sources */,
+				261F1A7929C2AB2E001D9861 /* FreeTrialBannerViewModel.swift in Sources */,
 				0313651328ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift in Sources */,
 				260C315E2523CC4000157BC2 /* RefundProductsTotalViewModel.swift in Sources */,
 				0286B27D23C7051F003D784B /* ProductImagesViewController.swift in Sources */,
@@ -12239,6 +12254,7 @@
 				6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */,
 				B9DA153E28101BE100FC67DD /* MockOrderRefundsOptionsDeterminer.swift in Sources */,
 				09C6A26227C01166001FAD73 /* BulkUpdateViewModelTests.swift in Sources */,
+				261F1A7C29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift in Sources */,
 				6856D806DE7DB61522D54044 /* NSMutableAttributedStringHelperTests.swift in Sources */,
 				023D69442588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift in Sources */,
 				026D4650295C08CA0037F59A /* StoreCreationSellingPlatformsQuestionViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialBannerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Free Trial/FreeTrialBannerViewModelTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import WooCommerce
+@testable import Networking
+
+final class FreeTrialBannerViewModelTests: XCTestCase {
+
+    /// All Expiry dates came in GMT from the API.
+    ///
+    static let gmtTimezone = TimeZone(secondsFromGMT: 0) ?? .current
+
+    func test_few_days_left_in_trial() {
+        // Given
+        let expiryDate = Date().adding(days: 3)?.startOfDay(timezone: Self.gmtTimezone)
+        let sitePlan = WPComSitePlan(hasDomainCredit: false, expiryDate: expiryDate)
+
+        // When
+        let viewModel = FreeTrialBannerViewModel(sitePlan: sitePlan)
+
+        // Then
+        XCTAssertEqual(viewModel.message, NSLocalizedString("3 days left in your trial.", comment: ""))
+    }
+
+    func test_1_day_left_in_trial() {
+        // Given
+        let expiryDate = Date().adding(days: 1)?.startOfDay(timezone: Self.gmtTimezone)
+        let sitePlan = WPComSitePlan(hasDomainCredit: false, expiryDate: expiryDate)
+
+        // When
+        let viewModel = FreeTrialBannerViewModel(sitePlan: sitePlan)
+
+        // Then
+        XCTAssertEqual(viewModel.message, NSLocalizedString("1 day left in your trial.", comment: ""))
+    }
+
+    func test_0_days_left_on_trial() {
+        // Given
+        let expiryDate = Date().startOfDay(timezone: Self.gmtTimezone)
+        let sitePlan = WPComSitePlan(hasDomainCredit: false, expiryDate: expiryDate)
+
+        // When
+        let viewModel = FreeTrialBannerViewModel(sitePlan: sitePlan)
+
+        // Then
+        XCTAssertEqual(viewModel.message, NSLocalizedString("Your trial has ended.", comment: ""))
+    }
+
+    func test_no_days_left_on_trial() {
+        // Given
+        let expiryDate = Date().adding(days: -3)?.startOfDay(timezone: Self.gmtTimezone)
+        let sitePlan = WPComSitePlan(hasDomainCredit: false, expiryDate: expiryDate)
+
+        // When
+        let viewModel = FreeTrialBannerViewModel(sitePlan: sitePlan)
+
+        // Then
+        XCTAssertEqual(viewModel.message, NSLocalizedString("Your trial has ended.", comment: ""))
+    }
+}


### PR DESCRIPTION
Closes: #9066 

# Why

This PR takes care of handling and presentation of the Free Trial Banner.

# How

- Added a `FreeTrialBannerViewModel` to take care of formatting how many days the free trial has.

- Update the dashboard to fetch the site plan status on each `viewWillAppear`, in order to always get the latest information.

- Observe the banner view model published variable to determine when to show or hide the free trial banner.

# Screenshot

![Simulator Screen Shot - iPhone 14 Pro - 2023-03-15 at 22 18 20](https://user-images.githubusercontent.com/562080/225509221-5a84d943-bec7-4df8-8fba-467b611046d6.png)

# Testing Steps

- Log into a free trial site
- See that in the dashboard there is a "Free trial banner" with the correct number of days left.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
