### PR TITLE
[Mobile Payments] Set up Tap to Pay analytics

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Fix: Prevent product variations not loading due to an encoding error for `permalink`, which was altered by a plugin. [https://github.com/woocommerce/woocommerce-ios/pull/9233]
 - [*] Login: Users can now log in to self-hosted sites without Jetpack by approving application password authorization to their sites. [https://github.com/woocommerce/woocommerce-ios/pull/9260]
 - [*] Payments: Tap to Pay on iPhone can now be selected from the Payment Methods screen [https://github.com/woocommerce/woocommerce-ios/pull/9242]
+- [**] Payments: Set up Tap to Pay on iPhone flow added to the Payments Menu. Use it to configure the reader, and try a payment, before collecting a card payment with a customer. [https://github.com/woocommerce/woocommerce-ios/pull/9280]
 
 12.8
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -897,6 +897,11 @@ extension WooAnalyticsEvent {
             case tapToPayTryAPayment = "tap_to_pay_try_a_payment"
         }
 
+        enum CardReaderType: String {
+            case external
+            case builtIn = "built_in"
+        }
+
         /// Common event keys
         ///
         private enum Keys {
@@ -905,12 +910,22 @@ extension WooAnalyticsEvent {
             static let paymentMethod = "payment_method"
             static let source = "source"
             static let flow = "flow"
+            static let cardReaderType = "card_reader_type"
         }
 
-        static func paymentsFlowCompleted(flow: Flow, amount: String, method: PaymentMethod) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .paymentsFlowCompleted, properties: [Keys.flow: flow.rawValue,
-                                                                             Keys.amount: amount,
-                                                                             Keys.paymentMethod: method.rawValue])
+        static func paymentsFlowCompleted(flow: Flow,
+                                          amount: String,
+                                          method: PaymentMethod,
+                                          cardReaderType: CardReaderType?) -> WooAnalyticsEvent {
+            var properties: [String: WooAnalyticsEventPropertyType] = [Keys.flow: flow.rawValue,
+                                                                       Keys.amount: amount,
+                                                                       Keys.paymentMethod: method.rawValue]
+
+            if let cardReaderType = cardReaderType {
+                properties[Keys.cardReaderType] = cardReaderType.rawValue
+            }
+
+            return WooAnalyticsEvent(statName: .paymentsFlowCompleted, properties: properties)
         }
 
         static func paymentsFlowCanceled(flow: Flow) -> WooAnalyticsEvent {
@@ -922,9 +937,16 @@ extension WooAnalyticsEvent {
                                                                           Keys.source: source.rawValue])
         }
 
-        static func paymentsFlowCollect(flow: Flow, method: PaymentMethod, millisecondsSinceOrderAddNew: Int64?) -> WooAnalyticsEvent {
+        static func paymentsFlowCollect(flow: Flow,
+                                        method: PaymentMethod,
+                                        cardReaderType: CardReaderType?,
+                                        millisecondsSinceOrderAddNew: Int64?) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [Keys.flow: flow.rawValue,
                               Keys.paymentMethod: method.rawValue]
+
+            if let cardReaderType = cardReaderType {
+                properties[Keys.cardReaderType] = cardReaderType.rawValue
+            }
 
             if let lapseSinceLastOrderAddNew = millisecondsSinceOrderAddNew {
                 properties[Orders.GlobalKeys.millisecondsSinceOrderAddNew] = lapseSinceLastOrderAddNew

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -277,6 +277,14 @@ public enum WooAnalyticsStat: String {
     case cardPresentOnboardingStepSkipped = "card_present_onboarding_step_skipped"
     case cardPresentOnboardingCtaTapped = "card_present_onboarding_cta_tapped"
 
+    // MARK: Tap to Pay
+    case tapToPaySummaryTryPaymentTapped = "tap_to_pay_summary_try_payment_tapped"
+    case tapToPaySummaryTryPaymentSkipTapped = "tap_to_pay_summary_try_payment_skip_tapped"
+    case tapToPaySetupInformationSetUpTapped = "tap_to_pay_set_up_information_set_up_tapped"
+    case tapToPaySetupInformationCancelTapped = "tap_to_pay_set_up_information_cancel_tapped"
+    case tapToPaySetupSuccessDoneTapped = "tap_to_pay_set_up_success_done_tapped"
+    case tapToPaySummaryShown = "tap_to_pay_summary_shown"
+
     // MARK: Cash on Delivery Enable events
     case enableCashOnDeliverySuccess = "enable_cash_on_delivery_success"
     case enableCashOnDeliveryFailed = "enable_cash_on_delivery_failed"
@@ -813,7 +821,7 @@ public enum WooAnalyticsStat: String {
     case paymentsMenuManageCardReadersTapped = "payments_hub_manage_card_readers_tapped"
     case paymentsMenuPaymentProviderTapped = "settings_card_present_select_payment_gateway_tapped"
     case inPersonPaymentsLearnMoreTapped = "in_person_payments_learn_more_tapped"
-    case setUpTapToPayOnIPhoneTapped = "set_up_tap_to_pay_on_iphone_tapped"
+    case setUpTapToPayOnIPhoneTapped = "payments_hub_tap_to_pay_tapped"
 
     // MARK: Payments Menu
     case pluginsNotSyncedYet = "plugins_not_synced_yet"

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -107,6 +107,9 @@ final class CardPresentPaymentPreflightController {
     private func checkForConnectedReader() async {
         if let connectedReader = connectedReader,
            let paymentGatewayAccount = await selectedPaymentGateway() {
+            // The reader was already connected when the analyticsTracker was created,
+            //so we need to pass it along for properties to be correct
+            analyticsTracker.setCandidateReader(connectedReader)
             if connectedReader.discoveryMethod == discoveryMethod {
                 // If we're already connected to a reader of the correct type, return it
                 return handleConnectionResult(.success(.connected(connectedReader)), paymentGatewayAccount: paymentGatewayAccount)

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -108,7 +108,7 @@ final class CardPresentPaymentPreflightController {
         if let connectedReader = connectedReader,
            let paymentGatewayAccount = await selectedPaymentGateway() {
             // The reader was already connected when the analyticsTracker was created,
-            //so we need to pass it along for properties to be correct
+            //`so we need to pass it along for properties to be correct
             analyticsTracker.setCandidateReader(connectedReader)
             if connectedReader.discoveryMethod == discoveryMethod {
                 // If we're already connected to a reader of the correct type, return it

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewModel.swift
@@ -14,6 +14,8 @@ final class SetUpTapToPayCompleteViewModel: PaymentSettingsFlowPresentedViewMode
     private let connectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker
     private let stores: StoresManager
 
+    private let analytics: Analytics = ServiceLocator.analytics
+
     private var subscriptions = Set<AnyCancellable>()
 
     init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?,
@@ -62,6 +64,7 @@ final class SetUpTapToPayCompleteViewModel: PaymentSettingsFlowPresentedViewMode
     }
 
     func doneTapped() {
+        analytics.track(.tapToPaySetupSuccessDoneTapped)
         doneWasTapped = true
         reevaluateShouldShow()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -30,7 +30,14 @@ final class SetUpTapToPayInformationViewController: UIHostingController<SetUpTap
 
         viewModel.alertsPresenter = alertsPresenter
         viewModel.connectionController = connectionController
+        configureViewModel()
         configureView()
+    }
+
+    private func configureViewModel() {
+        viewModel.dismiss = { [weak self] in
+            self?.dismiss(animated: true)
+        }
     }
 
     private func configureView() {
@@ -39,9 +46,6 @@ final class SetUpTapToPayInformationViewController: UIHostingController<SetUpTap
             WebviewHelper.launch(url, with: self)
         }
         rootView.learnMoreUrl = viewModel.learnMoreURL
-        rootView.dismiss = { [weak self] in
-            self?.dismiss(animated: true)
-        }
     }
 
     required init?(coder: NSCoder) {
@@ -58,7 +62,6 @@ struct SetUpTapToPayInformationView: View {
     @ObservedObject var viewModel: SetUpTapToPayInformationViewModel
     var showURL: ((URL) -> Void)? = nil
     var learnMoreUrl: URL? = nil
-    var dismiss: (() -> Void)? = nil
 
     @Environment(\.verticalSizeClass) var verticalSizeClass
 
@@ -74,7 +77,7 @@ struct SetUpTapToPayInformationView: View {
         VStack {
             HStack {
                 Button(Localization.cancelButton) {
-                    dismiss?()
+                    viewModel.cancelTapped()
                 }
                 Spacer()
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -7,6 +7,8 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
     var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?
     var didUpdate: (() -> Void)?
     let learnMoreURL: URL
+    var dismiss: (() -> Void)?
+
     private let stores: StoresManager
 
     @Published private(set) var enableSetup: Bool = true
@@ -17,6 +19,7 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
     let connectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker
     let connectivityObserver: ConnectivityObserver
 
+    private let analytics: Analytics = ServiceLocator.analytics
 
     var connectionController: BuiltInCardReaderConnectionController? = nil
     var alertsPresenter: CardPresentPaymentAlertsPresenting? = nil
@@ -97,6 +100,7 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
     }
 
     func setUpTapped() {
+        analytics.track(.tapToPaySetupInformationSetUpTapped)
         setUpInProgress = true
         connectionController?.searchAndConnect { [weak self] _ in
             /// No need for logic here. Once connected, the connected reader will publish
@@ -105,6 +109,11 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
             self?.alertsPresenter?.dismiss()
             self?.setUpInProgress = false
         }
+    }
+
+    func cancelTapped() {
+        analytics.track(.tapToPaySetupInformationCancelTapped)
+        dismiss?()
     }
 
     /// Updates whether the view this viewModel is associated with should be shown or not

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
@@ -107,7 +107,10 @@ struct SetUpTapToPayPaymentPromptView: View {
     ///
     private func paymentFlow() -> some View {
         WooNavigationSheet(viewModel: WooNavigationSheetViewModel(navigationTitle: Localization.setUpTryPaymentPromptTitle,
-                                                                  done: viewModel.dismiss ?? {})) {
+                                                                  done: {
+            paymentFlowDismissed()
+            viewModel.dismiss?()
+        })) {
             if let summaryViewModel = viewModel.summaryViewModel {
                 SimplePaymentsSummary(
                     dismiss: {
@@ -118,6 +121,10 @@ struct SetUpTapToPayPaymentPromptView: View {
             }
             EmptyView()
         }
+    }
+
+    private func paymentFlowDismissed() {
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCanceled(flow: .tapToPayTryAPayment))
     }
 
     private func showOrder(orderID: Int64, siteID: Int64) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
@@ -33,6 +33,11 @@ final class SetUpTapToPayTryPaymentPromptViewController: UIHostingController<Set
         fatalError("Not implemented")
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        viewModel.onAppear()
+        super.viewDidAppear(animated)
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         viewModel.didUpdate = nil
         super.viewWillDisappear(animated)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
@@ -103,11 +103,17 @@ final class SetUpTapToPayTryPaymentPromptViewModel: PaymentSettingsFlowPresented
     }
 
     func tryAPaymentTapped() {
+        analytics.track(.tapToPaySummaryTryPaymentTapped)
         startTestPayment()
     }
 
     func skipTapped() {
+        analytics.track(.tapToPaySummaryTryPaymentSkipTapped)
         dismiss?()
+    }
+
+    func onAppear() {
+        analytics.track(.tapToPaySummaryShown)
     }
 
     deinit {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
@@ -72,7 +72,8 @@ final class SetUpTapToPayTryPaymentPromptViewModel: PaymentSettingsFlowPresented
                 self.summaryViewModel = TryAPaymentSummaryViewModel(
                     simplePaymentSummaryViewModel: SimplePaymentsSummaryViewModel(order: order,
                                                                                   providedAmount: order.total,
-                                                                                  presentNoticeSubject: self.presentNoticeSubject),
+                                                                                  presentNoticeSubject: self.presentNoticeSubject,
+                                                                                  analyticsFlow: .tapToPayTryAPayment),
                     siteID: self.siteID,
                     orderID: order.orderID)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -205,8 +205,7 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     var tapToPayOnIPhoneSection: Section? {
-        guard featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhoneSetupFlow),
-              featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhone) else {
+        guard featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhone) else {
             return nil
         }
         return Section(header: nil, rows: [.setUpTapToPayOnIPhone])

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -283,7 +283,8 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func configureOrderCardReader(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell, accessibilityID: "order-card-reader")
+        prepareForReuse(cell)
+        cell.accessibilityIdentifier = "order-card-reader"
         cell.configure(image: .shoppingCartIcon, text: Localization.orderCardReader.localizedCapitalized)
     }
 
@@ -298,27 +299,31 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func configureManagePaymentGateways(cell: LeftImageTitleSubtitleTableViewCell) {
-        prepareForReuse(cell, accessibilityID: "manage-payment-gateways")
+        prepareForReuse(cell)
+        cell.accessibilityIdentifier = "manage-payment-gateways"
         cell.configure(image: .rectangleOnRectangleAngled,
                        text: Localization.managePaymentGateways.localizedCapitalized,
                        subtitle: pluginState?.preferred.pluginName ?? "")
     }
 
     func configureCardReaderManuals(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell, accessibilityID: "card-reader-manuals")
+        prepareForReuse(cell)
+        cell.accessibilityIdentifier = "card-reader-manuals"
         cell.configure(image: .cardReaderManualIcon, text: Localization.cardReaderManuals.localizedCapitalized)
     }
 
     func configureCollectPayment(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell, accessibilityID: "collect-payment")
+        prepareForReuse(cell)
+        cell.accessibilityIdentifier = "collect-payment"
         cell.configure(image: .moneyIcon, text: Localization.collectPayment.localizedCapitalized)
     }
 
     func configureToggleEnableCashOnDelivery(cell: LeftImageTitleSubtitleToggleTableViewCell) {
-        prepareForReuse(cell, accessibilityID: "pay-in-person")
+        prepareForReuse(cell)
         cell.leftImageView?.tintColor = .text
         cell.accessoryType = .none
         cell.selectionStyle = .none
+        cell.accessibilityIdentifier = "pay-in-person"
         cell.configure(image: .creditCardIcon,
                        text: Localization.toggleEnableCashOnDelivery,
                        subtitle: learnMoreViewModel.learnMoreAttributedString,
@@ -331,20 +336,21 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func configureSetUpTapToPayOnIPhone(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell, accessibilityID: "set-up-tap-to-pay")
+        prepareForReuse(cell)
         cell.accessoryType = enableSetUpTapToPayOnIPhoneCell ? .disclosureIndicator : .none
         cell.selectionStyle = enableSetUpTapToPayOnIPhoneCell ? .default : .none
+        cell.accessibilityIdentifier = "set-up-tap-to-pay"
         cell.configure(image: .tapToPayOnIPhoneIcon,
                        text: Localization.tapToPayOnIPhone)
 
         updateEnabledState(in: cell, shouldBeEnabled: enableSetUpTapToPayOnIPhoneCell)
     }
 
-    private func prepareForReuse(_ cell: UITableViewCell, accessibilityID: String) {
+    private func prepareForReuse(_ cell: UITableViewCell) {
         cell.imageView?.tintColor = .text
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.accessibilityIdentifier = accessibilityID
+        cell.accessibilityIdentifier = ""
         updateEnabledState(in: cell)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -30,6 +30,10 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         cardPresentPaymentsOnboardingUseCase.state.isCompleted
     }
 
+    private var enableSetUpTapToPayOnIPhoneCell: Bool {
+        cardPresentPaymentsOnboardingUseCase.state.isCompleted
+    }
+
     /// Main TableView
     ///
     private lazy var tableView: UITableView = {
@@ -70,6 +74,7 @@ final class InPersonPaymentsMenuViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        viewModel.viewDidLoad()
 
         registerUserActivity()
 
@@ -80,7 +85,6 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         configureTableReload()
         runCardPresentPaymentsOnboardingIfPossible()
         configureWebViewPresentation()
-        viewModel.viewDidLoad()
     }
 }
 
@@ -328,8 +332,12 @@ private extension InPersonPaymentsMenuViewController {
 
     func configureSetUpTapToPayOnIPhone(cell: LeftImageTableViewCell) {
         prepareForReuse(cell, accessibilityID: "set-up-tap-to-pay")
+        cell.accessoryType = enableSetUpTapToPayOnIPhoneCell ? .disclosureIndicator : .none
+        cell.selectionStyle = enableSetUpTapToPayOnIPhoneCell ? .default : .none
         cell.configure(image: .tapToPayOnIPhoneIcon,
                        text: Localization.tapToPayOnIPhone)
+
+        updateEnabledState(in: cell, shouldBeEnabled: enableSetUpTapToPayOnIPhoneCell)
     }
 
     private func prepareForReuse(_ cell: UITableViewCell, accessibilityID: String) {
@@ -348,6 +356,10 @@ private extension InPersonPaymentsMenuViewController {
 
     func configureTableReload() {
         cashOnDeliveryToggleRowViewModel.$cashOnDeliveryEnabledState.sink { [weak self] _ in
+            self?.tableView.reloadData()
+        }.store(in: &cancellables)
+
+        viewModel.$isEligibleForTapToPayOnIPhone.sink { [weak self] _ in
             self?.tableView.reloadData()
         }.store(in: &cancellables)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -128,7 +128,7 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
                     XCTFail("Unexpected CardPresentPaymentAction recieved")
                 }
             }
-            
+
             // When
             self.sut.viewDidLoad()
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9274
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the various tracks events that we require for Set up Tap to Pay on iPhone. They are designed to allow us to see when people are using the Set up flow, how far through it they get, and whether they complete the flow and subsequent connection. Other (`card_reader_connection` events will be relevant but don't require any changes.)

## New Events

- `payments_hub_tap_to_pay_tapped`
- `tap_to_pay_summary_try_payment_tapped`
- `tap_to_pay_summary_try_payment_skip_tapped`
- `tap_to_pay_set_up_information_set_up_tapped`
- `tap_to_pay_set_up_information_cancel_tapped`
- `tap_to_pay_set_up_success_done_tapped`
- `tap_to_pay_summary_shown`

### Changed Events

- `payments_flow_collect`, 
- `payments_flow_failed`, 
- `payments_flow_completed` 
- `payments_flow_canceled`

... triggered during the try a payment flow should all have the property `flow: tap_to_pay_try_a_payment` 

and `payments_flow_failed` should also have `source: tap_to_pay_try_a_payment_prompt` 

`payments_flow_collect` should have a new property `card_reader_type: external/built_in`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using an iPhone XS or newer on iOS 16 and above, and a US-based store:

Navigate to `Menu > Payments > Set up Tap to Pay on iPhone`
Follow the flow and observe the analytics events that are logged. In particular look out for the changes detailed above

Take a simple payment and an Order payment, using the built in reader and an external reader, and check that the properties are all as expected.

There are a lot, and I've tested them all, so use your judgement in how far you go with testing.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Events in the Set up flow
<img width="600" alt="tap-to-pay-set-up-tapped" src="https://user-images.githubusercontent.com/2472348/227210920-91fb554d-37bb-40dd-830a-57586d277ed7.png">
<img width="618" alt="tap-to-pay-success-done-tapped-summary-shown" src="https://user-images.githubusercontent.com/2472348/227210922-246c5909-e811-4e73-a7b0-e41870a59f64.png">
<img width="598" alt="tap-to-pay-try-payment-skipped" src="https://user-images.githubusercontent.com/2472348/227210931-a632d366-2f95-43e8-9855-e650f628e0f3.png">
<img width="622" alt="tap-to-pay-try-payment-tapped" src="https://user-images.githubusercontent.com/2472348/227210933-d23cbe13-2e47-48a4-8b11-1d88aa0f977c.png">
<img width="600" alt="payments-flow-builtin-trypayment-collect" src="https://user-images.githubusercontent.com/2472348/227210899-e3628724-be10-4f25-bf32-e2996985c4bf.png">
<img width="620" alt="payments-flow-builtin-trypayment-complete" src="https://user-images.githubusercontent.com/2472348/227210901-4be83878-25df-4df1-8175-ed182ecf8b29.png">
<img width="608" alt="payments-flow-trypayment-cancelled" src="https://user-images.githubusercontent.com/2472348/227210918-a40bd6e3-1b72-40db-99b2-98f2e3d9a42b.png">

### Related changes in the Simple Payments flows

<img width="600" alt="payments-flow-external-simple-collect" src="https://user-images.githubusercontent.com/2472348/227210912-810a0ecf-c9fb-4523-b14d-13aea33c5167.png">
<img width="605" alt="payments-flow-external-simple-complete" src="https://user-images.githubusercontent.com/2472348/227210917-12e13231-dac5-468b-a765-40b651b11b42.png">

### Related changes in the Order Payment flow

<img width="624" alt="payments-flow-builtin-order-collect" src="https://user-images.githubusercontent.com/2472348/227210896-fd731b0c-3755-4342-b22e-70bacbcc10fc.png">
<img width="621" alt="payments-flow-external-order-collect" src="https://user-images.githubusercontent.com/2472348/227210903-d1c5e7e8-7d45-463c-b695-46b5fa8c16f5.png">
<img width="591" alt="payments-flow-external-order-complete" src="https://user-images.githubusercontent.com/2472348/227210909-76afb525-c13c-457c-87da-c65620633b55.png">

### Automatic disconnect event (contains reader type now)

<img width="615" alt="card-reader-automatic-disconnect" src="https://user-images.githubusercontent.com/2472348/227210883-03a3cbc6-3ec4-476e-83b6-75313a11643a.png">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
