### PR TITLE
REST API: Web view for application password authorization

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -85,8 +85,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .freeTrial:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .applicationPasswordAuthorizationInWebView:
-            return ( buildConfig == .localDeveloper || buildConfig == .alpha ) && !isUITesting
+        case .manualErrorHandlingForSiteCredentialLogin:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -85,6 +85,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .freeTrial:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .applicationPasswordAuthorizationInWebView:
+            return ( buildConfig == .localDeveloper || buildConfig == .alpha ) && !isUITesting
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -175,4 +175,8 @@ public enum FeatureFlag: Int {
     /// Enables conditional behaviour when a site has a free trial plan.
     ///
     case freeTrial
+
+    /// Enables showing a web view for application password authorization during login.
+    ///
+    case applicationPasswordAuthorizationInWebView
 }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -176,7 +176,7 @@ public enum FeatureFlag: Int {
     ///
     case freeTrial
 
-    /// Enables showing a web view for application password authorization during login.
+    /// Enables manual error handling for site credential login.
     ///
-    case applicationPasswordAuthorizationInWebView
+    case manualErrorHandlingForSiteCredentialLogin
 }

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -780,6 +780,7 @@
 		DEC51AFB2769C66B009F3DF4 /* SystemStatusMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AFA2769C66B009F3DF4 /* SystemStatusMapperTests.swift */; };
 		DEC51B02276AFB35009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */; };
 		DEEDA4442975003800F845AB /* settings-general-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEDA4432975003800F845AB /* settings-general-without-data.json */; };
+		DEEF8E6529C832B500D47411 /* wordpress-site-info-with-auth-url.json in Resources */ = {isa = PBXBuildFile; fileRef = DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */; };
 		DEF13C5029629EEA0024A02B /* user-complete-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEF13C4F29629EEA0024A02B /* user-complete-without-data.json */; };
 		DEF13C562965689F0024A02B /* LeaderboardListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF13C552965689F0024A02B /* LeaderboardListMapperTests.swift */; };
 		DEF13C5A296571150024A02B /* leaderboards-year-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEF13C59296571150024A02B /* leaderboards-year-without-data.json */; };
@@ -1681,6 +1682,7 @@
 		DEC51AFA2769C66B009F3DF4 /* SystemStatusMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatusMapperTests.swift; sourceTree = "<group>"; };
 		DEC51B01276AFB34009F3DF4 /* SystemStatus+DropinMustUsePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemStatus+DropinMustUsePlugin.swift"; sourceTree = "<group>"; };
 		DEEDA4432975003800F845AB /* settings-general-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "settings-general-without-data.json"; sourceTree = "<group>"; };
+		DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wordpress-site-info-with-auth-url.json"; sourceTree = "<group>"; };
 		DEF13C4F29629EEA0024A02B /* user-complete-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "user-complete-without-data.json"; sourceTree = "<group>"; };
 		DEF13C552965689F0024A02B /* LeaderboardListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardListMapperTests.swift; sourceTree = "<group>"; };
 		DEF13C59296571150024A02B /* leaderboards-year-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "leaderboards-year-without-data.json"; sourceTree = "<group>"; };
@@ -2354,6 +2356,7 @@
 				DE9DEEF4291CF1B40070AD7C /* site-plugin-without-envelope.json */,
 				DE42F95E2967C88400D514C2 /* report-orders-total-without-data.json */,
 				DE42F95F2967C88400D514C2 /* report-orders-total.json */,
+				DEEF8E6429C832B500D47411 /* wordpress-site-info-with-auth-url.json */,
 				DE2E8EA8295416C9002E4B14 /* wordpress-site-info.json */,
 				DE4D23B529B5EC99003A4B5D /* close-account.json */,
 				028CB714290223CB00331C09 /* account-username-suggestions.json */,
@@ -3197,6 +3200,7 @@
 				74C8F06C20EEBD5D00B6EDC9 /* broken-order.json in Resources */,
 				DEC51A97274DD962009F3DF4 /* plugin.json in Resources */,
 				45D685FA23D0C3CF005F87D0 /* product-search-sku.json in Resources */,
+				DEEF8E6529C832B500D47411 /* wordpress-site-info-with-auth-url.json in Resources */,
 				D865CE5F278CA183002C8520 /* stripe-payment-intent-requires-action.json in Resources */,
 				CCF48B2C2628AE160034EA83 /* shipping-label-account-settings.json in Resources */,
 				31A451D927863A2E00FE81AA /* stripe-account-live-test.json in Resources */,

--- a/Networking/NetworkingTests/Responses/wordpress-site-info-with-auth-url.json
+++ b/Networking/NetworkingTests/Responses/wordpress-site-info-with-auth-url.json
@@ -1,0 +1,21 @@
+{
+    "name": "My WordPress Site",
+    "description": "Just another WordPress site",
+    "url": "https://example.com",
+    "home": "https://example.com",
+    "gmt_offset": "0",
+    "timezone_string": "",
+    "authentication": {
+        "application-passwords": {
+          "endpoints": {
+            "authorization": "https://example.com/wp-admin/authorize-application.php"
+          }
+        }
+      },
+    "namespaces": [
+        "oembed/1.0",
+        "wp/v2",
+        "wp-site-health/v1",
+        "wp-block-editor/v1"
+      ]
+}

--- a/Networking/NetworkingTests/Responses/wordpress-site-info.json
+++ b/Networking/NetworkingTests/Responses/wordpress-site-info.json
@@ -5,7 +5,7 @@
     "home": "https://test.com",
     "gmt_offset": "0",
     "timezone_string": "",
