### PR TITLE
[Composite Products] Display error notice when component options fail to load

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettings.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettings.swift
@@ -85,6 +85,7 @@ struct ComponentSettings: View {
             FooterNotice(infoText: viewModel.infoNotice)
                 .padding(.horizontal, insets: safeAreaInsets)
         }
+        .notice($viewModel.errorNotice, autoDismiss: false)
         .navigationTitle(viewModel.viewTitle)
         .ignoresSafeArea(edges: .horizontal)
         .background(

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Composite Products/ComponentSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Composite Products/ComponentSettingsViewModelTests.swift
@@ -150,6 +150,7 @@ final class ComponentSettingsViewModelTests: XCTestCase {
                        NSLocalizedString("None", comment: "Label when there is no default option for a component in a composite product"))
         XCTAssertFalse(viewModel.showOptionsLoadingIndicator)
         XCTAssertFalse(viewModel.showDefaultOptionLoadingIndicator)
+        XCTAssertNotNil(viewModel.errorNotice)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8956
⚠️ Depends on #9297
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds an error notice when component options fail to load on the Component Settings screen, for Composite Products. Tapping the "Retry" button retries the loading action that failed (syncing products or fetching categories).

### Changes

* Adds a notice to the view that is displayed when `errorNotice` is set on the view model.
* Creates and sets the error notice when product sync or category fetch fails.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. On a test store with a composite product, go to the Products tab.
2. Select a composite product.
3. Open the Components section.
4. Disable your internet connection. This will cause the product sync to fail (failing to load all component options for a component with product options, or the default option for a component with category options).
5. Select a component to open Component Settings.
6. Confirm the error notice appears.
7. Enable your internet connection.
8. Tap the "Retry" button and confirm the options load.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/8658164/230103515-a38fb58e-4f3d-4524-96fc-a34d54dcc021.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
