### PR TITLE
[Free Trial] Upgrade Plan from Upgrades screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -388,44 +388,10 @@ private extension DashboardViewController {
     /// Shows a web view for the merchant to update their site plan.
     ///
     func showUpgradePlanWebView() {
-        ServiceLocator.analytics.track(event: .FreeTrial.freeTrialUpgradeNowTapped(source: .banner))
-
-        // These URLs should be stored elsewhere.
-        // I'll wait until I reuse them in the plans menu to decide what is the best place for them.
-        // https://github.com/woocommerce/woocommerce-ios/issues/9057
-        guard let upgradeURL = URL(string: "https://wordpress.com/plans/\(siteID)") else { return }
-        let exitTrigger = "my-plan/trial-upgraded" // When a site is upgraded from a trial, this URL path is invoked.
-
-        let viewModel = DefaultAuthenticatedWebViewModel(title: Localization.upgradeNow,
-                                                         initialURL: upgradeURL,
-                                                         urlToTriggerExit: exitTrigger) { [weak self] in
-            self?.exitUpgradeFreeTrialFlowAfterUpgrade()
-        }
-
-        let webViewController = AuthenticatedWebViewController(viewModel: viewModel)
-        webViewController.navigationItem.leftBarButtonItem =  UIBarButtonItem(barButtonSystemItem: .cancel,
-                                                                              target: self,
-                                                                              action: #selector(exitUpgradeFreeTrialFlow))
-        let navigationController = UINavigationController(rootViewController: webViewController)
-        navigationController.isModalInPresentation = true
-        present(navigationController, animated: true)
-    }
-
-    /// Dismisses the upgrade now web view after the merchants successfully updates their plan.
-    ///
-    func exitUpgradeFreeTrialFlowAfterUpgrade() {
-        removeFreeTrialBanner()
-        dismiss(animated: true)
-
-        ServiceLocator.analytics.track(event: .FreeTrial.planUpgradeSuccess(source: .banner))
-    }
-
-    /// Dismisses the upgrade now web view when the user abandons the flow.
-    ///
-    @objc func exitUpgradeFreeTrialFlow() {
-        dismiss(animated: true)
-
-        ServiceLocator.analytics.track(event: .FreeTrial.planUpgradeAbandoned(source: .banner))
+        let upgradeController = UpgradePlanCoordinatingController(siteID: siteID, source: .banner, onSuccess: { [weak self] in
+            self?.removeFreeTrialBanner()
+        })
+        present(upgradeController, animated: true)
     }
 
     func configureDashboardUIContainer() {
@@ -874,7 +840,6 @@ private extension DashboardViewController {
             "My store",
             comment: "Title of the bottom tab item that presents the user's store dashboard, and default title for the store dashboard"
         )
-        static let upgradeNow = NSLocalizedString("Upgrade Now", comment: "Title for the WebView when upgrading a free trial plan")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradePlanCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradePlanCoordinatingController.swift
@@ -1,0 +1,94 @@
+import UIKit
+
+/// Controls navigation for the free trial upgrade plan flow. Meant to be presented modally
+///
+final class UpgradePlanCoordinatingController: WooNavigationController {
+
+    /// Current Site ID.
+    ///
+    private let siteID: Int64
+
+    /// Source of the action.
+    ///
+    private let source: WooAnalyticsEvent.FreeTrial.Source
+
+    /// Analytics provider.
+    ///
+    private let analytics: Analytics
+
+    /// Closure to be invoked when the plan is successfully upgraded.
+    ///
+    private let onSuccess: (() -> ())?
+
+    init(siteID: Int64,
+         source: WooAnalyticsEvent.FreeTrial.Source,
+         analytics: Analytics = ServiceLocator.analytics,
+         onSuccess: (() -> ())? = nil) {
+        self.siteID = siteID
+        self.source = source
+        self.analytics = analytics
+        self.onSuccess = onSuccess
+        super.init(nibName: nil, bundle: nil)
+        startNavigation()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Shows a web view for the merchant to update their site plan.
+    ///
+    private func startNavigation() {
+        analytics.track(event: .FreeTrial.freeTrialUpgradeNowTapped(source: source))
+
+        guard let upgradeURL = Constants.upgradeURL(siteID: siteID) else { return }
+        let viewModel = DefaultAuthenticatedWebViewModel(title: Localization.upgradeNow,
+                                                         initialURL: upgradeURL,
+                                                         urlToTriggerExit: Constants.exitTrigger) { [weak self] in
+            self?.exitUpgradeFreeTrialFlowAfterUpgrade()
+        }
+
+        isModalInPresentation = true
+        let webViewController = AuthenticatedWebViewController(viewModel: viewModel)
+        webViewController.navigationItem.leftBarButtonItem =  UIBarButtonItem(barButtonSystemItem: .cancel,
+                                                                              target: self,
+                                                                              action: #selector(exitUpgradeFreeTrialFlow))
+        setViewControllers([webViewController], animated: false)
+    }
+
+    /// Dismisses the upgrade now web view after the merchants successfully updates their plan.
+    ///
+    func exitUpgradeFreeTrialFlowAfterUpgrade() {
+        onSuccess?()
+        dismiss(animated: true)
+
+        analytics.track(event: .FreeTrial.planUpgradeSuccess(source: source))
+    }
+
+    /// Dismisses the upgrade now web view when the user abandons the flow.
+    ///
+    @objc func exitUpgradeFreeTrialFlow() {
+        dismiss(animated: true)
+
+        analytics.track(event: .FreeTrial.planUpgradeAbandoned(source: source))
+    }
+}
+
+private extension UpgradePlanCoordinatingController {
+    enum Constants {
+
+        /// URL Path invoked when a site is upgrade from a free trial.
+        ///
+        static let exitTrigger = "my-plan/trial-upgraded"
+
+        /// URL that allows merchants to upgrade their eCommerce plan.
+        ///
+        static func upgradeURL(siteID: Int64) -> URL? {
+            URL(string: "https://wordpress.com/plans/\(siteID)")
+        }
+    }
+
+    enum Localization {
+        static let upgradeNow = NSLocalizedString("Upgrade Now", comment: "Title for the WebView when upgrading a free trial plan")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -11,7 +11,7 @@ final class UpgradesHostingController: UIHostingController<UpgradesView> {
 
         // Assign after of `init` for `self` to be properly initialized.
         rootView.onUpgradeNowTapped = { [weak self] in
-            self?.showUpgradePlanWebView(siteID: siteID)
+            self?.showUpgradePlanWebView(siteID: siteID, viewModel: viewModel)
         }
     }
 
@@ -21,8 +21,10 @@ final class UpgradesHostingController: UIHostingController<UpgradesView> {
 
     /// Shows a web view for the merchant to update their site plan.
     ///
-    private func showUpgradePlanWebView(siteID: Int64) {
-        let upgradeController = UpgradePlanCoordinatingController(siteID: siteID, source: .upgradesScreen)
+    private func showUpgradePlanWebView(siteID: Int64, viewModel: UpgradesViewModel) {
+        let upgradeController = UpgradePlanCoordinatingController(siteID: siteID, source: .upgradesScreen, onSuccess: {
+            viewModel.loadPlan(forced: true)
+        })
         present(upgradeController, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -8,10 +8,22 @@ final class UpgradesHostingController: UIHostingController<UpgradesView> {
     init(siteID: Int64) {
         let viewModel = UpgradesViewModel(siteID: siteID)
         super.init(rootView: .init(viewModel: viewModel))
+
+        // Assign after of `init` for `self` to be properly initialized.
+        rootView.onUpgradeNowTapped = { [weak self] in
+            self?.showUpgradePlanWebView(siteID: siteID)
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Shows a web view for the merchant to update their site plan.
+    ///
+    private func showUpgradePlanWebView(siteID: Int64) {
+        let upgradeController = UpgradePlanCoordinatingController(siteID: siteID, source: .upgradesScreen)
+        present(upgradeController, animated: true)
     }
 }
 
@@ -23,6 +35,10 @@ struct UpgradesView: View {
     ///
     @StateObject var viewModel: UpgradesViewModel
 
+    /// Closure to be invoked when the "Upgrade Now" button is tapped.
+    ///
+    var onUpgradeNowTapped: (() -> ())?
+
     var body: some View {
         List {
             Section(content: {
@@ -30,7 +46,7 @@ struct UpgradesView: View {
                     .bodyStyle()
 
                 Button(Localization.upgradeNow) {
-                    print("Upgrade Now tapped")
+                    onUpgradeNowTapped?()
                 }
                 .linkStyle()
                 .renderedIf(viewModel.shouldShowUpgradeButton)

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
@@ -59,8 +59,9 @@ final class UpgradesViewModel: ObservableObject {
 
     /// Loads the plan from network if needed.
     ///
-    func loadPlan() {
-        guard planState == .notLoaded else { return }
+    func loadPlan(forced: Bool = false) {
+        // Do not fetch the plan anymore if it is loaded, unless a force-load is requested.
+        guard planState == .notLoaded || forced == true else { return }
 
         planState = .loading
         let action = PaymentAction.loadSiteCurrentPlan(siteID: siteID) { [weak self] result in

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
@@ -179,7 +179,7 @@ private extension UpgradesViewModel {
     enum Localization {
         static let freeTrial = NSLocalizedString("Free Trial", comment: "Plan name for an active free trial")
         static let trialEnded = NSLocalizedString("Trial ended", comment: "Plan name for an expired free trial")
-        static let trialEndedInfo = NSLocalizedString("Your free trial has ended and you have limited access to all the features. Subscribe to eCommerce now.",
+        static let trialEndedInfo = NSLocalizedString("Your free trial has ended, and you have limited access to all the features. Subscribe to eCommerce now.",
                                                       comment: "Info details for an expired free trial")
         static let planEndedInfo = NSLocalizedString("Your subscription has ended and you have limited access to all the features.",
                                                      comment: "Info details for an expired free trial")

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -641,6 +641,7 @@
 		261B526E29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */; };
 		261E91A029C961EE00A5C118 /* UpgradesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261E919F29C961EE00A5C118 /* UpgradesViewModel.swift */; };
 		261E91A329C9882600A5C118 /* UpgradesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261E91A229C9882600A5C118 /* UpgradesViewModelTests.swift */; };
+		261E91A529CA592E00A5C118 /* UpgradePlanCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261E91A429CA592E00A5C118 /* UpgradePlanCoordinatingController.swift */; };
 		261F1A7929C2AB2E001D9861 /* FreeTrialBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */; };
 		261F1A7C29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */; };
 		26281776278F0B0100C836D3 /* View+NoticesModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26281775278F0B0100C836D3 /* View+NoticesModifier.swift */; };
@@ -2827,6 +2828,7 @@
 		261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportFormMetadataProvider.swift; sourceTree = "<group>"; };
 		261E919F29C961EE00A5C118 /* UpgradesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModel.swift; sourceTree = "<group>"; };
 		261E91A229C9882600A5C118 /* UpgradesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModelTests.swift; sourceTree = "<group>"; };
+		261E91A429CA592E00A5C118 /* UpgradePlanCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradePlanCoordinatingController.swift; sourceTree = "<group>"; };
 		261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModel.swift; sourceTree = "<group>"; };
 		261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModelTests.swift; sourceTree = "<group>"; };
 		26281775278F0B0100C836D3 /* View+NoticesModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+NoticesModifier.swift"; sourceTree = "<group>"; };
@@ -5877,6 +5879,7 @@
 			children = (
 				264957A229C520860095AA4C /* UpgradesView.swift */,
 				261E919F29C961EE00A5C118 /* UpgradesViewModel.swift */,
+				261E91A429CA592E00A5C118 /* UpgradePlanCoordinatingController.swift */,
 			);
 			name = Upgrades;
 			path = Classes/ViewRelated/Upgrades;
@@ -11713,6 +11716,7 @@
 				D8610CE2257099E100A5DF27 /* FancyAlertViewController+UnifiedLogin.swift in Sources */,
 				038BC37D29C37AA400EAF565 /* SetUpTapToPayCompleteViewModel.swift in Sources */,
 				03E471CE293F63B4001A58AD /* PaymentCaptureOrchestrator.swift in Sources */,
+				261E91A529CA592E00A5C118 /* UpgradePlanCoordinatingController.swift in Sources */,
 				B5980A6321AC879F00EBF596 /* Bundle+Woo.swift in Sources */,
 				B59D1EE5219080B4009D1978 /* Note+Woo.swift in Sources */,
 				02913E9523A774C500707A0C /* UnitInputFormatter.swift in Sources */,


### PR DESCRIPTION
Closes: #9061 

# Why

This PR adds the ability to upgrade a free trial from the upgrades view

# How

- Extract the upgrade web view handling to a common `UpgradesPlanCoordinatingController` type
- Launch the `UpgradesPlanCoordinatingController` from the dashboard and from the upgrades view.
- Make sure the plan data is refreshed after a successful upgrade.

# Demo

https://user-images.githubusercontent.com/562080/226761213-87d9fe0c-d4df-4440-ad9c-c2ac749f7a81.mov

# Testing Steps

- Launch the app with a free trial site
- Go to the upgrades view
- Tap on "Upgrade Now"
- Complete the web flow
- See that after completion the plan data is refreshed.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