-    "authentication": [],
+    "authentication": {},
     "namespaces": [
         "oembed/1.0",
         "wp/v2",

--- a/Podfile
+++ b/Podfile
@@ -85,7 +85,7 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
 #  pod 'WordPressAuthenticator', '~> 5.5'
-   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'e2e5d1bd2aa44ee7bc678daf22f447476d76104d'
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'e9cf044bc38fe687ed4ba70780bd9b7411e82498'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -34,7 +34,7 @@ def tracks
 end
 
 def wordpress_shared
-  pod 'WordPressShared', '~> 2.0'
+  pod 'WordPressShared', '~> 2.1'
 end
 
 def keychain
@@ -84,8 +84,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 5.5'
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+#  pod 'WordPressAuthenticator', '~> 5.5'
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'e2e5d1bd2aa44ee7bc678daf22f447476d76104d'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -85,8 +85,8 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
 #  pod 'WordPressAuthenticator', '~> 5.5'
-   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'e9cf044bc38fe687ed4ba70780bd9b7411e82498'
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
+#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   wordpress_shared

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -39,21 +39,21 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (5.5.0):
+  - WordPressAuthenticator (5.7.0-beta.1):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
-    - WordPressKit (~> 6.0-beta)
-    - WordPressShared (~> 2.0-beta)
+    - WordPressKit (~> 7.0-beta)
+    - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (6.2.0):
+  - WordPressKit (7.0.0):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
     - WordPressShared (~> 2.0-beta)
     - wpxmlrpc (~> 0.10)
-  - WordPressShared (2.0.0)
+  - WordPressShared (2.1.0)
   - WordPressUI (1.12.5)
   - Wormholy (1.6.6)
   - WPMediaPicker (1.8.1)
@@ -84,8 +84,8 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 5.5)
-  - WordPressShared (~> 2.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `e2e5d1bd2aa44ee7bc678daf22f447476d76104d`)
+  - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.12.5)
   - Wormholy (~> 1.6.6)
   - WPMediaPicker (~> 1.8.1)
@@ -94,7 +94,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
     - WordPressKit
   trunk:
     - Alamofire
@@ -131,6 +130,16 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :commit: e2e5d1bd2aa44ee7bc678daf22f447476d76104d
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: e2e5d1bd2aa44ee7bc678daf22f447476d76104d
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AppAuth: 8fca6b5563a5baef2c04bee27538025e4ceb2add
@@ -152,9 +161,9 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 60611898815b218622f98d2c024d4eeae53dec1c
-  WordPressKit: edcc1a54aa003e0da020438ee2afe75d55c43363
-  WordPressShared: 35d41bdf0927e714af1fc85fa9cb692f934473be
+  WordPressAuthenticator: 505fdd48ded1c4de945f29e375b6a9c3dfe0a53e
+  WordPressKit: 4fa0defc318bfa6faec54ce9f06664023f2cc6e8
+  WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
   Wormholy: 09da0b876f9276031fd47383627cb75e194fc068
   WPMediaPicker: 9011a0ec1f468c039af7485c244576b4c9889a0f
@@ -168,6 +177,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 83cd8f88a8c42eb28a50c4856af876bed7cc43eb
+PODFILE CHECKSUM: d0638d255399c1468bd5b65b9b67700bb89dbe5b
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -84,7 +84,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `e9cf044bc38fe687ed4ba70780bd9b7411e82498`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `trunk`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.12.5)
   - Wormholy (~> 1.6.6)
@@ -132,12 +132,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: e9cf044bc38fe687ed4ba70780bd9b7411e82498
+    :branch: trunk
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: e9cf044bc38fe687ed4ba70780bd9b7411e82498
+    :commit: 2f3d4926faf85b28e5d5bcb317988d8c3d47ca6f
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -177,6 +177,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 6b5b01283512eafc04223efe3d973a3b7c223fa6
+PODFILE CHECKSUM: 3c5d780f073d93ef6927c47177253d7a0533b696
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -84,7 +84,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `e2e5d1bd2aa44ee7bc678daf22f447476d76104d`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `e9cf044bc38fe687ed4ba70780bd9b7411e82498`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.12.5)
   - Wormholy (~> 1.6.6)
@@ -132,12 +132,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: e2e5d1bd2aa44ee7bc678daf22f447476d76104d
+    :commit: e9cf044bc38fe687ed4ba70780bd9b7411e82498
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: e2e5d1bd2aa44ee7bc678daf22f447476d76104d
+    :commit: e9cf044bc38fe687ed4ba70780bd9b7411e82498
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -177,6 +177,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: d0638d255399c1468bd5b65b9b67700bb89dbe5b
+PODFILE CHECKSUM: 6b5b01283512eafc04223efe3d973a3b7c223fa6
 
 COCOAPODS: 1.11.3

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationViewModel.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// View model for `ApplicationPasswordAuthorizationWebViewController`.
+///
+final class ApplicationPasswordAuthorizationViewModel {
+
+}

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationViewModel.swift
@@ -1,7 +1,15 @@
 import Foundation
+import Yosemite
 
 /// View model for `ApplicationPasswordAuthorizationWebViewController`.
 ///
 final class ApplicationPasswordAuthorizationViewModel {
+    private let siteURL: String
+    private let stores: StoresManager
 
+    init(siteURL: String,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.siteURL = siteURL
+        self.stores = stores
+    }
 }

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationViewModel.swift
@@ -13,6 +13,7 @@ final class ApplicationPasswordAuthorizationViewModel {
         self.stores = stores
     }
 
