### PR TITLE
[Free Trial] Launch upgrade Web View from banner CTA

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2133,3 +2133,37 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - Free Trial
+//
+extension WooAnalyticsEvent {
+    enum FreeTrial {
+        enum Keys: String {
+            case source
+            case currentPlan = "current_plan"
+        }
+
+        enum Source: String {
+            case banner
+            case upgradesScreen = "upgrades_screen"
+        }
+
+        enum Plan: String {
+            case freeTrial = "ecommerce-trial-bundle-monthly"
+        }
+
+        static func freeTrialUpgradeNowTapped(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .freeTrialUpgradeNowTapped, properties: [Keys.source.rawValue: source.rawValue])
+        }
+
+        static func planUpgradeSuccess(source: Source, plan: Plan) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .planUpgradeSuccess, properties: [Keys.source.rawValue: source.rawValue,
+                                                                          Keys.currentPlan.rawValue: Plan.freeTrial.rawValue])
+        }
+
+        static func planUpgradeAbandoned(source: Source, plan: Plan) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .planUpgradeAbandoned, properties: [Keys.source.rawValue: source.rawValue,
+                                                                            Keys.currentPlan.rawValue: Plan.freeTrial.rawValue])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2140,7 +2140,6 @@ extension WooAnalyticsEvent {
     enum FreeTrial {
         enum Keys: String {
             case source
-            case currentPlan = "current_plan"
         }
 
         enum Source: String {
@@ -2148,22 +2147,16 @@ extension WooAnalyticsEvent {
             case upgradesScreen = "upgrades_screen"
         }
 
-        enum Plan: String {
-            case freeTrial = "ecommerce-trial-bundle-monthly"
-        }
-
         static func freeTrialUpgradeNowTapped(source: Source) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .freeTrialUpgradeNowTapped, properties: [Keys.source.rawValue: source.rawValue])
         }
 
-        static func planUpgradeSuccess(source: Source, plan: Plan) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .planUpgradeSuccess, properties: [Keys.source.rawValue: source.rawValue,
-                                                                          Keys.currentPlan.rawValue: Plan.freeTrial.rawValue])
+        static func planUpgradeSuccess(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .planUpgradeSuccess, properties: [Keys.source.rawValue: source.rawValue])
         }
 
