### PR TITLE
[Free Trial] Release Free Trial Store Creation feature

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -84,7 +84,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .productBundles:
             return true
         case .freeTrial:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .manualErrorHandlingForSiteCredentialLogin:
             return true
         case .compositeProducts:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 13.1
 -----
+- [***] Users can now create a Free Trial store from the app from the Get Started section of the app prologue. [https://github.com/woocommerce/woocommerce-ios/pull/9396]
 - [**] Adds support for Product Multi-selection when creating and/or editing Orders. [https://github.com/woocommerce/woocommerce-ios/issues/8888]
 - [**] Users can now install Jetpack for their non-Jetpack sites after logging in with application passwords. [https://github.com/woocommerce/woocommerce-ios/pull/9354]
 - [*] Payments: We show a Tap to Pay on iPhone feedback survey button in the Payments menu after the first Tap to Pay on iPhone payment is taken [https://github.com/woocommerce/woocommerce-ios/pull/9366]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 13.1
 -----
-- [***] Users can now create a Free Trial store from the app from the Get Started section of the app prologue. [https://github.com/woocommerce/woocommerce-ios/pull/9396]
+- [internal] Users can now create a Free Trial store from the app from the Get Started section of the app prologue. [https://github.com/woocommerce/woocommerce-ios/pull/9396]
 - [**] Adds support for Product Multi-selection when creating and/or editing Orders. [https://github.com/woocommerce/woocommerce-ios/issues/8888]
 - [**] Users can now install Jetpack for their non-Jetpack sites after logging in with application passwords. [https://github.com/woocommerce/woocommerce-ios/pull/9354]
 - [*] Payments: We show a Tap to Pay on iPhone feedback survey button in the Payments menu after the first Tap to Pay on iPhone payment is taken [https://github.com/woocommerce/woocommerce-ios/pull/9366]


### PR DESCRIPTION
Closes #9389

Summary
==========
Activates the Free Trial feature flag and updates the release notes advertising the new feature.

How to Test
==========
1. Run the Iteration 2 test plan. Reference: pe5pgL-2AD

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
