### PR TITLE
Switch `updateZeroQuantities` Bool with an Enum

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -19,12 +19,17 @@ struct ProductInputTransformer {
         }
     }
 
+    enum UpdateOrDelete {
+        case update
+        case delete
+    }
+
     /// Adds, deletes, or updates order items based on the given product input.
-    /// When `updateZeroQuantities` is true, items with `.zero` quantities will be updated instead of being deleted.
+    /// When `shouldUpdateOrDeleteZeroQuantities` value is `.update`, items with `.zero` quantities will be updated instead of being deleted.
     ///
-    static func update(input: OrderSyncProductInput, on order: Order, updateZeroQuantities: Bool) -> Order {
+    static func update(input: OrderSyncProductInput, on order: Order, shouldUpdateOrDeleteZeroQuantities: UpdateOrDelete) -> Order {
         // If the input's quantity is 0 or less, delete the item if required.
-        guard input.quantity > 0 || updateZeroQuantities else {
+        guard input.quantity > 0 || shouldUpdateOrDeleteZeroQuantities == .update else {
             return remove(input: input, from: order)
         }
 
@@ -40,10 +45,10 @@ struct ProductInputTransformer {
     /// - Parameters:
     ///   - inputs: Array of product types the OrderSynchronizer supports
     ///   - order: Represents an Order entity.
-    ///   - updateZeroQuantities: When true, items with `.zero` quantities will be updated instead of being deleted.
+    ///   - shouldUpdateOrDeleteZeroQuantities: When its value is `.update`, items with `.zero` quantities will be updated instead of being deleted.
     ///
     /// - Returns: An Order entity.
-    static func updateMultipleItems(with inputs: [OrderSyncProductInput], on order: Order, updateZeroQuantities: Bool) -> Order {
+    static func updateMultipleItems(with inputs: [OrderSyncProductInput], on order: Order, shouldUpdateOrDeleteZeroQuantities: UpdateOrDelete) -> Order {
         var updatedOrderItems = order.items
 
         for input in inputs {
@@ -53,7 +58,7 @@ struct ProductInputTransformer {
         // If the input's quantity is 0 or less, delete the item if required.
         // We perform a second loop for deletions so we don't attempt to access to overflown indexes
         for input in inputs {
-            guard input.quantity > 0 || updateZeroQuantities else {
+            guard input.quantity > 0 || shouldUpdateOrDeleteZeroQuantities == .update else {
                 updatedOrderItems.removeAll(where: { $0.itemID == input.id })
                 return order.copy(items: updatedOrderItems)
             }
@@ -90,12 +95,12 @@ private extension ProductInputTransformer {
     /// - Parameters:
     ///   - input: Types of products the synchronizer supports
     ///   - order: Represents an Order entity.
-    ///   - updateZeroQuantities: When true, items with `.zero` quantities will be updated instead of being deleted.
+    ///   - shouldUpdateOrDeleteZeroQuantities: When its value is `.update`, items with `.zero` quantities will be updated instead of being deleted.
     ///
     /// - Returns: An array of Order Item entities
-    private static func updateOrderItems(from input: OrderSyncProductInput, order: Order, updateZeroQuantities: Bool) -> [OrderItem] {
+    private static func updateOrderItems(from input: OrderSyncProductInput, order: Order, shouldUpdateOrDeleteZeroQuantities: UpdateOrDelete) -> [OrderItem] {
         // If the input's quantity is 0 or less, delete the item if required.
-        guard input.quantity > 0 || updateZeroQuantities else {
+        guard input.quantity > 0 || shouldUpdateOrDeleteZeroQuantities == .update else {
             return remove(input: input, from: order).items
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -139,7 +139,7 @@ private extension RemoteOrderSynchronizer {
             .map { [weak self] productInput, order -> Order in
                 guard let self = self else { return order }
                 let localInput = self.replaceInputWithLocalIDIfNeeded(productInput)
-                let updatedOrder = ProductInputTransformer.update(input: localInput, on: order, updateZeroQuantities: true)
+                let updatedOrder = ProductInputTransformer.update(input: localInput, on: order, shouldUpdateOrDeleteZeroQuantities: .update)
                 // Calculate order total locally while order is being synced
                 return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
             }
@@ -160,7 +160,7 @@ private extension RemoteOrderSynchronizer {
                 let updatedOrder = ProductInputTransformer.updateMultipleItems(
                     with: localInputs,
                     on: order,
-                    updateZeroQuantities: true)
+                    shouldUpdateOrDeleteZeroQuantities: .update)
 
                 return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
@@ -20,7 +20,7 @@ class ProductInputTransformerTests: XCTestCase {
         let originalOrder = OrderFactory.emptyNewOrder
 
         // When
-        let updatedOrder = ProductInputTransformer.update(input: input, on: originalOrder, updateZeroQuantities: false)
+        let updatedOrder = ProductInputTransformer.update(input: input, on: originalOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // Then
         let item = try XCTUnwrap(updatedOrder.items.first)
@@ -47,7 +47,7 @@ class ProductInputTransformerTests: XCTestCase {
         let updatedOrder = ProductInputTransformer.updateMultipleItems(
             with: input,
             on: originalOrder,
-            updateZeroQuantities: false)
+            shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // Then
         let items = try XCTUnwrap(updatedOrder.items)
@@ -73,7 +73,7 @@ class ProductInputTransformerTests: XCTestCase {
         let originalOrder = OrderFactory.emptyNewOrder
 
         // When
-        let updatedOrder = ProductInputTransformer.update(input: input, on: originalOrder, updateZeroQuantities: false)
+        let updatedOrder = ProductInputTransformer.update(input: input, on: originalOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // Then
         let item = try XCTUnwrap(updatedOrder.items.first)
@@ -104,7 +104,7 @@ class ProductInputTransformerTests: XCTestCase {
         let updatedOrder = ProductInputTransformer.updateMultipleItems(
             with: input,
             on: originalOrder,
-            updateZeroQuantities: false)
+            shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // Then
         let items = try XCTUnwrap(updatedOrder.items)
@@ -128,11 +128,11 @@ class ProductInputTransformerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let input1 = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
-        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, updateZeroQuantities: false)
+        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // When
         let input2 = OrderSyncProductInput(id: sampleInputID + 1, product: .product(product), quantity: 1)
-        let update2 = ProductInputTransformer.update(input: input2, on: update1, updateZeroQuantities: false)
+        let update2 = ProductInputTransformer.update(input: input2, on: update1, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // Then
         XCTAssertEqual(update2.items.count, 2)
@@ -142,11 +142,11 @@ class ProductInputTransformerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "9.99")
         let input1 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
-        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, updateZeroQuantities: false)
+        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // When
         let input2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 2)
-        let update2 = ProductInputTransformer.update(input: input2, on: update1, updateZeroQuantities: false)
+        let update2 = ProductInputTransformer.update(input: input2, on: update1, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // Then
         let item = try XCTUnwrap(update2.items.first)
@@ -162,11 +162,13 @@ class ProductInputTransformerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "9.99")
         let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
-        let initialOrder = ProductInputTransformer.updateMultipleItems(with: [productInput], on: OrderFactory.emptyNewOrder, updateZeroQuantities: false)
+        let initialOrder = ProductInputTransformer.updateMultipleItems(with: [productInput],
+                                                                       on: OrderFactory.emptyNewOrder,
+                                                                       shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // When
         let productInput2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 2)
-        let updatedOrder = ProductInputTransformer.updateMultipleItems(with: [productInput2], on: initialOrder, updateZeroQuantities: false)
+        let updatedOrder = ProductInputTransformer.updateMultipleItems(with: [productInput2], on: initialOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // Then
         // Confirm that we still have only 1 item
@@ -190,7 +192,7 @@ class ProductInputTransformerTests: XCTestCase {
 
         // When
         let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2)
-        let updatedOrder = ProductInputTransformer.update(input: input, on: order, updateZeroQuantities: true)
+        let updatedOrder = ProductInputTransformer.update(input: input, on: order, shouldUpdateOrDeleteZeroQuantities: .update)
 
         // Then
         let updatedItem = try XCTUnwrap(updatedOrder.items.first)
@@ -207,7 +209,7 @@ class ProductInputTransformerTests: XCTestCase {
 
         // When
         let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2)
-        let updatedOrder = ProductInputTransformer.updateMultipleItems(with: [input], on: order, updateZeroQuantities: true)
+        let updatedOrder = ProductInputTransformer.updateMultipleItems(with: [input], on: order, shouldUpdateOrDeleteZeroQuantities: .update)
 
         // Then
         let updatedItem = try XCTUnwrap(updatedOrder.items.first)
@@ -220,25 +222,29 @@ class ProductInputTransformerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let input1 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
-        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, updateZeroQuantities: false)
+        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // When
         let input2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0)
-        let update2 = ProductInputTransformer.update(input: input2, on: update1, updateZeroQuantities: false)
+        let update2 = ProductInputTransformer.update(input: input2, on: update1, shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // Then
         XCTAssertEqual(update2.items.count, 0)
     }
 
-    func test_order_when_updateMultipleItems_with_zero_quantity_product_input_and_updateZeroQuantities_is_false_then_deletes_item_on_order() throws {
+    func test_order_when_updateMultipleItems_with_zero_quantity_product_input_and_shouldUpdateOrDeleteZeroQuantities_is_false_then_deletes_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
-        let initialOrderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput], on: OrderFactory.emptyNewOrder, updateZeroQuantities: false)
+        let initialOrderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput],
+                                                                             on: OrderFactory.emptyNewOrder,
+                                                                             shouldUpdateOrDeleteZeroQuantities: .delete)
 
         // When
         let productInput2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0)
-        let orderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput2], on: initialOrderUpdate, updateZeroQuantities: false)
+        let orderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput2],
+                                                                      on: initialOrderUpdate,
+                                                                      shouldUpdateOrDeleteZeroQuantities: .delete)
         // Then
         XCTAssertEqual(orderUpdate.items.count, 0)
     }
@@ -247,26 +253,30 @@ class ProductInputTransformerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let input1 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
-        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, updateZeroQuantities: true)
+        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, shouldUpdateOrDeleteZeroQuantities: .update)
 
         // When
         let input2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0)
-        let update2 = ProductInputTransformer.update(input: input2, on: update1, updateZeroQuantities: true)
+        let update2 = ProductInputTransformer.update(input: input2, on: update1, shouldUpdateOrDeleteZeroQuantities: .update)
 
         // Then
         let item = try XCTUnwrap(update2.items.first)
         XCTAssertEqual(item.quantity, input2.quantity)
     }
 
-    func test_order_when_updateMultipleItems_with_zero_quantity_product_input_and_updateZeroQuantities_then_does_not_delete_item_on_order() throws {
+    func test_order_when_updateMultipleItems_with_zero_quantity_product_input_and_shouldUpdateOrDeleteZeroQuantities_then_does_not_delete_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
-        let initialOrderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput], on: OrderFactory.emptyNewOrder, updateZeroQuantities: true)
+        let initialOrderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput],
+                                                                             on: OrderFactory.emptyNewOrder,
+                                                                             shouldUpdateOrDeleteZeroQuantities: .update)
 
         // When
         let productInput2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0)
-        let orderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput2], on: initialOrderUpdate, updateZeroQuantities: true)
+        let orderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput2],
+                                                                      on: initialOrderUpdate,
+                                                                      shouldUpdateOrDeleteZeroQuantities: .update)
 
         // Then
         let item = try XCTUnwrap(orderUpdate.items.first)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
