### PR TITLE
[Free Trial] Fill subscription view with real site plan data

### DIFF
--- a/Networking/Networking/Remote/PaymentRemote.swift
+++ b/Networking/Networking/Remote/PaymentRemote.swift
@@ -64,7 +64,10 @@ public class PaymentRemote: Remote, PaymentRemoteProtocol {
         return .init(
             id: currentPlan.key,
             hasDomainCredit: currentPlan.value.hasDomainCredit ?? false,
-            expiryDate: currentPlan.value.expiryDate
+            expiryDate: currentPlan.value.expiryDate,
+            subscribedDate: currentPlan.value.subscribedDate,
+            name: currentPlan.value.name,
+            slug: currentPlan.value.slug
         )
     }
 
@@ -164,12 +167,30 @@ public struct WPComSitePlan: Equatable {
     ///
     public let expiryDate: Date?
 
+    /// Plan subscribe date. `Nil` if we are not subscribed to this plan.
+    ///
+    public let subscribedDate: Date?
+
+    /// Plan name
+    ///
+    public let name: String
+
+    /// Plan Slug
+    ///
+    public let slug: String
+
     public init(id: String = "",
                 hasDomainCredit: Bool,
-                expiryDate: Date? = nil) {
+                expiryDate: Date? = nil,
+                subscribedDate: Date? = nil,
+                name: String = "",
+                slug: String = "") {
         self.id = id
         self.hasDomainCredit = hasDomainCredit
         self.expiryDate = expiryDate
+        self.subscribedDate = subscribedDate
+        self.name = name
+        self.slug = slug
     }
 }
 
@@ -207,11 +228,17 @@ private struct SiteCurrentPlanResponse: Decodable {
     let isCurrentPlan: Bool?
     let hasDomainCredit: Bool?
     let expiryDate: Date?
+    let subscribedDate: Date?
+    let name: String
+    let slug: String
 
     private enum CodingKeys: String, CodingKey {
         case isCurrentPlan = "current_plan"
         case hasDomainCredit = "has_domain_credit"
         case expiryDate = "expiry"
+        case subscribedDate = "subscribed_date"
+        case name = "product_name"
+        case slug = "product_slug"
     }
 }
 

--- a/Networking/NetworkingTests/Remote/PaymentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/PaymentRemoteTests.swift
@@ -72,7 +72,10 @@ final class PaymentRemoteTests: XCTestCase {
         // Then
         XCTAssertEqual(plan, .init(id: "1008",
                                    hasDomainCredit: false,
-                                   expiryDate: DateFormatter.Defaults.iso8601.date(from: "2025-01-01T00:00:00+00:00")))
+                                   expiryDate: DateFormatter.Defaults.iso8601.date(from: "2025-01-01T00:00:00+00:00"),
+                                   subscribedDate: DateFormatter.Defaults.iso8601.date(from: "2019-04-29T04:32:29+00:00"),
+                                   name: "WordPress.com Business",
+                                   slug: "business-bundle"))
     }
 
     func test_loadSiteCurrentPlan_returns_noCurrentPlan_error_when_response_has_no_current_plan() async throws {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -76,6 +76,8 @@ struct HubMenu: View {
                                 showingCoupons = true
                             case HubMenuViewModel.InAppPurchases.id:
                                 showingIAPDebug = true
+                            case HubMenuViewModel.Upgrades.id:
+                                viewModel.presentUpgrades()
                             default:
                                 break
                             }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -123,6 +123,13 @@ final class HubMenuViewModel: ObservableObject {
         }
     }
 
