### PR TITLE
Coupons: Resolve filters and search queries working combined in product selector

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -360,7 +360,6 @@ struct OrderForm_Previews: PreviewProvider {
 private extension ProductSelectorView.Configuration {
     static func addProductToOrder() -> ProductSelectorView.Configuration {
         ProductSelectorView.Configuration(
-            showsFilters: true,
             multipleSelectionsEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1),
             searchHeaderBackgroundColor: .listBackground,
             prefersLargeTitle: false,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -360,6 +360,7 @@ struct OrderForm_Previews: PreviewProvider {
 private extension ProductSelectorView.Configuration {
     static func addProductToOrder() -> ProductSelectorView.Configuration {
         ProductSelectorView.Configuration(
+            showsFilters: true,
             multipleSelectionsEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1),
             searchHeaderBackgroundColor: .listBackground,
             prefersLargeTitle: false,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -139,7 +139,7 @@ struct ProductSelectorView: View {
         .notice($viewModel.notice, autoDismiss: false)
         .sheet(isPresented: $showingFilters) {
             FilterListView(viewModel: viewModel.filterListViewModel) { filters in
-                viewModel.filters.send(filters)
+                viewModel.updateFilters(filters)
             } onClearAction: {
                 // no-op
             } onDismissAction: {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -189,7 +189,7 @@ struct ProductSelectorView: View {
 
 extension ProductSelectorView {
     struct Configuration {
-        var showsFilters: Bool = false
+        var showsFilters: Bool = true
         var multipleSelectionsEnabled: Bool = false
         var searchHeaderBackgroundColor: UIColor = .listForeground(modal: false)
         var prefersLargeTitle: Bool = true

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -189,7 +189,7 @@ struct ProductSelectorView: View {
 
 extension ProductSelectorView {
     struct Configuration {
-        var showsFilters: Bool = true
+        var showsFilters: Bool = false
         var multipleSelectionsEnabled: Bool = false
         var searchHeaderBackgroundColor: UIColor = .listForeground(modal: false)
         var prefersLargeTitle: Bool = true

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -139,7 +139,7 @@ struct ProductSelectorView: View {
         .notice($viewModel.notice, autoDismiss: false)
         .sheet(isPresented: $showingFilters) {
             FilterListView(viewModel: viewModel.filterListViewModel) { filters in
-                viewModel.filters = filters
+                viewModel.filters.send(filters)
             } onClearAction: {
                 // no-op
             } onDismissAction: {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -178,7 +178,7 @@ final class ProductSelectorViewModel: ObservableObject {
         configureSyncingCoordinator()
         configureProductsResultsController()
         configureFirstPageLoad()
-        configureProductSearch()
+        synchronizedProductFilterSearch()
     }
 
     /// Initializer for multiple selections
@@ -211,7 +211,7 @@ final class ProductSelectorViewModel: ObservableObject {
         configureSyncingCoordinator()
         configureProductsResultsController()
         configureFirstPageLoad()
-        configureProductSearch()
+        synchronizedProductFilterSearch()
     }
 
     /// Select a product to add to the order
@@ -510,7 +510,7 @@ private extension ProductSelectorViewModel {
 
     /// Updates the product results predicate & triggers a new sync when search term changes
     ///
-    func configureProductSearch() {
+    func synchronizedProductFilterSearch() {
         let searchTermPublisher = $searchTerm
             .removeDuplicates()
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -35,7 +35,7 @@ final class ProductSelectorViewModel: ObservableObject {
         FilterProductListViewModel(filters: filters, siteID: siteID)
     }
 
-    /// Selected filter for the product list
+    /// Selected filters for the product list
     ///
     var filters: FilterProductListViewModel.Filters = FilterProductListViewModel.Filters() {
         didSet {
@@ -43,7 +43,11 @@ final class ProductSelectorViewModel: ObservableObject {
                                                       stockStatus: filters.stockStatus,
                                                       productStatus: filters.productStatus,
                                                       productType: filters.productType)
-            syncingCoordinator.resynchronize()
+            updateFilterButtonTitle(with: filters)
+            // Running the sync on the main thread is necessary as the Dispatcher should only be called from it
+            DispatchQueue.main.async { [weak self] in
+                self?.syncingCoordinator.resynchronize()
+            }
         }
     }
 
@@ -526,7 +530,6 @@ private extension ProductSelectorViewModel {
 
         searchTermPublisher.sink { [weak self] searchTerm in
             guard let self = self else { return }
-            self.updateFilterButtonTitle(with: self.filters)
             self.updatePredicate(searchTerm: searchTerm, filters: self.filters)
             self.updateProductsResultsController()
             self.syncingCoordinator.resynchronize()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -512,6 +512,7 @@ private extension ProductSelectorViewModel {
     ///
     func synchronizedProductFilterSearch() {
         let searchTermPublisher = $searchTerm
+            .dropFirst()
             .removeDuplicates()
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -432,12 +432,6 @@ extension ProductSelectorViewModel: SyncingCoordinatorDelegate {
     func updateFilters(_ filters: FilterProductListViewModel.Criteria) {
         filtersSubject.send(filters)
     }
-
-    /// Retrieves the latest selected filters from the product list
-    ///
-    func retrieveUpdatedFilters() -> FilterProductListViewModel.Filters {
-        filtersSubject.value
-    }
 }
 
 // MARK: - Finite State Machine Management

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -512,7 +512,6 @@ private extension ProductSelectorViewModel {
     ///
     func synchronizedProductFilterSearch() {
         let searchTermPublisher = $searchTerm
-            .dropFirst()
             .removeDuplicates()
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -37,7 +37,7 @@ final class ProductSelectorViewModel: ObservableObject {
 
     /// Selected filters for the product list
     ///
-    var filters = CurrentValueSubject<FilterProductListViewModel.Filters, Never>(.init())
+    private let filters = CurrentValueSubject<FilterProductListViewModel.Filters, Never>(.init())
 
     /// Title of the filter button, should be updated with number of active filters.
     ///
@@ -425,6 +425,18 @@ extension ProductSelectorViewModel: SyncingCoordinatorDelegate {
     func syncNextPage() {
         let lastIndex = productsResultsController.numberOfObjects - 1
         syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: lastIndex)
+    }
+
+    /// Updates the selected filters for the product list
+    ///
+    func updateFilters(_ filters: FilterProductListViewModel.Criteria) {
+        self.filters.send(filters)
+    }
+
+    /// Retrieves the latest selected filters from the product list
+    ///
+    func retrieveUpdatedFilters() -> FilterProductListViewModel.Filters {
+        self.filters.value
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -178,7 +178,7 @@ final class ProductSelectorViewModel: ObservableObject {
         configureSyncingCoordinator()
         configureProductsResultsController()
         configureFirstPageLoad()
-        synchronizedProductFilterSearch()
+        synchronizeProductFilterSearch()
     }
 
     /// Initializer for multiple selections
@@ -211,7 +211,7 @@ final class ProductSelectorViewModel: ObservableObject {
         configureSyncingCoordinator()
         configureProductsResultsController()
         configureFirstPageLoad()
-        synchronizedProductFilterSearch()
+        synchronizeProductFilterSearch()
     }
 
     /// Select a product to add to the order
@@ -510,7 +510,7 @@ private extension ProductSelectorViewModel {
 
     /// Updates the product results predicate & triggers a new sync when search term changes
     ///
-    func synchronizedProductFilterSearch() {
+    func synchronizeProductFilterSearch() {
         let searchTermPublisher = $searchTerm
             .removeDuplicates()
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -144,10 +144,17 @@ final class ProductSelectorViewModelTests: XCTestCase {
         }
 
         // When
-        viewModel.sync(pageNumber: 1, pageSize: 25, onCompletion: { _ in })
+        let _: Bool = waitFor { completion in
+            viewModel.sync(pageNumber: 1, pageSize: 25, onCompletion: { sync in
+                if let syncStatus = viewModel.syncStatus {
+                    syncStatusSpy.append(syncStatus)
+                }
+                completion(sync)
+            })
+        }
 
         // Then
-        XCTAssertTrue(syncStatusSpy.contains(.firstPageSync))
+        XCTAssertEqual(syncStatusSpy, [.firstPageSync, .results])
         XCTAssertEqual(viewModel.syncStatus, .results)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -144,12 +144,12 @@ final class ProductSelectorViewModelTests: XCTestCase {
         }
 
         // When
-        let _: Bool = waitFor { completion in
-            viewModel.sync(pageNumber: 1, pageSize: 25, onCompletion: { sync in
+        waitFor { promise in
+            viewModel.sync(pageNumber: 1, pageSize: 25, onCompletion: { _ in
                 if let syncStatus = viewModel.syncStatus {
                     syncStatusSpy.append(syncStatus)
                 }
-                completion(sync)
+                promise(())
             })
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -298,7 +298,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // When
         viewModel.searchTerm = "shirt"
-        viewModel.filters = .init(stockStatus: .outOfStock,
+        viewModel.filters.value = .init(stockStatus: .outOfStock,
                                   productStatus: .draft,
                                   productType: .simple,
                                   productCategory: nil,
@@ -307,7 +307,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.searchTerm, "")
-        XCTAssertEqual(viewModel.filters, FilterProductListViewModel.Filters())
+        XCTAssertEqual(viewModel.filters.value, FilterProductListViewModel.Filters())
     }
 
     func test_clearing_search_returns_full_product_list() {
@@ -344,11 +344,11 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.searchTerm, "")
-        XCTAssertNil(viewModel.filters.stockStatus)
-        XCTAssertNil(viewModel.filters.productCategory)
-        XCTAssertNil(viewModel.filters.productType)
-        XCTAssertNil(viewModel.filters.productCategory)
-        XCTAssertEqual(viewModel.filters.numberOfActiveFilters, 0)
+        XCTAssertNil(viewModel.filters.value.stockStatus)
+        XCTAssertNil(viewModel.filters.value.productCategory)
+        XCTAssertNil(viewModel.filters.value.productType)
+        XCTAssertNil(viewModel.filters.value.productCategory)
+        XCTAssertEqual(viewModel.filters.value.numberOfActiveFilters, 0)
     }
 
     func test_view_model_fires_error_notice_when_product_sync_fails() {
@@ -673,7 +673,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // When
         viewModel.searchTerm = ""
-        viewModel.filters = FilterProductListViewModel.Filters(
+        viewModel.filters.value = FilterProductListViewModel.Filters(
             stockStatus: ProductStockStatus.outOfStock,
             productStatus: ProductStatus.draft,
             productType: ProductType.simple,
@@ -695,7 +695,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID, storageManager: storageManager)
 
         // When
-        viewModel.filters = FilterProductListViewModel.Filters(
+        viewModel.filters.value = FilterProductListViewModel.Filters(
             stockStatus: nil,
             productStatus: nil,
             productType: ProductType.simple,
@@ -792,7 +792,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         }
 
         // When
-        viewModel.filters = filters
+        viewModel.filters.value = filters
         viewModel.searchTerm = ""
         try await Task.sleep(nanoseconds: searchDebounceTime)
 
@@ -831,7 +831,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         }
 
         // When
-        viewModel.filters = filters
+        viewModel.filters.value = filters
         viewModel.searchTerm = "hiii"
         try await Task.sleep(nanoseconds: searchDebounceTime)
 
@@ -871,7 +871,12 @@ final class ProductSelectorViewModelTests: XCTestCase {
             productCategory: nil,
             numberOfActiveFilters: 1
         )
-        viewModel.filters = updatedFilters
+        viewModel.filters.value = updatedFilters
+
+        // Then
+        XCTAssertEqual(viewModel.productRows.count, 0) // no product matches the filter and search term
+        // When
+
         viewModel.searchTerm = ""
         waitUntil {
             viewModel.productRows.isNotEmpty

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -838,12 +838,10 @@ final class ProductSelectorViewModelTests: XCTestCase {
         try await Task.sleep(nanoseconds: searchDebounceTime)
 
         // Then
-        let currentFilters = viewModel.filterListViewModel.criteria
-        assertEqual(filteredStockStatus, currentFilters.stockStatus)
-        assertEqual(filteredProductType, currentFilters.productType)
-        assertEqual(filteredProductStatus, currentFilters.productStatus)
-        assertEqual(filteredProductCategory, currentFilters.productCategory)
         assertEqual(filteredStockStatus, filters.stockStatus)
+        assertEqual(filteredProductType, filters.productType)
+        assertEqual(filteredProductStatus, filters.productStatus)
+        assertEqual(filteredProductCategory, filters.productCategory)
     }
 
     func test_searchProducts_are_triggered_with_correct_filters() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -872,11 +872,6 @@ final class ProductSelectorViewModelTests: XCTestCase {
             numberOfActiveFilters: 1
         )
         viewModel.filters = updatedFilters
-
-        // Then
-        XCTAssertEqual(viewModel.productRows.count, 0) // no product matches the filter and search term
-
-        // When
         viewModel.searchTerm = ""
         waitUntil {
             viewModel.productRows.isNotEmpty

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -330,7 +330,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.searchTerm, "")
-        XCTAssertEqual(viewModel.retrieveUpdatedFilters(), FilterProductListViewModel.Filters())
+        XCTAssertEqual(viewModel.filterListViewModel.criteria, FilterProductListViewModel.Filters())
     }
 
     func test_clearing_search_returns_full_product_list() {
@@ -366,7 +366,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID)
 
         // Then
-        let currentFilters = viewModel.retrieveUpdatedFilters()
+        let currentFilters = viewModel.filterListViewModel.criteria
         XCTAssertEqual(viewModel.searchTerm, "")
         XCTAssertNil(currentFilters.stockStatus)
         XCTAssertNil(currentFilters.productCategory)
@@ -838,11 +838,12 @@ final class ProductSelectorViewModelTests: XCTestCase {
         try await Task.sleep(nanoseconds: searchDebounceTime)
 
         // Then
-        let currentFilters = viewModel.retrieveUpdatedFilters()
+        let currentFilters = viewModel.filterListViewModel.criteria
         assertEqual(filteredStockStatus, currentFilters.stockStatus)
         assertEqual(filteredProductType, currentFilters.productType)
         assertEqual(filteredProductStatus, currentFilters.productStatus)
         assertEqual(filteredProductCategory, currentFilters.productCategory)
+        assertEqual(filteredStockStatus, filters.stockStatus)
     }
 
     func test_searchProducts_are_triggered_with_correct_filters() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -126,17 +126,15 @@ final class ProductSelectorViewModelTests: XCTestCase {
             storageManager: mockStorageManager,
             stores: mockStores
         )
+        var syncStatusSpy: [ProductSelectorViewModel.SyncStatus] = []
+
         mockStores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .synchronizeProducts(_, _, _, _, _, _, _, _, _, _, onCompletion):
-                // TODO: This assertion will fail if we ran the test class or suite, but not individually
-                // And will fail not here, but on `test_synchronizeProducts_are_triggered_with_correct_filters`
-                // most likely we're persisnting sync state?
-                //XCTAssertEqual(viewModel.syncStatus, .firstPageSync)
+                if let syncStatus = viewModel.syncStatus {
+                    syncStatusSpy.append(syncStatus)
+                }
                 let readOnlyProduct = Product.fake().copy(siteID: self.sampleSiteID, purchasable: true)
-                // TODO: Refactor
-                // We're making sure to insert the product in the correct context storage,
-                // in this case we can't use the factory method as is a different context and thread and will fail
                 let product = mockStorageManager.viewStorage.insertNewObject(ofType: StorageProduct.self)
                 product.update(with: readOnlyProduct)
                 onCompletion(.success(true))
@@ -149,6 +147,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         viewModel.sync(pageNumber: 1, pageSize: 25, onCompletion: { _ in })
 
         // Then
+        XCTAssertTrue(syncStatusSpy.contains(.firstPageSync))
         XCTAssertEqual(viewModel.syncStatus, .results)
     }
 


### PR DESCRIPTION
Closes: #9098 

## Description

This PR fixes the current Coupons filters implementation by wrapping the current `FilterProductListViewModel.Filters` struct into a `CurrentValueSubject` type, so filters and search queries work properly when combined.

Why? Subscribing to the publisher of a `@Published` variable gets the updated result when it changes, however, the notification is sent before the variable itself is updated (the latest value in `.sink` is in `willSet`, not in `didSet`), so we cannot use this update to trigger other methods that rely on the property, as we're passing the old value.

## Changes
* Changes the `FilterProductListViewModel.Filters` from using a `@Published` property wrapper to use `CurrentValueSubject` instead.
* Removes `.dropFirst()` from the search term publisher. This is necessary so we can combine the filter publisher notifications without having to rely on changes in the search terms happening first.
* Unit Test changes:
  * Inject mock storage on some tests that require synching and inserting products, as these would be flaky and crash when we attempt to mutate from a different context queue (I intend to do the same for all test as an improvement, but perhaps this is more suited for a different PR)
  * Declares `@MainActor` for these same tests, so we're sure they run in the main thread. This is necessary because the action Dispatcher requires it while async-await delegates those to background threads if needed.


## Testing instructions

- Go to Menu > Settings > Experimental toggle > Enable `Coupon Management`
- Go to Menu > Coupons > `+` > `Percentage discount` > All Products
- See that using the "search products" field and/or the "Filter" button now works as expected.

## Screenshots

<img width=450 src="https://user-images.githubusercontent.com/3812076/230409815-60795501-0fc1-467c-a74d-ba47657eb062.gif">


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