+    @MainActor
     func fetchAuthURL() async throws -> URL? {
         try await withCheckedThrowingContinuation { continuation in
             let action = WordPressSiteAction.fetchApplicationPasswordAuthorizationURL(siteURL: siteURL) { result in

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationViewModel.swift
@@ -12,4 +12,18 @@ final class ApplicationPasswordAuthorizationViewModel {
         self.siteURL = siteURL
         self.stores = stores
     }
+
+    func fetchAuthURL() async throws -> URL? {
+        try await withCheckedThrowingContinuation { continuation in
+            let action = WordPressSiteAction.fetchApplicationPasswordAuthorizationURL(siteURL: siteURL) { result in
+                switch result {
+                case .success(let url):
+                    continuation.resume(returning: url)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+            stores.dispatch(action)
+        }
+    }
 }

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
@@ -200,7 +200,10 @@ private extension ApplicationPasswordAuthorizationWebViewController {
     }
     enum Localization {
         static let login = NSLocalizedString("Log In", comment: "Title for the application password authorization web view")
-        static let cancel = NSLocalizedString("Cancel", comment: "Button to dismiss the view or error alerts of the application password authorization web view")
+        static let cancel = NSLocalizedString(
+            "Cancel",
+            comment: "Button to dismiss the view or error alerts of the application password authorization web view"
+        )
         static let tryAgain = NSLocalizedString("Retry", comment: "Button to retry fetching application password authorization URL during login")
         static let authorizationRejected = NSLocalizedString(
             "Unable to log in because the request to use application passwords to your site has been rejected.",

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
@@ -3,7 +3,7 @@ import WebKit
 
 /// View with embedded web view to authorize application password for a site.
 ///
-final class SiteCredentialLoginWebViewController: UIViewController {
+final class ApplicationPasswordAuthorizationWebViewController: UIViewController {
 
     /// Main web view
     private lazy var webView: WKWebView = {

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
@@ -147,9 +147,9 @@ private extension ApplicationPasswordAuthorizationWebViewController {
 
     func loadAuthorizationPage(url: URL) {
         let parameters: [URLQueryItem] = [
-            URLQueryItem(name: "app_name", value: appName),
-            URLQueryItem(name: "app_id", value: appID),
-            URLQueryItem(name: "success_url", value: Constants.successURL)
+            URLQueryItem(name: Constants.Query.appName, value: appName),
+            URLQueryItem(name: Constants.Query.appID, value: appID),
+            URLQueryItem(name: Constants.Query.successURL, value: Constants.successURL)
         ]
         var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
         components?.queryItems = parameters
@@ -167,8 +167,8 @@ private extension ApplicationPasswordAuthorizationWebViewController {
         }
         let components = URLComponents(url: url, resolvingAgainstBaseURL: true)
         guard let queryItems = components?.queryItems,
-              let username = queryItems.first(where: { $0.name == "user_login" })?.value,
-              let password = queryItems.first(where: { $0.name == "password" })?.value else {
+              let username = queryItems.first(where: { $0.name == Constants.Query.username })?.value,
+              let password = queryItems.first(where: { $0.name == Constants.Query.password })?.value else {
             DDLogError("⛔️ Authorization rejected for application passwords")
             return showErrorAlert(message: Localization.authorizationRejected)
         }
@@ -197,6 +197,13 @@ private extension ApplicationPasswordAuthorizationWebViewController {
 private extension ApplicationPasswordAuthorizationWebViewController {
     enum Constants {
         static let successURL = "woocommerce://application-password"
+        enum Query {
+            static let username = "user_login"
+            static let password = "password"
+            static let appName = "app_name"
+            static let appID = "app_id"
+            static let successURL = "success_url"
+        }
     }
     enum Localization {
         static let login = NSLocalizedString("Log In", comment: "Title for the application password authorization web view")

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
@@ -1,5 +1,7 @@
+import Combine
 import UIKit
 import WebKit
+import struct Networking.ApplicationPassword
 
 /// View with embedded web view to authorize application password for a site.
 ///
@@ -20,9 +22,16 @@ final class ApplicationPasswordAuthorizationWebViewController: UIViewController 
     }()
 
     private let viewModel: ApplicationPasswordAuthorizationViewModel
+    private let successHandler: (ApplicationPassword, UINavigationController?) -> Void
+    private let failureHandler: () -> Void
+    private var subscriptions: Set<AnyCancellable> = []
 
-    init(viewModel: ApplicationPasswordAuthorizationViewModel) {
+    init(viewModel: ApplicationPasswordAuthorizationViewModel,
+         onSuccess: @escaping (ApplicationPassword, UINavigationController?) -> Void,
+         onFailure: @escaping () -> Void) {
         self.viewModel = viewModel
+        self.successHandler = onSuccess
+        self.failureHandler = onFailure
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -32,8 +41,73 @@ final class ApplicationPasswordAuthorizationWebViewController: UIViewController 
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureNavigationBar()
+        configureWebView()
+        configureProgressBar()
+    }
+}
 
-        // Do any additional setup after loading the view.
+private extension ApplicationPasswordAuthorizationWebViewController {
+    func configureNavigationBar() {
+        title = Localization.authorizeAppPassword
     }
 
+    func configureWebView() {
+        view.addSubview(webView)
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: webView.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: webView.trailingAnchor),
+            view.safeTopAnchor.constraint(equalTo: webView.topAnchor),
+            view.safeBottomAnchor.constraint(equalTo: webView.bottomAnchor),
+        ])
+
+        extendContentUnderSafeAreas()
+        webView.configureForSandboxEnvironment()
+
+        webView.publisher(for: \.estimatedProgress)
+            .sink { [weak self] progress in
+                if progress == 1 {
+                    self?.progressBar.setProgress(0, animated: false)
+                } else {
+                    self?.progressBar.setProgress(Float(progress), animated: true)
+                }
+            }
+            .store(in: &subscriptions)
+
+        webView.publisher(for: \.url)
+            .sink { [weak self] url in
+                guard let url, url.absoluteString.hasPrefix(Constants.successURL) else {
+                    return
+                }
+                self?.handleAuthorizationResponse(with: url)
+            }
+            .store(in: &subscriptions)
+    }
+
+    func extendContentUnderSafeAreas() {
+        webView.scrollView.clipsToBounds = false
+        view.backgroundColor = webView.underPageBackgroundColor
+    }
+
+    func configureProgressBar() {
+        view.addSubview(progressBar)
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: progressBar.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: progressBar.trailingAnchor),
+            view.safeTopAnchor.constraint(equalTo: progressBar.topAnchor)
+        ])
+    }
+
+    func handleAuthorizationResponse(with url: URL) {
+        // TODO
+    }
+}
+
+private extension ApplicationPasswordAuthorizationWebViewController {
+    enum Constants {
+        static let successURL = "woocommerce://application-password"
+    }
+    enum Localization {
+        static let authorizeAppPassword = "Authorize application password"
+    }
 }

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
@@ -19,7 +19,10 @@ final class ApplicationPasswordAuthorizationWebViewController: UIViewController 
         return bar
     }()
 
-    init() {
+    private let viewModel: ApplicationPasswordAuthorizationViewModel
+
+    init(viewModel: ApplicationPasswordAuthorizationViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -638,9 +638,13 @@ private extension AuthenticationManager {
     ///
     func applicationPasswordWebView(for siteURL: String) -> UIViewController {
         let viewModel = ApplicationPasswordAuthorizationViewModel(siteURL: siteURL)
-        let controller = ApplicationPasswordAuthorizationWebViewController(viewModel: viewModel, onSuccess: { _, navigationController in
-            // TODO
-        })
+        let controller = ApplicationPasswordAuthorizationWebViewController(viewModel: viewModel)
+        controller.onSuccess = { _ in
+            // TODO: handle success
+        }
+        controller.onFailure = {
+            controller.navigationController?.popViewController(animated: true)
+        }
         return controller
     }
 

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -713,19 +713,16 @@ private extension AuthenticationManager {
     func handleSiteCredentialLoginError(_ error: SiteCredentialLoginError,
                                         for siteURL: String,
                                         in viewController: UIViewController) {
-        let webViewAction: (() -> Void)? = {
-            guard featureFlagService.isFeatureFlagEnabled(.applicationPasswordAuthorizationInWebView) else {
-                return nil
-            }
-            return { [weak self] in
+        guard featureFlagService.isFeatureFlagEnabled(.manualErrorHandlingForSiteCredentialLogin) else {
+            return
+        }
+        let alertController = FancyAlertViewController.makeSiteCredentialLoginErrorAlert(
+            message: error.underlyingError.localizedDescription,
+            defaultAction: { [weak self] in
                 guard let self else { return }
                 let webViewController = self.applicationPasswordWebView(for: siteURL)
                 viewController.present(UINavigationController(rootViewController: webViewController), animated: true)
             }
-        }()
-        let alertController = FancyAlertViewController.makeSiteCredentialLoginErrorAlert(
-            message: error.underlyingError.localizedDescription,
-            defaultAction: webViewAction
         )
         viewController.present(alertController, animated: true)
     }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -239,6 +239,9 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         if site.isWPCom || site.isJetpackConnected {
             let authenticationResult: WordPressAuthenticatorResult = .presentEmailController
             onCompletion(authenticationResult)
+        } else if featureFlagService.isFeatureFlagEnabled(.applicationPasswordAuthorizationInWebView) {
+            let webView = applicationPasswordWebView(for: site.url)
+            onCompletion(.injectViewController(value: webView))
         } else {
             let authenticationResult: WordPressAuthenticatorResult = .presentPasswordController(value: true)
             onCompletion(authenticationResult)
@@ -629,6 +632,16 @@ private extension AuthenticationManager {
     var noWPUI: UIViewController {
         let viewModel = NotWPErrorViewModel()
         return ULErrorViewController(viewModel: viewModel)
+    }
+
+    /// Web view to authorize application password for a given site.
+    ///
+    func applicationPasswordWebView(for siteURL: String) -> UIViewController {
+        let viewModel = ApplicationPasswordAuthorizationViewModel(siteURL: siteURL)
+        let controller = ApplicationPasswordAuthorizationWebViewController(viewModel: viewModel, onSuccess: { _, navigationController in
+            // TODO
+        })
+        return controller
     }
 
     /// The error screen to be displayed when Jetpack setup for a site is required.

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginWebView/SiteCredentialLoginWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginWebView/SiteCredentialLoginWebViewController.swift
@@ -1,0 +1,36 @@
+import UIKit
+import WebKit
+
+/// View with embedded web view to authorize application password for a site.
+///
+final class SiteCredentialLoginWebViewController: UIViewController {
+
+    /// Main web view
+    private lazy var webView: WKWebView = {
+        let webView = WKWebView(frame: .zero)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        return webView
+    }()
+
+    /// Progress bar for the web view
+    private lazy var progressBar: UIProgressView = {
+        let bar = UIProgressView(progressViewStyle: .bar)
+        bar.translatesAutoresizingMaskIntoConstraints = false
+        return bar
+    }()
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+}

--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -39,6 +39,7 @@ extension WordPressAuthenticator {
                                                                 skipXMLRPCCheckForSiteDiscovery: true,
                                                                 skipXMLRPCCheckForSiteAddressLogin: true,
                                                                 enableManualSiteCredentialLogin: true,
+                                                                enableManualErrorHandlingForSiteCredentialLogin: true,
                                                                 useEnterEmailAddressAsStepValueForGetStartedVC: true,
                                                                 enableSiteAddressLoginOnlyInPrologue: true,
                                                                 enableSiteCredentialLoginForJetpackSites: false)

--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -9,6 +9,7 @@ extension WordPressAuthenticator {
         let isWPComMagicLinkPreferredToPassword = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasis)
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = featureFlagService.isFeatureFlagEnabled(.loginMagicLinkEmphasisM2)
         let isStoreCreationMVPEnabled = featureFlagService.isFeatureFlagEnabled(.storeCreationMVP)
+        let isManualErrorHandlingEnabled = featureFlagService.isFeatureFlagEnabled(.manualErrorHandlingForSiteCredentialLogin)
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
                                                                 wpcomScheme: dotcomAuthScheme,
@@ -39,7 +40,7 @@ extension WordPressAuthenticator {
                                                                 skipXMLRPCCheckForSiteDiscovery: true,
                                                                 skipXMLRPCCheckForSiteAddressLogin: true,
                                                                 enableManualSiteCredentialLogin: true,
-                                                                enableManualErrorHandlingForSiteCredentialLogin: true,
+                                                                enableManualErrorHandlingForSiteCredentialLogin: isManualErrorHandlingEnabled,
                                                                 useEnterEmailAddressAsStepValueForGetStartedVC: true,
                                                                 enableSiteAddressLoginOnlyInPrologue: true,
                                                                 enableSiteCredentialLoginForJetpackSites: false)

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
@@ -53,6 +53,32 @@ extension FancyAlertViewController {
         let controller = FancyAlertViewController.controllerWithConfiguration(configuration: config)
         return controller
     }
+
+    static func makeSiteCredentialLoginErrorAlert(message: String, defaultAction: (() -> Void)?) -> FancyAlertViewController {
+        let moreHelpButton = makeNeedMoreHelpButton()
+        let cancelButton = Config.ButtonConfig(Localization.cancelButton) { controller, _ in
+            controller.dismiss(animated: true)
+        }
+        let webViewButton: Config.ButtonConfig? = {
+            guard let defaultAction else {
+                return nil
+            }
+            return Config.ButtonConfig(Localization.loginWithWebViewButton) { controller, _ in
+                controller.dismiss(animated: true, completion: defaultAction)
+            }
+        }()
+        let config = FancyAlertViewController.Config(titleText: nil,
+                                                     bodyText: message,
+                                                     headerImage: nil,
+                                                     dividerPosition: .top,
+                                                     defaultButton: cancelButton,
+                                                     cancelButton: webViewButton,
+                                                     moreInfoButton: moreHelpButton,
+                                                     dismissAction: {})
+
+        let controller = FancyAlertViewController.controllerWithConfiguration(configuration: config)
+        return controller
+    }
 }
 
 
@@ -106,6 +132,16 @@ private extension FancyAlertViewController {
             "Please contact the site owner for an invitation to the site as a shop manager or administrator to use the app.",
             comment: "Description of alert for suggestion on how to connect to a WP.com site" +
             "Presented when a user logs in with an email that does not have access to a WP.com site"
+        )
+
+        static let cancelButton = NSLocalizedString(
+            "Cancel",
+            comment: "Title of dismiss button presented when site credential login fails"
+        )
+
+        static let loginWithWebViewButton = NSLocalizedString(
+            "Try again with WP-Admin page",
+            comment: "Title of the action button to log in with WP-Admin page in a web view, presented when site credential login fails"
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
@@ -55,7 +55,6 @@ extension FancyAlertViewController {
     }
 
     static func makeSiteCredentialLoginErrorAlert(message: String, defaultAction: (() -> Void)?) -> FancyAlertViewController {
-        let moreHelpButton = makeNeedMoreHelpButton()
         let cancelButton = Config.ButtonConfig(Localization.cancelButton) { controller, _ in
             controller.dismiss(animated: true)
         }
@@ -73,7 +72,7 @@ extension FancyAlertViewController {
                                                      dividerPosition: .top,
                                                      defaultButton: cancelButton,
                                                      cancelButton: webViewButton,
-                                                     moreInfoButton: moreHelpButton,
+                                                     moreInfoButton: nil,
                                                      dismissAction: {})
 
         let controller = FancyAlertViewController.controllerWithConfiguration(configuration: config)

--- a/WooCommerce/Classes/Yosemite/DeauthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/DeauthenticatedState.swift
@@ -21,7 +21,8 @@ class DeauthenticatedState: StoresManagerState {
             AccountCreationStore(dotcomClientID: ApiCredentials.dotcomAppId,
                                  dotcomClientSecret: ApiCredentials.dotcomSecret,
                                  network: network,
-                                 dispatcher: dispatcher)
+                                 dispatcher: dispatcher),
+            WordPressSiteStore(network: network, dispatcher: dispatcher)
         ]
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1950,6 +1950,7 @@
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DE971219290A9615000C0BD3 /* AddStoreFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE971218290A9615000C0BD3 /* AddStoreFooterView.swift */; };
 		DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA426992875440500265B0C /* PaymentMethodsScreen.swift */; };
+		DEC0293729C418FF00FD0E2F /* SiteCredentialLoginWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0293629C418FF00FD0E2F /* SiteCredentialLoginWebViewController.swift */; };
 		DEC1508227F450AC00F4487C /* CouponAllowedEmails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC1508127F450AC00F4487C /* CouponAllowedEmails.swift */; };
 		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */; };
 		DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */; };
@@ -4139,6 +4140,7 @@
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DE971218290A9615000C0BD3 /* AddStoreFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddStoreFooterView.swift; sourceTree = "<group>"; };
 		DEA426992875440500265B0C /* PaymentMethodsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsScreen.swift; sourceTree = "<group>"; };
+		DEC0293629C418FF00FD0E2F /* SiteCredentialLoginWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCredentialLoginWebViewController.swift; sourceTree = "<group>"; };
 		DEC1508127F450AC00F4487C /* CouponAllowedEmails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmails.swift; sourceTree = "<group>"; };
 		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormListViewModel.swift; sourceTree = "<group>"; };
 		DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormList.swift; sourceTree = "<group>"; };
@@ -7501,6 +7503,7 @@
 		B55D4C0420B6026700D7A50F /* Authentication */ = {
 			isa = PBXGroup;
 			children = (
+				DEC0293829C419F500FD0E2F /* SiteCredentialLoginWebView */,
 				DE2FE5842925D9040018040A /* Jetpack Setup */,
 				AEB4DB95290AE72D00AE4340 /* WebAuth */,
 				D881A318256B5C9C00FE5605 /* Navigation Exceptions */,
@@ -9477,6 +9480,14 @@
 			path = Plugins;
 			sourceTree = "<group>";
 		};
+		DEC0293829C419F500FD0E2F /* SiteCredentialLoginWebView */ = {
+			isa = PBXGroup;
+			children = (
+				DEC0293629C418FF00FD0E2F /* SiteCredentialLoginWebViewController.swift */,
+			);
+			path = SiteCredentialLoginWebView;
+			sourceTree = "<group>";
+		};
 		DEC2961D26BD15D3005A056B /* Customs */ = {
 			isa = PBXGroup;
 			children = (
@@ -11040,6 +11051,7 @@
 				B59D1EEC2190B08B009D1978 /* Age.swift in Sources */,
 				CE27257C21924A8C002B22EB /* HelpAndSupportViewController.swift in Sources */,
 				025B174A237AA49D00C780B4 /* Product+ProductForm.swift in Sources */,
+				DEC0293729C418FF00FD0E2F /* SiteCredentialLoginWebViewController.swift in Sources */,
 				B57C744720F55BC800EEFC87 /* UIView+Helpers.swift in Sources */,
 				45912FE32526642200982948 /* ProductFormViewController+Helpers.swift in Sources */,
 				B55D4C0620B6027200D7A50F /* AuthenticationManager.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -817,7 +817,6 @@
 		31C21FA626D994B700916E2E /* SeveralReadersFoundViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 31C21FA526D994B700916E2E /* SeveralReadersFoundViewController.xib */; };
 		31E6F21F26B3577800227E6F /* LegacyCardReaderConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E6F21E26B3577800227E6F /* LegacyCardReaderConnectionController.swift */; };
 		31E906A326CC91A70099A985 /* LegacyCardReaderConnectionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E906A226CC91A70099A985 /* LegacyCardReaderConnectionControllerTests.swift */; };
-		31EF399C26430C6D0093C6F6 /* PaymentSettingsFlowPrioritizedViewModelsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EF399B26430C6D0093C6F6 /* PaymentSettingsFlowPrioritizedViewModelsProvider.swift */; };
 		31F21B02263C8E150035B50A /* CardReaderSettingsSearchingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F21B01263C8E150035B50A /* CardReaderSettingsSearchingViewModelTests.swift */; };
 		31F21B5A263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F21B59263CB41A0035B50A /* MockCardPresentPaymentsStoresManager.swift */; };
 		31F21B60263CB78A0035B50A /* MockCardReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F21B5F263CB78A0035B50A /* MockCardReader.swift */; };
@@ -11045,9 +11044,7 @@
 				451A04E62386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift in Sources */,
 				02E19B9C284743A40010B254 /* ProductImageUploader.swift in Sources */,
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,
-				31EF399C26430C6D0093C6F6 /* PaymentSettingsFlowPrioritizedViewModelsProvider.swift in Sources */,
 				CC857C7129B23A6C00E19D1E /* BundledProductsListViewController.swift in Sources */,
-				31EF399C26430C6D0093C6F6 /* PaymentSettingsFlowPrioritizedViewModelsProvider.swift in Sources */,
 				D85136C1231E09C300DD0539 /* ReviewsDataSourceProtocol.swift in Sources */,
 				CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */,
 				45968545254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1951,6 +1951,7 @@
 		DE971219290A9615000C0BD3 /* AddStoreFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE971218290A9615000C0BD3 /* AddStoreFooterView.swift */; };
 		DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA426992875440500265B0C /* PaymentMethodsScreen.swift */; };
 		DEC0293729C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0293629C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift */; };
+		DEC0293A29C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0293929C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift */; };
 		DEC1508227F450AC00F4487C /* CouponAllowedEmails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC1508127F450AC00F4487C /* CouponAllowedEmails.swift */; };
 		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */; };
 		DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */; };
