### PR TITLE
[Composite Products] Load component options data in Component Settings view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettings.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettings.swift
@@ -67,11 +67,11 @@ struct ComponentSettings: View {
                     .padding()
 
                 optionsList
+                    .redacted(reason: viewModel.showOptionsLoadingIndicator ? .placeholder : [])
+                    .shimmering(active: viewModel.showOptionsLoadingIndicator)
             }
             .padding(.horizontal, insets: safeAreaInsets)
             .addingTopAndBottomDividers()
-            .redacted(reason: viewModel.showOptionLoadingIndicator ? .placeholder : [])
-            .shimmering(active: viewModel.showOptionLoadingIndicator)
             .background(Color(.listForeground(modal: false)))
 
             // Default component option

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettings.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettings.swift
@@ -7,7 +7,7 @@ struct ComponentSettings: View {
 
     /// View model that directs the view content.
     ///
-    let viewModel: ComponentSettingsViewModel
+    @ObservedObject var viewModel: ComponentSettingsViewModel
 
     /// Dynamic image width for the component image, also used for its height.
     ///
@@ -66,11 +66,15 @@ struct ComponentSettings: View {
             }
             .padding(.horizontal, insets: safeAreaInsets)
             .addingTopAndBottomDividers()
+            .redacted(reason: viewModel.showOptionLoadingIndicator ? .placeholder : [])
+            .shimmering(active: viewModel.showOptionLoadingIndicator)
             .background(Color(.listForeground(modal: false)))
 
             TitleAndValueRow(title: Localization.defaultOption, value: .placeholder(viewModel.defaultOptionTitle))
                 .padding(.horizontal, insets: safeAreaInsets)
                 .addingTopAndBottomDividers()
+                .redacted(reason: viewModel.showDefaultOptionLoadingIndicator ? .placeholder : [])
+                .shimmering(active: viewModel.showDefaultOptionLoadingIndicator)
                 .background(Color(.listForeground(modal: false)))
 
             FooterNotice(infoText: viewModel.infoNotice)
@@ -153,8 +157,7 @@ struct ComponentSettings_Previews: PreviewProvider {
                                                            description: "",
                                                            imageURL: nil,
                                                            optionsType: "Products",
-                                                           options: [],
-                                                           defaultOptionTitle: "")
+                                                           options: [])
 
     static var previews: some View {
         ComponentSettings(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettings.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettings.swift
@@ -24,6 +24,7 @@ struct ComponentSettings: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+                // Component image
                 KFImage(viewModel.imageURL)
                     .placeholder {
                         Image(uiImage: .productPlaceholderImage)
@@ -37,6 +38,7 @@ struct ComponentSettings: View {
                     .padding()
                     .renderedIf(viewModel.shouldShowImage)
 
+                // Component title
                 Text(viewModel.componentTitle)
                     .headlineStyle()
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -47,6 +49,7 @@ struct ComponentSettings: View {
                         .padding(.leading)
                         .padding(.trailing, insets: -safeAreaInsets)
 
+                    // Component description
                     TitleAndSubtitleRow(title: Localization.description, subtitle: viewModel.description)
                 }
                 .renderedIf(viewModel.shouldShowDescription)
@@ -55,6 +58,7 @@ struct ComponentSettings: View {
             .addingTopAndBottomDividers()
             .background(Color(.listForeground(modal: false)))
 
+            // Component options
             ListHeaderView(text: Localization.componentOptions.uppercased(), alignment: .left)
                 .padding(.horizontal, insets: safeAreaInsets)
             LazyVStack(alignment: .leading, spacing: Layout.sectionSpacing) {
@@ -70,6 +74,7 @@ struct ComponentSettings: View {
             .shimmering(active: viewModel.showOptionLoadingIndicator)
             .background(Color(.listForeground(modal: false)))
 
+            // Default component option
             TitleAndValueRow(title: Localization.defaultOption, value: .placeholder(viewModel.defaultOptionTitle))
                 .padding(.horizontal, insets: safeAreaInsets)
                 .addingTopAndBottomDividers()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettings.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettings.swift
@@ -7,7 +7,7 @@ struct ComponentSettings: View {
 
     /// View model that directs the view content.
     ///
-    @ObservedObject var viewModel: ComponentSettingsViewModel
+    @StateObject var viewModel: ComponentSettingsViewModel
 
     /// Dynamic image width for the component image, also used for its height.
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettingsViewModel.swift
@@ -185,7 +185,9 @@ private extension ComponentSettingsViewModel {
                 }
                 self.productsState = .loaded
             case .failure(let error):
-                self.options = []
+                if type == .productIDs {
+                    self.options = []
+                }
                 self.productsState = .notLoaded
                 DDLogError("⛔️ Unable to fetch products for composite component settings: \(error)")
                 // TODO-8956: Display notice about loading error

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettingsViewModel.swift
@@ -89,6 +89,8 @@ final class ComponentSettingsViewModel: ObservableObject {
 
     /// Current component options dependency state.
     ///
+    /// This state reflects either the `productsState` or `categoriesState`, depending on the component option type.
+    ///
     private var componentOptionsState: LoadState {
         optionsType == CompositeComponentOptionType.productIDs.description ? productsState : categoriesState
     }
@@ -122,6 +124,9 @@ final class ComponentSettingsViewModel: ObservableObject {
 
 // MARK: Initializers
 extension ComponentSettingsViewModel {
+    /// Initializes the view model using a `Component` from the `ComponentsListViewModel`.
+    /// Used when navigating to `ComponentSettings` from `ComponentsList`.
+    ///
     convenience init(siteID: Int64,
                      component: ComponentsListViewModel.Component,
                      stores: StoresManager = ServiceLocator.stores,
@@ -187,7 +192,6 @@ private extension ComponentSettingsViewModel {
             }
         }
 
-        options = [ComponentOption(id: 1, title: "Component Option", imageURL: nil)]
         productsState = .loading
         stores.dispatch(productAction)
     }
@@ -206,12 +210,15 @@ private extension ComponentSettingsViewModel {
         do {
             try resultsController.performFetch()
             self.options = resultsController.fetchedObjects.map { category in
+                // TODO-8965: Either add support for category images or hide the placeholder in the UI
+                // We currently don't parse category images from the API response
                 ComponentOption(id: category.categoryID, title: category.name, imageURL: nil)
             }
             self.categoriesState = .loaded
         } catch {
             self.categoriesState = .notLoaded
-            DDLogError("⛔️ Unable to fetch the composite component's category options: \(error)")
+            DDLogError("⛔️ Unable to fetch categories for the composite component settings: \(error)")
+            // TODO-8956: Display notice about loading error
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettingsViewModel.swift
@@ -97,7 +97,7 @@ final class ComponentSettingsViewModel: ObservableObject {
 
     /// Indicates if the Component Options section should should show a redacted state.
     ///
-    var showOptionLoadingIndicator: Bool {
+    var showOptionsLoadingIndicator: Bool {
         componentOptionsState == .loading
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettingsViewModel.swift
@@ -81,11 +81,11 @@ final class ComponentSettingsViewModel: ObservableObject {
 
     /// Current product dependency state.
     ///
-    private var productsState: LoadState = .notLoaded
+    @Published private var productsState: LoadState = .notLoaded
 
     /// Current category dependency state.
     ///
-    private var categoriesState: LoadState = .notLoaded
+    @Published private var categoriesState: LoadState = .notLoaded
 
     /// Current component options dependency state.
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettingsViewModel.swift
@@ -216,6 +216,7 @@ private extension ComponentSettingsViewModel {
             }
             self.categoriesState = .loaded
         } catch {
+            self.options = []
             self.categoriesState = .notLoaded
             DDLogError("⛔️ Unable to fetch categories for the composite component settings: \(error)")
             // TODO-8956: Display notice about loading error

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettingsViewModel.swift
@@ -222,7 +222,6 @@ private extension ComponentSettingsViewModel {
                     self?.categoriesState = .notLoaded
                     // TODO-8956: Display notice about loading error
                     DDLogError("⛔️ Unable to fetch category \(categoryID) for the composite component settings: \(error)")
-                    break
                 }
             }
             stores.dispatch(categoryAction)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentsList.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentsList.swift
@@ -90,10 +90,10 @@ private enum Layout {
 // MARK: Previews
 struct ComponentsList_Previews: PreviewProvider {
 
-    static let viewModel = ComponentsListViewModel(components: [
-        .init(id: "1", title: "Camera Body", imageURL: nil, description: "", optionType: .productIDs),
-        .init(id: "2", title: "Lens", imageURL: nil, description: "", optionType: .categoryIDs),
-        .init(id: "3", title: "Memory Card", imageURL: nil, description: "", optionType: .categoryIDs)
+    static let viewModel = ComponentsListViewModel(siteID: 123, components: [
+        .init(id: "1", title: "Camera Body", imageURL: nil, description: "", optionType: .productIDs, optionIDs: [], defaultOptionID: ""),
+        .init(id: "2", title: "Lens", imageURL: nil, description: "", optionType: .categoryIDs, optionIDs: [], defaultOptionID: ""),
+        .init(id: "3", title: "Memory Card", imageURL: nil, description: "", optionType: .categoryIDs, optionIDs: [], defaultOptionID: "")
     ])
 
     static var previews: some View {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentsListViewModel.swift
@@ -5,6 +5,10 @@ import Yosemite
 ///
 final class ComponentsListViewModel: ObservableObject {
 
+    /// Site ID
+    ///
+    private let siteID: Int64
+
     /// Represents a component
     ///
     struct Component: Identifiable, Equatable {
@@ -22,6 +26,12 @@ final class ComponentsListViewModel: ObservableObject {
 
         /// Type of component options (e.g. products or categories)
         let optionType: CompositeComponentOptionType
+
+        /// Product IDs or category IDs to use for populating component options.
+        let optionIDs: [Int64]
+
+        /// The product ID of the default/pre-selected component option.
+        let defaultOptionID: String
     }
 
     /// View title
@@ -36,22 +46,25 @@ final class ComponentsListViewModel: ObservableObject {
     ///
     let components: [Component]
 
-    init(components: [Component]) {
+    init(siteID: Int64, components: [Component]) {
+        self.siteID = siteID
         self.components = components
     }
 }
 
 // MARK: Initializers
 extension ComponentsListViewModel {
-    convenience init(components: [ProductCompositeComponent]) {
+    convenience init(siteID: Int64, components: [ProductCompositeComponent]) {
         let viewModels = components.map { component in
             return Component(id: component.componentID,
                              title: component.title,
                              imageURL: URL(string: component.imageURL),
                              description: component.description,
-                             optionType: component.optionType)
+                             optionType: component.optionType,
+                             optionIDs: component.optionIDs,
+                             defaultOptionID: component.defaultOptionID)
         }
-        self.init(components: viewModels)
+        self.init(siteID: siteID, components: viewModels)
     }
 }
 
@@ -60,7 +73,7 @@ extension ComponentsListViewModel {
     /// Returns a `ComponentSettingsViewModel` for the provided component.
     ///
     func getSettingsViewModel(for component: Component) -> ComponentSettingsViewModel {
-        ComponentSettingsViewModel(component: component)
+        ComponentSettingsViewModel(siteID: siteID, component: component)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1704,7 +1704,7 @@ private extension ProductFormViewController {
         guard let product = product as? EditableProductModel else {
             return
         }
-        let viewModel = ComponentsListViewModel(components: product.compositeComponents)
+        let viewModel = ComponentsListViewModel(siteID: product.siteID, components: product.compositeComponents)
         let viewController = ComponentsListViewController(viewModel: viewModel)
         show(viewController, sender: self)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Composite Products/ComponentSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Composite Products/ComponentSettingsViewModelTests.swift
@@ -148,7 +148,7 @@ final class ComponentSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.options.count, 0, "Loading placeholder was not removed after loading error.")
         XCTAssertEqual(viewModel.defaultOptionTitle,
                        NSLocalizedString("None", comment: "Label when there is no default option for a component in a composite product"))
-        XCTAssertFalse(viewModel.showOptionLoadingIndicator)
+        XCTAssertFalse(viewModel.showOptionsLoadingIndicator)
         XCTAssertFalse(viewModel.showDefaultOptionLoadingIndicator)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Composite Products/ComponentSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Composite Products/ComponentSettingsViewModelTests.swift
@@ -4,6 +4,8 @@ import XCTest
 
 final class ComponentSettingsViewModelTests: XCTestCase {
 
+    private let sampleSiteID: Int64 = 12345
+
     func test_component_image_and_description_visible_when_set() throws {
         // Given
         let imageURL = try XCTUnwrap(URL(string: "https://woocommerce.com/woo.jpg"))
@@ -34,10 +36,12 @@ final class ComponentSettingsViewModelTests: XCTestCase {
                                                           title: "Camera Body",
                                                           imageURL: URL(string: "https://woocommerce.com/woo.jpg"),
                                                           description: "Choose between the Nikon D600 or the powerful Canon EOS 5D Mark IV.",
-                                                          optionType: .productIDs)
+                                                          optionType: .productIDs,
+                                                          optionIDs: [],
+                                                          defaultOptionID: "")
 
         // When
-        let viewModel = ComponentSettingsViewModel(component: component)
+        let viewModel = ComponentSettingsViewModel(siteID: sampleSiteID, component: component)
 
         // Then
         XCTAssertEqual(viewModel.componentTitle, component.title)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Composite Products/ComponentsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Composite Products/ComponentsListViewModelTests.swift
@@ -4,6 +4,8 @@ import XCTest
 
 final class ComponentsListViewModelTests: XCTestCase {
 
+    private let sampleSiteID: Int64 = 12345
+
     func test_view_model_prefills_component_data_correctly() throws {
         // Given
         let compositeComponent = ProductCompositeComponent.fake().copy(componentID: "1",
@@ -13,7 +15,7 @@ final class ComponentsListViewModelTests: XCTestCase {
                                                                        optionType: .productIDs)
 
         // When
-        let viewModel = ComponentsListViewModel(components: [compositeComponent])
+        let viewModel = ComponentsListViewModel(siteID: sampleSiteID, components: [compositeComponent])
         let component = try XCTUnwrap(viewModel.components.first)
 
         // Then


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8956
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR loads the **list of component options** and **default option** in the Component Settings view, for Composite Products. Component options can be products or categories, while the default option is always a specific product. This means that products always need to be loaded (at least to get the default option), and categories sometimes need to be loaded.

When the data is loaded:

* Products are synced from remote (in case not all products have been synced yet).
* Categories are fetched from storage since they are fully synced on the product details screen.

Note: We will add loading error handling in another PR.

### Changes

* Loads component options using the option IDs and option type (products or categories).
* Fetches the name of the default option from remote (this is always a product).
* Shows a loading view in the component options and default option sections while the loading is in progress.

## Testing instructions

### Prerequisites

1. Install and activate the [Composite Products extension](https://woocommerce.com/products/composite-products/) on your store.
2. Create at least one product with the Composite Products type, with at least one component.

### To test

1. Build and run the app.
2. Go to the Products tab.
3. Open a Composite Product.
4. Select the Components row in product details.
5. Select a component from the list.
6. When the Component Settings view opens, confirm it shows loading indicators for the component options and default option, which are replaced by the actual data when loading is complete.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/8658164/229860817-d65968b5-3af3-43fa-85ce-4d0373fc8bc6.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
