### PR TITLE
[Composite Products] Add Components row to product details

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -87,6 +87,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .manualErrorHandlingForSiteCredentialLogin:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .compositeProducts:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -179,4 +179,8 @@ public enum FeatureFlag: Int {
     /// Enables manual error handling for site credential login.
     ///
     case manualErrorHandlingForSiteCredentialLogin
+
+    /// Enables composite product settings in product details
+    ///
+    case compositeProducts
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -114,6 +114,8 @@ private extension DefaultProductFormTableViewModel {
                 return .attributes(viewModel: productVariationsAttributesRow(product: product.product, isEditable: editable), isEditable: editable)
             case .bundledProducts(let actionable):
                 return .bundledProducts(viewModel: bundledProductsRow(product: product, isActionable: actionable), isActionable: actionable)
+            case .components(let actionable):
+                return .components(viewModel: componentsRow(product: product, isActionable: actionable), isActionable: actionable)
             default:
                 assertionFailure("Unexpected action in the settings section: \(action)")
                 return nil
@@ -531,6 +533,28 @@ private extension DefaultProductFormTableViewModel {
                                                         details: details,
                                                         isActionable: isActionable)
     }
+
+    // MARK: Composite products only
+
+    func componentsRow(product: ProductFormDataModel, isActionable: Bool) -> ProductFormSection.SettingsRow.ViewModel {
+        let icon = UIImage.widgetsImage
+        let title = Localization.componentsTitle
+        let details: String
+
+        switch product.compositeComponents.count {
+        case 1:
+            details = .localizedStringWithFormat(Localization.singularComponentFormat, product.compositeComponents.count)
+        case 2...:
+            details = .localizedStringWithFormat(Localization.pluralComponentsFormat, product.compositeComponents.count)
+        default:
+            details = ""
+        }
+
+        return ProductFormSection.SettingsRow.ViewModel(icon: icon,
+                                                        title: title,
+                                                        details: details,
+                                                        isActionable: isActionable)
+    }
 }
 
 private extension DefaultProductFormTableViewModel {
@@ -730,5 +754,12 @@ private extension DefaultProductFormTableViewModel {
                                                                     comment: "Format of the number of bundled products in singular form")
         static let pluralBundledProductsFormat = NSLocalizedString("%ld products",
                                                                    comment: "Format of the number of bundled products in plural form")
+
+        // Components
+        static let componentsTitle = NSLocalizedString("Components", comment: "Title for Components row in the product form screen.")
+        static let singularComponentFormat = NSLocalizedString("%ld component",
+                                                               comment: "Format of the number of components in singular form")
+        static let pluralComponentsFormat = NSLocalizedString("%ld components",
+                                                              comment: "Format of the number of components in plural form")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -171,6 +171,10 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
         product.bundleStockQuantity
     }
 
+    var compositeComponents: [ProductCompositeComponent] {
+        product.compositeComponents
+    }
+
     func isStockStatusEnabled() -> Bool {
         // Only a variable product's stock status is not editable.
         productType != .variable

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -182,6 +182,10 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
         nil
     }
 
