### PR TITLE
Store onboarding > get paid: support admin links in self-hosted sites

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -50,6 +50,12 @@ final class AuthenticatedWebViewController: UIViewController {
             return nil
         }()
         super.init(nibName: nil, bundle: nil)
+
+        if var viewModel = viewModel as? WebviewReloadable {
+            viewModel.loadWebview = { [weak self] url in
+                self?.webView.load(.init(url: url))
+            }
+        }
     }
 
     required init?(coder: NSCoder) {

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -51,9 +51,10 @@ final class AuthenticatedWebViewController: UIViewController {
         }()
         super.init(nibName: nil, bundle: nil)
 
-        if var viewModel = viewModel as? WebviewReloadable {
-            viewModel.loadWebview = { [weak self] url in
-                self?.webView.load(.init(url: url))
+        if let initialURL = viewModel.initialURL,
+           var viewModel = viewModel as? WebviewReloadable {
+            viewModel.reloadWebview = { [weak self] in
+                self?.webView.load(.init(url: initialURL))
             }
         }
     }

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
@@ -3,9 +3,10 @@ import WebKit
 
 /// Optional conformance for a `AuthenticatedWebViewModel` implementation to reload a webview asynchronously.
 protocol WebviewReloadable {
-    /// Allows the view model to load a URL in the webview at anytime.
-    /// This is useful when we have custom redirect handling for WordPress.com login in self-hosted sites.
-    var loadWebview: (_ url: URL) -> Void { get set }
+    /// Allows the view model to reload the initial URL in the webview at anytime.
+    /// This is useful when we have custom redirect handling for WordPress.com login in self-hosted sites where WPCOM authentication
+    /// does not redirect to the initial URL.
+    var reloadWebview: () -> Void { get set }
 }
 
 /// Abstracts different configurations and logic for web view controllers

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
@@ -1,9 +1,10 @@
 import Foundation
 import WebKit
 
+/// Optional conformance for a `AuthenticatedWebViewModel` implementation to reload a webview asynchronously.
 protocol WebviewReloadable {
     /// Allows the view model to load a URL in the webview at anytime.
-    /// This is useful when we have custom redirect handling for WordPress.com login in self-hosted states.
+    /// This is useful when we have custom redirect handling for WordPress.com login in self-hosted sites.
     var loadWebview: (_ url: URL) -> Void { get set }
 }
 

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
@@ -1,6 +1,11 @@
 import Foundation
 import WebKit
-import WordPressAuthenticator
+
+protocol WebviewReloadable {
+    /// Allows the view model to load a URL in the webview at anytime.
+    /// This is useful when we have custom redirect handling for WordPress.com login in self-hosted states.
+    var loadWebview: (_ url: URL) -> Void { get set }
+}
 
 /// Abstracts different configurations and logic for web view controllers
 /// which are authenticated for WordPress.com, where possible

--- a/WooCommerce/Classes/Authentication/WPAdminWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPAdminWebViewModel.swift
@@ -5,7 +5,7 @@ import WebKit
 /// `/wp-admin/admin.php?page=jetpack#/settings`.
 final class WPAdminWebViewModel: AuthenticatedWebViewModel, WebviewReloadable {
     /// Set in `AuthenticatedWebViewController`.
-    var loadWebview: (URL) -> Void = { _ in }
+    var reloadWebview: () -> Void = {}
 
     let title: String
     let initialURL: URL?
@@ -24,9 +24,8 @@ final class WPAdminWebViewModel: AuthenticatedWebViewModel, WebviewReloadable {
         // If the self-hosted site allows login with WPCOM as a Jetpack feature,
         // WPCOM authentication is complete after redirecting to the WPCOM homepage.
         if url?.absoluteString.removingSuffix("/") == URLs.urlAfterWPComAuth,
-           initialURL?.absoluteString != URLs.urlAfterWPComAuth,
-           let initialURL {
-            loadWebview(initialURL)
+           initialURL?.absoluteString != URLs.urlAfterWPComAuth {
+            reloadWebview()
         }
     }
 

--- a/WooCommerce/Classes/Authentication/WPAdminWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPAdminWebViewModel.swift
@@ -1,0 +1,42 @@
+import Foundation
+import WebKit
+
+/// A view model for authenticated web view for a wp-admin URL in self-hosted sites when WPCOM login is enabled as a Jetpack feature at
+/// `/wp-admin/admin.php?page=jetpack#/settings`.
+final class WPAdminWebViewModel: AuthenticatedWebViewModel, WebviewReloadable {
+    /// Set in `AuthenticatedWebViewController`.
+    var loadWebview: (URL) -> Void = { _ in }
+
+    let title: String
+    let initialURL: URL?
+
+    init(title: String = "",
+         initialURL: URL) {
+        self.title = title
+        self.initialURL = initialURL
+    }
+
+    func handleDismissal() {
+        // no-op
+    }
+
+    func handleRedirect(for url: URL?) {
+        // If the self-hosted site allows login with WPCOM as a Jetpack feature,
+        // WPCOM authentication is complete after redirecting to the WPCOM homepage.
+        if url?.absoluteString.removingSuffix("/") == URLs.urlAfterWPComAuth,
+           initialURL?.absoluteString != URLs.urlAfterWPComAuth,
+           let initialURL {
+            loadWebview(initialURL)
+        }
+    }
+
+    func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy {
+        .allow
+    }
+}
+
+private extension WPAdminWebViewModel {
+    enum URLs {
+        static let urlAfterWPComAuth = "https://wordpress.com"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingPaymentsSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingPaymentsSetupCoordinator.swift
@@ -54,7 +54,7 @@ private extension StoreOnboardingPaymentsSetupCoordinator {
             return assertionFailure("Invalid URL for onboarding payments setup: \(urlString)")
         }
 
-        let webViewModel = DefaultAuthenticatedWebViewModel(title: title, initialURL: url)
+        let webViewModel = WPAdminWebViewModel(title: title, initialURL: url)
         let webViewController = AuthenticatedWebViewController(viewModel: webViewModel)
         webViewController.navigationItem.leftBarButtonItem = .init(barButtonSystemItem: .done, target: self, action: #selector(dismissWebview))
         navigationController.show(webViewController, sender: navigationController)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -389,6 +389,8 @@
 		02B1AA6729A4709400D54FCB /* FilterTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B1AA6629A4709400D54FCB /* FilterTabBar.swift */; };
 		02B1AFEC24BC5AE5005DB1E3 /* LinkedProductListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B1AFEB24BC5AE5005DB1E3 /* LinkedProductListSelectorDataSource.swift */; };
 		02B1AFEE24BC5BA9005DB1E3 /* LinkedProductListSelectorDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B1AFED24BC5BA9005DB1E3 /* LinkedProductListSelectorDataSourceTests.swift */; };
+		02B21C5329C830EB00C5623B /* WPAdminWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B21C5229C830EB00C5623B /* WPAdminWebViewModel.swift */; };
+		02B21C5529C84E4A00C5623B /* WPAdminWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B21C5429C84E4A00C5623B /* WPAdminWebViewModelTests.swift */; };
 		02B2828E27C35061004A332A /* RefreshableInfiniteScrollList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2828D27C35061004A332A /* RefreshableInfiniteScrollList.swift */; };
 		02B2829027C352DA004A332A /* RefreshableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2828F27C352DA004A332A /* RefreshableScrollView.swift */; };
 		02B2829227C4808D004A332A /* InfiniteScrollIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2829127C4808D004A332A /* InfiniteScrollIndicator.swift */; };
