### PR TITLE
[Free Trial] Launch support from upgrades view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -13,6 +13,10 @@ final class UpgradesHostingController: UIHostingController<UpgradesView> {
         rootView.onUpgradeNowTapped = { [weak self] in
             self?.showUpgradePlanWebView(siteID: siteID, viewModel: viewModel)
         }
+
+        rootView.onReportIssueTapped = { [weak self] in
+            self?.showContactSupportForm()
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -27,6 +31,11 @@ final class UpgradesHostingController: UIHostingController<UpgradesView> {
         })
         present(upgradeController, animated: true)
     }
+
+    private func showContactSupportForm() {
+        let supportController = SupportFormHostingController(viewModel: .init())
+        supportController.show(from: self)
+    }
 }
 
 /// Main view for the plan settings.
@@ -40,6 +49,10 @@ struct UpgradesView: View {
     /// Closure to be invoked when the "Upgrade Now" button is tapped.
     ///
     var onUpgradeNowTapped: (() -> ())?
+
+    /// Closure to be invoked when the "Report Issue" button is tapped.
+    ///
+    var onReportIssueTapped: (() -> ())?
 
     var body: some View {
         List {
@@ -67,7 +80,7 @@ struct UpgradesView: View {
 
             Section(Localization.troubleshooting) {
                 Button(Localization.report) {
-                    print("Report Subscription Tapped")
+                    onReportIssueTapped?()
                 }
                 .linkStyle()
             }


### PR DESCRIPTION
Closes: #9063 
Closes: #9064 

# Why

This PR adds launches the new Support Form from the Upgrades View.

# Demo

https://user-images.githubusercontent.com/562080/226972756-ad463b07-58cd-4f94-9f63-c46175f2233a.mov

# Testing

- Launch the app on a WPCom site
- Go to the upgrades view
- Tap the "Report Subscription Issue"
- Make sure we can submit a support ticket - Be sure to use a non A8C email.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
