### PR TITLE
[Mobile Payments] Tap to Pay on iPhone – Setup complete screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
@@ -15,11 +15,11 @@ final class SetUpTapToPayCompleteViewController: UIHostingController<SetUpTapToP
 
         super.init(rootView: SetUpTapToPayCompleteView(viewModel: viewModel))
 
-        configureView()
+        configureViewModel()
     }
 
-    private func configureView() {
-        rootView.dismiss = { [weak self] in
+    private func configureViewModel() {
+        viewModel.dismiss = { [weak self] in
             self?.dismiss(animated: true)
         }
     }
@@ -36,7 +36,6 @@ final class SetUpTapToPayCompleteViewController: UIHostingController<SetUpTapToP
 
 struct SetUpTapToPayCompleteView: View {
     @ObservedObject var viewModel: SetUpTapToPayCompleteViewModel
-    var dismiss: (() -> Void)? = nil
 
     @Environment(\.verticalSizeClass) var verticalSizeClass
 
@@ -104,7 +103,7 @@ private enum Constants {
 private extension SetUpTapToPayCompleteView {
     enum Localization {
         static let setUpCompleteTitle = NSLocalizedString(
-            "Congratulations on your setup",
+            "Set up complete",
             comment: "Settings > Set up Tap to Pay on iPhone > Complete > Inform user that " +
             "Tap to Pay on iPhone is ready"
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
@@ -109,7 +109,7 @@ private extension SetUpTapToPayCompleteView {
         )
 
         static let setUpCompleteDescription = NSLocalizedString(
-            "Your phone is ready for Tap to Pay on iPhone. Your customer can tap their card or " +
+            "Your phone is ready for Tap to Pay on iPhone. Your customers can tap their card or " +
             "device on your phone to pay.",
             comment: "Settings > Set up Tap to Pay on iPhone > Complete > Description"
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+
+/// This view controller is used when no reader is connected. It assists
+/// the merchant in connecting to a reader.
+///
+final class SetUpTapToPayCompleteViewController: UIHostingController<SetUpTapToPayCompleteView>, PaymentSettingsFlowViewModelPresenter {
+
+    private var viewModel: SetUpTapToPayCompleteViewModel
+
+    init?(viewModel: PaymentSettingsFlowPresentedViewModel) {
+        guard let viewModel = viewModel as? SetUpTapToPayCompleteViewModel else {
+            return nil
+        }
+        self.viewModel = viewModel
+
+        super.init(rootView: SetUpTapToPayCompleteView(viewModel: viewModel))
+
+        configureView()
+    }
+
+    private func configureView() {
+        rootView.dismiss = { [weak self] in
+            self?.dismiss(animated: true)
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("Not implemented")
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        viewModel.didUpdate = nil
+        super.viewWillDisappear(animated)
+    }
+}
+
+struct SetUpTapToPayCompleteView: View {
+    @ObservedObject var viewModel: SetUpTapToPayCompleteViewModel
+    var dismiss: (() -> Void)? = nil
+
+    @Environment(\.verticalSizeClass) var verticalSizeClass
+
+    var isCompact: Bool {
+        verticalSizeClass == .compact
+    }
+
+    var imageMaxHeight: CGFloat {
+        isCompact ? Constants.maxCompactImageHeight : Constants.maxImageHeight
+    }
+
+    var imageFontSize: CGFloat {
+        isCompact ? Constants.maxCompactImageHeight : Constants.imageFontSize
+    }
+
+    var body: some View {
+        ScrollableVStack(padding: 0) {
+            Image(systemName: "checkmark.circle")
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(Color(.systemGreen))
+                .scaledToFit()
+                .frame(maxHeight: imageMaxHeight)
+                .font(.system(size: imageFontSize))
+                .padding()
+
+            Text(Localization.setUpCompleteTitle)
+                .font(.title2.weight(.semibold))
+                .multilineTextAlignment(.center)
+                .padding()
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(Localization.setUpCompleteDescription)
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .padding()
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer()
+
+            Text(Localization.setUpCompleteDetail)
+                .font(.subheadline)
+                .foregroundColor(.gray)
+                .multilineTextAlignment(.center)
+                .padding()
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button(Localization.doneButton, action: {
+                viewModel.doneTapped()
+            })
+            .buttonStyle(PrimaryButtonStyle())
+        }
+        .padding()
+    }
+}
+
+private enum Constants {
+    static let maxImageHeight: CGFloat = 180
+    static let maxCompactImageHeight: CGFloat = 80
+    static let imageFontSize: CGFloat = 120
+    static let compactImageFontSize: CGFloat = 40
+}
+
+// MARK: - Localization
+//
+private extension SetUpTapToPayCompleteView {
+    enum Localization {
+        static let setUpCompleteTitle = NSLocalizedString(
+            "Congratulations on your setup",
+            comment: "Settings > Set up Tap to Pay on iPhone > Complete > Inform user that " +
+            "Tap to Pay on iPhone is ready"
+        )
+
+        static let setUpCompleteDescription = NSLocalizedString(
+            "Your phone is ready for Tap to Pay on iPhone. Your customer can tap their card or " +
+            "device on your phone to pay.",
+            comment: "Settings > Set up Tap to Pay on iPhone > Complete > Description"
+        )
+
+        static let setUpCompleteDetail = NSLocalizedString(
+            "You can find Tap to Pay on iPhone in Menu > Payments > Collect Payment, or from " +
+            "Order Details. Choose Tap to Pay on iPhone as the payment method.",
+            comment: "Settings > Set up Tap to Pay on iPhone > Complete > Detail"
+        )
+
+        static let doneButton = NSLocalizedString(
+            "Done",
+            comment: "Settings > Set up Tap to Pay on iPhone > Complete > A button to move to the " +
+            "next for testing Tap to Pay on iPhone"
+        )
+    }
+}
+
+struct SetUpTapToPayCompleteView_Previews: PreviewProvider {
+    static var previews: some View {
+
+        let config = CardPresentConfigurationLoader().configuration
+        let viewModel = SetUpTapToPayCompleteViewModel(
+            didChangeShouldShow: nil,
+            connectionAnalyticsTracker: .init(configuration: config))
+        SetUpTapToPayCompleteView(viewModel: viewModel)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
@@ -103,7 +103,7 @@ private enum Constants {
 private extension SetUpTapToPayCompleteView {
     enum Localization {
         static let setUpCompleteTitle = NSLocalizedString(
-            "Set up complete",
+            "Setup complete",
             comment: "Settings > Set up Tap to Pay on iPhone > Complete > Inform user that " +
             "Tap to Pay on iPhone is ready"
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewModel.swift
@@ -6,6 +6,7 @@ final class SetUpTapToPayCompleteViewModel: PaymentSettingsFlowPresentedViewMode
     private(set) var shouldShow: CardReaderSettingsTriState = .isUnknown
     var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?
     var didUpdate: (() -> Void)?
+    var dismiss: (() -> Void)?
 
     private(set) var connectedReader: CardReaderSettingsTriState = .isUnknown {
         didSet {
@@ -58,7 +59,7 @@ final class SetUpTapToPayCompleteViewModel: PaymentSettingsFlowPresentedViewMode
     }
 
     func doneTapped() {
-
+        dismiss?()
     }
 
     deinit {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewModel.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Yosemite
+import Combine
+
+final class SetUpTapToPayCompleteViewModel: PaymentSettingsFlowPresentedViewModel, ObservableObject {
+    private(set) var shouldShow: CardReaderSettingsTriState = .isUnknown
+    var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?
+    var didUpdate: (() -> Void)?
+
+    private(set) var connectedReader: CardReaderSettingsTriState = .isUnknown {
+        didSet {
+            didUpdate?()
+        }
+    }
+
+    private let connectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker
+    private let stores: StoresManager
+
+    private var subscriptions = Set<AnyCancellable>()
+
+    init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?,
+         connectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.didChangeShouldShow = didChangeShouldShow
+        self.connectionAnalyticsTracker = connectionAnalyticsTracker
+        self.stores = stores
+
+        beginConnectedReaderObservation()
+    }
+
+    /// Set up to observe readers connecting / disconnecting
+    ///
+    private func beginConnectedReaderObservation() {
+        // This completion should be called repeatedly as the list of connected readers changes
+        let connectedAction = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
+            guard let self = self else {
+                return
+            }
+            self.connectedReader = readers.isNotEmpty ? .isTrue : .isFalse
+            self.reevaluateShouldShow()
+        }
+        stores.dispatch(connectedAction)
+    }
+
+    /// Updates whether the view this viewModel is associated with should be shown or not
+    /// Notifies the viewModel owner if a change occurs via didChangeShouldShow
+    ///
+    private func reevaluateShouldShow() {
+        let newShouldShow: CardReaderSettingsTriState = connectedReader
+
+        let didChange = newShouldShow != shouldShow
+
+        shouldShow = newShouldShow
+
+        if didChange {
+            didChangeShouldShow?(shouldShow)
+        }
+    }
+
+    func doneTapped() {
+
+    }
+
+    deinit {
+        subscriptions.removeAll()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -56,7 +56,6 @@ final class SetUpTapToPayInformationViewController: UIHostingController<SetUpTap
 
 struct SetUpTapToPayInformationView: View {
     @ObservedObject var viewModel: SetUpTapToPayInformationViewModel
-    var setUpButtonAction: (() -> Void)? = nil
     var showURL: ((URL) -> Void)? = nil
     var learnMoreUrl: URL? = nil
     var dismiss: (() -> Void)? = nil
@@ -139,14 +138,6 @@ private enum Constants {
     static let hintSpacing: CGFloat = 16
 }
 
-private struct ViewSizeKey: PreferenceKey {
-    static var defaultValue: CGSize = .zero
-
-    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
-        value = nextValue()
-    }
-}
-
 // MARK: - Localization
 //
 private enum Localization {
@@ -213,7 +204,6 @@ struct SetUpTapToPayInformationView_Previews: PreviewProvider {
             didChangeShouldShow: nil,
             activePaymentGateway: .wcPay,
             connectionAnalyticsTracker: .init(configuration: config))
-        SetUpTapToPayInformationView(viewModel: viewModel,
-                                     setUpButtonAction: {})
+        SetUpTapToPayInformationView(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
@@ -33,7 +33,7 @@ final class SetUpTapToPayViewModelsOrderedList: PaymentSettingsFlowPrioritizedVi
         /// priority, so viewmodels related to starting set up should come before viewmodels
         /// that expect set up to be completed, etc.
         ///
-        viewModelsAndViews.append(
+        viewModelsAndViews.append(contentsOf: [
             PaymentSettingsFlowViewModelAndView(
                 viewModel: SetUpTapToPayInformationViewModel(
                     siteID: siteID,
@@ -45,8 +45,18 @@ final class SetUpTapToPayViewModelsOrderedList: PaymentSettingsFlowPrioritizedVi
                     connectionAnalyticsTracker: cardReaderConnectionAnalyticsTracker
                 ),
                 viewPresenter: SetUpTapToPayInformationViewController.self
+            ),
+
+            PaymentSettingsFlowViewModelAndView(
+                viewModel: SetUpTapToPayCompleteViewModel(
+                    didChangeShouldShow: { [weak self] state in
+                        self?.onDidChangeShouldShow(state)
+                    },
+                    connectionAnalyticsTracker: cardReaderConnectionAnalyticsTracker
+                ),
+                viewPresenter: SetUpTapToPayCompleteViewController.self
             )
-        )
+        ])
 
         /// And then immediately get a priority view if possible
         reevaluatePriorityViewModelAndView()

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -543,6 +543,8 @@
 		0379C51B27BFE23F00A7E284 /* RefundConfirmationCardDetailsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0379C51A27BFE23F00A7E284 /* RefundConfirmationCardDetailsCell.swift */; };
 		037D270D28CA444F00A3F924 /* CardReaderModalFlowViewControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037D270C28CA444F00A3F924 /* CardReaderModalFlowViewControllerProtocol.swift */; };
 		0386CFEB2852108B00134466 /* PaymentMethodsHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0386CFEA2852108B00134466 /* PaymentMethodsHostingController.swift */; };
+		038BC37D29C37AA400EAF565 /* SetUpTapToPayCompleteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038BC37C29C37AA400EAF565 /* SetUpTapToPayCompleteViewModel.swift */; };
+		038BC37F29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038BC37E29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift */; };
 		0396CFAD2981476900E91436 /* CardPresentModalBuiltInConnectingFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */; };
 		039D948D27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */; };
 		039D948F276113490044EF38 /* UIView+SuperviewConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */; };
@@ -2708,6 +2710,8 @@
 		0379C51A27BFE23F00A7E284 /* RefundConfirmationCardDetailsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundConfirmationCardDetailsCell.swift; sourceTree = "<group>"; };
 		037D270C28CA444F00A3F924 /* CardReaderModalFlowViewControllerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderModalFlowViewControllerProtocol.swift; sourceTree = "<group>"; };
 		0386CFEA2852108B00134466 /* PaymentMethodsHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsHostingController.swift; sourceTree = "<group>"; };
+		038BC37C29C37AA400EAF565 /* SetUpTapToPayCompleteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUpTapToPayCompleteViewModel.swift; sourceTree = "<group>"; };
+		038BC37E29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUpTapToPayCompleteViewController.swift; sourceTree = "<group>"; };
 		0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInConnectingFailed.swift; sourceTree = "<group>"; };
 		039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SafeAreaConstraints.swift"; sourceTree = "<group>"; };
 		039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SuperviewConstraints.swift"; sourceTree = "<group>"; };
@@ -6107,6 +6111,7 @@
 				31EF399B26430C6D0093C6F6 /* PaymentSettingsFlowPrioritizedViewModelsProvider.swift */,
 				31B19B66263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift */,
 				0365986829AFB0C100F297D3 /* SetUpTapToPayInformationViewModel.swift */,
+				038BC37C29C37AA400EAF565 /* SetUpTapToPayCompleteViewModel.swift */,
 				317F679726420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift */,
 				0365986629AFAEFC00F297D3 /* SetUpTapToPayViewModelsOrderedList.swift */,
 				3142663E2645E2AB00500598 /* PaymentSettingsFlowViewModelPresenter.swift */,
@@ -6114,6 +6119,7 @@
 				314DC4BE268D183600444C9E /* CardReaderSettingsKnownReaderStorage.swift */,
 				ABC353433EABC5F0EC796222 /* CardReaderSettingsSearchingViewController.swift */,
 				0365986A29AFB11E00F297D3 /* SetUpTapToPayInformationViewController.swift */,
+				038BC37E29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift */,
 				31FC8CE627B47591004B9456 /* CardReaderSettingsDataSource.swift */,
 				31FC8CE827B476BA004B9456 /* CardReaderSettingsResultsControllers.swift */,
 			);
@@ -11577,6 +11583,7 @@
 				E10BC15E26CC06970064F5E2 /* ScrollableVStack.swift in Sources */,
 				B50BB4162141828F00AF0F3C /* FooterSpinnerView.swift in Sources */,
 				D8610CE2257099E100A5DF27 /* FancyAlertViewController+UnifiedLogin.swift in Sources */,
+				038BC37D29C37AA400EAF565 /* SetUpTapToPayCompleteViewModel.swift in Sources */,
 				03E471CE293F63B4001A58AD /* PaymentCaptureOrchestrator.swift in Sources */,
 				B5980A6321AC879F00EBF596 /* Bundle+Woo.swift in Sources */,
 				B59D1EE5219080B4009D1978 /* Note+Woo.swift in Sources */,
@@ -11687,6 +11694,7 @@
 				26B9875D273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift in Sources */,
 				DEF36DEA2898D3CF00178AC2 /* AuthenticatedWebViewModel.swift in Sources */,
 				45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */,
+				038BC37F29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift in Sources */,
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
 				028CB70F290138EF00331C09 /* Publisher+Concurrency.swift in Sources */,
 				311F827426CD897900DF5BAD /* CardReaderSettingsAlertsProvider.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9182
Merge #9154 first
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In the new Set up Tap to Pay on iPhone flow, we ask the user to connect the built in reader for the first time, to do all required set up steps. Once they're connected, we want to clearly show to the merchant that the reader is ready to use.

This adds the `Set up complete` screen

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

On an iPhone XS or newer, using a US store:

1. Navigate to Menu > Payments > Set up Tap to Pay on iPhone
2. Tap `Set up Tap to Pay on iPhone`
3. Wait for the connection to complete
4. Observe that the new set up complete screen is shown.
5. Tap Done
6. Observe that the set up complete screen is dismissed (temporary behaviour)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/225877302-1c9d1666-441a-457b-9bae-697c77cf7bff.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
