### PR TITLE
Store onboarding: hide `view all` CTA when there are 3 tasks that are incomplete

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -36,17 +36,16 @@ class StoreOnboardingViewModel: ObservableObject {
             return placeholderTasks
         }
 
-        if isExpanded || !shouldShowViewAllButton {
+        if isExpanded {
             return taskViewModels
         }
 
-        let maxNumberOfTasksToDisplayInCollapsedMode = 3
-        let incompleteTasks = taskViewModels.filter({ !$0.isComplete })
-        return isExpanded ? taskViewModels : Array(incompleteTasks.prefix(maxNumberOfTasksToDisplayInCollapsedMode))
+        let incompleteTasks = Array(taskViewModels.filter({ !$0.isComplete }).prefix(Constants.maxNumberOfTasksToDisplayInCollapsedMode))
+        return incompleteTasks
     }
 
     var shouldShowViewAllButton: Bool {
-        !isExpanded && !isRedacted && !(taskViewModels.count < 3)
+        !isExpanded && !isRedacted && (taskViewModels.count > tasksForDisplay.count)
     }
 
     let isExpanded: Bool
@@ -164,6 +163,12 @@ private extension StoreOnboardingViewModel {
 
     func hasPendingTasks(_ tasks: [StoreOnboardingTaskViewModel]) -> Bool {
         tasks.contains(where: { $0.isComplete == false })
+    }
+}
+
+private extension StoreOnboardingViewModel {
+    enum Constants {
+        static let maxNumberOfTasksToDisplayInCollapsedMode = 3
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -213,7 +213,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         XCTAssertTrue(sut.shouldShowViewAllButton)
     }
 
-    func test_view_all_button_is_visible_when_task_count_is_greater_than_2() async {
+    func test_view_all_button_is_visible_when_task_count_is_greater_than_3() async {
         // Given
         mockLoadOnboardingTasks(result: .success([
             .init(isComplete: false, type: .addFirstProduct),
@@ -230,6 +230,24 @@ final class StoreOnboardingViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(sut.shouldShowViewAllButton)
+    }
+
+    func test_view_all_button_is_hidden_when_task_count_is_3() async {
+        // Given
+        mockLoadOnboardingTasks(result: .success([
+            .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .launchStore),
+            .init(isComplete: false, type: .customizeDomains)
+        ]))
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: false,
+                                           stores: stores,
+                                           defaults: defaults)
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertFalse(sut.shouldShowViewAllButton)
     }
 
     func test_view_all_button_is_hidden_when_task_count_is_less_than_3() async {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9282 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR handled a case where there are 3 onboarding tasks that are all incomplete, which can be the case when testing a brand-new self-hosted site. Since there are no other tasks, it doesn't make sense to show the `View all` CTA in the collapsed mode. A test case was also added.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: a new JN site with 3 onboarding tasks that are all incomplete

- Log in to the site in the prerequisite --> in the My store tab, the onboarding card should not have the `View all` CTA

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

2/3 incomplete tasks | 3/3 incomplete tasks | 3/5 incomplete tasks
-- | -- | --
![Simulator Screen Shot - iPhone 14 - 2023-03-24 at 15 25 05](https://user-images.githubusercontent.com/1945542/227453561-d77ccfd8-5c86-49af-aff1-4ebd27390029.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-24 at 15 24 44](https://user-images.githubusercontent.com/1945542/227453556-cebec7b1-8fc0-4e3b-a7af-4ac8218c6c5a.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-24 at 15 25 18](https://user-images.githubusercontent.com/1945542/227453563-d6b931fc-fc6e-4e20-acba-bcb24efc99d1.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
