### PR TITLE
[Composite Products] Add support for component description and default option ID

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -961,9 +961,11 @@ extension Networking.ProductCompositeComponent {
         .init(
             componentID: .fake(),
             title: .fake(),
+            description: .fake(),
             imageURL: .fake(),
             optionType: .fake(),
-            optionIDs: .fake()
+            optionIDs: .fake(),
+            defaultOptionID: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1334,22 +1334,28 @@ extension Networking.ProductCompositeComponent {
     public func copy(
         componentID: CopiableProp<String> = .copy,
         title: CopiableProp<String> = .copy,
+        description: CopiableProp<String> = .copy,
         imageURL: CopiableProp<String> = .copy,
         optionType: CopiableProp<CompositeComponentOptionType> = .copy,
-        optionIDs: CopiableProp<[Int64]> = .copy
+        optionIDs: CopiableProp<[Int64]> = .copy,
+        defaultOptionID: CopiableProp<String> = .copy
     ) -> Networking.ProductCompositeComponent {
         let componentID = componentID ?? self.componentID
         let title = title ?? self.title
+        let description = description ?? self.description
         let imageURL = imageURL ?? self.imageURL
         let optionType = optionType ?? self.optionType
         let optionIDs = optionIDs ?? self.optionIDs
+        let defaultOptionID = defaultOptionID ?? self.defaultOptionID
 
         return Networking.ProductCompositeComponent(
             componentID: componentID,
             title: title,
+            description: description,
             imageURL: imageURL,
             optionType: optionType,
-            optionIDs: optionIDs
+            optionIDs: optionIDs,
+            defaultOptionID: defaultOptionID
         )
     }
 }

--- a/Networking/Networking/Model/Product/ProductCompositeComponent.swift
+++ b/Networking/Networking/Model/Product/ProductCompositeComponent.swift
@@ -10,6 +10,9 @@ public struct ProductCompositeComponent: Codable, Equatable, GeneratedCopiable, 
     /// Title of the component.
     public let title: String
 
+    /// Description of the component.
+    public let description: String
+
     /// URL of the image associated with this component.
     public let imageURL: String
 
@@ -19,18 +22,25 @@ public struct ProductCompositeComponent: Codable, Equatable, GeneratedCopiable, 
     /// Product IDs or category IDs to use for populating component options.
     public let optionIDs: [Int64]
 
+    /// The product ID of the default/pre-selected component option.
+    public let defaultOptionID: String
+
     /// ProductCompositeComponent struct initializer
     ///
     public init(componentID: String,
                 title: String,
+                description: String,
                 imageURL: String,
                 optionType: CompositeComponentOptionType,
-                optionIDs: [Int64]) {
+                optionIDs: [Int64],
+                defaultOptionID: String) {
         self.componentID = componentID
         self.title = title
+        self.description = description
         self.imageURL = imageURL
         self.optionType = optionType
         self.optionIDs = optionIDs
+        self.defaultOptionID = defaultOptionID
     }
 }
 
@@ -39,11 +49,13 @@ public struct ProductCompositeComponent: Codable, Equatable, GeneratedCopiable, 
 private extension ProductCompositeComponent {
 
     enum CodingKeys: String, CodingKey {
-        case componentID    = "id"
+        case componentID     = "id"
         case title
-        case imageURL       = "thumbnail_src"
-        case optionType     = "query_type"
-        case optionIDs      = "query_ids"
+        case description
+        case imageURL        = "thumbnail_src"
+        case optionType      = "query_type"
+        case optionIDs       = "query_ids"
+        case defaultOptionID = "default_option_id"
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -334,9 +334,12 @@ final class ProductMapperTests: XCTestCase {
         // Check parsed ProductCompositeComponent properties
         XCTAssertEqual(compositeComponent.componentID, "1679310855")
         XCTAssertEqual(compositeComponent.title, "Camera Body")
+        XCTAssertEqual(compositeComponent.description,
+                       "<p>Choose between the Nikon D600 or the powerful 5D Mark III and take your creativity to new levels.</p>\n")
         XCTAssertEqual(compositeComponent.imageURL, "https://example.com/woo.jpg")
         XCTAssertEqual(compositeComponent.optionType, .productIDs)
         XCTAssertEqual(compositeComponent.optionIDs, [413, 412])
+        XCTAssertEqual(compositeComponent.defaultOptionID, "413")
     }
 }
 

--- a/Storage/Storage/Model/ProductCompositeComponent+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductCompositeComponent+CoreDataProperties.swift
@@ -13,6 +13,8 @@ extension ProductCompositeComponent {
     @NSManaged public var optionType: String?
     @NSManaged public var imageURL: String?
     @NSManaged public var optionIDs: [Int64]?
+    @NSManaged public var componentDescription: String?
+    @NSManaged public var defaultOptionID: String?
     @NSManaged public var product: Product?
 
 }

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 82.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 82.xcdatamodel/contents
@@ -499,7 +499,9 @@
         <relationship name="products" optional="YES" toMany="YES" deletionRule="Deny" destinationEntity="Product" inverseName="categories" inverseEntity="Product"/>
     </entity>
     <entity name="ProductCompositeComponent" representedClassName="ProductCompositeComponent" syncable="YES">
+        <attribute name="componentDescription" attributeType="String" defaultValueString=""/>
         <attribute name="componentID" attributeType="String" defaultValueString=""/>
+        <attribute name="defaultOptionID" attributeType="String" defaultValueString=""/>
         <attribute name="imageURL" attributeType="String" defaultValueString=""/>
         <attribute name="optionIDs" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="optionType" attributeType="String" defaultValueString=""/>

--- a/Storage/StorageTests/CoreData/MigrationTests.swift
+++ b/Storage/StorageTests/CoreData/MigrationTests.swift
@@ -1666,6 +1666,8 @@ final class MigrationTests: XCTestCase {
         XCTAssertNotNil(component.value(forKey: "imageURL"))
         XCTAssertNotNil(component.value(forKey: "optionType"))
         XCTAssertNotNil(component.value(forKey: "optionIDs"))
+        XCTAssertNotNil(component.value(forKey: "componentDescription"))
+        XCTAssertNotNil(component.value(forKey: "defaultOptionID"))
         XCTAssertEqual(component.value(forKey: "product") as? NSManagedObject, migratedProduct)
 
         // Product components attribute exists.

--- a/Yosemite/Yosemite/Model/Storage/ProductCompositeComponent+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductCompositeComponent+ReadOnlyConvertible.swift
@@ -11,9 +11,11 @@ extension Storage.ProductCompositeComponent: ReadOnlyConvertible {
     public func update(with compositeComponent: Yosemite.ProductCompositeComponent) {
         componentID = compositeComponent.componentID
         title = compositeComponent.title
+        componentDescription = compositeComponent.description
         imageURL = compositeComponent.imageURL
         optionType = compositeComponent.optionType.rawValue
         optionIDs = compositeComponent.optionIDs
+        defaultOptionID = compositeComponent.defaultOptionID
     }
 
     /// Returns a ReadOnly version of the receiver.
@@ -21,10 +23,10 @@ extension Storage.ProductCompositeComponent: ReadOnlyConvertible {
     public func toReadOnly() -> Yosemite.ProductCompositeComponent {
         return ProductCompositeComponent(componentID: componentID ?? "",
                                          title: title ?? "",
-                                         description: "", // TODO-8955: Convert description
+                                         description: componentDescription ?? "",
                                          imageURL: imageURL ?? "",
                                          optionType: CompositeComponentOptionType(rawValue: optionType ?? "product_ids") ?? .productIDs,
                                          optionIDs: optionIDs ?? [],
-                                         defaultOptionID: "") // TODO-8955: Convert default option ID
+                                         defaultOptionID: defaultOptionID ?? "")
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/ProductCompositeComponent+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductCompositeComponent+ReadOnlyConvertible.swift
@@ -21,8 +21,10 @@ extension Storage.ProductCompositeComponent: ReadOnlyConvertible {
     public func toReadOnly() -> Yosemite.ProductCompositeComponent {
         return ProductCompositeComponent(componentID: componentID ?? "",
                                          title: title ?? "",
+                                         description: "", // TODO-8955: Convert description
                                          imageURL: imageURL ?? "",
                                          optionType: CompositeComponentOptionType(rawValue: optionType ?? "product_ids") ?? .productIDs,
-                                         optionIDs: optionIDs ?? [])
+                                         optionIDs: optionIDs ?? [],
+                                         defaultOptionID: "") // TODO-8955: Convert default option ID
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8955
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a followup to the PRs for #8955 that added support for composite products in the Networking, Storage, and Yosemite layers. It adds two more fields for composite product components: description and default option ID. These will be needed for the proposed UI (internal ref: pe5pgL-2wF-p2).

### Changes

* Updates the Networking model `ProductCompositeComponent` to include a `description` and `defaultOptionID`.
* Updates generated `fake()` and `copy()` methods.
* Updates the Core Data Model 82 to include attributes on the `ProductCompositeComponent` entity to store the description and default option ID. **Note:** I didn't create a new Core Data model because we just added this model (and there have been no other Storage layer changes), it hasn't been released yet, and the only changes here are to add more attributes to the entity that was added in this model. Let me know if you have any concerns about that.
* Updates `ProductCompositeComponent+ReadOnlyConvertible` to include the description and default option ID.
* Updates related unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
These new fields aren't yet used in the UI, so make sure unit tests pass and you can still load the Products list in the app.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.