@@ -2568,6 +2570,8 @@
 		02B1AA6629A4709400D54FCB /* FilterTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTabBar.swift; sourceTree = "<group>"; };
 		02B1AFEB24BC5AE5005DB1E3 /* LinkedProductListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedProductListSelectorDataSource.swift; sourceTree = "<group>"; };
 		02B1AFED24BC5BA9005DB1E3 /* LinkedProductListSelectorDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedProductListSelectorDataSourceTests.swift; sourceTree = "<group>"; };
+		02B21C5229C830EB00C5623B /* WPAdminWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPAdminWebViewModel.swift; sourceTree = "<group>"; };
+		02B21C5429C84E4A00C5623B /* WPAdminWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPAdminWebViewModelTests.swift; sourceTree = "<group>"; };
 		02B2828D27C35061004A332A /* RefreshableInfiniteScrollList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshableInfiniteScrollList.swift; sourceTree = "<group>"; };
 		02B2828F27C352DA004A332A /* RefreshableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshableScrollView.swift; sourceTree = "<group>"; };
 		02B2829127C4808D004A332A /* InfiniteScrollIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollIndicator.swift; sourceTree = "<group>"; };
@@ -6887,6 +6891,7 @@
 				020D0BFC2914E92800BB3DCE /* StorePickerCoordinatorTests.swift */,
 				DEF13C532963ED4E0024A02B /* PostSiteCredentialLoginCheckerTests.swift */,
 				DE66C56E2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift */,