@@ -4141,6 +4142,7 @@
 		DE971218290A9615000C0BD3 /* AddStoreFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddStoreFooterView.swift; sourceTree = "<group>"; };
 		DEA426992875440500265B0C /* PaymentMethodsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsScreen.swift; sourceTree = "<group>"; };
 		DEC0293629C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordAuthorizationWebViewController.swift; sourceTree = "<group>"; };
+		DEC0293929C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordAuthorizationViewModel.swift; sourceTree = "<group>"; };
 		DEC1508127F450AC00F4487C /* CouponAllowedEmails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmails.swift; sourceTree = "<group>"; };
 		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormListViewModel.swift; sourceTree = "<group>"; };
 		DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormList.swift; sourceTree = "<group>"; };
@@ -9484,6 +9486,7 @@
 			isa = PBXGroup;
 			children = (
 				DEC0293629C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift */,
+				DEC0293929C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift */,
 			);
 			path = "Application Password";
 			sourceTree = "<group>";
@@ -11571,6 +11574,7 @@
 				02F49ADA23BF356E00FA0BFA /* TitleAndTextFieldTableViewCell.ViewModel+State.swift in Sources */,
 				02645D8527BA2DB40065DC68 /* InboxNoteRowViewModel.swift in Sources */,
 				740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */,
