### PR TITLE
Store onboarding: design polishes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -61,7 +61,8 @@ final class DashboardViewController: UIViewController {
     private lazy var innerStackView: UIStackView = {
         let view = UIStackView()
         let horizontalMargin = Constants.horizontalMargin
-        view.layoutMargins = UIEdgeInsets(top: 0, left: horizontalMargin, bottom: 0, right: horizontalMargin)
+        let verticalMargin = Constants.verticalMargin
+        view.layoutMargins = UIEdgeInsets(top: 0, left: horizontalMargin, bottom: verticalMargin, right: horizontalMargin)
         view.isLayoutMarginsRelativeArrangement = true
         return view
     }()
@@ -887,6 +888,7 @@ private extension DashboardViewController {
         static let animationDurationSeconds = CGFloat(0.3)
         static let bannerBottomMargin = CGFloat(8)
         static let horizontalMargin = CGFloat(16)
+        static let verticalMargin = CGFloat(16)
         static let storeNameTextColor: UIColor = .secondaryLabel
         static let backgroundColor: UIColor = .listForeground(modal: false)
         static let iPhoneCollapsedNavigationBarHeight = CGFloat(44)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -36,10 +36,11 @@ struct StoreOnboardingTaskView: View {
                     .redacted(reason: isRedacted ? .placeholder : [])
 
                 VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
+                    Spacer().frame(height: Layout.spacerHeight)
+
                     HStack {
                         // Task labels
                         VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
-                            Spacer().frame(height: Layout.spacerHeight)
 
                             HStack {
                                 // Task title.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -65,6 +65,7 @@ struct StoreOnboardingTaskView: View {
                                 .subheadlineStyle()
                                 .multilineTextAlignment(.leading)
                                 .redacted(reason: isRedacted ? .placeholder : [])
+                                // This size modifier is necessary so that the subtitle is never truncated.
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         Spacer()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -70,7 +70,7 @@ struct StoreOnboardingTaskView: View {
                         Image(uiImage: .chevronImage)
                             .flipsForRightToLeftLayoutDirection(true)
                             .foregroundColor(Color(.textTertiary))
-                            .renderedIf(!isRedacted)
+                            .renderedIf(!isRedacted && !viewModel.isComplete)
                     }
 
                     Spacer().frame(height: Layout.spacerHeight)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -64,6 +64,7 @@ struct StoreOnboardingTaskView: View {
                                 .subheadlineStyle()
                                 .multilineTextAlignment(.leading)
                                 .redacted(reason: isRedacted ? .placeholder : [])
+                                .fixedSize(horizontal: false, vertical: true)
                         }
                         Spacer()
                         // Chevron icon

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -110,7 +110,7 @@ struct StoreOnboardingView: View {
     }
 
     private var content: some View {
-        VStack {
+        VStack(spacing: 0) {
             Color(uiColor: .listBackground)
                 .frame(height: Layout.VerticalSpacing.collapsedMode)
                 .renderedIf(!viewModel.isExpanded)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -125,7 +125,7 @@ struct StoreOnboardingView: View {
                                        isRedacted: viewModel.isRedacted)
 
                 // Task list
-                VStack(alignment: .leading, spacing: Layout.verticalSpacingBetweenTasks) {
+                VStack(alignment: .leading, spacing: 0) {
                     ForEach(viewModel.tasksForDisplay) { taskViewModel in
                         let isLastTask = taskViewModel == viewModel.tasksForDisplay.last
 
@@ -180,7 +180,6 @@ private extension StoreOnboardingView {
             static let collapsedMode: CGFloat = 16
             static let expandedMode: CGFloat = 40
         }
-        static let verticalSpacingBetweenTasks: CGFloat = 4
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -145,7 +145,8 @@ struct StoreOnboardingView: View {
                 Spacer()
                     .renderedIf(viewModel.isExpanded)
             }
-            .padding(insets: Layout.insets)
+            .padding(insets: viewModel.shouldShowViewAllButton ?
+                     Layout.insetsWithViewAllButton: Layout.insetsWithoutViewAllButton)
             .if(!viewModel.isExpanded) { $0.background(Color(uiColor: .listForeground(modal: false))) }
 
             Color(uiColor: .listBackground)
@@ -173,7 +174,8 @@ private extension StoreOnboardingView {
 
 private extension StoreOnboardingView {
     enum Layout {
-        static let insets: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+        static let insetsWithViewAllButton: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+        static let insetsWithoutViewAllButton: EdgeInsets = .init(top: 16, leading: 16, bottom: 0, trailing: 16)
         enum VerticalSpacing {
             static let collapsedMode: CGFloat = 16
             static let expandedMode: CGFloat = 40

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreSetupProgressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreSetupProgressView.swift
@@ -35,6 +35,7 @@ struct StoreSetupProgressView: View {
                     .footnoteStyle()
                     .multilineTextAlignment(isExpanded ? .center : .leading)
                     .redacted(reason: isRedacted ? .placeholder : [])
+                    .shimmering(active: isRedacted)
             }
 
             Spacer()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainPurchaseSuccessView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Domains/DomainPurchaseSuccessView.swift
@@ -74,7 +74,7 @@ private extension DomainPurchaseSuccessView {
             comment: "Title of the domain purchase success screen."
         )
         static let subtitle = NSLocalizedString(
-            "Your site address is being set up. It may take up 30 minutes for your domain to start working.",
+            "Your site address is being set up. It may take up to 30 minutes for your domain to start working.",
             comment: "Subtitle of the domain purchase success screen."
         )
         static let instructions = NSLocalizedString(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9227 
Closes: #9184 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR aims to address a few design polishes for the upcoming release.

### Fix occasional extra vertical padding around the onboarding card

Before this PR, there was a UI issue where a 10px padding shows up at the top and bottom of the onboarding card **sometimes** (example below if we set a different color to the hosting controller's view). For the longest time, I thought it was an issue using `UIHostingController`. Then I tried commenting out different parts of the UI and found the root cause of the issue to be the subtitle in `StoreOnboardingTaskView`. The reason is that the subtitle could be showing a different number of lines for each task, and the SwiftUI `Text` doesn't always show all of the content by default. After trying `.lineLimit(nil)` which didn't work, I found [a workaround](https://stackoverflow.com/a/59277022/9185596) to set a size modifier to always fit the height to the content. After the change, the subtitle isn't truncated anymore and the 10px vertical padding issue is fixed.

**Before** (the view's background color is set to orange, notice the subtitle of the first task is truncated): 
<img src="https://user-images.githubusercontent.com/1945542/226843841-5e92b941-e766-4d07-9c36-50cbaa03954a.png" width="300" />

### Add a 16px bottom margin to store name label

In `DashboardViewController`, a 16px bottom margin was added to the store name label now that the onboarding card can be shown at the top with a spacer of a different background color. The 16px value is from the design.

### Other `StoreOnboardingTaskView` polishes

- The chevron icon is hidden when a task is complete
- The top vertical spacer is moved from the HStack to the outside so that the task image icon and the chevron icon can align (you can see in the **Before** screenshot above that they aren't aligned vertically)

### `StoreOnboardingView` polishes

- Updated two VStacks to have 0 spacing to match the design
- When the `View all` CTA isn't shown, the bottom padding is now 0 to match the design VyLr7LvKodHE4kINfBE7Lw-fi-3115-99398

### `StoreSetupProgressView` polish

In the redacted (loading) state, part of the progress bar now also shimmers.

### Domain purchase success typo fix

Fixed a typo in the domain purchase success view “It may take up **to** 30 minutes for your domain to start working.” (ref p1679457036926879/1679456923.870899-slack-C045CUK1Y3U).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### WPCOM site with onboarding tasks

Prerequisite: the site is hosted on WPCOM and has some pending onboarding tasks

- Log in to the site in the prerequisite --> the onboarding card should look as expected without the unexpected vertical padding
- Switch to another tab and then back, and rotate the device optionally --> the onboarding card should look as expected in both the loading and loaded states. in the loading state, the progress view should also shimmer

### Self-hosted site with onboarding tasks

Prerequisite: the site is self-hosted and has some pending onboarding tasks

- Log in to the site in the prerequisite --> the onboarding card should look as expected without the unexpected vertical padding, and without the `View all` CTA
- Switch to another tab and then back, and rotate the device optionally --> the onboarding card should look as expected in both the loading and loaded states. in the loading state, the progress view should also shimmer

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

light | dark
-- | --
![Simulator Screen Shot - iPhone 14 - 2023-03-22 at 16 42 48](https://user-images.githubusercontent.com/1945542/226847869-e89bbb69-9305-4b34-9fb8-9d3edb5041cf.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-22 at 16 44 24](https://user-images.githubusercontent.com/1945542/226848054-b4dfa189-09d0-44aa-b3bc-fee9c5f6b9d3.png)

https://user-images.githubusercontent.com/1945542/226848060-568942f2-cc12-4084-b733-05554469e962.mov



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.