+				02B21C5429C84E4A00C5623B /* WPAdminWebViewModelTests.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -7529,6 +7534,7 @@
 				D89CFE8F25B256E9000E4683 /* ULAccountMatcher.swift */,
 				DEF36DE62898D3CF00178AC2 /* AuthenticatedWebViewController.swift */,
 				DEF36DE72898D3CF00178AC2 /* AuthenticatedWebViewModel.swift */,
+				02B21C5229C830EB00C5623B /* WPAdminWebViewModel.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -11384,6 +11390,7 @@
 				26F94E21267A41BE00DB6CCF /* ProductAddOnsListViewModel.swift in Sources */,
 				45F5A3C123DF206B007D40E5 /* ShippingInputFormatter.swift in Sources */,
 				45C8B2582313FA570002FA77 /* CustomerNoteTableViewCell.swift in Sources */,
+				02B21C5329C830EB00C5623B /* WPAdminWebViewModel.swift in Sources */,
 				02C3FACE282A93020095440A /* WooAnalyticsEvent+Dashboard.swift in Sources */,
 				DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */,
 				7493BB8E2149852A003071A9 /* TopPerformersHeaderView.swift in Sources */,
@@ -12118,6 +12125,7 @@
 				453904F323BB88B5007C4956 /* ProductTaxStatusListSelectorCommandTests.swift in Sources */,
 				02BAB02124D0235F00F8B06E /* ProductPriceSettingsViewModel+ProductVariationTests.swift in Sources */,
 				CC2E72F727B6BFB800A62872 /* ProductVariationFormatterTests.swift in Sources */,
+				02B21C5529C84E4A00C5623B /* WPAdminWebViewModelTests.swift in Sources */,
 				D802547826551DB8001B2CC1 /* CardPresentModalDisplayMessageTests.swift in Sources */,
 				02503C632538301400FD235D /* ProductVariationFormActionsFactory+ReadonlyVariationTests.swift in Sources */,
 				DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/WPAdminWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WPAdminWebViewModelTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import WooCommerce
+
+final class WPAdminWebViewModelTests: XCTestCase {
+    func test_title_is_set_from_init() throws {
+        // Given
+        let viewModel = WPAdminWebViewModel(title: "Woo Test", initialURL: WooConstants.URLs.blog.asURL())
+
+        // Then
+        XCTAssertEqual(viewModel.title, "Woo Test")
+    }
+
+    func test_initialURL_is_set_from_init() throws {
+        // Given
+        let url = try XCTUnwrap(URL(string: "https://woocommerce.com"))
+        let viewModel = WPAdminWebViewModel(initialURL: url)
+
+        // Then
+        XCTAssertEqual(viewModel.initialURL?.absoluteString, "https://woocommerce.com")
+    }
+
+    func test_redirecting_to_wpcom_invokes_loadWebview_for_initialURL() throws {
+        // Given
+        let url = try XCTUnwrap(URL(string: "https://woocommerce.com"))
+        let urlAfterWPComAuth = try XCTUnwrap(URL(string: URLs.urlAfterWPComAuth))
+        let viewModel = WPAdminWebViewModel(initialURL: url)
+
+        // When
+        let urlToLoad: URL = waitFor { promise in
+            viewModel.loadWebview = { url in
+                promise(url)
+            }
+            viewModel.handleRedirect(for: urlAfterWPComAuth)
+        }
+
+        // Then it loads the initial URL
+        XCTAssertEqual(urlToLoad, url)
+    }
+
+    func test_redirecting_to_non_wpcom_does_not_invoke_loadWebview() throws {
+        // Given
+        let url = try XCTUnwrap(URL(string: "https://woocommerce.com"))
+        let nonWPComAuthURL = try XCTUnwrap(URL(string: "https://example.com"))
+        let viewModel = WPAdminWebViewModel(initialURL: url)
+
+        // When
+        viewModel.loadWebview = { url in
+            // Then
+            XCTFail("Unexpected webview load for \(url)")
+        }
+        viewModel.handleRedirect(for: nonWPComAuthURL)
+    }
+}
+
+private extension WPAdminWebViewModelTests {
+    enum URLs {
+        static let urlAfterWPComAuth = "https://wordpress.com"
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/WPAdminWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WPAdminWebViewModelTests.swift
@@ -19,7 +19,7 @@ final class WPAdminWebViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.initialURL?.absoluteString, "https://woocommerce.com")
     }
 
