### PR TITLE
REST API: Authenticate user after Jetpack setup completes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -228,6 +228,7 @@ private extension JetpackSetupCoordinator {
 
     func authenticateUserAndRefreshSite(with credentials: Credentials) {
         stores.authenticate(credentials: credentials)
+        registerForPushNotifications()
         let progressView = InProgressViewController(viewProperties: .init(title: Localization.pleaseWait, message: ""))
         rootViewController.topmostPresentedViewController.present(progressView, animated: true)
 
@@ -238,7 +239,6 @@ private extension JetpackSetupCoordinator {
                 self.stores.updateDefaultStore(storeID: site.siteID)
                 self.stores.synchronizeEntities { [weak self] in
                     self?.stores.updateDefaultStore(site)
-                    self?.registerForPushNotifications()
                     self?.rootViewController.dismiss(animated: true)
                 }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -238,6 +238,7 @@ private extension JetpackSetupCoordinator {
                 self.stores.updateDefaultStore(storeID: site.siteID)
                 self.stores.synchronizeEntities { [weak self] in
                     self?.stores.updateDefaultStore(site)
+                    self?.registerForPushNotifications()
                     self?.rootViewController.dismiss(animated: true)
                 }
 
@@ -252,6 +253,16 @@ private extension JetpackSetupCoordinator {
             }
         }
         stores.dispatch(action)
+    }
+
+    func registerForPushNotifications() {
+        #if targetEnvironment(simulator)
+            DDLogVerbose("👀 Push Notifications are not supported in the Simulator!")
+        #else
+            let pushNotesManager = ServiceLocator.pushNotesManager
+            pushNotesManager.registerForRemoteNotifications()
+            pushNotesManager.ensureAuthorizationIsRequested(includesProvisionalAuth: false, onCompletion: nil)
+        #endif
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -228,7 +228,6 @@ private extension JetpackSetupCoordinator {
 
     func authenticateUserAndRefreshSite(with credentials: Credentials) {
         stores.authenticate(credentials: credentials)
-        registerForPushNotifications()
         let progressView = InProgressViewController(viewProperties: .init(title: Localization.pleaseWait, message: ""))
         rootViewController.topmostPresentedViewController.present(progressView, animated: true)
 
@@ -239,7 +238,9 @@ private extension JetpackSetupCoordinator {
                 self.stores.updateDefaultStore(storeID: site.siteID)
                 self.stores.synchronizeEntities { [weak self] in
                     self?.stores.updateDefaultStore(site)
-                    self?.rootViewController.dismiss(animated: true)
+                    self?.rootViewController.dismiss(animated: true, completion: {
+                        self?.registerForPushNotifications()
+                    })
                 }
 
             case .failure(let error):

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -228,7 +228,7 @@ private extension JetpackSetupCoordinator {
 
     func authenticateUserAndRefreshSite(with credentials: Credentials) {
         stores.authenticate(credentials: credentials)
-        let progressView = InProgressViewController(viewProperties: .init(title: Localization.pleaseWait, message: ""))
+        let progressView = InProgressViewController(viewProperties: .init(title: Localization.syncingData, message: ""))
         rootViewController.topmostPresentedViewController.present(progressView, animated: true)
 
         let action = AccountAction.synchronizeSitesAndReturnSelectedSiteInfo(siteAddress: site.url) { [weak self] result in
@@ -397,6 +397,10 @@ private extension JetpackSetupCoordinator {
         static let pleaseWait = NSLocalizedString(
             "Please wait",
             comment: "Message on the loading view displayed when the magic link authentication for Jetpack setup is in progress"
+        )
+        static let syncingData = NSLocalizedString(
+            "Syncing data",
+            comment: "Message on the loading view displayed when the data is being synced after Jetpack setup completes"
         )
         static let errorFetchingWPComAccount = NSLocalizedString(
             "Unable to fetch the logged in WordPress.com account. Please try again.",

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -235,8 +235,12 @@ private extension JetpackSetupCoordinator {
             guard let self else { return }
             switch result {
             case .success(let site):
-                self.stores.updateDefaultStore(site)
-                self.rootViewController.dismiss(animated: true)
+                self.stores.updateDefaultStore(storeID: site.siteID)
+                self.stores.synchronizeEntities { [weak self] in
+                    self?.stores.updateDefaultStore(site)
+                    self?.rootViewController.dismiss(animated: true)
+                }
+
             case .failure(let error):
                 DDLogError("⛔️ Error fetching sites after Jetpack setup: \(error)")
                 progressView.dismiss(animated: true, completion: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -232,6 +232,7 @@ private extension JetpackSetupCoordinator {
     }
 
     func authenticateUserAndRefreshSite(with credentials: Credentials) {
+        stores.sessionManager.deleteApplicationPassword()
         stores.authenticate(credentials: credentials)
         let progressView = InProgressViewController(viewProperties: .init(title: Localization.syncingData, message: ""))
         rootViewController.topmostPresentedViewController.present(progressView, animated: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -210,4 +210,52 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
             (self.navigationController.presentedViewController as? UINavigationController)?.topViewController is JetpackSetupHostingController
         }
     }
+
+    func test_handleAuthenticationUrl_proceeds_to_authenticate_user_if_jetpack_is_already_connected() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
+        let expectedScheme = "scheme"
+        let coordinator = JetpackSetupCoordinator(site: testSite, dotcomAuthScheme: expectedScheme, rootViewController: navigationController, stores: stores)
+        let url = try XCTUnwrap(URL(string: "scheme://magic-login?token=test"))
+
+        let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil)
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case let .loadWPComAccount(_, onCompletion):
+                onCompletion(expectedAccount)
+            case let .fetchJetpackUser(completion):
+                let dotcomUser = DotcomUser.fake().copy(id: expectedAccount.userID, username: expectedAccount.username, email: expectedAccount.email)
+                completion(.success(JetpackUser.fake().copy(wpcomUser: dotcomUser)))
+            default:
+                break
+            }
+        }
+
+        let expectedSite = Site.fake().copy(siteID: 44, url: "https://example.com")
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case .synchronizeSitesAndReturnSelectedSiteInfo(_, let onCompletion):
+                onCompletion(.success(expectedSite))
+            case .synchronizeAccount(let onCompletion):
+                onCompletion(.success(expectedAccount))
+            case .synchronizeAccountSettings(_, let onCompletion):
+                onCompletion(.success(AccountSettings.fake()))
+            case .synchronizeSites(_, let onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+
+        // When
+        _ = coordinator.handleAuthenticationUrl(url)
+
+        // Then
+        waitUntil {
+            stores.sessionManager.defaultSite == expectedSite
+        }
+        assertEqual(expectedSite.siteID, stores.sessionManager.defaultStoreID)
+        assertEqual(expectedAccount, stores.sessionManager.defaultAccount)
+    }
 }

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -12,6 +12,7 @@ public enum AccountAction: Action {
     case synchronizeAccountSettings(userID: Int64, onCompletion: (Result<AccountSettings, Error>) -> Void)
     /// The boolean in the completion block indicates whether the sites contain any JCP sites (connected to Jetpack without Jetpack-the-plugin).
     case synchronizeSites(selectedSiteID: Int64?, onCompletion: (Result<Bool, Error>) -> Void)
+    case synchronizeSitesAndReturnSelectedSiteInfo(siteAddress: String, onCompletion: (Result<Site, Error>) -> Void)
     case synchronizeSitePlan(siteID: Int64, onCompletion: (Result<Void, Error>) -> Void)
     case updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: (Result<Void, Error>) -> Void)
     case closeAccount(onCompletion: (Result<Void, Error>) -> Void)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8921 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR finalizes the Jetpack setup flow by authenticating the user and reloading site info after the setup completes. Changes include:
- Show alert when fetching the logged-in wpcom account fails. This makes sure that we always have the logged-in username/email after login.
- Handled post-setup work:
  - Authenticating the user with the logged-in wpcom.
  - Syncing Jetpack sites and returning the site matching the current one.
  - Updating the selected site and syncing all entities again.
  - Registering for remote notifications.
- The Account action and store have also been updated to support syncing sites while returning the site with a provided URL. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: Ensure you can access a self-hosted site with WooCommerce but no Jetpack.
- Build the app to a physical device to test push notifications later.
- Log in to the test store with either site credentials or through the application password authorization web view.
- Open the Jetpack setup flow by either tapping the Jetpack benefit banner on the dashboard screen or the Install Jetpack row in Menu > Settings.
- Go through the setup flow, and confirm all steps are complete.
- Tap the Go to Store button when the setup completes. Notice that a progress view is displayed when data is being synced.
- When the progress view is dismissed, confirm that the dashboard screen can show all stats. All features should still work correctly. Hub menu should display the correct avatar with the Switch store button available.
- Put the app in the background and place an order or review a product on your test store. Push notifications should work for both cases.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/228117842-56ffe91f-5599-4559-8221-ea306a8d7aad.mov



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