-        static func planUpgradeAbandoned(source: Source, plan: Plan) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .planUpgradeAbandoned, properties: [Keys.source.rawValue: source.rawValue,
-                                                                            Keys.currentPlan.rawValue: Plan.freeTrial.rawValue])
+        static func planUpgradeAbandoned(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .planUpgradeAbandoned, properties: [Keys.source.rawValue: source.rawValue])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -840,6 +840,11 @@ public enum WooAnalyticsStat: String {
     // MARK: Application password Events
     case applicationPasswordsNewPasswordCreated = "application_passwords_new_password_created"
     case applicationPasswordsGenerationFailed = "application_passwords_generation_failed"
+
+    // MARK: Free Trial
+    case freeTrialUpgradeNowTapped = "free_trial_upgrade_now_tapped"
+    case planUpgradeSuccess = "plan_upgrade_success"
+    case planUpgradeAbandoned = "plan_upgrade_abandoned"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -395,10 +395,7 @@ private extension DashboardViewController {
         let viewModel = DefaultAuthenticatedWebViewModel(title: Localization.upgradeNow,
                                                          initialURL: upgradeURL,
                                                          urlToTriggerExit: exitTrigger) { [weak self] in
-            self?.dismiss(animated: true)
-
-            // TODO: Plan should not be hardcoded. Will adjust it https://github.com/woocommerce/woocommerce-ios/issues/9064
-            ServiceLocator.analytics.track(event: .FreeTrial.planUpgradeSuccess(source: .banner, plan: .freeTrial))
+            self?.exitUpgradeFreeTrialFlowAfterUpgrade()
         }
 
         let webViewController = AuthenticatedWebViewController(viewModel: viewModel)
@@ -410,7 +407,17 @@ private extension DashboardViewController {
         present(navigationController, animated: true)
     }
 
-    /// Dismisses any controller presented modally.
+    /// Dismisses the upgrade now web view after the merchants successfully updates their plan.
+    ///
+    func exitUpgradeFreeTrialFlowAfterUpgrade() {
+        removeFreeTrialBanner()
+        dismiss(animated: true)
+
+        // TODO: Plan should not be hardcoded. Will adjust it https://github.com/woocommerce/woocommerce-ios/issues/9064
+        ServiceLocator.analytics.track(event: .FreeTrial.planUpgradeSuccess(source: .banner, plan: .freeTrial))
+    }
+
+    /// Dismisses the upgrade now web view when the user abandons the flow.
     ///
     @objc func exitUpgradeFreeTrialFlow() {
         dismiss(animated: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -352,6 +352,7 @@ private extension DashboardViewController {
     ///
     func addFreeTrialBar(contentText: String) {
         let freeTrialViewController = FreeTrialBannerHostingViewController(mainText: contentText) { [weak self] in
+            ServiceLocator.analytics.track(event: .FreeTrial.freeTrialUpgradeNowTapped(source: .banner))
             self?.showUpgradePlanWebView()
         }
         freeTrialViewController.view.translatesAutoresizingMaskIntoConstraints = false
@@ -394,14 +395,16 @@ private extension DashboardViewController {
         let viewModel = DefaultAuthenticatedWebViewModel(title: Localization.upgradeNow,
                                                          initialURL: upgradeURL,
                                                          urlToTriggerExit: exitTrigger) { [weak self] in
-            self?.dismissModalViewController()
-            // TODO: Add tracks event
+            self?.dismiss(animated: true)
+
+            // TODO: Plan should not be hardcoded. Will adjust it https://github.com/woocommerce/woocommerce-ios/issues/9064
+            ServiceLocator.analytics.track(event: .FreeTrial.planUpgradeSuccess(source: .banner, plan: .freeTrial))
         }
 
         let webViewController = AuthenticatedWebViewController(viewModel: viewModel)
         webViewController.navigationItem.leftBarButtonItem =  UIBarButtonItem(barButtonSystemItem: .cancel,
                                                                               target: self,
-                                                                              action: #selector(dismissModalViewController))
+                                                                              action: #selector(exitUpgradeFreeTrialFlow))
         let navigationController = UINavigationController(rootViewController: webViewController)
         navigationController.isModalInPresentation = true
         present(navigationController, animated: true)
@@ -409,8 +412,11 @@ private extension DashboardViewController {
 
     /// Dismisses any controller presented modally.
     ///
-    @objc func dismissModalViewController() {
+    @objc func exitUpgradeFreeTrialFlow() {
         dismiss(animated: true)
+
+        // TODO: Plan should not be hardcoded. Will adjust it https://github.com/woocommerce/woocommerce-ios/issues/9064
+        ServiceLocator.analytics.track(event: .FreeTrial.planUpgradeAbandoned(source: .banner, plan: .freeTrial))
     }
 
     func configureDashboardUIContainer() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -352,7 +352,6 @@ private extension DashboardViewController {
     ///
     func addFreeTrialBar(contentText: String) {
         let freeTrialViewController = FreeTrialBannerHostingViewController(mainText: contentText) { [weak self] in
-            ServiceLocator.analytics.track(event: .FreeTrial.freeTrialUpgradeNowTapped(source: .banner))
             self?.showUpgradePlanWebView()
         }
         freeTrialViewController.view.translatesAutoresizingMaskIntoConstraints = false
@@ -388,7 +387,11 @@ private extension DashboardViewController {
     /// Shows a web view for the merchant to update their site plan.
     ///
     func showUpgradePlanWebView() {
-        // These URLs should be stored elsewhere but I'll wait until I reuse them in the plans menu to decide what is the best place for them.
+        ServiceLocator.analytics.track(event: .FreeTrial.freeTrialUpgradeNowTapped(source: .banner))
+
+        // These URLs should be stored elsewhere.
+        // I'll wait until I reuse them in the plans menu to decide what is the best place for them.
+        // https://github.com/woocommerce/woocommerce-ios/issues/9057
         guard let upgradeURL = URL(string: "https://wordpress.com/plans/\(siteID)") else { return }
         let exitTrigger = "my-plan/trial-upgraded" // When a site is upgraded from a trial, this URL path is invoked.
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -416,8 +416,7 @@ private extension DashboardViewController {
         removeFreeTrialBanner()
         dismiss(animated: true)
 
-        // TODO: Plan should not be hardcoded. Will adjust it https://github.com/woocommerce/woocommerce-ios/issues/9064
-        ServiceLocator.analytics.track(event: .FreeTrial.planUpgradeSuccess(source: .banner, plan: .freeTrial))
+        ServiceLocator.analytics.track(event: .FreeTrial.planUpgradeSuccess(source: .banner))
     }
 
     /// Dismisses the upgrade now web view when the user abandons the flow.
@@ -425,8 +424,7 @@ private extension DashboardViewController {
     @objc func exitUpgradeFreeTrialFlow() {
         dismiss(animated: true)
 
-        // TODO: Plan should not be hardcoded. Will adjust it https://github.com/woocommerce/woocommerce-ios/issues/9064
-        ServiceLocator.analytics.track(event: .FreeTrial.planUpgradeAbandoned(source: .banner, plan: .freeTrial))
+        ServiceLocator.analytics.track(event: .FreeTrial.planUpgradeAbandoned(source: .banner))
     }
 
     func configureDashboardUIContainer() {


### PR DESCRIPTION
Closes: #9160 

# Why

This PR takes care of launching the "Upgrade Now" web view when the merchants taps on the "Upgrade Now" button from the free trial banner.

# How

- Launch the Authenticated WebView when required.
- Dismiss banner after a successful plan upgrade.
- Add track events.

### Track Events Registration

- https://github.com/Automattic/tracks-events-registration/pull/1458
- https://github.com/Automattic/tracks-events-registration/pull/1457
- https://github.com/Automattic/tracks-events-registration/pull/1456

# Demo

https://user-images.githubusercontent.com/562080/225528435-b03d0927-1933-41c2-a7ef-6b0b7586ddc8.mov

# Testing Steps

- Launch the app on a free site.
- Tap the "Upgrade Now" button from the free trial banner
- Proceed to upgrade your plan (make sure you have credits)
- See that the banner disappears and that all track events are fired.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
