### PR TITLE
[Product Multi-selection] Sync selected items when view is dismissed or closed

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -194,6 +194,7 @@ final class EditableOrderViewModel: ObservableObject {
             }, onAllSelectionsCleared: { [weak self] in
                 guard let self = self else { return }
                 self.clearAllSelectedItems()
+                self.syncInitialSelectedState()
             }, onSelectedVariationsCleared: { [weak self] in
                 guard let self = self else { return }
                 self.clearSelectedVariations()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -142,6 +142,7 @@ struct ProductSelectorView: View {
                 // no-op
             }
         }
+        .interactiveDismissDisabled()
     }
 
     /// Creates the `ProductRow` for a product, depending on whether the product is variable.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -125,6 +125,9 @@ struct ProductSelectorView: View {
                 if let cancelButtonTitle = configuration.cancelButtonTitle {
                     Button(cancelButtonTitle) {
                         isPresented.toggle()
+                        if !isPresented {
+                            viewModel.clearSelection()
+                        }
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
@@ -108,6 +108,7 @@ struct ProductVariationSelector: View {
             onMultipleSelections?(viewModel.selectedProductVariationIDs)
         }
         .notice($viewModel.notice, autoDismiss: false)
+        .interactiveDismissDisabled()
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9319 

## Description
During QE testing we discovered that if a merchant dismisses or closes the product selector without saving changes, there will be discrepancies between which items are part of an order and which ones appear selected the next time they open the Product Selector.  With this PR we're sure to keep these in sync.

## Changes
- Disallows dismiss on swipe for the Product Selector and Product Variation Selector by using `.interactiveDismissDisabled()`. I considered potential improvements like intercepting the SwiftUI swipe action, or making these views non-modal by using [fullScreenCover](https://developer.apple.com/documentation/swiftui/view/fullscreencover(ispresented:ondismiss:content:)) instead, but adds extra complexity and we can revisit this again once we get a design review, they can still close the views by tapping either on `<` or `Close`.
- When the `Close` button is tapped, we 1. Clear all selections, and 2. Sync the current Order state. This way we're sure to only display exactly what's part of the Order the next time the selector is opened.

## Testing instructions
- Go to Menu > Settings > Experimental features > and enable "Product Multi-Selection"
- Go to Orders > Tap `+` > Tap on `+ Add Products`.
- Attempt to swipe down to dismiss the Product Selector view, see how it can't be dismissed. The same will happen for Product Variations Selector.
- Select some items and tap `X product selected` to create an Order.
- Tap on `+ Add Products` again, select some more items, but this time tap `Close` to not save any update. See how the Order still contains the initial items, and by tapping on `+ Add Products` again the correct items are selected as well.

![Simulator Screen Recording - iPhone Xs - 2023-03-30 at 08 29 51](https://user-images.githubusercontent.com/3812076/228704647-3c9313a3-5dbc-4c7f-bed5-db58cf80403d.gif)