+				DEC0293A29C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift in Sources */,
 				03191AE628E1DF0600670723 /* WooCommercePluginViewModel.swift in Sources */,
 				CE22709F2293052700C0626C /* WebviewHelper.swift in Sources */,
 				02BA12852461674B008D8325 /* Optional+String.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1950,7 +1950,7 @@
 		DE8C946E264699B600C94823 /* PluginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8C946D264699B600C94823 /* PluginListViewModel.swift */; };
 		DE971219290A9615000C0BD3 /* AddStoreFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE971218290A9615000C0BD3 /* AddStoreFooterView.swift */; };
 		DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA426992875440500265B0C /* PaymentMethodsScreen.swift */; };
-		DEC0293729C418FF00FD0E2F /* SiteCredentialLoginWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0293629C418FF00FD0E2F /* SiteCredentialLoginWebViewController.swift */; };
+		DEC0293729C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0293629C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift */; };
 		DEC1508227F450AC00F4487C /* CouponAllowedEmails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC1508127F450AC00F4487C /* CouponAllowedEmails.swift */; };
 		DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */; };
 		DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */; };
@@ -4140,7 +4140,7 @@
 		DE8C946D264699B600C94823 /* PluginListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginListViewModel.swift; sourceTree = "<group>"; };
 		DE971218290A9615000C0BD3 /* AddStoreFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddStoreFooterView.swift; sourceTree = "<group>"; };
 		DEA426992875440500265B0C /* PaymentMethodsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsScreen.swift; sourceTree = "<group>"; };
-		DEC0293629C418FF00FD0E2F /* SiteCredentialLoginWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCredentialLoginWebViewController.swift; sourceTree = "<group>"; };
+		DEC0293629C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordAuthorizationWebViewController.swift; sourceTree = "<group>"; };
 		DEC1508127F450AC00F4487C /* CouponAllowedEmails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponAllowedEmails.swift; sourceTree = "<group>"; };
 		DEC2961E26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormListViewModel.swift; sourceTree = "<group>"; };
 		DEC2962026BD1627005A056B /* ShippingLabelCustomsFormList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormList.swift; sourceTree = "<group>"; };
@@ -7503,7 +7503,7 @@
 		B55D4C0420B6026700D7A50F /* Authentication */ = {
 			isa = PBXGroup;
 			children = (
-				DEC0293829C419F500FD0E2F /* SiteCredentialLoginWebView */,
+				DEC0293829C419F500FD0E2F /* Application Password */,
 				DE2FE5842925D9040018040A /* Jetpack Setup */,
 				AEB4DB95290AE72D00AE4340 /* WebAuth */,
 				D881A318256B5C9C00FE5605 /* Navigation Exceptions */,
@@ -9480,12 +9480,12 @@
 			path = Plugins;
 			sourceTree = "<group>";
 		};
-		DEC0293829C419F500FD0E2F /* SiteCredentialLoginWebView */ = {
+		DEC0293829C419F500FD0E2F /* Application Password */ = {
 			isa = PBXGroup;
 			children = (
-				DEC0293629C418FF00FD0E2F /* SiteCredentialLoginWebViewController.swift */,
+				DEC0293629C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift */,
 			);
-			path = SiteCredentialLoginWebView;
+			path = "Application Password";
 			sourceTree = "<group>";
 		};
 		DEC2961D26BD15D3005A056B /* Customs */ = {
@@ -11051,7 +11051,7 @@
 				B59D1EEC2190B08B009D1978 /* Age.swift in Sources */,
 				CE27257C21924A8C002B22EB /* HelpAndSupportViewController.swift in Sources */,
 				025B174A237AA49D00C780B4 /* Product+ProductForm.swift in Sources */,
-				DEC0293729C418FF00FD0E2F /* SiteCredentialLoginWebViewController.swift in Sources */,
+				DEC0293729C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift in Sources */,
 				B57C744720F55BC800EEFC87 /* UIView+Helpers.swift in Sources */,
 				45912FE32526642200982948 /* ProductFormViewController+Helpers.swift in Sources */,
 				B55D4C0620B6027200D7A50F /* AuthenticationManager.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1982,6 +1982,7 @@
 		DEE6437826D8DAD900888A75 /* InProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE6437726D8DAD900888A75 /* InProgressView.swift */; };
 		DEEDA239298A11FB0088256B /* SiteCredentialLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEDA238298A11FB0088256B /* SiteCredentialLoginUseCase.swift */; };
 		DEEDA23D298A22180088256B /* SiteCredentialLoginUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEDA23C298A22180088256B /* SiteCredentialLoginUseCaseTests.swift */; };
