### PR TITLE
[UI Tests] - Add new Filter Products test

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -370,6 +370,7 @@ private extension FilterListViewController {
 
         func configureCell(cell: BasicTableViewCell, model: FilterType) {
             cell.textLabel?.text = model.description
+            cell.accessibilityIdentifier = model.description
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -644,6 +644,7 @@ private extension ProductsViewController {
         let filterTitle = NSLocalizedString("Filter", comment: "Title of the toolbar button to filter products by different attributes.")
         filterButton.setTitle(filterTitle, for: .normal)
         filterButton.addTarget(self, action: #selector(filterButtonTapped), for: .touchUpInside)
+        filterButton.accessibilityIdentifier = "product-filter-button"
 
         [sortButton, filterButton].forEach {
             $0.applyLinkButtonStyle()

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductFilterScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductFilterScreen.swift
@@ -22,7 +22,7 @@ public final class ProductFilterScreen: ScreenObject {
         )
     }
 
-    public func setStockStatusFilterAs(filter: String) throws -> ProductsScreen {
+    public func setStockStatusFilterAs(_ filter: String) throws -> ProductsScreen {
         stockStatusButton.tap()
         app.cells[filter].tap()
         showProductsButton.tap()

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductFilterScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductFilterScreen.swift
@@ -1,0 +1,32 @@
+import ScreenObject
+import XCTest
+
+public final class ProductFilterScreen: ScreenObject {
+
+    private let stockStatusButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["Stock Status"]
+    }
+
+    private let showProductsButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["Show Products"]
+    }
+
+    private var stockStatusButton: XCUIElement { stockStatusButtonGetter(app) }
+    private var showProductsButton: XCUIElement { showProductsButtonGetter(app) }
+
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ stockStatusButtonGetter, showProductsButtonGetter ],
+            app: app
+        )
+    }
+
+    public func setStockStatusFilterAs(filter: String) throws -> ProductsScreen {
+        stockStatusButton.tap()
+        app.cells[filter].tap()
+        showProductsButton.tap()
+
+        return try ProductsScreen()
+    }
+}

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -121,11 +121,13 @@ public final class ProductsScreen: ScreenObject {
 
     @discardableResult
     public func verifyProductFilterResults(products: [ProductData], filter: String) throws -> Self {
-        // get filtered mock file responses to compare with elements displayed on UI
-        let filteredProduct = products.filter { $0.stock_status == filter.lowercased() }
+        let filteredProducts = products.filter { $0.stock_status == filter.lowercased() }
 
-        productsTableView.assertTextVisibilityCount(textToFind: (filteredProduct[0].name), expectedCount: 1)
-        productsTableView.assertTextVisibilityCount(textToFind: filteredProduct[0].stock_status, expectedCount: 1)
+        for product in filteredProducts {
+            productsTableView.assertTextVisibilityCount(textToFind: product.name, expectedCount: 1)
+        }
+
+        productsTableView.assertTextVisibilityCount(textToFind: filter, expectedCount: filteredProducts.count)
 
         return self
     }

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -124,8 +124,8 @@ public final class ProductsScreen: ScreenObject {
         // get filtered mock file responses to compare with elements displayed on UI
         let filteredProduct = products.filter { $0.stock_status == filter.lowercased() }
 
-        productsTableView.assertTextVisibilityCount(textToFind: (filteredProduct[0].name))
-        productsTableView.assertTextVisibilityCount(textToFind: filteredProduct[0].stock_status)
+        productsTableView.assertTextVisibilityCount(textToFind: (filteredProduct[0].name), expectedCount: 1)
+        productsTableView.assertTextVisibilityCount(textToFind: filteredProduct[0].stock_status, expectedCount: 1)
 
         return self
     }

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -11,6 +11,14 @@ public final class ProductsScreen: ScreenObject {
         $0.buttons["product-search-button"]
     }
 
+    private let productFilterButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["product-filter-button"]
+    }
+
+    private let productsTableViewGetter: (XCUIApplication) -> XCUIElement = {
+        $0.tables["products-table-view"]
+    }
+
     private let topBannerViewExpandButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["top-banner-view-expand-collapse-button"]
     }
@@ -21,6 +29,8 @@ public final class ProductsScreen: ScreenObject {
 
     private var productAddButton: XCUIElement { productAddButtonGetter(app) }
     private var productSearchButton: XCUIElement { productSearchButtonGetter(app) }
+    private var productFilterButton: XCUIElement { productFilterButtonGetter(app) }
+    private var productsTableView: XCUIElement { productsTableViewGetter(app) }
     private var topBannerViewExpandButton: XCUIElement { topBannerViewExpandButtonGetter(app) }
     private var topBannerViewInfoLabel: XCUIElement { topBannerViewInfoLabelGetter(app) }
 
@@ -102,5 +112,21 @@ public final class ProductsScreen: ScreenObject {
     public func selectSearchButton() throws -> ProductSearchScreen {
         productSearchButton.tap()
         return try ProductSearchScreen()
+    }
+
+    public func tapFilterButton() throws -> ProductFilterScreen {
+        productFilterButton.tap()
+        return try ProductFilterScreen()
+    }
+
+    @discardableResult
+    public func verifyProductFilterResults(products: [ProductData], filter: String) throws -> Self {
+        // get filtered mock file responses to compare with elements displayed on UI
+        let filteredProduct = products.filter { $0.stock_status == filter.lowercased() }
+
+        productsTableView.assertTextVisibilityCount(textToFind: (filteredProduct[0].name))
+        productsTableView.assertTextVisibilityCount(textToFind: filteredProduct[0].stock_status)
+
+        return self
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1277,6 +1277,7 @@
 		80DA4F1C29CC505800BDF3BF /* products_search_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 80DA4F1B29CC505800BDF3BF /* products_search_results.json */; };
 		80E6FC6D276312D50086CD67 /* products.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00C923E9BD5500157A78 /* products.json */; };
 		80E6FC79276C3FD60086CD67 /* MockDataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E6FC742763579D0086CD67 /* MockDataReader.swift */; };
