### PR TITLE
Fix clear selection for existing Orders while in Editing flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -195,7 +195,7 @@ final class EditableOrderViewModel: ObservableObject {
             }, onAllSelectionsCleared: { [weak self] in
                 guard let self = self else { return }
                 self.clearAllSelectedItems()
-                self.syncInitialSelectedState()
+                self.syncClearSelectionState()
             }, onSelectedVariationsCleared: { [weak self] in
                 guard let self = self else { return }
                 self.clearSelectedVariations()
@@ -1218,6 +1218,17 @@ private extension EditableOrderViewModel {
                     selectedProducts.append(product)
                 }
             }
+        }
+    }
+
+    /// Syncs initial selected state for all items in the Order when clearing selections
+    ///
+    func syncClearSelectionState() {
+        if flow == .creation {
+            syncInitialSelectedState()
+        } else {
+            selectedProducts = []
+            selectedProductVariations = []
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9376 

## Description
During testing we've found out that the "Clear Selection" button doesn't clear selected products when we're in Editing flow (this happens when we're editing an Order that was previously created, after has been sent to the remote for the first time). 

This happens because we sync the selected product state by checking the items on the `ordersynchronizer`, so we're sure to have the correct state when a merchant discards or closes an Order while creating it (Creation flow). This however, doesn't work for Orders that are in Editing flow as all changes are committed already, so clearing selection checks the current order state, finds all the items in the Order (as expected) and syncs the state selecting all of them again, hence seeing no changes on tapping the button.

## Changes
- Extract the clear selection sync logic to its own method
- Sync initial order state only when in creation flow. In editing flow we only need to clear the selected items arrays.

## Testing instructions
- Go to Orders > Tap on an existing Order with products > Tap `Edit` > Tap `+ Add Products` > Tap `Clear Selection`
- See how items are correctly unselected

Tapping in `Done` without saving changes and tapping again on `+ Add Products` will keep the products unselected, this is expected. We will only update the state if either we exit the view by tapping on `Done` again to exit the editing mode, or if we actually update the Order via tapping "X products selected"

## Screenshots
| Before: Can't clear selections in editing mode | After: Can clear selections |
|--|--|
| <img width=400 src="https://user-images.githubusercontent.com/3812076/230248403-0bcd1d8a-1a78-4adf-9190-173bcd293017.gif"> | <img width=400 src="https://user-images.githubusercontent.com/3812076/230248441-a09d79a3-2a29-4174-9d6c-5fcf93f4d752.gif"> |

