### PR TITLE
REST API: Analytics for Jetpack setup flow

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+JetpackSetup.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+JetpackSetup.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+extension WooAnalyticsEvent {
+    enum JetpackSetup {
+        private enum Key: String {
+            case isAlreadyConnected = "is_already_connected"
+            case requiresConnectionOnly = "requires_connection_only"
+            case tap
+            case step
+        }
+
+        enum LoginFlow {
+            enum TapTarget: String {
+                case submit
+                case dismiss
+            }
+
+            enum Step: String {
+                case emailAddress = "email_address"
+                case password
+                case magicLink = "magic_link"
+                case verificationCode = "verification_code"
+            }
+        }
+
+        enum SetupFlow {
+            enum TapTarget: String {
+                case dismiss
+                case support
+                case continueSetup = "continue_setup"
+                case goToStore = "go_to_store"
+            }
+
+            enum Step: String {
+                case fetchPluginDetail = "fetch_plugin_detail"
+                case install
+                case activate
+                case fetchConnectionURL = "fetch_connection_url"
+                case checkConnection = "check_connection"
+            }
+        }
+
+        static func connectionCheckCompleted(isAlreadyConnected: Bool, requiresConnectionOnly: Bool) -> WooAnalyticsEvent {
+            .init(statName: .jetpackSetupConnectionCheckCompleted, properties: [
+                Key.isAlreadyConnected.rawValue: isAlreadyConnected,
+                Key.requiresConnectionOnly.rawValue: requiresConnectionOnly
+            ])
+        }
+
+        static func loginFlow(step: LoginFlow.Step, tap: LoginFlow.TapTarget? = nil, failure: Error? = nil) -> WooAnalyticsEvent {
+            var properties: [String: WooAnalyticsEventPropertyType] = [Key.step.rawValue: step.rawValue]
+            if let tap {
+                properties[Key.tap.rawValue] = tap.rawValue
+            }
+            return .init(statName: .jetpackSetupLoginFlow, properties: properties, error: failure)
+        }
+
+        static func setupFlow(step: SetupFlow.Step, tap: SetupFlow.TapTarget? = nil, failure: Error? = nil) -> WooAnalyticsEvent {
+            var properties: [String: WooAnalyticsEventPropertyType] = [Key.step.rawValue: step.rawValue]
+            if let tap {
+                properties[Key.tap.rawValue] = tap.rawValue
+            }
+            return .init(statName: .jetpackSetupFlow, properties: properties, error: failure)
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+JetpackSetup.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+JetpackSetup.swift
@@ -29,14 +29,7 @@ extension WooAnalyticsEvent {
                 case support
                 case continueSetup = "continue_setup"
                 case goToStore = "go_to_store"
-            }
-
-            enum Step: String {
-                case fetchPluginDetail = "fetch_plugin_detail"
-                case install
-                case activate
-                case fetchConnectionURL = "fetch_connection_url"
-                case checkConnection = "check_connection"
+                case retry
             }
         }
 
@@ -55,8 +48,8 @@ extension WooAnalyticsEvent {
             return .init(statName: .jetpackSetupLoginFlow, properties: properties, error: failure)
         }
 
-        static func setupFlow(step: SetupFlow.Step, tap: SetupFlow.TapTarget? = nil, failure: Error? = nil) -> WooAnalyticsEvent {
-            var properties: [String: WooAnalyticsEventPropertyType] = [Key.step.rawValue: step.rawValue]
+        static func setupFlow(step: JetpackInstallStep, tap: SetupFlow.TapTarget? = nil, failure: Error? = nil) -> WooAnalyticsEvent {
+            var properties: [String: WooAnalyticsEventPropertyType] = [Key.step.rawValue: step.analyticsValue]
             if let tap {
                 properties[Key.tap.rawValue] = tap.rawValue
             }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -876,7 +876,7 @@ public enum WooAnalyticsStat: String {
     case applicationPasswordAuthorizationURLFetchFailed = "application_password_authorization_url_fetch_failed"
 
     // MARK: Jetpack setup for non-Jetpack sites
-    case jetpackSetupLoginButtonTapped = "jetpack_benfits_login_button_tapped"
+    case jetpackSetupLoginButtonTapped = "jetpack_benefits_login_button_tapped"
     case jetpackSetupConnectionCheckCompleted = "jetpack_setup_connection_check_completed"
     case jetpackSetupConnectionCheckFailed = "jetpack_setup_connection_check_failed"
     case jetpackSetupLoginFlow = "jetpack_setup_login_flow"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -874,6 +874,16 @@ public enum WooAnalyticsStat: String {
     case applicationPasswordAuthorizationApproved = "application_password_authorization_approved"
     case applicationPasswordAuthorizationURLNotAvailable = "application_password_authorization_url_not_available"
     case applicationPasswordAuthorizationURLFetchFailed = "application_password_authorization_url_fetch_failed"
+
+    // MARK: Jetpack setup for non-Jetpack sites
+    case jetpackSetupLoginButtonTapped = "jetpack_benfits_login_button_tapped"
+    case jetpackSetupConnectionCheckCompleted = "jetpack_setup_connection_check_completed"
+    case jetpackSetupConnectionCheckFailed = "jetpack_setup_connection_check_failed"
+    case jetpackSetupLoginFlow = "jetpack_setup_login_flow"
+    case jetpackSetupLoginCompleted = "jetpack_setup_login_completed"
+    case jetpackSetupFlow = "jetpack_setup_flow"
+    case jetpackSetupCompleted = "jetpack_setup_completed"
+    case jetpackSetupSynchronizationCompleted = "jetpack_setup_synchronization_completed"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupView.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupView.swift
@@ -12,8 +12,12 @@ final class JetpackSetupHostingController: UIHostingController<JetpackSetupView>
          connectionOnly: Bool,
          connectionWebViewCredentials: Credentials? = nil,
          authentication: Authentication = ServiceLocator.authenticationManager,
+         analytics: Analytics = ServiceLocator.analytics,
          onStoreNavigation: @escaping (String?) -> Void) {
-        self.viewModel = JetpackSetupViewModel(siteURL: siteURL, connectionOnly: connectionOnly, onStoreNavigation: onStoreNavigation)
+        self.viewModel = JetpackSetupViewModel(siteURL: siteURL,
+                                               connectionOnly: connectionOnly,
+                                               analytics: analytics,
+                                               onStoreNavigation: onStoreNavigation)
         self.authentication = authentication
         self.connectionWebViewCredentials = connectionWebViewCredentials
         super.init(rootView: JetpackSetupView(viewModel: viewModel))

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupView.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupView.swift
@@ -5,7 +5,6 @@ import enum Yosemite.Credentials
 ///
 final class JetpackSetupHostingController: UIHostingController<JetpackSetupView> {
     private let viewModel: JetpackSetupViewModel
-    private let analytics: Analytics
     private let authentication: Authentication
     private let connectionWebViewCredentials: Credentials?
 
@@ -13,9 +12,7 @@ final class JetpackSetupHostingController: UIHostingController<JetpackSetupView>
          connectionOnly: Bool,
          connectionWebViewCredentials: Credentials? = nil,
          authentication: Authentication = ServiceLocator.authenticationManager,
-         analytics: Analytics = ServiceLocator.analytics,
          onStoreNavigation: @escaping (String?) -> Void) {
-        self.analytics = analytics
         self.viewModel = JetpackSetupViewModel(siteURL: siteURL, connectionOnly: connectionOnly, onStoreNavigation: onStoreNavigation)
         self.authentication = authentication
         self.connectionWebViewCredentials = connectionWebViewCredentials
@@ -28,7 +25,8 @@ final class JetpackSetupHostingController: UIHostingController<JetpackSetupView>
         rootView.supportHandler = { [weak self] in
             guard let self else { return }
 
-            self.analytics.track(.loginJetpackSetupScreenGetSupportTapped, withProperties: self.viewModel.currentSetupStep?.analyticsDescription)
+            self.viewModel.trackSetupDuringLogin(.loginJetpackSetupScreenGetSupportTapped, properties: self.viewModel.currentSetupStep?.analyticsDescription)
+            self.viewModel.trackSetupAfterLogin(tap: .support)
             self.presentSupport()
         }
 
@@ -43,7 +41,7 @@ final class JetpackSetupHostingController: UIHostingController<JetpackSetupView>
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        analytics.track(.loginJetpackSetupScreenViewed)
+        viewModel.trackSetupDuringLogin(.loginJetpackSetupScreenViewed)
         configureNavigationBarAppearance()
     }
 
@@ -56,8 +54,8 @@ final class JetpackSetupHostingController: UIHostingController<JetpackSetupView>
 
     @objc
     private func dismissView() {
-        analytics.track(.loginJetpackSetupScreenDismissed,
-                        withProperties: viewModel.currentSetupStep?.analyticsDescription)
+        viewModel.trackSetupDuringLogin(.loginJetpackSetupScreenDismissed, properties: viewModel.currentSetupStep?.analyticsDescription)
+        viewModel.trackSetupAfterLogin(tap: .dismiss)
         dismiss(animated: true)
     }
 

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupView.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupView.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import enum Yosemite.Credentials
+import Yosemite
 
 /// Hosting controller for `JetpackSetupView`.
 ///
@@ -11,11 +11,13 @@ final class JetpackSetupHostingController: UIHostingController<JetpackSetupView>
     init(siteURL: String,
          connectionOnly: Bool,
          connectionWebViewCredentials: Credentials? = nil,
+         stores: StoresManager = ServiceLocator.stores,
          authentication: Authentication = ServiceLocator.authenticationManager,
          analytics: Analytics = ServiceLocator.analytics,
          onStoreNavigation: @escaping (String?) -> Void) {
         self.viewModel = JetpackSetupViewModel(siteURL: siteURL,
                                                connectionOnly: connectionOnly,
+                                               stores: stores,
                                                analytics: analytics,
                                                onStoreNavigation: onStoreNavigation)
         self.authentication = authentication

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackConnectionWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackConnectionWebViewModel.swift
@@ -32,7 +32,9 @@ final class JetpackConnectionWebViewModel: AuthenticatedWebViewModel {
         guard isCompleted == false else {
             return
         }
-        analytics.track(.loginJetpackConnectDismissed)
+        if ServiceLocator.stores.isAuthenticated == false {
+            analytics.track(.loginJetpackConnectDismissed)
+        }
         dismissalHandler()
     }
 
@@ -53,7 +55,9 @@ final class JetpackConnectionWebViewModel: AuthenticatedWebViewModel {
 
     private func handleSetupCompletion() {
         isCompleted = true
-        analytics.track(.loginJetpackConnectCompleted)
+        if ServiceLocator.stores.isAuthenticated == false {
+            analytics.track(.loginJetpackConnectCompleted)
+        }
         completionHandler()
     }
 

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackConnectionWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackConnectionWebViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WebKit
+import Yosemite
 
 /// View model used for the web view controller to setup Jetpack connection during the login flow.
 ///
@@ -11,16 +12,19 @@ final class JetpackConnectionWebViewModel: AuthenticatedWebViewModel {
     let completionHandler: () -> Void
     let dismissalHandler: () -> Void
 
+    private let stores: StoresManager
     private let analytics: Analytics
     private var isCompleted = false
 
     init(initialURL: URL,
          siteURL: String,
          title: String = Localization.title,
+         stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          completion: @escaping () -> Void,
          onDismissal: @escaping () -> Void = {}) {
         self.title = title
+        self.stores = stores
         self.analytics = analytics
         self.initialURL = initialURL
         self.siteURL = siteURL
@@ -32,7 +36,7 @@ final class JetpackConnectionWebViewModel: AuthenticatedWebViewModel {
         guard isCompleted == false else {
             return
         }
-        if ServiceLocator.stores.isAuthenticated == false {
+        if stores.isAuthenticated == false {
             analytics.track(.loginJetpackConnectDismissed)
         }
         dismissalHandler()
@@ -55,7 +59,7 @@ final class JetpackConnectionWebViewModel: AuthenticatedWebViewModel {
 
     private func handleSetupCompletion() {
         isCompleted = true
-        if ServiceLocator.stores.isAuthenticated == false {
+        if stores.isAuthenticated == false {
             analytics.track(.loginJetpackConnectCompleted)
         }
         completionHandler()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JCPJetpackInstall/JetpackInstallSteps.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JCPJetpackInstall/JetpackInstallSteps.swift
@@ -100,19 +100,20 @@ extension JetpackInstallStep {
     /// Description dictionary for Analytics
     ///
     var analyticsDescription: [String: String] {
-        let stepDescription = {
-            switch self {
-            case .installation:
-                return "installation"
-            case .activation:
-                return "activation"
-            case .connection:
-                return "connection"
-            case .done:
-                return "all_done"
-            }
-        }()
-        return ["jetpack_install_step": stepDescription]
+        ["jetpack_install_step": analyticsValue]
+    }
+
+    var analyticsValue: String {
+        switch self {
+        case .installation:
+            return "installation"
+        case .activation:
+            return "activation"
+        case .connection:
+            return "connection"
+        case .done:
+            return "all_done"
+        }
     }
 
     private enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsView.swift
@@ -4,19 +4,17 @@ import Yosemite
 /// Hosting controller wrapper for `JetpackBenefitsView`
 ///
 final class JetpackBenefitsHostingController: UIHostingController<JetpackBenefitsView> {
-    init(siteURL: String, isJetpackCPSite: Bool) {
+    init(siteURL: String, isJetpackCPSite: Bool,
+         onSubmit: @escaping () async -> Void,
+         onDismiss: @escaping () -> Void) {
         let viewModel = JetpackBenefitsViewModel(siteURL: siteURL, isJetpackCPSite: isJetpackCPSite)
-        super.init(rootView: JetpackBenefitsView(viewModel: viewModel))
+        super.init(rootView: JetpackBenefitsView(viewModel: viewModel,
+                                                 onSubmit: onSubmit,
+                                                 onDismiss: onDismiss))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    func setActions(installAction: @escaping (Result<JetpackUser, Error>) -> Void,
-                    dismissAction: @escaping () -> Void) {
-        rootView.installAction = installAction
-        rootView.dismissAction = dismissAction
     }
 }
 
@@ -25,16 +23,20 @@ struct JetpackBenefitsView: View {
 
     private let viewModel: JetpackBenefitsViewModel
 
-    /// Closure invoked when the install button is tapped
-    ///
-    var installAction: (Result<JetpackUser, Error>) -> Void = { _ in }
-
     /// Closure invoked when the "Not Now" button is tapped
     ///
-    var dismissAction: () -> Void = {}
+    private var dismissAction: () -> Void
 
-    init(viewModel: JetpackBenefitsViewModel) {
+    /// Closure invoked when the submit CTA is tapped
+    ///
+    private var onSubmit: () async -> Void
+
+    init(viewModel: JetpackBenefitsViewModel,
+         onSubmit: @escaping () async -> Void,
+         onDismiss: @escaping () -> Void) {
         self.viewModel = viewModel
+        self.onSubmit = onSubmit
+        self.dismissAction = onDismiss
     }
 
     @State private var isPrimaryButtonLoading = false
@@ -85,11 +87,15 @@ struct JetpackBenefitsView: View {
             VStack(spacing: Layout.spacingBetweenCTAs) {
                 // Primary Button to install Jetpack
                 Button(viewModel.isJetpackCPSite ? Localization.installAction : Localization.loginAction) {
+                    if viewModel.isJetpackCPSite {
+                        ServiceLocator.analytics.track(event: .jetpackInstallButtonTapped(source: .benefitsModal))
+                    } else {
+                        ServiceLocator.analytics.track(.jetpackSetupLoginButtonTapped)
+                    }
                     Task { @MainActor in
                         isPrimaryButtonLoading = true
-                        let result = await viewModel.fetchJetpackUser()
+                        await onSubmit()
                         isPrimaryButtonLoading = false
-                        installAction(result)
                     }
                 }
                 .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isPrimaryButtonLoading))
@@ -162,10 +168,10 @@ private extension JetpackBenefitsView {
 
 struct JetpackBenefits_Previews: PreviewProvider {
     static var previews: some View {
-        JetpackBenefitsView(viewModel: .init(siteURL: "https://example.com", isJetpackCPSite: true))
+        JetpackBenefitsView(viewModel: .init(siteURL: "https://example.com", isJetpackCPSite: true), onSubmit: {}, onDismiss: {})
             .preferredColorScheme(.light)
             .previewLayout(.fixed(width: 414, height: 780))
-        JetpackBenefitsView(viewModel: .init(siteURL: "https://example.com", isJetpackCPSite: false))
+        JetpackBenefitsView(viewModel: .init(siteURL: "https://example.com", isJetpackCPSite: false), onSubmit: {}, onDismiss: {})
             .preferredColorScheme(.light)
             .previewLayout(.fixed(width: 800, height: 300))
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/JetpackConnectionPackageSites/JetpackBenefitsViewModel.swift
@@ -1,6 +1,5 @@
 import Experiments
 import Foundation
-import Yosemite
 
 /// View model for `JetpackBenefitsView`
 ///
@@ -14,36 +13,16 @@ final class JetpackBenefitsViewModel {
     /// URL to install Jetpack in wp-admin
     let wpAdminInstallURL: URL?
 
-    private let stores: StoresManager
-
     init(siteURL: String,
          isJetpackCPSite: Bool,
-         stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.isJetpackCPSite = isJetpackCPSite
-        self.stores = stores
         self.wpAdminInstallURL = URL(string: String(format: Constants.jetpackInstallString, siteURL))
         self.shouldShowWebViewForJetpackInstall = !isJetpackCPSite && featureFlagService.isFeatureFlagEnabled(.jetpackSetupWithApplicationPassword) == false
-    }
-
-    @MainActor
-    func fetchJetpackUser() async -> Result<JetpackUser, Error> {
-        guard !isJetpackCPSite else {
-            return .failure(FetchJetpackUserError.notSupportedForJCPSites)
-        }
-        return await withCheckedContinuation { continuation in
-            let action = JetpackConnectionAction.fetchJetpackUser { result in
-                continuation.resume(returning: result)
-            }
-            stores.dispatch(action)
-        }
     }
 }
 
 extension JetpackBenefitsViewModel {
-    enum FetchJetpackUserError: Error, Equatable {
-        case notSupportedForJCPSites
-    }
 
     private enum Constants {
         static let jetpackInstallString = "https://wordpress.com/jetpack/connect?url=%@&from=mobile"

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -154,9 +154,9 @@ private extension JetpackSetupCoordinator {
     }
 
     func startAuthentication(with email: String?) {
-        analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress))
         if let email {
             Task { @MainActor in
+                analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress))
                 await emailLoginViewModel.checkWordPressComAccount(email: email)
             }
         } else {
@@ -311,6 +311,7 @@ private extension JetpackSetupCoordinator {
     }
 
     func showWPComEmailLogin() {
+        analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress))
         let emailLoginController = WPComEmailLoginHostingController(viewModel: emailLoginViewModel)
         let loginNavigationController = LoginNavigationController(rootViewController: emailLoginController)
         rootViewController.dismiss(animated: true) {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -17,7 +17,6 @@ final class JetpackSetupCoordinator {
     private let analytics: Analytics
     private let dotcomAuthScheme: String
 
-    private var benefitsController: JetpackBenefitsHostingController?
     private var loginNavigationController: LoginNavigationController?
     private var setupStepsNavigationController: UINavigationController?
 
@@ -55,7 +54,6 @@ final class JetpackSetupCoordinator {
             self?.rootViewController.dismiss(animated: true, completion: nil)
         })
         rootViewController.present(benefitsController, animated: true, completion: nil)
-        self.benefitsController = benefitsController
     }
 
     func handleAuthenticationUrl(_ url: URL) -> Bool {
@@ -164,12 +162,11 @@ private extension JetpackSetupCoordinator {
         let viewController = AdminRoleRequiredHostingController(siteID: site.siteID, onClose: { [weak self] in
             self?.rootViewController.dismiss(animated: true)
         }, onSuccess: { [weak self] in
-            guard let self else { return }
-            self.benefitsController?.dismiss(animated: true) {
-                self.showWPComEmailLogin()
+            self?.rootViewController.dismiss(animated: true) {
+                self?.showWPComEmailLogin()
             }
         })
-        benefitsController?.present(UINavigationController(rootViewController: viewController), animated: true)
+        rootViewController.topmostPresentedViewController.present(UINavigationController(rootViewController: viewController), animated: true)
     }
 
     /// After magic link login, fetch username and

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -408,8 +408,8 @@ private extension JetpackSetupCoordinator {
 
 // MARK: - Subtypes
 private extension JetpackSetupCoordinator {
-    enum JetpackCheckError: Error {
-        case missingPermission
+    enum JetpackCheckError: Int, Error {
+        case missingPermission = 403
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -57,6 +57,7 @@ final class JetpackSetupCoordinator {
                 self.analytics.track(.jetpackSetupLoginButtonTapped)
                 do {
                     try self.saveJetpackConnectionStateIfPossible(result)
+                    self.analytics.track(event: .JetpackSetup.connectionCheckCompleted(isAlreadyConnected: self.jetpackConnectedEmail != nil, requiresConnectionOnly: self.requiresConnectionOnly))
                     if let connectedEmail = self.jetpackConnectedEmail {
                         self.startAuthentication(with: connectedEmail)
                     } else {
@@ -64,8 +65,10 @@ final class JetpackSetupCoordinator {
                     }
                 } catch JetpackCheckError.missingPermission {
                     self.displayAdminRoleRequiredError()
+                    self.analytics.track(.jetpackSetupConnectionCheckFailed, withError: JetpackCheckError.missingPermission)
                 } catch {
                     DDLogError("⛔️ Jetpack status fetched error: \(error)")
+                    self.analytics.track(.jetpackSetupConnectionCheckFailed, withError: error)
                     self.showAlert(message: Localization.errorCheckingJetpack)
                 }
             } else {
@@ -126,7 +129,6 @@ private extension JetpackSetupCoordinator {
         case .success(let user):
             requiresConnectionOnly = true
             jetpackConnectedEmail = user.wpcomUser?.email
-            analytics.track(event: .JetpackSetup.connectionCheckCompleted(isAlreadyConnected: jetpackConnectedEmail != nil, requiresConnectionOnly: true))
 
         case .failure(let error):
             requiresConnectionOnly = false
@@ -136,18 +138,14 @@ private extension JetpackSetupCoordinator {
                 let roles = stores.sessionManager.defaultRoles
                 if roles.contains(.administrator) {
                     jetpackConnectedEmail = nil
-                    analytics.track(event: .JetpackSetup.connectionCheckCompleted(isAlreadyConnected: false, requiresConnectionOnly: false))
                 } else {
-                    analytics.track(.jetpackSetupConnectionCheckFailed, withError: error)
                     throw JetpackCheckError.missingPermission
                 }
             case AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 403)):
                 /// 403 means the site Jetpack connection is not established yet
                 /// and the user has no permission to handle this.
-                analytics.track(.jetpackSetupConnectionCheckFailed, withError: error)
                 throw JetpackCheckError.missingPermission
             default:
-                analytics.track(.jetpackSetupConnectionCheckFailed, withError: error)
                 throw error
             }
         }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -52,8 +52,9 @@ final class JetpackSetupCoordinator {
         let benefitsController = JetpackBenefitsHostingController(siteURL: site.url, isJetpackCPSite: site.isJetpackCPConnected)
         benefitsController.setActions (installAction: { [weak self] result in
             guard let self else { return }
-            self.analytics.track(event: .jetpackInstallButtonTapped(source: .benefitsModal))
+
             if self.site.isNonJetpackSite {
+                self.analytics.track(.jetpackSetupLoginButtonTapped)
                 do {
                     try self.saveJetpackConnectionStateIfPossible(result)
                     if let connectedEmail = self.jetpackConnectedEmail {
@@ -68,6 +69,7 @@ final class JetpackSetupCoordinator {
                     self.showAlert(message: Localization.errorCheckingJetpack)
                 }
             } else {
+                self.analytics.track(event: .jetpackInstallButtonTapped(source: .benefitsModal))
                 self.presentJCPJetpackInstallFlow()
             }
         }, dismissAction: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -209,6 +209,8 @@ private extension JetpackSetupCoordinator {
     }
 
     func showSetupSteps(username: String, authToken: String) {
+        analytics.track(.jetpackSetupLoginCompleted)
+
         /// WPCom credentials to authenticate the user in the Jetpack connection web view automatically
         let credentials: Credentials = .wpcom(username: username, authToken: authToken, siteAddress: site.url)
         guard jetpackConnectedEmail == nil else {
@@ -239,6 +241,7 @@ private extension JetpackSetupCoordinator {
     }
 
     func authenticateUserAndRefreshSite(with credentials: Credentials) {
+        analytics.track(.jetpackSetupCompleted)
         stores.sessionManager.deleteApplicationPassword()
         stores.authenticate(credentials: credentials)
         let progressView = InProgressViewController(viewProperties: .init(title: Localization.syncingData, message: ""))
@@ -252,6 +255,7 @@ private extension JetpackSetupCoordinator {
                 self.stores.synchronizeEntities { [weak self] in
                     self?.stores.updateDefaultStore(site)
                     self?.rootViewController.dismiss(animated: true, completion: {
+                        self?.analytics.track(.jetpackSetupSynchronizationCompleted)
                         self?.registerForPushNotifications()
                     })
                 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -57,7 +57,10 @@ final class JetpackSetupCoordinator {
                 self.analytics.track(.jetpackSetupLoginButtonTapped)
                 do {
                     try self.saveJetpackConnectionStateIfPossible(result)
-                    self.analytics.track(event: .JetpackSetup.connectionCheckCompleted(isAlreadyConnected: self.jetpackConnectedEmail != nil, requiresConnectionOnly: self.requiresConnectionOnly))
+                    self.analytics.track(event: .JetpackSetup.connectionCheckCompleted(
+                        isAlreadyConnected: self.jetpackConnectedEmail != nil,
+                        requiresConnectionOnly: self.requiresConnectionOnly
+                    ))
                     if let connectedEmail = self.jetpackConnectedEmail {
                         self.startAuthentication(with: connectedEmail)
                     } else {

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -154,6 +154,7 @@ private extension JetpackSetupCoordinator {
     }
 
     func startAuthentication(with email: String?) {
+        analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress))
         if let email {
             Task { @MainActor in
                 await emailLoginViewModel.checkWordPressComAccount(email: email)
@@ -319,11 +320,13 @@ private extension JetpackSetupCoordinator {
     }
 
     func showMagicLinkUI(email: String) {
+        analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink))
         let viewController = WPComMagicLinkHostingController(email: email, requiresConnectionOnly: requiresConnectionOnly)
         loginNavigationController?.pushViewController(viewController, animated: true)
     }
 
     func showPasswordUI(email: String) {
+        analytics.track(event: .JetpackSetup.loginFlow(step: .password))
         let viewModel = WPComPasswordLoginViewModel(
             siteURL: site.url,
             email: email,
@@ -333,6 +336,7 @@ private extension JetpackSetupCoordinator {
             },
             onLoginFailure: { [weak self] error in
                 guard let self else { return }
+                self.analytics.track(event: .JetpackSetup.loginFlow(step: .password, failure: error))
                 let message = error.localizedDescription
                 self.showAlert(message: message)
             },
@@ -360,11 +364,13 @@ private extension JetpackSetupCoordinator {
     }
 
     func show2FALoginUI(with loginFields: LoginFields) {
+        analytics.track(event: .JetpackSetup.loginFlow(step: .verificationCode))
         let viewModel = WPCom2FALoginViewModel(
             loginFields: loginFields,
             requiresConnectionOnly: requiresConnectionOnly,
             onLoginFailure: { [weak self] error in
                 guard let self else { return }
+                self.analytics.track(event: .JetpackSetup.loginFlow(step: .verificationCode, failure: error))
                 let message = error.localizedDescription
                 self.showAlert(message: message)
             },

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
@@ -72,6 +72,7 @@ struct WPCom2FALoginView: View {
             VStack {
                 // Primary CTA
                 Button(viewModel.titleString) {
+                    ServiceLocator.analytics.track(event: .JetpackSetup.loginFlow(step: .verificationCode, tap: .submit))
                     viewModel.handleLogin()
                 }
                 .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLoggingIn))

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPCom2FALoginView.swift
@@ -17,6 +17,13 @@ final class WPCom2FALoginHostingController: UIHostingController<WPCom2FALoginVie
         super.viewDidLoad()
         configureTransparentNavigationBar()
     }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if isMovingFromParent {
+            ServiceLocator.analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink, tap: .dismiss))
+        }
+    }
 }
 
 /// View for 2FA login screen of the custom WPCom login flow for Jetpack setup.

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Hosting controller for `WPComEmailLoginView`
 final class WPComEmailLoginHostingController: UIHostingController<WPComEmailLoginView> {
@@ -20,6 +21,7 @@ final class WPComEmailLoginHostingController: UIHostingController<WPComEmailLogi
     override func viewDidLoad() {
         super.viewDidLoad()
         configureTransparentNavigationBar()
+        presentationController?.delegate = self
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: Localization.cancel, style: .plain, target: self, action: #selector(dismissView))
     }
 
@@ -27,6 +29,14 @@ final class WPComEmailLoginHostingController: UIHostingController<WPComEmailLogi
     private func dismissView() {
         dismiss(animated: true)
         ServiceLocator.analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, tap: .dismiss))
+    }
+}
+
+/// Intercepts to the dismiss drag gesture.
+///
+extension WPComEmailLoginHostingController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
+        return false // disable swipe to dismiss
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
@@ -21,7 +21,7 @@ final class WPComEmailLoginHostingController: UIHostingController<WPComEmailLogi
     override func viewDidLoad() {
         super.viewDidLoad()
         configureTransparentNavigationBar()
-        presentationController?.delegate = self
+        navigationController?.presentationController?.delegate = self
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: Localization.cancel, style: .plain, target: self, action: #selector(dismissView))
     }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
@@ -80,6 +80,7 @@ struct WPComEmailLoginView: View {
             VStack {
                 // Primary CTA
                 Button(viewModel.titleString) {
+                    ServiceLocator.analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, tap: .submit))
                     Task { @MainActor in
                         isPrimaryButtonLoading = true
                         await viewModel.checkWordPressComAccount(email: viewModel.emailAddress)

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginView.swift
@@ -26,6 +26,7 @@ final class WPComEmailLoginHostingController: UIHostingController<WPComEmailLogi
     @objc
     private func dismissView() {
         dismiss(animated: true)
+        ServiceLocator.analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, tap: .dismiss))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComEmailLoginViewModel.swift
@@ -21,6 +21,7 @@ final class WPComEmailLoginViewModel: ObservableObject {
     let termsAttributedString: NSAttributedString
 
     private let accountService: WordPressComAccountServiceProtocol
+    private let analytics: Analytics
     private let onPasswordUIRequest: (String) -> Void
     private let onMagicLinkUIRequest: (String) -> Void
     private let onError: (String) -> Void
@@ -31,9 +32,11 @@ final class WPComEmailLoginViewModel: ObservableObject {
          requiresConnectionOnly: Bool,
          debounceDuration: Double = Constants.fieldDebounceDuration,
          accountService: WordPressComAccountServiceProtocol = WordPressComAccountService(),
+         analytics: Analytics = ServiceLocator.analytics,
          onPasswordUIRequest: @escaping (String) -> Void,
          onMagicLinkUIRequest: @escaping (String) -> Void,
          onError: @escaping (String) -> Void) {
+        self.analytics = analytics
         self.accountService = accountService
         self.onPasswordUIRequest = onPasswordUIRequest
         self.onMagicLinkUIRequest = onMagicLinkUIRequest
@@ -74,6 +77,7 @@ final class WPComEmailLoginViewModel: ObservableObject {
             }
             await startAuthentication(email: email, isPasswordlessAccount: passwordless)
         } catch {
+            analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, failure: error))
             onError(error.localizedDescription)
         }
     }
@@ -100,6 +104,7 @@ final class WPComEmailLoginViewModel: ObservableObject {
             onMagicLinkUIRequest(email)
         } catch {
             onError(error.localizedDescription)
+            analytics.track(event: .JetpackSetup.loginFlow(step: .emailAddress, failure: error))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComMagicLinkView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComMagicLinkView.swift
@@ -67,6 +67,7 @@ struct WPComMagicLinkView: View {
             VStack {
                 // Primary CTA
                 Button(Localization.openMail) {
+                    ServiceLocator.analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink, tap: .submit))
                     onOpenMail()
                 }
                 .buttonStyle(PrimaryButtonStyle())

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComMagicLinkView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComMagicLinkView.swift
@@ -23,6 +23,13 @@ final class WPComMagicLinkHostingController: UIHostingController<WPComMagicLinkV
         super.viewDidLoad()
         configureTransparentNavigationBar()
     }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if isMovingFromParent {
+            ServiceLocator.analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink, tap: .dismiss))
+        }
+    }
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
@@ -92,6 +92,7 @@ struct WPComPasswordLoginView: View {
                 // Primary CTA
                 Button(Localization.primaryAction) {
                     viewModel.handleLogin()
+                    ServiceLocator.analytics.track(event: .JetpackSetup.loginFlow(step: .password, tap: .submit))
                 }
                 .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLoggingIn))
                 .disabled(viewModel.password.isEmpty)

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginView.swift
@@ -19,6 +19,13 @@ final class WPComPasswordLoginHostingController: UIHostingController<WPComPasswo
         super.viewDidLoad()
         configureTransparentNavigationBar()
     }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if isMovingFromParent {
+            ServiceLocator.analytics.track(event: .JetpackSetup.loginFlow(step: .magicLink, tap: .dismiss))
+        }
+    }
 }
 
 /// Screen for entering the password for a WPCom account during the Jetpack setup flow

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2096,7 +2096,7 @@
 		EEB4E2DA29B5F8FC00371C3C /* CouponLineDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2D929B5F8FC00371C3C /* CouponLineDetailsViewModel.swift */; };
 		EEB4E2DC29B600B800371C3C /* CouponLineDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2DB29B600B800371C3C /* CouponLineDetails.swift */; };
 		EEB4E2DE29B61AAD00371C3C /* CouponInputTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2DD29B61AAD00371C3C /* CouponInputTransformer.swift */; };
-		EEC2D27F292CF60E0072132E /* LoginJetpackSetupHostingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC2D27E292CF60E0072132E /* LoginJetpackSetupHostingControllerTests.swift */; };
+		EEC2D27F292CF60E0072132E /* JetpackSetupHostingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC2D27E292CF60E0072132E /* JetpackSetupHostingControllerTests.swift */; };
 		EEC2D281292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC2D280292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift */; };
 		EEC5E01129A70CC300416CAC /* StoreSetupProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5E01029A70CC300416CAC /* StoreSetupProgressView.swift */; };
 		EECB7EE02862115C0028C888 /* MockProductImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB7EDF2862115C0028C888 /* MockProductImageUploader.swift */; };
@@ -4312,7 +4312,7 @@
 		EEB4E2D929B5F8FC00371C3C /* CouponLineDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponLineDetailsViewModel.swift; sourceTree = "<group>"; };
 		EEB4E2DB29B600B800371C3C /* CouponLineDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponLineDetails.swift; sourceTree = "<group>"; };
 		EEB4E2DD29B61AAD00371C3C /* CouponInputTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponInputTransformer.swift; sourceTree = "<group>"; };
-		EEC2D27E292CF60E0072132E /* LoginJetpackSetupHostingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginJetpackSetupHostingControllerTests.swift; sourceTree = "<group>"; };
+		EEC2D27E292CF60E0072132E /* JetpackSetupHostingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupHostingControllerTests.swift; sourceTree = "<group>"; };
 		EEC2D280292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCredentialLoginHostingViewControllerTests.swift; sourceTree = "<group>"; };
 		EEC5E01029A70CC300416CAC /* StoreSetupProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreSetupProgressView.swift; sourceTree = "<group>"; };
 		EECB7EDF2862115C0028C888 /* MockProductImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductImageUploader.swift; sourceTree = "<group>"; };
@@ -9505,7 +9505,7 @@
 			children = (
 				DE2FE58F29261DED0018040A /* SiteCredentialLoginViewModelTests.swift */,
 				DEE183EC292BD900008818AB /* JetpackSetupViewModelTests.swift */,
-				EEC2D27E292CF60E0072132E /* LoginJetpackSetupHostingControllerTests.swift */,
+				EEC2D27E292CF60E0072132E /* JetpackSetupHostingControllerTests.swift */,
 				EEC2D280292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift */,
 				EEAA45FC293073FE0047D125 /* JetpackInstallStepTests.swift */,
 			);
@@ -12241,7 +12241,7 @@
 				022C7D7729793ABE0036568D /* PaidDomainSelectorDataProviderTests.swift in Sources */,
 				03CF78D127C3DBC000523706 /* WCPayCardBrand+IconsTests.swift in Sources */,
 				AEFF77AA29786DAA00667F7A /* PriceInputViewModelTests.swift in Sources */,
-				EEC2D27F292CF60E0072132E /* LoginJetpackSetupHostingControllerTests.swift in Sources */,
+				EEC2D27F292CF60E0072132E /* JetpackSetupHostingControllerTests.swift in Sources */,
 				4535EE82281BE726004212B4 /* CouponCodeInputFormatterTests.swift in Sources */,
 				EEB4E2D829B20F0F00371C3C /* StoreOnboardingTaskViewModel.swift in Sources */,
 				DEF36DEC2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1943,6 +1943,7 @@
 		DE61978F289A5674005E4362 /* NoWooErrorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61978E289A5674005E4362 /* NoWooErrorViewModelTests.swift */; };
 		DE61979328A20C17005E4362 /* StorePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61979228A20C17005E4362 /* StorePickerViewModel.swift */; };
 		DE61979528A25842005E4362 /* StorePickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE61979428A25842005E4362 /* StorePickerViewModelTests.swift */; };
+		DE621F6A29D67E1B000DE3BD /* WooAnalyticsEvent+JetpackSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE621F6929D67E1B000DE3BD /* WooAnalyticsEvent+JetpackSetup.swift */; };
 		DE66C56F2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE66C56E2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift */; };
 		DE67D46726B98FD000EFE8DB /* Publisher+WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */; };
 		DE67D46926BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */; };
@@ -4159,6 +4160,7 @@
 		DE61978E289A5674005E4362 /* NoWooErrorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWooErrorViewModelTests.swift; sourceTree = "<group>"; };
 		DE61979228A20C17005E4362 /* StorePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePickerViewModel.swift; sourceTree = "<group>"; };
 		DE61979428A25842005E4362 /* StorePickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePickerViewModelTests.swift; sourceTree = "<group>"; };
+		DE621F6929D67E1B000DE3BD /* WooAnalyticsEvent+JetpackSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+JetpackSetup.swift"; sourceTree = "<group>"; };
 		DE66C56E2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordDisabledViewModelTests.swift; sourceTree = "<group>"; };
 		DE67D46626B98FD000EFE8DB /* Publisher+WithLatestFrom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFrom.swift"; sourceTree = "<group>"; };
 		DE67D46826BAA82600EFE8DB /* Publisher+WithLatestFromTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithLatestFromTests.swift"; sourceTree = "<group>"; };
@@ -7186,6 +7188,7 @@
 				B946881929BA2AC6000646B0 /* WooAnalyticsEvent+Spotlight.swift */,
 				B9F3DAB029BB83E600DDD545 /* WooAnalyticsEvent+AppIntents.swift */,
 				02B21C5629C9EEF900C5623B /* WooAnalyticsEvent+StoreOnboarding.swift */,
+				DE621F6929D67E1B000DE3BD /* WooAnalyticsEvent+JetpackSetup.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -11558,6 +11561,7 @@
 				4520A15E2722BA3E001FA573 /* OrderDateRangeFilter+Utils.swift in Sources */,
 				DEF8CF0F29A890E900800A60 /* JetpackBenefitsViewModel.swift in Sources */,
 				B946880E29B627EB000646B0 /* SearchableActivityConvertable.swift in Sources */,
+				DE621F6A29D67E1B000DE3BD /* WooAnalyticsEvent+JetpackSetup.swift in Sources */,
 				DEE183F1292E0ED0008818AB /* JetpackSetupInterruptedView.swift in Sources */,
 				028A465329597A91001CF6CE /* StoreCreationSellingPlatformsQuestionViewModel.swift in Sources */,
 				027CB045295D7B8B00F98F7C /* StoreCreationCountryQuestionViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupHostingControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupHostingControllerTests.swift
@@ -3,9 +3,9 @@ import XCTest
 
 @testable import WooCommerce
 
-/// Test cases for `LoginJetpackSetupHostingController`.
+/// Test cases for `JetpackSetupHostingController`.
 ///
-final class LoginJetpackSetupHostingControllerTests: XCTestCase {
+final class JetpackSetupHostingControllerTests: XCTestCase {
     private let testURL = "https://test.com"
 
     func test_it_tracks_login_jetpack_setup_screen_viewed_when_view_loads() throws {

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupHostingControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupHostingControllerTests.swift
@@ -8,11 +8,16 @@ import XCTest
 final class JetpackSetupHostingControllerTests: XCTestCase {
     private let testURL = "https://test.com"
 
-    func test_it_tracks_login_jetpack_setup_screen_viewed_when_view_loads() throws {
+    func test_it_tracks_login_jetpack_setup_screen_viewed_when_view_loads_for_unauthenticated_users() throws {
         // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewController = JetpackSetupHostingController(siteURL: testURL, connectionOnly: true, analytics: analytics, onStoreNavigation: { _ in })
+        let viewController = JetpackSetupHostingController(siteURL: testURL,
+                                                           connectionOnly: true,
+                                                           stores: stores,
+                                                           analytics: analytics,
+                                                           onStoreNavigation: { _ in })
 
         // When
         _ = try XCTUnwrap(viewController.view)
@@ -21,11 +26,16 @@ final class JetpackSetupHostingControllerTests: XCTestCase {
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_setup_screen_viewed" }))
     }
 
-    func test_it_tracks_login_jetpack_setup_screen_dismissed_when_view_is_dismissed() throws {
+    func test_it_tracks_login_jetpack_setup_screen_dismissed_when_view_is_dismissed_for_unauthenticated_users() throws {
         // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewController = JetpackSetupHostingController(siteURL: testURL, connectionOnly: true, analytics: analytics, onStoreNavigation: { _ in })
+        let viewController = JetpackSetupHostingController(siteURL: testURL,
+                                                           connectionOnly: true,
+                                                           stores: stores,
+                                                           analytics: analytics,
+                                                           onStoreNavigation: { _ in })
 
         // When
         _ = try XCTUnwrap(viewController.view)

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
@@ -733,9 +733,10 @@ final class JetpackSetupViewModelTests: XCTestCase {
     // MARK: - Analytics
     func test_it_tracks_login_jetpack_setup_go_to_store_button_tapped_when_tapping_go_to_store_button() {
         // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, analytics: analytics)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
 
         // When
         // Tapping "Go to Store" button
@@ -743,11 +744,12 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_setup_go_to_store_button_tapped" }))
+        XCTAssertNil(analyticsProvider.receivedEvents.first(where: { $0 == "jetpack_setup_flow" }))
     }
 
     func test_it_tracks_correct_event_when_jetpack_installation_is_successful() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
@@ -769,11 +771,12 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_setup_install_successful" }))
+        XCTAssertNil(analyticsProvider.receivedEvents.first(where: { $0 == "jetpack_setup_flow" }))
     }
 
     func test_it_tracks_correct_event_when_jetpack_installation_fails() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
@@ -795,11 +798,12 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_setup_install_failed" }))
+        XCTAssertNil(analyticsProvider.receivedEvents.first(where: { $0 == "jetpack_setup_flow" }))
     }
 
     func test_it_tracks_correct_event_when_jetpack_activation_is_successful() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
@@ -823,11 +827,12 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_setup_activation_successful" }))
+        XCTAssertNil(analyticsProvider.receivedEvents.first(where: { $0 == "jetpack_setup_flow" }))
     }
 
     func test_it_tracks_correct_event_when_jetpack_activation_fails() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
@@ -850,11 +855,12 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_setup_activation_failed" }))
+        XCTAssertNil(analyticsProvider.receivedEvents.first(where: { $0 == "jetpack_setup_flow" }))
     }
 
     func test_it_tracks_correct_event_when_fetching_jetpack_connection_url_is_successful() throws {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
@@ -881,11 +887,12 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_setup_fetch_jetpack_connection_url_successful" }))
+        XCTAssertNil(analyticsProvider.receivedEvents.first(where: { $0 == "jetpack_setup_flow" }))
     }
 
     func test_it_tracks_correct_event_when_fetching_jetpack_connection_url_fails() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
@@ -911,11 +918,12 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_setup_fetch_jetpack_connection_url_failed" }))
+        XCTAssertNil(analyticsProvider.receivedEvents.first(where: { $0 == "jetpack_setup_flow" }))
     }
 
     func test_it_tracks_correct_event_when_checking_jetpack_connection_is_successful() throws {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
@@ -935,11 +943,12 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_setup_all_steps_marked_done" }))
+        XCTAssertNil(analyticsProvider.receivedEvents.first(where: { $0 == "jetpack_setup_flow" }))
     }
 
     func test_it_tracks_correct_event_when_checking_jetpack_connection_is_successful_but_no_wpCom_user_present() throws {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
@@ -959,11 +968,12 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_setup_cannot_find_WPCOM_user" }))
+        XCTAssertNil(analyticsProvider.receivedEvents.first(where: { $0 == "jetpack_setup_flow" }))
     }
 
     func test_it_tracks_correct_event_when_checking_jetpack_connection_fails() throws {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
@@ -987,18 +997,21 @@ final class JetpackSetupViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_setup_error_checking_jetpack_connection" }))
+        XCTAssertNil(analyticsProvider.receivedEvents.first(where: { $0 == "jetpack_setup_flow" }))
     }
 
-    func test_it_tracks_correct_event_when_retying_setup() {
+    func test_it_tracks_correct_event_when_retrying_setup() {
         // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
-        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, analytics: analytics)
+        let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
 
         // When
         viewModel.retryAllSteps()
 
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "login_jetpack_setup_try_again_button_tapped" }))
+        XCTAssertNil(analyticsProvider.receivedEvents.first(where: { $0 == "jetpack_setup_flow" }))
     }
 }

--- a/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
+++ b/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
@@ -17,7 +17,7 @@ extension SessionManager {
 
     /// Create an instance of unit testing.
     ///
-    static func makeForTesting(authenticated: Bool = false, isWPCom: Bool = true) -> SessionManager {
+    static func makeForTesting(authenticated: Bool = false, isWPCom: Bool = true, defaultRoles: [User.Role] = [.administrator]) -> SessionManager {
         let manager = SessionManager(defaults: SessionSettings.defaults, keychainServiceName: SessionSettings.keychainServiceName)
         // Force setting to `nil` if `authenticated` is `false` so that any auto-loaded credentials
         // will be removed.
@@ -26,6 +26,7 @@ extension SessionManager {
         }()
         manager.defaultCredentials = authenticated ? credentials : nil
         manager.setStoreId(nil)
+        manager.defaultRoles = defaultRoles
         return manager
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/JetpackInstall/JetpackBenefitsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/JetpackInstall/JetpackBenefitsViewModelTests.swift
@@ -6,62 +6,6 @@ import XCTest
 final class JetpackBenefitsViewModelTests: XCTestCase {
     private let siteURL = "https://example.com"
 
-    func test_fetchJetpackUser_returns_error_for_jcp_sites() async {
-        // Given
-        let viewModel = JetpackBenefitsViewModel(siteURL: siteURL, isJetpackCPSite: true)
-
-        // When
-        let result = await viewModel.fetchJetpackUser()
-
-        // Then
-        XCTAssertEqual(result.failure as? JetpackBenefitsViewModel.FetchJetpackUserError,
-                       JetpackBenefitsViewModel.FetchJetpackUserError.notSupportedForJCPSites)
-    }
-
-    func test_fetchJetpackUser_returns_result_from_jetpack_fetch_correctly() async throws {
-        // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackBenefitsViewModel(siteURL: siteURL, isJetpackCPSite: false, stores: stores)
-        let testUser = JetpackUser.fake().copy(username: "test")
-
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackUser(let completion):
-                completion(.success(testUser))
-            default:
-                break
-            }
-        }
-
-        // When
-        let result = await viewModel.fetchJetpackUser()
-
-        //  Then
-        XCTAssertEqual(try result.get().username, testUser.username)
-    }
-
-    func test_fetchJetpackUser_relays_error_from_jetpack_fetch() async throws {
-        // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let viewModel = JetpackBenefitsViewModel(siteURL: siteURL, isJetpackCPSite: false, stores: stores)
-        let testError = NSError(domain: "Test", code: 404)
-
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case .fetchJetpackUser(let completion):
-                completion(.failure(testError))
-            default:
-                break
-            }
-        }
-
-        // When
-        let result = await viewModel.fetchJetpackUser()
-
-        //  Then
-        XCTAssertEqual(result.failure as? NSError, testError)
-    }
-
     func test_shouldShowWebViewForJetpackInstall_is_false_for_jcp_sites() {
         // Given
         let viewModel = JetpackBenefitsViewModel(siteURL: siteURL, isJetpackCPSite: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -96,6 +96,35 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
         XCTAssertTrue(result)
     }
 
+    func test_handleAuthenticationUrl_presents_role_error_if_user_does_not_have_admin_role() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false, defaultRoles: [.shopManager]))
+        let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
+        let expectedScheme = "scheme"
+        let coordinator = JetpackSetupCoordinator(site: testSite, dotcomAuthScheme: expectedScheme, rootViewController: navigationController, stores: stores)
+        let url = try XCTUnwrap(URL(string: "scheme://magic-login?token=test"))
+
+        let expectedAccount = Account(userID: 123, displayName: "Test", email: "test@example.com", username: "test", gravatarUrl: nil)
+        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
+            switch action {
+            case let .loadWPComAccount(_, onCompletion):
+                onCompletion(expectedAccount)
+            case let .fetchJetpackUser(completion):
+                completion(.success(JetpackUser.fake()))
+            default:
+                break
+            }
+        }
+
+        // When
+        _ = coordinator.handleAuthenticationUrl(url)
+
+        // Then
+        waitUntil {
+            (self.navigationController.presentedViewController as? UINavigationController)?.topViewController is AdminRoleRequiredHostingController
+        }
+    }
+
     func test_handleAuthenticationUrl_presents_jetpack_setup_flow_after_fetching_wpcom_account_and_jetpack_user() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8919 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds analytics for the Jetpack setup flow with application passwords.
Also added some refactoring:
- Updated JetpackBenefitView and view model to reuse the Jetpack check from the setup coordinator.
- Updated JetpackSetupViewModel to track both cases when the setup is handled during and after login.
- Disabled swipe to dismiss on the wpcom login flow during Jetpack setup.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: make sure that you have a self-hosted Woo store without Jetpack.
- On the dashboard screen, tap the Jetpack benefit banner at the bottom or navigate to Menu > Settings > Install Jetpack.
- Tap the button Log in to continue. Notice in Xcode console: `🔵 Tracked jetpack_benfits_login_button_tapped, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("blog_id"): -1]`.
- When the Jetpack check completes successfully, you should see in Xcode console: `🔵 Tracked jetpack_setup_connection_check_completed, properties: [AnyHashable("blog_id"): -1, AnyHashable("is_wpcom_store"): false, AnyHashable("is_already_connected"): false, AnyHashable("requires_connection_only"): true]` with `is_already_connected` and `requires_connection_only` reflects the correct connection state of your store.
- When the login screen is displayed, a new event is tracked: `🔵 Tracked jetpack_setup_login_flow, properties: [AnyHashable("step"): "email_address", AnyHashable("is_wpcom_store"): false, AnyHashable("blog_id"): -1]`.
- Proceed to log in with incorrect username/password/magic link/2FA code, you should see the correct step, error and submit events being tracked properly following the events listed in #8919.
- When the login completes, the Jetpack setup flow is presented. Then the correct steps should be tracked: `🔵 Tracked jetpack_setup_flow, properties: [AnyHashable("blog_id"): -1, AnyHashable("is_wpcom_store"): false, AnyHashable("step"): "connection"]`. Notice that the events are tracked correctly; no events with the prefix `login_jetpack` are tracked.
- When Jetpack setup completes, you should see event: `🔵 Tracked jetpack_setup_flow, properties: [AnyHashable("blog_id"): -1, AnyHashable("is_wpcom_store"): false, AnyHashable("step"): "all_done"]`.
- Tap the "Go to Store" button, you should then see events with blog ID other than -1, and after all synchronization is done, Xcode console should log: `🔵 Tracked jetpack_setup_synchronization_completed, properties: [AnyHashable("blog_id"): 216745888, AnyHashable("is_wpcom_store"): false]`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
