### PR TITLE
[UI Test] - Add payments universal link test

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+public final class ExternalAppScreen {
+
+    public private(set) var app: XCUIApplication!
+
+    public init() {
+        app = XCUIApplication()
+    }
+
+    public func openUniversalLinkFromRemindersApp(link: String) {
+
+        let reminders = XCUIApplication(bundleIdentifier: "com.apple.reminders")
+        reminders.launch()
+
+        // To dismiss the welcome screen if displayed
+        let continueButton = reminders.buttons["Continue"]
+        if continueButton.exists {
+            continueButton.tap()
+        }
+
+        // Add universal link as reminder
+        let remindersTable = reminders.otherElements["RemindersList.ID.RemindersTable"]
+        remindersTable.tap()
+        reminders.typeText("\(link)")
+        remindersTable.tap()
+
+        // Mark reminder as done to remove from list on next visit
+        reminders.buttons["CompleteOff"].tap()
+
+        // Tap first reminder on list
+        reminders.cells.firstMatch.tap()
+    }
+}

--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -21,7 +21,7 @@ public final class ExternalAppScreen {
 
         // Add universal link as reminder
         let remindersTable = reminders.otherElements["RemindersList.ID.RemindersTable"]
-        remindersTable.tap()
+        if !reminders.textFields["Title"].exists { remindersTable.tap() }
         reminders.textFields["Title"].typeText("\(link)")
         remindersTable.tap()
 

--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -21,7 +21,10 @@ public final class ExternalAppScreen {
 
         // Add universal link as reminder
         let remindersTable = reminders.otherElements["RemindersList.ID.RemindersTable"]
-        if !reminders.textFields["Title"].exists { remindersTable.tap() }
+        if !reminders.textFields["Title"].exists {
+            remindersTable.tap()
+        }
+
         reminders.textFields["Title"].typeText("\(link)")
         remindersTable.tap()
 

--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -22,13 +22,13 @@ public final class ExternalAppScreen {
         // Add universal link as reminder
         let remindersTable = reminders.otherElements["RemindersList.ID.RemindersTable"]
         remindersTable.tap()
-        reminders.typeText("\(link)")
+        reminders.textFields["Title"].typeText("\(link)")
         remindersTable.tap()
 
         // Mark reminder as done to remove from list on next visit
         reminders.buttons["CompleteOff"].tap()
 
         // Tap first reminder on list
-        reminders.cells.firstMatch.tap()
+        reminders.cells.links.firstMatch.tap()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -15,7 +15,7 @@ public final class PaymentsScreen: ScreenObject {
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [ collectPaymentButtonGetter ],
+            expectedElementGetters: [ collectPaymentButtonGetter, cardReaderManualsButtonGetter ],
             app: app
         )
     }

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -19,10 +19,20 @@ public final class PaymentsScreen: ScreenObject {
             app: app
         )
     }
+    
+    static var isVisible: Bool {
+        (try? ProductsScreen().isLoaded) ?? false
+    }
 
     @discardableResult
     public func tapCardReaderManuals() throws -> CardReaderManualsScreen {
         cardReaderManualsButton.tap()
         return try CardReaderManualsScreen()
+    }
+
+    @discardableResult
+    public func verifyPaymentsScreenLoaded() throws -> PaymentsScreen {
+        XCTAssertTrue(isLoaded)
+        return self
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -19,10 +19,6 @@ public final class PaymentsScreen: ScreenObject {
             app: app
         )
     }
-    
-    static var isVisible: Bool {
-        (try? ProductsScreen().isLoaded) ?? false
-    }
 
     @discardableResult
     public func tapCardReaderManuals() throws -> CardReaderManualsScreen {

--- a/WooCommerce/UITestsFoundation/XCTest+Extensions.swift
+++ b/WooCommerce/UITestsFoundation/XCTest+Extensions.swift
@@ -47,18 +47,6 @@ extension XCTestCase {
         }
     }
 
-    public func waitForElementToNotExist(element: XCUIElement, timeout: TimeInterval? = nil) {
-        let notExistsPredicate = NSPredicate(format: "exists == false")
-        let expectation = XCTNSPredicateExpectation(predicate: notExistsPredicate,
-                                                    object: element)
-
-        let timeoutValue = timeout ?? 30
-        guard XCTWaiter().wait(for: [expectation], timeout: timeoutValue) == .completed else {
-            XCTFail("\(element) still exists after \(timeoutValue) seconds.")
-            return
-        }
-    }
-
     public func getRandomPhrase() -> String {
         var wordArray: [String] = []
         let phraseLength = Int.random(in: 3...6)
@@ -109,6 +97,18 @@ extension XCTestCase {
 }
 
 extension XCUIElement {
+
+    public func waitForElementToNotExist(element: XCUIElement, timeout: TimeInterval? = nil) {
+        let notExistsPredicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: notExistsPredicate,
+                                                    object: element)
+
+        let timeoutValue = timeout ?? 30
+        guard XCTWaiter().wait(for: [expectation], timeout: timeoutValue) == .completed else {
+            XCTFail("\(element) still exists after \(timeoutValue) seconds.")
+            return
+        }
+    }
 
     public func scroll(byDeltaX deltaX: CGFloat, deltaY: CGFloat) {
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1274,7 +1274,7 @@
 		80C362732779A7EF005CEAD3 /* products_reviews_all.json in Resources */ = {isa = PBXBuildFile; fileRef = 80C362722779A7EF005CEAD3 /* products_reviews_all.json */; };
 		80CA638929C05E7B002E6BE6 /* PaymentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CA638829C05E7B002E6BE6 /* PaymentsTests.swift */; };
 		80CA638C29C06029002E6BE6 /* PaymentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CA638B29C06029002E6BE6 /* PaymentsScreen.swift */; };
-		80CC80E729DE74D400CA1687 /* ExternalAppScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */; };
+		80CC80E829DEA3C700CA1687 /* ExternalAppScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */; };
 		80D9300329C8660C008865D8 /* CardReaderManualsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D9300229C8660C008865D8 /* CardReaderManualsScreen.swift */; };
 		80DA4F1C29CC505800BDF3BF /* products_search_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 80DA4F1B29CC505800BDF3BF /* products_search_results.json */; };
 		80E6FC6D276312D50086CD67 /* products.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00C923E9BD5500157A78 /* products.json */; };
