### PR TITLE
[Product Bundles] Sync bundled products if needed, to get missing product images

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
@@ -72,9 +72,9 @@ private enum Layout {
 struct BundledProductsList_Previews: PreviewProvider {
 
     static let viewModel = BundledProductsListViewModel(bundledProducts: [
-        .init(id: 1, productID: 11, title: "Beanie with Logo", stockStatus: "In stock", imageURL: nil),
-        .init(id: 2, productID: 12, title: "T-Shirt with Logo", stockStatus: "In stock", imageURL: nil),
-        .init(id: 3, productID: 13, title: "Hoodie with Logo", stockStatus: "Out of stock", imageURL: nil)
+        .init(id: 1, title: "Beanie with Logo", stockStatus: "In stock", imageURL: nil),
+        .init(id: 2, title: "T-Shirt with Logo", stockStatus: "In stock", imageURL: nil),
+        .init(id: 3, title: "Hoodie with Logo", stockStatus: "Out of stock", imageURL: nil)
     ])
 
     static var previews: some View {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
@@ -25,7 +25,7 @@ struct BundledProductsList: View {
 
     /// View model that directs the view content.
     ///
-    let viewModel: BundledProductsListViewModel
+    @ObservedObject var viewModel: BundledProductsListViewModel
 
     /// Dynamic image width, also used for its height.
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
@@ -72,9 +72,9 @@ private enum Layout {
 struct BundledProductsList_Previews: PreviewProvider {
 
     static let viewModel = BundledProductsListViewModel(bundledProducts: [
-        .init(id: 1, title: "Beanie with Logo", stockStatus: "In stock", imageURL: nil),
-        .init(id: 2, title: "T-Shirt with Logo", stockStatus: "In stock", imageURL: nil),
-        .init(id: 3, title: "Hoodie with Logo", stockStatus: "Out of stock", imageURL: nil)
+        .init(id: 1, productID: 11, title: "Beanie with Logo", stockStatus: "In stock", imageURL: nil),
+        .init(id: 2, productID: 12, title: "T-Shirt with Logo", stockStatus: "In stock", imageURL: nil),
+        .init(id: 3, productID: 13, title: "Hoodie with Logo", stockStatus: "Out of stock", imageURL: nil)
     ])
 
     static var previews: some View {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
@@ -9,8 +9,11 @@ final class BundledProductsListViewModel {
     /// Represents a bundled product
     ///
     struct BundledProduct: Identifiable {
-        /// Bundled product ID
+        /// ID of the bundled product (item ID unique to the bundled product list)
         let id: Int64
+
+        /// Product ID of the bundled product
+        let productID: Int64
 
         /// Title of the bundled product
         let title: String
@@ -32,7 +35,7 @@ final class BundledProductsListViewModel {
 
     /// Bundled products
     ///
-    let bundledProducts: [BundledProduct]
+    var bundledProducts: [BundledProduct]
 
     init(bundledProducts: [BundledProduct]) {
         self.bundledProducts = bundledProducts
@@ -42,19 +45,33 @@ final class BundledProductsListViewModel {
 // MARK: Initializers
 extension BundledProductsListViewModel {
     convenience init(siteID: Int64, bundledProducts: [Yosemite.ProductBundleItem], storageManager: StorageManagerType = ServiceLocator.storageManager) {
-        let products = BundledProductsListViewModel.fetchProducts(for: siteID, including: bundledProducts.map { $0.productID }, storageManager: storageManager)
-        let viewModels = bundledProducts.map { bundledProduct in
-            BundledProduct(id: bundledProduct.bundledItemID,
-                           title: bundledProduct.title,
-                           stockStatus: bundledProduct.stockStatus.description,
-                           imageURL: products.first(where: { $0.productID == bundledProduct.productID })?.imageURL) // URL for bundled product's first image
-        }
+        let viewModels = BundledProductsListViewModel.getViewModels(for: bundledProducts, siteID: siteID, storageManager: storageManager)
         self.init(bundledProducts: viewModels)
+
+        // Re-sync bundled products to get product images if needed
+        synchronizeBundledProductsIfNeeded(for: siteID) { [weak self] in
+            self?.bundledProducts = BundledProductsListViewModel.getViewModels(for: bundledProducts, siteID: siteID, storageManager: storageManager)
+        }
     }
 }
 
 // MARK: Private helpers
 private extension BundledProductsListViewModel {
+    /// Creates `BundledProduct` view models for the provided Product Bundle Items
+    ///
+    static func getViewModels(for bundleItems: [ProductBundleItem], siteID: Int64, storageManager: StorageManagerType) -> [BundledProduct] {
+        let products = fetchProducts(for: siteID, including: bundleItems.map { $0.productID }, storageManager: storageManager)
+        return bundleItems.map { bundleItem in
+            BundledProduct(id: bundleItem.bundledItemID,
+                           productID: bundleItem.productID,
+                           title: bundleItem.title,
+                           stockStatus: bundleItem.stockStatus.description,
+                           imageURL: products.first(where: { $0.productID == bundleItem.productID })?.imageURL) // URL for bundle item's first image
+        }
+    }
+
+    /// Fetches the provided product IDs from storage
+    ///
     static func fetchProducts(for siteID: Int64, including productIDs: [Int64], storageManager: StorageManagerType) -> [Product] {
         let predicate = NSPredicate(format: "siteID == %lld AND productID IN %@", siteID, productIDs)
         let controller = ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortedBy: [])
@@ -66,6 +83,26 @@ private extension BundledProductsListViewModel {
         }
 
         return controller.fetchedObjects
+    }
+
+    /// Synchronizes the products matching the provided product IDs, to retrieve their product images
+    ///
+    func synchronizeBundledProductsIfNeeded(for siteID: Int64, onCompletion: @escaping () -> Void) {
+        // We only need to sync if the bundled products are missing images
+        guard bundledProducts.filter({ $0.imageURL == nil }).isNotEmpty else { return }
+
+        let action = ProductAction.retrieveProducts(siteID: siteID, productIDs: bundledProducts.map { $0.productID }) { result in
+            switch result {
+            case .success:
+                break
+            case .failure(let error):
+                DDLogError("⛔️ Error synchronizing products: \(error)")
+            }
+
+            onCompletion()
+        }
+
+        ServiceLocator.stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewModel.swift
@@ -4,7 +4,7 @@ import protocol Storage.StorageManagerType
 
 /// ViewModel for `BundledProductsList`
 ///
-final class BundledProductsListViewModel {
+final class BundledProductsListViewModel: ObservableObject {
 
     /// Represents a bundled product
     ///
@@ -35,7 +35,7 @@ final class BundledProductsListViewModel {
 
     /// Bundled products
     ///
-    var bundledProducts: [BundledProduct]
+    @Published var bundledProducts: [BundledProduct]
 
     init(bundledProducts: [BundledProduct]) {
         self.bundledProducts = bundledProducts

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1686,7 +1686,7 @@ private extension ProductFormViewController {
         guard let product = product as? EditableProductModel else {
             return
         }
-        let viewModel = BundledProductsListViewModel(siteID: product.siteID, bundledProducts: product.bundledItems)
+        let viewModel = BundledProductsListViewModel(siteID: product.siteID, bundleItems: product.bundledItems)
         let viewController = BundledProductsListViewController(viewModel: viewModel)
         show(viewController, sender: self)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Bundled Products/BundledProductsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Bundled Products/BundledProductsListViewModelTests.swift
@@ -28,7 +28,7 @@ final class BundledProductsListViewModelTests: XCTestCase {
         let bundleItem = ProductBundleItem.fake().copy(bundledItemID: 1, title: "Hoodie", stockStatus: .outOfStock)
 
         // When
-        let viewModel = BundledProductsListViewModel(siteID: sampleSiteID, bundledProducts: [bundleItem])
+        let viewModel = BundledProductsListViewModel(siteID: sampleSiteID, bundleItems: [bundleItem])
         let bundledProduct = try XCTUnwrap(viewModel.bundledProducts.first)
 
         // Then
@@ -45,7 +45,7 @@ final class BundledProductsListViewModelTests: XCTestCase {
         insert(product)
 
         // When
-        let viewModel = BundledProductsListViewModel(siteID: sampleSiteID, bundledProducts: [bundleItem], storageManager: storageManager)
+        let viewModel = BundledProductsListViewModel(siteID: sampleSiteID, bundleItems: [bundleItem], storageManager: storageManager)
         let bundledProduct = try XCTUnwrap(viewModel.bundledProducts.first)
 
         // Then


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9127
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
For the Bundled Products list (for product bundles), we are currently fetching products from storage to get their product images. However, as noted in https://github.com/woocommerce/woocommerce-ios/pull/9158#discussion_r1138904319 this only works if all products in the product bundle have already been synced.

This PR adds a conditional product sync to the Bundled Products list:

* If all the product images are fetched from storage, we don't sync anything.
* If any bundled products are missing images after fetching products from storage, we perform a remote sync to retrieve the products.
* When the sync is complete, we update the bundled products (any image placeholders are replaced with the retrieved product images).

We decided not to use a full loading UI so we can immediately show all of the available bundled product details (rather than blocking it while we load the images). Internal ref: p1679002866072969-slack-C02KUCFCSFP

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Prerequisites

1. Install and activate the [Product Bundles extension](https://woocommerce.com/products/product-bundles/) on your store.
2. Create a product with the Product Bundle type, and add bundled products that have product images.
   * Name the product so it appears in the first page of products loaded in the app.
   * Include at least one product that isn't loaded in the first page of products.

### To test

1. Build and run the app.
2. Go to the Products tab and pull to refresh, so only the first page of products is synced.
3. Select your product bundle.
4. Select "Bundled products" in product details.
5. Notice that an image placeholder appears for any bundled products with un-synced product details, and confirm that their images are eventually loaded and appear in the list.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/8658164/225907959-64ddca16-0690-4adf-b9d2-b79d59e8f024.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.