+		80ECB4E229D2A51A00C62EEC /* ProductFilterScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80ECB4E129D2A51A00C62EEC /* ProductFilterScreen.swift */; };
 		8194A48313C34FE1782D51BC /* Pods_StoreWidgetsExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2886DE5218EEA78ABAF0BE67 /* Pods_StoreWidgetsExtension.framework */; };
 		86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */; };
 		8CD41D4A21F8A7E300CF3C2B /* RELEASE-NOTES.txt in Resources */ = {isa = PBXBuildFile; fileRef = 8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */; };
@@ -3456,6 +3457,7 @@
 		80DA4F1B29CC505800BDF3BF /* products_search_results.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_search_results.json; sourceTree = "<group>"; };
 		80E6FC6E276325F60086CD67 /* Clibsodium.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Clibsodium.xcframework; path = ../Pods/Sodium/Clibsodium.xcframework; sourceTree = "<group>"; };
 		80E6FC742763579D0086CD67 /* MockDataReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataReader.swift; sourceTree = "<group>"; };
+		80ECB4E129D2A51A00C62EEC /* ProductFilterScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterScreen.swift; sourceTree = "<group>"; };
 		8A659E65308A3D9DD79A95F9 /* Pods-WooCommerceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release.xcconfig"; sourceTree = "<group>"; };
 		8CA4F6DD220B257000A47B5D /* WooCommerce.debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = WooCommerce.debug.xcconfig; path = ../config/WooCommerce.debug.xcconfig; sourceTree = "<group>"; };
 		8CA4F6DE220B257000A47B5D /* WooCommerce.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = WooCommerce.release.xcconfig; path = ../config/WooCommerce.release.xcconfig; sourceTree = "<group>"; };
@@ -9939,6 +9941,7 @@
 				F93E8E5724087FE10057FF21 /* ProductsScreen.swift */,
 				F93E8E5824087FE10057FF21 /* SingleProductScreen.swift */,
 				803B0A4529CC2CE20051EFD6 /* ProductSearchScreen.swift */,
+				80ECB4E129D2A51A00C62EEC /* ProductFilterScreen.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -10730,6 +10733,7 @@
 				3F0CF3102704490A00EF3D71 /* SingleOrderScreen.swift in Sources */,
 				3F0CF3062704490A00EF3D71 /* SingleReviewScreen.swift in Sources */,
 				80D9300329C8660C008865D8 /* CardReaderManualsScreen.swift in Sources */,
+				80ECB4E229D2A51A00C62EEC /* ProductFilterScreen.swift in Sources */,
 				3F0CF3112704490A00EF3D71 /* ProductsScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WooCommerce/WooCommerceUITests/README.md
+++ b/WooCommerce/WooCommerceUITests/README.md
@@ -48,8 +48,8 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
     - [x] Add new product - Variable product
     - [ ] Add new product - Grouped product
     - [ ] Add new product - External product
-    - [x] Search for product
-    - [ ] Filters for product
+    - [x] Search product
+    - [x] Filter product
     - [ ] Edit product
     - [ ] Add media library image to existing product
     - [ ] Add camera image to existing product

--- a/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
@@ -51,7 +51,7 @@ final class ProductsTests: XCTestCase {
 
         try TabNavComponent().goToProductsScreen()
             .tapFilterButton()
-            .setStockStatusFilterAs(filter: "Out of stock")
+            .setStockStatusFilterAs("Out of stock")
             .verifyProductFilterResults(products: products, filter: "Out of stock" )
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/ProductsTests.swift
@@ -45,4 +45,13 @@ final class ProductsTests: XCTestCase {
             .enterSearchCriteria(text: products[0].name)
             .verifyProductSearchResults(expectedProduct: products[0])
     }
+
+    func test_filter_product() throws {
+        let products = try GetMocks.readProductsData()
+
+        try TabNavComponent().goToProductsScreen()
+            .tapFilterButton()
+            .setStockStatusFilterAs(filter: "Out of stock")
+            .verifyProductFilterResults(products: products, filter: "Out of stock" )
+    }
 }


### PR DESCRIPTION
## Description
This adds a new "Filter Product" test. The flow for the test is the following:
1. Go to products screen and tap on the filter button
2. Filter by stock status set to out of stock (there's only one product in the mock file with this stock status)
3. Verify on the filtered product screen that only one product is displayed

Note on Accessibiilty Identifier: I tried to add accessibility identifiers to specific tables/buttons but couldn't figure out where to add them correctly individually, so did the next best thing - the implementation adds the description as the accessibility identifiers instead of the usual style of: `some-product-button` (see the change in `WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift` file)

One point of discussion for the team - currently, this test only filters based on 1 criterion (Stock Status). Do you all see value in filtering the other criteria too? Personally, I think one should be enough to cover this from a UI perspective and if we want to cover more, we'd also have to update the mock files to meet each criterion (and the question is: would the value justify the cost of updating the mock files? while isn't hard it is tedious)

## Testing instructions
New test `test_filter_product` should work locally and in CI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