@@ -10751,7 +10751,7 @@
 				02DEA23328810B7A0057FC40 /* LoginOnboardingScreen.swift in Sources */,
 				3F0CF2FE270420DD00EF3D71 /* ScreenObject+Extension.swift in Sources */,
 				3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */,
-				80CC80E729DE74D400CA1687 /* ExternalAppScreen.swift in Sources */,
+				80CC80E829DEA3C700CA1687 /* ExternalAppScreen.swift in Sources */,
 				3F0CF3002704490A00EF3D71 /* OrderSearchScreen.swift in Sources */,
 				DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */,
 				3F0CF3012704490A00EF3D71 /* ReviewsScreen.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1274,6 +1274,7 @@
 		80C362732779A7EF005CEAD3 /* products_reviews_all.json in Resources */ = {isa = PBXBuildFile; fileRef = 80C362722779A7EF005CEAD3 /* products_reviews_all.json */; };
 		80CA638929C05E7B002E6BE6 /* PaymentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CA638829C05E7B002E6BE6 /* PaymentsTests.swift */; };
 		80CA638C29C06029002E6BE6 /* PaymentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CA638B29C06029002E6BE6 /* PaymentsScreen.swift */; };
+		80CC80E729DE74D400CA1687 /* ExternalAppScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */; };
 		80D9300329C8660C008865D8 /* CardReaderManualsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D9300229C8660C008865D8 /* CardReaderManualsScreen.swift */; };
 		80DA4F1C29CC505800BDF3BF /* products_search_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 80DA4F1B29CC505800BDF3BF /* products_search_results.json */; };
 		80E6FC6D276312D50086CD67 /* products.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00C923E9BD5500157A78 /* products.json */; };
