### PR TITLE
[Composite Products] Add and navigate to Components list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentsList.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentsList.swift
@@ -31,6 +31,10 @@ struct ComponentsList: View {
     ///
     @ScaledMetric private var imageWidth = Layout.standardImageWidth
 
+    /// Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
+
     var body: some View {
         ScrollView {
             LazyVStack(spacing: Layout.sectionSpacing) {
@@ -45,20 +49,22 @@ struct ComponentsList: View {
                             .frame(width: imageWidth, height: imageWidth)
                             .cornerRadius(Layout.imageCornerRadius)
                             .accessibilityHidden(true)
-                            .padding(.leading)
+                            .padding()
 
                         Text(component.title)
                             .bodyStyle()
                             .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding()
                     }
-                    Divider().padding(.leading)
+                    Divider()
                 }
+                .padding(.leading, insets: safeAreaInsets)
             }
             .background(Color(.listForeground(modal: false)))
 
             FooterNotice(infoText: viewModel.infoNotice)
+                .padding(.horizontal, insets: safeAreaInsets)
         }
+        .ignoresSafeArea(edges: .horizontal)
         .background(
             Color(.listBackground).edgesIgnoringSafeArea(.all)
         )

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentsList.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentsList.swift
@@ -1,0 +1,97 @@
+import UIKit
+import SwiftUI
+import Kingfisher
+
+// MARK: Hosting Controller
+
+/// Hosting controller that wraps a `ComponentsList` view.
+///
+final class ComponentsListViewController: UIHostingController<ComponentsList> {
+    init(viewModel: ComponentsListViewModel) {
+        super.init(rootView: ComponentsList(viewModel: viewModel))
+        title = viewModel.title
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: Views
+
+/// Renders a list of components in a composite product
+///
+struct ComponentsList: View {
+
+    /// View model that directs the view content.
+    ///
+    let viewModel: ComponentsListViewModel
+
+    /// Dynamic image width, also used for its height.
+    ///
+    @ScaledMetric private var imageWidth = Layout.standardImageWidth
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: Layout.sectionSpacing) {
+                ForEach(viewModel.components) { component in
+                    HStack {
+                        KFImage(component.imageURL)
+                            .placeholder {
+                                Image(uiImage: .productPlaceholderImage)
+                                    .foregroundColor(Color(.listIcon))
+                            }
+                            .resizable()
+                            .frame(width: imageWidth, height: imageWidth)
+                            .cornerRadius(Layout.imageCornerRadius)
+                            .accessibilityHidden(true)
+                            .padding(.leading)
+
+                        Text(component.title)
+                            .bodyStyle()
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding()
+                    }
+                    Divider().padding(.leading)
+                }
+            }
+            .background(Color(.listForeground(modal: false)))
+
+            FooterNotice(infoText: viewModel.infoNotice)
+        }
+        .background(
+            Color(.listBackground).edgesIgnoringSafeArea(.all)
+        )
+    }
+}
+
+private enum Layout {
+    static let standardImageWidth: CGFloat = 48.0
+    static let imageCornerRadius: CGFloat = 4.0
+    static let sectionSpacing: CGFloat = 0
+}
+
+
+// MARK: Previews
+struct ComponentsList_Previews: PreviewProvider {
+
+    static let viewModel = ComponentsListViewModel(components: [
+        .init(id: "1", title: "Camera Body", imageURL: nil),
+        .init(id: "2", title: "Lens", imageURL: nil),
+        .init(id: "3", title: "Memory Card", imageURL: nil)
+    ])
+
+    static var previews: some View {
+        ComponentsList(viewModel: viewModel)
+            .environment(\.colorScheme, .light)
+            .previewDisplayName("Light")
+
+        ComponentsList(viewModel: viewModel)
+            .environment(\.colorScheme, .dark)
+            .previewDisplayName("Dark")
+
+        ComponentsList(viewModel: viewModel)
+            .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+            .previewDisplayName("Large Font")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentsList.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentsList.swift
@@ -25,7 +25,7 @@ struct ComponentsList: View {
 
     /// View model that directs the view content.
     ///
-    let viewModel: ComponentsListViewModel
+    @StateObject var viewModel: ComponentsListViewModel
 
     /// Dynamic image width, also used for its height.
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentsListViewModel.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Yosemite
+
+/// ViewModel for `ComponentsList`
+///
+final class ComponentsListViewModel {
+
+    /// Represents a component
+    ///
+    struct Component: Identifiable {
+        /// Component ID
+        let id: String
+
+        /// Title of the component
+        let title: String
+
+        /// Default image for the component
+        let imageURL: URL?
+    }
+
+    /// View title
+    ///
+    let title = Localization.title
+
+    /// View info notice
+    ///
+    let infoNotice = Localization.infoNotice
+
+    /// Components
+    ///
+    let components: [Component]
+
+    init(components: [Component]) {
+        self.components = components
+    }
+}
+
+// MARK: Initializers
+extension ComponentsListViewModel {
+    convenience init(components: [ProductCompositeComponent]) {
+        let viewModels = components.map { component in
+            Component(id: component.componentID, title: component.title, imageURL: URL(string: component.imageURL))
+        }
+        self.init(components: viewModels)
+    }
+}
+
+// MARK: Constants
+private extension ComponentsListViewModel {
+    enum Localization {
+        static let title = NSLocalizedString("Components", comment: "Title for the list of components in a composite product")
+        static let infoNotice = NSLocalizedString("You can edit components in the web dashboard.",
+                                                  comment: "Info notice at the bottom of the components screen")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentsListViewModel.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// ViewModel for `ComponentsList`
 ///
-final class ComponentsListViewModel {
+final class ComponentsListViewModel: ObservableObject {
 
     /// Represents a component
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -453,8 +453,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 guard isActionable else {
                     return
                 }
-                // TODO-8956: Track composite row is tapped
-                // TODO-8956: Navigate to Components view
+                // TODO-9237: Track composite row is tapped
+                showCompositeComponents()
             }
         case .optionsCTA(let rows):
             let row = rows[indexPath.row]
@@ -1693,6 +1693,19 @@ private extension ProductFormViewController {
         }
         let viewModel = BundledProductsListViewModel(siteID: product.siteID, bundleItems: product.bundledItems)
         let viewController = BundledProductsListViewController(viewModel: viewModel)
+        show(viewController, sender: self)
+    }
+}
+
+// MARK: Action - Show Composite Product Components
+//
+private extension ProductFormViewController {
+    func showCompositeComponents() {
+        guard let product = product as? EditableProductModel else {
+            return
+        }
+        let viewModel = ComponentsListViewModel(components: product.compositeComponents)
+        let viewController = ComponentsListViewController(viewModel: viewModel)
         show(viewController, sender: self)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1546,6 +1546,7 @@
 		CC04918F292BD6AC00F719D8 /* StatsDataTextFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC04918E292BD6AC00F719D8 /* StatsDataTextFormatterTests.swift */; };
 		CC078531266E706300BA9AC1 /* ErrorTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC078530266E706300BA9AC1 /* ErrorTopBannerFactory.swift */; };
 		CC07860526736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC07860426736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift */; };
+		CC09A91229CB1ADB00D6C4AD /* ComponentsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC09A91129CB1ADB00D6C4AD /* ComponentsListViewModelTests.swift */; };
 		CC13C0CB278E021300C0B5B5 /* ProductVariationSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13C0CA278E021300C0B5B5 /* ProductVariationSelectorViewModel.swift */; };
 		CC13C0CD278E086D00C0B5B5 /* ProductVariationSelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13C0CC278E086D00C0B5B5 /* ProductVariationSelectorViewModelTests.swift */; };
 		CC1AB56827FC5822003DEF43 /* OrderStatusScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1AB56727FC5821003DEF43 /* OrderStatusScreen.swift */; };
