### PR TITLE
Remove reference to non existing property

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1040,7 +1040,6 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                featureFlagService: featureFlagService)
 
         // When
-        viewModel.isProductMultiSelectionBetaFeatureEnabled = true
         viewModel.productSelectorViewModel.clearSelection()
 
         // Then


### PR DESCRIPTION
## Changes

Removes a reference in unit tests to the non-existant `isProductMultiSelectionBetaFeatureEnabled`, which breaks trunk from building.

## Testing instructions
- Tests should pass
