### PR TITLE
[Product Multi-Selection] Always render `Clear Selection` button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -179,7 +179,6 @@ final class EditableOrderViewModel: ObservableObject {
             storageManager: storageManager,
             stores: stores,
             supportsMultipleSelection: isProductMultiSelectionBetaFeatureEnabled,
-            isClearSelectionEnabled: isProductMultiSelectionBetaFeatureEnabled,
             toggleAllVariationsOnSelection: false,
             onProductSelected: { [weak self] product in
                 guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -361,7 +361,6 @@ private extension ProductSelectorView.Configuration {
     static func addProductToOrder() -> ProductSelectorView.Configuration {
         ProductSelectorView.Configuration(
             multipleSelectionsEnabled: ServiceLocator.generalAppSettings.betaFeatureEnabled(.productMultiSelection),
-            clearSelectionEnabled: ServiceLocator.generalAppSettings.betaFeatureEnabled(.productMultiSelection),
             searchHeaderBackgroundColor: .listBackground,
             prefersLargeTitle: false,
             doneButtonTitleSingularFormat: Localization.doneButtonSingular,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -50,7 +50,7 @@ struct ProductSelectorView: View {
                 }
                 .buttonStyle(LinkButtonStyle())
                 .fixedSize()
-                .disabled(viewModel.totalSelectedItemsCount == 0 && viewModel.syncStatus != .results)
+                .disabled(viewModel.totalSelectedItemsCount == 0 || viewModel.syncStatus != .results)
                 Spacer()
 
                 Button(viewModel.filterButtonTitle) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -50,7 +50,7 @@ struct ProductSelectorView: View {
                 }
                 .buttonStyle(LinkButtonStyle())
                 .fixedSize()
-                .renderedIf(viewModel.totalSelectedItemsCount > 0 && viewModel.syncStatus == .results)
+                .disabled(viewModel.totalSelectedItemsCount == 0 && viewModel.syncStatus != .results)
                 Spacer()
 
                 Button(viewModel.filterButtonTitle) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -50,6 +50,7 @@ struct ProductSelectorView: View {
                 }
                 .buttonStyle(LinkButtonStyle())
                 .fixedSize()
+                .renderedIf(viewModel.supportsMultipleSelection)
                 .disabled(viewModel.totalSelectedItemsCount == 0 || viewModel.syncStatus != .results)
                 Spacer()
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -50,7 +50,7 @@ struct ProductSelectorView: View {
                 }
                 .buttonStyle(LinkButtonStyle())
                 .fixedSize()
-                .renderedIf(configuration.clearSelectionEnabled && viewModel.totalSelectedItemsCount > 0 && viewModel.syncStatus == .results)
+                .renderedIf(viewModel.totalSelectedItemsCount > 0 && viewModel.syncStatus == .results)
                 Spacer()
 
                 Button(viewModel.filterButtonTitle) {
@@ -190,7 +190,6 @@ extension ProductSelectorView {
     struct Configuration {
         var showsFilters: Bool = false
         var multipleSelectionsEnabled: Bool = false
-        var clearSelectionEnabled: Bool = true
         var searchHeaderBackgroundColor: UIColor = .listForeground(modal: false)
         var prefersLargeTitle: Bool = true
         var doneButtonTitleSingularFormat: String = ""

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -60,10 +60,6 @@ final class ProductSelectorViewModel: ObservableObject {
     ///
     let supportsMultipleSelection: Bool
 
-    /// Determines if the Clear Selection button is enabled
-    ///
-    let isClearSelectionEnabled: Bool
-
     /// Determines if it is possible to toggle all variation items upon selection
     ///
     let toggleAllVariationsOnSelection: Bool
@@ -159,7 +155,6 @@ final class ProductSelectorViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          supportsMultipleSelection: Bool = false,
-         isClearSelectionEnabled: Bool = true,
          toggleAllVariationsOnSelection: Bool = true,
          onProductSelected: ((Product) -> Void)? = nil,
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil,
@@ -171,7 +166,6 @@ final class ProductSelectorViewModel: ObservableObject {
         self.stores = stores
         self.analytics = analytics
         self.supportsMultipleSelection = supportsMultipleSelection
-        self.isClearSelectionEnabled = isClearSelectionEnabled
         self.toggleAllVariationsOnSelection = toggleAllVariationsOnSelection
         self.onProductSelected = onProductSelected
         self.onVariationSelected = onVariationSelected
@@ -196,7 +190,6 @@ final class ProductSelectorViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          supportsMultipleSelection: Bool = false,
-         isClearSelectionEnabled: Bool = true,
          toggleAllVariationsOnSelection: Bool = true,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil,
          onAllSelectionsCleared: (() -> Void)? = nil,
@@ -206,7 +199,6 @@ final class ProductSelectorViewModel: ObservableObject {
         self.stores = stores
         self.analytics = analytics
         self.supportsMultipleSelection = supportsMultipleSelection
-        self.isClearSelectionEnabled = isClearSelectionEnabled
         self.toggleAllVariationsOnSelection = toggleAllVariationsOnSelection
         self.onProductSelected = nil
         self.onVariationSelected = nil
@@ -254,7 +246,6 @@ final class ProductSelectorViewModel: ObservableObject {
                                                  selectedProductVariationIDs: selectedItems,
                                                  purchasableItemsOnly: purchasableItemsOnly,
                                                  supportsMultipleSelection: supportsMultipleSelection,
-                                                 isClearSelectionEnabled: isClearSelectionEnabled,
                                                  onVariationSelected: onVariationSelected,
                                                  onSelectionsCleared: onSelectedVariationsCleared)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
@@ -43,7 +43,7 @@ struct ProductVariationSelector: View {
                     }
                     .buttonStyle(LinkButtonStyle())
                     .fixedSize()
-                    .renderedIf(viewModel.isClearSelectionEnabled && viewModel.selectedProductVariationIDs.isNotEmpty)
+                    .renderedIf(viewModel.selectedProductVariationIDs.isNotEmpty)
 
                     InfiniteScrollList(isLoading: viewModel.shouldShowScrollIndicator,
                                        loadAction: viewModel.syncNextPage) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
@@ -43,6 +43,7 @@ struct ProductVariationSelector: View {
                     }
                     .buttonStyle(LinkButtonStyle())
                     .fixedSize()
+                    .renderedIf(viewModel.supportsMultipleSelection)
                     .disabled(viewModel.selectedProductVariationIDs.isEmpty || viewModel.syncStatus != .results)
 
                     InfiniteScrollList(isLoading: viewModel.shouldShowScrollIndicator,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
@@ -43,7 +43,6 @@ struct ProductVariationSelector: View {
                     }
                     .buttonStyle(LinkButtonStyle())
                     .fixedSize()
-                    .renderedIf(viewModel.selectedProductVariationIDs.isNotEmpty)
 
                     InfiniteScrollList(isLoading: viewModel.shouldShowScrollIndicator,
                                        loadAction: viewModel.syncNextPage) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
@@ -43,6 +43,7 @@ struct ProductVariationSelector: View {
                     }
                     .buttonStyle(LinkButtonStyle())
                     .fixedSize()
+                    .disabled(viewModel.selectedProductVariationIDs.isEmpty || viewModel.syncStatus != .results)
 
                     InfiniteScrollList(isLoading: viewModel.shouldShowScrollIndicator,
                                        loadAction: viewModel.syncNextPage) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -20,10 +20,6 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     ///
     let supportsMultipleSelection: Bool
 
-    /// Determines if the Clear Selection button is enabled
-    ///
-    let isClearSelectionEnabled: Bool
-
     /// Store for publishers subscriptions
     ///
     private var subscriptions = Set<AnyCancellable>()
@@ -125,7 +121,6 @@ final class ProductVariationSelectorViewModel: ObservableObject {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          supportsMultipleSelection: Bool = false,
-         isClearSelectionEnabled: Bool = true,
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil,
          onSelectionsCleared: (() -> Void)? = nil) {
         self.siteID = siteID
@@ -135,7 +130,6 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         self.storageManager = storageManager
         self.stores = stores
         self.supportsMultipleSelection = supportsMultipleSelection
-        self.isClearSelectionEnabled = isClearSelectionEnabled
         self.onVariationSelected = onVariationSelected
         self.selectedProductVariationIDs = selectedProductVariationIDs
         self.purchasableItemsOnly = purchasableItemsOnly
@@ -153,7 +147,6 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      stores: StoresManager = ServiceLocator.stores,
                      supportsMultipleSelection: Bool = false,
-                     isClearSelectionEnabled: Bool = true,
                      onVariationSelected: ((ProductVariation, Product) -> Void)? = nil,
                      onSelectionsCleared: (() -> Void)? = nil) {
         self.init(siteID: siteID,
@@ -165,7 +158,6 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                   storageManager: storageManager,
                   stores: stores,
                   supportsMultipleSelection: supportsMultipleSelection,
-                  isClearSelectionEnabled: isClearSelectionEnabled,
                   onVariationSelected: onVariationSelected,
                   onSelectionsCleared: onSelectionsCleared)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -43,7 +43,6 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.productSelectorViewModel.supportsMultipleSelection)
-        XCTAssertFalse(viewModel.productSelectorViewModel.isClearSelectionEnabled)
         XCTAssertFalse(viewModel.productSelectorViewModel.toggleAllVariationsOnSelection)
     }
 
@@ -57,7 +56,6 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.productSelectorViewModel.supportsMultipleSelection)
-        XCTAssertTrue(viewModel.productSelectorViewModel.isClearSelectionEnabled)
         XCTAssertFalse(viewModel.productSelectorViewModel.toggleAllVariationsOnSelection)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -52,7 +52,6 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.supportsMultipleSelection)
-        XCTAssertTrue(viewModel.isClearSelectionEnabled)
         XCTAssertTrue(viewModel.toggleAllVariationsOnSelection)
         XCTAssertEqual(viewModel.filterButtonTitle, "Filter")
         XCTAssertNil(viewModel.notice)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9318 

## Description

This PR makes "Clear Selection" button visible at all times, rather than appearing when there's selections to be cleared. The button will be disabled if there's no products selected, and enabled if there's something to be cleared. 

This is done for consistency between the different views, and as a pre-work to adding Filters as well to this view.

## Changes
- Removes `isClearSelectionEnabled` property from `ProductSelectorViewModel` and `ProductVariationSelectorViewModel`. This was introduced initially so we could disable "clear selection"  for product multi-selection, but keep it with coupons. This is no longer needed.
- Makes the "Clear Selection" button render at all times if multi-selection is allowed
- We keep the previous logic for rendering the button, but now just disables it under the same conditions: If item selected count is 0, or the viewModel's sync status is not `.results`

## Testing instructions
- Go to Orders > Tap `+` > Tap on `+ Add Products`. Clear Selection button does not appear for single-selection.
- Go to Menu > Settings > Experimental features > and enable "Product Multi-Selection"
- Go to Orders > Tap `+` > Tap on `+ Add Products`. Clear Selection appears for multiple-selection. The button will only be enabled when there's any item selected.
- The same behaviour will be displayed when adding products to coupons, on Menu > Coupons > + > All Products

## Screenshots

|  Disabled | Enabled | 
|---|---|
| <img width=450 src="https://user-images.githubusercontent.com/3812076/229004538-294b216b-9857-4700-acf3-8a253628bc41.png"> | <img width=450 src="https://user-images.githubusercontent.com/3812076/229004546-06131d48-347b-4800-95d8-2b8a79aeb1cc.png"> |
