### PR TITLE
[Product Multi-Selection] Capitalize "Products Selected" strings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -375,10 +375,10 @@ private extension ProductSelectorView.Configuration {
     enum Localization {
         static let title = NSLocalizedString("Add Product", comment: "Title for the screen to add a product to an order")
         static let close = NSLocalizedString("Close", comment: "Text for the close button in the Add Product screen")
-        static let doneButtonSingular = NSLocalizedString("1 Product selected",
+        static let doneButtonSingular = NSLocalizedString("1 Product Selected",
                                                           comment: "Title of the action button at the bottom of the Select Products screen " +
                                                           "when one product is selected")
-        static let doneButtonPlural = NSLocalizedString("%1$d Products selected",
+        static let doneButtonPlural = NSLocalizedString("%1$d Products Selected",
                                                         comment: "Title of the action button at the bottom of the Select Products screen " +
                                                         "when more than 1 item is selected, reads like: 5 Products selected")
         static let productRowAccessibilityHint = NSLocalizedString("Adds product to order.",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -380,7 +380,7 @@ private extension ProductSelectorView.Configuration {
                                                           "when one product is selected")
         static let doneButtonPlural = NSLocalizedString("%1$d Products Selected",
                                                         comment: "Title of the action button at the bottom of the Select Products screen " +
-                                                        "when more than 1 item is selected, reads like: 5 Products selected")
+                                                        "when more than 1 item is selected, reads like: 5 Products Selected")
         static let productRowAccessibilityHint = NSLocalizedString("Adds product to order.",
                                                                    comment: "Accessibility hint for selecting a product in the Add Product screen")
         static let variableProductRowAccessibilityHint = NSLocalizedString(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9320

## Description
This PR addresses capitalizing the word "Selected" on "X Products Selected", when product multi-selection is enabled.

## Changes
- Edits the `NSLocalizedStrings` for `doneButtonSingular` and `doneButtonPlural`

## Testing instructions
- Go to Menu > Settings > Experimental features > and enable "Product Multi-Selection"
- Go to Orders > Tap `+` > Tap on `+ Add Products`.
- Select 1 or more products, see that "Products Selected" is capitalized.

## Screenshots
<img width=450 src="https://user-images.githubusercontent.com/3812076/228723605-fc01dfb7-128a-4876-8ad9-6323cb1bdb33.png">
