### PR TITLE
[Composite Products] Track when the Components row is tapped

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -396,6 +396,12 @@ extension WooAnalyticsEvent {
         static func bundledProductsTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productDetailViewBundledProductsTapped, properties: [:])
         }
+
+        /// Tracks when the merchant taps the Components row (applicable for composite-type products only).
+        ///
+        static func componentsTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDetailViewComponentsTapped, properties: [:])
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -568,6 +568,7 @@ public enum WooAnalyticsStat: String {
     case productDetailPreviewTapped = "product_detail_preview_tapped"
     case productDetailPreviewFailed = "product_detail_preview_failed"
     case productDetailViewBundledProductsTapped = "product_detail_view_bundled_products_tapped"
+    case productDetailViewComponentsTapped = "product_details_view_components_tapped"
 
     // MARK: Edit Product Variation Events
     //

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -453,7 +453,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 guard isActionable else {
                     return
                 }
-                // TODO-9237: Track composite row is tapped
+                ServiceLocator.analytics.track(event: .ProductDetail.componentsTapped())
                 showCompositeComponents()
             }
         case .optionsCTA(let rows):


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9237
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds an analytics event when the Components row is tapped in product details (for Composite Products):

* `product_details_view_components_tapped` (Event registration: 1520-gh-tracks-events-registration)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Prerequisites

1. Install and activate the [Composite Products extension](https://woocommerce.com/products/composite-products/) on your store.
2. Create at least one product with the Composite Products type, with at least one component.

### To test

1. Build and run the app.
2. Open the Products tab and select a composite product.
3. Tap the Components row in the product details. Confirm the new event is triggered.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