+    /// Presents the `Upgrades` view from the view model's navigation controller property.
+    ///
+    func presentUpgrades() {
+        let upgradesViewController = UpgradesHostingController(siteID: siteID)
+        navigationController?.show(upgradesViewController, sender: self)
+    }
+
     func showReviewDetails(using parcel: ProductReviewFromNoteParcel) {
         productReviewFromNoteParcel = parcel
         showingReviewDetail = true

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
@@ -179,8 +179,9 @@ private extension UpgradesViewModel {
         }
 
         static func planInfo(planName: String, expirationDate: String) -> String {
-            let format = NSLocalizedString("You are a %1@ subscriber! You have access to all our features until %2@.",
-                                           comment: "Reads like: You are a eCommerce subscriber! You have access to all our features until Nov 28, 2023.")
+            let format = NSLocalizedString("You are subscribed to the %1@ plan! You have access to all our features until %2@.",
+                                           comment: "Reads like: You are subscribed to the eCommerce plan! " +
+                                                    "You have access to all our features until Nov 28, 2023.")
             return String.localizedStringWithFormat(format, planName, expirationDate)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// ViewModel for the Upgrades View
 ///
-final class UpgradesViewModel {
+final class UpgradesViewModel: ObservableObject {
 
     /// Dependency state.
     ///
@@ -51,7 +51,7 @@ final class UpgradesViewModel {
     ///
     private let analytics: Analytics
 
-    init(siteID: Int64, stores: StoresManager, analytics: Analytics) {
+    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores, analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.stores = stores
         self.analytics = analytics

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
@@ -93,8 +93,9 @@ private extension UpgradesViewModel {
     ///
     static func getPlanName(from plan: WPComSitePlan) -> String {
         // Handle the "Free trial" case specially.
+        let daysLeft = daysLeft(for: plan)
         if plan.isFreeTrial {
-            if daysLeft(for: plan) > 0 {
+            if daysLeft > 0 {
                 return Localization.freeTrial
             } else {
                 return Localization.trialEnded
@@ -104,7 +105,12 @@ private extension UpgradesViewModel {
         // For non-free trials plans  remove any mention to WPCom.
         let toRemove = "WordPress.com"
         let sanitizedName = plan.name.replacingOccurrences(of: toRemove, with: "").trimmingCharacters(in: .whitespacesAndNewlines)
-        return sanitizedName
+
+        if daysLeft > 0 {
+            return sanitizedName
+        } else {
+            return Localization.planEndedName(name: sanitizedName)
+        }
     }
 
     /// Returns a plan specific details information.
@@ -124,6 +130,10 @@ private extension UpgradesViewModel {
         let planName = getPlanName(from: plan)
         guard let expireDate = plan.expiryDate else {
             return ""
+        }
+
+        guard daysLeft > 0 else {
+            return Localization.planEndedInfo
         }
 
         let expireText = DateFormatter.mediumLengthLocalizedDateFormatter.string(from: expireDate)
@@ -170,6 +180,14 @@ private extension UpgradesViewModel {
         static let trialEnded = NSLocalizedString("Trial ended", comment: "Plan name for an expired free trial")
         static let trialEndedInfo = NSLocalizedString("Your free trial has ended and you have limited access to all the features. Subscribe to eCommerce now.",
                                                       comment: "Info details for an expired free trial")
+        static let planEndedInfo = NSLocalizedString("Your subscription has ended and you have limited access to all the features.",
+                                                     comment: "Info details for an expired free trial")
+
+        static func planEndedName(name: String) -> String {
+            let format = NSLocalizedString("%@ ended", comment: "Reads like: eCommerce ended")
+            return String.localizedStringWithFormat(format, name)
+        }
+
         static func freeTrialPlanInfo(planDuration: Int, daysLeft: Int) -> String {
             let format = NSLocalizedString("You are in the %1$d-day free trial. The free trial will end in %2$d days. " +
                                            "Upgrade to unlock new features and keep your store running.",

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
@@ -95,9 +95,9 @@ private extension UpgradesViewModel {
         // Handle the "Free trial" case specially.
         if plan.isFreeTrial {
             if daysLeft(for: plan) > 0 {
-                return "Free Trial"
+                return Localization.freeTrial
             } else {
-                return "Trial ended"
+                return Localization.trialEnded
             }
         }
 
@@ -115,20 +115,19 @@ private extension UpgradesViewModel {
 
         if plan.isFreeTrial {
             if daysLeft > 0 {
-                return "You are in the \(planDuration)-day free trial. The free trial will end in \(daysLeft) days. " +
-                "Upgrade to unlock new features and keep your store running."
+                return Localization.freeTrialPlanInfo(planDuration: planDuration, daysLeft: daysLeft)
             } else {
-                return "Your free trial has ended and have limited access to all the features. Subscribe to eCommerce now."
+                return Localization.trialEndedInfo
             }
         }
 
         let planName = getPlanName(from: plan)
         guard let expireDate = plan.expiryDate else {
-            return "You are a \(planName) subscriber!"
+            return ""
         }
 
         let expireText = DateFormatter.mediumLengthLocalizedDateFormatter.string(from: expireDate)
-        return "You are a \(planName) subscriber! You have access to all our features until \(expireText)."
+        return Localization.planInfo(planName: planName, expirationDate: expireText)
     }
 
     /// Only allow to upgrade the plan if we are on a free trial.
@@ -161,5 +160,28 @@ private extension UpgradesViewModel {
 
         let daysLeft = Calendar.current.dateComponents([.day], from: today, to: expiryDate).day ?? 0
         return daysLeft
+    }
+}
+
+// MARK: Definitions
+private extension UpgradesViewModel {
+    enum Localization {
+        static let freeTrial = NSLocalizedString("Free Trial", comment: "Plan name for an active free trial")
+        static let trialEnded = NSLocalizedString("Trial ended", comment: "Plan name for an expired free trial")
+        static let trialEndedInfo = NSLocalizedString("Your free trial has ended and have limited access to all the features. Subscribe to eCommerce now.",
+                                                      comment: "Info details for an expired free trial")
+        static func freeTrialPlanInfo(planDuration: Int, daysLeft: Int) -> String {
+            let format = NSLocalizedString("You are in the %1d-day free trial. The free trial will end in %2d days. " +
+                                           "Upgrade to unlock new features and keep your store running.",
+                                           comment: "Reads like: You are in the 14-day free trial. The free trial will end in 5 days. " +
+                                           "Upgrade to unlock new features and keep your store running.")
+            return String.localizedStringWithFormat(format, planDuration, daysLeft)
+        }
+
+        static func planInfo(planName: String, expirationDate: String) -> String {
+            let format = NSLocalizedString("You are a %1@ subscriber! You have access to all our features until %2@.",
+                                           comment: "Reads like: You are a eCommerce subscriber! You have access to all our features until Nov 28, 2023.")
+            return String.localizedStringWithFormat(format, planName, expirationDate)
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Yosemite
+
+/// ViewModel for the Upgrades View
+///
+final class UpgradesViewModel {
+
+    /// Dependency state.
+    ///
+    enum PlanState: Equatable {
+        case notLoaded
+        case loading
+        case loaded(WPComSitePlan)
+    }
+
+    /// Indicates if the view should should a redacted state.
+    ///
+    var showLoadingIndicator: Bool {
+        planState == .loading
+    }
+
+    /// Current store plan.
+    ///
+    private(set) var planName = ""
+
+    /// Current store plan details information.
+    ///
+    private(set) var planInfo = ""
+
+    /// Defines if the view should show the "Upgrade Now" button.
+    ///
+    private(set) var shouldShowUpgradeButton = false
+
+    /// Defines if the view should show the "Cancel Free Trial"  button.
+    ///
+    private(set) var shouldShowCancelTrialButton = false
+
+    /// Current dependency state.
+    ///
+    private var planState = PlanState.notLoaded
+
+    /// Current site id.
+    ///
+    private let siteID: Int64
+
+    /// Stores manager.
+    ///
+    private let stores: StoresManager
+
+    /// Analytics provider.
+    ///
+    private let analytics: Analytics
+
+    init(siteID: Int64, stores: StoresManager, analytics: Analytics) {
+        self.siteID = siteID
+        self.stores = stores
+        self.analytics = analytics
+    }
+
+    /// Loads the plan from network if needed.
+    ///
+    func loadPlan() {
+        guard planState == .notLoaded else { return }
+
+        planState = .loading
+        let action = PaymentAction.loadSiteCurrentPlan(siteID: siteID) { [weak self] result in
+            guard let self else { return }
+
+            switch result {
+            case .success(let plan):
+                self.planState = .loaded(plan)
+                self.updateViewProperties(from: plan)
+            case .failure(let error):
+                self.planState = .notLoaded
+                DDLogError("⛔️ Unable to fetch site's plan: \(error)")
+                // TODO: Abort flow and inform user
+            }
+        }
+    }
+}
+
+// MARK: Helpers
+private extension UpgradesViewModel {
+    func updateViewProperties(from plan: WPComSitePlan) {
+        planName = Self.getPlanName(from: plan)
+        planInfo = Self.getPlanInfo(from: plan)
+        shouldShowUpgradeButton = Self.getUpgradeNowButtonVisibility(from: plan)
+    }
+
+    /// Removes any occurrences of `WordPress.com` from the site's name.
+    /// Free Trial's have an special handling!
+    ///
+    static func getPlanName(from plan: WPComSitePlan) -> String {
+        // Handle the "Free trial" case specially.
+        if plan.isFreeTrial {
+            if daysLeft(for: plan) > 0 {
+                return "Free Trial"
+            } else {
+                return "Trial ended"
+            }
+        }
+
+        // For non-free trials plans  remove any mention to WPCom.
+        let toRemove = "WordPress.com"
+        let sanitizedName = plan.name.replacingOccurrences(of: toRemove, with: "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return sanitizedName
+    }
+
+    /// Returns a plan specific details information.
+    ///
+    static func getPlanInfo(from plan: WPComSitePlan) -> String {
+        let daysLeft = daysLeft(for: plan)
+        let planDuration = planDurationInDays(for: plan)
+
+        if plan.isFreeTrial {
+            if daysLeft > 0 {
+                return "You are in the \(planDuration)-day free trial. The free trial will end in \(daysLeft) days. " +
+                "Upgrade to unlock new features and keep your store running."
+            } else {
+                return "You free trial has ended and have limited access to all the features. Subscribe to Commerce now."
+            }
+        }
+
+        guard let expireDate = plan.expiryDate else {
+            return "You are a \(plan.name) subscriber!"
+        }
+
+        let expireText = DateFormatter.mediumLengthLocalizedDateFormatter.string(from: expireDate)
+        return "You are a \(plan.name) subscriber! You have access to all our features until \(expireText)."
+    }
+
+    /// Only allow to upgrade the plan if we are on a free trial.
+    ///
+    static func getUpgradeNowButtonVisibility(from plan: WPComSitePlan) -> Bool {
+        plan.isFreeTrial
+    }
+
+    /// Returns a site plan duration in days.
+    ///
+    static func planDurationInDays(for plan: WPComSitePlan) -> Int {
+        // Normalize dates in the same timezone.
+        guard let subscribedDate = plan.subscribedDate?.startOfDay(timezone: .current),
+              let expiryDate = plan.expiryDate?.startOfDay(timezone: .current) else {
+            return 0
+        }
+
+        let duration = Calendar.current.dateComponents([.day], from: subscribedDate, to: expiryDate).day ?? 0
+        return duration
+    }
+
+    /// Returns how many days site  plan has left.
+    ///
+    static func daysLeft(for plan: WPComSitePlan) -> Int {
+        // Normalize dates in the same timezone.
+        let today = Date().startOfDay(timezone: .current)
+        guard let expiryDate = plan.expiryDate?.startOfDay(timezone: .current) else {
+            return 0
+        }
+
+        let daysLeft = Calendar.current.dateComponents([.day], from: today, to: expiryDate).day ?? 0
+        return daysLeft
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
@@ -168,7 +168,7 @@ private extension UpgradesViewModel {
     enum Localization {
         static let freeTrial = NSLocalizedString("Free Trial", comment: "Plan name for an active free trial")
         static let trialEnded = NSLocalizedString("Trial ended", comment: "Plan name for an expired free trial")
-        static let trialEndedInfo = NSLocalizedString("Your free trial has ended and have limited access to all the features. Subscribe to eCommerce now.",
+        static let trialEndedInfo = NSLocalizedString("Your free trial has ended and you have limited access to all the features. Subscribe to eCommerce now.",
                                                       comment: "Info details for an expired free trial")
         static func freeTrialPlanInfo(planDuration: Int, daysLeft: Int) -> String {
             let format = NSLocalizedString("You are in the %1d-day free trial. The free trial will end in %2d days. " +

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
@@ -37,7 +37,7 @@ final class UpgradesViewModel: ObservableObject {
 
     /// Current dependency state.
     ///
-    private var planState = PlanState.notLoaded
+    @Published private var planState = PlanState.notLoaded
 
     /// Current site id.
     ///
@@ -76,6 +76,7 @@ final class UpgradesViewModel: ObservableObject {
                 // TODO: Abort flow and inform user
             }
         }
+        stores.dispatch(action)
     }
 }
 
@@ -117,16 +118,17 @@ private extension UpgradesViewModel {
                 return "You are in the \(planDuration)-day free trial. The free trial will end in \(daysLeft) days. " +
                 "Upgrade to unlock new features and keep your store running."
             } else {
-                return "You free trial has ended and have limited access to all the features. Subscribe to Commerce now."
+                return "Your free trial has ended and have limited access to all the features. Subscribe to eCommerce now."
             }
         }
 
+        let planName = getPlanName(from: plan)
         guard let expireDate = plan.expiryDate else {
-            return "You are a \(plan.name) subscriber!"
+            return "You are a \(planName) subscriber!"
         }
 
         let expireText = DateFormatter.mediumLengthLocalizedDateFormatter.string(from: expireDate)
-        return "You are a \(plan.name) subscriber! You have access to all our features until \(expireText)."
+        return "You are a \(planName) subscriber! You have access to all our features until \(expireText)."
     }
 
     /// Only allow to upgrade the plan if we are on a free trial.

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
@@ -171,7 +171,7 @@ private extension UpgradesViewModel {
         static let trialEndedInfo = NSLocalizedString("Your free trial has ended and you have limited access to all the features. Subscribe to eCommerce now.",
                                                       comment: "Info details for an expired free trial")
         static func freeTrialPlanInfo(planDuration: Int, daysLeft: Int) -> String {
-            let format = NSLocalizedString("You are in the %1d-day free trial. The free trial will end in %2d days. " +
+            let format = NSLocalizedString("You are in the %1$d-day free trial. The free trial will end in %2$d days. " +
                                            "Upgrade to unlock new features and keep your store running.",
                                            comment: "Reads like: You are in the 14-day free trial. The free trial will end in 5 days. " +
                                            "Upgrade to unlock new features and keep your store running.")

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -635,6 +635,7 @@
 		261AA30C2753119E009530FE /* PaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30B2753119E009530FE /* PaymentMethodsViewModel.swift */; };
 		261AA30E275506DE009530FE /* PaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30D275506DE009530FE /* PaymentMethodsViewModelTests.swift */; };
 		261B526E29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */; };
+		261E91A029C961EE00A5C118 /* UpgradesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261E919F29C961EE00A5C118 /* UpgradesViewModel.swift */; };
 		261F1A7929C2AB2E001D9861 /* FreeTrialBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */; };
 		261F1A7C29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */; };
 		26281776278F0B0100C836D3 /* View+NoticesModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26281775278F0B0100C836D3 /* View+NoticesModifier.swift */; };
@@ -2813,6 +2814,7 @@
 		261AA30B2753119E009530FE /* PaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsViewModel.swift; sourceTree = "<group>"; };
 		261AA30D275506DE009530FE /* PaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
 		261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportFormMetadataProvider.swift; sourceTree = "<group>"; };
+		261E919F29C961EE00A5C118 /* UpgradesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModel.swift; sourceTree = "<group>"; };
 		261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModel.swift; sourceTree = "<group>"; };
 		261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModelTests.swift; sourceTree = "<group>"; };
 		26281775278F0B0100C836D3 /* View+NoticesModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+NoticesModifier.swift"; sourceTree = "<group>"; };
@@ -5850,6 +5852,7 @@
 			isa = PBXGroup;
 			children = (
 				264957A229C520860095AA4C /* UpgradesView.swift */,
+				261E919F29C961EE00A5C118 /* UpgradesViewModel.swift */,
 			);
 			name = Upgrades;
 			path = Classes/ViewRelated/Upgrades;
@@ -11496,6 +11499,7 @@
 				CE16177A21B7192A00B82A47 /* AuthenticationConstants.swift in Sources */,
 				26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */,
 				DE971219290A9615000C0BD3 /* AddStoreFooterView.swift in Sources */,
+				261E91A029C961EE00A5C118 /* UpgradesViewModel.swift in Sources */,
 				4574745D24EA84D800CF49BC /* ProductTypeBottomSheetListSelectorCommand.swift in Sources */,
 				26578C4126277AFF00A15097 /* OrderAddOnsListViewController.swift in Sources */,
 				02F67FEE25805F9C00C3BAD2 /* ShippingLabelTrackingURLGenerator.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -636,6 +636,7 @@
 		261AA30E275506DE009530FE /* PaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30D275506DE009530FE /* PaymentMethodsViewModelTests.swift */; };
 		261B526E29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */; };
 		261E91A029C961EE00A5C118 /* UpgradesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261E919F29C961EE00A5C118 /* UpgradesViewModel.swift */; };
+		261E91A329C9882600A5C118 /* UpgradesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261E91A229C9882600A5C118 /* UpgradesViewModelTests.swift */; };
 		261F1A7929C2AB2E001D9861 /* FreeTrialBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */; };
 		261F1A7C29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */; };
 		26281776278F0B0100C836D3 /* View+NoticesModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26281775278F0B0100C836D3 /* View+NoticesModifier.swift */; };
@@ -2815,6 +2816,7 @@
 		261AA30D275506DE009530FE /* PaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
 		261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportFormMetadataProvider.swift; sourceTree = "<group>"; };
 		261E919F29C961EE00A5C118 /* UpgradesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModel.swift; sourceTree = "<group>"; };
+		261E91A229C9882600A5C118 /* UpgradesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModelTests.swift; sourceTree = "<group>"; };
 		261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModel.swift; sourceTree = "<group>"; };
 		261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModelTests.swift; sourceTree = "<group>"; };
 		26281775278F0B0100C836D3 /* View+NoticesModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+NoticesModifier.swift"; sourceTree = "<group>"; };
@@ -5762,6 +5764,14 @@
 			);
 			name = "Add Attributes";
 			path = "Variations/Add Attributes";
+			sourceTree = "<group>";
+		};
+		261E91A129C9880C00A5C118 /* Upgrades */ = {
+			isa = PBXGroup;
+			children = (
+				261E91A229C9882600A5C118 /* UpgradesViewModelTests.swift */,
+			);
+			path = Upgrades;
 			sourceTree = "<group>";
 		};
 		261F1A7A29C2B081001D9861 /* Free Trial */ = {
@@ -9154,6 +9164,7 @@
 				2614EB1A24EB60DB00968D4B /* TopBanner */,
 				2619FA2A25C897720006DAFF /* Add Attributes */,
 				454453C62755170100464AC5 /* HubMenu */,
+				261E91A129C9880C00A5C118 /* Upgrades */,
 				D85B8335222FCDA1002168F3 /* StatusListTableViewCellTests.swift */,
 				D816DDBB22265DA300903E59 /* OrderTrackingTableViewCellTests.swift */,
 				45C8B25A231521510002FA77 /* CustomerNoteTableViewCellTests.swift */,
@@ -12318,6 +12329,7 @@
 				6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */,
 				025A1248247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift in Sources */,
 				BAFEF51E273C2151005F94CC /* SettingsViewModelTests.swift in Sources */,
+				261E91A329C9882600A5C118 /* UpgradesViewModelTests.swift in Sources */,
 				6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */,
 				4596854B254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift in Sources */,
 				26B9875F273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class UpgradesViewModelTests: XCTestCase {
+
+    let sampleSiteID: Int64 = 123
+    let freeTrialID = "1052"
+
+    func test_active_free_trial_plan_has_correct_view_model_values() {
+        // Given
+        let expireDate = Date().addingDays(14)
+        let plan = WPComSitePlan(id: freeTrialID,
+                                 hasDomainCredit: false,
+                                 expiryDate: expireDate)
+
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: PaymentAction.self) { action in
+            switch action {
+            case .loadSiteCurrentPlan(_, let completion):
+                completion(.success(plan))
+            default:
+                break
+            }
+        }
+        let viewModel = UpgradesViewModel(siteID: sampleSiteID, stores: stores)
+
+        // When
+        viewModel.loadPlan()
+
+        // Then
+        XCTAssertEqual(viewModel.planName, NSLocalizedString("Free Trial", comment: ""))
+        XCTAssertTrue(viewModel.planInfo.isNotEmpty)
+        XCTAssertTrue(viewModel.shouldShowUpgradeButton)
+        XCTAssertFalse(viewModel.shouldShowCancelTrialButton)
+    }
+
+    func test_expired_free_trial_plan_has_correct_view_model_values() {
+        // Given
+        let expireDate = Date().addingDays(-3)
+        let plan = WPComSitePlan(id: freeTrialID,
+                                 hasDomainCredit: false,
+                                 expiryDate: expireDate)
+
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: PaymentAction.self) { action in
+            switch action {
+            case .loadSiteCurrentPlan(_, let completion):
+                completion(.success(plan))
+            default:
+                break
+            }
+        }
+        let viewModel = UpgradesViewModel(siteID: sampleSiteID, stores: stores)
+
+        // When
+        viewModel.loadPlan()
+
+        // Then
+        XCTAssertEqual(viewModel.planName, NSLocalizedString("Trial ended", comment: ""))
+        XCTAssertTrue(viewModel.planInfo.isNotEmpty)
+        XCTAssertTrue(viewModel.shouldShowUpgradeButton)
+        XCTAssertFalse(viewModel.shouldShowCancelTrialButton)
+    }
+
+    func test_active_regular_plan_has_correct_view_model_values() {
+        // Given
+        let expireDate = Date().addingDays(300)
+        let plan = WPComSitePlan(id: "another-id",
+                                 hasDomainCredit: false,
+                                 expiryDate: expireDate,
+                                 name: "WordPress.com eCommerce")
+
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: PaymentAction.self) { action in
+            switch action {
+            case .loadSiteCurrentPlan(_, let completion):
+                completion(.success(plan))
+            default:
+                break
+            }
+        }
+        let viewModel = UpgradesViewModel(siteID: sampleSiteID, stores: stores)
+
+        // When
+        viewModel.loadPlan()
+
+        // Then
+        XCTAssertEqual(viewModel.planName, NSLocalizedString("eCommerce", comment: ""))
+        XCTAssertTrue(viewModel.planInfo.isNotEmpty)
+        XCTAssertFalse(viewModel.shouldShowUpgradeButton)
+        XCTAssertFalse(viewModel.shouldShowCancelTrialButton)
+    }
+}


### PR DESCRIPTION
closes #9133
part of #9061

# Why

This PR adds a `ViewModel` to the `UpgradesView`.

**Things that the PR adds**

- Fetched plan name, plan slug and subscribed date from the remote entity.
- Navigates from menu to upgrades view
- Fetch sites plan 
- Handle active free trials, expired free trials, active regular plans

**Things that the PR does not handles yet**
- Loading errors
- Expired regular plans.
- Upgrade now functionality
- Report functionality 

# Screenshots

Active Free Trial | Expired Free Trial | Active Regular Plan
--- | --- | ---
<img width="441" alt="active-free-trial" src="https://user-images.githubusercontent.com/562080/226537951-cd22e16e-7e49-4939-8641-c6d648798701.png"> | <img width="438" alt="expired-free-trial" src="https://user-images.githubusercontent.com/562080/226537954-397712ea-30cc-4816-a66c-c5aa96d5c1cf.png"> | <img width="441" alt="active-plan" src="https://user-images.githubusercontent.com/562080/226537957-1f234201-be26-4dbe-a3fa-8d098143945b.png">


# Testing Steps

**On an Active Free trial**
- Navigate to the upgrades view
- See that the plan name is "Free Trial"
- See that the is a correct "days left" info text.
- See that there is an "Upgrade Now" button.

---

**On an Expired Free trial**
- Navigate to the upgrades view
- See that the plan name is "Trial ended"
- See that the is a correct "expired" info text.
- See that there is an "Upgrade Now" button.

--- 


**On an Active Regular trial**
- Navigate to the upgrades view
- See that the plan name is "eCommerce"
- See that the is a correct "expiration" info text.
- See that there is **not** an "Upgrade Now" button.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
