### PR TITLE
[Free Trial] Connect Summary Screen

### DIFF
--- a/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSummaryView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Free Trial/FreeTrialSummaryView.swift
@@ -6,6 +6,7 @@ import UIKit
 final class FreeTrialSummaryHostingController: UIHostingController<FreeTrialSummaryView> {
     init(onClose: (() -> ())? = nil, onContinue: (() -> ())? = nil) {
         super.init(rootView: FreeTrialSummaryView(onClose: onClose, onContinue: onContinue))
+        modalPresentationStyle = .fullScreen
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -417,6 +417,9 @@ private extension StoreCreationCoordinator {
     @MainActor
     func createFreeTrialStore(from navigationController: UINavigationController, storeName: String) async {
 
+        // Make sure that nothing is presented on the view controller before showing the loading screen
+        navigationController.presentedViewController?.dismiss(animated: true)
+
         // Show a progress view while the free trial store is created.
         showInProgressView(from: navigationController, viewProperties: .init(title: Localization.WaitingForJetpackSite.title, message: ""))
 

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -312,7 +312,7 @@ private extension StoreCreationCoordinator {
         alert.addCancelActionWithTitle(Localization.DiscardChangesAlert.cancelActionTitle) { _ in }
 
         // Presents the alert with the presented webview.
-        navigationController.presentedViewController?.present(alert, animated: true)
+        navigationController.topmostPresentedViewController.present(alert, animated: true)
     }
 
     func showSupport(from navigationController: UINavigationController) {


### PR DESCRIPTION
Closes: #9346 #9347 

# Why

This PR takes care of presenting the **Free Trial Summary Screen** before creating the free trial store.

# How

- Launch the screen with a `.fullScreen`modal presentation style.

- Make sure that no view is presented in the main navigation controller(the summary view) before proceeding to create the store.

- Make sure that the cancelation alert is always presented in the top most presented view controller.

# Demo

## Cancel

https://user-images.githubusercontent.com/562080/229847636-1d5e4a95-488f-4629-9954-de49f5bf0f13.mov

## Success

https://user-images.githubusercontent.com/562080/229847579-d8b7b1ee-eb96-4088-8f19-a7fc38aafc64.mov

# Testing Steps


- Start the create store flow
- Enter the store name
- See the summary view
- Tap on the top X button
- See that you can cancel the store creation flow

----

- Start the create store flow
- Enter the store name
- See the summary view
- Tap on the top "Try It For Free" button
- See that the free trial creation flow continues as expected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
