### PR TITLE
[Store onboarding] Add launch store task for free trial sites

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
@@ -32,7 +32,7 @@ struct StoreOnboardingLaunchStoreView: View {
 
     var body: some View {
         ScrollView {
-            #warning("TODO: 9122 - show upsell banner when the launch store action requires an upgraded plan")
+            #warning("TODO: 9141 - show upsell banner when the launch store action requires an upgraded plan")
 
             // Readonly webview for the site.
             WebView(isPresented: .constant(true), url: viewModel.siteURL)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -107,10 +107,10 @@ class StoreOnboardingViewModel: ObservableObject {
 private extension StoreOnboardingViewModel {
     @MainActor
     func loadTasks() async throws -> [StoreOnboardingTaskViewModel] {
-        let shouldManuallyAppendLaunchStoreTask = await isFreeTrialPlan()
+        async let shouldManuallyAppendLaunchStoreTask = isFreeTrialPlan()
         let tasksFromServer: [StoreOnboardingTask] = try await fetchTasks()
 
-        if shouldManuallyAppendLaunchStoreTask {
+        if await shouldManuallyAppendLaunchStoreTask {
             return (tasksFromServer + [.init(isComplete: false, type: .launchStore)])
                 .sorted()
                 .map { .init(task: $0) }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -194,7 +194,7 @@ private extension StoreOnboardingViewModel {
                     return continuation.resume(returning: plan.isFreeTrial)
                 case .failure(let error):
                     DDLogError("⛔️ Error fetching the current site's plan information: \(error)")
-                    continuation.resume(returning: false)
+                    return continuation.resume(returning: false)
                 }
             }
             stores.dispatch(action)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -1,21 +1,26 @@
 import XCTest
 import Yosemite
 @testable import WooCommerce
+@testable import Yosemite
 
 final class StoreOnboardingViewModelTests: XCTestCase {
     private var stores: MockStoresManager!
     private var defaults: UserDefaults!
     private let placeholderTaskCount = 3
+    private let freeTrialID = "1052"
+    private var sessionManager: SessionManager!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         let uuid = UUID().uuidString
         defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+        sessionManager = .makeForTesting(authenticated: true)
+        stores = MockStoresManager(sessionManager: sessionManager)
     }
 
     override func tearDown() {
         stores = nil
+        sessionManager = nil
         defaults = nil
         super.tearDown()
     }
@@ -129,6 +134,92 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         XCTAssertEqual(sut.tasksForDisplay.count, 2)
         XCTAssertEqual(sut.tasksForDisplay[0].task.type, .addFirstProduct)
         XCTAssertEqual(sut.tasksForDisplay[1].task.type, .launchStore)
+    }
+
+    func test_tasksForDisplay_contains_launch_store_task_for_WPCOM_site_under_free_trail() async {
+        // Given
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)
+        sessionManager.defaultRoles = [.administrator]
+        mockLoadOnboardingTasks(result: .success([
+            .init(isComplete: false, type: .addFirstProduct),
+        ]))
+
+        let sitePlan = WPComSitePlan(id: self.freeTrialID,
+                                     hasDomainCredit: false,
+                                     expiryDate: Date().addingDays(14))
+        mockLoadSiteCurrentPlan(result: .success(sitePlan))
+
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: true,
+                                           stores: stores,
+                                           defaults: defaults)
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertTrue(sut.tasksForDisplay.filter({ $0.task.type == .launchStore}).isNotEmpty)
+    }
+
+    func test_tasksForDisplay_does_not_contain_launch_store_task_for_non_WPCOM_site() async {
+        // Given
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: false)
+        sessionManager.defaultRoles = [.administrator]
+        mockLoadOnboardingTasks(result: .success([
+            .init(isComplete: false, type: .addFirstProduct),
+        ]))
+
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: true,
+                                           stores: stores,
+                                           defaults: defaults)
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertTrue(sut.tasksForDisplay.filter({ $0.task.type == .launchStore}).isEmpty)
+    }
+
+    func test_tasksForDisplay_does_not_contain_launch_store_task_for_WPCOM_site_not_under_free_trial() async {
+        // Given
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: false)
+        sessionManager.defaultRoles = [.administrator]
+        mockLoadOnboardingTasks(result: .success([
+            .init(isComplete: false, type: .addFirstProduct),
+        ]))
+
+        let sitePlan = WPComSitePlan(hasDomainCredit: false)
+        mockLoadSiteCurrentPlan(result: .success(sitePlan))
+
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: true,
+                                           stores: stores,
+                                           defaults: defaults)
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertTrue(sut.tasksForDisplay.filter({ $0.task.type == .launchStore}).isEmpty)
+    }
+
+    func test_tasksForDisplay_does_not_contain_launch_store_task_for_WPCOM_site_when_checking_site_plan_fails() async {
+        // Given
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: false)
+        sessionManager.defaultRoles = [.administrator]
+        mockLoadOnboardingTasks(result: .success([
+            .init(isComplete: false, type: .addFirstProduct),
+        ]))
+
+        mockLoadSiteCurrentPlan(result: .failure(MockError()))
+
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: true,
+                                           stores: stores,
+                                           defaults: defaults)
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertTrue(sut.tasksForDisplay.filter({ $0.task.type == .launchStore}).isEmpty)
     }
 
     // MARK: - shouldShowViewAllButton
@@ -574,6 +665,15 @@ private extension StoreOnboardingViewModelTests {
     func mockLoadOnboardingTasks(result: Result<[StoreOnboardingTask], Error>) {
         stores.whenReceivingAction(ofType: StoreOnboardingTasksAction.self) { action in
             guard case let .loadOnboardingTasks(_, completion) = action else {
+                return XCTFail()
+            }
+            completion(result)
+        }
+    }
+
+    func mockLoadSiteCurrentPlan(result: Result<WPComSitePlan, Error>) {
+        stores.whenReceivingAction(ofType: PaymentAction.self) { action in
+            guard case let .loadSiteCurrentPlan(_, completion) = action else {
                 return XCTFail()
             }
             completion(result)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -136,7 +136,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         XCTAssertEqual(sut.tasksForDisplay[1].task.type, .launchStore)
     }
 
-    func test_tasksForDisplay_contains_launch_store_task_for_WPCOM_site_under_free_trail() async {
+    func test_tasksForDisplay_contains_launch_store_task_for_WPCOM_site_under_free_trial() async {
         // Given
         sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)
         sessionManager.defaultRoles = [.administrator]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9141
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

The server doesn't provide the "Launch store" task for free trial tasks. In this PR, we are manually adding the "Launch store" task for "Free trial" sites.

In a future PR, we will add a way to purchase an eCommerce plan from the Launch store screen.  

## Testing instructions
Prerequisite
- Create a free trial site by visiting - https://wordpress.com/setup/wooexpress/
- Create a JN site with Woo and connect Jetpack for easy store switching while testing

1. Login into the app using the free trial site
1. Validate that you see the "Launch store" task
1. Switch to a self-hosted site (JN site) and validate that the "Launch store" task is not displayed


## Screenshots

For a free trial site
| Before | After |
|--------|--------|
| ![Before](https://user-images.githubusercontent.com/524475/228412071-117aa7cd-110e-46c5-94f1-bbe4ca938bde.png) | ![After](https://user-images.githubusercontent.com/524475/228412065-0e488a58-cfd2-4f0b-aa4b-cf9c5188aaaa.png) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
