### PR TITLE
[Product Multi-Selection] Add new track event for clear selection

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -454,6 +454,7 @@ extension WooAnalyticsEvent {
             static let hasMultipleShippingLines = "has_multiple_shipping_lines"
             static let hasMultipleFeeLines = "has_multiple_fee_lines"
             static let itemType = "item_type"
+            static let source = "source"
         }
 
         static func orderOpen(order: Order) -> WooAnalyticsEvent {
@@ -592,6 +593,12 @@ extension WooAnalyticsEvent {
         static func orderCreationProductSelectorConfirmButtonTapped(productCount: Int) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderCreationProductSelectorConfirmButtonTapped, properties: [
                 Keys.productCount: Int64(productCount)
+            ])
+        }
+
+        static func orderCreationProductSelectorClearSelectionButtonTapped(productType: ProductType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderCreationProductSelectorClearSelectionButtonTapped, properties: [
+                Keys.source: productType.rawValue + "_selector"
             ])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -354,6 +354,7 @@ public enum WooAnalyticsStat: String {
     case orderCreationProductSelectorItemSelected = "order_creation_product_selector_item_selected"
     case orderCreationProductSelectorItemUnselected = "order_creation_product_selector_item_unselected"
     case orderCreationProductSelectorConfirmButtonTapped = "order_creation_product_selector_confirm_button_tapped"
+    case orderCreationProductSelectorClearSelectionButtonTapped = "order_creation_product_selector_clear_selection_button_tapped"
     case orderContactAction = "order_contact_action"
     case orderCustomerAdd = "order_customer_add"
     case orderEditButtonTapped = "order_edit_button_tapped"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -381,23 +381,15 @@ final class EditableOrderViewModel: ObservableObject {
     /// Clears selected products and variations
     ///
     private func clearAllSelectedItems() {
-        selectedProducts.forEach { _ in
-            analytics.track(event: WooAnalyticsEvent.Orders.orderCreationProductSelectorItemUnselected(productType: .product))
-        }
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCreationProductSelectorClearSelectionButtonTapped(productType: .product))
         selectedProducts.removeAll()
-
-        selectedProductVariations.forEach { _ in
-            analytics.track(event: WooAnalyticsEvent.Orders.orderCreationProductSelectorItemUnselected(productType: .variation))
-        }
         selectedProductVariations.removeAll()
     }
 
     /// Clears selected variations
     /// 
     private func clearSelectedVariations() {
-        selectedProductVariations.forEach { _ in
-            analytics.track(event: WooAnalyticsEvent.Orders.orderCreationProductSelectorItemUnselected(productType: .variation))
-        }
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCreationProductSelectorClearSelectionButtonTapped(productType: .variation))
         selectedProductVariations.removeAll()
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1040,6 +1040,37 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(properties, "creation")
     }
 
+    func test_product_selector_source_is_tracked_when_product_selector_clear_selection_button_is_tapped() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isProductMultiSelectionM1Enabled: true)
+        let analytics = MockAnalyticsProvider()
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               storageManager: storageManager,
+                                               analytics: WooAnalytics(analyticsProvider: analytics),
+                                               featureFlagService: featureFlagService)
+
+        // When
+        viewModel.isProductMultiSelectionBetaFeatureEnabled = true
+        viewModel.productSelectorViewModel.clearSelection()
+
+        // Then
+        XCTAssertTrue(analytics.receivedEvents.contains(where: {
+            $0.description == WooAnalyticsStat.orderCreationProductSelectorClearSelectionButtonTapped.rawValue })
+        )
+
+        guard let eventIndex = analytics.receivedEvents.firstIndex(where: {
+            $0.description == WooAnalyticsStat.orderCreationProductSelectorClearSelectionButtonTapped.rawValue }) else {
+            return XCTFail("No event received")
+        }
+
+        let eventProperties = analytics.receivedProperties[eventIndex]
+        guard let event = eventProperties.first(where: { $0.key as? String == "source"}) else {
+            return XCTFail("No property received")
+        }
+
+        XCTAssertEqual(event.value as? String, "product_selector")
+    }
+
     func test_shipping_method_tracked_when_added() throws {
         // Given
         let analytics = MockAnalyticsProvider()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9350 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds a track event for when the Product Multi-Selection "Clear Selection" button is tapped, rather than sending multiple events, one per each product that is cleared.

## Changes
- Adds a new `WooAnalyticsEvents`: `orderCreationProductSelectorClearSelectionButtonTapped`

## Testing instructions

- Go to Menu > Settings > Experimental features > and enable Product Multi-Selection
- Go to Orders > Tap `+` > Tap on `+ Add Products` > Tap on different products and variations to select different items > Tap the `Clear selection` button. 
- This will trigger the `order_creation_product_selector_clear_selection_button_tapped` event, either with `source: product_selector` if we tapped on the Product Selector, or `source: variation_selector` if we tapped in the Product Variation Selector.


```
🔵 Tracked order_creation_product_selector_clear_selection_button_tapped, properties: 
...
AnyHashable("source"): "product_selector"]
```

```
🔵 Tracked order_creation_product_selector_clear_selection_button_tapped, properties: 
...
AnyHashable("source"): "variation_selector"]
```

Due to the [internals](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift#L240) of getting the variations viewModel from the `EditableOrderViewModel`, I'm not Unit Testing testing for the `variation_selector` event, just for `product_selector`. We can attempt this as an improvement on a future PR.
