### PR TITLE
[Product Multi-Selection] Add product IDs as product type to OrderSynchronizer

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -17,6 +17,7 @@ struct OrderSyncProductInput {
     ///
     enum ProductType {
         case product(Product)
+        case productID(Int64)
         case variation(ProductVariation)
     }
     var id: Int64 = .zero

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -124,6 +124,11 @@ private extension ProductInputTransformer {
             case .product(let product):
                 let price: Decimal = existingItem?.price.decimalValue ?? Decimal(string: product.price) ?? .zero
                 return OrderItemParameters(quantity: input.quantity, price: price, productID: product.productID, variationID: nil)
+            case .productID(let productID):
+                // TODO: Potential problem: Without passing a price, will always be zero.
+                // However is not a problem if the item already has a price assigned, as uses that one.
+                let price: Decimal = existingItem?.price.decimalValue ?? .zero
+                return OrderItemParameters(quantity: input.quantity, price: price, productID: productID, variationID: nil)
             case .variation(let variation):
                 let price: Decimal = existingItem?.price.decimalValue ?? Decimal(string: variation.price) ?? .zero
                 return OrderItemParameters(quantity: input.quantity, price: price, productID: variation.productID, variationID: variation.productVariationID)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -125,8 +125,6 @@ private extension ProductInputTransformer {
                 let price: Decimal = existingItem?.price.decimalValue ?? Decimal(string: product.price) ?? .zero
                 return OrderItemParameters(quantity: input.quantity, price: price, productID: product.productID, variationID: nil)
             case .productID(let productID):
-                // TODO: Potential problem: Without passing a price, will always be zero.
-                // However is not a problem if the item already has a price assigned, as uses that one.
                 let price: Decimal = existingItem?.price.decimalValue ?? .zero
                 return OrderItemParameters(quantity: input.quantity, price: price, productID: productID, variationID: nil)
             case .variation(let variation):

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -556,8 +556,8 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         // Then
         XCTAssertTrue(submittedItems.isNotEmpty)
         for item in submittedItems {
-            XCTAssertTrue(item.total.isNotEmpty)
-            XCTAssertTrue(item.subtotal.isNotEmpty)
+            XCTAssertEqual(item.total, "0")
+            XCTAssertEqual(item.subtotal, "0")
         }
     }
 
@@ -591,12 +591,8 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         // Then
         XCTAssertTrue(submittedItems.isNotEmpty)
         for item in submittedItems {
-            XCTAssertEqual(item.itemID, sampleInputID)
-            XCTAssertEqual(item.productID, sampleProductID)
             XCTAssertEqual(item.price, 20.0)
             XCTAssertEqual(item.quantity, 2)
-            XCTAssertTrue(item.total.isNotEmpty)
-            XCTAssertTrue(item.subtotal.isNotEmpty)
             XCTAssertEqual(item.subtotal, "40")
             XCTAssertEqual(item.total, "40")
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -61,7 +61,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertEqual(item.quantity, input.quantity)
     }
 
-    func test_sending_new_productID_input_updates_local_order() throws {
+    func test_sending_new_productID_input_adds_product_to_local_order() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -929,8 +929,8 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         // When
         let states: [OrderSyncState] = waitFor { promise in
             synchronizer.statePublisher
-                .dropFirst()
-                .collect(2)
+                .dropFirst() // Initialized with .synced state, so we drop the first value
+                .collect(2) // Collect the following sync states when an Order is created
                 .sink { states in
                     promise(states)
                 }
@@ -941,7 +941,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(states, [.syncing(blocking: true), .synced])
+        assertEqual([.syncing(blocking: true), .synced], states)
     }
 
     func test_states_are_properly_set_upon_success_order_update_with_new_items() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -207,37 +207,37 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
+        let initialInput = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
+        synchronizer.setProduct.send(initialInput)
 
         // When
-        let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
-        let input2 = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2)
-        synchronizer.setProduct.send(input)
-        synchronizer.setProduct.send(input2)
+        let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2)
+        synchronizer.setProduct.send(updatedInput)
 
         // Then
         let item = try XCTUnwrap(synchronizer.order.items.first)
-        XCTAssertEqual(item.itemID, input2.id)
+        XCTAssertEqual(item.itemID, updatedInput.id)
         XCTAssertEqual(item.productID, product.productID)
-        XCTAssertEqual(item.quantity, input2.quantity)
+        XCTAssertEqual(item.quantity, updatedInput.quantity)
     }
 
     func test_sending_update_productID_input_updates_local_order() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