@@ -1623,6 +1624,8 @@
 		CCF4346E290AE1F900B4475A /* ProductsOnboardingAnnouncementCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF4346D290AE1F900B4475A /* ProductsOnboardingAnnouncementCardViewModel.swift */; };
 		CCF87BBE279047BC00461C43 /* InfiniteScrollList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF87BBD279047BC00461C43 /* InfiniteScrollList.swift */; };
 		CCF87BC02790582500461C43 /* ProductVariationSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF87BBF2790582400461C43 /* ProductVariationSelector.swift */; };
+		CCFBBCF429C4B8AF0081B595 /* ComponentsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFBBCF329C4B8AF0081B595 /* ComponentsList.swift */; };
+		CCFBBCF629C4B9A30081B595 /* ComponentsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFBBCF529C4B9A30081B595 /* ComponentsListViewModel.swift */; };
 		CCFC00B523E9BD1500157A78 /* ScreenshotCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFC00B423E9BD1500157A78 /* ScreenshotCredentials.swift */; };
 		CCFC00EE23E9BD5500157A78 /* oauth2_token.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00BC23E9BD5500157A78 /* oauth2_token.json */; };
 		CCFC00EF23E9BD5500157A78 /* auth_options.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00BD23E9BD5500157A78 /* auth_options.json */; };
@@ -3740,6 +3743,7 @@
 		CC04918E292BD6AC00F719D8 /* StatsDataTextFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsDataTextFormatterTests.swift; sourceTree = "<group>"; };
 		CC078530266E706300BA9AC1 /* ErrorTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTopBannerFactory.swift; sourceTree = "<group>"; };
 		CC07860426736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTopBannerFactoryTests.swift; sourceTree = "<group>"; };
+		CC09A91129CB1ADB00D6C4AD /* ComponentsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentsListViewModelTests.swift; sourceTree = "<group>"; };
 		CC13C0CA278E021300C0B5B5 /* ProductVariationSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationSelectorViewModel.swift; sourceTree = "<group>"; };
 		CC13C0CC278E086D00C0B5B5 /* ProductVariationSelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationSelectorViewModelTests.swift; sourceTree = "<group>"; };
 		CC1AB56727FC5821003DEF43 /* OrderStatusScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusScreen.swift; sourceTree = "<group>"; };
@@ -3818,6 +3822,8 @@
 		CCF4346D290AE1F900B4475A /* ProductsOnboardingAnnouncementCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsOnboardingAnnouncementCardViewModel.swift; sourceTree = "<group>"; };
 		CCF87BBD279047BC00461C43 /* InfiniteScrollList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollList.swift; sourceTree = "<group>"; };
 		CCF87BBF2790582400461C43 /* ProductVariationSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationSelector.swift; sourceTree = "<group>"; };
+		CCFBBCF329C4B8AF0081B595 /* ComponentsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentsList.swift; sourceTree = "<group>"; };
+		CCFBBCF529C4B9A30081B595 /* ComponentsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentsListViewModel.swift; sourceTree = "<group>"; };
 		CCFC00B423E9BD1500157A78 /* ScreenshotCredentials.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenshotCredentials.swift; sourceTree = "<group>"; };
 		CCFC00BC23E9BD5500157A78 /* oauth2_token.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = oauth2_token.json; sourceTree = "<group>"; };
 		CCFC00BD23E9BD5500157A78 /* auth_options.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = auth_options.json; sourceTree = "<group>"; };
@@ -4517,6 +4523,7 @@
 		020B2F9723BDF2D000BD79AD /* Edit Product */ = {
 			isa = PBXGroup;
 			children = (
+				CC09A91029CB1AB700D6C4AD /* Composite Products */,
 				CCE785C629C1E80D0003977F /* Bundled Products */,
 				455208592582907C001CF873 /* Add Product Variation */,
 				AEB73C1525CD8E3100A8454A /* Edit Product Variation */,
@@ -4625,6 +4632,7 @@
 				4592A54824BF58A200BC3DE0 /* Edit Tags */,
 				45E9A6E124DAE18E00A600E8 /* Reviews */,
 				CC01CE5B29B2342E004FF537 /* Bundled Products */,
+				CCFBBCF229C4B8820081B595 /* Composite Product Components */,
 				02162724237963AF000208D2 /* ProductFormViewController.swift */,
 				02162725237963AF000208D2 /* ProductFormViewController.xib */,
 				45912FE22526642200982948 /* ProductFormViewController+Helpers.swift */,
@@ -8225,6 +8233,14 @@
 			path = "Product Settings";
 			sourceTree = "<group>";
 		};
+		CC09A91029CB1AB700D6C4AD /* Composite Products */ = {
+			isa = PBXGroup;
+			children = (
+				CC09A91129CB1ADB00D6C4AD /* ComponentsListViewModelTests.swift */,
+			);
+			path = "Composite Products";
+			sourceTree = "<group>";
+		};
 		CC200BAF27847D9300EC5884 /* PaymentSection */ = {
 			isa = PBXGroup;
 			children = (
@@ -8357,6 +8373,15 @@
 				CCE785C729C1E8280003977F /* BundledProductsListViewModelTests.swift */,
 			);
 			path = "Bundled Products";
+			sourceTree = "<group>";
+		};
+		CCFBBCF229C4B8820081B595 /* Composite Product Components */ = {
+			isa = PBXGroup;
+			children = (
+				CCFBBCF329C4B8AF0081B595 /* ComponentsList.swift */,
+				CCFBBCF529C4B9A30081B595 /* ComponentsListViewModel.swift */,
+			);
+			path = "Composite Product Components";
 			sourceTree = "<group>";
 		};
 		CCFC00B623E9BD5500157A78 /* Mocks */ = {
@@ -10936,6 +10961,7 @@
 				45B6F4EF27592A4000C18782 /* ReviewsView.swift in Sources */,
 				268FD44727580A81008FDF9B /* LegacyCollectOrderPaymentUseCase.swift in Sources */,
 				B6F37970293798ED00718561 /* AnalyticsHubTodayRangeData.swift in Sources */,
+				CCFBBCF629C4B9A30081B595 /* ComponentsListViewModel.swift in Sources */,
 				269098B427D2BBFC001FEB07 /* ShippingInputTransformer.swift in Sources */,
 				740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */,
 				45F627B6253603AE00894B86 /* Product+DownloadSettingsViewModels.swift in Sources */,
@@ -11877,6 +11903,7 @@
 				0365986729AFAEFC00F297D3 /* SetUpTapToPayViewModelsOrderedList.swift in Sources */,
 				6856D31F941A33BAE66F394D /* KeyboardFrameAdjustmentProvider.swift in Sources */,
 				CCFC50592743E021001E505F /* EditableOrderViewModel.swift in Sources */,
+				CCFBBCF429C4B8AF0081B595 /* ComponentsList.swift in Sources */,
 				B96D6C0729081AE5003D2DC0 /* InAppPurchasesForWPComPlansManager.swift in Sources */,
 				6856DB2E741639716E149967 /* KeyboardStateProvider.swift in Sources */,
 				ABC35F18E744C5576B986CB3 /* InPersonPaymentsUnavailableView.swift in Sources */,
@@ -12086,6 +12113,7 @@
 				2655905B27863D1300BB8457 /* MockCollectOrderPaymentUseCase.swift in Sources */,
 				027F83EF29B048E2002688C6 /* DashboardTopPerformersViewModelTests.swift in Sources */,
 				D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */,
+				CC09A91229CB1ADB00D6C4AD /* ComponentsListViewModelTests.swift in Sources */,
 				A650BE862578E76600C655E0 /* MockStorageManager+Sample.swift in Sources */,
 				5791FB4224EC834300117FD6 /* MainTabViewModelTests.swift in Sources */,
 				020BE76D23B4A404007FE54C /* AztecStrikethroughFormatBarCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Composite Products/ComponentsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Composite Products/ComponentsListViewModelTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class ComponentsListViewModelTests: XCTestCase {
+
+    func test_view_model_prefills_component_data_correctly() throws {
+        // Given
+        let compositeComponent = ProductCompositeComponent.fake().copy(componentID: "1", title: "Camera Body", imageURL: "https://woocommerce.com/woo.jpg")
+
+        // When
+        let viewModel = ComponentsListViewModel(components: [compositeComponent])
+        let component = try XCTUnwrap(viewModel.components.first)
+
+        // Then
+        XCTAssertEqual(component.id, compositeComponent.componentID)
+        XCTAssertEqual(component.title, compositeComponent.title)
+        XCTAssertEqual(component.imageURL?.absoluteString, compositeComponent.imageURL)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8956
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a basic Components list view, to display the list of components in a composite product. It includes the component title and image.

A future PR will add more component details. Design discussion (internal ref): pe5pgL-2wF-p2

### Changes

* Adds a new `ComponentsList` view with a `UIHostingController`.
* Adds a view model `ComponentsListViewModel` to power the view, including a convenience init to create the view model from a `ProductCompositeComponent`.
* Updates `ProductFormViewController` to navigate to the components list when the Components row is tapped in product details.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Product Details|New Components View
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-22 at 11 20 35](https://user-images.githubusercontent.com/8658164/226924689-f80d18f8-4846-4dde-93c5-23b78d58ac7b.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-22 at 11 20 38](https://user-images.githubusercontent.com/8658164/226924710-a2b91c92-7494-4b41-b694-72115aa40655.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.