### PR TITLE
[Mobile Payments] Tap to Pay Try a Payment flow

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -880,6 +880,7 @@ extension WooAnalyticsEvent {
             case amount
             case summary
             case paymentMethod = "payment_method"
+            case tapToPayTryAPaymentPrompt = "tap_to_pay_try_a_payment_prompt"
         }
 
         /// Possible flows
@@ -887,6 +888,7 @@ extension WooAnalyticsEvent {
         enum Flow: String {
             case simplePayment = "simple_payment"
             case orderPayment = "order_payment"
+            case tapToPayTryAPayment = "tap_to_pay_try_a_payment"
         }
 
         /// Common event keys

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/PaymentSettingsFlowPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/PaymentSettingsFlowPresentingViewController.swift
@@ -41,8 +41,11 @@ final class PaymentSettingsFlowPresentingViewController: UIViewController {
         childViewController?.removeFromParent()
         childViewController?.view.removeFromSuperview()
 
-        guard let viewModelAndView = viewModelAndView,
-              let childViewController = viewModelAndView.viewPresenter.init(viewModel: viewModelAndView.viewModel) else {
+        guard let viewModelAndView = viewModelAndView else {
+            return
+        }
+
+        guard let childViewController = viewModelAndView.viewPresenter.init(viewModel: viewModelAndView.viewModel) else {
             DDLogError("⛔️ Unexpectedly unable to create PaymentSettingsFlow Child View Controller using: \(String(describing: viewModelAndView))")
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewController.swift
@@ -14,14 +14,6 @@ final class SetUpTapToPayCompleteViewController: UIHostingController<SetUpTapToP
         self.viewModel = viewModel
 
         super.init(rootView: SetUpTapToPayCompleteView(viewModel: viewModel))
-
-        configureViewModel()
-    }
-
-    private func configureViewModel() {
-        viewModel.dismiss = { [weak self] in
-            self?.dismiss(animated: true)
-        }
     }
 
     required init?(coder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewModel.swift
@@ -45,10 +45,10 @@ final class SetUpTapToPayCompleteViewModel: PaymentSettingsFlowPresentedViewMode
     ///
     private func reevaluateShouldShow() {
         let newShouldShow: CardReaderSettingsTriState
-        switch (doneWasTapped, connectedReader) {
-        case (true, _):
+
+        if doneWasTapped {
             newShouldShow = .isFalse
-        case (false, _):
+        } else {
             newShouldShow = connectedReader
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -73,9 +73,9 @@ struct SetUpTapToPayInformationView: View {
     var body: some View {
         VStack {
             HStack {
-                Button("Cancel", action: {
+                Button(Localization.cancelButton) {
                     dismiss?()
-                })
+                }
                 Spacer()
             }
             .padding(.top)
@@ -193,6 +193,10 @@ private enum Localization {
                  which should be translated separately and considered part of this sentence.
                  """
     )
+
+    static let cancelButton = NSLocalizedString(
+        "Cancel",
+        comment: "Settings > Set up Tap to Pay on iPhone > Information > Cancel button")
 }
 
 struct SetUpTapToPayInformationView_Previews: PreviewProvider {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+
+/// This view controller is used when no reader is connected. It assists
+/// the merchant in connecting to a reader.
+///
+final class SetUpTapToPayTryPaymentPromptViewController: UIHostingController<SetUpTapToPayPaymentPromptView>, PaymentSettingsFlowViewModelPresenter {
+
+    private var viewModel: SetUpTapToPayTryPaymentPromptViewModel
+
+    init?(viewModel: PaymentSettingsFlowPresentedViewModel) {
+        guard let viewModel = viewModel as? SetUpTapToPayTryPaymentPromptViewModel else {
+            return nil
+        }
+        self.viewModel = viewModel
+
+        super.init(rootView: SetUpTapToPayPaymentPromptView(viewModel: viewModel))
+
+        configureViewModel()
+    }
+
+    private func configureViewModel() {
+        viewModel.dismiss = { [weak self] in
+            self?.dismiss(animated: true)
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("Not implemented")
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        viewModel.didUpdate = nil
+        super.viewWillDisappear(animated)
+    }
+}
+
+struct SetUpTapToPayPaymentPromptView: View {
+    @ObservedObject var viewModel: SetUpTapToPayTryPaymentPromptViewModel
+
+    @Environment(\.verticalSizeClass) var verticalSizeClass
+
+    var isCompact: Bool {
+        verticalSizeClass == .compact
+    }
+
+    var imageMaxHeight: CGFloat {
+        isCompact ? Constants.maxCompactImageHeight : Constants.maxImageHeight
+    }
+
+    var imageFontSize: CGFloat {
+        isCompact ? Constants.maxCompactImageHeight : Constants.imageFontSize
+    }
+
+    var body: some View {
+        ScrollableVStack(padding: 0) {
+            Image(systemName: "wave.3.right.circle.fill")
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(Color(.wooCommercePurple(.shade50)))
+                .scaledToFit()
+                .frame(maxHeight: imageMaxHeight)
+                .font(.system(size: imageFontSize))
+                .padding()
+
+            Text(Localization.setUpTryPaymentPromptTitle)
+                .font(.title2.weight(.semibold))
+                .multilineTextAlignment(.center)
+                .padding()
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(Localization.setUpTryPaymentPromptDescription)
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .padding()
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer()
+
+            Button(Localization.tryAPaymentButton, action: {
+                viewModel.tryAPaymentTapped()
+            })
+            .buttonStyle(PrimaryButtonStyle())
+
+            Button(Localization.skipButton, action: {
+                viewModel.skipTapped()
+            })
+            .buttonStyle(SecondaryButtonStyle())
+        }
+        .padding()
+    }
+}
+
+private enum Constants {
+    static let maxImageHeight: CGFloat = 180
+    static let maxCompactImageHeight: CGFloat = 80
+    static let imageFontSize: CGFloat = 120
+    static let compactImageFontSize: CGFloat = 40
+}
+
+// MARK: - Localization
+//
+private extension SetUpTapToPayPaymentPromptView {
+    enum Localization {
+        static let setUpTryPaymentPromptTitle = NSLocalizedString(
+            "Try a payment",
+            comment: "Settings > Set up Tap to Pay on iPhone > Try a Payment > Inform user that " +
+            "Tap to Pay on iPhone is ready"
+        )
+
+        static let setUpTryPaymentPromptDescription = NSLocalizedString(
+            "Try taking a payment of $0.50 to see how Tap to Pay on iPhone works. Use your " +
+            "debit or credit card: you can refund it when you're done.",
+            comment: "Settings > Set up Tap to Pay on iPhone > Try a Payment > Description"
+        )
+
+        static let tryAPaymentButton = NSLocalizedString(
+            "Try a Payment",
+            comment: "Settings > Set up Tap to Pay on iPhone > Try a Payment > A button to start " +
+            "a payment for testing Tap to Pay on iPhone using the merchant's own card."
+        )
+
+        static let skipButton = NSLocalizedString(
+            "Skip",
+            comment: "Settings > Set up Tap to Pay on iPhone > Try a Payment > A button to skip " +
+            "to the trial payment and dismiss the Set up Tap to Pay on iPhone flow"
+        )
+    }
+}
+
+struct SetUpTapToPayPaymentPromptView_Previews: PreviewProvider {
+    static var previews: some View {
+
+        let config = CardPresentConfigurationLoader().configuration
+        let viewModel = SetUpTapToPayTryPaymentPromptViewModel(
+            didChangeShouldShow: nil,
+            connectionAnalyticsTracker: .init(configuration: config))
+        SetUpTapToPayPaymentPromptView(viewModel: viewModel)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
@@ -104,12 +104,22 @@ struct SetUpTapToPayPaymentPromptView: View {
         WooNavigationSheet(viewModel: WooNavigationSheetViewModel(navigationTitle: Localization.setUpTryPaymentPromptTitle,
                                                                   done: viewModel.dismiss ?? {})) {
             if let summaryViewModel = viewModel.summaryViewModel {
-                    SimplePaymentsSummary(dismiss: viewModel.dismiss ?? {},
-                                          rootViewController: rootViewController?.navigationController,
-                                          viewModel: summaryViewModel)
+                SimplePaymentsSummary(
+                    dismiss: {
+                        showOrder(orderID: summaryViewModel.orderID, siteID: summaryViewModel.siteID)
+                    },
+                    rootViewController: rootViewController?.navigationController,
+                    viewModel: summaryViewModel.simplePaymentSummaryViewModel)
             }
             EmptyView()
         }
+    }
+
+    private func showOrder(orderID: Int64, siteID: Int64) {
+        let orderViewController = OrderLoaderViewController(orderID: orderID, siteID: siteID)
+        orderViewController.addCloseNavigationBarButton(title: Localization.doneButton)
+        rootViewController?.navigationController?.navigationBar.isHidden = false
+        rootViewController?.navigationController?.setViewControllers([orderViewController], animated: true)
     }
 }
 
@@ -152,6 +162,11 @@ private extension SetUpTapToPayPaymentPromptView {
             "Cancel",
             comment: "Settings > Set up Tap to Pay on iPhone > Try a Payment > Payment flow " +
             "> Cancel button")
+
+        static let doneButton = NSLocalizedString(
+            "Done",
+            comment: "Settings > Set up Tap to Pay on iPhone > Try a Payment > Payment flow " +
+            "> Review Order > Done button")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
@@ -2,14 +2,17 @@ import Foundation
 import Yosemite
 import Combine
 
-final class SetUpTapToPayCompleteViewModel: PaymentSettingsFlowPresentedViewModel, ObservableObject {
+final class SetUpTapToPayTryPaymentPromptViewModel: PaymentSettingsFlowPresentedViewModel, ObservableObject {
     private(set) var shouldShow: CardReaderSettingsTriState = .isUnknown
     var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?
     var didUpdate: (() -> Void)?
+    var dismiss: (() -> Void)?
 
-    private var doneWasTapped: Bool = false
-
-    private(set) var connectedReader: CardReaderSettingsTriState = .isUnknown
+    private(set) var connectedReader: CardReaderSettingsTriState = .isUnknown {
+        didSet {
+            didUpdate?()
+        }
+    }
 
     private let connectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker
     private let stores: StoresManager
@@ -44,13 +47,7 @@ final class SetUpTapToPayCompleteViewModel: PaymentSettingsFlowPresentedViewMode
     /// Notifies the viewModel owner if a change occurs via didChangeShouldShow
     ///
     private func reevaluateShouldShow() {
-        let newShouldShow: CardReaderSettingsTriState
-        switch (doneWasTapped, connectedReader) {
-        case (true, _):
-            newShouldShow = .isFalse
-        case (false, _):
-            newShouldShow = connectedReader
-        }
+        let newShouldShow: CardReaderSettingsTriState = connectedReader
 
         let didChange = newShouldShow != shouldShow
 
@@ -61,9 +58,12 @@ final class SetUpTapToPayCompleteViewModel: PaymentSettingsFlowPresentedViewMode
         }
     }
 
-    func doneTapped() {
-        doneWasTapped = true
+    func tryAPaymentTapped() {
         reevaluateShouldShow()
+    }
+
+    func skipTapped() {
+        dismiss?()
     }
 
     deinit {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
@@ -18,7 +18,7 @@ final class SetUpTapToPayTryPaymentPromptViewModel: PaymentSettingsFlowPresented
     private let stores: StoresManager
 
     @Published var loading: Bool = false
-    var summaryViewModel: SimplePaymentsSummaryViewModel? = nil {
+    var summaryViewModel: TryAPaymentSummaryViewModel? = nil {
         didSet {
             summaryActive = summaryViewModel != nil
         }
@@ -69,9 +69,13 @@ final class SetUpTapToPayTryPaymentPromptViewModel: PaymentSettingsFlowPresented
 
             switch result {
             case .success(let order):
-                self.summaryViewModel = SimplePaymentsSummaryViewModel(order: order,
-                                                                       providedAmount: order.total,
-                                                                       presentNoticeSubject: self.presentNoticeSubject)
+                self.summaryViewModel = TryAPaymentSummaryViewModel(
+                    simplePaymentSummaryViewModel: SimplePaymentsSummaryViewModel(order: order,
+                                                                                  providedAmount: order.total,
+                                                                                  presentNoticeSubject: self.presentNoticeSubject),
+                    siteID: self.siteID,
+                    orderID: order.orderID)
+
 
             case .failure(let error):
                 self.presentNoticeSubject.send(.error(Localization.errorCreatingTestPayment))
@@ -121,4 +125,10 @@ extension SetUpTapToPayTryPaymentPromptViewModel {
             "The trial payment could not be started, please try again, or contact support if this problem persists.",
             comment: "Error notice shown when the try a payment option in Set up Tap to Pay on iPhone fails.")
     }
+}
+
+struct TryAPaymentSummaryViewModel {
+    let simplePaymentSummaryViewModel: SimplePaymentsSummaryViewModel
+    let siteID: Int64
+    let orderID: Int64
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
@@ -84,7 +84,7 @@ final class SetUpTapToPayTryPaymentPromptViewModel: PaymentSettingsFlowPresented
                 DDLogError("⛔️ Error creating Tap to Pay try a payment order: \(error)")
             }
         }
-        ServiceLocator.stores.dispatch(action)
+        stores.dispatch(action)
     }
 
     /// Updates whether the view this viewModel is associated with should be shown or not

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
@@ -55,7 +55,17 @@ final class SetUpTapToPayViewModelsOrderedList: PaymentSettingsFlowPrioritizedVi
                     connectionAnalyticsTracker: cardReaderConnectionAnalyticsTracker
                 ),
                 viewPresenter: SetUpTapToPayCompleteViewController.self
-            )
+            ),
+
+            PaymentSettingsFlowViewModelAndView(
+                viewModel: SetUpTapToPayTryPaymentPromptViewModel(
+                    didChangeShouldShow: { [weak self] state in
+                        self?.onDidChangeShouldShow(state)
+                    },
+                    connectionAnalyticsTracker: cardReaderConnectionAnalyticsTracker
+                ),
+                viewPresenter: SetUpTapToPayTryPaymentPromptViewController.self
+            ),
         ])
 
         /// And then immediately get a priority view if possible

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -545,6 +545,8 @@
 		0386CFEB2852108B00134466 /* PaymentMethodsHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0386CFEA2852108B00134466 /* PaymentMethodsHostingController.swift */; };
 		038BC37D29C37AA400EAF565 /* SetUpTapToPayCompleteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038BC37C29C37AA400EAF565 /* SetUpTapToPayCompleteViewModel.swift */; };
 		038BC37F29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038BC37E29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift */; };
+		038BC38129C4B8AC00EAF565 /* SetUpTapToPayTryPaymentPromptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038BC38029C4B8AC00EAF565 /* SetUpTapToPayTryPaymentPromptViewModel.swift */; };
+		038BC38329C4B8ED00EAF565 /* SetUpTapToPayTryPaymentPromptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038BC38229C4B8ED00EAF565 /* SetUpTapToPayTryPaymentPromptViewController.swift */; };
 		0396CFAD2981476900E91436 /* CardPresentModalBuiltInConnectingFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */; };
 		039D948D27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */; };
 		039D948F276113490044EF38 /* UIView+SuperviewConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */; };
@@ -2712,6 +2714,8 @@
 		0386CFEA2852108B00134466 /* PaymentMethodsHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsHostingController.swift; sourceTree = "<group>"; };
 		038BC37C29C37AA400EAF565 /* SetUpTapToPayCompleteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUpTapToPayCompleteViewModel.swift; sourceTree = "<group>"; };
 		038BC37E29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUpTapToPayCompleteViewController.swift; sourceTree = "<group>"; };
+		038BC38029C4B8AC00EAF565 /* SetUpTapToPayTryPaymentPromptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUpTapToPayTryPaymentPromptViewModel.swift; sourceTree = "<group>"; };
+		038BC38229C4B8ED00EAF565 /* SetUpTapToPayTryPaymentPromptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUpTapToPayTryPaymentPromptViewController.swift; sourceTree = "<group>"; };
 		0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInConnectingFailed.swift; sourceTree = "<group>"; };
 		039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SafeAreaConstraints.swift"; sourceTree = "<group>"; };
 		039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SuperviewConstraints.swift"; sourceTree = "<group>"; };
@@ -6112,6 +6116,7 @@
 				31B19B66263B5E580099DAA6 /* CardReaderSettingsSearchingViewModel.swift */,
 				0365986829AFB0C100F297D3 /* SetUpTapToPayInformationViewModel.swift */,
 				038BC37C29C37AA400EAF565 /* SetUpTapToPayCompleteViewModel.swift */,
+				038BC38029C4B8AC00EAF565 /* SetUpTapToPayTryPaymentPromptViewModel.swift */,
 				317F679726420E9D00BA2A7A /* CardReaderSettingsViewModelsOrderedList.swift */,
 				0365986629AFAEFC00F297D3 /* SetUpTapToPayViewModelsOrderedList.swift */,
 				3142663E2645E2AB00500598 /* PaymentSettingsFlowViewModelPresenter.swift */,
@@ -6120,6 +6125,7 @@
 				ABC353433EABC5F0EC796222 /* CardReaderSettingsSearchingViewController.swift */,
 				0365986A29AFB11E00F297D3 /* SetUpTapToPayInformationViewController.swift */,
 				038BC37E29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift */,
+				038BC38229C4B8ED00EAF565 /* SetUpTapToPayTryPaymentPromptViewController.swift */,
 				31FC8CE627B47591004B9456 /* CardReaderSettingsDataSource.swift */,
 				31FC8CE827B476BA004B9456 /* CardReaderSettingsResultsControllers.swift */,
 			);
@@ -10764,6 +10770,7 @@
 				02DC2ED2242061BF002F9676 /* ProductPriceSettingsViewModel.swift in Sources */,
 				E138D4F4269ED9C3006EA5C6 /* InPersonPaymentsViewController.swift in Sources */,
 				26838358296F9A1E00CCF60A /* GenerateAllVariationsUseCase.swift in Sources */,
+				038BC38329C4B8ED00EAF565 /* SetUpTapToPayTryPaymentPromptViewController.swift in Sources */,
 				CE2A9FD023C4F2C8002BEC1C /* RefundedProductsViewController.swift in Sources */,
 				0262DA5823A23AC80029AF30 /* ProductShippingSettingsViewController.swift in Sources */,
 				451C77732404534000413F73 /* ProductSettingsSections.swift in Sources */,
@@ -11401,6 +11408,7 @@
 				452FE64B25657EC100EB54A0 /* LinkedProductsViewController.swift in Sources */,
 				450C6EEA286F4334002DB168 /* SitePlugin+Woo.swift in Sources */,
 				45B9C64123A9139A007FC4C5 /* Product+PriceSettingsViewModels.swift in Sources */,
+				038BC38129C4B8AC00EAF565 /* SetUpTapToPayTryPaymentPromptViewModel.swift in Sources */,
 				773077ED251E943700178696 /* Product+DownloadFileViewModels.swift in Sources */,
 				743EDD9F214B05350039071B /* TopEarnerStatsItem+Woo.swift in Sources */,
 				B5BBD6DE21B1703700E3207E /* PushNotificationsManager.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9202 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a new Try a Payment screen to the Set up Tap to Pay on iPhone flow. The new screen invites and informs the user about trying a payment out, and the `Try a Payment` button opens the Simple Payments flow with a pre-set amount of $0.50.

When the user completes their trial payment, we show the Order details for their payment, so they can do a refund.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using an iPhone XS or newer, running iOS 16.0+, and a US-based store:

1. Navigate to `Menu > Payments > Set up Tap to Pay on iPhone`
2. Follow the flow until you get to the `Try a Payment` screen 
3. Tap `Try a Payment` 
4. Follow the simple payments flow, and tap `Card` on the Payment Methods screen (in a future PR, this will be split in to `Tap to Pay on iPhone` and `Card Reader`)
5. Pay with a test card
6. Observe that after you tap `Save receipt and continue`, or any other button on the final alert, the Order Details are shown
7. Refund the order
8. Observe that the refund completes successfully
9. Tap Done


Repeat to try the `Skip` button
1. Follow the flow until you get to the `Try a Payment` screen (N.B. if you've not left the app since the first time, you'll go straight to `Setup Complete`)
2. Tap `Skip`
3. Observe that the flow is closed and you're back on the Payments menu 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/2472348/226418882-28f8fd55-28f2-4bd3-9e83-4ce6c3b98e0a.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
