### PR TITLE
[Store onboarding] Upgrade plan from launch store screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 13.0
 -----
-
+- [*] Adds a banner in "Launch store" task screen to upgrade from free trial plan. [https://github.com/woocommerce/woocommerce-ios/pull/9323]
 
 12.9
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2192,7 +2192,6 @@ extension WooAnalyticsEvent {
         enum Source: String {
             case banner
             case upgradesScreen = "upgrades_screen"
-            case bannerInLaunchYourStoreOnboardingTask = "launch_your_store_screen_banner"
         }
 
         static func freeTrialUpgradeNowTapped(source: Source) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2192,6 +2192,7 @@ extension WooAnalyticsEvent {
         enum Source: String {
             case banner
             case upgradesScreen = "upgrades_screen"
+            case bannerInLaunchYourStoreOnboardingTask = "launch_your_store_screen_banner"
         }
 
         static func freeTrialUpgradeNowTapped(source: Source) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -640,6 +640,10 @@ private extension DashboardViewController {
         let hostingController = StoreOnboardingViewHostingController(viewModel: viewModel.storeOnboardingViewModel,
                                                                      navigationController: navigationController,
                                                                      site: site,
+                                                                     onUpgradePlan: { [weak self] in
+            guard let self else { return }
+            self.viewModel.syncFreeTrialBanner(siteID: self.siteID)
+        },
                                                                      shareFeedbackAction: { [weak self] in
             // Present survey
             let navigationController = SurveyCoordinatingController(survey: .storeSetup)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -40,7 +40,8 @@ final class StoreOnboardingCoordinator: Coordinator {
         let onboardingViewController = StoreOnboardingViewHostingController(viewModel: .init(siteID: site.siteID,
                                                                                              isExpanded: true),
                                                                             navigationController: onboardingNavigationController,
-                                                                            site: site)
+                                                                            site: site,
+                                                                            onUpgradePlan: onUpgradePlan)
         onboardingNavigationController.pushViewController(onboardingViewController, animated: false)
         navigationController.present(onboardingNavigationController, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -107,6 +107,9 @@ private extension StoreOnboardingCoordinator {
         let coordinator = StoreOnboardingLaunchStoreCoordinator(site: site,
                                                                 isLaunched: task.isComplete,
                                                                 navigationController: navigationController,
+                                                                onUpgradeTapped: { [weak self] in
+            self?.showUpgradePlanWebView()
+        },
                                                                 onStoreLaunched: { [weak self] in
             self?.onTaskCompleted(.launchStore)
         })
@@ -136,5 +139,18 @@ private extension StoreOnboardingCoordinator {
          })
         self.paymentsSetupCoordinator = coordinator
         coordinator.start()
+    }
+}
+
+private extension StoreOnboardingCoordinator {
+    /// Shows a web view for the merchant to update their site plan.
+    ///
+    func showUpgradePlanWebView() {
+        let upgradeController = UpgradePlanCoordinatingController(siteID: site.siteID,
+                                                                  source: .bannerInLaunchYourStoreOnboardingTask,
+                                                                  onSuccess: { [weak self] in
+            self?.reloadTasks()
+        })
+        navigationController.present(upgradeController, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -150,7 +150,7 @@ private extension StoreOnboardingCoordinator {
     ///
     func showUpgradePlanWebView() {
         let upgradeController = UpgradePlanCoordinatingController(siteID: site.siteID,
-                                                                  source: .bannerInLaunchYourStoreOnboardingTask,
+                                                                  source: .banner,
                                                                   onSuccess: { [weak self] in
             self?.onUpgradePlan?()
             self?.reloadTasks()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -19,15 +19,18 @@ final class StoreOnboardingCoordinator: Coordinator {
     private let site: Site
     private let onTaskCompleted: (_ task: TaskType) -> Void
     private let reloadTasks: () -> Void
+    private let onUpgradePlan: (() -> Void)?
 
     init(navigationController: UINavigationController,
          site: Site,
          onTaskCompleted: @escaping (_ task: TaskType) -> Void,
-         reloadTasks: @escaping () -> Void) {
+         reloadTasks: @escaping () -> Void,
+         onUpgradePlan: (() -> Void)? = nil) {
         self.navigationController = navigationController
         self.site = site
         self.onTaskCompleted = onTaskCompleted
         self.reloadTasks = reloadTasks
+        self.onUpgradePlan = onUpgradePlan
     }
 
     /// Navigates to the fullscreen store onboarding view.
@@ -149,6 +152,7 @@ private extension StoreOnboardingCoordinator {
         let upgradeController = UpgradePlanCoordinatingController(siteID: site.siteID,
                                                                   source: .bannerInLaunchYourStoreOnboardingTask,
                                                                   onSuccess: { [weak self] in
+            self?.onUpgradePlan?()
             self?.reloadTasks()
         })
         navigationController.present(upgradeController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreCoordinator.swift
@@ -7,20 +7,24 @@ final class StoreOnboardingLaunchStoreCoordinator: Coordinator {
     let navigationController: UINavigationController
     private let site: Site
     private let isLaunched: Bool
+    private let onUpgradeTapped: () -> Void
     private let onStoreLaunched: (() -> Void)?
 
     /// - Parameters:
     ///   - site: The site for the launch store onboarding task.
     ///   - isLaunched: Whether the site has already been launched.
     ///   - navigationController: The navigation controller that presents the launch store flow.
+    ///   - onUpgradeTapped: Fired upon tapping `Upgrade` button from free trial banne
     ///   - onStoreLaunched: Fired when the store is launched successfully
     init(site: Site,
          isLaunched: Bool,
          navigationController: UINavigationController,
+         onUpgradeTapped: @escaping () -> Void,
          onStoreLaunched: (() -> Void)? = nil) {
         self.site = site
         self.isLaunched = isLaunched
         self.navigationController = navigationController
+        self.onUpgradeTapped = onUpgradeTapped
         self.onStoreLaunched = onStoreLaunched
     }
 
@@ -45,6 +49,9 @@ private extension StoreOnboardingLaunchStoreCoordinator {
         let launchStoreController = StoreOnboardingLaunchStoreHostingController(viewModel: .init(siteURL: siteURL, siteID: site.siteID) { [weak self] in
             self?.onStoreLaunched?()
             self?.showLaunchedView(siteURL: siteURL, in: modalNavigationController)
+        } onUpgradeTapped: { [weak self] in
+            self?.dismiss()
+            self?.onUpgradeTapped()
         })
         modalNavigationController.pushViewController(launchStoreController, animated: false)
         navigationController.present(modalNavigationController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
@@ -97,7 +97,7 @@ struct StoreOnboardingLaunchStoreView: View {
         }
         .padding(insets: Layout.FreeTrialBanner.padding)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(.wooCommercePurple(.shade0)))
+        .background(Color(.bannerBackground))
         .onTapGesture {
             viewModel.didTapUpgrade()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
@@ -88,7 +88,7 @@ private extension StoreOnboardingLaunchStoreView {
             Image(uiImage: .infoOutlineImage)
                 .resizable()
                 .renderingMode(.template)
-                .foregroundColor(Color(.withColorStudio(.green, shade: .shade80)))
+                .foregroundColor(Color(.text))
                 .frame(width: Layout.FreeTrialBanner.infoIconSize.width * scale, height: Layout.FreeTrialBanner.infoIconSize.height * scale)
 
             AttributedText(viewModel.upgradePlanAttributedString)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
@@ -33,6 +33,7 @@ struct StoreOnboardingLaunchStoreView: View {
     var body: some View {
         ScrollView {
             freeTrialBanner
+                .renderedIf(viewModel.state == .needsPlanUpgrade)
 
             // Readonly webview for the site.
             WebView(isPresented: .constant(true), url: viewModel.siteURL)
@@ -50,13 +51,14 @@ struct StoreOnboardingLaunchStoreView: View {
                         await viewModel.launchStore()
                     }
                 }
-                .if(viewModel.canPublishStore) {
-                    $0.buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLaunchingStore))
+                .if((viewModel.state == .launchingStore || viewModel.state == .readyToPublish)) {
+                    $0.buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.state == .launchingStore))
                 }
-                .if(!viewModel.canPublishStore) {
+                .if(viewModel.state == .needsPlanUpgrade) {
                     $0.buttonStyle(PrimaryButtonStyle()).disabled(true)
                 }
                 .padding(insets: Layout.buttonContainerPadding)
+                .renderedIf(viewModel.state != .checkingSitePlan)
             }
             .background(Color(.systemBackground))
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
@@ -84,7 +84,9 @@ struct StoreOnboardingLaunchStoreView: View {
             await viewModel.checkEligibilityToPublishStore()
         }
     }
+}
 
+private extension StoreOnboardingLaunchStoreView {
     var freeTrialBanner: some View {
         HStack(alignment: .top, spacing: Layout.FreeTrialBanner.horizontalSpacing) {
             Image(uiImage: .infoOutlineImage)
@@ -102,9 +104,7 @@ struct StoreOnboardingLaunchStoreView: View {
             viewModel.didTapUpgrade()
         }
     }
-}
 
-private extension StoreOnboardingLaunchStoreView {
     var upgradePlanAttributedString: NSAttributedString {
         let font: UIFont = .body
         let foregroundColor: UIColor = .text

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
@@ -95,7 +95,7 @@ private extension StoreOnboardingLaunchStoreView {
                 .foregroundColor(Color(.withColorStudio(.green, shade: .shade80)))
                 .frame(width: Layout.FreeTrialBanner.infoIconSize.width * scale, height: Layout.FreeTrialBanner.infoIconSize.height * scale)
 
-            AttributedText(upgradePlanAttributedString)
+            AttributedText(viewModel.upgradePlanAttributedString)
         }
         .padding(insets: Layout.FreeTrialBanner.padding)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -103,30 +103,6 @@ private extension StoreOnboardingLaunchStoreView {
         .onTapGesture {
             viewModel.didTapUpgrade()
         }
-    }
-
-    var upgradePlanAttributedString: NSAttributedString {
-        let font: UIFont = .body
-        let foregroundColor: UIColor = .text
-        let linkColor: UIColor = .textLink
-        let linkContent = Localization.upgrade
-
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.alignment = .left
-
-        let attributedString = NSMutableAttributedString(
-            string: .localizedStringWithFormat(Localization.upgradePlanToLaunchStore, linkContent),
-            attributes: [.font: font,
-                         .foregroundColor: foregroundColor,
-                         .paragraphStyle: paragraphStyle,
-                        ]
-        )
-        let upgradeLink = NSAttributedString(string: linkContent, attributes: [.font: font,
-                                                                                      .foregroundColor: linkColor,
-                                                                                      .underlineStyle: NSUnderlineStyle.single.rawValue,
-                                                                                      .underlineColor: UIColor.textLink])
-        attributedString.replaceFirstOccurrence(of: linkContent, with: upgradeLink)
-        return attributedString
     }
 
     enum Layout {
@@ -148,12 +124,6 @@ private extension StoreOnboardingLaunchStoreView {
             "Publish My Store",
             comment: "Title of the primary button on the store onboarding > launch store screen to publish a store."
         )
-        static let upgradePlanToLaunchStore = NSLocalizedString(
-            "To launch your store, you need to upgrade to our plan. %1$@",
-            comment: "Message to ask the user to upgrade free trial plan to launch store."
-            + "Reads - To launch your store, you need to upgrade to our plan. Upgrade"
-        )
-        static let upgrade = NSLocalizedString("Upgrade", comment: "Title on the button to upgrade a free trial plan.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreView.swift
@@ -51,12 +51,8 @@ struct StoreOnboardingLaunchStoreView: View {
                         await viewModel.launchStore()
                     }
                 }
-                .if((viewModel.state == .launchingStore || viewModel.state == .readyToPublish)) {
-                    $0.buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.state == .launchingStore))
-                }
-                .if(viewModel.state == .needsPlanUpgrade) {
-                    $0.buttonStyle(PrimaryButtonStyle()).disabled(true)
-                }
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.state == .launchingStore))
+                .disabled(viewModel.state == .needsPlanUpgrade)
                 .padding(insets: Layout.buttonContainerPadding)
                 .renderedIf(viewModel.state != .checkingSitePlan)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
@@ -67,7 +67,7 @@ final class StoreOnboardingLaunchStoreViewModel: ObservableObject {
     @MainActor
     func checkEligibilityToPublishStore() async {
         update(state: .checkingSitePlan)
-        if await isFreeTrialPlan() {
+        if await isFreeTrialPlan {
             update(state: .needsPlanUpgrade)
         } else {
             update(state: .readyToPublish)
@@ -101,24 +101,26 @@ private extension StoreOnboardingLaunchStoreViewModel {
     }
 
     @MainActor
-    func isFreeTrialPlan() async -> Bool {
-        // Only fetch free trial information if the site is a WPCom site.
-        guard stores.sessionManager.defaultSite?.isWordPressComStore == true else {
-            return false
-        }
-
-        return await withCheckedContinuation({ continuation in
-            let action = PaymentAction.loadSiteCurrentPlan(siteID: siteID) { result in
-                switch result {
-                case .success(let plan):
-                    return continuation.resume(returning: plan.isFreeTrial)
-                case .failure(let error):
-                    DDLogError("⛔️ Error fetching the current site's plan information: \(error)")
-                    return continuation.resume(returning: false)
-                }
+    var isFreeTrialPlan: Bool {
+        get async {
+            // Only fetch free trial information if the site is a WPCom site.
+            guard stores.sessionManager.defaultSite?.isWordPressComStore == true else {
+                return false
             }
-            stores.dispatch(action)
-        })
+
+            return await withCheckedContinuation({ continuation in
+                let action = PaymentAction.loadSiteCurrentPlan(siteID: siteID) { result in
+                    switch result {
+                    case .success(let plan):
+                        return continuation.resume(returning: plan.isFreeTrial)
+                    case .failure(let error):
+                        DDLogError("⛔️ Error fetching the current site's plan information: \(error)")
+                        return continuation.resume(returning: false)
+                    }
+                }
+                stores.dispatch(action)
+            })
+        }
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
@@ -7,19 +7,31 @@ final class StoreOnboardingLaunchStoreViewModel: ObservableObject {
 
     @Published private(set) var isLaunchingStore: Bool = false
     @Published var error: SiteLaunchError?
+    @Published private(set) var canPublishStore: Bool = false
 
     private let siteID: Int64
     private let stores: StoresManager
     private let onLaunch: () -> Void
 
+    /// Closure invoked when the merchants taps on the `Upgrade` button.
+    ///
+    private let onUpgradeTapped: () -> Void
+
     init(siteURL: URL,
          siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
-         onLaunch: @escaping () -> Void) {
+         onLaunch: @escaping () -> Void,
+         onUpgradeTapped: @escaping () -> Void) {
         self.siteURL = siteURL
         self.siteID = siteID
         self.stores = stores
         self.onLaunch = onLaunch
+        self.onUpgradeTapped = onUpgradeTapped
+    }
+
+    @MainActor
+    func checkEligibilityToPublishStore() async {
+        canPublishStore = !(await isFreeTrialPlan())
     }
 
     @MainActor
@@ -35,9 +47,35 @@ final class StoreOnboardingLaunchStoreViewModel: ObservableObject {
         }
         isLaunchingStore = false
     }
+
+    @MainActor
+    func didTapUpgrade() {
+        onUpgradeTapped()
+    }
 }
 
 private extension StoreOnboardingLaunchStoreViewModel {
+    @MainActor
+    func isFreeTrialPlan() async -> Bool {
+        // Only fetch free trial information if the site is a WPCom site.
+        guard stores.sessionManager.defaultSite?.isWordPressComStore == true else {
+            return false
+        }
+
+        return await withCheckedContinuation({ continuation in
+            let action = PaymentAction.loadSiteCurrentPlan(siteID: siteID) { result in
+                switch result {
+                case .success(let plan):
+                    return continuation.resume(returning: plan.isFreeTrial)
+                case .failure(let error):
+                    DDLogError("⛔️ Error fetching the current site's plan information: \(error)")
+                    return continuation.resume(returning: false)
+                }
+            }
+            stores.dispatch(action)
+        })
+    }
+
     @MainActor
     func launchStoreRemotely() async -> Result<Void, SiteLaunchError> {
         await withCheckedContinuation { continuation in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
@@ -5,9 +5,13 @@ import Yosemite
 final class StoreOnboardingLaunchStoreViewModel: ObservableObject {
     /// UI state of the lauch store view.
     enum State {
+        // Checking current site's plan to check for free trial
         case checkingSitePlan
+        // Using free trial. Need to purchase plan before publishing site.
         case needsPlanUpgrade
+        // Ready to publish site.
         case readyToPublish
+        // Processing launch store request
         case launchingStore
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
@@ -20,6 +20,30 @@ final class StoreOnboardingLaunchStoreViewModel: ObservableObject {
     @Published private(set) var state: State = .checkingSitePlan
     @Published var error: SiteLaunchError?
 
+    lazy var upgradePlanAttributedString: NSAttributedString = {
+        let font: UIFont = .body
+        let foregroundColor: UIColor = .text
+        let linkColor: UIColor = .textLink
+        let linkContent = Localization.upgrade
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .left
+
+        let attributedString = NSMutableAttributedString(
+            string: .localizedStringWithFormat(Localization.upgradePlanToLaunchStore, linkContent),
+            attributes: [.font: font,
+                         .foregroundColor: foregroundColor,
+                         .paragraphStyle: paragraphStyle,
+                        ]
+        )
+        let upgradeLink = NSAttributedString(string: linkContent, attributes: [.font: font,
+                                                                                      .foregroundColor: linkColor,
+                                                                                      .underlineStyle: NSUnderlineStyle.single.rawValue,
+                                                                                      .underlineColor: UIColor.textLink])
+        attributedString.replaceFirstOccurrence(of: linkContent, with: upgradeLink)
+        return attributedString
+    }()
+
     private let siteID: Int64
     private let stores: StoresManager
     private let onLaunch: () -> Void
@@ -104,5 +128,16 @@ private extension StoreOnboardingLaunchStoreViewModel {
                 continuation.resume(returning: result)
             })
         }
+    }
+}
+
+private extension StoreOnboardingLaunchStoreViewModel {
+    enum Localization {
+        static let upgradePlanToLaunchStore = NSLocalizedString(
+            "To launch your store, you need to upgrade to our plan. %1$@",
+            comment: "Message to ask the user to upgrade free trial plan to launch store."
+            + "Reads - To launch your store, you need to upgrade to our plan. Upgrade"
+        )
+        static let upgrade = NSLocalizedString("Upgrade", comment: "Title on the button to upgrade a free trial plan.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModel.swift
@@ -20,7 +20,7 @@ final class StoreOnboardingLaunchStoreViewModel: ObservableObject {
     @Published private(set) var state: State = .checkingSitePlan
     @Published var error: SiteLaunchError?
 
-    lazy var upgradePlanAttributedString: NSAttributedString = {
+    private(set) lazy var upgradePlanAttributedString: NSAttributedString = {
         let font: UIFont = .body
         let foregroundColor: UIColor = .text
         let linkColor: UIColor = .textLink

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -8,6 +8,8 @@ final class StoreOnboardingViewHostingController: SelfSizingHostingController<St
     private let viewModel: StoreOnboardingViewModel
     private let sourceNavigationController: UINavigationController
     private let site: Site
+    private let onUpgradePlan: (() -> Void)?
+
     private lazy var coordinator = StoreOnboardingCoordinator(navigationController: sourceNavigationController,
                                                               site: site,
                                                               onTaskCompleted: { [weak self] task in
@@ -16,15 +18,19 @@ final class StoreOnboardingViewHostingController: SelfSizingHostingController<St
         ServiceLocator.analytics.track(event: .StoreOnboarding.storeOnboardingTaskCompleted(task: task))
     }, reloadTasks: { [weak self] in
         self?.reloadTasks()
+    }, onUpgradePlan: { [weak self] in
+        self?.onUpgradePlan?()
     })
 
     init(viewModel: StoreOnboardingViewModel,
          navigationController: UINavigationController,
          site: Site,
+         onUpgradePlan: (() -> Void)? = nil,
          shareFeedbackAction: (() -> Void)? = nil) {
         self.viewModel = viewModel
         self.sourceNavigationController = navigationController
         self.site = site
+        self.onUpgradePlan = onUpgradePlan
         super.init(rootView: StoreOnboardingView(viewModel: viewModel,
                                                  shareFeedbackAction: shareFeedbackAction))
         if #unavailable(iOS 16.0) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModelTests.swift
@@ -7,6 +7,7 @@ final class StoreOnboardingLaunchStoreViewModelTests: XCTestCase {
     private var stores: MockStoresManager!
     private var sessionManager: SessionManager!
     private let freeTrialID = "1052"
+    private let siteID: Int64 = 134
 
     override func setUp() {
         super.setUp()
@@ -34,12 +35,11 @@ final class StoreOnboardingLaunchStoreViewModelTests: XCTestCase {
 
     func test_launchStore_triggers_onLaunch_on_success() throws {
         // Given
-        let siteID: Int64 = 134
         stores.whenReceivingAction(ofType: SiteAction.self) { action in
             guard case let .launchSite(siteIDValue, completion) = action else {
                 return XCTFail("Unexpected action: \(action)")
             }
-            guard siteIDValue == siteID else {
+            guard siteIDValue == self.siteID else {
                 return XCTFail("Launch site with unexpected ID: \(siteIDValue)")
             }
             completion(.success(()))
@@ -49,7 +49,7 @@ final class StoreOnboardingLaunchStoreViewModelTests: XCTestCase {
         waitFor { promise in
             Task {
                 let viewModel = StoreOnboardingLaunchStoreViewModel(siteURL: self.exampleURL,
-                                                                    siteID: siteID,
+                                                                    siteID: self.siteID,
                                                                     stores: self.stores,
                                                                     onLaunch: {
                     // Then
@@ -63,7 +63,6 @@ final class StoreOnboardingLaunchStoreViewModelTests: XCTestCase {
 
     func test_launchStore_sets_alreadyLaunched_error_on_failure() async throws {
         // Given
-        let siteID: Int64 = 134
         stores.whenReceivingAction(ofType: SiteAction.self) { action in
             guard case let .launchSite(_, completion) = action else {
                 return XCTFail("Unexpected action: \(action)")
@@ -83,11 +82,52 @@ final class StoreOnboardingLaunchStoreViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.error, .alreadyLaunched)
     }
 
-    // MARK: - `canPublishStore`
-
-    func test_canPublishStore_is_false_by_default() async throws {
+    func test_launchStore_updates_state_to_launchingStore_when_there_is_no_error() async throws {
         // Given
-        let siteID: Int64 = 134
+        stores.whenReceivingAction(ofType: SiteAction.self) { action in
+            guard case let .launchSite(_, completion) = action else {
+                return XCTFail("Unexpected action: \(action)")
+            }
+            completion(.success(()))
+        }
+
+        let sut = StoreOnboardingLaunchStoreViewModel(siteURL: self.exampleURL,
+                                                      siteID: siteID,
+                                                      stores: self.stores,
+                                                      onLaunch: {},
+                                                      onUpgradeTapped: {})
+        // When
+        await sut.launchStore()
+
+        // Then
+        XCTAssertEqual(sut.state, .launchingStore)
+    }
+
+    func test_launchStore_updates_state_to_readyToPublish_when_there_is_error() async throws {
+        // Given
+        stores.whenReceivingAction(ofType: SiteAction.self) { action in
+            guard case let .launchSite(_, completion) = action else {
+                return XCTFail("Unexpected action: \(action)")
+            }
+            completion(.failure(SiteLaunchError.unexpected(description: "mock")))
+        }
+
+        let sut = StoreOnboardingLaunchStoreViewModel(siteURL: self.exampleURL,
+                                                      siteID: siteID,
+                                                      stores: self.stores,
+                                                      onLaunch: {},
+                                                      onUpgradeTapped: {})
+        // When
+        await sut.launchStore()
+
+        // Then
+        XCTAssertEqual(sut.state, .readyToPublish)
+    }
+
+    // MARK: - `state`
+
+    func test_state_is_checkingSitePlan_by_default() async throws {
+        // Given
         let sut = StoreOnboardingLaunchStoreViewModel(siteURL: exampleURL,
                                                       siteID: siteID,
                                                       stores: stores,
@@ -95,15 +135,14 @@ final class StoreOnboardingLaunchStoreViewModelTests: XCTestCase {
                                                       onUpgradeTapped: {})
 
         // Then
-        XCTAssertFalse(sut.canPublishStore)
+        XCTAssertEqual(sut.state, .checkingSitePlan)
     }
 
-    func test_canPublishStore_is_false_for_WPCOM_site_under_free_trail() async {
+    func test_state_is_needsPlanUpgrade_for_WPCOM_site_under_free_trail() async {
         // Given
         sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)
         sessionManager.defaultRoles = [.administrator]
 
-        let siteID: Int64 = 134
         let sitePlan = WPComSitePlan(id: self.freeTrialID,
                                      hasDomainCredit: false,
                                      expiryDate: Date().addingDays(14))
@@ -118,32 +157,13 @@ final class StoreOnboardingLaunchStoreViewModelTests: XCTestCase {
         await sut.checkEligibilityToPublishStore()
 
         // Then
-        XCTAssertFalse(sut.canPublishStore)
+        XCTAssertEqual(sut.state, .needsPlanUpgrade)
     }
 
-    func test_canPublishStore_is_true_for_non_WPCOM_site() async {
+    func test_state_is_readyToPublish_for_WPCOM_site_not_under_free_trial() async {
         // Given
-        sessionManager.defaultSite = .fake().copy(isWordPressComStore: false)
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)
         sessionManager.defaultRoles = [.administrator]
-        let siteID: Int64 = 134
-
-        let sut = StoreOnboardingLaunchStoreViewModel(siteURL: exampleURL,
-                                                      siteID: siteID,
-                                                      stores: stores,
-                                                      onLaunch: {},
-                                                      onUpgradeTapped: {})
-        // When
-        await sut.checkEligibilityToPublishStore()
-
-        // Then
-        XCTAssertTrue(sut.canPublishStore)
-    }
-
-    func test_canPublishStore_is_true_for_WPCOM_site_not_under_free_trial() async {
-        // Given
-        sessionManager.defaultSite = .fake().copy(isWordPressComStore: false)
-        sessionManager.defaultRoles = [.administrator]
-        let siteID: Int64 = 134
 
         let sitePlan = WPComSitePlan(hasDomainCredit: false)
         mockLoadSiteCurrentPlan(result: .success(sitePlan))
@@ -157,14 +177,13 @@ final class StoreOnboardingLaunchStoreViewModelTests: XCTestCase {
         await sut.checkEligibilityToPublishStore()
 
         // Then
-        XCTAssertTrue(sut.canPublishStore)
+        XCTAssertEqual(sut.state, .readyToPublish)
     }
 
-    func test_canPublishStore_is_true_for_WPCOM_site_when_checking_site_plan_fails() async {
+    func test_state_is_readyToPublish_for_WPCOM_site_when_checking_site_plan_fails() async {
         // Given
-        sessionManager.defaultSite = .fake().copy(isWordPressComStore: false)
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)
         sessionManager.defaultRoles = [.administrator]
-        let siteID: Int64 = 134
 
         mockLoadSiteCurrentPlan(result: .failure(MockError()))
 
@@ -177,7 +196,7 @@ final class StoreOnboardingLaunchStoreViewModelTests: XCTestCase {
         await sut.checkEligibilityToPublishStore()
 
         // Then
-        XCTAssertTrue(sut.canPublishStore)
+        XCTAssertEqual(sut.state, .readyToPublish)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingLaunchStoreViewModelTests.swift
@@ -1,18 +1,22 @@
 import XCTest
-import Yosemite
 @testable import WooCommerce
+@testable import Yosemite
 
 final class StoreOnboardingLaunchStoreViewModelTests: XCTestCase {
     private let exampleURL: URL = WooConstants.URLs.privacy.asURL()
     private var stores: MockStoresManager!
+    private var sessionManager: SessionManager!
+    private let freeTrialID = "1052"
 
     override func setUp() {
         super.setUp()
-        stores = MockStoresManager(sessionManager: .makeForTesting())
+        sessionManager = .makeForTesting(authenticated: true)
+        stores = MockStoresManager(sessionManager: sessionManager)
     }
 
     override func tearDown() {
         stores = nil
+        sessionManager = nil
         super.tearDown()
     }
 
@@ -20,7 +24,7 @@ final class StoreOnboardingLaunchStoreViewModelTests: XCTestCase {
 
     func test_siteURL_is_set_from_init_value() throws {
         // Given
-        let viewModel = StoreOnboardingLaunchStoreViewModel(siteURL: exampleURL, siteID: 1, onLaunch: {})
+        let viewModel = StoreOnboardingLaunchStoreViewModel(siteURL: exampleURL, siteID: 1, onLaunch: {}, onUpgradeTapped: {})
 
         // Then
         XCTAssertEqual(viewModel.siteURL, exampleURL)
@@ -50,7 +54,8 @@ final class StoreOnboardingLaunchStoreViewModelTests: XCTestCase {
                                                                     onLaunch: {
                     // Then
                     promise(())
-                })
+                },
+                                                                    onUpgradeTapped: {})
                 await viewModel.launchStore()
             }
         }
@@ -68,7 +73,8 @@ final class StoreOnboardingLaunchStoreViewModelTests: XCTestCase {
         let viewModel = StoreOnboardingLaunchStoreViewModel(siteURL: self.exampleURL,
                                                             siteID: siteID,
                                                             stores: self.stores,
-                                                            onLaunch: {})
+                                                            onLaunch: {},
+                                                            onUpgradeTapped: {})
 
         // When
         await viewModel.launchStore()
@@ -76,4 +82,114 @@ final class StoreOnboardingLaunchStoreViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.error, .alreadyLaunched)
     }
+
+    // MARK: - `canPublishStore`
+
+    func test_canPublishStore_is_false_by_default() async throws {
+        // Given
+        let siteID: Int64 = 134
+        let sut = StoreOnboardingLaunchStoreViewModel(siteURL: exampleURL,
+                                                      siteID: siteID,
+                                                      stores: stores,
+                                                      onLaunch: {},
+                                                      onUpgradeTapped: {})
+
+        // Then
+        XCTAssertFalse(sut.canPublishStore)
+    }
+
+    func test_canPublishStore_is_false_for_WPCOM_site_under_free_trail() async {
+        // Given
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)
+        sessionManager.defaultRoles = [.administrator]
+
+        let siteID: Int64 = 134
+        let sitePlan = WPComSitePlan(id: self.freeTrialID,
+                                     hasDomainCredit: false,
+                                     expiryDate: Date().addingDays(14))
+        mockLoadSiteCurrentPlan(result: .success(sitePlan))
+
+        let sut = StoreOnboardingLaunchStoreViewModel(siteURL: exampleURL,
+                                                      siteID: siteID,
+                                                      stores: stores,
+                                                      onLaunch: {},
+                                                      onUpgradeTapped: {})
+        // When
+        await sut.checkEligibilityToPublishStore()
+
+        // Then
+        XCTAssertFalse(sut.canPublishStore)
+    }
+
+    func test_canPublishStore_is_true_for_non_WPCOM_site() async {
+        // Given
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: false)
+        sessionManager.defaultRoles = [.administrator]
+        let siteID: Int64 = 134
+
+        let sut = StoreOnboardingLaunchStoreViewModel(siteURL: exampleURL,
+                                                      siteID: siteID,
+                                                      stores: stores,
+                                                      onLaunch: {},
+                                                      onUpgradeTapped: {})
+        // When
+        await sut.checkEligibilityToPublishStore()
+
+        // Then
+        XCTAssertTrue(sut.canPublishStore)
+    }
+
+    func test_canPublishStore_is_true_for_WPCOM_site_not_under_free_trial() async {
+        // Given
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: false)
+        sessionManager.defaultRoles = [.administrator]
+        let siteID: Int64 = 134
+
+        let sitePlan = WPComSitePlan(hasDomainCredit: false)
+        mockLoadSiteCurrentPlan(result: .success(sitePlan))
+
+        let sut = StoreOnboardingLaunchStoreViewModel(siteURL: exampleURL,
+                                                      siteID: siteID,
+                                                      stores: stores,
+                                                      onLaunch: {},
+                                                      onUpgradeTapped: {})
+        // When
+        await sut.checkEligibilityToPublishStore()
+
+        // Then
+        XCTAssertTrue(sut.canPublishStore)
+    }
+
+    func test_canPublishStore_is_true_for_WPCOM_site_when_checking_site_plan_fails() async {
+        // Given
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: false)
+        sessionManager.defaultRoles = [.administrator]
+        let siteID: Int64 = 134
+
+        mockLoadSiteCurrentPlan(result: .failure(MockError()))
+
+        let sut = StoreOnboardingLaunchStoreViewModel(siteURL: exampleURL,
+                                                      siteID: siteID,
+                                                      stores: stores,
+                                                      onLaunch: {},
+                                                      onUpgradeTapped: {})
+        // When
+        await sut.checkEligibilityToPublishStore()
+
+        // Then
+        XCTAssertTrue(sut.canPublishStore)
+    }
+}
+
+private extension StoreOnboardingLaunchStoreViewModelTests {
+    func mockLoadSiteCurrentPlan(result: Result<WPComSitePlan, Error>) {
+        stores.whenReceivingAction(ofType: PaymentAction.self) { action in
+            guard case let .loadSiteCurrentPlan(_, completion) = action else {
+                return XCTFail()
+            }
+            completion(result)
+        }
+    }
+
+    final class MockError: Error { }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -181,7 +181,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
 
     func test_tasksForDisplay_does_not_contain_launch_store_task_for_WPCOM_site_not_under_free_trial() async {
         // Given
-        sessionManager.defaultSite = .fake().copy(isWordPressComStore: false)
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)
         sessionManager.defaultRoles = [.administrator]
         mockLoadOnboardingTasks(result: .success([
             .init(isComplete: false, type: .addFirstProduct),
@@ -203,7 +203,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
 
     func test_tasksForDisplay_does_not_contain_launch_store_task_for_WPCOM_site_when_checking_site_plan_fails() async {
         // Given
-        sessionManager.defaultSite = .fake().copy(isWordPressComStore: false)
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true)
         sessionManager.defaultRoles = [.administrator]
         mockLoadOnboardingTasks(result: .success([
             .init(isComplete: false, type: .addFirstProduct),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9141
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

For free trial WPCOM sites, we cannot publish the site without upgrading the plan.

This PR,
- Adds a banner in the "Launch store" screen
- Enables the "Publish My Store" button only if the site is not under free trial

## Testing instructions

Prerequisite: Create a free trial by visiting - https://wordpress.com/setup/wooexpress/

- Login into the app using the free trial site
- In the dashboard screen, you should also see the "X days left in your trial.." banner at the bottom of the screen.
- You should also see the "Launch your store" task on the dashboard screen. 
- Tap on the "Launch your store" task. 
- In the "Preview" screen, verify that you see a banner at the top asking you to upgrade the plan to launch your store
- Also validate the "Publish My Store" button is disabled
- Tap on the `Upgrade` button and purchase a plan (using credits)
- You should be navigated back to the dashboard after purchasing a plan.
- Validate that you no longer see the "X days left in your trial.." banner at the bottom of the dashboard screen
- If you don't see "Launch your store" task, pull to refresh to reload the onboarding task list. (Takes a few secs for the purchase to take effect)
- Tap on "Launch your store" task, verify that now the "Publish My Store" button is enabled, and the "Upgrade plan" banner is no longer visible.

## Screenshots

Launch store screen
| Site | Dark | Light |
|--------|--------|--------|
| Free trial |  ![Dark](https://user-images.githubusercontent.com/524475/228572757-085373c4-5d31-4266-a449-e1cf0f098fd1.png) | ![Light](https://user-images.githubusercontent.com/524475/228572798-9b34457e-bb67-49f9-b517-29cdd28ef626.png) |
| WPCOM after upgrade plan | ![D-ReadyToPublish](https://user-images.githubusercontent.com/524475/228532578-cacf81c2-5fbe-4bb2-a14b-b9e52a4f79b0.png) | ![L-ReadyToPublish](https://user-images.githubusercontent.com/524475/228532594-715aee82-0d0e-4ad6-91d5-1368581dc14d.png) |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