+    var compositeComponents: [ProductCompositeComponent] {
+        []
+    }
+
     // Visibility logic
 
     func allowsMultipleImages() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -73,6 +73,9 @@ protocol ProductFormDataModel {
     var bundleStockStatus: ProductStockStatus? { get }
     var bundleStockQuantity: Int64? { get }
 
+    // Composite Products
+    var compositeComponents: [ProductCompositeComponent] { get }
+
     /// True if a product has been saved remotely.
     var existsRemotely: Bool { get }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -80,7 +80,8 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
              .status,
              .noPriceWarning,
              .attributes,
-             .bundledProducts:
+             .bundledProducts,
+             .components:
             return [ImageAndTitleAndTextTableViewCell.self]
         case .reviews:
             return [ProductReviewsTableViewCell.self]
@@ -110,7 +111,8 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
              .status,
              .noPriceWarning,
              .attributes,
-             .bundledProducts:
+             .bundledProducts,
+             .components:
             return ImageAndTitleAndTextTableViewCell.self
         case .reviews:
             return ProductReviewsTableViewCell.self

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -257,7 +257,8 @@ private extension ProductFormTableViewDataSource {
              .linkedProducts(let viewModel, _),
              .variations(let viewModel),
              .attributes(let viewModel, _),
-             .bundledProducts(let viewModel, _):
+             .bundledProducts(let viewModel, _),
+             .components(let viewModel, _):
             configureSettings(cell: cell, viewModel: viewModel)
         case .reviews(let viewModel, let ratingCount, let averageRating):
             configureReviews(cell: cell, viewModel: viewModel, ratingCount: ratingCount, averageRating: averageRating)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -45,6 +45,7 @@ enum ProductFormSection: Equatable {
         case linkedProducts(viewModel: ViewModel, isEditable: Bool)
         case attributes(viewModel: ViewModel, isEditable: Bool)
         case bundledProducts(viewModel: ViewModel, isActionable: Bool)
+        case components(viewModel: ViewModel, isActionable: Bool)
 
         struct ViewModel {
             let icon: UIImage

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -449,7 +449,12 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 }
                 ServiceLocator.analytics.track(event: .ProductDetail.bundledProductsTapped())
                 showBundledProducts()
-                return
+            case .components(_, let isActionable):
+                guard isActionable else {
+                    return
+                }
+                // TODO-8956: Track composite row is tapped
+                // TODO-8956: Navigate to Components view
             }
         case .optionsCTA(let rows):
             let row = rows[indexPath.row]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -672,6 +672,53 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
         assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
     }
+
+    func test_view_model_for_composite_product_with_feature_flag_disabled() {
+        // Arrange
+        let product = Fixtures.compositeProduct
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isCompositeProductsEnabled: false)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: false, hideSeparator: false),
+                                                                       .reviews,
+                                                                       .inventorySettings(editable: false),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: false)]
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
+        assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
+    }
+
+    func test_view_model_for_composite_product_with_feature_flag_enabled() {
+        // Arrange
+        let product = Fixtures.compositeProduct
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isCompositeProductsEnabled: true)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.components(actionable: true),
+                                                                       .priceSettings(editable: false, hideSeparator: false),
+                                                                       .reviews,
+                                                                       .inventorySettings(editable: false),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: false)]
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
+        assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
+    }
 }
 
 private extension ProductFormActionsFactoryTests {
@@ -722,6 +769,9 @@ private extension ProductFormActionsFactoryTests {
         // Bundle product, missing price/short description/categories/tags
         static let bundleProduct = affiliateProduct.copy(productTypeKey: ProductType.bundle.rawValue)
 
+        // Composite product with price and composite components
+        static let compositeProduct = affiliateProduct.copy(productTypeKey: ProductType.composite.rawValue, regularPrice: "2", compositeComponents: [.fake()])
+
         // Non-core product, missing price/short description/categories/tags
         static let nonCoreProductWithoutPrice = affiliateProduct.copy(productTypeKey: "other", regularPrice: "")
 
@@ -740,6 +790,7 @@ private extension ProductFormActionsFactoryTests {
                                    isCategoriesActionAlwaysEnabled: Bool = false,
                                    isDownloadableFilesSettingBased: Bool = true,
                                    isBundledProductsEnabled: Bool = false,
+                                   isCompositeProductsEnabled: Bool = false,
                                    variationsPrice: ProductFormActionsFactory.VariationsPrice = .unknown) -> ProductFormActionsFactory {
             ProductFormActionsFactory(product: product,
                                       formType: formType,
@@ -752,6 +803,7 @@ private extension ProductFormActionsFactoryTests {
                                       isCategoriesActionAlwaysEnabled: isCategoriesActionAlwaysEnabled,
                                       isDownloadableFilesSettingBased: isDownloadableFilesSettingBased,
                                       isBundledProductsEnabled: isBundledProductsEnabled,
+                                      isCompositeProductsEnabled: isCompositeProductsEnabled,
                                       variationsPrice: variationsPrice)
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8956
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds a (non-actionable for now) Components row to the product details screen for Composite Products, behind a feature flag. This row shows the number of components in a Composite Product.

### Changes

* Adds a `compositeProducts` feature flag.
* Adds the Components row view model to `DefaultProductFormTableViewModel`.
* Defines the rows to show for Composite Products in `ProductFormActionsFactory`. These are the same as before (for non-core products) with the addition of the Components row.
* Adds the new row to the Product Form (VC, table data source, etc.).
* Adds unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Prerequisites

1. Install and activate the [Composite Products extension](https://woocommerce.com/products/composite-products/) on your store.
2. Create at least one product with the Composite Products type, with at least one component.

### To test

1. Build and run the app.
2. Go to the Products tab.
3. Open a Composite Product and confirm the new Components row appears as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before/Feature flag disabled|Feature flag enabled
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-22 at 10 53 08](https://user-images.githubusercontent.com/8658164/226882083-dec703ac-3799-427c-a95d-e66460e3a82f.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-22 at 10 40 46](https://user-images.githubusercontent.com/8658164/226881877-59da823e-3df0-419d-bca1-31b408c84792.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
