### PR TITLE
[Composite Products] Only show images for product component options

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettings.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettings.swift
@@ -107,11 +107,14 @@ struct ComponentSettings: View {
                         .frame(width: optionImageWidth, height: optionImageWidth)
                         .cornerRadius(Layout.imageCornerRadius)
                         .accessibilityHidden(true)
-                        .padding()
+                        .padding(.trailing)
+                        .renderedIf(viewModel.shouldShowOptionImages)
 
                     Text(option.title)
                         .bodyStyle()
                 }
+                .padding()
+
                 Divider()
                     .padding(.leading)
                     .padding(.trailing, insets: -safeAreaInsets)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Composite Product Components/ComponentSettingsViewModel.swift
@@ -69,6 +69,12 @@ final class ComponentSettingsViewModel: ObservableObject {
         description.isNotEmpty
     }
 
+    /// Whether to display images for component options
+    ///
+    /// Used to disable images when component options are categories.
+    ///
+    let shouldShowOptionImages: Bool
+
     // MARK: Loading State
 
     /// Dependency state.
@@ -112,13 +118,15 @@ final class ComponentSettingsViewModel: ObservableObject {
          imageURL: URL?,
          optionsType: String,
          options: [ComponentOption],
-         defaultOptionTitle: String = Localization.noDefaultOption) {
+         defaultOptionTitle: String = Localization.noDefaultOption,
+         shouldShowOptionImages: Bool = true) {
         self.componentTitle = title
         self.description = description
         self.imageURL = imageURL
         self.optionsType = optionsType
         self.options = options
         self.defaultOptionTitle = defaultOptionTitle
+        self.shouldShowOptionImages = shouldShowOptionImages
     }
 }
 
@@ -136,7 +144,8 @@ extension ComponentSettingsViewModel {
                   description: component.description.removedHTMLTags.trimmingCharacters(in: .whitespacesAndNewlines),
                   imageURL: component.imageURL,
                   optionsType: component.optionType.description,
-                  options: ComponentSettingsViewModel.optionsLoadingPlaceholder)
+                  options: ComponentSettingsViewModel.optionsLoadingPlaceholder,
+                  shouldShowOptionImages: component.optionType != .categoryIDs)
 
         // Then load details about the component options.
         loadComponentOptions(siteID: siteID,
@@ -212,8 +221,7 @@ private extension ComponentSettingsViewModel {
         do {
             try resultsController.performFetch()
             self.options = resultsController.fetchedObjects.map { category in
-                // TODO-8965: Either add support for category images or hide the placeholder in the UI
-                // We currently don't parse category images from the API response
+                // We don't show images for categories in the app, so the image URL is always nil.
                 ComponentOption(id: category.categoryID, title: category.name, imageURL: nil)
             }
             self.categoriesState = .loaded

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Composite Products/ComponentSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Composite Products/ComponentSettingsViewModelTests.swift
@@ -97,6 +97,7 @@ final class ComponentSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.options.first?.title, expectedCategory.name)
         XCTAssertEqual(viewModel.options.first?.imageURL, nil)
         XCTAssertEqual(viewModel.defaultOptionTitle, defaultProduct.name)
+        XCTAssertFalse(viewModel.shouldShowOptionImages)
     }
 
     func test_view_model_loads_product_component_options() {
@@ -127,6 +128,7 @@ final class ComponentSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.options.first?.title, expectedProduct.name)
         XCTAssertEqual(viewModel.options.first?.imageURL, expectedProduct.imageURL)
         XCTAssertEqual(viewModel.defaultOptionTitle, expectedProduct.name)
+        XCTAssertTrue(viewModel.shouldShowOptionImages)
     }
 
     func test_view_model_has_expected_values_after_loading_error() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8956
⚠️ Depends on 9297
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This hides images in the Component Settings > Component Options list (for Composite Products) when the options are categories.

While product categories can have an image associated with them, we don't parse those images from the API or show them anywhere in the app. Also, category images aren't shown in component settings in `wp-admin` or on the composite product on the front of the store.

Rather than adding support for category images just for the component options list, this hides the image placeholder when component options are categories. Images are still shown when the component options are products.

FYI @atorresveiga 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

0. Create a composite product with at least one component with category component options.
1. In the app, go to the Products tab.
2. Select a composite product.
3. Select Components.
4. Select a component.
5. Confirm the Component Settings shows a list of component options with images (or image placeholders) when the options are products, and without images or placeholders when the options are categories.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
/|Before|After
-|-|-
Category options|<img src="https://user-images.githubusercontent.com/8658164/230112197-e514b570-ee1e-425a-bd1a-3897d71adc39.png" width="300px">|<img src="https://user-images.githubusercontent.com/8658164/230112213-c7c348c8-fec3-4846-90b7-c0a47e9ba586.png" width="300px">
Product options (no change)|<img src="https://user-images.githubusercontent.com/8658164/230112181-7ea77f29-ff70-468b-87be-58d126694077.png" width="300px">|<img src="https://user-images.githubusercontent.com/8658164/230112224-7861dd5b-c8e3-4ceb-a1a3-166f5121de2b.png" width="300px">

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
