### PR TITLE
[Free Trial] Update info copy for a trial-ended site

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
@@ -199,7 +199,8 @@ private extension UpgradesViewModel {
     enum Localization {
         static let freeTrial = NSLocalizedString("Free Trial", comment: "Plan name for an active free trial")
         static let trialEnded = NSLocalizedString("Trial ended", comment: "Plan name for an expired free trial")
-        static let trialEndedInfo = NSLocalizedString("Your free trial has ended, and you have limited access to all the features. Subscribe to eCommerce now.",
+        static let trialEndedInfo = NSLocalizedString("Your free trial has ended and you have limited access to all the features. " +
+                                                      "Subscribe to Woo Express Performance Plan now.",
                                                       comment: "Info details for an expired free trial")
         static let planEndedInfo = NSLocalizedString("Your subscription has ended and you have limited access to all the features.",
                                                      comment: "Info details for an expired free trial")


### PR DESCRIPTION
Closes: #9324 

# Why

As per the latest discussions, this PR updates the info text in the subscriptions view when a site's free trial has ended.

<img width="449" alt="Screenshot 2023-03-29 at 4 50 09 PM" src="https://user-images.githubusercontent.com/562080/228677247-724ba43b-4603-41de-9c1b-2ebf7c33434e.png">


# Testing Steps

- Log in on an expired free-trial site.
- Navigate to Menu -> Upgrades
- See that the info test reads like:

> Your free trial has ended and you have limited access to all the features. Subscribe to Woo Express Performance Plan now.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
