### PR TITLE
[Free Trial] Adds Upgrades View

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -1,0 +1,88 @@
+import Foundation
+import SwiftUI
+
+/// Main view for the plan settings.
+///
+final class UpgradesHostingController: UIHostingController<UpgradesView> {
+
+    init(currentPlan: String, planInfo: String) {
+        super.init(rootView: .init(currentPlan: currentPlan, planInfo: planInfo))
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// Main view for the plan settings.
+///
+struct UpgradesView: View {
+
+    /// Store's Current Plan name
+    let currentPlan: String
+
+    /// Store's plan information
+    let planInfo: String
+
+    var body: some View {
+        List {
+            Section(content: {
+                Text(Localization.currentPlan(currentPlan))
+                    .bodyStyle()
+
+                Button(Localization.upgradeNow) {
+                    print("Upgrade Now tapped")
+                }
+                .linkStyle()
+            }, header: {
+                Text(Localization.subscriptionStatus)
+            }, footer: {
+                Text(planInfo)
+            })
+
+            Button(Localization.cancelTrial) {
+                print("Cancel Free Trial tapped")
+            }
+            .foregroundColor(Color(.systemRed))
+
+            Section(Localization.troubleshooting) {
+                Button(Localization.report) {
+                    print("Report Subscription Tapped")
+                }
+                .linkStyle()
+            }
+        }
+        .background(Color(.listBackground))
+        .navigationTitle(Localization.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// Definitions
+private extension UpgradesView {
+    enum Localization {
+        static let title = NSLocalizedString("Subscriptions", comment: "Title for the Subscriptions / Upgrades view")
+        static let subscriptionStatus = NSLocalizedString("SUBSCRIPTION STATUS", comment: "Title for the plan section on the subscriptions view. Uppercased")
+        static let upgradeNow = NSLocalizedString("Upgrade Now", comment: "Title for the button to upgrade from a free trial")
+        static let cancelTrial = NSLocalizedString("Cancel Free Trial", comment: "Title for the button to cancel a free trial")
+        static let troubleshooting = NSLocalizedString("TROUBLESHOOTING",
+                                                       comment: "Title for the section to contact support on the subscriptions view. Uppercased")
+        static let report = NSLocalizedString("Report Subscription Issue", comment: "Title for the button to contact support on the Subscriptions view")
+
+        static func currentPlan(_ plan: String) -> String {
+            let format = NSLocalizedString("Current: %@", comment: "Reads like: Current: Free Trial")
+            return .localizedStringWithFormat(format, plan)
+        }
+    }
+}
+
+// MARK: Previews
+struct UpgradesPreviews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            UpgradesView(currentPlan: "Free Trial",
+                         planInfo: "You are in the 14-day free trial. The free trial will end in 6 days. " +
+                                   "Upgrade to unlock new features and keep your store running.")
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -659,6 +659,7 @@
 		263EB409242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */; };
 		2647F7B529280A7F00D59FDF /* AnalyticsHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */; };
 		2647F7BA292BE2F900D59FDF /* AnalyticsReportCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */; };
+		264957A329C520860095AA4C /* UpgradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264957A229C520860095AA4C /* UpgradesView.swift */; };
 		265284022624937600F91BA1 /* AddOnCrossreferenceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */; };
 		265284092624ACE900F91BA1 /* AddOnCrossreferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265284082624ACE900F91BA1 /* AddOnCrossreferenceTests.swift */; };
 		2655905B27863D1300BB8457 /* MockCollectOrderPaymentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2655905A27863D1300BB8457 /* MockCollectOrderPaymentUseCase.swift */; };
@@ -2832,6 +2833,7 @@
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
 		2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubView.swift; sourceTree = "<group>"; };
 		2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportCard.swift; sourceTree = "<group>"; };
+		264957A229C520860095AA4C /* UpgradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesView.swift; sourceTree = "<group>"; };
 		265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceUseCase.swift; sourceTree = "<group>"; };
 		265284082624ACE900F91BA1 /* AddOnCrossreferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOnCrossreferenceTests.swift; sourceTree = "<group>"; };
 		2655905A27863D1300BB8457 /* MockCollectOrderPaymentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCollectOrderPaymentUseCase.swift; sourceTree = "<group>"; };
@@ -5844,6 +5846,15 @@
 			path = "Analytics Hub";
 			sourceTree = "<group>";
 		};
+		264957A129C5206B0095AA4C /* Upgrades */ = {
+			isa = PBXGroup;
+			children = (
+				264957A229C520860095AA4C /* UpgradesView.swift */,
+			);
+			name = Upgrades;
+			path = Classes/ViewRelated/Upgrades;
+			sourceTree = SOURCE_ROOT;
+		};
 		265284002624933B00F91BA1 /* AddOns */ = {
 			isa = PBXGroup;
 			children = (
@@ -7661,6 +7672,7 @@
 				022BF7FA23B9D681000A1DFB /* Progress */,
 				0282DD92233C9397006A5FDB /* Search */,
 				0202B6932387ACE000F3EBE0 /* TabBar */,
+				264957A129C5206B0095AA4C /* Upgrades */,
 				26B119B524D0B36700FED5C7 /* Survey */,
 				02817B37242B34260050AD8B /* Toolbar */,
 				02404EE52315272C00FF1170 /* Top Banner */,
@@ -11297,6 +11309,7 @@
 				579CDEFF274D7E7900E8903D /* StoreStatsUsageTracksEventEmitter.swift in Sources */,
 				74F9E9CE214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift in Sources */,
 				314DC4BD268D158F00444C9E /* CardReaderSettingsKnownReadersProvider.swift in Sources */,
+				264957A329C520860095AA4C /* UpgradesView.swift in Sources */,
 				02DE39D92968647100BB31D4 /* DomainSettingsViewModel.swift in Sources */,
 				576EA39225264C7400AFC0B3 /* RefundConfirmationViewController.swift in Sources */,
 				2688641B25D3202B00821BA5 /* EditAttributesViewController.swift in Sources */,


### PR DESCRIPTION
closes #9057 

# Why

This PR just adds the main view for the Upgrades section. 

# Testing Steps

It is not connected and has no logic on it yet so just take a look at the code.

# Screenshots

Light | Dark 
--- | ---
<img width="324" alt="light" src="https://user-images.githubusercontent.com/562080/226510772-e3528b4b-900d-4225-8f7b-4093806e711c.png"> |  <img width="331" alt="dark" src="https://user-images.githubusercontent.com/562080/226510778-72bfb42c-852b-4b68-9316-ad5a0875e157.png">

Landscape | Big Fonts | Big Fonts (Scrolled)
--- | --- | ---
<img width="670" alt="landscape" src="https://user-images.githubusercontent.com/562080/226510783-f4943c0c-77fa-45e7-b476-465908e96c99.png"> | <img width="319" alt="big-fonts-1" src="https://user-images.githubusercontent.com/562080/226510780-624ecfff-5e71-480c-a2f8-031bbc14bcce.png"> | <img width="326" alt="big-fonts-2" src="https://user-images.githubusercontent.com/562080/226510784-582a1f50-f000-408d-9ae5-d9ee4bb6c357.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