@@ -232,7 +232,7 @@ class ProductInputTransformerTests: XCTestCase {
         XCTAssertEqual(update2.items.count, 0)
     }
 
-    func test_order_when_updateMultipleItems_with_zero_quantity_product_input_and_shouldUpdateOrDeleteZeroQuantities_is_false_then_deletes_item_on_order() throws {
+    func test_order_when_updateMultipleItems_with_zero_quantity_product_input_and_deletes_zero_quantities_then_deletes_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
@@ -264,7 +264,7 @@ class ProductInputTransformerTests: XCTestCase {
         XCTAssertEqual(item.quantity, input2.quantity)
     }
 
-    func test_order_when_updateMultipleItems_with_zero_quantity_product_input_and_shouldUpdateOrDeleteZeroQuantities_then_does_not_delete_item_on_order() throws {
+    func test_order_when_updateMultipleItems_with_zero_quantity_product_input_and_updates_zero_quantities_then_updates_item_on_order() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9201 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR renames and refactors the `updateZeroQuantities` parameter on different methods used across the `ProductInputTransformer`, and the `RemoteOrderSynchronizer`, to use an Enum type rather than a bool.

This change intends to make the method signature more expressive regarding what it does.  In the former implementation, the intention of `updateZeroQuantities` was that:
- If `true`, items with `.zero` quantities would be updated instead of being deleted.
- If `false` , items with `.zero` quantities would be deleted.

By using an Enum, we change this for two cases: `update` or `delete`.

## Changes, and testing instructions
No logic has been changed, tests should pass.
