### PR TITLE
[Free Trial] Upgrades View - Error Handling

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -72,6 +72,7 @@ struct UpgradesView: View {
                 .linkStyle()
             }
         }
+        .notice($viewModel.errorNotice, autoDismiss: false)
         .redacted(reason: viewModel.showLoadingIndicator ? .placeholder : [])
         .shimmering(active: viewModel.showLoadingIndicator)
         .background(Color(.listBackground))

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
@@ -11,7 +11,6 @@ final class UpgradesViewModel: ObservableObject {
         case notLoaded
         case loading
         case loaded(WPComSitePlan)
-        case error
     }
 
     /// Indicates if the view should should a redacted state.
@@ -66,7 +65,7 @@ final class UpgradesViewModel: ObservableObject {
     ///
     func loadPlan(forced: Bool = false) {
         // Do not fetch the plan anymore if it is loaded, unless a force-load is requested.
-        guard planState == .notLoaded || planState == .error || forced == true else { return }
+        guard planState == .notLoaded || forced == true else { return }
 
         planState = .loading
         let action = PaymentAction.loadSiteCurrentPlan(siteID: siteID) { [weak self] result in
@@ -189,8 +188,8 @@ private extension UpgradesViewModel {
     /// Creates an error notice that allows to retry fetching a plan.
     ///
     func createErrorNotice() -> Notice {
-        .init(title: Localization.fetchErrorNotice, feedbackType: .error, actionTitle: Localization.retry) {
-            self.loadPlan()
+        .init(title: Localization.fetchErrorNotice, feedbackType: .error, actionTitle: Localization.retry) { [weak self] in
+            self?.loadPlan()
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -33,6 +33,7 @@ final class UpgradesViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.planInfo.isNotEmpty)
         XCTAssertTrue(viewModel.shouldShowUpgradeButton)
         XCTAssertFalse(viewModel.shouldShowCancelTrialButton)
+        XCTAssertNil(viewModel.errorNotice)
     }
 
     func test_expired_free_trial_plan_has_correct_view_model_values() {
@@ -61,6 +62,7 @@ final class UpgradesViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.planInfo.isNotEmpty)
         XCTAssertTrue(viewModel.shouldShowUpgradeButton)
         XCTAssertFalse(viewModel.shouldShowCancelTrialButton)
+        XCTAssertNil(viewModel.errorNotice)
     }
 
     func test_active_regular_plan_has_correct_view_model_values() {
@@ -90,5 +92,32 @@ final class UpgradesViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.planInfo.isNotEmpty)
         XCTAssertFalse(viewModel.shouldShowUpgradeButton)
         XCTAssertFalse(viewModel.shouldShowCancelTrialButton)
+        XCTAssertNil(viewModel.errorNotice)
     }
+
+    func test_error_fetching_plan_has_correct_view_model_values() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: PaymentAction.self) { action in
+            switch action {
+            case .loadSiteCurrentPlan(_, let completion):
+                let error = NSError(domain: "", code: 0)
+                completion(.failure(error))
+            default:
+                break
+            }
+        }
+        let viewModel = UpgradesViewModel(siteID: sampleSiteID, stores: stores)
+
+        // When
+        viewModel.loadPlan()
+
+        // Then
+        XCTAssertTrue(viewModel.planName.isEmpty)
+        XCTAssertTrue(viewModel.planInfo.isEmpty)
+        XCTAssertFalse(viewModel.shouldShowUpgradeButton)
+        XCTAssertFalse(viewModel.shouldShowCancelTrialButton)
+        XCTAssertNotNil(viewModel.errorNotice)
+    }
+
 }


### PR DESCRIPTION
Closes: #9246  

# Why

This PR makes sure that the upgrades views handle the scenario of not being able to fetch the plan details. Additionally it shows a notice allowing the merchant to retry loading the plan details.

# Demo

https://user-images.githubusercontent.com/562080/226799047-9572526f-5d39-4ed7-8cd2-0a90bee5c98b.mov

# Testing Steps

- Launch the app on a WPCom site
- Turn off wifi
- Go to the upgrades view
- See the error notice appear
- Turn on wifi
- Tap the retry button on the notice
- See the plan details load successfully.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
