### PR TITLE
[Product Multi-Selection] Add `RemoteOrderSynchronizer` support for multiple products

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -69,6 +69,10 @@ protocol OrderSynchronizer {
     ///
     var setProduct: PassthroughSubject<OrderSyncProductInput, Never> { get }
 
+    /// Sets multiple products with their quantities.
+    ///
+    var setProducts: PassthroughSubject<[OrderSyncProductInput], Never> { get }
+
     /// Sets or removes the order shipping & billing addresses.
     ///
     var setAddresses: PassthroughSubject<OrderSyncAddressesInput?, Never> { get }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -30,14 +30,7 @@ struct ProductInputTransformer {
 
         // Add or update the order items with the new input.
         var items = order.items
-        if let itemIndex = order.items.firstIndex(where: { $0.itemID == input.id }) {
-            let newItem = createOrderItem(using: input, usingPriceFrom: items[itemIndex])
-            items[itemIndex] = newItem
-        } else {
-            let newItem = createOrderItem(using: input, usingPriceFrom: nil)
-            items.append(newItem)
-        }
-
+        updateOrderItems(from: order, with: input, orderItems: &items)
         return order.copy(items: items)
     }
 
@@ -54,15 +47,7 @@ struct ProductInputTransformer {
         var updatedOrderItems = order.items
 
         for input in inputs {
-            // If the item already exists, update the existing OrderItem
-            if let itemIndex = order.items.firstIndex(where: {$0.itemID == input.id}) {
-                let newItem = createOrderItem(using: input, usingPriceFrom: updatedOrderItems[itemIndex])
-                updatedOrderItems[itemIndex] = newItem
-            } else {
-                // If the item doesn't exist, create a new OrderItem and append it to our updated Order
-                let newItem = createOrderItem(using: input, usingPriceFrom: nil)
-                updatedOrderItems.append(newItem)
-            }
+            updateOrderItems(from: order, with: input, orderItems: &updatedOrderItems)
         }
 
         // If the input's quantity is 0 or less, delete the item if required.
@@ -75,6 +60,27 @@ struct ProductInputTransformer {
         }
 
         return order.copy(items: updatedOrderItems)
+    }
+}
+
+// MARK: ProductInputTransformer helper methods
+//
+private extension ProductInputTransformer {
+    /// Creates, or updates existing `OrderItems` of a given `Order` with any `OrderSyncProductInput` update
+    ///
+    /// - Parameters:
+    ///   - order: Represents an Order entity.
+    ///   - input: Types of products the synchronizer supports
+    ///   - updatedOrderItems: An array of `[OrderItem]` entities
+    ///
+    static func updateOrderItems(from order: Order, with input: OrderSyncProductInput, orderItems updatedOrderItems: inout [OrderItem]) {
+        if let itemIndex = order.items.firstIndex(where: { $0.itemID == input.id }) {
+            let newItem = createOrderItem(using: input, usingPriceFrom: updatedOrderItems[itemIndex])
+            updatedOrderItems[itemIndex] = newItem
+        } else {
+            let newItem = createOrderItem(using: input, usingPriceFrom: nil)
+            updatedOrderItems.append(newItem)
+        }
     }
 
     /// Updates the `OrderItems` array with `OrderSyncProductInput`.
@@ -97,13 +103,7 @@ struct ProductInputTransformer {
 
         // Adds or updates the Order items with the new input:
         var updatedOrderItems = order.items
-        if let itemIndex = order.items.firstIndex(where: { $0.itemID == input.id }) {
-            let newItem = createOrderItem(using: input, usingPriceFrom: updatedOrderItems[itemIndex])
-            updatedOrderItems[itemIndex] = newItem
-        } else {
-            let newItem = createOrderItem(using: input, usingPriceFrom: nil)
-            updatedOrderItems.append(newItem)
-        }
+        updateOrderItems(from: order, with: input, orderItems: &updatedOrderItems)
 
         return updatedOrderItems
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -40,7 +40,7 @@ struct ProductInputTransformer {
 
         return order.copy(items: items)
     }
-    
+
     /// Adds, deletes, or updates order items based on the multiple given product inputs
     ///
     /// - Parameters:
@@ -63,7 +63,6 @@ struct ProductInputTransformer {
         return order.copy(items: items)
     }
 
-    
     /// Updates the `OrderItems` array with `OrderSyncProductInput`.
     /// Uses the same implementation as `update()` but returns an array of OrderItems instead,
     /// rather than aggregating them into the Order

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -41,6 +41,20 @@ struct ProductInputTransformer {
         return order.copy(items: items)
     }
 
+    /// Adds, deletes, or updates order items based on the given product input array
+    ///
+    static func update(input: [OrderSyncProductInput], on order: Order, updateZeroQuantities: Bool) -> Order {
+        // TODO: Add rest of logic. For now does the minimum:
+        // Accepts [OrderSyncProductInput] -> Transforms to [OrderItem] -> returns Order copy
+        var items = order.items
+        let _ = input.map { item in
+            let newItem = createOrderItem(using: item, usingPriceFrom: nil)
+            items.append(newItem)
+        }
+
+        return order.copy(items: items )
+    }
+
     /// Removes an order item from an order when the `item.itemID` matches the `input.id`.
     ///
     private static func remove(input: OrderSyncProductInput, from order: Order) -> Order {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -96,8 +96,7 @@ private extension ProductInputTransformer {
     private static func updateOrderItems(from input: OrderSyncProductInput, order: Order, updateZeroQuantities: Bool) -> [OrderItem] {
         // If the input's quantity is 0 or less, delete the item if required.
         guard input.quantity > 0 || updateZeroQuantities else {
-            let updatedOrder = remove(input: input, from: order)
-            return updatedOrder.items
+            return remove(input: input, from: order).items
         }
 
         // Adds or updates the Order items with the new input:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -93,8 +93,7 @@ private extension ProductInputTransformer {
     ///   - updateZeroQuantities: When true, items with `.zero` quantities will be updated instead of being deleted.
     ///
     /// - Returns: An array of Order Item entities
-    private static func updateOrderItems(from input: OrderSyncProductInput,
-                                         order: Order, updateZeroQuantities: Bool) -> [OrderItem] {
+    private static func updateOrderItems(from input: OrderSyncProductInput, order: Order, updateZeroQuantities: Bool) -> [OrderItem] {
         // If the input's quantity is 0 or less, delete the item if required.
         guard input.quantity > 0 || updateZeroQuantities else {
             let updatedOrder = remove(input: input, from: order)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -54,12 +54,6 @@ struct ProductInputTransformer {
         var updatedOrderItems = order.items
 
         for input in inputs {
-            // 1. If the input quantity is 0 or less, delete the item if needed
-            // TODO: case for deleting and having updateZeroQuantities
-            //  if input.quantity <= 0 {
-            //      updatedOrderItems.removeAll(where: { $0.itemID == input.id})
-            //  }
-
             // If the item already exists, update the existing OrderItem
             if let itemIndex = order.items.firstIndex(where: {$0.itemID == input.id}) {
                 let newItem = createOrderItem(using: input, usingPriceFrom: updatedOrderItems[itemIndex])
@@ -68,6 +62,15 @@ struct ProductInputTransformer {
                 // If the item doesn't exist, create a new OrderItem and append it to our updated Order
                 let newItem = createOrderItem(using: input, usingPriceFrom: nil)
                 updatedOrderItems.append(newItem)
+            }
+        }
+
+        // If the input's quantity is 0 or less, delete the item if required.
+        // We perform a second loop for deletions so we don't attempt to access to overflown indexes
+        for input in inputs {
+            guard input.quantity > 0 || updateZeroQuantities else {
+                updatedOrderItems.removeAll(where: { $0.itemID == input.id })
+                return order.copy(items: updatedOrderItems)
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -53,7 +53,6 @@ struct ProductInputTransformer {
         for productInput in input {
             items.append(contentsOf: updateOrderItems(
                 from: productInput,
-                on: items,
                 order: order,
                 updateZeroQuantities: updateZeroQuantities)
             )
@@ -65,7 +64,6 @@ struct ProductInputTransformer {
     ///
     ///
     private static func updateOrderItems(from input: OrderSyncProductInput,
-                                         on initialOrderItems: [OrderItem],
                                          order: Order, updateZeroQuantities: Bool) -> [OrderItem] {
         // If the input's quantity is 0 or less, delete the item if required.
         guard input.quantity > 0 || updateZeroQuantities else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -41,18 +41,18 @@ struct ProductInputTransformer {
         return order.copy(items: items)
     }
 
-    /// Adds, deletes, or updates order items based on the multiple given product inputs
+    /// Adds, deletes, or updates Order items based on the multiple given product inputs
     ///
     /// - Parameters:
-    ///   - input: Array of types of products the synchronizer supports
+    ///   - inputs: Array of product types the OrderSynchronizer supports
     ///   - order: Represents an Order entity.
     ///   - updateZeroQuantities: When true, items with `.zero` quantities will be updated instead of being deleted.
     ///
     /// - Returns: An Order entity.
-    static func updateMultiple(input: [OrderSyncProductInput], on order: Order, updateZeroQuantities: Bool) -> Order {
+    static func updateMultipleItems(with inputs: [OrderSyncProductInput], on order: Order, updateZeroQuantities: Bool) -> Order {
         var items = order.items
 
-        for productInput in input {
+        for productInput in inputs {
             items.append(contentsOf: updateOrderItems(
                 from: productInput,
                 order: order,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -71,6 +71,7 @@ struct ProductInputTransformer {
     ///   - input: Types of products the synchronizer supports
     ///   - order: Represents an Order entity.
     ///   - updateZeroQuantities: When true, items with `.zero` quantities will be updated instead of being deleted.
+    ///
     /// - Returns: An array of Order Item entities
     private static func updateOrderItems(from input: OrderSyncProductInput,
                                          order: Order, updateZeroQuantities: Bool) -> [OrderItem] {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -40,16 +40,18 @@ struct ProductInputTransformer {
 
         return order.copy(items: items)
     }
-
-    /// Adds, deletes, or updates order items based on the given multiple products input.
-    /// When `updateZeroQuantities` is true, items with `.zero` quantities will be updated instead of being deleted.
+    
+    /// Adds, deletes, or updates order items based on the multiple given product inputs
     ///
-    /// Accepts `[OrderSyncProductInput]`,  transforms into `[OrderItem]`, returns returns the updated `Order` copy
+    /// - Parameters:
+    ///   - input: Array of types of products the synchronizer supports
+    ///   - order: Represents an Order entity.
+    ///   - updateZeroQuantities: When true, items with `.zero` quantities will be updated instead of being deleted.
+    ///
+    /// - Returns: An Order entity.
     static func updateMultiple(input: [OrderSyncProductInput], on order: Order, updateZeroQuantities: Bool) -> Order {
-
         var items = order.items
 
-        // Transforms into `[OrderItem]` that we'll pass to the Order copy
         for productInput in input {
             items.append(contentsOf: updateOrderItems(
                 from: productInput,
@@ -61,8 +63,16 @@ struct ProductInputTransformer {
         return order.copy(items: items)
     }
 
+    
+    /// Updates the `OrderItems` array with `OrderSyncProductInput`.
+    /// Uses the same implementation as `update()` but returns an array of OrderItems instead,
+    /// rather than aggregating them into the Order
     ///
-    ///
+    /// - Parameters:
+    ///   - input: Types of products the synchronizer supports
+    ///   - order: Represents an Order entity.
+    ///   - updateZeroQuantities: When true, items with `.zero` quantities will be updated instead of being deleted.
+    /// - Returns: An array of Order Item entities
     private static func updateOrderItems(from input: OrderSyncProductInput,
                                          order: Order, updateZeroQuantities: Bool) -> [OrderItem] {
         // If the input's quantity is 0 or less, delete the item if required.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -151,15 +151,18 @@ private extension RemoteOrderSynchronizer {
 
         setProducts.withLatestFrom(orderPublisher)
             .map { productsInput, order -> Order in
-                // TODO: 1., pass localInputs through replaceInputWithLocalIDIfNeeded
+                // 1. Replace localInputs with localID as needed
+                let _ = productsInput.map {
+                    self.replaceInputWithLocalIDIfNeeded($0)
+                }
 
-                // 2. Update Order with product inputs (new method that accepts an array of inputs)
-                let updatedOrder = ProductInputTransformer.update(
+                // 2. Updates the Order with multiple product inputs
+                let updatedOrder = ProductInputTransformer.updateMultiple(
                     input: productsInput,
                     on: order,
                     updateZeroQuantities: true)
 
-                // 3. Update Order totals locally while the Order is being synced
+                // 3. Updates the Order Totals locally while the Order is being synchronized
                 return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
             }
             .sink { order in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -151,11 +151,16 @@ private extension RemoteOrderSynchronizer {
 
         setProducts.withLatestFrom(orderPublisher)
             .map { productsInput, order -> Order in
-                return ProductInputTransformer.update(
-                    // TODO: This has to accept multiple inputs
-                    input: productsInput[0],
+                // TODO: 1., pass localInputs through replaceInputWithLocalIDIfNeeded
+
+                // 2. Update Order with product inputs (new method that accepts an array of inputs)
+                let updatedOrder = ProductInputTransformer.update(
+                    input: productsInput,
                     on: order,
                     updateZeroQuantities: true)
+
+                // 3. Update Order totals locally while the Order is being synced
+                return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
             }
             .sink { order in
                 self.order = order

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -157,8 +157,8 @@ private extension RemoteOrderSynchronizer {
                     self.replaceInputWithLocalIDIfNeeded($0)
                 }
 
-                let updatedOrder = ProductInputTransformer.updateMultiple(
-                    input: productsInput,
+                let updatedOrder = ProductInputTransformer.updateMultipleItems(
+                    with: productsInput,
                     on: order,
                     updateZeroQuantities: true)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -28,6 +28,9 @@ final class EditableOrderViewModelTests: XCTestCase {
         let featureFlagService = MockFeatureFlagService(isProductMultiSelectionM1Enabled: false)
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, featureFlagService: featureFlagService)
 
+        // When
+        viewModel.isProductMultiSelectionBetaFeatureEnabled = false
+
         // Then
         XCTAssertFalse(viewModel.addProductViewModel.supportsMultipleSelection)
         XCTAssertFalse(viewModel.addProductViewModel.isClearSelectionEnabled)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
@@ -169,8 +169,10 @@ class ProductInputTransformerTests: XCTestCase {
         let updatedOrder = ProductInputTransformer.updateMultipleItems(with: [productInput2], on: initialOrder, updateZeroQuantities: false)
 
         // Then
-        XCTAssertEqual(updatedOrder.items.count, 1) // Confirm that we still have only 1 item
+        // Confirm that we still have only 1 item
+        XCTAssertEqual(updatedOrder.items.count, 1)
         let item = try XCTUnwrap(updatedOrder.items.first)
+        // Confirm that the item is updated
         XCTAssertEqual(item.itemID, productInput2.id)
         XCTAssertEqual(item.quantity, productInput2.quantity)
         XCTAssertEqual(item.productID, product.productID)
@@ -228,10 +230,7 @@ class ProductInputTransformerTests: XCTestCase {
         XCTAssertEqual(update2.items.count, 0)
     }
 
-    // TODO: Failing test
-    // As the other cases with updateMultipleItems(),
-    // we're not updating the unique product, but we're duplicating the product
-    func test_order_when_updateMultipleItems_with_zero_quantity_product_input_and_updateZeroQuantities_is_false_then_does_not_delete_item_on_order() throws {
+    func test_order_when_updateMultipleItems_with_zero_quantity_product_input_and_updateZeroQuantities_is_false_then_deletes_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
@@ -259,9 +258,6 @@ class ProductInputTransformerTests: XCTestCase {
         XCTAssertEqual(item.quantity, input2.quantity)
     }
 
-    // TODO: Failing test
-    // As the other cases with updateMultipleItems(),
-    // we're not updating the unique product, but we're duplicating the product
     func test_order_when_updateMultipleItems_with_zero_quantity_product_input_and_updateZeroQuantities_then_does_not_delete_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
@@ -158,20 +158,15 @@ class ProductInputTransformerTests: XCTestCase {
         XCTAssertEqual(item.total, "19.98")
     }
 
-    // TODO: Failing test
-    // At the moment the current implementation of updateMultipleItems will not update existing items, but copy and append the update:
-    // In this case we're not updating the unique product from quantity 1 to 2, but we're duplicating the product.
     func test_updatedOrder_when_updateMultipleItems_sends_an_updated_product_input_then_updates_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "9.99")
         let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
         let initialOrder = ProductInputTransformer.updateMultipleItems(with: [productInput], on: OrderFactory.emptyNewOrder, updateZeroQuantities: false)
-        // po update1.items.count = 1
 
         // When
         let productInput2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 2)
         let updatedOrder = ProductInputTransformer.updateMultipleItems(with: [productInput2], on: initialOrder, updateZeroQuantities: false)
-        // po update2.items.count = 2 -> updateMultipleItems is adding a second product here, when we actually want to update the existing product
 
         // Then
         XCTAssertEqual(updatedOrder.items.count, 1) // Confirm that we still have only 1 item
@@ -202,9 +197,6 @@ class ProductInputTransformerTests: XCTestCase {
         XCTAssertEqual(updatedItem.total, "16")
     }
 
-    // TODO: Failing test
-    // As the other cases with updateMultipleItems(),
-    // we're not updating the unique product, but we're duplicating the product.
     func test_updatedOrder_when_updateMultipleItems_sends_an_updated_product_input_then_updates_price_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "9.99")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
@@ -243,7 +243,7 @@ class ProductInputTransformerTests: XCTestCase {
         XCTAssertEqual(orderUpdate.items.count, 0)
     }
 
-    func test_sending_a_zero_quantity_update_product_input_dont_delete_item_on_order() throws {
+    func test_sending_a_zero_quantity_update_product_input_does_not_delete_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let input1 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -80,7 +80,10 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertEqual(synchronizer.order.items.count, 1)
 
         let item = try XCTUnwrap(synchronizer.order.items.first)
-        XCTAssertEqual(item.itemID, productInput.id)
+        // TODO: XCTAssertEqual(item.itemID, productInput.id)
+        // This test will fail as long as we call replaceInputWithLocalIDIfNeeded but
+        // don't implement the ProductInputTransformer.update() for multiple inputs
+        // as in this case the item.id is expected to be -1
         XCTAssertEqual(item.productID, product.productID)
         XCTAssertEqual(item.quantity, productInput.quantity)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -63,7 +63,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
     func test_setProducts_sends_single_product_input_then_updates_order_successfully() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
         let product = Product.fake().copy(productID: sampleProductID)
         let productInput = OrderSyncProductInput(
             product: .product(product),
@@ -89,7 +89,29 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
     }
 
     func test_setProducts_sends_multiple_product_input_then_updates_order_successfully() throws {
-        XCTFail("TODO")
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
+        let product = Product.fake().copy(productID: sampleProductID)
+        let anotherProduct = Product.fake().copy(productID: 12345)
+        let productInput = OrderSyncProductInput(
+            product: .product(product),
+            quantity: 1
+        )
+        let anotherProductInput = OrderSyncProductInput(
+            product: .product(anotherProduct),
+            quantity: 1
+        )
+
+        // Confidence check
+        XCTAssertEqual(synchronizer.order.items.count, 0)
+
+        // When
+        let inputs: [OrderSyncProductInput] = [productInput, anotherProductInput]
+        synchronizer.setProducts.send(inputs)
+
+        // Then
+        XCTAssertEqual(synchronizer.order.items.count, 2)
     }
 
     func test_sending_update_product_input_updates_local_order() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -60,6 +60,35 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertEqual(item.quantity, input.quantity)
     }
 
+    func test_setProducts_sends_single_product_input_then_updates_order_successfully() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation)
+        let product = Product.fake().copy(productID: sampleProductID)
+        let productInput = OrderSyncProductInput(
+            product: .product(product),
+            quantity: 1
+        )
+        // Confidence check
+        XCTAssertEqual(synchronizer.order.items.count, 0)
+
+        // When
+        let inputs: [OrderSyncProductInput] = [productInput]
+        synchronizer.setProducts.send(inputs)
+
+        // Then
+        XCTAssertEqual(synchronizer.order.items.count, 1)
+
+        let item = try XCTUnwrap(synchronizer.order.items.first)
+        XCTAssertEqual(item.itemID, productInput.id)
+        XCTAssertEqual(item.productID, product.productID)
+        XCTAssertEqual(item.quantity, productInput.quantity)
+    }
+
+    func test_setProducts_sends_multiple_product_input_then_updates_order_successfully() throws {
+        XCTFail("TODO")
+    }
+
     func test_sending_update_product_input_updates_local_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -80,10 +80,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertEqual(synchronizer.order.items.count, 1)
 
         let item = try XCTUnwrap(synchronizer.order.items.first)
-        // TODO: XCTAssertEqual(item.itemID, productInput.id)
-        // This test will fail as long as we call replaceInputWithLocalIDIfNeeded but
-        // don't implement the ProductInputTransformer.update() for multiple inputs
-        // as in this case the item.id is expected to be -1
+        XCTAssertEqual(item.itemID, productInput.id)
         XCTAssertEqual(item.productID, product.productID)
         XCTAssertEqual(item.quantity, productInput.quantity)
     }
@@ -112,6 +109,16 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(synchronizer.order.items.count, 2)
+        let item = try XCTUnwrap(synchronizer.order.items[0])
+        let anotherItem = try XCTUnwrap(synchronizer.order.items[1])
+
+        XCTAssertEqual(item.itemID, productInput.id)
+        XCTAssertEqual(item.productID, product.productID)
+        XCTAssertEqual(item.quantity, productInput.quantity)
+
+        XCTAssertEqual(anotherItem.itemID, anotherProductInput.id)
+        XCTAssertEqual(anotherItem.productID, anotherProduct.productID)
+        XCTAssertEqual(anotherItem.quantity, anotherProductInput.quantity)
     }
 
     func test_sending_update_product_input_updates_local_order() throws {


### PR DESCRIPTION
Closes: #8923 

## Description
As part of Product Multi-Selection M1.1, we'll be sending an unique request to the remote with all products that conform an Order, for this we need to update the `RemoteOrderSynchronizer` to accept multiple products.

## Changes
- Updates the `RemoteOrderSynchronizer` and `OrderSynchronizerprotocol` with a new `PassthroughSubject` variable, which accepts an `[OrderSyncProductInput]` array as Output.
- Inside this subject, called `setProducts()`, we'll update the Order that has to be sync by transforming inputs as necessary, following the same implementation as the existing `setProduct()`. We use those to update the underlying Order as inputs are received.
- Add Unit Tests

Question: The static methods `update()` and `updateOrderItems()` are pretty much identical, with the difference of the former returning an `Order` object, and the latter retuning an `[OrderItem]` object. I found this distinction necessary when updating the multiple `OrderSyncProductInputs` into a single `Order` and couldn't simplify it into a single method without extensive changes. Happy to get any feedback on this so I can tackle it here or on a different PR

## Testing instructions
- Unit Tests should pass
- We can also test this UI wise, **please note that this is not the final behaviour**, but just to see if works as expected:
1. In [EditableOrderViewModel](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/ViewRelated/Orders/Order%20Creation/EditableOrderViewModel.swift#L731), change the following line inside the `addProductToOrder()` method :
```
//orderSynchronizer.setProduct.send(input)
orderSynchronizer.setProducts.send([input, input, input, input, input])
```
2. Run the app. Go to Orders > `+` > `Add Products` > Tap on any product > See how 5 products of the same type are added to the Order.

![Simulator Screen Recording - iPhone 13 Pro - 2023-03-16 at 19 45 41](https://user-images.githubusercontent.com/3812076/225621376-4a8681ee-45e0-418b-9a7b-0902973f99ef.gif)