+		DEEF8E6629C833C600D47411 /* PaymentSettingsFlowPrioritizedViewModelsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EF399B26430C6D0093C6F6 /* PaymentSettingsFlowPrioritizedViewModelsProvider.swift */; };
 		DEF13C522963D0B20024A02B /* PostSiteCredentialLoginChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF13C512963D0B20024A02B /* PostSiteCredentialLoginChecker.swift */; };
 		DEF13C542963ED4E0024A02B /* PostSiteCredentialLoginCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF13C532963ED4E0024A02B /* PostSiteCredentialLoginCheckerTests.swift */; };
 		DEF3300C270444070073AE29 /* ShippingLabelSelectedRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF3300B270444060073AE29 /* ShippingLabelSelectedRate.swift */; };
@@ -10624,6 +10625,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DEEF8E6629C833C600D47411 /* PaymentSettingsFlowPrioritizedViewModelsProvider.swift in Sources */,
 				B5F571A421BEC90D0010D1B8 /* NoteDetailsHeaderPlainTableViewCell.swift in Sources */,
 				EE57C11F297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift in Sources */,
 				AEA3F91127BEC08800B9F555 /* PriceFieldFormatter.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/PostSiteCredentialLoginCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/PostSiteCredentialLoginCheckerTests.swift
@@ -128,6 +128,8 @@ final class PostSiteCredentialLoginCheckerTests: XCTestCase {
             case .fetchSiteInfo(_, let completion):
                 let site = Site.fake().copy(isWooCommerceActive: true)
                 completion(.success(site))
+            default:
+                break
             }
         }
         checker.checkEligibility(for: testURL, from: navigationController) {
@@ -155,6 +157,8 @@ final class PostSiteCredentialLoginCheckerTests: XCTestCase {
             case .fetchSiteInfo(_, let completion):
                 let site = Site.fake().copy(isWooCommerceActive: false)
                 completion(.success(site))
+            default:
+                break
             }
         }
         checker.checkEligibility(for: testURL, from: navigationController) {
@@ -183,6 +187,8 @@ final class PostSiteCredentialLoginCheckerTests: XCTestCase {
             switch action {
             case .fetchSiteInfo(_, let completion):
                 completion(.failure(NetworkError.timeout))
+            default:
+                break
             }
         }
         checker.checkEligibility(for: testURL, from: navigationController) {

--- a/Yosemite/Yosemite/Actions/WordPressSiteAction.swift
+++ b/Yosemite/Yosemite/Actions/WordPressSiteAction.swift
@@ -5,4 +5,6 @@ import Foundation
 public enum WordPressSiteAction: Action {
     /// Fetches information for a given WordPress site URL.
     case fetchSiteInfo(siteURL: String, completion: (Result<Site, Error>) -> Void)
+    /// Fetches application password authorization URL for a given WordPress site if it's enabled.
+    case fetchApplicationPasswordAuthorizationURL(siteURL: String, completion: (Result<URL?, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/WordPressSiteStore.swift
+++ b/Yosemite/Yosemite/Stores/WordPressSiteStore.swift
@@ -31,6 +31,8 @@ public final class WordPressSiteStore: DeauthenticatedStore {
         switch action {
         case let .fetchSiteInfo(siteURL, completion):
             fetchSiteInfo(for: siteURL, completion: completion)
+        case let .fetchApplicationPasswordAuthorizationURL(siteURL, completion):
+            fetchApplicationPasswordAuthorizationURL(for: siteURL, completion: completion)
         }
     }
 }
@@ -42,6 +44,22 @@ private extension WordPressSiteStore {
                 let wpSite = try await remote.fetchSiteInfo(for: siteURL)
                 let site = wpSite.asSite
                 completion(.success(site))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func fetchApplicationPasswordAuthorizationURL(for siteURL: String, completion: @escaping (Result<URL?, Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let wpSite = try await remote.fetchSiteInfo(for: siteURL)
+                if let path = wpSite.applicationPasswordAuthorizationURL,
+                   let url = URL(string: path) {
+                    completion(.success(url))
+                } else {
+                    completion(.success(nil))
+                }
             } catch {
                 completion(.failure(error))
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9186 
Please also review https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/758.
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new web view for authorizing application password during login to help with cases where site credential login fails when handled programmatically. Changes include:
- Networking: updated the `WordPressSite` model to decode the application password authorization URL if it exists.
- Yosemite: updated `WordPressSiteStore` and action to fetch application password authorization URL.
- UI:
  - Added a new view controller for application password authorization. This controller handles fetching the authorization URL and showing it in a web view.
  - Updated the `AuthenticationManager` to enable a new config for manual error handling of site credential login.
  - Implemented the new delegate method to show a custom alert with the entry point to application password authorization in web view.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Attempt to log in to a self-hosted site with incorrect credentials.
- Notice that the error alert has a button to log in through WP-Admin.
- Log in with the correct credentials on the presented web view.
- Reject the authorization, the web view should be dismissed after clicking on Cancel button of the presented error alert.

The success case will be handled in a subsequent PR.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/226259290-434eac62-3565-4124-8e7a-c6591bec5b0a.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
