### PR TITLE
[Product Bundles] Accessibility improvements in bundled products list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
@@ -31,6 +31,10 @@ struct BundledProductsList: View {
     ///
     @ScaledMetric private var imageWidth = Layout.standardImageWidth
 
+    ///   Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
+
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
@@ -49,13 +53,16 @@ struct BundledProductsList: View {
 
                         TitleAndSubtitleRow(title: bundledProduct.title, subtitle: bundledProduct.stockStatus)
                     }
-                    Divider().padding(.leading)
+                    .padding(.horizontal, insets: safeAreaInsets)
+                    Divider().padding(.leading, insets: safeAreaInsets)
                 }
             }
             .background(Color(.listForeground(modal: false)))
 
             FooterNotice(infoText: viewModel.infoNotice)
+                .padding(.horizontal, insets: safeAreaInsets)
         }
+        .ignoresSafeArea(edges: .horizontal)
         .background(
             Color(.listBackground).edgesIgnoringSafeArea(.all)
         )

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Bundled Products/Bundled Product List/BundledProductsListViewController.swift
@@ -52,6 +52,7 @@ struct BundledProductsList: View {
                             .padding(.leading)
 
                         TitleAndSubtitleRow(title: bundledProduct.title, subtitle: bundledProduct.stockStatus)
+                            .accessibilityElement(children: .combine)
                     }
                     .padding(.horizontal, insets: safeAreaInsets)
                     Divider().padding(.leading, insets: safeAreaInsets)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FooterNotice.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FooterNotice.swift
@@ -11,6 +11,7 @@ struct FooterNotice: View {
     var body: some View {
         HStack {
             Image(uiImage: .infoOutlineImage)
+                .accessibilityHidden(true)
             Text(infoText)
         }
         .footnoteStyle()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9261
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes a few minor accessibility issues found on the Bundled Products screen in testing:

* Makes the list background extend edge-to-edge in landscape orientation.
* Combines the product name and stock status when read by VoiceOver.
* Hides the footer notice icon from VoiceOver, since it's decorative.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Select a site with the Product Bundles extension and at least one product bundle with bundled products in it.
2. On the Products tab, select a product bundle.
3. Select the Bundled Products row in product details.
4. Rotate your device to landscape and confirm the background extends edge-to-edge.
5. Enable VoiceOver and confirm it reads the expected labels (see also the screencast below).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![IMG_1076](https://user-images.githubusercontent.com/8658164/226971582-a44586e0-f64d-401f-9d97-434d67e2b556.PNG)|![IMG_1082](https://user-images.githubusercontent.com/8658164/226971954-dcf1a810-7122-40d5-83e1-ab31551c81bd.PNG)


https://user-images.githubusercontent.com/8658164/226971361-54ae3b8d-3e06-49d4-8818-d8c61624fb16.mov



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
