### PR TITLE
[Free Trial] Update Site Creation module per free trial requirements

### DIFF
--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -5,9 +5,9 @@ public protocol SiteRemoteProtocol {
     /// Creates a site given
     /// - Parameters:
     ///   - name: The name of the site.
-    ///   - domain: The domain selected for the site.
+    ///   - flow: The creation flow to follow.
     /// - Returns: The response with the site creation.
-    func createSite(name: String, domain: String) async throws -> SiteCreationResponse
+    func createSite(name: String, flow: SiteCreationFlow) async throws -> SiteCreationResponse
 
     /// Launches a site publicly through WPCOM.
     /// - Parameter siteID: Remote WPCOM ID of the site.
@@ -30,25 +30,26 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
         super.init(network: network)
     }
 
-    public func createSite(name: String,
-                           domain: String) async throws -> SiteCreationResponse {
+    public func createSite(name: String, flow: SiteCreationFlow) async throws -> SiteCreationResponse {
         let path = Path.siteCreation
+        let subdomainName = flow.domain.split(separator: ".").first
 
-        // Domain input should be a `wordpress.com` subdomain.
-        guard let subdomainName = domain.split(separator: ".").first else {
+        // If we provide a domain, we should have been able to extract the subdomain name.
+        if !flow.domain.isEmpty && subdomainName == nil {
             throw SiteCreationError.invalidDomain
         }
+
         let parameters: [String: Any] = [
-            "blog_name": subdomainName,
+            "blog_name": subdomainName ?? "",
             "blog_title": name,
             "client_id": dotcomClientID,
             "client_secret": dotcomClientSecret,
-            "find_available_url": false,
+            "find_available_url": flow.useRandomURL,
             "public": 0,
             "validate": false,
             "options": [
                 "default_annotation_as_primary_fallback": true,
-                "site_creation_flow": "onboarding",
+                "site_creation_flow": flow.flowID,
                 "site_information": [
                     "title": ""
                 ],
@@ -72,6 +73,40 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
         let path = Path.enableFreeTrial(siteID: siteID)
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path)
         return try await enqueue(request)
+    }
+}
+
+/// Possible Site Creation Flows
+///
+public enum SiteCreationFlow {
+    case onboarding(domain: String)
+    case wooexpress
+
+    var domain: String {
+        switch self {
+        case .onboarding(let domain):
+            return domain
+        case .wooexpress:
+            return ""
+        }
+    }
+
+    var useRandomURL: Bool {
+        switch self {
+        case .onboarding:
+            return false
+        case .wooexpress:
+            return true
+        }
+    }
+
+    var flowID: String {
+        switch self {
+        case .onboarding:
+            return "onboarding"
+        case .wooexpress:
+            return "wooexpress"
+        }
     }
 }
 

--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -34,9 +34,12 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
         let path = Path.siteCreation
         let subdomainName = flow.domain.split(separator: ".").first
 
-        // If we provide a domain, we should have been able to extract the subdomain name.
-        if !flow.domain.isEmpty && subdomainName == nil {
+        // Do not allow nil subdomains on the `.onboarding` flow
+        switch flow {
+        case .onboarding where subdomainName == nil:
             throw SiteCreationError.invalidDomain
+        default:
+            break
         }
 
         let parameters: [String: Any] = [

--- a/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
@@ -27,7 +27,7 @@ final class SiteRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "sites/new", filename: "site-creation-success")
 
         // When
-        let response = try await remote.createSite(name: "Wapuu swags", domain: "wapuu.store")
+        let response = try await remote.createSite(name: "Wapuu swags", flow: .onboarding(domain: "wapuu.store"))
 
         // Then
         XCTAssertTrue(response.success)
@@ -38,7 +38,7 @@ final class SiteRemoteTests: XCTestCase {
     }
 
     func test_createSite_returns_invalidDomain_error_when_domain_is_empty() async throws {
-        await assertThrowsError({ _ = try await remote.createSite(name: "Wapuu swags", domain: "") },
+        await assertThrowsError({ _ = try await remote.createSite(name: "Wapuu swags", flow: .onboarding(domain: "")) },
                                 errorAssert: { ($0 as? SiteCreationError) == .invalidDomain} )
     }
 
@@ -48,7 +48,7 @@ final class SiteRemoteTests: XCTestCase {
 
         await assertThrowsError({
             // When
-            _ = try await remote.createSite(name: "Wapuu swags", domain: "wapuu.store")
+            _ = try await remote.createSite(name: "Wapuu swags", flow: .onboarding(domain: "wapuu.store"))
         }, errorAssert: { ($0 as? DotcomError) == .unknown(code: "blog_name_only_lowercase_letters_and_numbers",
                                                 message: "Site names can only contain lowercase letters (a-z) and numbers.")
         })
@@ -57,7 +57,7 @@ final class SiteRemoteTests: XCTestCase {
     func test_createSite_returns_failure_on_empty_response() async throws {
         await assertThrowsError({
             // When
-            _ = try await remote.createSite(name: "Wapuu swags", domain: "wapuu.store")
+            _ = try await remote.createSite(name: "Wapuu swags", flow: .onboarding(domain: "wapuu.store"))
         }, errorAssert: { ($0 as? NetworkError) == .notFound })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -96,6 +96,8 @@ struct AccountCreationForm: View {
                                                                   isSecure: false,
                                                                   errorMessage: viewModel.emailErrorMessage,
                                                                   isFocused: focusedField == .email))
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
                     .focused($focusedField, equals: .email)
                     .disabled(isPerformingTask)
 
@@ -107,6 +109,8 @@ struct AccountCreationForm: View {
                                                                   isSecure: true,
                                                                   errorMessage: viewModel.passwordErrorMessage,
                                                                   isFocused: focusedField == .password))
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
                     .focused($focusedField, equals: .password)
                     .disabled(isPerformingTask)
 

--- a/Yosemite/Yosemite/Actions/SiteAction.swift
+++ b/Yosemite/Yosemite/Actions/SiteAction.swift
@@ -1,4 +1,5 @@
 import Foundation
+import enum Networking.SiteCreationFlow
 
 /// SiteAction: Defines all of the Actions supported by the SiteStore.
 ///
@@ -6,10 +7,10 @@ public enum SiteAction: Action {
     /// Creates a site in the store creation flow.
     /// - Parameters:
     ///   - name: The name of the site.
-    ///   - domain: Domain name selected for the site.
+    ///   - flow: The creation flow to follow.
     ///   - completion: The result of site creation.
     case createSite(name: String,
-                    domain: String,
+                    flow: SiteCreationFlow,
                     completion: (Result<SiteCreationResult, SiteCreationError>) -> Void)
 
     /// Launches a site publicly through WPCOM.

--- a/Yosemite/Yosemite/Stores/SiteStore.swift
+++ b/Yosemite/Yosemite/Stores/SiteStore.swift
@@ -112,7 +112,7 @@ public enum SiteCreationError: Error, Equatable {
     /// Unknown error that is not a `DotcomError` nor `Networking.SiteCreationError`.
     case unknown(description: String)
 
-    init(remoteError: Error) {
+    public init(remoteError: Error) {
         switch remoteError {
         case let remoteError as Networking.SiteCreationError:
             switch remoteError {

--- a/Yosemite/Yosemite/Stores/SiteStore.swift
+++ b/Yosemite/Yosemite/Stores/SiteStore.swift
@@ -40,8 +40,8 @@ public final class SiteStore: Store {
             return
         }
         switch action {
-        case .createSite(let name, let domain, let completion):
-            createSite(name: name, domain: domain, completion: completion)
+        case .createSite(let name, let flow, let completion):
+            createSite(name: name, flow: flow, completion: completion)
         case let .launchSite(siteID, completion):
             launchSite(siteID: siteID, completion: completion)
         case let .enableFreeTrial(siteID, completion):
@@ -52,11 +52,11 @@ public final class SiteStore: Store {
 
 private extension SiteStore {
     func createSite(name: String,
-                    domain: String,
+                    flow: SiteCreationFlow,
                     completion: @escaping (Result<SiteCreationResult, SiteCreationError>) -> Void) {
         Task { @MainActor in
             do {
-                let response = try await remote.createSite(name: name, domain: domain)
+                let response = try await remote.createSite(name: name, flow: flow)
 
                 guard response.success else {
                     return completion(.failure(SiteCreationError.unsuccessful))

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
@@ -25,7 +25,7 @@ final class MockSiteRemote {
 }
 
 extension MockSiteRemote: SiteRemoteProtocol {
-    func createSite(name: String, domain: String) async throws -> SiteCreationResponse {
+    func createSite(name: String, flow: SiteCreationFlow) async throws -> SiteCreationResponse {
         guard let result = createSiteResult else {
             XCTFail("Could not find result for creating a site.")
             throw NetworkError.notFound

--- a/Yosemite/YosemiteTests/Stores/SiteStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SiteStoreTests.swift
@@ -53,7 +53,7 @@ final class SiteStoreTests: XCTestCase {
         // When
         let result = waitFor { promise in
             self.store.onAction(SiteAction.createSite(name: "Salsa",
-                                                      domain: "salsa.roja",
+                                                      flow: .onboarding(domain: "salsa.roja"),
                                                       completion: { result in
                 promise(result)
             }))
@@ -78,7 +78,7 @@ final class SiteStoreTests: XCTestCase {
         // When
         let result = waitFor { promise in
             self.store.onAction(SiteAction.createSite(name: "Salsa",
-                                                      domain: "salsa.roja",
+                                                      flow: .onboarding(domain: "salsa.roja"),
                                                       completion: { result in
                 promise(result)
             }))
@@ -98,7 +98,7 @@ final class SiteStoreTests: XCTestCase {
         // When
         let result = waitFor { promise in
             self.store.onAction(SiteAction.createSite(name: "Salsa",
-                                                      domain: "salsa.roja",
+                                                      flow: .onboarding(domain: "salsa.roja"),
                                                       completion: { result in
                 promise(result)
             }))
@@ -118,7 +118,7 @@ final class SiteStoreTests: XCTestCase {
         // When
         let result = waitFor { promise in
             self.store.onAction(SiteAction.createSite(name: "Salsa",
-                                                      domain: "salsa.roja",
+                                                      flow: .onboarding(domain: "salsa.roja"),
                                                       completion: { result in
                 promise(result)
             }))
@@ -139,7 +139,7 @@ final class SiteStoreTests: XCTestCase {
         // When
         let result = waitFor { promise in
             self.store.onAction(SiteAction.createSite(name: "Salsa",
-                                                      domain: "salsa.roja",
+                                                      flow: .onboarding(domain: "salsa.roja"),
                                                       completion: { result in
                 promise(result)
             }))


### PR DESCRIPTION
Closes: #9244 

# Why

This PR does 4 main things.

1. Reduces the steps of the site creation flow when the free trial feature flag is enabled. In particular, it removes the "domain selection screen", the "purchase plan screen",  and the  "summary screen"

2. Updates the site creation flow to enable a free trial to a newly created site. Additionally, it pushes the "in progress" screen earlier so the experience does not feel blocked.

3. Increases the time between the "check if jetpack has been installed on the site" requests as the logic was constantly timing out for free trial sites.

4. Removes autocorrection and autocapitalization on the create account form screen.


# Notes

I have noticed some errors after creating a site like:

- The site is not being detected as a WPCom site, hence not being identified as a trial site.
- There seems to be an odd completion screen after creating a site.
- Lots of timeout errors.

I will be investigating and handling those on different PRs.

# How

- Update relevant `Actions` and `Stores` to differentiate between the current `onboarding` flow  and the new `wooexpress`  flow (free trial)

- Update the `StoreCreationCoordinator` class to add a new `createFreeTrialStore()` method that orchestrates the necessary steps to create a free trial flow.

- Update the `StoreCreationCoordinator` to increase the wait time between "checkForJetpack" requests from 5 seconds to 10 seconds.


# Demos

### Create from scratch

https://user-images.githubusercontent.com/562080/228430627-23592d18-ecd2-43d4-a978-bca39e44a497.mov

### Create from existing store

https://user-images.githubusercontent.com/562080/228430655-ede4b8c9-2cbc-4586-8660-0090bf076728.mov

### Time-out error

https://user-images.githubusercontent.com/562080/228430659-7b69f3ae-5e06-4351-a199-9461c8a3e966.mov

# Testing Steps

- Open the app in a logged out state.
- Tap on "Get Started" and create a new account.
- Select the store name & tap "continue"
- See the "In Progress" screen while the store is being created
- After a while see that you are transitioned to a "success screen" and tap "manage store"
- See that you land on the new store dashboard

----

- Open the store picker from settings
- Scroll the site list and tap the "add store" button
- Select the store name & tap "continue"
- See the "In Progress" screen while the store is being created
- After a while see that you are transitioned to a "success screen" and tap "manage store"
- See that you land on the new store dashboard

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