-    func test_redirecting_to_wpcom_invokes_loadWebview_for_initialURL() throws {
+    func test_redirecting_to_wpcom_invokes_reloadWebview() throws {
         // Given
         let url = try XCTUnwrap(URL(string: "https://woocommerce.com"))
         let urlAfterWPComAuth = try XCTUnwrap(URL(string: URLs.urlAfterWPComAuth))
@@ -27,7 +27,7 @@ final class WPAdminWebViewModelTests: XCTestCase {
 
         // When
         let urlToLoad: URL = waitFor { promise in
-            viewModel.loadWebview = { url in
+            viewModel.reloadWebview = {
                 promise(url)
             }
             viewModel.handleRedirect(for: urlAfterWPComAuth)
@@ -37,27 +37,27 @@ final class WPAdminWebViewModelTests: XCTestCase {
         XCTAssertEqual(urlToLoad, url)
     }
 
-    func test_redirecting_to_wpcom_does_not_invoke_loadWebview_when_initialURL_is_the_same() throws {
+    func test_redirecting_to_wpcom_does_not_invoke_reloadWebview_when_initialURL_is_the_same() throws {
         // Given
         let url = try XCTUnwrap(URL(string: URLs.urlAfterWPComAuth))
         let viewModel = WPAdminWebViewModel(initialURL: url)
 
         // When
-        viewModel.loadWebview = { url in
+        viewModel.reloadWebview = {
             // Then
             XCTFail("Unexpected webview load for \(url)")
         }
         viewModel.handleRedirect(for: url)
     }
 
-    func test_redirecting_to_non_wpcom_does_not_invoke_loadWebview() throws {
+    func test_redirecting_to_non_wpcom_does_not_invoke_reloadWebview() throws {
         // Given
         let url = try XCTUnwrap(URL(string: "https://woocommerce.com"))
         let nonWPComAuthURL = try XCTUnwrap(URL(string: "https://example.com"))
         let viewModel = WPAdminWebViewModel(initialURL: url)
 
         // When
-        viewModel.loadWebview = { url in
+        viewModel.reloadWebview = {
             // Then
             XCTFail("Unexpected webview load for \(url)")
         }

--- a/WooCommerce/WooCommerceTests/Authentication/WPAdminWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WPAdminWebViewModelTests.swift
@@ -37,6 +37,19 @@ final class WPAdminWebViewModelTests: XCTestCase {
         XCTAssertEqual(urlToLoad, url)
     }
 
+    func test_redirecting_to_wpcom_does_not_invoke_loadWebview_when_initialURL_is_the_same() throws {
+        // Given
+        let url = try XCTUnwrap(URL(string: URLs.urlAfterWPComAuth))
+        let viewModel = WPAdminWebViewModel(initialURL: url)
+
+        // When
+        viewModel.loadWebview = { url in
+            // Then
+            XCTFail("Unexpected webview load for \(url)")
+        }
+        viewModel.handleRedirect(for: url)
+    }
+
     func test_redirecting_to_non_wpcom_does_not_invoke_loadWebview() throws {
         // Given
         let url = try XCTUnwrap(URL(string: "https://woocommerce.com"))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9149
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In self-hosted sites authenticated with WPCOM, the default `AuthenticatedWebViewController` doesn't work for wp-admin links and it lands on `https://wordpress.com` (stats for the default site) for wp-admin URLs. This is because when we try authenticating with their WPCOM credentials, the URL that the `WKWebview+authenticateForWPComAndRedirect` implementation redirects to is `https://wordpress.com/wp-admin` which eventually redirects to `https://wordpress.com` for a wp-admin URL. This results in a broken experience because the original wp-admin URL doesn't even allow the user to log in. For self-hosted sites with WPCOM login enabled as a Jetpack setting (`/wp-admin/admin.php?page=jetpack#/settings`), it also loses the opportunity to allow the user to log in with one click.

## The workaround

In order to take advantage of the WPCOM authentication for self-hosted sites with WPCOM login enabled, I decided to create a new view model `WPAdminWebViewModel` that conforms to `AuthenticatedWebViewModel` and a new protocol `WebviewReloadable` in order to reload the webview after WPCOM authentication is complete, when it redirects to `https://wordpress.com`. I called it a workaround because it's not a clean solution since it's based on the assumption that a successful WPCOM authentication redirects to the WPCOM homepage. Ideally, the `WKWebview+authenticateForWPComAndRedirect` just redirects to the initial URL instead of `https://wordpress.com`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Self-hosted sites without WPCOM login

Prerequisite: the site is a self-hosted site with WPCOM login disabled as a Jetpack feature at `/wp-admin/admin.php?page=jetpack#/settings` (the default behavior of a JN or Pressable site). to make it easier for testing, you can enable the onboarding card view all button to be shown all the time by commenting out [this line](https://github.com/woocommerce/woocommerce-ios/blob/76d6a2e17fb70b3c2677047e3f66f9e79673490a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift#L146)

- Log in to the site in the prerequisite if needed through WPCOM authentication flow
- In the My store, tap on the `Get paid` task in either the collapsed or expanded state
- Tap `Continue Setup` --> it should navigate to a webview with wp-admin login form
- Log in with the wp-admin credentials --> the payments admin panel should be shown

### Self-hosted sites with WPCOM login

Prerequisite: the site is a self-hosted site with WPCOM login enabled as a Jetpack feature at `/wp-admin/admin.php?page=jetpack#/settings`

- Log in to the site in the prerequisite if needed through WPCOM authentication flow
- In the My store, tap on the `Get paid` task in either the collapsed or expanded state
- Tap `Continue Setup` --> it should navigate to a webview with a CTA to log in with WPCOM
- Tap on `Log in with WordPress.com`  --> the payments admin panel should be shown shortly without having to enter wp-admin credentials

### WPCOM sites with WPCOM login

Prerequisite: the site is a WPCOM site

- Log in to the site in the prerequisite if needed through WPCOM authentication flow
- In the My store, tap on the `Get paid` task in either the collapsed or expanded state
- Tap `Continue Setup` --> it should directly navigate to a webview with the payments setup

---
- [x] @jaclync tests login with application password

Prerequisite: the site is a self-hosted site

- Log in to the site in the prerequisite with self-hosted site crednetials
- In the My store, tap on the `Get paid` task in either the collapsed or expanded state
- Tap `Continue Setup` --> it should directly navigate to a webview with the payments setup


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

WPCOM login enabled | WPCOM login disabled
-- | --
![Simulator Screen Shot - iPhone 14 - 2023-03-20 at 13 46 20](https://user-images.githubusercontent.com/1945542/226358244-aed5218c-f1a4-4997-854e-e60e027af8e8.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-20 at 13 46 41](https://user-images.githubusercontent.com/1945542/226358264-0c223369-3555-4193-9fce-ee43fa99b4bd.png)


Notice that the webview works for the payments setup link but not from the Menu tab > WC Admin because of the redirect implementation.

https://user-images.githubusercontent.com/1945542/226293723-d1cfd80b-7a58-4b80-9799-f4a501a7aac4.mov




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
