### PR TITLE
[Free Trial] Support profiler questions + free trial combo

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -140,6 +140,10 @@ private extension StoreCreationCoordinator {
         let isFreeTrialEnabled = featureFlagService.isFeatureFlagEnabled(.freeTrial)
         let storeNameForm = StoreNameFormHostingController { [weak self] storeName in
             if isProfilerEnabled {
+                /// `storeCreationM3Profiler` is currently disabled.
+                /// Before enabling it again, make sure the onboarding questions are properly sent on the trial flow around line `343`.
+                /// Ref: https://github.com/woocommerce/woocommerce-ios/issues/9326#issuecomment-1490012032
+                ///
                 self?.showCategoryQuestion(from: navigationController, storeName: storeName, planToPurchase: planToPurchase)
             } else {
                 if isFreeTrialEnabled {
@@ -367,15 +371,22 @@ private extension StoreCreationCoordinator {
                                   category: StoreCreationCategoryAnswer?,
                                   sellingStatus: StoreCreationSellingStatusAnswer?,
                                   planToPurchase: WPComPlanProduct) {
+        let isFreeTrialEnabled = featureFlagService.isFeatureFlagEnabled(.freeTrial)
         let questionController = StoreCreationCountryQuestionHostingController(viewModel:
                 .init(storeName: storeName) { [weak self] countryCode in
                     guard let self else { return }
-                    self.showDomainSelector(from: navigationController,
-                                            storeName: storeName,
-                                            category: category,
-                                            sellingStatus: sellingStatus,
-                                            countryCode: countryCode,
-                                            planToPurchase: planToPurchase)
+                    if isFreeTrialEnabled {
+                        Task {
+                            await self.createFreeTrialStore(from: navigationController, storeName: storeName)
+                        }
+                    } else {
+                        self.showDomainSelector(from: navigationController,
+                                                storeName: storeName,
+                                                category: category,
+                                                sellingStatus: sellingStatus,
+                                                countryCode: countryCode,
+                                                planToPurchase: planToPurchase)
+                    }
                 } onSupport: { [weak self] in
                     self?.showSupport(from: navigationController)
                 })


### PR DESCRIPTION
Closes: #9326

# Why

Profiler questions when creating a store are currently disabled, however there are plans to change this once the necessary APIs are available.  pe5sF9-1mX-p2

For that reason, this PR makes sure that the free trial flow is also "connected" when the `storeCreationM3Profiler` is enable.

# Demo

https://user-images.githubusercontent.com/562080/228972497-1568356c-1c38-4e15-aaec-dff6df07c918.mov

# Testing Steps

- Enable the `storeCreationM3Profiler` feature flag on `DefaultFeatureFlagService.swift`
- Start to create a new store
- See that the profiler questions are presented and the created site is a free trial site.

**Note:** Be aware that some of the times the created store does not has the complete information. Please switch to another store and then switch back for it to refresh successfully.

- https://github.com/woocommerce/woocommerce-ios/issues/9338


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
