### PR TITLE
Store launched screen - Remove scheme from store URL

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingStoreLaunchedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingStoreLaunchedView.swift
@@ -41,7 +41,7 @@ struct StoreOnboardingStoreLaunchedView: View {
                     }
 
                     // URL label.
-                    Text(siteURL.absoluteString)
+                    Text(siteURL.absoluteString.trimHTTPScheme())
                         .underline()
                         .foregroundColor(.init(.textSubtle))
                         .captionStyle()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9122 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Store launched screen - Remove scheme from store URL

## Testing instructions

Prerequisite: a site with an eCommerce or Business WPCOM plan that hasn't been launched yet

- Log in to the site in the prerequisite
- In the My store tab, tap on the `Launch your store` task 
- Tap `Publish My Store` to launch the store
- In the launched screen validate that you don't see the scheme ("https:://") in the store URL

## Screenshots
| Before | After |
|--------|--------|
| ![Before](https://user-images.githubusercontent.com/524475/227507725-7e598a9b-2712-47ab-9a77-17d938944222.png) | ![After](https://user-images.githubusercontent.com/524475/227507700-17470fa5-fef9-467a-8f52-116ce9a438d5.png) | 

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
