### PR TITLE
REST API: Analytics and feature flag enabling for application password authorization in web view

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -86,7 +86,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .freeTrial:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .manualErrorHandlingForSiteCredentialLogin:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .compositeProducts:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/Networking/Networking/Model/WordPressSite.swift
+++ b/Networking/Networking/Model/WordPressSite.swift
@@ -71,8 +71,8 @@ public struct WordPressSite: Decodable, Equatable {
             }
         }()
         let namespaces = try container.decode([String].self, forKey: .namespaces)
-        let authentication = try container.decode(Authentication.self, forKey: .authentication)
-        let applicationPasswordURL = authentication.applicationPasswords?.endpoints?.authorization
+        let authentication = try? container.decode(Authentication.self, forKey: .authentication)
+        let applicationPasswordURL = authentication?.applicationPasswords?.endpoints?.authorization
 
         self.init(name: name,
                   description: description,

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Payments: Local search is added to the products selection screen in the order creation flow to speed the process. [https://github.com/woocommerce/woocommerce-ios/pull/9178]
 - [*] Fix: Prevent product variations not loading due to an encoding error for `permalink`, which was altered by a plugin. [https://github.com/woocommerce/woocommerce-ios/pull/9233]
+- [*] Login: Users can now log in to self-hosted sites without Jetpack by approving application password authorization to their sites. [https://github.com/woocommerce/woocommerce-ios/pull/9260]
 
 12.8
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -847,6 +847,14 @@ public enum WooAnalyticsStat: String {
     case freeTrialUpgradeNowTapped = "free_trial_upgrade_now_tapped"
     case planUpgradeSuccess = "plan_upgrade_success"
     case planUpgradeAbandoned = "plan_upgrade_abandoned"
+
+    // MARK: Application password authorization in web view
+    case applicationPasswordAuthorizationButtonTapped = "application_password_authorization_button_tapped"
+    case applicationPasswordAuthorizationWebViewShown = "application_password_authorization_web_view_shown"
+    case applicationPasswordAuthorizationRejected = "application_password_authorization_rejected"
+    case applicationPasswordAuthorizationApproved = "application_password_authorization_approved"
+    case applicationPasswordAuthorizationURLNotAvailable = "application_password_authorization_url_not_available"
+    case applicationPasswordAuthorizationURLFetchFailed = "application_password_authorization_url_fetch_failed"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -297,6 +297,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
                 guard let self else { return }
                 let webViewController = self.applicationPasswordWebView(for: siteURL)
                 viewController.navigationController?.pushViewController(webViewController, animated: true)
+                self.analytics.track(.applicationPasswordAuthorizationButtonTapped)
             }
         )
         viewController.present(alertController, animated: true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9186
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a few changes:
- Analytics for events related to application password authorization in the web view.
- Fixed issue parsing `WordPressSite` when application password is disabled by making decoding the `authentication` property failable.
- Enabled the feature flag for the entry point of application password authorization.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: make sure that you have access to a self-hosted site with Woo but not Jetpack.
- Attempt to log in to your test store with incorrect credentials.
- On the error alert displayed, tap the button to log in with wp-admin.
- Notice in Xcode console: `🔵 Tracked application_password_authorization_button_tapped`
- If your site doesn't block application password, you should then see in Xcode console: `🔵 Tracked application_password_authorization_web_view_shown`.
- Log in with the correct credentials in the displayed wp-admin page.
- Tap the button to not approve the authorization. Notice in Xcode console: `🔵 Tracked application_password_authorization_rejected`
- Try again, this time tap the approve button. Notice in Xcode console: `🔵 Tracked application_password_authorization_approved`.

Test failure cases:
- Install [WordFence](https://wordpress.org/plugins/wordfence/) plugin on your test store and configure it. This should disable application passwords on your site.
- Repeat the steps above to open the authorization web view, notice an alert saying application password is disabled. 
- Notice in Xcode console: `🔵 Tracked application_password_authorization_url_not_available`.
- Try again, this time disable your connection before tapping the log in with wp-admin button. 
- After a while, notice an alert about the failure to fetch the authorization URL. 
- Notice in Xcode console: `🔵 Tracked application_password_authorization_url_fetch_failed` with the relevant error.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
