### PR TITLE
Fix products parsing errors

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -442,8 +442,13 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         let bundleStockQuantity = container.failsafeDecodeIfPresent(Int64.self, forKey: .bundleStockQuantity)
         let bundledItems = try container.decodeIfPresent([ProductBundleItem].self, forKey: .bundledItems) ?? []
 
+        ///`ProductCompositeComponent.defaultOptionID` is being returned as an `Int` instead of as a `String` in some test store.
+        /// Since this feature is still in development I'm defaulting to evict any composite component when a parsing error occurs.
+        /// We should identify why that field can be of multiple types before releasing the feature to the public.
+        ///
         // Composite Product properties
-        let compositeComponents = try container.decodeIfPresent([ProductCompositeComponent].self, forKey: .compositeComponents) ?? []
+        let compositeComponents = (try? container.decodeIfPresent([ProductCompositeComponent].self, forKey: .compositeComponents)) ?? []
+
 
         self.init(siteID: siteID,
                   productID: productID,

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -403,7 +403,14 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         let shippingClassID = try container.decode(Int64.self, forKey: .shippingClassID)
 
         let reviewsAllowed = try container.decode(Bool.self, forKey: .reviewsAllowed)
-        let averageRating = try container.decode(String.self, forKey: .averageRating)
+
+        /// We have noticed this value coming as a number on some stores.
+        /// As this was introduced quite a while ago it's cheaper to handle both types than letting the whole parsing fail.
+        ///
+        let averageRating = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                              forKey: .averageRating,
+                                                              alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })]) ?? ""
+
         let ratingCount = try container.decode(Int.self, forKey: .ratingCount)
 
         let relatedIDs = try container.decode([Int64].self, forKey: .relatedIDs)


### PR DESCRIPTION
# Why

While reviewing https://github.com/woocommerce/woocommerce-ios/pull/9295 I noticed that some test stores weren't loading products correctly.

After looking for the problem I found two:

## Composite Components

For my test store `dulces.mystagingwebsite.com` the `defaultOptionID` field comes as an `int` instead of as a `String`. As this feature is still in development I've opted for shadowing the error and dropping any corrupt composite product. The idea is for @rachelmcr to analyze a correct solution when she comes back.

## Average Ratings

For Rachel's test store `teststore.rachel-test-domain.com` I found a product that had an `average_rating` coming as an `int` instead of as a `String`. As this field was introduced quite a while ago, we aren't working actively on reviews I think it's cheaper to handle both types than letting the whole parsing fail.

# Testing Steps

- Login to the following store `dulces.mystagingwebsite.com` ask for access in case you don't have it.
- Load all products (scroll to the very end)
- Make sure no errors occur

---

- Login to the following store `https://teststore.rachel-test-domain.com/` ask for access in case you don't have it.
- Load all products (scroll to the very end)
- Make sure no errors occur

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
