### PR TITLE
[Mobile Payments] Add SiteID to IPP analytics

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 13.1
 -----
 - [**] Users can now install Jetpack for their non-Jetpack sites after logging in with application passwords. [https://github.com/woocommerce/woocommerce-ios/pull/9354]
+- [Internal] Added SiteID to some IPP tracks events [https://github.com/woocommerce/woocommerce-ios/pull/9371]
 
 
 13.0

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1046,6 +1046,7 @@ extension WooAnalyticsEvent {
             static let enabled = "enabled"
             static let cancellationSource = "cancellation_source"
             static let millisecondsSinceCardCollectPaymentFlow = "milliseconds_since_card_collect_payment_flow"
+            static let siteID = "site_id"
         }
 
         static let unknownGatewayID = "unknown"
@@ -1147,12 +1148,16 @@ extension WooAnalyticsEvent {
         ///   - error: the error to be included in the event properties.
         ///   - countryCode: the country code of the store.
         ///
-        static func cardReaderDiscoveryFailed(forGatewayID: String?, error: Error, countryCode: String) -> WooAnalyticsEvent {
+        static func cardReaderDiscoveryFailed(forGatewayID: String?,
+                                              error: Error,
+                                              countryCode: String,
+                                              siteID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderDiscoveryFailed,
                               properties: [
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
-                                Keys.errorDescription: error.localizedDescription
+                                Keys.errorDescription: error.localizedDescription,
+                                Keys.siteID: siteID
                               ]
             )
         }
@@ -1190,13 +1195,18 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - cardReaderModel: the model type of the card reader.
         ///
-        static func cardReaderConnectionFailed(forGatewayID: String?, error: Error, countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+        static func cardReaderConnectionFailed(forGatewayID: String?,
+                                               error: Error,
+                                               countryCode: String,
+                                               cardReaderModel: String?,
+                                               siteID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderConnectionFailed,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
-                                Keys.errorDescription: error.localizedDescription
+                                Keys.errorDescription: error.localizedDescription,
+                                Keys.siteID: siteID
                               ]
             )
         }
@@ -1363,7 +1373,11 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - cardReaderModel: the model type of the card reader, if available.
         ///
-        static func collectPaymentFailed(forGatewayID: String?, error: Error, countryCode: String, cardReaderModel: String?) -> WooAnalyticsEvent {
+        static func collectPaymentFailed(forGatewayID: String?,
+                                         error: Error,
+                                         countryCode: String,
+                                         cardReaderModel: String?,
+                                         siteID: Int64) -> WooAnalyticsEvent {
             let paymentMethod: PaymentMethod? = {
                 guard case let CardReaderServiceError.paymentCaptureWithPaymentMethod(_, paymentMethod) = error else {
                     return nil
@@ -1394,7 +1408,8 @@ extension WooAnalyticsEvent {
                 Keys.countryCode: countryCode,
                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
                 Keys.paymentMethodType: paymentMethod?.analyticsValue,
-                Keys.errorDescription: errorDescription
+                Keys.errorDescription: errorDescription,
+                Keys.siteID: String(siteID)
             ].compactMapValues { $0 }
             return WooAnalyticsEvent(statName: .collectPaymentFailed,
                                      properties: properties)
@@ -1410,13 +1425,15 @@ extension WooAnalyticsEvent {
         static func collectPaymentCanceled(forGatewayID: String?,
                                            countryCode: String,
                                            cardReaderModel: String?,
-                                           cancellationSource: CancellationSource) -> WooAnalyticsEvent {
+                                           cancellationSource: CancellationSource,
+                                           siteID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentCanceled,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
                                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
-                                Keys.cancellationSource: cancellationSource.rawValue
+                                Keys.cancellationSource: cancellationSource.rawValue,
+                                Keys.siteID: siteID
                               ]
             )
         }
@@ -1448,12 +1465,14 @@ extension WooAnalyticsEvent {
                                           paymentMethod: PaymentMethod,
                                           cardReaderModel: String?,
                                           millisecondsSinceOrderAddNew: Int64?,
-                                          millisecondsSinceCardPaymentStarted: Int64?) -> WooAnalyticsEvent {
+                                          millisecondsSinceCardPaymentStarted: Int64?,
+                                          siteID: Int64) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [
                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                 Keys.countryCode: countryCode,
                 Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
-                Keys.paymentMethodType: paymentMethod.analyticsValue
+                Keys.paymentMethodType: paymentMethod.analyticsValue,
+                Keys.siteID: siteID
             ]
 
             if let lapseSinceLastOrderAddNew = millisecondsSinceOrderAddNew {
@@ -1478,12 +1497,14 @@ extension WooAnalyticsEvent {
         ///
         static func collectInteracPaymentSuccess(gatewayID: String?,
                                                  countryCode: String,
-                                                 cardReaderModel: String?) -> WooAnalyticsEvent {
+                                                 cardReaderModel: String?,
+                                                 siteID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectInteracPaymentSuccess,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
-                                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID)
+                                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
+                                Keys.siteID: siteID
                               ])
         }
 
@@ -1496,12 +1517,14 @@ extension WooAnalyticsEvent {
         ///
         static func interacRefundSuccess(gatewayID: String?,
                                          countryCode: String,
-                                         cardReaderModel: String?) -> WooAnalyticsEvent {
+                                         cardReaderModel: String?,
+                                         siteID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .interacRefundSuccess,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
-                                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID)
+                                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
+                                Keys.siteID: siteID
                               ])
         }
 
@@ -1516,12 +1539,14 @@ extension WooAnalyticsEvent {
         static func interacRefundFailed(error: Error,
                                         gatewayID: String?,
                                         countryCode: String,
-                                        cardReaderModel: String?) -> WooAnalyticsEvent {
+                                        cardReaderModel: String?,
+                                        siteID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .interacRefundFailed,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
-                                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID)
+                                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
+                                Keys.siteID: siteID
                               ],
                               error: error)
         }
