### PR TITLE
[Mobile Payments] Reveal Set up Tap to Pay on iPhone flow from behind feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Fix: Prevent product variations not loading due to an encoding error for `permalink`, which was altered by a plugin. [https://github.com/woocommerce/woocommerce-ios/pull/9233]
 - [*] Login: Users can now log in to self-hosted sites without Jetpack by approving application password authorization to their sites. [https://github.com/woocommerce/woocommerce-ios/pull/9260]
 - [*] Payments: Tap to Pay on iPhone can now be selected from the Payment Methods screen [https://github.com/woocommerce/woocommerce-ios/pull/9242]
+- [**] Payments: Set up Tap to Pay on iPhone flow added to the Payments Menu. Use it to configure the reader, and try a payment, before collecting a card payment with a customer. [https://github.com/woocommerce/woocommerce-ios/pull/9280]
 
 12.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -205,8 +205,7 @@ private extension InPersonPaymentsMenuViewController {
     }
 
     var tapToPayOnIPhoneSection: Section? {
-        guard featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhoneSetupFlow),
-              featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhone) else {
+        guard featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhone) else {
             return nil
         }
         return Section(header: nil, rows: [.setUpTapToPayOnIPhone])


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8905
Merge after: #9279
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is the first release for sTAP Away M2. Follow-up development on the set up flow will continue behind the existing feature flag, so it is no longer checked, rather than removed.

Unfortunately, the row will not show up in a local simulator build with the Release configuration, because StripeTerminal does not report that the device supports Tap to Pay from the simulator in this config.

I have tested that if we ignores the response to `checkSupport` (which we know works correctly as it is already used in the production release of TTP) then the row _does_ show up.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
