### PR TITLE
[Speedy IPP] Retrieve products based on popularity

### DIFF
--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -63,10 +63,10 @@ public enum ProductAction: Action {
         pageSize: Int = ProductsRemote.Default.pageSize,
         onCompletion: (Result<(products: [Product], hasNextPage: Bool), Error>) -> Void)
 
-    /// Retrieve cached products sorted by popularity, that is, those that were included
+    /// Retrieve cached popular products, that is, those that were included
     /// in a completed order most often, in descending order.
     ///
-    case retrieveProductsInCacheSortedByDescendingPopularity(siteID: Int64, onCompletion: ([Product]) -> Void)
+    case retrievePopularCachedProducts(siteID: Int64, onCompletion: ([Product]) -> Void)
 
     /// Deletes all of the cached products.
     ///

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -63,6 +63,12 @@ public enum ProductAction: Action {
         pageSize: Int = ProductsRemote.Default.pageSize,
         onCompletion: (Result<(products: [Product], hasNextPage: Bool), Error>) -> Void)
 
+    /// Retrieve cached products sorted by popularity, that is, those that were included
+    /// in a completed order most often.
+    ///
+    case retrieveMostPopularProductsInCache(siteID: Int64,
+                                            onCompletion: ([Product]) -> Void)
+
     /// Deletes all of the cached products.
     ///
     case resetStoredProducts(onCompletion: () -> Void)

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -66,8 +66,7 @@ public enum ProductAction: Action {
     /// Retrieve cached products sorted by popularity, that is, those that were included
     /// in a completed order most often, in descending order.
     ///
-    case retrieveProductsInCacheSortedByDescendingPopularity(siteID: Int64,
-                                            onCompletion: ([Product]) -> Void)
+    case retrieveProductsInCacheSortedByDescendingPopularity(siteID: Int64, onCompletion: ([Product]) -> Void)
 
     /// Deletes all of the cached products.
     ///

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -64,9 +64,9 @@ public enum ProductAction: Action {
         onCompletion: (Result<(products: [Product], hasNextPage: Bool), Error>) -> Void)
 
     /// Retrieve cached products sorted by popularity, that is, those that were included
-    /// in a completed order most often.
+    /// in a completed order most often, in descending order.
     ///
-    case retrieveMostPopularProductsInCache(siteID: Int64,
+    case retrieveProductsInCacheSortedByDescendingPopularity(siteID: Int64,
                                             onCompletion: ([Product]) -> Void)
 
     /// Deletes all of the cached products.

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -193,6 +193,7 @@ public typealias StorageInboxNote = Storage.InboxNote
 public typealias StorageInboxAction = Storage.InboxAction
 public typealias StorageNote = Storage.Note
 public typealias StorageOrder = Storage.Order
+public typealias StorageOrderItem = Storage.OrderItem
 public typealias StorageOrderItemAttribute = Storage.OrderItemAttribute
 public typealias StorageOrderItemRefund = Storage.OrderItemRefund
 public typealias StorageOrderNote = Storage.OrderNote

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -350,8 +350,6 @@ private extension ProductStore {
         onCompletion(products)
     }
 
-
-
     /// Adds a product.
     ///
     func addProduct(product: Product, onCompletion: @escaping (Result<Product, ProductUpdateError>) -> Void) {

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -46,8 +46,8 @@ public class ProductStore: Store {
             retrieveProduct(siteID: siteID, productID: productID, onCompletion: onCompletion)
         case .retrieveProducts(let siteID, let productIDs, let pageNumber, let pageSize, let onCompletion):
             retrieveProducts(siteID: siteID, productIDs: productIDs, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
-        case .retrieveMostPopularProductsInCache(let siteID, let onCompletion):
-            retrieveMostPopularProductsInCache(siteID: siteID, onCompletion: onCompletion)
+        case .retrieveProductsInCacheSortedByDescendingPopularity(let siteID, let onCompletion):
+            retrieveProductsInCacheSortedByDescendingPopularity(siteID: siteID, onCompletion: onCompletion)
         case let.searchProductsInCache(siteID, keyword, pageSize, onCompletion):
             searchInCache(siteID: siteID, keyword: keyword, pageSize: pageSize, onCompletion: onCompletion)
         case let .searchProducts(siteID,
@@ -321,7 +321,7 @@ private extension ProductStore {
         }
     }
 
-    func retrieveMostPopularProductsInCache(siteID: Int64, onCompletion: @escaping ([Product]) -> Void) {
+    func retrieveProductsInCacheSortedByDescendingPopularity(siteID: Int64, onCompletion: @escaping ([Product]) -> Void) {
         // Get completed orders
         let completedOrderPredicate = NSPredicate(format: "statusKey ==[c] %@", OrderStatusEnum.completed.rawValue)
         let sitePredicate = NSPredicate(format: "siteID == %lld", siteID)

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -46,8 +46,8 @@ public class ProductStore: Store {
             retrieveProduct(siteID: siteID, productID: productID, onCompletion: onCompletion)
         case .retrieveProducts(let siteID, let productIDs, let pageNumber, let pageSize, let onCompletion):
             retrieveProducts(siteID: siteID, productIDs: productIDs, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
-        case .retrieveProductsInCacheSortedByDescendingPopularity(let siteID, let onCompletion):
-            retrieveProductsInCacheSortedByDescendingPopularity(siteID: siteID, onCompletion: onCompletion)
+        case .retrievePopularCachedProducts(let siteID, let onCompletion):
+            retrievePopularCachedProducts(siteID: siteID, onCompletion: onCompletion)
         case let.searchProductsInCache(siteID, keyword, pageSize, onCompletion):
             searchInCache(siteID: siteID, keyword: keyword, pageSize: pageSize, onCompletion: onCompletion)
         case let .searchProducts(siteID,
@@ -321,7 +321,7 @@ private extension ProductStore {
         }
     }
 
-    func retrieveProductsInCacheSortedByDescendingPopularity(siteID: Int64, onCompletion: @escaping ([Product]) -> Void) {
+    func retrievePopularCachedProducts(siteID: Int64, onCompletion: @escaping ([Product]) -> Void) {
         // Get completed orders
         let completedOrderPredicate = NSPredicate(format: "statusKey ==[c] %@", OrderStatusEnum.completed.rawValue)
         let sitePredicate = NSPredicate(format: "siteID == %lld", siteID)

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
@@ -141,6 +141,14 @@ extension MockStorageManager {
         return newOrder
     }
 
+    @discardableResult
+    func insertSampleOrderItem(readOnlyOrderItem: OrderItem) -> StorageOrderItem {
+        let newOrderItem = viewStorage.insertNewObject(ofType: StorageOrderItem.self)
+        newOrderItem.update(with: readOnlyOrderItem)
+
+        return newOrderItem
+    }
+
     /// Inserts a new (Sample) Coupon into the specified context.
     ///
     @discardableResult

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -787,7 +787,7 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         let cachedPopularProducts: [Yosemite.Product] = waitFor { promise in
-            let action = ProductAction.retrieveMostPopularProductsInCache(siteID: self.sampleSiteID, onCompletion: { result in
+            let action = ProductAction.retrieveProductsInCacheSortedByDescendingPopularity(siteID: self.sampleSiteID, onCompletion: { result in
                 promise(result)
             })
 
@@ -827,7 +827,7 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         let cachedPopularProducts: [Yosemite.Product] = waitFor { promise in
-            let action = ProductAction.retrieveMostPopularProductsInCache(siteID: self.sampleSiteID, onCompletion: { result in
+            let action = ProductAction.retrieveProductsInCacheSortedByDescendingPopularity(siteID: self.sampleSiteID, onCompletion: { result in
                 promise(result)
             })
 
@@ -865,7 +865,7 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         let cachedPopularProducts: [Yosemite.Product] = waitFor { promise in
-            let action = ProductAction.retrieveMostPopularProductsInCache(siteID: 555, onCompletion: { result in
+            let action = ProductAction.retrieveProductsInCacheSortedByDescendingPopularity(siteID: 555, onCompletion: { result in
                 promise(result)
             })
 

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -787,7 +787,7 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         let cachedPopularProducts: [Yosemite.Product] = waitFor { promise in
-            let action = ProductAction.retrieveProductsInCacheSortedByDescendingPopularity(siteID: self.sampleSiteID, onCompletion: { result in
+            let action = ProductAction.retrievePopularCachedProducts(siteID: self.sampleSiteID, onCompletion: { result in
                 promise(result)
             })
 
@@ -827,7 +827,7 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         let cachedPopularProducts: [Yosemite.Product] = waitFor { promise in
-            let action = ProductAction.retrieveProductsInCacheSortedByDescendingPopularity(siteID: self.sampleSiteID, onCompletion: { result in
+            let action = ProductAction.retrievePopularCachedProducts(siteID: self.sampleSiteID, onCompletion: { result in
                 promise(result)
             })
 
@@ -865,7 +865,7 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         let cachedPopularProducts: [Yosemite.Product] = waitFor { promise in
-            let action = ProductAction.retrieveProductsInCacheSortedByDescendingPopularity(siteID: 555, onCompletion: { result in
+            let action = ProductAction.retrievePopularCachedProducts(siteID: 555, onCompletion: { result in
                 promise(result)
             })
 

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -760,28 +760,8 @@ final class ProductStoreTests: XCTestCase {
     // MARK: - ProductAction.retrieveMostPopularProductsInCache
 
     func test_retrieveMostPopularProductsInCache_when_there_are_several_popular_products_returns_them_sorted() {
-        let firstProductID: Int64 = 1
-        let secondProductID: Int64 = 2
-        let thirdProductID: Int64 = 3
-
-        storageManager.insertSampleProduct(readOnlyProduct: Product.fake().copy(productID: firstProductID))
-        storageManager.insertSampleProduct(readOnlyProduct: Product.fake().copy(productID: secondProductID))
-        storageManager.insertSampleProduct(readOnlyProduct: Product.fake().copy(productID: thirdProductID))
-
-        let firstOrderItem = OrderItem.fake().copy(productID: firstProductID)
-        let secondOrderItem = OrderItem.fake().copy(productID: secondProductID)
-        let thirdOrderItem = OrderItem.fake().copy(productID: thirdProductID)
-
-        let firstOrder = Order.fake().copy(siteID: sampleSiteID, status: .completed)
-        let secondOrder = Order.fake().copy(siteID: sampleSiteID, status: .completed)
-        let thirdOrder = Order.fake().copy(siteID: sampleSiteID, status: .completed)
-
-        storageManager.insertSampleOrder(readOnlyOrder: firstOrder).items = [storageManager.insertSampleOrderItem(readOnlyOrderItem: firstOrderItem)]
-        storageManager.insertSampleOrder(readOnlyOrder: secondOrder).items = [storageManager.insertSampleOrderItem(readOnlyOrderItem: firstOrderItem),
-                                                                              storageManager.insertSampleOrderItem(readOnlyOrderItem: secondOrderItem)]
-        storageManager.insertSampleOrder(readOnlyOrder: thirdOrder).items = [storageManager.insertSampleOrderItem(readOnlyOrderItem: firstOrderItem),
-                                                                             storageManager.insertSampleOrderItem(readOnlyOrderItem: secondOrderItem),
-                                                                             storageManager.insertSampleOrderItem(readOnlyOrderItem: thirdOrderItem)]
+        let productIDs: [Int64] = [1, 2, 3]
+        preparePopularProductsSamples(with: productIDs)
 
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
@@ -794,34 +774,13 @@ final class ProductStoreTests: XCTestCase {
             store.onAction(action)
         }
 
-        XCTAssertEqual(cachedPopularProducts.first?.productID, firstProductID)
-        XCTAssertEqual(cachedPopularProducts[1].productID, secondProductID)
-        XCTAssertEqual(cachedPopularProducts.last?.productID, thirdProductID)
+        XCTAssertEqual(cachedPopularProducts.first?.productID, productIDs.first)
+        XCTAssertEqual(cachedPopularProducts[1].productID, productIDs[1])
+        XCTAssertEqual(cachedPopularProducts.last?.productID, productIDs.last)
     }
 
     func test_retrieveMostPopularProductsInCache_when_there_are_several_popular_products_but_orders_are_not_completed_returns_empty_array() {
-        let firstProductID: Int64 = 1
-        let secondProductID: Int64 = 2
-        let thirdProductID: Int64 = 3
-
-        storageManager.insertSampleProduct(readOnlyProduct: Product.fake().copy(productID: firstProductID))
-        storageManager.insertSampleProduct(readOnlyProduct: Product.fake().copy(productID: secondProductID))
-        storageManager.insertSampleProduct(readOnlyProduct: Product.fake().copy(productID: thirdProductID))
-
-        let firstOrderItem = OrderItem.fake().copy(productID: firstProductID)
-        let secondOrderItem = OrderItem.fake().copy(productID: secondProductID)
-        let thirdOrderItem = OrderItem.fake().copy(productID: thirdProductID)
-
-        let firstOrder = Order.fake().copy(siteID: sampleSiteID, status: .pending)
-        let secondOrder = Order.fake().copy(siteID: sampleSiteID, status: .pending)
-        let thirdOrder = Order.fake().copy(siteID: sampleSiteID, status: .pending)
-
-        storageManager.insertSampleOrder(readOnlyOrder: firstOrder).items = [storageManager.insertSampleOrderItem(readOnlyOrderItem: firstOrderItem)]
-        storageManager.insertSampleOrder(readOnlyOrder: secondOrder).items = [storageManager.insertSampleOrderItem(readOnlyOrderItem: firstOrderItem),
-                                                                              storageManager.insertSampleOrderItem(readOnlyOrderItem: secondOrderItem)]
-        storageManager.insertSampleOrder(readOnlyOrder: thirdOrder).items = [storageManager.insertSampleOrderItem(readOnlyOrderItem: firstOrderItem),
-                                                                             storageManager.insertSampleOrderItem(readOnlyOrderItem: secondOrderItem),
-                                                                             storageManager.insertSampleOrderItem(readOnlyOrderItem: thirdOrderItem)]
+        preparePopularProductsSamples(with: [1, 2, 3], orderStatus: .pending)
 
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
@@ -838,28 +797,7 @@ final class ProductStoreTests: XCTestCase {
     }
 
     func test_retrieveMostPopularProductsInCache_when_there_are_several_popular_products_but_siteID_is_different_returns_empty_array() {
-        let firstProductID: Int64 = 1
-        let secondProductID: Int64 = 2
-        let thirdProductID: Int64 = 3
-
-        storageManager.insertSampleProduct(readOnlyProduct: Product.fake().copy(productID: firstProductID))
-        storageManager.insertSampleProduct(readOnlyProduct: Product.fake().copy(productID: secondProductID))
-        storageManager.insertSampleProduct(readOnlyProduct: Product.fake().copy(productID: thirdProductID))
-
-        let firstOrderItem = OrderItem.fake().copy(productID: firstProductID)
-        let secondOrderItem = OrderItem.fake().copy(productID: secondProductID)
-        let thirdOrderItem = OrderItem.fake().copy(productID: thirdProductID)
-
-        let firstOrder = Order.fake().copy(siteID: sampleSiteID, status: .pending)
-        let secondOrder = Order.fake().copy(siteID: sampleSiteID, status: .pending)
-        let thirdOrder = Order.fake().copy(siteID: sampleSiteID, status: .pending)
-
-        storageManager.insertSampleOrder(readOnlyOrder: firstOrder).items = [storageManager.insertSampleOrderItem(readOnlyOrderItem: firstOrderItem)]
-        storageManager.insertSampleOrder(readOnlyOrder: secondOrder).items = [storageManager.insertSampleOrderItem(readOnlyOrderItem: firstOrderItem),
-                                                                              storageManager.insertSampleOrderItem(readOnlyOrderItem: secondOrderItem)]
-        storageManager.insertSampleOrder(readOnlyOrder: thirdOrder).items = [storageManager.insertSampleOrderItem(readOnlyOrderItem: firstOrderItem),
-                                                                             storageManager.insertSampleOrderItem(readOnlyOrderItem: secondOrderItem),
-                                                                             storageManager.insertSampleOrderItem(readOnlyOrderItem: thirdOrderItem)]
+        preparePopularProductsSamples(with: [1, 2, 3])
 
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
@@ -2275,5 +2213,19 @@ private extension ProductStoreTests {
                                                             Networking.ProductAddOnOption.fake().copy(label: "No", price: "", priceType: .flatFee)
                                                            ])
         return [topping, soda, delivery]
+    }
+
+    func preparePopularProductsSamples(with productIDs: [Int64], orderStatus: OrderStatusEnum = .completed) {
+        productIDs.forEach { storageManager.insertSampleProduct(readOnlyProduct: Product.fake().copy(productID: $0))}
+
+        let orderItems = productIDs.map { OrderItem.fake().copy(productID: $0) }
+        let orders = (0 ..< 3).map { _ in Order.fake().copy(siteID: sampleSiteID, status: orderStatus) }
+
+        storageManager.insertSampleOrder(readOnlyOrder: orders[0]).items = NSOrderedSet(array: (0 ..< 1)
+            .map { index in storageManager.insertSampleOrderItem(readOnlyOrderItem: orderItems[index]) })
+        storageManager.insertSampleOrder(readOnlyOrder: orders[1]).items = NSOrderedSet(array: (0 ..< 2)
+            .map { index in storageManager.insertSampleOrderItem(readOnlyOrderItem: orderItems[index]) })
+        storageManager.insertSampleOrder(readOnlyOrder: orders[2]).items = NSOrderedSet(array: (0 ..< 3)
+            .map { index in storageManager.insertSampleOrderItem(readOnlyOrderItem: orderItems[index]) })
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9189 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we retrieve products sorted based on popularity. That means that:

- They belong to a completed order.
- Thar order belongs to the specified site.
- They are sorted descending based on occurrences on those orders, ignoring the quantity on a single order.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
As this is not applied to UI yet, just please make sure that unit tests pass.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