@@ -1535,12 +1560,14 @@ extension WooAnalyticsEvent {
         ///
         static func interacRefundCanceled(gatewayID: String?,
                                           countryCode: String,
-                                          cardReaderModel: String?) -> WooAnalyticsEvent {
+                                          cardReaderModel: String?,
+                                          siteID: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .interacRefundCanceled,
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode,
-                                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID)
+                                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
+                                Keys.siteID: siteID
                               ])
         }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -248,7 +248,8 @@ private extension BuiltInCardReaderConnectionController {
                 ServiceLocator.analytics.track(
                     event: WooAnalyticsEvent.InPersonPayments.cardReaderDiscoveryFailed(forGatewayID: self.gatewayID,
                                                                                         error: error,
-                                                                                        countryCode: self.configuration.countryCode)
+                                                                                        countryCode: self.configuration.countryCode,
+                                                                                        siteID: self.siteID)
                 )
                 self.state = .discoveryFailed(error)
             })
@@ -389,7 +390,8 @@ private extension BuiltInCardReaderConnectionController {
                         event: WooAnalyticsEvent.InPersonPayments.cardReaderConnectionFailed(forGatewayID: self.gatewayID,
                                                                                              error: error,
                                                                                              countryCode: self.configuration.countryCode,
-                                                                                             cardReaderModel: candidateReader.readerType.model)
+                                                                                             cardReaderModel: candidateReader.readerType.model,
+                                                                                             siteID: self.siteID)
                     )
                     self.state = .connectingFailed(error)
                 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -379,7 +379,8 @@ private extension CardReaderConnectionController {
                 ServiceLocator.analytics.track(
                     event: WooAnalyticsEvent.InPersonPayments.cardReaderDiscoveryFailed(forGatewayID: self.gatewayID,
                                                                                         error: error,
-                                                                                        countryCode: self.configuration.countryCode)
+                                                                                        countryCode: self.configuration.countryCode,
+                                                                                        siteID: self.siteID)
                 )
                 self.state = .discoveryFailed(error)
             })
@@ -579,7 +580,8 @@ private extension CardReaderConnectionController {
                     event: WooAnalyticsEvent.InPersonPayments.cardReaderConnectionFailed(forGatewayID: self.gatewayID,
                                                                                          error: error,
                                                                                          countryCode: self.configuration.countryCode,
-                                                                                         cardReaderModel: candidateReader.readerType.model)
+                                                                                         cardReaderModel: candidateReader.readerType.model,
+                                                                                         siteID: self.siteID)
                 )
                 self.state = .connectingFailed(error)
             }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyCardReaderConnectionController.swift
@@ -388,7 +388,8 @@ private extension LegacyCardReaderConnectionController {
                 ServiceLocator.analytics.track(
                     event: WooAnalyticsEvent.InPersonPayments.cardReaderDiscoveryFailed(forGatewayID: self.gatewayID,
                                                                                         error: error,
-                                                                                        countryCode: self.configuration.countryCode)
+                                                                                        countryCode: self.configuration.countryCode,
+                                                                                        siteID: self.siteID)
                 )
                 self.state = .discoveryFailed(error)
             })
