### PR TITLE
[Store onboarding] Show all tasks if view all button is not displayed in collapsed mode.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -143,7 +143,7 @@ struct StoreOnboardingView: View {
 
                 // View all button
                 viewAllButton(action: viewAllTapped, text: String(format: Localization.viewAll, viewModel.taskViewModels.count))
-                    .renderedIf(!viewModel.isExpanded && !viewModel.isRedacted && !(viewModel.taskViewModels.count < 3))
+                    .renderedIf(viewModel.shouldShowViewAllButton)
 
                 Spacer()
                     .renderedIf(viewModel.isExpanded)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -4,7 +4,7 @@ import Yosemite
 
 /// View model for `StoreOnboardingView`.
 class StoreOnboardingViewModel: ObservableObject {
-    /// UI state of the dashboard top performers.
+    /// UI state of the store onboarding tasks.
     enum State {
         /// Shows placeholder rows.
         case loading

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -36,6 +36,10 @@ class StoreOnboardingViewModel: ObservableObject {
         return isExpanded ? taskViewModels : Array(incompleteTasks.prefix(maxNumberOfTasksToDisplayInCollapsedMode))
     }
 
+    var shouldShowViewAllButton: Bool {
+        !isExpanded && !isRedacted && !(taskViewModels.count < 3)
+    }
+
     let isExpanded: Bool
 
     private let siteID: Int64

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -25,12 +25,18 @@ class StoreOnboardingViewModel: ObservableObject {
     }
 
     var tasksForDisplay: [StoreOnboardingTaskViewModel] {
-        guard isRedacted == false else {
+        if isRedacted {
             return placeholderTasks
         }
-        guard !isExpanded else {
+
+        if isExpanded {
             return taskViewModels
         }
+
+        if !isExpanded && !shouldShowViewAllButton {
+            return taskViewModels
+        }
+
         let maxNumberOfTasksToDisplayInCollapsedMode = 3
         let incompleteTasks = taskViewModels.filter({ !$0.isComplete })
         return isExpanded ? taskViewModels : Array(incompleteTasks.prefix(maxNumberOfTasksToDisplayInCollapsedMode))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -29,11 +29,7 @@ class StoreOnboardingViewModel: ObservableObject {
             return placeholderTasks
         }
 
-        if isExpanded {
-            return taskViewModels
-        }
-
-        if !isExpanded && !shouldShowViewAllButton {
+        if isExpanded || !shouldShowViewAllButton {
             return taskViewModels
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -77,6 +77,50 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         XCTAssertEqual(sut.tasksForDisplay.count, 4)
     }
 
+    func test_tasksForDisplay_returns_first_3_incomplete_tasks_when_view_all_button_is_visible_in_collapsed_mode() async {
+        // Given
+        mockLoadOnboardingTasks(result: .success([
+            .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .launchStore),
+            .init(isComplete: false, type: .customizeDomains),
+            .init(isComplete: false, type: .payments)
+        ]))
+        let sut = StoreOnboardingViewModel(isExpanded: false,
+                                           siteID: 0,
+                                           stores: stores)
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertTrue(sut.shouldShowViewAllButton)
+
+        XCTAssertEqual(sut.tasksForDisplay.count, 3)
+
+        XCTAssertEqual(sut.tasksForDisplay[0].task.type, .addFirstProduct)
+        XCTAssertEqual(sut.tasksForDisplay[1].task.type, .launchStore)
+        XCTAssertEqual(sut.tasksForDisplay[2].task.type, .customizeDomains)
+    }
+
+    func test_tasksForDisplay_returns_all_tasks_when_view_all_button_is_hidden_in_collapsed_mode() async {
+        // Given
+        mockLoadOnboardingTasks(result: .success([
+            .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .launchStore)
+        ]))
+        let sut = StoreOnboardingViewModel(isExpanded: false,
+                                           siteID: 0,
+                                           stores: stores)
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertFalse(sut.shouldShowViewAllButton)
+
+        XCTAssertEqual(sut.tasksForDisplay.count, 2)
+        XCTAssertEqual(sut.tasksForDisplay[0].task.type, .addFirstProduct)
+        XCTAssertEqual(sut.tasksForDisplay[1].task.type, .launchStore)
+    }
+
     // MARK: - shouldShowViewAllButton
 
     func test_view_all_button_is_hidden_in_expanded_mode() async {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9170 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

- Start showing all tasks in collapsed mode when the "View all" button is hidden. Previously we were showing only incomplete tasks which made it impossible to view the completed tasks. 
- Move view all button visibility logic to view model and add unit tests.
- Add unit tests to test redacted state. 

## Testing instructions
Prerequisite: 
- A store with two tasks. Out of those two tasks one should be pending and one should be complete.
- You can create a JN site and enable "Cash on delivery" to finish the "Get paid" task (WooCommerce -> Settings -> Payments)

**Steps**
- Launch and login using the above-mentioned store
- In the dashboard ensure that you can see both tasks. 
- Notice that "Get paid" is a completed task and still it is displayed on the dashboard. 

## Screenshots
| Before | After |
| - | - |
| ![Before](https://user-images.githubusercontent.com/524475/225619873-b903c469-21f3-4f08-9df2-afe29425ce98.png) | ![After](https://user-images.githubusercontent.com/524475/225619850-680fe945-9442-4de0-b1c3-e0e6bc2038cf.png) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
