### PR TITLE
[Store onboarding] Reload task list using `UIAdaptivePresentationControllerDelegate`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -664,6 +664,7 @@ private extension DashboardViewController {
         let hostingController = StoreOnboardingViewHostingController(viewModel: viewModel.storeOnboardingViewModel,
                                                                      navigationController: navigationController,
                                                                      site: site,
+                                                                     presentationControllerDelegate: self,
                                                                      shareFeedbackAction: { [weak self] in
             // Present survey
             let navigationController = SurveyCoordinatingController(survey: .storeSetup)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -664,7 +664,7 @@ private extension DashboardViewController {
         let hostingController = StoreOnboardingViewHostingController(viewModel: viewModel.storeOnboardingViewModel,
                                                                      navigationController: navigationController,
                                                                      site: site,
-                                                                     presentationControllerDelegate: self,
+                                                                     collapsedModePresentationControllerDelegate: self,
                                                                      shareFeedbackAction: { [weak self] in
             // Present survey
             let navigationController = SurveyCoordinatingController(survey: .storeSetup)
@@ -695,7 +695,7 @@ extension DashboardViewController: UIAdaptivePresentationControllerDelegate {
 
         if let onboardingNavigationController = presentationController.presentedViewController as? UINavigationController,
            let vc = onboardingNavigationController.viewControllers.first,
-           isPresentedByStoreOnboardingTaskList(vc) {
+           vc is StoreOnboardingViewHostingController || StoreOnboardingCoordinator.isRelatedToOnboardingTask(vc) {
             Task { @MainActor in
                 await viewModel.reloadStoreOnboardingTasks()
             }
@@ -809,12 +809,6 @@ private extension DashboardViewController {
 // MARK: - Private Helpers
 //
 private extension DashboardViewController {
-    func isPresentedByStoreOnboardingTaskList(_ vc: UIViewController) -> Bool {
-        vc is StoreOnboardingViewHostingController ||
-        vc is DomainSettingsHostingController || vc is StoreOnboardingLaunchStoreHostingController ||
-        vc is StoreOnboardingStoreLaunchedHostingController || vc is StoreOnboardingPaymentsSetupHostingController
-    }
-
     @MainActor
     func reloadData(forced: Bool) async {
         DDLogInfo("♻️ Requesting dashboard data be reloaded...")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -692,6 +692,14 @@ extension DashboardViewController: UIAdaptivePresentationControllerDelegate {
                 await viewModel.syncAnnouncements(for: siteID)
             }
         }
+
+        if let onboardingNavigationController = presentationController.presentedViewController as? UINavigationController,
+           let vc = onboardingNavigationController.viewControllers.first,
+           isPresentedByStoreOnboardingTaskList(vc) {
+            Task { @MainActor in
+                await viewModel.reloadStoreOnboardingTasks()
+            }
+        }
     }
 }
 
@@ -801,6 +809,12 @@ private extension DashboardViewController {
 // MARK: - Private Helpers
 //
 private extension DashboardViewController {
+    func isPresentedByStoreOnboardingTaskList(_ vc: UIViewController) -> Bool {
+        vc is StoreOnboardingViewHostingController ||
+        vc is DomainSettingsHostingController || vc is StoreOnboardingLaunchStoreHostingController ||
+        vc is StoreOnboardingStoreLaunchedHostingController || vc is StoreOnboardingPaymentsSetupHostingController
+    }
+
     @MainActor
     func reloadData(forced: Bool) async {
         DDLogInfo("♻️ Requesting dashboard data be reloaded...")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -56,6 +56,16 @@ final class StoreOnboardingCoordinator: Coordinator {
             assertionFailure("Unexpected onboarding task: \(task)")
         }
     }
+
+    /// Determines whether a VC is related to a onboarding task
+    /// This check is run to reload the onboarding task list screen upon dismissing the the `vc`
+    ///
+    /// - Parameter vc: view controller to check
+    /// - Returns: true is the view controller type is related to a onboarding task
+    static func isRelatedToOnboardingTask(_ vc: UIViewController) -> Bool {
+        vc is DomainSettingsHostingController || vc is StoreOnboardingLaunchStoreHostingController ||
+        vc is StoreOnboardingStoreLaunchedHostingController || vc is StoreOnboardingPaymentsSetupHostingController
+    }
 }
 
 private extension StoreOnboardingCoordinator {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -14,10 +14,14 @@ final class StoreOnboardingCoordinator: Coordinator {
     private var paymentsSetupCoordinator: StoreOnboardingPaymentsSetupCoordinator?
 
     private let site: Site
+    private weak var presentationControllerDelegate: UIAdaptivePresentationControllerDelegate?
 
-    init(navigationController: UINavigationController, site: Site) {
+    init(navigationController: UINavigationController,
+         site: Site,
+         presentationControllerDelegate: UIAdaptivePresentationControllerDelegate? = nil) {
         self.navigationController = navigationController
         self.site = site
+        self.presentationControllerDelegate = presentationControllerDelegate
     }
 
     /// Navigates to the fullscreen store onboarding view.
@@ -29,6 +33,7 @@ final class StoreOnboardingCoordinator: Coordinator {
                                                                             navigationController: onboardingNavigationController,
                                                                             site: site)
         onboardingNavigationController.pushViewController(onboardingViewController, animated: false)
+        onboardingNavigationController.presentationController?.delegate = presentationControllerDelegate
         navigationController.present(onboardingNavigationController, animated: true)
     }
 
@@ -66,28 +71,40 @@ private extension StoreOnboardingCoordinator {
 
     @MainActor
     func showCustomDomains() {
-        let coordinator = DomainSettingsCoordinator(source: .dashboardOnboarding, site: site, navigationController: navigationController)
+        let coordinator = DomainSettingsCoordinator(source: .dashboardOnboarding,
+                                                    site: site,
+                                                    navigationController: navigationController,
+                                                    presentationControllerDelegate: presentationControllerDelegate)
         self.domainSettingsCoordinator = coordinator
         coordinator.start()
     }
 
     @MainActor
     func launchStore(task: StoreOnboardingTask) {
-        let coordinator = StoreOnboardingLaunchStoreCoordinator(site: site, isLaunched: task.isComplete, navigationController: navigationController)
+        let coordinator = StoreOnboardingLaunchStoreCoordinator(site: site,
+                                                                isLaunched: task.isComplete,
+                                                                navigationController: navigationController,
+                                                                presentationControllerDelegate: presentationControllerDelegate)
         self.launchStoreCoordinator = coordinator
         coordinator.start()
     }
 
     @MainActor
     func showWCPaySetup() {
-        let coordinator = StoreOnboardingPaymentsSetupCoordinator(task: .wcPay, site: site, navigationController: navigationController)
+        let coordinator = StoreOnboardingPaymentsSetupCoordinator(task: .wcPay,
+                                                                  site: site,
+                                                                  navigationController: navigationController,
+                                                                  presentationControllerDelegate: presentationControllerDelegate)
         self.paymentsSetupCoordinator = coordinator
         coordinator.start()
     }
 
     @MainActor
     func showPaymentsSetup() {
-        let coordinator = StoreOnboardingPaymentsSetupCoordinator(task: .payments, site: site, navigationController: navigationController)
+        let coordinator = StoreOnboardingPaymentsSetupCoordinator(task: .payments,
+                                                                  site: site,
+                                                                  navigationController: navigationController,
+                                                                  presentationControllerDelegate: presentationControllerDelegate)
         self.paymentsSetupCoordinator = coordinator
         coordinator.start()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreCoordinator.swift
@@ -7,15 +7,21 @@ final class StoreOnboardingLaunchStoreCoordinator: Coordinator {
     let navigationController: UINavigationController
     private let site: Site
     private let isLaunched: Bool
+    private weak var presentationControllerDelegate: UIAdaptivePresentationControllerDelegate?
 
     /// - Parameters:
     ///   - site: The site for the launch store onboarding task.
     ///   - isLaunched: Whether the site has already been launched.
     ///   - navigationController: The navigation controller that presents the launch store flow.
-    init(site: Site, isLaunched: Bool, navigationController: UINavigationController) {
+    ///   - presentationControllerDelegate: Delegate used to listen when the view gets dismissed.
+    init(site: Site,
+         isLaunched: Bool,
+         navigationController: UINavigationController,
+         presentationControllerDelegate: UIAdaptivePresentationControllerDelegate? = nil) {
         self.site = site
         self.isLaunched = isLaunched
         self.navigationController = navigationController
+        self.presentationControllerDelegate = presentationControllerDelegate
     }
 
     func start() {
@@ -40,12 +46,14 @@ private extension StoreOnboardingLaunchStoreCoordinator {
             self?.showLaunchedView(siteURL: siteURL, in: modalNavigationController)
         })
         modalNavigationController.pushViewController(launchStoreController, animated: false)
+        modalNavigationController.presentationController?.delegate = presentationControllerDelegate
         navigationController.present(modalNavigationController, animated: true)
     }
 
     func presentLaunchedView(siteURL: URL, in modalNavigationController: UINavigationController) {
         let launchedStoreController = createLaunchedStoreController(siteURL: siteURL)
         modalNavigationController.pushViewController(launchedStoreController, animated: false)
+        modalNavigationController.presentationController?.delegate = presentationControllerDelegate
         navigationController.present(modalNavigationController, animated: true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingPaymentsSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingPaymentsSetupCoordinator.swift
@@ -13,17 +13,23 @@ final class StoreOnboardingPaymentsSetupCoordinator: Coordinator {
 
     private let task: Task
     private let site: Site
+    private weak var presentationControllerDelegate: UIAdaptivePresentationControllerDelegate?
 
-    init(task: Task, site: Site, navigationController: UINavigationController) {
+    init(task: Task,
+         site: Site,
+         navigationController: UINavigationController,
+         presentationControllerDelegate: UIAdaptivePresentationControllerDelegate? = nil) {
         self.task = task
         self.site = site
         self.navigationController = navigationController
+        self.presentationControllerDelegate = presentationControllerDelegate
     }
 
     func start() {
         // Navigation controller for the payments setup flow.
         let modalNavigationController = WooNavigationController()
         showSetupView(in: modalNavigationController)
+        modalNavigationController.presentationController?.delegate = presentationControllerDelegate
         navigationController.present(modalNavigationController, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -9,15 +9,19 @@ final class StoreOnboardingViewHostingController: SelfSizingHostingController<St
     private let sourceNavigationController: UINavigationController
     private let site: Site
     private lazy var coordinator: StoreOnboardingCoordinator = .init(navigationController: sourceNavigationController,
-                                                                     site: site)
+                                                                     site: site,
+                                                                     presentationControllerDelegate: presentationControllerDelegate)
+    private weak var presentationControllerDelegate: UIAdaptivePresentationControllerDelegate?
 
     init(viewModel: StoreOnboardingViewModel,
          navigationController: UINavigationController,
          site: Site,
+         presentationControllerDelegate: UIAdaptivePresentationControllerDelegate? = nil,
          shareFeedbackAction: (() -> Void)? = nil) {
         self.viewModel = viewModel
         self.sourceNavigationController = navigationController
         self.site = site
+        self.presentationControllerDelegate = presentationControllerDelegate
         super.init(rootView: StoreOnboardingView(viewModel: viewModel,
                                                  shareFeedbackAction: shareFeedbackAction))
         if #unavailable(iOS 16.0) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -159,7 +159,7 @@ struct StoreOnboardingView: View {
 
                 // View all button
                 viewAllButton(action: viewAllTapped, text: String(format: Localization.viewAll, viewModel.taskViewModels.count))
-                    //.renderedIf(viewModel.shouldShowViewAllButton)
+                    .renderedIf(viewModel.shouldShowViewAllButton)
 
                 Spacer()
                     .renderedIf(viewModel.isExpanded)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainSettingsCoordinator.swift
@@ -18,15 +18,18 @@ final class DomainSettingsCoordinator: Coordinator {
     private let stores: StoresManager
     private let source: Source
     private let analytics: Analytics
+    private weak var presentationControllerDelegate: UIAdaptivePresentationControllerDelegate?
 
     init(source: Source,
          site: Site,
          navigationController: UINavigationController,
+         presentationControllerDelegate: UIAdaptivePresentationControllerDelegate? = nil,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.source = source
         self.site = site
         self.navigationController = navigationController
+        self.presentationControllerDelegate = presentationControllerDelegate
         self.stores = stores
         self.analytics = analytics
     }
@@ -42,6 +45,7 @@ final class DomainSettingsCoordinator: Coordinator {
             self?.navigationController.dismiss(animated: true)
         }
         settingsNavigationController.pushViewController(domainSettings, animated: false)
+        settingsNavigationController.presentationController?.delegate = presentationControllerDelegate
         navigationController.present(settingsNavigationController, animated: true)
         analytics.track(event: .DomainSettings.domainSettingsStep(source: source,
                                                                   step: .dashboard))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinatorTests.swift
@@ -35,4 +35,23 @@ final class StoreOnboardingCoordinatorTests: XCTestCase {
         let presentedNavigationController = try XCTUnwrap(coordinator.navigationController.presentedViewController as? WooNavigationController)
         assertThat(presentedNavigationController.topViewController, isAnInstanceOf: DomainSettingsHostingController.self)
     }
+
+    func test_isRelatedToOnboardingTask_returns_true_for_relevant_types() {
+        let url = URL(string: "https://example.com/")!
+        let domain = DomainSettingsHostingController(viewModel: .init(siteID: 0),
+                                                     addDomain: { _, _ in },
+                                                     onClose: {})
+        XCTAssertTrue(StoreOnboardingCoordinator.isRelatedToOnboardingTask(domain))
+
+        let launch = StoreOnboardingLaunchStoreHostingController(viewModel: .init(siteURL: url,
+                                                                                  siteID: 9,
+                                                                                  onLaunch: {}))
+        XCTAssertTrue(StoreOnboardingCoordinator.isRelatedToOnboardingTask(launch))
+
+        let launched = StoreOnboardingStoreLaunchedHostingController(siteURL: url, onContinue: {})
+        XCTAssertTrue(StoreOnboardingCoordinator.isRelatedToOnboardingTask(launched))
+
+        let payments = StoreOnboardingPaymentsSetupHostingController(task: .wcPay, onContinue: {}, onDismiss: {})
+        XCTAssertTrue(StoreOnboardingCoordinator.isRelatedToOnboardingTask(payments))
+    }
 }


### PR DESCRIPTION
Part of: #9172

## Description
Reloads onboarding task list using `UIAdaptivePresentationControllerDelegate`
- Uses `DashboardViewController` as delegate for collapsed mode.
- Uses `StoreOnboardingViewHostingController` as delegate for expanded mode.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
