### PR TITLE
[Free Trial ] Use correct theme for wooexpress flow

### DIFF
--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -56,7 +56,7 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
                 "site_information": [
                     "title": ""
                 ],
-                "theme": "pub/zoologist",
+                "theme": flow.theme,
                 "use_theme_annotation": false,
                 "wpcom_public_coming_soon": 1
             ]
@@ -109,6 +109,15 @@ public enum SiteCreationFlow {
             return "onboarding"
         case .wooexpress:
             return "wooexpress"
+        }
+    }
+
+    var theme: String {
+        switch self {
+        case .onboarding:
+            return "pub/zoologist"
+        case .wooexpress:
+            return "pub/twentytwentytwo"
         }
     }
 }


### PR DESCRIPTION
Closes: #9325 

# Why

As per discussions on paYKcK-2Pw-p2 this PR makes sure that a new site is created with the `pub/twentytwentytwo` theme so it can be converted later(internally) to the `Tsubaki` theme when the `free trial` plan is added.

# Screenshots

<img width="704" alt="Screenshot 2023-03-29 at 5 26 20 PM" src="https://user-images.githubusercontent.com/562080/228682833-e92d4bd6-8a98-4114-ab2a-4ac281ab69e4.png">

# Testing Steps

- Create a new free trial site.
- After creation, check that the site has the `Tsubaki` theme.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