@@ -607,7 +608,8 @@ private extension LegacyCardReaderConnectionController {
                     event: WooAnalyticsEvent.InPersonPayments.cardReaderConnectionFailed(forGatewayID: self.gatewayID,
                                                                                          error: error,
                                                                                          countryCode: self.configuration.countryCode,
-                                                                                         cardReaderModel: candidateReader.readerType.model)
+                                                                                         cardReaderModel: candidateReader.readerType.model,
+                                                                                         siteID: self.siteID)
                 )
                 self.state = .connectingFailed(error)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentAnalytics.swift
@@ -3,6 +3,7 @@ import Yosemite
 
 final class CollectOrderPaymentAnalytics {
 
+    private let siteID: Int64
     private let analytics: Analytics
     private let configuration: CardPresentPaymentsConfiguration
     private let orderDurationRecorder: OrderDurationRecorderProtocol
@@ -13,11 +14,13 @@ final class CollectOrderPaymentAnalytics {
         connectedReader?.readerType.model
     }
 
-    init(analytics: Analytics = ServiceLocator.analytics,
+    init(siteID: Int64,
+         analytics: Analytics = ServiceLocator.analytics,
          configuration: CardPresentPaymentsConfiguration,
          orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
          connectedReader: CardReader? = nil,
          paymentGatewayAccount: PaymentGatewayAccount? = nil) {
+        self.siteID = siteID
         self.analytics = analytics
         self.configuration = configuration
         self.orderDurationRecorder = orderDurationRecorder
@@ -47,7 +50,8 @@ final class CollectOrderPaymentAnalytics {
             analytics.track(event: .InPersonPayments
                 .collectInteracPaymentSuccess(gatewayID: paymentGatewayAccount?.gatewayID,
                                               countryCode: configuration.countryCode,
-                                              cardReaderModel: connectedReaderModel))
+                                              cardReaderModel: connectedReaderModel,
+                                              siteID: siteID))
         default:
             return
         }
@@ -60,7 +64,8 @@ final class CollectOrderPaymentAnalytics {
                                    paymentMethod: capturedPaymentData.paymentMethod,
                                    cardReaderModel: connectedReaderModel,
                                    millisecondsSinceOrderAddNew: try? orderDurationRecorder.millisecondsSinceOrderAddNew(),
-                                   millisecondsSinceCardPaymentStarted: try? orderDurationRecorder.millisecondsSinceCardPaymentStarted()))
+                                   millisecondsSinceCardPaymentStarted: try? orderDurationRecorder.millisecondsSinceCardPaymentStarted(),
+                                   siteID: siteID))
         orderDurationRecorder.reset()
     }
 
@@ -68,14 +73,16 @@ final class CollectOrderPaymentAnalytics {
         analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentFailed(forGatewayID: paymentGatewayAccount?.gatewayID,
                                                                                        error: error,
                                                                                        countryCode: configuration.countryCode,
-                                                                                       cardReaderModel: connectedReader?.readerType.model))
+                                                                                       cardReaderModel: connectedReader?.readerType.model,
+                                                                                       siteID: siteID))
     }
 
     func trackPaymentCancelation(cancelationSource: WooAnalyticsEvent.InPersonPayments.CancellationSource) {
         analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentCanceled(forGatewayID: paymentGatewayAccount?.gatewayID,
                                                                                          countryCode: configuration.countryCode,
                                                                                          cardReaderModel: connectedReaderModel,
-                                                                                         cancellationSource: cancelationSource))
+                                                                                         cancellationSource: cancelationSource,
+                                                                                         siteID: siteID))
     }
 
     func trackEmailTapped() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -102,7 +102,8 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
         self.configuration = configuration
         self.stores = stores
         self.paymentCaptureCelebration = paymentCaptureCelebration
