### PR TITLE
Store onboarding: feature release

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -78,7 +78,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .jetpackSetupWithApplicationPassword:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .dashboardOnboarding:
-            return ( buildConfig == .localDeveloper || buildConfig == .alpha ) && !isUITesting
+            return true
         case .addCouponToOrder:
             return ( buildConfig == .localDeveloper || buildConfig == .alpha ) && !isUITesting
         case .productBundles:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 12.9
 -----
+- [**] Dashboard: an onboarding card is shown for sites with the following tasks if any is incomplete: "tell us more about your store" (store location) that opens a webview, "add your first product" that starts the product creation flow, "launch your store" that publishes the store, "customize your domain" that starts the domain purchase flow, and "get paid" that opens a webview. A subset of the tasks may be shown to self-hosted sites and WPCOM sites on a free trial. [https://github.com/woocommerce/woocommerce-ios/pull/9285]
 - [*] Jetpack benefit banner and modal is now available on the dashboard screen after logging in with site credentials. [https://github.com/woocommerce/woocommerce-ios/pull/9232]
 - [*] Payments: Local search is added to the products selection screen in the order creation flow to speed the process. [https://github.com/woocommerce/woocommerce-ios/pull/9178]
 - [*] Fix: Prevent product variations not loading due to an encoding error for `permalink`, which was altered by a plugin. [https://github.com/woocommerce/woocommerce-ios/pull/9233]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9284 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR enabled the store onboarding feature flag `dashboardOnboarding` for the upcoming release. UI tests are still passing, so no other changes are required.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please feel free to do a confidence check by switching to a few sites and making sure the onboarding is shown or hidden accordingly.

Task availability for different store types (x means the task is available):

task \ store type | wpcom stores | wpcom stores on a free trial | self-hosted stores | how to complete the task
-- | -- | -- | -- | --
tell us more about your store | x | x | x | the store has set the location in WC settings
add your first product | x | x | x | at least a product has been added remotely
launch your store | x | | | the store status is public (not "coming soon" or private)
customize your domain | x | x | | a non-staging domain has been set
get paid | x | x | x | for sites without WCPay, at lease a payment method has been enabled. for sites with WCPay, the plugin has been set up.

When all the available tasks are complete, 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
