### PR TITLE
[Mobile Payments] Set visibility and enabled state for Set up Tap to Pay on iPhone

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -283,7 +283,8 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func configureOrderCardReader(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell, accessibilityID: "order-card-reader")
+        prepareForReuse(cell)
+        cell.accessibilityIdentifier = "order-card-reader"
         cell.configure(image: .shoppingCartIcon, text: Localization.orderCardReader.localizedCapitalized)
     }
 
@@ -298,27 +299,31 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func configureManagePaymentGateways(cell: LeftImageTitleSubtitleTableViewCell) {
-        prepareForReuse(cell, accessibilityID: "manage-payment-gateways")
+        prepareForReuse(cell)
+        cell.accessibilityIdentifier = "manage-payment-gateways"
         cell.configure(image: .rectangleOnRectangleAngled,
                        text: Localization.managePaymentGateways.localizedCapitalized,
                        subtitle: pluginState?.preferred.pluginName ?? "")
     }
 
     func configureCardReaderManuals(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell, accessibilityID: "card-reader-manuals")
+        prepareForReuse(cell)
+        cell.accessibilityIdentifier = "card-reader-manuals"
         cell.configure(image: .cardReaderManualIcon, text: Localization.cardReaderManuals.localizedCapitalized)
     }
 
     func configureCollectPayment(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell, accessibilityID: "collect-payment")
+        prepareForReuse(cell)
+        cell.accessibilityIdentifier = "collect-payment"
         cell.configure(image: .moneyIcon, text: Localization.collectPayment.localizedCapitalized)
     }
 
     func configureToggleEnableCashOnDelivery(cell: LeftImageTitleSubtitleToggleTableViewCell) {
-        prepareForReuse(cell, accessibilityID: "pay-in-person")
+        prepareForReuse(cell)
         cell.leftImageView?.tintColor = .text
         cell.accessoryType = .none
         cell.selectionStyle = .none
+        cell.accessibilityIdentifier = "pay-in-person"
         cell.configure(image: .creditCardIcon,
                        text: Localization.toggleEnableCashOnDelivery,
                        subtitle: learnMoreViewModel.learnMoreAttributedString,
@@ -331,20 +336,21 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     func configureSetUpTapToPayOnIPhone(cell: LeftImageTableViewCell) {
-        prepareForReuse(cell, accessibilityID: "set-up-tap-to-pay")
+        prepareForReuse(cell)
         cell.accessoryType = enableSetUpTapToPayOnIPhoneCell ? .disclosureIndicator : .none
         cell.selectionStyle = enableSetUpTapToPayOnIPhoneCell ? .default : .none
+        cell.accessibilityIdentifier = "set-up-tap-to-pay"
         cell.configure(image: .tapToPayOnIPhoneIcon,
                        text: Localization.tapToPayOnIPhone)
 
         updateEnabledState(in: cell, shouldBeEnabled: enableSetUpTapToPayOnIPhoneCell)
     }
 
-    private func prepareForReuse(_ cell: UITableViewCell, accessibilityID: String) {
+    private func prepareForReuse(_ cell: UITableViewCell) {
         cell.imageView?.tintColor = .text
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.accessibilityIdentifier = accessibilityID
+        cell.accessibilityIdentifier = ""
         updateEnabledState(in: cell)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -30,6 +30,10 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         cardPresentPaymentsOnboardingUseCase.state.isCompleted
     }
 
+    private var enableSetUpTapToPayOnIPhoneCell: Bool {
+        cardPresentPaymentsOnboardingUseCase.state.isCompleted
+    }
+
     /// Main TableView
     ///
     private lazy var tableView: UITableView = {
@@ -70,6 +74,7 @@ final class InPersonPaymentsMenuViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        viewModel.viewDidLoad()
 
         registerUserActivity()
 
@@ -80,7 +85,6 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         configureTableReload()
         runCardPresentPaymentsOnboardingIfPossible()
         configureWebViewPresentation()
-        viewModel.viewDidLoad()
     }
 }
 
@@ -328,8 +332,12 @@ private extension InPersonPaymentsMenuViewController {
 
     func configureSetUpTapToPayOnIPhone(cell: LeftImageTableViewCell) {
         prepareForReuse(cell, accessibilityID: "set-up-tap-to-pay")
+        cell.accessoryType = enableSetUpTapToPayOnIPhoneCell ? .disclosureIndicator : .none
+        cell.selectionStyle = enableSetUpTapToPayOnIPhoneCell ? .default : .none
         cell.configure(image: .tapToPayOnIPhoneIcon,
                        text: Localization.tapToPayOnIPhone)
+
+        updateEnabledState(in: cell, shouldBeEnabled: enableSetUpTapToPayOnIPhoneCell)
     }
 
     private func prepareForReuse(_ cell: UITableViewCell, accessibilityID: String) {
@@ -348,6 +356,10 @@ private extension InPersonPaymentsMenuViewController {
 
     func configureTableReload() {
         cashOnDeliveryToggleRowViewModel.$cashOnDeliveryEnabledState.sink { [weak self] _ in
+            self?.tableView.reloadData()
+        }.store(in: &cancellables)
+
+        viewModel.$isEligibleForTapToPayOnIPhone.sink { [weak self] _ in
             self?.tableView.reloadData()
         }.store(in: &cancellables)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -128,7 +128,7 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
                     XCTFail("Unexpected CardPresentPaymentAction recieved")
                 }
             }
-            
+
             // When
             self.sut.viewDidLoad()
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9278
Merge after: #9277
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In sTAP Away M2, we've added a set up flow for Tap to Pay on iPhone. Currently its feature flagged, and the `Set up Tap to Pay on iPhone` row was shown on any device. This PR makes it visible only when the device and store both support Tap to Pay, and enables the row to be tapped only after Onboarding is in the `.complete` state.

Tap to Pay on iPhone is only available on iPhones XS and newer, running iOS 16 and above, for stores in the US.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Using an iPhone XS or newer running iOS 16 or above

On a US-based store:

1. Force-quit and relauch the app
2. Navigate to `Menu > Payments`
3. Observe that `Set up Tap to Pay on iPhone` is immediately visible, but disabled (same as `Manage card reader`)
4. If onboarding completes, observe that the `Set up` row is enabled, and tapping on it opens the flow as expected
5. If onboarding does not complete, tap the `Continue set up` notice and resolve the outstanding steps
6. Observe that the `Set up Tap to Pay on iPhone` row is then enabled as expected

On a Canada-based store:

1. Force-quit and relauch the app
2. Navigate to `Menu > Payments`
3. Observe that `Set up Tap to Pay on iPhone` is not visible, but `Manage card reader` still is

On a store based in another country:

1. Force-quit and relauch the app
2. Navigate to `Menu > Payments`
3. Observe that `Set up Tap to Pay on iPhone` is not visible, and neither is `Manage card reader`

### Unsupported devices/OS

Repeat the following test using these devices, if possible.

- Using an iPhone XS or newer running iOS 15.x
- Using an iPhone X or 8 running iOS 16 or above
- Any iPhone running iOS 15.x
- Any iPad running iOS 16 or above
- Any iPad running iOS 15.x

On a US-based store:

1. Navigate to `Menu > Payments`
2. Observe that `Set up Tap to Pay on iPhone` is not visible, but `Manage card reader` still is


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/227257168-913b0ca2-8575-4a53-9529-8f182bdd35c5.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