-        self.analyticsTracker = CollectOrderPaymentAnalytics(analytics: analytics,
+        self.analyticsTracker = CollectOrderPaymentAnalytics(siteID: siteID,
+                                                             analytics: analytics,
                                                              configuration: configuration,
                                                              orderDurationRecorder: orderDurationRecorder)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/LegacyCollectOrderPaymentUseCase.swift
@@ -334,12 +334,13 @@ private extension LegacyCollectOrderPaymentUseCase {
                                  onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
         // Record success
         analytics.track(event: WooAnalyticsEvent.InPersonPayments
-                            .collectPaymentSuccess(forGatewayID: paymentGatewayAccount.gatewayID,
-                                                   countryCode: configuration.countryCode,
-                                                   paymentMethod: capturedPaymentData.paymentMethod,
-                                                   cardReaderModel: connectedReader?.readerType.model ?? "",
-                                                   millisecondsSinceOrderAddNew: try? orderDurationRecorder.millisecondsSinceOrderAddNew(),
-                                                   millisecondsSinceCardPaymentStarted: try? orderDurationRecorder.millisecondsSinceCardPaymentStarted()))
+            .collectPaymentSuccess(forGatewayID: paymentGatewayAccount.gatewayID,
+                                   countryCode: configuration.countryCode,
+                                   paymentMethod: capturedPaymentData.paymentMethod,
+                                   cardReaderModel: connectedReader?.readerType.model ?? "",
+                                   millisecondsSinceOrderAddNew: try? orderDurationRecorder.millisecondsSinceOrderAddNew(),
+                                   millisecondsSinceCardPaymentStarted: try? orderDurationRecorder.millisecondsSinceCardPaymentStarted(),
+                                   siteID: siteID))
         orderDurationRecorder.reset()
 
         // Success Callback
@@ -383,7 +384,8 @@ private extension LegacyCollectOrderPaymentUseCase {
         analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentFailed(forGatewayID: paymentGatewayAccount.gatewayID,
                                                                                        error: error,
                                                                                        countryCode: configuration.countryCode,
-                                                                                       cardReaderModel: connectedReader?.readerType.model))
+                                                                                       cardReaderModel: connectedReader?.readerType.model,
+                                                                                       siteID: siteID))
     }
 
     /// Cancels payment and record analytics.
@@ -399,7 +401,8 @@ private extension LegacyCollectOrderPaymentUseCase {
         analytics.track(event: WooAnalyticsEvent.InPersonPayments.collectPaymentCanceled(forGatewayID: paymentGatewayAccount.gatewayID,
                                                                                          countryCode: configuration.countryCode,
                                                                                          cardReaderModel: connectedReader?.readerType.model ?? "",
-                                                                                         cancellationSource: .other))
+                                                                                         cancellationSource: .other,
+                                                                                         siteID: siteID))
     }
 
     /// Allow merchants to print or email the payment receipt.
@@ -494,7 +497,8 @@ private extension LegacyCollectOrderPaymentUseCase {
             analytics.track(event: .InPersonPayments
                 .collectInteracPaymentSuccess(gatewayID: paymentGatewayAccount.gatewayID,
                                               countryCode: configuration.countryCode,
-                                              cardReaderModel: connectedReader?.readerType.model ?? ""))
+                                              cardReaderModel: connectedReader?.readerType.model ?? "",
+                                              siteID: siteID))
         default:
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -443,7 +443,8 @@ private extension RefundSubmissionUseCase {
             analytics.track(event: WooAnalyticsEvent.InPersonPayments
                 .interacRefundSuccess(gatewayID: paymentGatewayAccount.gatewayID,
                                       countryCode: cardPresentConfiguration.countryCode,
-                                      cardReaderModel: connectedReader?.readerType.model ?? ""))
+                                      cardReaderModel: connectedReader?.readerType.model ?? "",
+                                      siteID: order.siteID))
         default:
             // Tracks refund success events with other payment methods if needed.
             return
@@ -458,7 +459,8 @@ private extension RefundSubmissionUseCase {
                 .interacRefundFailed(error: error,
                                      gatewayID: paymentGatewayAccount.gatewayID,
                                      countryCode: cardPresentConfiguration.countryCode,
-                                     cardReaderModel: connectedReader?.readerType.model ?? ""))
+                                     cardReaderModel: connectedReader?.readerType.model ?? "",
+                                     siteID: order.siteID))
         default:
             // Tracks refund failure events with other payment methods if needed.
             return
@@ -471,7 +473,8 @@ private extension RefundSubmissionUseCase {
         case .interacPresent:
             analytics.track(event: .InPersonPayments.interacRefundCanceled(gatewayID: paymentGatewayAccount.gatewayID,
                                                                            countryCode: cardPresentConfiguration.countryCode,
-                                                                           cardReaderModel: connectedReader?.readerType.model ?? ""))
+                                                                           cardReaderModel: connectedReader?.readerType.model ?? "",
+                                                                           siteID: order.siteID))
         default:
             // Tracks refund cancellation events with other payment methods if needed.
             return


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR logs the Site ID on some key In Person Payment analytics events

This shouldn’t strictly be necessary, as Tracks should include the blogID… however, sometimes users are tracked anonymously by mistake. There does not appear to be any option for a user to choose to be tracked anonymously (only to opt out of tracking all together). Anonymous IDs are intended for tracking logged-out users... which doesn't apply to this part of the app.

For IPP related events, the number of merchants is low enough that it is sometimes important to be able to identify a merchant who is having issues, to learn more about what changes we need to make to the app.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
