### PR TITLE
[Store onboarding] Start in redacted state

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -15,7 +15,7 @@ class StoreOnboardingViewModel: ObservableObject {
         case failed
     }
 
-    @Published private(set) var isRedacted: Bool = false
+    @Published private(set) var isRedacted: Bool = true
     @Published private(set) var taskViewModels: [StoreOnboardingTaskViewModel] = []
 
     /// Used to determine whether the task list should be displayed in dashboard

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -5,6 +5,7 @@ import Yosemite
 final class StoreOnboardingViewModelTests: XCTestCase {
     private var stores: MockStoresManager!
     private var defaults: UserDefaults!
+    private let placeholderTaskCount = 3
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -369,14 +370,14 @@ final class StoreOnboardingViewModelTests: XCTestCase {
                                            stores: stores,
                                            defaults: defaults)
         // Then
-        XCTAssertTrue(sut.tasksForDisplay.containsOnlyPlaceHolderTasks())
+        XCTAssertTrue(sut.tasksForDisplay.count == placeholderTaskCount)
 
         // When
         mockLoadOnboardingTasks(result: .success(tasks))
         await sut.reloadTasks()
 
         // Then
-        XCTAssertTrue(sut.tasksForDisplay.containsOnlyPlaceHolderTasks())
+        XCTAssertTrue(sut.tasksForDisplay.count == placeholderTaskCount)
     }
 
     func test_it_sends_network_request_when_completedAllStoreOnboardingTasks_is_nil() async {
@@ -392,14 +393,13 @@ final class StoreOnboardingViewModelTests: XCTestCase {
                                            stores: stores,
                                            defaults: defaults)
         // Then
-        XCTAssertTrue(sut.tasksForDisplay.containsOnlyPlaceHolderTasks())
+        XCTAssertTrue(sut.tasksForDisplay.count == placeholderTaskCount)
 
         // When
         mockLoadOnboardingTasks(result: .success(tasks))
         await sut.reloadTasks()
 
         // Then
-        XCTAssertFalse(sut.tasksForDisplay.containsOnlyPlaceHolderTasks())
         XCTAssertTrue(sut.tasksForDisplay.count == 4)
     }
 
@@ -563,10 +563,4 @@ private extension StoreOnboardingViewModelTests {
     }
 
     final class MockError: Error { }
-}
-
-private extension Array where Element == StoreOnboardingTaskViewModel {
-    func containsOnlyPlaceHolderTasks() -> Bool {
-        map({ $0.task.type }).filter({ $0 != .launchStore }).isEmpty
-    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -369,14 +369,14 @@ final class StoreOnboardingViewModelTests: XCTestCase {
                                            stores: stores,
                                            defaults: defaults)
         // Then
-        XCTAssertTrue(sut.tasksForDisplay.isEmpty)
+        XCTAssertTrue(sut.tasksForDisplay.containsOnlyPlaceHolderTasks())
 
         // When
         mockLoadOnboardingTasks(result: .success(tasks))
         await sut.reloadTasks()
 
         // Then
-        XCTAssertTrue(sut.tasksForDisplay.isEmpty)
+        XCTAssertTrue(sut.tasksForDisplay.containsOnlyPlaceHolderTasks())
     }
 
     func test_it_sends_network_request_when_completedAllStoreOnboardingTasks_is_nil() async {
@@ -392,14 +392,15 @@ final class StoreOnboardingViewModelTests: XCTestCase {
                                            stores: stores,
                                            defaults: defaults)
         // Then
-        XCTAssertTrue(sut.tasksForDisplay.isEmpty)
+        XCTAssertTrue(sut.tasksForDisplay.containsOnlyPlaceHolderTasks())
 
         // When
         mockLoadOnboardingTasks(result: .success(tasks))
         await sut.reloadTasks()
 
         // Then
-        XCTAssertTrue(sut.tasksForDisplay.isNotEmpty)
+        XCTAssertFalse(sut.tasksForDisplay.containsOnlyPlaceHolderTasks())
+        XCTAssertTrue(sut.tasksForDisplay.count == 4)
     }
 
     // MARK: completedAllStoreOnboardingTasks user defaults
@@ -562,4 +563,10 @@ private extension StoreOnboardingViewModelTests {
     }
 
     final class MockError: Error { }
+}
+
+private extension Array where Element == StoreOnboardingTaskViewModel {
+    func containsOnlyPlaceHolderTasks() -> Bool {
+        map({ $0.task.type }).filter({ $0 != .launchStore }).isEmpty
+    }
 }


### PR DESCRIPTION
Closes: #9269 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

When the view is loaded initially there will be no tasks to display. But, the default value for `isRedacted` was set as false which showed the view with a `spinner` before it starts loading. 

We are fixing this by assigning `true` as the default value for `isRedacted`. This will make the view load in a redacted state initially. 

## Testing instructions
- Login using a site with onboarding tasks
- Stop the app and relaunch
- Ensure that the spinner reported #9269 in is not visible.


## Screenshots
**Before**
https://user-images.githubusercontent.com/524475/227167244-39eb478d-66e0-4a17-8e8e-d4707e5240aa.mp4

**After**
https://user-images.githubusercontent.com/524475/227167230-55bc3d1f-f7f7-44c6-94ee-ec27dc2c71a0.mp4 

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
