### PR TITLE
[Store creation] Present store creation after login

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -584,17 +584,6 @@ private extension AuthenticationManager {
                           source: SignInSource? = nil,
                           in navigationController: UINavigationController,
                           onDismiss: @escaping () -> Void = {}) {
-        // Start the store creation process if the user
-        // logged in from the store creation flow.
-        if case .custom(let source) = source,
-           let storeCreationSource = LoggedOutStoreCreationCoordinator.Source(rawValue: source),
-           storeCreationSource == .prologue {
-            let coordinator = StoreCreationCoordinator(source: .loggedOut(source: storeCreationSource),
-                                                       navigationController: navigationController)
-            self.storeCreationCoordinator = coordinator
-            return coordinator.start()
-        }
-
         // Start the store picker
         let config: StorePickerConfiguration = {
             switch source {
@@ -614,6 +603,17 @@ private extension AuthenticationManager {
             storePickerCoordinator?.didSelectStore(with: siteID, onCompletion: onDismiss)
         } else {
             storePickerCoordinator?.start()
+        }
+
+        // Start the store creation process if the user
+        // logged in from the store creation flow.
+        if case .custom(let source) = source,
+           let storeCreationSource = LoggedOutStoreCreationCoordinator.Source(rawValue: source),
+           storeCreationSource == .prologue {
+            let coordinator = StoreCreationCoordinator(source: .loggedOut(source: storeCreationSource),
+                                                       navigationController: navigationController)
+            self.storeCreationCoordinator = coordinator
+            coordinator.start()
         }
     }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -178,8 +178,9 @@ private extension StorePickerConfiguration {
             return .fullscreen
         case .switchingStores:
             return .modally
-        case .storeCreationFromLogin:
-            return .navigationStack(animated: true)
+        case .storeCreationFromLogin(let source):
+            let willPresentStoreCreationScreenAfterNavigation = source == .prologue
+            return .navigationStack(animated: willPresentStoreCreationScreenAfterNavigation ? false : true)
         default:
             return .navigationStack(animated: true)
         }


### PR DESCRIPTION
Closes: #9351 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Presents store creation flow after the user logs in by tapping the "Get Started" button from the prologue screen. 

## Testing instructions

- Launch the app
- Tap on "Get Started" button to open the sign up screen
- Tap on "Log in" and login using your WPCOM account
- After login, verify that you are navigated to the following screen to begin the store creation flow.
- <img src="https://user-images.githubusercontent.com/524475/229454961-778a0fa3-eb27-4dd8-b6b3-a913c43dba48.png" width="300"/>
- Previously the user was being navigated to the store picker screen

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
