### PR TITLE
Update code to avoid new Xcode 14.3 warnings 

### DIFF
--- a/Networking/Networking/Remote/PaymentRemote.swift
+++ b/Networking/Networking/Remote/PaymentRemote.swift
@@ -98,7 +98,7 @@ public class PaymentRemote: Remote, PaymentRemoteProtocol {
                     "extra": [
                         "privacy": domain.supportsPrivacy
                     ]
-                ]
+                ] as [String: Any]
             ],
             "temporary": isTemporary
         ]

--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -59,7 +59,7 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
                 "theme": flow.theme,
                 "use_theme_annotation": false,
                 "wpcom_public_coming_soon": 1
-            ]
+            ] as [String: Any]
         ]
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters)
 

--- a/Networking/NetworkingTests/Mapper/RefundMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/RefundMapperTests.swift
@@ -100,7 +100,7 @@ final class RefundMapperTests: XCTestCase {
                     "refund_tax": [
                         "\(refund.items[0].taxes[0].taxID)": refund.items[0].taxes[0].total
                     ]
-                ]
+                ] as [String: Any]
             ]
         ]
 
@@ -128,7 +128,7 @@ final class RefundMapperTests: XCTestCase {
                     "qty": refund.items[0].quantity,
                     "refund_total": refund.items[0].total,
                     "refund_tax": [:]
-                ]
+                ] as [String: Any]
             ]
         ]
 

--- a/Networking/NetworkingTests/Mapper/RefundMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/RefundMapperTests.swift
@@ -127,7 +127,7 @@ final class RefundMapperTests: XCTestCase {
                 "\(refund.items[0].itemID)": [
                     "qty": refund.items[0].quantity,
                     "refund_total": refund.items[0].total,
-                    "refund_tax": [:]
+                    "refund_tax": [String: Any]()
                 ] as [String: Any]
             ]
         ]

--- a/Storage/StorageTests/CoreData/MigrationTests.swift
+++ b/Storage/StorageTests/CoreData/MigrationTests.swift
@@ -1969,7 +1969,7 @@ private extension MigrationTests {
             "shippingRequired": false,
             "shippingTaxable": false,
             "reviewsAllowed": true,
-            "groupedProducts": [],
+            "groupedProducts": [Int64](),
             "virtual": true,
             "stockStatusKey": "",
             "statusKey": "",
@@ -2155,7 +2155,7 @@ private extension MigrationTests {
             "title": "WooCommerce Payments",
             "gatewayDescription": "WooCommerce Payments - easy payments by Woo",
             "enabled": true,
-            "features": []
+            "features": [String]()
         ])
     }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1369,15 +1369,15 @@ extension WooAnalyticsEvent {
                 }
                 switch paymentMethod {
                 case let .cardPresent(details):
-                    return [
+                    return ([
                         "underlyingError": underlyingError,
                         "cardBrand": details.brand
-                    ].description
+                    ] as [String: Any]).description
                 case let .interacPresent(details):
-                    return [
+                    return ([
                         "underlyingError": underlyingError,
                         "cardBrand": details.brand
-                    ].description
+                    ] as [String: Any]).description
                 default:
                     return underlyingError.localizedDescription
                 }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -269,7 +269,7 @@ private extension StoreCreationCoordinator {
     @MainActor
     func syncSites(forSiteThatMatchesPossibleURLs possibleURLs: Set<String>) async throws -> Site {
         return try await withCheckedThrowingContinuation { [weak self] continuation in
-            storePickerViewModel.refreshSites(currentlySelectedSiteID: nil) { [weak self] in
+            self?.storePickerViewModel.refreshSites(currentlySelectedSiteID: nil) { [weak self] in
                 guard let self else {
                     return continuation.resume(throwing: StoreCreationCoordinatorError.selfDeallocated)
                 }
@@ -683,7 +683,7 @@ private extension StoreCreationCoordinator {
     @MainActor
     func syncSites(forSiteThatMatchesSiteID siteID: Int64, expectedStoreName: String) async throws -> Site {
         return try await withCheckedThrowingContinuation { [weak self] continuation in
-            storePickerViewModel.refreshSites(currentlySelectedSiteID: nil) { [weak self] in
+            self?.storePickerViewModel.refreshSites(currentlySelectedSiteID: nil) { [weak self] in
                 guard let self else {
                     return continuation.resume(throwing: StoreCreationCoordinatorError.selfDeallocated)
                 }

--- a/WooCommerce/Classes/Tools/Logging/Dictionary+Logging.swift
+++ b/WooCommerce/Classes/Tools/Logging/Dictionary+Logging.swift
@@ -21,7 +21,7 @@ extension Dictionary where Key == String {
                     "Code": nsError.code,
                     "Description": nsError.localizedDescription,
                     "User Info": nsError.userInfo.description
-                ]
+                ] as [String: Any]
                 return formattedProperties
             }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -219,8 +219,8 @@ final class DashboardViewModel {
                 }
             }
 
-            Task { @MainActor in
-                stores.dispatch(action)
+            Task { @MainActor [weak self] in
+                self?.stores.dispatch(action)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UpdateProgressImage.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UpdateProgressImage.swift
@@ -63,9 +63,7 @@ struct UpdateProgressImage_Previews: PreviewProvider {
 
         var body: some View {
             VStack {
-                if let image = UIImage.softwareUpdateProgress(progress: complete) {
-                    Image(uiImage: image)
-                }
+                Image(uiImage: UIImage.softwareUpdateProgress(progress: complete))
                 Slider(value: $complete, in: 0...1)
             }
         }

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -607,7 +607,7 @@ private extension PushNotificationsManagerTests {
                     "subtitle": subtitle,
                     "body": message
                 ]
-            ],
+            ] as [String: Any],
             "note_id": noteID,
             "type": type.rawValue,
             "blog": siteID

--- a/WooCommerce/WooCommerceTests/Tools/MockShippingLabelAccountSettings.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockShippingLabelAccountSettings.swift
@@ -1,3 +1,4 @@
+import Networking
 import Yosemite
 
 /// Generates mock `ShippingLabelAccountSettings`


### PR DESCRIPTION
## Description

If you build `trunk` in Xcode 14.3, you'll see a bunch of new warnings. This PR addresses them and the cool thing is that every change is compatible with Xcode 14.2

## Testing instructions
Build the app from this branch and observe only the expected/known warnings are shown.

## Next Steps

https://github.com/woocommerce/woocommerce-ios/pull/9356

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
