### PR TITLE
[Mobile Payments] Fix connection loop for external readers after Set up Tap to Pay

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -98,12 +98,12 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
 
     func setUpTapped() {
         setUpInProgress = true
-        connectionController?.searchAndConnect { _ in
+        connectionController?.searchAndConnect { [weak self] _ in
             /// No need for logic here. Once connected, the connected reader will publish
             /// through the `cardReaderAvailableSubscription`, so we can just
             /// dismiss the connection flow alerts.
-            self.alertsPresenter?.dismiss()
-            self.setUpInProgress = false
+            self?.alertsPresenter?.dismiss()
+            self?.setUpInProgress = false
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9224
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There was still a retain cycle between the `SetUpTapToPayInformationViewModel` and its connection controller. This resulted in a loop of connection and automatic disconnection when later connecting to a physical reader.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Open Menu > Payments > Set up Tap to Pay on iPhone
2. Tap `Set up Tap to Pay on iPhone`
3. When there's a blank screen, drag it down to dismiss
4. Tap `Manage card reader`
5. Connect to an external reader
6. Observe that the reader connects as expected, and stays connected (before this fix, it would disconnect and then start searching again.)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
