### PR TITLE
Add accessibilityIdentifiers on payments menu cells

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -279,7 +279,7 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func configureOrderCardReader(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell, accessibilityId: "order-card-reader")
+        prepareForReuse(cell, accessibilityID: "order-card-reader")
         cell.configure(image: .shoppingCartIcon, text: Localization.orderCardReader.localizedCapitalized)
     }
 
@@ -294,24 +294,24 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func configureManagePaymentGateways(cell: LeftImageTitleSubtitleTableViewCell) {
-        prepareForReuse(cell, accessibilityId: "manage-payment-gateways")
+        prepareForReuse(cell, accessibilityID: "manage-payment-gateways")
         cell.configure(image: .rectangleOnRectangleAngled,
                        text: Localization.managePaymentGateways.localizedCapitalized,
                        subtitle: pluginState?.preferred.pluginName ?? "")
     }
 
     func configureCardReaderManuals(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell, accessibilityId: "card-reader-manuals")
+        prepareForReuse(cell, accessibilityID: "card-reader-manuals")
         cell.configure(image: .cardReaderManualIcon, text: Localization.cardReaderManuals.localizedCapitalized)
     }
 
     func configureCollectPayment(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell, accessibilityId: "collect-payment")
+        prepareForReuse(cell, accessibilityID: "collect-payment")
         cell.configure(image: .moneyIcon, text: Localization.collectPayment.localizedCapitalized)
     }
 
     func configureToggleEnableCashOnDelivery(cell: LeftImageTitleSubtitleToggleTableViewCell) {
-        prepareForReuse(cell, accessibilityId: "pay-in-person")
+        prepareForReuse(cell, accessibilityID: "pay-in-person")
         cell.leftImageView?.tintColor = .text
         cell.accessoryType = .none
         cell.selectionStyle = .none
@@ -327,16 +327,16 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func configureSetUpTapToPayOnIPhone(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell, accessibilityId: "set-up-tap-to-pay")
+        prepareForReuse(cell, accessibilityID: "set-up-tap-to-pay")
         cell.configure(image: UIImage(systemName: "wave.3.right.circle") ?? .creditCardIcon,
                        text: Localization.tapToPayOnIPhone)
     }
 
-    private func prepareForReuse(_ cell: UITableViewCell, accessibilityId: String) {
+    private func prepareForReuse(_ cell: UITableViewCell, accessibilityID: String) {
         cell.imageView?.tintColor = .text
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.accessibilityIdentifier = accessibilityId
+        cell.accessibilityIdentifier = accessibilityID
         updateEnabledState(in: cell)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -279,7 +279,7 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func configureOrderCardReader(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell)
+        prepareForReuse(cell, accessibilityId: "order-card-reader")
         cell.configure(image: .shoppingCartIcon, text: Localization.orderCardReader.localizedCapitalized)
     }
 
@@ -287,30 +287,31 @@ private extension InPersonPaymentsMenuViewController {
         cell.imageView?.tintColor = .text
         cell.accessoryType = enableManageCardReaderCell ? .disclosureIndicator : .none
         cell.selectionStyle = enableManageCardReaderCell ? .default : .none
+        cell.accessibilityIdentifier = "manage-card-reader"
         cell.configure(image: .creditCardIcon, text: Localization.manageCardReader.localizedCapitalized)
 
         updateEnabledState(in: cell, shouldBeEnabled: enableManageCardReaderCell)
     }
 
     func configureManagePaymentGateways(cell: LeftImageTitleSubtitleTableViewCell) {
-        prepareForReuse(cell)
+        prepareForReuse(cell, accessibilityId: "manage-payment-gateways")
         cell.configure(image: .rectangleOnRectangleAngled,
                        text: Localization.managePaymentGateways.localizedCapitalized,
                        subtitle: pluginState?.preferred.pluginName ?? "")
     }
 
     func configureCardReaderManuals(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell)
+        prepareForReuse(cell, accessibilityId: "card-reader-manuals")
         cell.configure(image: .cardReaderManualIcon, text: Localization.cardReaderManuals.localizedCapitalized)
     }
 
     func configureCollectPayment(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell)
+        prepareForReuse(cell, accessibilityId: "collect-payment")
         cell.configure(image: .moneyIcon, text: Localization.collectPayment.localizedCapitalized)
     }
 
     func configureToggleEnableCashOnDelivery(cell: LeftImageTitleSubtitleToggleTableViewCell) {
-        prepareForReuse(cell)
+        prepareForReuse(cell, accessibilityId: "pay-in-person")
         cell.leftImageView?.tintColor = .text
         cell.accessoryType = .none
         cell.selectionStyle = .none
@@ -326,15 +327,16 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func configureSetUpTapToPayOnIPhone(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell)
+        prepareForReuse(cell, accessibilityId: "set-up-tap-to-pay")
         cell.configure(image: UIImage(systemName: "wave.3.right.circle") ?? .creditCardIcon,
                        text: Localization.tapToPayOnIPhone)
     }
 
-    private func prepareForReuse(_ cell: UITableViewCell) {
+    private func prepareForReuse(_ cell: UITableViewCell, accessibilityId: String) {
         cell.imageView?.tintColor = .text
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
+        cell.accessibilityIdentifier = accessibilityId
         updateEnabledState(in: cell)
     }
 


### PR DESCRIPTION
## Description
As preparation to expand our coverage of critical flows on the app, I'm adding `accessibilityIdentifiers` to each of the Payments menu item cells so that it would be easier to interact with them on the UI test level. There are currently labels but labels are localized so if we were to depend on them the tests might break should we decide to test in a language other than English.

The identifiers are added in `./InPersonPaymentsMenuViewController.swift` file, I think the changes look safe but let me know if there are side effects from this and/or other recommendations.

## Testing instructions
All tests should work as expected

## Screenshots
Before change:
<img width="1106" src="https://user-images.githubusercontent.com/17252150/226537043-8c9b3f17-7d34-44f7-a8a5-73b0bf8039fe.png">


After change:
<img width="1147" src="https://user-images.githubusercontent.com/17252150/226536554-88028da2-60bc-4683-91ff-1a9f581b8a28.png">