+        let initialInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 1)
+        synchronizer.setProduct.send(initialInput)
 
         // When
-        let input = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 1)
-        let input2 = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 2)
-        synchronizer.setProduct.send(input)
-        synchronizer.setProduct.send(input2)
+        let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 2)
+        synchronizer.setProduct.send(updatedInput)
 
         // Then
         let item = try XCTUnwrap(synchronizer.order.items.first)
-        XCTAssertEqual(item.itemID, input2.id)
+        XCTAssertEqual(item.itemID, updatedInput.id)
         XCTAssertEqual(item.productID, sampleProductID)
         XCTAssertEqual(item.variationID, 0)
-        XCTAssertEqual(item.quantity, input2.quantity)
+        XCTAssertEqual(item.quantity, updatedInput.quantity)
     }
 
     func test_sending_delete_product_input_updates_local_order() throws {
@@ -245,12 +245,12 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
+        let initialInput = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
+        synchronizer.setProduct.send(initialInput)
 
         // When
-        let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
-        let input2 = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 0)
-        synchronizer.setProduct.send(input)
-        synchronizer.setProduct.send(input2)
+        let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 0)
+        synchronizer.setProduct.send(updatedInput)
 
         // Then
         XCTAssertEqual(synchronizer.order.items.count, 1)
@@ -261,12 +261,12 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
+        let initialInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 1)
+        synchronizer.setProduct.send(initialInput)
 
         // When
-        let input = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 1)
-        let input2 = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 0)
-        synchronizer.setProduct.send(input)
-        synchronizer.setProduct.send(input2)
+        let updatedInput = OrderSyncProductInput(id: sampleInputID, product: .productID(sampleProductID), quantity: 0)
+        synchronizer.setProduct.send(updatedInput)
 
         // Then
         XCTAssertEqual(synchronizer.order.items.count, 1)


### PR DESCRIPTION
Part of: #9272 

## Description
This PR adds support to the `OrderSynchronizer` for creating `OrderItems` providing only a `productID` when creating an  `OrderSynchronizerProductInput` for products, rather than needing a `Product` model. A PR for `ProductVariations` will be done separately.

## Context
At the moment we're using full `Product` and `ProductVariation` models on the ProductSelectors when tapping on different rows, in order to create an Order. This comes with some complexity around managing shared state when different actions are performed (select, unselect, add, remove) as well as when we deal with passing the data through different Models and responding to changes. 

As the `OrderItem` API only requires an ID and given quantities, we can simplify the different ProductSelectors by managing IDs rather than Product models.

## Changes
- Adds a new `productID(Int64)` type to `OrderSynchronizer`
- Adds a new `productID(Int64)` case to `ProductInputTransformer`
- 99% of the changes are Unit Tests being duplicated to be sure that the new `productID` implementation acts as the previous one using `Product` models . There's still a couple of tests to be added, but the PR was getting long, so these can be added separately.

<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

## Testing instructions
- Unit Tests should pass
- This can also be tested directly in app by adding the following lines to the `EditableOrderViewModel's` [productInputAdditionsToSync method in line 797](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/ViewRelated/Orders/Order%20Creation/EditableOrderViewModel.swift#L797) , before retuning. Just change `.productID(21)` for any other product ID that exists in your testing store:

```
let testOrderItemUsingID = OrderSyncProductInput(product: .productID(21), quantity: 1)
productInputs.append(testOrderItemUsingID)
```
Then go to Menu > Orders > `+` > `+ Add Items` >  tap `Done` without the need to add any other product ( or add it if you like) and see the extra product being added to the Order.


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
