### PR TITLE
[Free Trial] Release 1st Iteration

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Payments: Local search is added to the products selection screen in the order creation flow to speed the process. [https://github.com/woocommerce/woocommerce-ios/pull/9178]
 - [*] Fix: Prevent product variations not loading due to an encoding error for `permalink`, which was altered by a plugin. [https://github.com/woocommerce/woocommerce-ios/pull/9233]
+- [Internal] You can now see your current WPCom plan details and upgrade from a free trial. [https://github.com/woocommerce/woocommerce-ios/issues/9265]
 
 12.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,6 @@
 -----
 - [*] Payments: Local search is added to the products selection screen in the order creation flow to speed the process. [https://github.com/woocommerce/woocommerce-ios/pull/9178]
 - [*] Fix: Prevent product variations not loading due to an encoding error for `permalink`, which was altered by a plugin. [https://github.com/woocommerce/woocommerce-ios/pull/9233]
-- [Internal] You can now see your current WPCom plan details and upgrade from a free trial. [https://github.com/woocommerce/woocommerce-ios/issues/9265]
 
 12.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -174,11 +174,6 @@ final class DashboardViewModel {
     /// Fetches the current site plan.
     ///
     func syncFreeTrialBanner(siteID: Int64) {
-        // Only fetch free trial information when the local feature flag is enabled.
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.freeTrial) else {
-            return
-        }
-
         // Only fetch free trial information is the site is a WPCom site.
         guard stores.sessionManager.defaultSite?.isWordPressComStore == true else {
             return DDLogInfo("⚠️ Site is not a WPCOM site.")

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -82,7 +82,7 @@ final class HubMenuViewModel: ObservableObject {
         }
 
         // Only show the upgrades menu on WPCom sites
-        if featureFlagService.isFeatureFlagEnabled(.freeTrial) && stores.sessionManager.defaultSite?.isWordPressComStore == true {
+        if stores.sessionManager.defaultSite?.isWordPressComStore == true {
             menuElements.append(Upgrades())
         }
 


### PR DESCRIPTION
Closes: #9251 

# Why

This PR removes code that was behind the `.freeTrial` feature flag so it is available on the next release `v12.9`.

~The release note is marked as internal as per this comment pe5pgL-2wc-p2#comment-2112~

# Test

The feature will be tested on the test plan pe5pgL-2ti-p2

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