@@ -3460,6 +3461,7 @@
 		80C362722779A7EF005CEAD3 /* products_reviews_all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = products_reviews_all.json; sourceTree = "<group>"; };
 		80CA638829C05E7B002E6BE6 /* PaymentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsTests.swift; sourceTree = "<group>"; };
 		80CA638B29C06029002E6BE6 /* PaymentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsScreen.swift; sourceTree = "<group>"; };
+		80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalAppScreen.swift; sourceTree = "<group>"; };
 		80D9300229C8660C008865D8 /* CardReaderManualsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsScreen.swift; sourceTree = "<group>"; };
 		80DA4F1B29CC505800BDF3BF /* products_search_results.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_search_results.json; sourceTree = "<group>"; };
 		80E6FC6E276325F60086CD67 /* Clibsodium.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Clibsodium.xcframework; path = ../Pods/Sodium/Clibsodium.xcframework; sourceTree = "<group>"; };
@@ -9902,6 +9904,7 @@
 				F9BB249623F4B1C60068A420 /* Products */,
 				F9BB249923F501FB0068A420 /* Settings */,
 				F997172F23DBCEB200592D8E /* TabNavComponent.swift */,
+				80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -10748,6 +10751,7 @@
 				02DEA23328810B7A0057FC40 /* LoginOnboardingScreen.swift in Sources */,
 				3F0CF2FE270420DD00EF3D71 /* ScreenObject+Extension.swift in Sources */,
 				3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */,
+				80CC80E729DE74D400CA1687 /* ExternalAppScreen.swift in Sources */,
 				3F0CF3002704490A00EF3D71 /* OrderSearchScreen.swift in Sources */,
 				DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */,
 				3F0CF3012704490A00EF3D71 /* ReviewsScreen.swift in Sources */,

--- a/WooCommerce/WooCommerceUITests/README.md
+++ b/WooCommerce/WooCommerceUITests/README.md
@@ -63,9 +63,12 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
     - [ ] New order results in a push notification
     - [ ] Orders push notification opens the correct order
     - [ ] Reviews push notification opens the correct review
-7. Settings
+7. Universal Links and Deeplinks
+    - [x] Universal Link to Payments screen
+    - [ ] Universal Link to an Order
+8. Settings
     - [ ] Contact support
-8. Payments
+9. Payments
     - [ ] Make a Simple payment
     - [ ] Make a Tap to Pay on iPhone payment
     - [ ] Manage Card Reader - Connect/Disconnect Reader

--- a/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
@@ -19,4 +19,11 @@ final class PaymentsTests: XCTestCase {
             .tapChipperManual()
             .verifyChipperManualLoadedOnWebView()
     }
+
+    func test_load_payments_universal_link() throws {
+        let paymentsLink = "https://woocommerce.com/mobile/payments"
+
+        ExternalAppScreen().openUniversalLinkFromRemindersApp(link: paymentsLink)
+        try PaymentsScreen().verifyPaymentsScreenLoaded()
+    }
 }


### PR DESCRIPTION
## Description
This PR adds a new test to validate that universal links work on the app. 

I tried several apps before landing on the Reminders app for a few reasons:
1. Notes app is not pre-installed in the simulator, this would have been my first choice if it was
2. Safari did not work in this case as it strips the URL resulting in a generic URL of only ./mobile, which doesn't work in this case
3. Messages app worked, but it made the test flaky because the time taken for the text "bubble" to appear seems to be unpredictable. It could have been fixed by adding an implicit wait, but I didn't want to add that to the code
4. Reminders app was the last app I tried that seemed to work the best in this case, I ended up using it

There is also a possibility of using Wiremock to create an HTML page that contains all the links (h/t to @tiagomar for this suggestion!) I think that should be a separate PR as that might take a while to implement (it looks possible, but I've not tested it out).

Test flow:
1. Test would still need to go through the login flow to be in a logged state 
2. Launch reminders app, add and tap the universal link from reminders app
3. Verify that test is redirected to the correct screen

## Testing instructions
The test should pass locally and in CI

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
