### PR TITLE
[Composite Products] Support String or Int values for composite component default option ID

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -449,12 +449,8 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         let bundleStockQuantity = container.failsafeDecodeIfPresent(Int64.self, forKey: .bundleStockQuantity)
         let bundledItems = try container.decodeIfPresent([ProductBundleItem].self, forKey: .bundledItems) ?? []
 
-        ///`ProductCompositeComponent.defaultOptionID` is being returned as an `Int` instead of as a `String` in some test store.
-        /// Since this feature is still in development I'm defaulting to evict any composite component when a parsing error occurs.
-        /// We should identify why that field can be of multiple types before releasing the feature to the public.
-        ///
         // Composite Product properties
-        let compositeComponents = (try? container.decodeIfPresent([ProductCompositeComponent].self, forKey: .compositeComponents)) ?? []
+        let compositeComponents = try container.decodeIfPresent([ProductCompositeComponent].self, forKey: .compositeComponents) ?? []
 
 
         self.init(siteID: siteID,

--- a/Networking/Networking/Model/Product/ProductCompositeComponent.swift
+++ b/Networking/Networking/Model/Product/ProductCompositeComponent.swift
@@ -42,6 +42,31 @@ public struct ProductCompositeComponent: Codable, Equatable, GeneratedCopiable, 
         self.optionIDs = optionIDs
         self.defaultOptionID = defaultOptionID
     }
+
+    /// The public initializer for ProductCompositeComponent.
+    ///
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let componentID = try container.decode(String.self, forKey: .componentID)
+        let title = try container.decode(String.self, forKey: .title)
+        let description = try container.decode(String.self, forKey: .description)
+        let imageURL = try container.decode(String.self, forKey: .imageURL)
+        let optionType = try container.decode(CompositeComponentOptionType.self, forKey: .optionType)
+        let optionIDs = try container.decode([Int64].self, forKey: .optionIDs)
+
+        // Default option ID can be Int or String.
+        // The field value is an empty string if no default option is set.
+        let defaultOptionID = container.failsafeDecodeIfPresent(stringForKey: .defaultOptionID) ?? ""
+
+        self.init(componentID: componentID,
+                  title: title,
+                  description: description,
+                  imageURL: imageURL,
+                  optionType: optionType,
+                  optionIDs: optionIDs,
+                  defaultOptionID: defaultOptionID)
+    }
 }
 
 /// Defines all of the ProductCompositeComponent CodingKeys


### PR DESCRIPTION
Part of: #8955

## Description

This is a followup to #9298, to resolve the parsing errors for composite products. As noted there, the `defaultOptionID` field value can be an `Int` or a `String`.

The type for this field depends on the composite product and option settings. On the same store, depending on the product settings, the default option ID can be an `Int` or `String`. If no default option is set, it is an empty string. This difference comes from the extension itself, rather than other factors on the store.

I'm also checking with the extension team in https://github.com/woocommerce/woocommerce-composite-products/issues/942 to see if that's the expected behavior for the extension.


## Testing instructions

1. Login to the following store `https://teststore.rachel-test-domain.com/` ask for access in case you don't have it.
2. Load all products (scroll to the very end)
3. Make sure no errors occur

You can also test this by creating a composite product on your store:

- Add a non-optional component with a single product component option.
- Add another component with multiple component options.
- Add an optional component with no default option selected.

Then, load all products in the app (including the new composite product) and confirm no errors occur.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
