### PR TITLE
[Product Multi-Selection] Remove selections on clear selection

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -211,11 +211,11 @@ final class EditableOrderViewModel: ObservableObject {
 
     /// Keeps track of selected/unselected Products, if any
     ///
-    @Published private(set) var selectedProducts: [Product] = []
+    @Published private var selectedProducts: [Product] = []
 
     /// Keeps track of selected/unselected Product Variations, if any
     ///
-    @Published private(set) var selectedProductVariations: [ProductVariation] = []
+    @Published private var selectedProductVariations: [ProductVariation] = []
 
     /// Keeps track of all selected Products and Product Variations IDs
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -216,7 +216,7 @@ final class EditableOrderViewModel: ObservableObject {
 
     /// Keeps track of all selected Products and Product Variations IDs
     ///
-    var selectedProductsAndVariationsIDs: [Int64] {
+    private var selectedProductsAndVariationsIDs: [Int64] {
         let selectedProductsCount = selectedProducts.compactMap { $0.productID }
         let selectedProductVariationsCount = selectedProductVariations.compactMap { $0.productVariationID }
         return selectedProductsCount + selectedProductVariationsCount

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -191,7 +191,7 @@ final class EditableOrderViewModel: ObservableObject {
             }, onMultipleSelectionCompleted: { [weak self] _ in
                 guard let self = self else { return }
                 self.syncOrderItems(products: self.selectedProducts, variations: self.selectedProductVariations)
-            }, onClearedSelection: { [weak self] in
+            }, onSelectionsCleared: { [weak self] in
                 guard let self = self else { return }
                 self.clearSelectedItems()
             })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -377,7 +377,7 @@ final class EditableOrderViewModel: ObservableObject {
 
     /// Clears selected products and variations
     ///
-    func clearSelectedItems() {
+    private func clearSelectedItems() {
         selectedProducts.removeAll()
         selectedProductVariations.removeAll()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -191,6 +191,9 @@ final class EditableOrderViewModel: ObservableObject {
             }, onMultipleSelectionCompleted: { [weak self] _ in
                 guard let self = self else { return }
                 self.syncOrderItems(products: self.selectedProducts, variations: self.selectedProductVariations)
+            }, onClearedSelection: { [weak self] in
+                guard let self = self else { return }
+                self.clearSelectedItems()
             })
     }
 
@@ -370,6 +373,13 @@ final class EditableOrderViewModel: ObservableObject {
             }
         }
         return itemsInOrder
+    }
+
+    /// Clears selected products and variations
+    ///
+    func clearSelectedItems() {
+        selectedProducts.removeAll()
+        selectedProductVariations.removeAll()
     }
 
     /// Selects an order item by setting the `selectedProductViewModel`.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -179,7 +179,7 @@ final class EditableOrderViewModel: ObservableObject {
             storageManager: storageManager,
             stores: stores,
             supportsMultipleSelection: isProductMultiSelectionBetaFeatureEnabled,
-            isClearSelectionEnabled: false,
+            isClearSelectionEnabled: isProductMultiSelectionBetaFeatureEnabled,
             toggleAllVariationsOnSelection: false,
             onProductSelected: { [weak self] product in
                 guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -208,11 +208,11 @@ final class EditableOrderViewModel: ObservableObject {
 
     /// Keeps track of selected/unselected Products, if any
     ///
-    @Published var selectedProducts: [Product] = []
+    @Published private(set) var selectedProducts: [Product] = []
 
     /// Keeps track of selected/unselected Product Variations, if any
     ///
-    @Published var selectedProductVariations: [ProductVariation] = []
+    @Published private(set) var selectedProductVariations: [ProductVariation] = []
 
     /// Keeps track of all selected Products and Product Variations IDs
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -191,9 +191,12 @@ final class EditableOrderViewModel: ObservableObject {
             }, onMultipleSelectionCompleted: { [weak self] _ in
                 guard let self = self else { return }
                 self.syncOrderItems(products: self.selectedProducts, variations: self.selectedProductVariations)
-            }, onSelectionsCleared: { [weak self] in
+            }, onAllSelectionsCleared: { [weak self] in
                 guard let self = self else { return }
-                self.clearSelectedItems()
+                self.clearAllSelectedItems()
+            }, onSelectedVariationsCleared: { [weak self] in
+                guard let self = self else { return }
+                self.clearSelectedVariations()
             })
     }
 
@@ -377,8 +380,14 @@ final class EditableOrderViewModel: ObservableObject {
 
     /// Clears selected products and variations
     ///
-    private func clearSelectedItems() {
+    private func clearAllSelectedItems() {
         selectedProducts.removeAll()
+        selectedProductVariations.removeAll()
+    }
+
+    /// Clears selected variations
+    /// 
+    private func clearSelectedVariations() {
         selectedProductVariations.removeAll()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -361,7 +361,7 @@ private extension ProductSelectorView.Configuration {
     static func addProductToOrder() -> ProductSelectorView.Configuration {
         ProductSelectorView.Configuration(
             multipleSelectionsEnabled: ServiceLocator.generalAppSettings.betaFeatureEnabled(.productMultiSelection),
-            clearSelectionEnabled: false,
+            clearSelectionEnabled: ServiceLocator.generalAppSettings.betaFeatureEnabled(.productMultiSelection),
             searchHeaderBackgroundColor: .listBackground,
             prefersLargeTitle: false,
             doneButtonTitleSingularFormat: Localization.doneButtonSingular,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -289,7 +289,7 @@ final class ProductSelectorViewModel: ObservableObject {
     /// Unselect all items.
     ///
     func clearSelection() {
-        let _ = products.map { product in
+        products.forEach { product in
             // Callback to deselect products
             if selectedProductIDs.contains(where: { $0 == product.productID }) {
                 if let onProductSelected {
@@ -304,12 +304,6 @@ final class ProductSelectorViewModel: ObservableObject {
                 let intersection = Set(variationIDs).intersection(Set(selectedProductVariationIDs))
                 if intersection.count != 0 {
                     let variations = retrieveVariations(for: product.productID)
-                    // TODO: Decide which behavior to keep
-                    // 1. If we call the product only, we don't unselect variations from ProductSelector
-                    if let onProductSelected {
-                        onProductSelected(product)
-                    }
-                    // 2. If we call variations, we unselect it from ProductSelector
                     if let onVariationSelected, let variation = variations.first(where: { $0.productID == product.productID }) {
                         onVariationSelected(variation, product)
                     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -297,21 +297,11 @@ final class ProductSelectorViewModel: ObservableObject {
     /// Unselect all items.
     ///
     func clearSelection() {
-
         initialSelectedItems = []
         selectedProductIDs = []
         selectedProductVariationIDs = []
 
         onClearedSelection?()
-    }
-
-    private func retrieveVariations(for productID: Int64) -> [ProductVariation] {
-        let variationsViewModel = getVariationsViewModel(for: productID)
-        guard let variationsViewModel else {
-            DDLogError("No variations found for productID \(productID)")
-            return []
-        }
-        return variationsViewModel.productVariations
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -140,7 +140,7 @@ final class ProductSelectorViewModel: ObservableObject {
 
     /// Closure to be invoked when "Clear Selection" is called.
     ///
-    private let onClearedSelection: (() -> Void)?
+    private let onSelectionsCleared: (() -> Void)?
 
     /// Initializer for single selection
     ///
@@ -167,7 +167,7 @@ final class ProductSelectorViewModel: ObservableObject {
         self.onMultipleSelectionCompleted = onMultipleSelectionCompleted
         self.initialSelectedItems = selectedItemIDs
         self.purchasableItemsOnly = purchasableItemsOnly
-        self.onClearedSelection = onSelectionsCleared
+        self.onSelectionsCleared = onSelectionsCleared
 
         configureSyncingCoordinator()
         configureProductsResultsController()
@@ -198,7 +198,7 @@ final class ProductSelectorViewModel: ObservableObject {
         self.onMultipleSelectionCompleted = onMultipleSelectionCompleted
         self.initialSelectedItems = selectedItemIDs
         self.purchasableItemsOnly = purchasableItemsOnly
-        self.onClearedSelection = onClearedSelection
+        self.onSelectionsCleared = onClearedSelection
 
         configureSyncingCoordinator()
         configureProductsResultsController()
@@ -302,7 +302,7 @@ final class ProductSelectorViewModel: ObservableObject {
         selectedProductIDs = []
         selectedProductVariationIDs = []
 
-        onClearedSelection?()
+        onSelectionsCleared?()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -186,7 +186,7 @@ final class ProductSelectorViewModel: ObservableObject {
          isClearSelectionEnabled: Bool = true,
          toggleAllVariationsOnSelection: Bool = true,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil,
-         onClearedSelection: (() -> Void)? = nil ) {
+         onSelectionsCleared: (() -> Void)? = nil ) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
@@ -198,7 +198,7 @@ final class ProductSelectorViewModel: ObservableObject {
         self.onMultipleSelectionCompleted = onMultipleSelectionCompleted
         self.initialSelectedItems = selectedItemIDs
         self.purchasableItemsOnly = purchasableItemsOnly
-        self.onSelectionsCleared = onClearedSelection
+        self.onSelectionsCleared = onSelectionsCleared
 
         configureSyncingCoordinator()
         configureProductsResultsController()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -239,7 +239,8 @@ final class ProductSelectorViewModel: ObservableObject {
                                                  purchasableItemsOnly: purchasableItemsOnly,
                                                  supportsMultipleSelection: supportsMultipleSelection,
                                                  isClearSelectionEnabled: isClearSelectionEnabled,
-                                                 onVariationSelected: onVariationSelected)
+                                                 onVariationSelected: onVariationSelected,
+                                                 onSelectionsCleared: clearSelection)
     }
 
     /// Clears the current search term and filters to display the full product list.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -140,7 +140,11 @@ final class ProductSelectorViewModel: ObservableObject {
 
     /// Closure to be invoked when "Clear Selection" is called.
     ///
-    private let onSelectionsCleared: (() -> Void)?
+    private let onAllSelectionsCleared: (() -> Void)?
+
+    /// Closure to be invoked when variations "Clear Selection" is called.
+    ///
+    private let onSelectedVariationsCleared: (() -> Void)?
 
     /// Initializer for single selection
     ///
@@ -155,7 +159,8 @@ final class ProductSelectorViewModel: ObservableObject {
          onProductSelected: ((Product) -> Void)? = nil,
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil,
-         onSelectionsCleared: (() -> Void)? = nil) {
+         onAllSelectionsCleared: (() -> Void)? = nil,
+         onSelectedVariationsCleared: (() -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
@@ -167,7 +172,8 @@ final class ProductSelectorViewModel: ObservableObject {
         self.onMultipleSelectionCompleted = onMultipleSelectionCompleted
         self.initialSelectedItems = selectedItemIDs
         self.purchasableItemsOnly = purchasableItemsOnly
-        self.onSelectionsCleared = onSelectionsCleared
+        self.onAllSelectionsCleared = onAllSelectionsCleared
+        self.onSelectedVariationsCleared = onSelectedVariationsCleared
 
         configureSyncingCoordinator()
         configureProductsResultsController()
@@ -186,7 +192,8 @@ final class ProductSelectorViewModel: ObservableObject {
          isClearSelectionEnabled: Bool = true,
          toggleAllVariationsOnSelection: Bool = true,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil,
-         onSelectionsCleared: (() -> Void)? = nil ) {
+         onAllSelectionsCleared: (() -> Void)? = nil,
+         onSelectedVariationsCleared: (() -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
@@ -198,7 +205,8 @@ final class ProductSelectorViewModel: ObservableObject {
         self.onMultipleSelectionCompleted = onMultipleSelectionCompleted
         self.initialSelectedItems = selectedItemIDs
         self.purchasableItemsOnly = purchasableItemsOnly
-        self.onSelectionsCleared = onSelectionsCleared
+        self.onAllSelectionsCleared = onAllSelectionsCleared
+        self.onSelectedVariationsCleared = onSelectedVariationsCleared
 
         configureSyncingCoordinator()
         configureProductsResultsController()
@@ -302,7 +310,7 @@ final class ProductSelectorViewModel: ObservableObject {
         selectedProductIDs = []
         selectedProductVariationIDs = []
 
-        onSelectionsCleared?()
+        onAllSelectionsCleared?()
     }
 
     private func clearSelectedVariations() {
@@ -310,9 +318,9 @@ final class ProductSelectorViewModel: ObservableObject {
         // We're sure to clear only those that belong to variations and leave the product ones
         let initialSelectedVariations = Set(selectedProductVariationIDs)
         initialSelectedItems = initialSelectedItems.filter { !initialSelectedVariations.contains($0) }
-
         selectedProductVariationIDs = []
-        onSelectionsCleared?()
+
+        onSelectedVariationsCleared?()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -248,7 +248,7 @@ final class ProductSelectorViewModel: ObservableObject {
                                                  supportsMultipleSelection: supportsMultipleSelection,
                                                  isClearSelectionEnabled: isClearSelectionEnabled,
                                                  onVariationSelected: onVariationSelected,
-                                                 onSelectionsCleared: clearSelectedVariations)
+                                                 onSelectionsCleared: onSelectedVariationsCleared)
     }
 
     /// Clears the current search term and filters to display the full product list.
@@ -311,16 +311,6 @@ final class ProductSelectorViewModel: ObservableObject {
         selectedProductVariationIDs = []
 
         onAllSelectionsCleared?()
-    }
-
-    private func clearSelectedVariations() {
-        // InitialSelectedItems contains both IDs for products and variations
-        // We're sure to clear only those that belong to variations and leave the product ones
-        let initialSelectedVariations = Set(selectedProductVariationIDs)
-        initialSelectedItems = initialSelectedItems.filter { !initialSelectedVariations.contains($0) }
-        selectedProductVariationIDs = []
-
-        onSelectedVariationsCleared?()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -289,6 +289,13 @@ final class ProductSelectorViewModel: ObservableObject {
     /// Unselect all items.
     ///
     func clearSelection() {
+        let _ = products.map { product in
+            if selectedProductIDs.contains(where: { $0 == product.productID }) {
+                if let onProductSelected {
+                    onProductSelected(product)
+                }
+            }
+        }
         initialSelectedItems = []
         selectedProductIDs = []
         selectedProductVariationIDs = []

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -240,7 +240,7 @@ final class ProductSelectorViewModel: ObservableObject {
                                                  supportsMultipleSelection: supportsMultipleSelection,
                                                  isClearSelectionEnabled: isClearSelectionEnabled,
                                                  onVariationSelected: onVariationSelected,
-                                                 onSelectionsCleared: clearSelection)
+                                                 onSelectionsCleared: clearSelectedVariations)
     }
 
     /// Clears the current search term and filters to display the full product list.
@@ -302,6 +302,16 @@ final class ProductSelectorViewModel: ObservableObject {
         selectedProductIDs = []
         selectedProductVariationIDs = []
 
+        onSelectionsCleared?()
+    }
+
+    private func clearSelectedVariations() {
+        // InitialSelectedItems contains both IDs for products and variations
+        // We're sure to clear only those that belong to variations and leave the product ones
+        let initialSelectedVariations = Set(selectedProductVariationIDs)
+        initialSelectedItems = initialSelectedItems.filter { !initialSelectedVariations.contains($0) }
+
+        selectedProductVariationIDs = []
         onSelectionsCleared?()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -155,7 +155,7 @@ final class ProductSelectorViewModel: ObservableObject {
          onProductSelected: ((Product) -> Void)? = nil,
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil,
-         onClearedSelection: (() -> Void)? = nil) {
+         onSelectionsCleared: (() -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
@@ -167,7 +167,7 @@ final class ProductSelectorViewModel: ObservableObject {
         self.onMultipleSelectionCompleted = onMultipleSelectionCompleted
         self.initialSelectedItems = selectedItemIDs
         self.purchasableItemsOnly = purchasableItemsOnly
-        self.onClearedSelection = onClearedSelection
+        self.onClearedSelection = onSelectionsCleared
 
         configureSyncingCoordinator()
         configureProductsResultsController()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
@@ -106,7 +106,6 @@ struct ProductVariationSelector: View {
                 return
             }
             onMultipleSelections?(viewModel.selectedProductVariationIDs)
-            viewModel.clearSelection()
         }
         .notice($viewModel.notice, autoDismiss: false)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
@@ -106,6 +106,7 @@ struct ProductVariationSelector: View {
                 return
             }
             onMultipleSelections?(viewModel.selectedProductVariationIDs)
+            viewModel.clearSelection()
         }
         .notice($viewModel.notice, autoDismiss: false)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -51,7 +51,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
 
     /// All purchasable product variations for the product.
     ///
-    @Published private var productVariations: [ProductVariation] = []
+    @Published var productVariations: [ProductVariation] = []
 
     /// View models for each product variation row
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -51,7 +51,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
 
     /// All purchasable product variations for the product.
     ///
-    @Published private(set) var productVariations: [ProductVariation] = []
+    @Published private var productVariations: [ProductVariation] = []
 
     /// View models for each product variation row
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -191,7 +191,23 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     /// Unselect all items.
     ///
     func clearSelection() {
-        selectedProductVariationIDs = []
+        if ServiceLocator.generalAppSettings.betaFeatureEnabled(.productMultiSelection) &&
+           ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
+            // Multi-Selection
+            selectedProductVariationIDs.forEach { variationID in
+                guard let parentProduct = productResultsController.fetchedObjects.first,
+                      let selectedVariation = productVariations.first(where: { $0.productVariationID == variationID  }) else {
+                    return
+                }
+                if let onVariationSelected {
+                    onVariationSelected(selectedVariation, parentProduct)
+                }
+            }
+            selectedProductVariationIDs = []
+        // Single-Selection
+        } else {
+            selectedProductVariationIDs = []
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -51,7 +51,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
 
     /// All purchasable product variations for the product.
     ///
-    @Published var productVariations: [ProductVariation] = []
+    @Published private(set) var productVariations: [ProductVariation] = []
 
     /// View models for each product variation row
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -61,6 +61,10 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     ///
     let onVariationSelected: ((ProductVariation, Product) -> Void)?
 
+    /// Closure to be invoked when "Clear Selection" is called.
+    ///
+    private let onSelectionsCleared: (() -> Void)?
+
     /// All selected product variations if the selector supports multiple selections.
     ///
     @Published private(set) var selectedProductVariationIDs: [Int64]
@@ -122,7 +126,8 @@ final class ProductVariationSelectorViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          supportsMultipleSelection: Bool = false,
          isClearSelectionEnabled: Bool = true,
-         onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
+         onVariationSelected: ((ProductVariation, Product) -> Void)? = nil,
+         onSelectionsCleared: (() -> Void)? = nil) {
         self.siteID = siteID
         self.productID = productID
         self.productName = productName
@@ -134,6 +139,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         self.onVariationSelected = onVariationSelected
         self.selectedProductVariationIDs = selectedProductVariationIDs
         self.purchasableItemsOnly = purchasableItemsOnly
+        self.onSelectionsCleared = onSelectionsCleared
 
         configureSyncingCoordinator()
         configureProductVariationsResultsController()
@@ -148,7 +154,8 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                      stores: StoresManager = ServiceLocator.stores,
                      supportsMultipleSelection: Bool = false,
                      isClearSelectionEnabled: Bool = true,
-                     onVariationSelected: ((ProductVariation, Product) -> Void)? = nil) {
+                     onVariationSelected: ((ProductVariation, Product) -> Void)? = nil,
+                     onSelectionsCleared: (() -> Void)? = nil) {
         self.init(siteID: siteID,
                   productID: product.productID,
                   productName: product.name,
@@ -159,7 +166,8 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                   stores: stores,
                   supportsMultipleSelection: supportsMultipleSelection,
                   isClearSelectionEnabled: isClearSelectionEnabled,
-                  onVariationSelected: onVariationSelected)
+                  onVariationSelected: onVariationSelected,
+                  onSelectionsCleared: onSelectionsCleared)
     }
 
     /// Select a product variation to add to the order
@@ -192,6 +200,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     ///
     func clearSelection() {
         selectedProductVariationIDs = []
+        onSelectionsCleared?()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -191,23 +191,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     /// Unselect all items.
     ///
     func clearSelection() {
-        if ServiceLocator.generalAppSettings.betaFeatureEnabled(.productMultiSelection) &&
-           ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1) {
-            // Multi-Selection
-            selectedProductVariationIDs.forEach { variationID in
-                guard let parentProduct = productResultsController.fetchedObjects.first,
-                      let selectedVariation = productVariations.first(where: { $0.productVariationID == variationID  }) else {
-                    return
-                }
-                if let onVariationSelected {
-                    onVariationSelected(selectedVariation, parentProduct)
-                }
-            }
-            selectedProductVariationIDs = []
-        // Single-Selection
-        } else {
-            selectedProductVariationIDs = []
-        }
+        selectedProductVariationIDs = []
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -37,7 +37,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productRows.count, 0)
         XCTAssertEqual(viewModel.selectedProducts.count, 0)
         XCTAssertEqual(viewModel.selectedProductVariations.count, 0)
-        XCTAssertEqual(viewModel.selectedProductsAndVariationsIDs.count, 0)
     }
 
     func test_view_model_product_list_is_initialized_with_expected_values_given_product_multiselection_is_disabled() {
@@ -392,28 +391,6 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.selectedProducts.count, 1)
-    }
-
-    func test_selectedProductsAndVariationsIDs_keeps_track_of_products_and_variations_added_to_the_order() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isProductMultiSelectionM1Enabled: true)
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, productTypeKey: "variable", purchasable: true, variations: [20])
-        let productVariation = ProductVariation.fake().copy(siteID: sampleSiteID,
-                                                            productID: sampleProductID,
-                                                            productVariationID: 20,
-                                                            sku: "product-variation", purchasable: true)
-        storageManager.insertSampleProduct(readOnlyProduct: product)
-        storageManager.insertSampleProductVariation(readOnlyProductVariation: productVariation, on: product)
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager, featureFlagService: featureFlagService)
-
-        // When
-        viewModel.isProductMultiSelectionBetaFeatureEnabled = true
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
-        viewModel.productSelectorViewModel.getVariationsViewModel(for: product.productID)?.selectVariation(productVariation.productVariationID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
-
-        // Then
-        XCTAssertEqual(viewModel.selectedProductsAndVariationsIDs.count, 2)
     }
 
     func test_createProductRowViewModel_creates_expected_row_for_product() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -60,7 +60,7 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.productSelectorViewModel.supportsMultipleSelection)
-        XCTAssertFalse(viewModel.productSelectorViewModel.isClearSelectionEnabled)
+        XCTAssertTrue(viewModel.productSelectorViewModel.isClearSelectionEnabled)
         XCTAssertFalse(viewModel.productSelectorViewModel.toggleAllVariationsOnSelection)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -418,6 +418,7 @@ final class EditableOrderViewModelTests: XCTestCase {
 
     func test_clearSelectedItems_clears_selectedProducts_and_selectedProductVariations() {
         // Given
+        let featureFlagService = MockFeatureFlagService(isProductMultiSelectionM1Enabled: true)
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, productTypeKey: "variable", purchasable: true, variations: [20])
         let productVariation = ProductVariation.fake().copy(siteID: sampleSiteID,
                                                             productID: sampleProductID,
@@ -425,7 +426,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                             sku: "product-variation", purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
         storageManager.insertSampleProductVariation(readOnlyProductVariation: productVariation, on: product)
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager, featureFlagService: featureFlagService)
 
         // When
         viewModel.productSelectorViewModel.selectProduct(product.productID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -409,7 +409,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         // When
         viewModel.isProductMultiSelectionBetaFeatureEnabled = true
         viewModel.productSelectorViewModel.selectProduct(product.productID)
-        viewModel.selectedProductVariations.append(productVariation)
+        viewModel.productSelectorViewModel.getVariationsViewModel(for: product.productID)?.selectVariation(productVariation.productVariationID)
         viewModel.productSelectorViewModel.completeMultipleSelection()
 
         // Then
@@ -431,7 +431,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         // When
         viewModel.isProductMultiSelectionBetaFeatureEnabled = true
         viewModel.productSelectorViewModel.selectProduct(product.productID)
-        viewModel.selectedProductVariations.append(productVariation)
+        viewModel.productSelectorViewModel.getVariationsViewModel(for: product.productID)?.selectVariation(productVariation.productVariationID)
 
         // Confidence check
         XCTAssertEqual(viewModel.selectedProducts.count, 1)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -416,34 +416,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedProductsAndVariationsIDs.count, 2)
     }
 
-    func test_clearSelectedItems_clears_selectedProducts_and_selectedProductVariations() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isProductMultiSelectionM1Enabled: true)
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, productTypeKey: "variable", purchasable: true, variations: [20])
-        let productVariation = ProductVariation.fake().copy(siteID: sampleSiteID,
-                                                            productID: sampleProductID,
-                                                            productVariationID: 20,
-                                                            sku: "product-variation", purchasable: true)
-        storageManager.insertSampleProduct(readOnlyProduct: product)
-        storageManager.insertSampleProductVariation(readOnlyProductVariation: productVariation, on: product)
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager, featureFlagService: featureFlagService)
-
-        // When
-        viewModel.isProductMultiSelectionBetaFeatureEnabled = true
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
-        viewModel.productSelectorViewModel.getVariationsViewModel(for: product.productID)?.selectVariation(productVariation.productVariationID)
-
-        // Confidence check
-        XCTAssertEqual(viewModel.selectedProducts.count, 1)
-        XCTAssertEqual(viewModel.selectedProductVariations.count, 1)
-
-        viewModel.clearSelectedItems()
-
-        // Then
-        XCTAssertEqual(viewModel.selectedProducts.count, 0)
-        XCTAssertEqual(viewModel.selectedProductVariations.count, 0)
-    }
-
     func test_createProductRowViewModel_creates_expected_row_for_product() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -416,6 +416,32 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedProductsAndVariationsIDs.count, 2)
     }
 
+    func test_clearSelectedItems_clears_selectedProducts_and_selectedProductVariations() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, productTypeKey: "variable", purchasable: true, variations: [20])
+        let productVariation = ProductVariation.fake().copy(siteID: sampleSiteID,
+                                                            productID: sampleProductID,
+                                                            productVariationID: 20,
+                                                            sku: "product-variation", purchasable: true)
+        storageManager.insertSampleProduct(readOnlyProduct: product)
+        storageManager.insertSampleProductVariation(readOnlyProductVariation: productVariation, on: product)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+
+        // When
+        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.selectedProductVariations.append(productVariation)
+
+        // Confidence check
+        XCTAssertEqual(viewModel.selectedProducts.count, 1)
+        XCTAssertEqual(viewModel.selectedProductVariations.count, 1)
+
+        viewModel.clearSelectedItems()
+
+        // Then
+        XCTAssertEqual(viewModel.selectedProducts.count, 0)
+        XCTAssertEqual(viewModel.selectedProductVariations.count, 0)
+    }
+
     func test_createProductRowViewModel_creates_expected_row_for_product() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -35,8 +35,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.navigationTrailingItem, .create)
         XCTAssertEqual(viewModel.statusBadgeViewModel.title, "pending")
         XCTAssertEqual(viewModel.productRows.count, 0)
-        XCTAssertEqual(viewModel.selectedProducts.count, 0)
-        XCTAssertEqual(viewModel.selectedProductVariations.count, 0)
     }
 
     func test_view_model_product_list_is_initialized_with_expected_values_given_product_multiselection_is_disabled() {
@@ -374,23 +372,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(viewModel.productRows.contains(where: { $0.productOrVariationID == product0.productID }))
         XCTAssertEqual(viewModel.productRows.map { $0.id }, [expectedRemainingRow].map { $0.id })
-    }
-
-    func test_selectedProducts_are_added_when_product_is_added_to_order_called_then_selectProducts_has_one_product() {
-
-        // Given
-        let featureFlagService = MockFeatureFlagService(isProductMultiSelectionM1Enabled: true)
-        let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
-        storageManager.insertProducts([product])
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager, featureFlagService: featureFlagService)
-
-        // When
-        viewModel.isProductMultiSelectionBetaFeatureEnabled = true
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
-        viewModel.productSelectorViewModel.completeMultipleSelection()
-
-        // Then
-        XCTAssertEqual(viewModel.selectedProducts.count, 1)
     }
 
     func test_createProductRowViewModel_creates_expected_row_for_product() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -429,6 +429,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager, featureFlagService: featureFlagService)
 
         // When
+        viewModel.isProductMultiSelectionBetaFeatureEnabled = true
         viewModel.productSelectorViewModel.selectProduct(product.productID)
         viewModel.selectedProductVariations.append(productVariation)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -660,18 +660,18 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(variableProductRow?.selectedState, .notSelected)
     }
 
-    func test_clearSelection_invokes_onClearedSelection_closure() {
+    func test_clearSelection_invokes_onSelectionsCleared_closure() {
         // Given
-        var onClearedSelectionCalled = false
-        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID, selectedItemIDs: [1, 12, 20], onClearedSelection: {
-            onClearedSelectionCalled = true
+        var onSelectionsClearedCalled = false
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID, selectedItemIDs: [1, 12, 20], onSelectionsCleared: {
+            onSelectionsClearedCalled = true
         })
 
         // When
         viewModel.clearSelection()
 
         // Then
-        XCTAssertTrue(onClearedSelectionCalled)
+        XCTAssertTrue(onSelectionsClearedCalled)
     }
 
     func test_synchronizeProducts_are_triggered_with_correct_filters() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -660,18 +660,18 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(variableProductRow?.selectedState, .notSelected)
     }
 
-    func test_clearSelection_invokes_onSelectionsCleared_closure() {
+    func test_clearSelection_invokes_onAllSelectionsCleared_closure() {
         // Given
-        var onSelectionsClearedCalled = false
-        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID, selectedItemIDs: [1, 12, 20], onSelectionsCleared: {
-            onSelectionsClearedCalled = true
+        var onAllSelectionsClearedCalled = false
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID, selectedItemIDs: [1, 12, 20], onAllSelectionsCleared: {
+            onAllSelectionsClearedCalled = true
         })
 
         // When
         viewModel.clearSelection()
 
         // Then
-        XCTAssertTrue(onSelectionsClearedCalled)
+        XCTAssertTrue(onAllSelectionsClearedCalled)
     }
 
     func test_synchronizeProducts_are_triggered_with_correct_filters() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -660,6 +660,20 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(variableProductRow?.selectedState, .notSelected)
     }
 
+    func test_clearSelection_invokes_onClearedSelection_closure() {
+        // Given
+        var onClearedSelectionCalled = false
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID, selectedItemIDs: [1, 12, 20], onClearedSelection: {
+            onClearedSelectionCalled = true
+        })
+
+        // When
+        viewModel.clearSelection()
+
+        // Then
+        XCTAssertTrue(onClearedSelectionCalled)
+    }
+
     func test_synchronizeProducts_are_triggered_with_correct_filters() async throws {
         // Given
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID, stores: stores)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8973

## DESCRIPTION

This PR adds back "Clear Selection" back to both the Product selector and the ProductVariation selector, which were removed temporarily for Product Multi-Selection iteration 1.

## Changes:
- Switches the existing Configuration's `isClearSelectionEnabled` to true when the Product Multi-Selection feature is enabled (as Single-Selection does not use it).
- Adds a `onClearedSelection` callback to the `ProductSelectorViewModel`'s initializer, which is called when we tap on "Clear Selection".

This is necessary to clear the `selectedProducts` and `selectedProductVariations` published properties from the `EditableOrderViewModel`, as these are passed as initial selected items into the `ProductSelectorViewModel` when is initialized and then the different views are re-rendered, causing a bug where variations are never properly unselected because they're persisted and passed through the different objects.

## Testing instructions
- Go to Menu > Settings > Experimental features > and enable Product Multi-Selection
- Go to Orders > Tap `+` > Tap on `+ Add Products` > Tap on different products and variations and tap on `Clear Selection`.
- See how products are unselected.
