### PR TITLE
Shipping Labels: Require phone number for origin address

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -97,14 +97,16 @@ final class ShippingLabelAddressFormViewController: UIViewController {
          address: ShippingLabelAddress?,
          email: String?,
          phoneNumberRequired: Bool = false,
+         needsPhoneNumberValidation: Bool = false,
          validationError: ShippingLabelAddressValidationError?,
          countries: [Country],
-         completion: @escaping Completion ) {
+         completion: @escaping Completion) {
         viewModel = ShippingLabelAddressFormViewModel(siteID: siteID,
                                                       type: type,
                                                       address: address,
                                                       email: email,
                                                       phoneNumberRequired: phoneNumberRequired,
+                                                      needsPhoneNumberValidation: needsPhoneNumberValidation,
                                                       validationError: validationError,
                                                       countries: countries)
         onCompletion = completion

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -611,9 +611,8 @@ private extension ShippingLabelAddressFormViewController {
                                                     comment: "Error showed in Shipping Label Address Validation for the state field")
         static let missingCountry = NSLocalizedString("Country missing",
                                                       comment: "Error showed in Shipping Label Address Validation for the country field")
-        static let missingPhoneNumber = NSLocalizedString("A phone number is required because this shipment requires a customs form",
-                                                          comment: "Error shown in Shipping Label Origin Address validation for " +
-                                                          "phone number field for international shipment")
+        static let missingPhoneNumber = NSLocalizedString("A phone number is required",
+                                                          comment: "Error shown in Shipping Label Origin Address validation for phone number field")
         static let invalidPhoneNumber = NSLocalizedString("Custom forms require a 10-digit phone number",
                                                           comment: "Error shown in Shipping Label Origin Address validation for " +
                                                             "phone number when the it doesn't have expected length for international shipment.")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -18,10 +18,12 @@ final class ShippingLabelAddressFormViewModel {
 
     let siteID: Int64
     let type: ShipType
+    let phoneNumberRequired: Bool
+    let needsPhoneNumberValidation: Bool
+
     private(set) var address: ShippingLabelAddress?
     private(set) var addressValidationError: ShippingLabelAddressValidationError?
     private(set) var addressValidated: Validation = .none
-    private(set) var phoneNumberRequired: Bool
     private(set) var email: String?
 
     private let stores: StoresManager
@@ -86,6 +88,7 @@ final class ShippingLabelAddressFormViewModel {
         address: ShippingLabelAddress?,
         email: String?,
         phoneNumberRequired: Bool = false,
+        needsPhoneNumberValidation: Bool = false,
         stores: StoresManager = ServiceLocator.stores,
         validationError: ShippingLabelAddressValidationError?,
         countries: [Country]
@@ -95,6 +98,7 @@ final class ShippingLabelAddressFormViewModel {
         self.address = address
         self.email = email
         self.phoneNumberRequired = phoneNumberRequired
+        self.needsPhoneNumberValidation = needsPhoneNumberValidation
         self.stores = stores
         if let validationError = validationError {
             addressValidationError = validationError
@@ -244,7 +248,7 @@ extension ShippingLabelAddressFormViewModel {
         if phoneNumberRequired {
             if addressToBeValidated.phone.isEmpty {
                 return .missingPhoneNumber
-            } else if !isPhoneNumberValid {
+            } else if needsPhoneNumberValidation, !isPhoneNumberValid {
                 return .invalidPhoneNumber
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -219,9 +219,8 @@ private extension ShippingLabelFormViewController {
             ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "origin_address_started"])
 
             // Skip remote validation and navigate to edit address
-            // if customs form is required and phone number is not found.
-            if self.viewModel.customsFormRequired,
-               let originAddress = self.viewModel.originAddress,
+            // if phone number is not found.
+            if let originAddress = self.viewModel.originAddress,
                originAddress.phone.isEmpty {
                 return self.displayEditAddressFormVC(address: originAddress, email: nil, validationError: nil, type: .origin)
             }
@@ -392,7 +391,7 @@ private extension ShippingLabelFormViewController {
             ServiceLocator.noticePresenter.enqueue(notice: notice)
             return
         }
-        let isPhoneNumberRequired = viewModel.customsFormRequired
+        let isPhoneNumberRequired = viewModel.customsFormRequired || type == .origin
         let shippingAddressVC = ShippingLabelAddressFormViewController(
             siteID: viewModel.siteID,
             type: type,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -398,6 +398,7 @@ private extension ShippingLabelFormViewController {
             address: address,
             email: email,
             phoneNumberRequired: isPhoneNumberRequired,
+            needsPhoneNumberValidation: viewModel.customsFormRequired,
             validationError: validationError,
             countries: viewModel.filteredCountries(for: type),
             completion: { [weak self] (newShippingLabelAddress) in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
@@ -272,7 +272,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.sections, [ShippingLabelAddressFormViewModel.Section(rows: expectedRows)])
     }
 
-    func test_sections_are_returned_correctly_if_phone_is_required_and_invalid() {
+    func test_sections_are_returned_correctly_if_phone_is_required_and_invalid_and_validation_is_required() {
         // Given
         let shippingAddress = MockShippingLabelAddress.sampleAddress(phone: "0123", country: "US")
         let stores = MockStoresManager(sessionManager: .testingInstance)
@@ -293,6 +293,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
                                                           address: shippingAddress,
                                                           email: nil,
                                                           phoneNumberRequired: true,
+                                                          needsPhoneNumberValidation: true,
                                                           stores: stores,
                                                           validationError: nil,
                                                           countries: [])
@@ -304,6 +305,50 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
                                                                      .company,
                                                                      .phone,
                                                                      .fieldError(.invalidPhoneNumber),
+                                                                     .address,
+                                                                     .fieldError(.address),
+                                                                     .address2,
+                                                                     .city,
+                                                                     .fieldError(.city),
+                                                                     .postcode,
+                                                                     .fieldError(.postcode),
+                                                                     .state,
+                                                                     .country]
+        XCTAssertEqual(viewModel.sections, [ShippingLabelAddressFormViewModel.Section(rows: expectedRows)])
+    }
+
+    func test_sections_are_returned_correctly_if_phone_is_required_and_invalid_and_validation_is_not_required() {
+        // Given
+        let shippingAddress = MockShippingLabelAddress.sampleAddress(phone: "0123", country: "US")
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let validationError = ShippingLabelAddressValidationError(addressError: "Error", generalError: nil)
+
+        // When
+        stores.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
+            switch action {
+            case let .validateAddress(_, _, onCompletion):
+                onCompletion(.failure(validationError))
+            default:
+                break
+            }
+        }
+
+        let viewModel = ShippingLabelAddressFormViewModel(siteID: 10,
+                                                          type: .origin,
+                                                          address: shippingAddress,
+                                                          email: nil,
+                                                          phoneNumberRequired: true,
+                                                          needsPhoneNumberValidation: false,
+                                                          stores: stores,
+                                                          validationError: nil,
+                                                          countries: [])
+        viewModel.validateAddress(onlyLocally: false) { _ in }
+
+        // Then
+        let expectedRows: [ShippingLabelAddressFormViewModel.Row] = [.name,
+                                                                     .fieldError(.name),
+                                                                     .company,
+                                                                     .phone,
                                                                      .address,
                                                                      .fieldError(.address),
                                                                      .address2,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9199 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the requirement for phone number on the original address of shipping labels. Now that phone number is required, tapping on the "Continue" button should always navigate to the address form with an inline error for the phone field if the phone number is empty.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Make sure to set up your test store to create shipping labels in test mode.
- Build the app and log in to your store if needed.
- Navigate to the Orders tab and select the order that is eligible for creating shipping labels.
- Tap the Create Shipping Label button on the order detail screen.
- Tap Continue on the origin address row. Notice that the app navigates to the address form with an inline error for a required phone number.
- Enter a number and continue to create the label. The label should be created successfully.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/226587730-2b470aeb-314a-468f-b2f2-b40b7817a699.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
