### PR TITLE
[Store onboarding] Reload on tapping `Done` from web view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreDetails/StoreOnboardingStoreDetailsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreDetails/StoreOnboardingStoreDetailsCoordinator.swift
@@ -8,10 +8,14 @@ final class StoreOnboardingStoreDetailsCoordinator: Coordinator {
     let navigationController: UINavigationController
 
     private let site: Site
+    private let onDismiss: (() -> Void)?
 
-    init(site: Site, navigationController: UINavigationController) {
+    init(site: Site,
+         navigationController: UINavigationController,
+         onDismiss: (() -> Void)? = nil) {
         self.site = site
         self.navigationController = navigationController
+        self.onDismiss = onDismiss
     }
 
     func start() {
@@ -36,6 +40,7 @@ private extension StoreOnboardingStoreDetailsCoordinator {
     }
 
     @objc func dismissWebview() {
+        onDismiss?()
         navigationController.dismiss(animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -18,13 +18,16 @@ final class StoreOnboardingCoordinator: Coordinator {
 
     private let site: Site
     private let onTaskCompleted: (_ task: TaskType) -> Void
+    private let reloadTasks: () -> Void
 
     init(navigationController: UINavigationController,
          site: Site,
-         onTaskCompleted: @escaping (_ task: TaskType) -> Void) {
+         onTaskCompleted: @escaping (_ task: TaskType) -> Void,
+         reloadTasks: @escaping () -> Void) {
         self.navigationController = navigationController
         self.site = site
         self.onTaskCompleted = onTaskCompleted
+        self.reloadTasks = reloadTasks
     }
 
     /// Navigates to the fullscreen store onboarding view.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -68,7 +68,11 @@ final class StoreOnboardingCoordinator: Coordinator {
 private extension StoreOnboardingCoordinator {
     @MainActor
     func showStoreDetails() {
-        let coordinator = StoreOnboardingStoreDetailsCoordinator(site: site, navigationController: navigationController)
+        let coordinator = StoreOnboardingStoreDetailsCoordinator(site: site,
+                                                                 navigationController: navigationController,
+                                                                 onDismiss: { [weak self] in
+            self?.reloadTasks()
+        })
         self.storeDetailsCoordinator = coordinator
         coordinator.start()
     }
@@ -112,14 +116,24 @@ private extension StoreOnboardingCoordinator {
 
     @MainActor
     func showWCPaySetup() {
-        let coordinator = StoreOnboardingPaymentsSetupCoordinator(task: .wcPay, site: site, navigationController: navigationController)
+        let coordinator = StoreOnboardingPaymentsSetupCoordinator(task: .wcPay,
+                                                                  site: site,
+                                                                  navigationController: navigationController,
+                                                                  onDismiss: { [weak self] in
+             self?.reloadTasks()
+         })
         self.paymentsSetupCoordinator = coordinator
         coordinator.start()
     }
 
     @MainActor
     func showPaymentsSetup() {
-        let coordinator = StoreOnboardingPaymentsSetupCoordinator(task: .payments, site: site, navigationController: navigationController)
+        let coordinator = StoreOnboardingPaymentsSetupCoordinator(task: .payments,
+                                                                  site: site,
+                                                                  navigationController: navigationController,
+                                                                  onDismiss: { [weak self] in
+            self?.reloadTasks()
+         })
         self.paymentsSetupCoordinator = coordinator
         coordinator.start()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingPaymentsSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingPaymentsSetupCoordinator.swift
@@ -13,11 +13,16 @@ final class StoreOnboardingPaymentsSetupCoordinator: Coordinator {
 
     private let task: Task
     private let site: Site
+    private let onDismiss: (() -> Void)?
 
-    init(task: Task, site: Site, navigationController: UINavigationController) {
+    init(task: Task,
+         site: Site,
+         navigationController: UINavigationController,
+         onDismiss: (() -> Void)? = nil) {
         self.task = task
         self.site = site
         self.navigationController = navigationController
+        self.onDismiss = onDismiss
     }
 
     func start() {
@@ -61,6 +66,7 @@ private extension StoreOnboardingPaymentsSetupCoordinator {
     }
 
     @objc func dismissWebview() {
+        onDismiss?()
         navigationController.dismiss(animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -14,6 +14,8 @@ final class StoreOnboardingViewHostingController: SelfSizingHostingController<St
         guard let self else { return }
         self.reloadTasks()
         ServiceLocator.analytics.track(event: .StoreOnboarding.storeOnboardingTaskCompleted(task: task))
+    }, reloadTasks: { [weak self] in
+        self?.reloadTasks()
     })
 
     init(viewModel: StoreOnboardingViewModel,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinatorTests.swift
@@ -23,7 +23,7 @@ final class StoreOnboardingCoordinatorTests: XCTestCase {
 
     func test_starting_with_customDomains_task_presents_DomainSettingsHostingController() throws {
         // Given
-        let coordinator = StoreOnboardingCoordinator(navigationController: navigationController, site: .fake(), onTaskCompleted: { _ in })
+        let coordinator = StoreOnboardingCoordinator(navigationController: navigationController, site: .fake(), onTaskCompleted: { _ in }, reloadTasks: {})
 
         // When
         coordinator.start(task: .init(isComplete: true, type: .customizeDomains))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9302
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Our strategy is to reload the task when a user finishes it. But, for the “Tell us more about your store” and “Get paid” tasks, we use a web view. It is not straightforward to know when these get completed in a web view.

As a workaround, this PR stars reloading the task list when the user taps on `Done` button to dismiss a web view. 

## Testing instructions

Prerequisite: Create a new JN site to have empty onboarding tasks. (Don't select country or any store details from web)

1. Launch the app and login using the JN site
1. Navigate to the dashboard screen if you are not already on the screen
1. In the dashboard tap on `Tell us more about your store` task from the store onboarding task list
1. A web view will be launched. Tap `Done` to dismiss the web view and validate that the task list is reloaded
1. Tap on the `Get Paid` task and tap the `Continue Setup` button to open web view
1. Tap `Done` to dismiss web view  and validate that the task list is reloaded

## Screenshots

| Before | After |
|--------|--------|
| ![Before](https://user-images.githubusercontent.com/524475/227935790-d193bf3e-8097-45cd-9570-fe653acd7594.gif) | ![After](https://user-images.githubusercontent.com/524475/227935749-d2e83d76-6b0a-48f7-b764-0724fa706f0e.gif) | 



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
