### PR TITLE
[UI Tests] - Refactor test methods

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
@@ -29,12 +29,12 @@ public final class PrologueScreen: ScreenObject {
         )
     }
 
-    public func selectContinueWithWordPress() throws -> GetStartedScreen {
+    public func tapContinueWithWordPress() throws -> GetStartedScreen {
         continueButton.tap()
         return try GetStartedScreen()
     }
 
-    public func selectSiteAddress() throws -> LoginSiteAddressScreen {
+    public func tapSiteAddress() throws -> LoginSiteAddressScreen {
         selectSiteButton.tap()
         return try LoginSiteAddressScreen()
     }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/AddProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/AddProductScreen.swift
@@ -20,18 +20,18 @@ public final class AddProductScreen: ScreenObject {
         )
     }
 
-    /// Selects a product from the list.
+    /// Taps a product from the list.
     /// - Returns: Unified Order screen object.
     @discardableResult
-    public func selectProduct(byName name: String) throws -> UnifiedOrderScreen {
+    public func tapProduct(byName name: String) throws -> UnifiedOrderScreen {
         app.buttons.staticTexts[name].tap()
         return try UnifiedOrderScreen()
     }
 
-    /// Selects multiple products from the list.
+    /// Taps multiple products from the list.
     /// - Returns: Unified Order screen object.
     @discardableResult
-    public func selectMultipleProducts(numberOfProductsToAdd: Int) throws -> UnifiedOrderScreen {
+    public func tapMultipleProducts(numberOfProductsToAdd: Int) throws -> UnifiedOrderScreen {
         for product in 0..<numberOfProductsToAdd {
             let products = app.buttons.matching(identifier: "product-item")
             products.element(boundBy: product).tap()

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrderStatusScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrderStatusScreen.swift
@@ -18,10 +18,10 @@ public final class OrderStatusScreen: ScreenObject {
         )
     }
 
-    /// Selects a new order status from the list.
+    /// Taps a new order status from the list.
     /// - Returns: Order Status screen object (self).
     @discardableResult
-    public func selectOrderStatus(atIndex index: Int) throws -> UnifiedOrderScreen {
+    public func tapOrderStatus(atIndex index: Int) throws -> UnifiedOrderScreen {
         orderStatusTable.cells.element(boundBy: index).tap()
         return try UnifiedOrderScreen()
     }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
@@ -56,8 +56,8 @@ public final class OrdersScreen: ScreenObject {
     public func verifyOrdersList(orders: [OrderData]) throws -> Self {
         let ordersTableView = app.tables.matching(identifier: "orders-table-view")
         XCTAssertEqual(orders.count, ordersTableView.cells.count, "Expecting '\(orders.count)' orders, got '\(app.tables.cells.count)' instead!")
-        ordersTableView.element.assertTextVisibilityCount(textToFind: String(orders[0].id))
-        ordersTableView.element.assertTextVisibilityCount(textToFind: String(orders[0].total))
+        ordersTableView.element.assertTextVisibilityCount(textToFind: String(orders[0].id), expectedCount: 1)
+        ordersTableView.element.assertTextVisibilityCount(textToFind: String(orders[0].total), expectedCount: 1)
         ordersTableView.element.assertLabelContains(firstSubstring: String(orders[0].id), secondSubstring: orders[0].billing.first_name)
 
         return self

--- a/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/OrdersScreen.swift
@@ -33,13 +33,13 @@ public final class OrdersScreen: ScreenObject {
     }
 
     @discardableResult
-    public func selectOrder(atIndex index: Int) throws -> SingleOrderScreen {
+    public func tapOrder(atIndex index: Int) throws -> SingleOrderScreen {
         app.tables.cells.element(boundBy: index).tap()
         return try SingleOrderScreen()
     }
 
     @discardableResult
-    public func selectOrder(byOrderNumber orderNumber: String) throws -> SingleOrderScreen {
+    public func tapOrder(byOrderNumber orderNumber: String) throws -> SingleOrderScreen {
         let orderNumberPredicate = NSPredicate(format: "label CONTAINS[c] %@", orderNumber)
         app.staticTexts.containing(orderNumberPredicate).firstMatch.tap()
 

--- a/WooCommerce/UITestsFoundation/Screens/Orders/PaymentMethodsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/PaymentMethodsScreen.swift
@@ -27,7 +27,7 @@ public final class PaymentMethodsScreen: ScreenObject {
     }
 
     @discardableResult
-    public func selectCardPresentPayment() throws -> CardPresentPaymentsModalScreen {
+    public func tapCardPresentPayment() throws -> CardPresentPaymentsModalScreen {
         cardMethodButton.tap()
         return try CardPresentPaymentsModalScreen()
     }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -155,21 +155,21 @@ public final class UnifiedOrderScreen: ScreenObject {
     /// - Returns: Unified Order screen object.
     public func editOrderStatus() throws -> UnifiedOrderScreen {
       return try openOrderStatusScreen()
-            .selectOrderStatus(atIndex: 1)
+            .tapOrderStatus(atIndex: 1)
     }
 
-    /// Select the first product from the addProductScreen
+    /// Tap the first product from the addProductScreen
     /// - Returns: Unified Order screen object.
     public func addProduct(byName name: String) throws -> UnifiedOrderScreen {
         return try openAddProductScreen()
-            .selectProduct(byName: name)
+            .tapProduct(byName: name)
     }
 
-    /// Select the first product from the addProductScreen
+    /// Tap the first product from the addProductScreen
     /// - Returns: Unified Order screen object.
     public func addProducts(numberOfProductsToAdd numberOfProducts: Int) throws -> UnifiedOrderScreen {
         return try openAddProductScreen()
-            .selectMultipleProducts(numberOfProductsToAdd: numberOfProducts)
+            .tapMultipleProducts(numberOfProductsToAdd: numberOfProducts)
     }
 
     /// Adds minimal customer details on the Customer Details screen

--- a/WooCommerce/UITestsFoundation/Screens/Payments/CardReaderManualsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/CardReaderManualsScreen.swift
@@ -27,7 +27,7 @@ public final class CardReaderManualsScreen: ScreenObject {
     }
 
     @discardableResult
-    public func selectChipperManual() throws -> Self {
+    public func tapChipperManual() throws -> Self {
         chipperManualButton.tap()
         return self
     }

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -21,8 +21,8 @@ public final class PaymentsScreen: ScreenObject {
     }
 
     @discardableResult
-    public func selectCardReaderManuals() throws -> CardReaderManualsScreen {
         selectCardReaderManualsButton.tap()
+    public func tapCardReaderManuals() throws -> CardReaderManualsScreen {
         return try CardReaderManualsScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -6,12 +6,12 @@ public final class PaymentsScreen: ScreenObject {
         $0.cells["collect-payment"]
     }
 
-    private let selectCardReaderManualsButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let cardReaderManualsButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["card-reader-manuals"]
     }
 
     private var collectPaymentButton: XCUIElement { collectPaymentButtonGetter(app) }
-    private var selectCardReaderManualsButton: XCUIElement { selectCardReaderManualsButtonGetter(app) }
+    private var cardReaderManualsButton: XCUIElement { cardReaderManualsButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -21,8 +21,8 @@ public final class PaymentsScreen: ScreenObject {
     }
 
     @discardableResult
-        selectCardReaderManualsButton.tap()
     public func tapCardReaderManuals() throws -> CardReaderManualsScreen {
+        cardReaderManualsButton.tap()
         return try CardReaderManualsScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductSearchScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductSearchScreen.swift
@@ -38,7 +38,7 @@ public final class ProductSearchScreen: ScreenObject {
         try verifyNumberOfProductsInSearchResults(equals: 1, accessibilityId: updatedSearchResultsID)
 
         let productsTableView = app.tables.matching(identifier: updatedSearchResultsID)
-        productsTableView.element.assertTextVisibilityCount(textToFind: String(expectedProduct.name))
-        productsTableView.element.assertTextVisibilityCount(textToFind: String(expectedProduct.stock_status))
+        productsTableView.element.assertTextVisibilityCount(textToFind: String(expectedProduct.name), expectedCount: 1)
+        productsTableView.element.assertTextVisibilityCount(textToFind: String(expectedProduct.stock_status), expectedCount: 1)
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -40,7 +40,7 @@ public final class ProductsScreen: ScreenObject {
     }
 
     @discardableResult
-    public func selectAddProduct() -> Self {
+    public func tapAddProduct() -> Self {
         guard productAddButton.waitForExistence(timeout: 3) else {
             return self
         }
@@ -67,13 +67,13 @@ public final class ProductsScreen: ScreenObject {
     }
 
     @discardableResult
-    public func selectProduct(atIndex index: Int) throws -> SingleProductScreen {
+    public func tapProduct(atIndex index: Int) throws -> SingleProductScreen {
         app.tables.cells.element(boundBy: index).tap()
         return try SingleProductScreen()
     }
 
     @discardableResult
-    public func selectProduct(byName name: String) throws -> SingleProductScreen {
+    public func tapProduct(byName name: String) throws -> SingleProductScreen {
         app.tables.cells.staticTexts[name].tap()
         return try SingleProductScreen()
     }
@@ -93,13 +93,13 @@ public final class ProductsScreen: ScreenObject {
         return self
     }
 
-    public func selectProductType(productType: String) throws -> SingleProductScreen {
+    public func tapProductType(productType: String) throws -> SingleProductScreen {
         let productTypeLabel = NSPredicate(format: "label CONTAINS[c] %@", productType)
         app.staticTexts.containing(productTypeLabel).firstMatch.tap()
         return try SingleProductScreen()
     }
 
-    public func selectSearchButton() throws -> ProductSearchScreen {
+    public func tapSearchButton() throws -> ProductSearchScreen {
         productSearchButton.tap()
         return try ProductSearchScreen()
     }

--- a/WooCommerce/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Reviews/ReviewsScreen.swift
@@ -19,13 +19,13 @@ public final class ReviewsScreen: ScreenObject {
     }
 
     @discardableResult
-    public func selectReview(atIndex index: Int) throws -> SingleReviewScreen {
+    public func tapReview(atIndex index: Int) throws -> SingleReviewScreen {
         app.tables.cells.element(boundBy: index).tap()
         return try SingleReviewScreen()
     }
 
     @discardableResult
-    public func selectReview(byReviewer reviewer: String) throws -> SingleReviewScreen {
+    public func tapReview(byReviewer reviewer: String) throws -> SingleReviewScreen {
         let reviewerPredicate = NSPredicate(format: "label CONTAINS[c] %@", reviewer)
         app.staticTexts.containing(reviewerPredicate).firstMatch.tap()
 

--- a/WooCommerce/UITestsFoundation/XCTest+Extensions.swift
+++ b/WooCommerce/UITestsFoundation/XCTest+Extensions.swift
@@ -123,9 +123,8 @@ extension XCUIElement {
         return staticTexts.containing(predicate).count
     }
 
-        let count = try! getStaticTextVisibilityCount(textToFind: textToFind)
-        XCTAssertTrue(count == expectedCount, "Expected '\(textToFind)' to appear \(expectedCount) times, but it appeared '\(count)' times!")
     public func assertTextVisibilityCount(textToFind: String, expectedCount: Int) {
+        XCTAssertEqual(try! getStaticTextVisibilityCount(textToFind: textToFind), expectedCount)
     }
 
     // Parent element is accessibilityIdentifier, child element is staticText

--- a/WooCommerce/UITestsFoundation/XCTest+Extensions.swift
+++ b/WooCommerce/UITestsFoundation/XCTest+Extensions.swift
@@ -123,9 +123,9 @@ extension XCUIElement {
         return staticTexts.containing(predicate).count
     }
 
-    public func assertTextVisibilityCount(textToFind: String, expectedCount: Int = 1) {
         let count = try! getStaticTextVisibilityCount(textToFind: textToFind)
         XCTAssertTrue(count == expectedCount, "Expected '\(textToFind)' to appear \(expectedCount) times, but it appeared '\(count)' times!")
+    public func assertTextVisibilityCount(textToFind: String, expectedCount: Int) {
     }
 
     // Parent element is accessibilityIdentifier, child element is staticText

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -54,9 +54,9 @@ class WooCommerceScreenshots: XCTestCase {
         .cancelOrderCreation()
 
         // Collect payment
-        .selectOrder(atIndex: 0)
+        .tapOrder(atIndex: 0)
         .tapCollectPaymentButton()
-        .selectCardPresentPayment()
+        .tapCardPresentPayment()
         .thenTakeScreenshot(named: "order-payment")
         .goBackToPaymentMethodsScreen()
         .goBackToOrderScreen()
@@ -65,7 +65,7 @@ class WooCommerceScreenshots: XCTestCase {
         // Products
         try TabNavComponent()
         .goToProductsScreen()
-        .selectAddProduct()
+        .tapAddProduct()
         .thenTakeScreenshot(named: "product-add")
 
         // Push notification

--- a/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
@@ -14,7 +14,7 @@ class LoginFlow {
 
     @discardableResult
     static func logInWithWPcom() throws -> MyStoreScreen {
-        try PrologueScreen().selectContinueWithWordPress()
+        try PrologueScreen().tapContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
 
@@ -26,7 +26,7 @@ class LoginFlow {
     @discardableResult
     static func logInWithSiteAddress() throws -> MyStoreScreen {
         try PrologueScreen()
-            .selectSiteAddress()
+            .tapSiteAddress()
             .proceedWith(siteUrl: TestCredentials.siteUrl)
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)

--- a/WooCommerce/WooCommerceUITests/Flows/ProductFlow.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/ProductFlow.swift
@@ -7,8 +7,8 @@ class ProductFlow {
         let product = try GetMocks.readNewProductData()
 
         try TabNavComponent().goToProductsScreen()
-            .selectAddProduct()
-            .selectProductType(productType: productType)
+            .tapAddProduct()
+            .tapProductType(productType: productType)
             .verifyProductTypeScreenLoaded(productType: productType)
             .addProductTitle(productTitle: product.name)
             .publishProduct()

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -17,7 +17,7 @@ final class LoginTests: XCTestCase {
             return
         }
         try PrologueScreen()
-            .selectSiteAddress()
+            .tapSiteAddress()
             .proceedWith(siteUrl: TestCredentials.siteUrl)
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
@@ -35,7 +35,7 @@ final class LoginTests: XCTestCase {
         guard try PrologueScreen().isWPComLoginAvailable() else {
             return
         }
-        try PrologueScreen().selectContinueWithWordPress()
+        try PrologueScreen().tapContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)
 
@@ -56,7 +56,7 @@ final class LoginTests: XCTestCase {
         guard try PrologueScreen().isWPComLoginAvailable() else {
             return
         }
-        _ = try PrologueScreen().selectContinueWithWordPress()
+        _ = try PrologueScreen().tapContinueWithWordPress()
             .proceedWith(email: TestCredentials.emailAddress)
             .tryProceed(password: "invalidPswd")
             .verifyLoginError()

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -19,14 +19,13 @@ final class OrdersTests: XCTestCase {
         try TabNavComponent().goToOrdersScreen()
             .verifyOrdersScreenLoaded()
             .verifyOrdersList(orders: orders)
-            .selectOrder(byOrderNumber: orders[0].number)
+            .tapOrder(byOrderNumber: orders[0].number)
             .verifySingleOrder(order: orders[0])
             .goBackToOrdersScreen()
             .verifyOrdersScreenLoaded()
     }
 
     func test_create_new_order() throws {
-        let products = try GetMocks.readProductsData()
         let order = try GetMocks.readNewOrderData()
 
         try TabNavComponent().goToOrdersScreen()
@@ -47,7 +46,7 @@ final class OrdersTests: XCTestCase {
         let orders = try GetMocks.readOrdersData()
 
         try TabNavComponent().goToOrdersScreen()
-            .selectOrder(byOrderNumber: orders[0].number)
+            .tapOrder(byOrderNumber: orders[0].number)
             .tapEditOrderButton()
             .checkForExistingOrderTitle(byOrderNumber: orders[0].number)
             .checkForExistingProducts(byName: orders[0].line_items.map { $0.name })

--- a/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
@@ -15,8 +15,8 @@ final class PaymentsTests: XCTestCase {
     func test_load_chipper_card_reader_manual() throws {
         try TabNavComponent().goToMenuScreen()
             .goToPaymentsScreen()
-            .selectCardReaderManuals()
-            .selectChipperManual()
+            .tapCardReaderManuals()
+            .tapChipperManual()
             .verifyChipperManualLoadedOnWebView()
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
@@ -18,7 +18,7 @@ final class ProductsTests: XCTestCase {
         try TabNavComponent().goToProductsScreen()
             .verifyProductsScreenLoaded()
             .verifyProductList(products: products)
-            .selectProduct(byName: products[0].name)
+            .tapProduct(byName: products[0].name)
             .verifyProduct(product: products[0])
             .goBackToProductList()
             .verifyProductsScreenLoaded()
@@ -40,7 +40,7 @@ final class ProductsTests: XCTestCase {
         let products = try GetMocks.readProductsData()
 
         try TabNavComponent().goToProductsScreen()
-            .selectSearchButton()
+            .tapSearchButton()
             .verifyNumberOfProductsInSearchResults(equals: products.count)
             .enterSearchCriteria(text: products[0].name)
             .verifyProductSearchResults(expectedProduct: products[0])

--- a/WooCommerce/WooCommerceUITests/Tests/ReviewsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/ReviewsTests.swift
@@ -24,7 +24,7 @@ final class ReviewsTests: XCTestCase {
             .goToReviewsScreen()
             .verifyReviewsScreenLoaded()
             .verifyReviewList(reviews: reviews)
-            .selectReview(byReviewer: reviews[0].reviewer)
+            .tapReview(byReviewer: reviews[0].reviewer)
             .verifySingleReviewScreenLoaded()
             .verifyReview(review: reviews[0])
             .goBackToReviewsScreen()


### PR DESCRIPTION
## Description
A follow up PR from comments in PR https://github.com/woocommerce/woocommerce-ios/pull/9276. Changes in this PR are broken into commits:
1. For better consistency across the repo and so we don't end up with multiple functions that do the same thing, rename all tap related methods to `tap...` - https://github.com/woocommerce/woocommerce-ios/pull/9305/commits/485b067b6e3c800012ca752f8602d2bc053aeed3
2. Remove the default value of 1 on `assertTextVisibilityCount` and make `expectedCount` mandatory to make it easier to read - https://github.com/woocommerce/woocommerce-ios/pull/9305/commits/8417e261dacd61cfa9473f162e3ba8c2b4ea5d7a
3. Update a typo in a button name (from `selectCardReaderManualsButton` to `cardReaderManualsButton`) - https://github.com/woocommerce/woocommerce-ios/pull/9305/commits/c164ae3eb0d91a74f0bbedd08501c2affe83a113 
4. Use `XCTAssertEqual` instead of `XCTAssertTrue` for `assertTextVisibilityCount ()` to simplify the code - https://github.com/woocommerce/woocommerce-ios/pull/9305/commits/c261feb011e8175887d5ad5fad7be7fff90f6ba0 

## Testing instructions
All tests should work as expected

