### PR TITLE
[Free Trial] Action to add site to free trial plan

### DIFF
--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -120,7 +120,7 @@ private extension SiteRemote {
         ///Path to add enable the free trial on a site.
         ///
         static func enableFreeTrial(siteID: Int64) -> String {
-            "v1.1/sites/\(siteID)/ecommerce-trial/add/ecommerce-trial-bundle-monthly"
+            "sites/\(siteID)/ecommerce-trial/add/ecommerce-trial-bundle-monthly"
         }
     }
 }

--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -12,6 +12,10 @@ public protocol SiteRemoteProtocol {
     /// Launches a site publicly through WPCOM.
     /// - Parameter siteID: Remote WPCOM ID of the site.
     func launchSite(siteID: Int64) async throws
+
+    /// Enables a free trial plan for a site.
+    ///
+    func enableFreeTrial(siteID: Int64) async throws
 }
 
 /// Site: Remote Endpoints
@@ -63,6 +67,12 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: path)
         return try await enqueue(request)
     }
+
+    public func enableFreeTrial(siteID: Int64) async throws {
+        let path = Path.enableFreeTrial(siteID: siteID)
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path)
+        return try await enqueue(request)
+    }
 }
 
 /// Site creation API response.
@@ -105,6 +115,12 @@ private extension SiteRemote {
         static let siteCreation = "sites/new"
         static func siteLaunch(siteID: Int64) -> String {
             "sites/\(siteID)/launch"
+        }
+
+        ///Path to add enable the free trial on a site.
+        ///
+        static func enableFreeTrial(siteID: Int64) -> String {
+            "v1.1/sites/\(siteID)/ecommerce-trial/add/ecommerce-trial-bundle-monthly"
         }
     }
 }

--- a/Yosemite/Yosemite/Actions/SiteAction.swift
+++ b/Yosemite/Yosemite/Actions/SiteAction.swift
@@ -17,6 +17,10 @@ public enum SiteAction: Action {
     ///   - siteID: ID of the site to launch.
     ///   - completion: Called when the result of site launch is available.
     case launchSite(siteID: Int64, completion: (Result<Void, SiteLaunchError>) -> Void)
+
+    /// Enables a free trial plan for a site.
+    ///
+    case enableFreeTrial(siteID: Int64, completion: (Result<Void, Error>) -> Void)
 }
 
 /// The result of site creation including necessary site information.

--- a/Yosemite/Yosemite/Stores/SiteStore.swift
+++ b/Yosemite/Yosemite/Stores/SiteStore.swift
@@ -44,6 +44,8 @@ public final class SiteStore: Store {
             createSite(name: name, domain: domain, completion: completion)
         case let .launchSite(siteID, completion):
             launchSite(siteID: siteID, completion: completion)
+        case let .enableFreeTrial(siteID, completion):
+            enableFreeTrial(siteID: siteID, completion: completion)
         }
     }
 }
@@ -79,6 +81,17 @@ private extension SiteStore {
                 completion(.success(()))
             } catch {
                 completion(.failure(SiteLaunchError(remoteError: error)))
+            }
+        }
+    }
+
+    func enableFreeTrial(siteID: Int64, completion: @escaping (Result<Void, Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                try await remote.enableFreeTrial(siteID: siteID)
+                completion(.success(()))
+            } catch {
+                completion(.failure(error))
             }
         }
     }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
@@ -10,6 +10,9 @@ final class MockSiteRemote {
     /// The results to return in `launchSite`.
     private var launchSiteResult: Result<Void, Error>?
 
+    /// The results to return in `enableFreeTrial`.
+    private var enableFreeTrialResult: Result<Void, Error>?
+
     /// Returns the value when `createSite` is called.
     func whenCreatingSite(thenReturn result: Result<SiteCreationResponse, Error>) {
         createSiteResult = result
@@ -34,6 +37,15 @@ extension MockSiteRemote: SiteRemoteProtocol {
     func launchSite(siteID: Int64) async throws {
         guard let result = launchSiteResult else {
             XCTFail("Could not find result for launching a site.")
+            throw NetworkError.notFound
+        }
+
+        return try result.get()
+    }
+
+    func enableFreeTrial(siteID: Int64) async throws {
+        guard let result = enableFreeTrialResult else {
+            XCTFail("Could not find result for enabling a trial.")
             throw NetworkError.notFound
         }
 


### PR DESCRIPTION
part of #9243 

# Why

In preparation for the "Create a free trial store" feature, this PR takes care of adding the action to enable a free trial on a site.

# Testing Steps

This code is not yet used, but I have hand-tested it and set a site to a free trial successfully.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
