### PR TITLE
[UI Tests] - Add universal links test for payments

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -8,32 +8,7 @@ public final class ExternalAppScreen {
         app = XCUIApplication()
     }
 
-    // To open universal links without depending on mocks
-    public func openUniversalLinkFromRemindersApp(link: String) {
-
-        let reminders = XCUIApplication(bundleIdentifier: "com.apple.reminders")
-        reminders.launch()
-
-        // To dismiss the welcome screen if displayed
-        let continueButton = reminders.buttons["Continue"]
-        if continueButton.exists {
-            continueButton.tap()
-        }
-
-        // Add universal link as reminder
-        let remindersTable = reminders.otherElements["RemindersList.ID.RemindersTable"]
-        if !reminders.textFields["Title"].exists { remindersTable.tap() }
-        reminders.textFields["Title"].typeText("\(link)")
-        remindersTable.tap()
-
-        // Mark reminder as done to remove from list on next visit
-        reminders.buttons["CompleteOff"].tap()
-
-        // Tap first reminder on list
-        reminders.cells.links.firstMatch.tap()
-    }
-
-    // To open universal links using mocks
+    // To open universal links listed in mocked HTML file
     public func openUniversalLinkFromSafariApp(link: String) {
 
         let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")

--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+public final class ExternalAppScreen {
+
+    public private(set) var app: XCUIApplication!
+
+    public init() {
+        app = XCUIApplication()
+    }
+
+    public func openUniversalLinkFromRemindersApp(link: String) {
+
+        let reminders = XCUIApplication(bundleIdentifier: "com.apple.reminders")
+        reminders.launch()
+
+        // To dismiss the welcome screen if displayed
+        let continueButton = reminders.buttons["Continue"]
+        if continueButton.exists {
+            continueButton.tap()
+        }
+
+        // Add universal link as reminder
+        let remindersTable = reminders.otherElements["RemindersList.ID.RemindersTable"]
+        remindersTable.tap()
+        reminders.typeText("\(link)")
+        remindersTable.tap()
+
+        // Mark reminder as done to remove from list on next visit
+        reminders.buttons["CompleteOff"].tap()
+
+        // Tap first reminder on list
+        reminders.cells.firstMatch.tap()
+    }
+}

--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -21,7 +21,7 @@ public final class ExternalAppScreen {
 
         // Add universal link as reminder
         let remindersTable = reminders.otherElements["RemindersList.ID.RemindersTable"]
-        remindersTable.tap()
+        if !reminders.textFields["Title"].exists { remindersTable.tap() }
         reminders.textFields["Title"].typeText("\(link)")
         remindersTable.tap()
 

--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -39,8 +39,11 @@ public final class ExternalAppScreen {
         let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
         safari.launch()
 
+        // To accommodate elements on both iPhone and iPad
+        let searchBarElement = UIDevice.current.userInterfaceIdiom == .phone ? "TabBarItemTitle" : "UnifiedTabBarItemView?isSelected=true"
+
         // Go to Wiremock's HTML file with universal links
-        safari.textFields["TabBarItemTitle"].tap()
+        safari.textFields[searchBarElement].tap()
         safari.typeText("http://localhost:8282/links.html")
         safari.buttons["Go"].tap()
 

--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -8,7 +8,15 @@ public final class ExternalAppScreen {
         app = XCUIApplication()
     }
 
+    let universalLinks = [
+        "payments": "https://woocommerce.com/mobile/payments"
+    ]
+
     // To open universal links listed in mocked HTML file
+    public func openUniversalLinkFromSafariApp(linkedScreen: String) throws {
+        guard let universalLink = universalLinks[linkedScreen] else {
+            throw NSError(domain: "UI Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Universal link not found for key: \(linkedScreen)"])
+        }
 
         let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
         safari.launch()
@@ -22,5 +30,6 @@ public final class ExternalAppScreen {
         safari.buttons["Go"].tap()
 
         // Tap on the universal link
+        if safari.staticTexts["TESTING LINKS"].exists { safari.links[universalLink].tap() }
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -9,20 +9,18 @@ public final class ExternalAppScreen {
     }
 
     // To open universal links listed in mocked HTML file
-    public func openUniversalLinkFromSafariApp(link: String) {
 
         let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
         safari.launch()
 
         // To accommodate elements on both iPhone and iPad
-        let searchBarElement = UIDevice.current.userInterfaceIdiom == .phone ? "TabBarItemTitle" : "UnifiedTabBarItemView?isSelected=true"
+        let searchBarElement = UIDevice.current.userInterfaceIdiom == .phone ? "CapsuleNavigationBar?isSelected=true" : "UnifiedTabBar"
 
         // Go to Wiremock's HTML file with universal links
-        safari.textFields[searchBarElement].tap()
+        safari.otherElements[searchBarElement].tap()
         safari.typeText("http://localhost:8282/links.html")
         safari.buttons["Go"].tap()
 
         // Tap on the universal link
-        if safari.staticTexts["TESTING LINKS"].exists { safari.links[link].tap() }
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -41,11 +41,10 @@ public final class ExternalAppScreen {
 
         // Go to Wiremock's HTML file with universal links
         safari.textFields["TabBarItemTitle"].tap()
-        // 
         safari.typeText("http://localhost:8282/links.html")
         safari.buttons["Go"].tap()
 
-        // Tap on the Payments link
+        // Tap on the universal link
         if safari.staticTexts["TESTING LINKS"].exists { safari.links[link].tap() }
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -8,6 +8,7 @@ public final class ExternalAppScreen {
         app = XCUIApplication()
     }
 
+    // To open universal links without depending on mocks
     public func openUniversalLinkFromRemindersApp(link: String) {
 
         let reminders = XCUIApplication(bundleIdentifier: "com.apple.reminders")
@@ -30,5 +31,21 @@ public final class ExternalAppScreen {
 
         // Tap first reminder on list
         reminders.cells.links.firstMatch.tap()
+    }
+
+    // To open universal links using mocks
+    public func openUniversalLinkFromSafariApp(link: String) {
+
+        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        safari.launch()
+
+        // Go to Wiremock's HTML file with universal links
+        safari.textFields["TabBarItemTitle"].tap()
+        // 
+        safari.typeText("http://localhost:8282/links.html")
+        safari.buttons["Go"].tap()
+
+        // Tap on the Payments link
+        if safari.staticTexts["TESTING LINKS"].exists { safari.links[link].tap() }
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -22,13 +22,13 @@ public final class ExternalAppScreen {
         // Add universal link as reminder
         let remindersTable = reminders.otherElements["RemindersList.ID.RemindersTable"]
         remindersTable.tap()
-        reminders.typeText("\(link)")
+        reminders.textFields["Title"].typeText("\(link)")
         remindersTable.tap()
 
         // Mark reminder as done to remove from list on next visit
         reminders.buttons["CompleteOff"].tap()
 
         // Tap first reminder on list
-        reminders.cells.firstMatch.tap()
+        reminders.cells.links.firstMatch.tap()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -15,7 +15,7 @@ public final class PaymentsScreen: ScreenObject {
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [ collectPaymentButtonGetter ],
+            expectedElementGetters: [ collectPaymentButtonGetter, cardReaderManualsButtonGetter ],
             app: app
         )
     }

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -19,10 +19,20 @@ public final class PaymentsScreen: ScreenObject {
             app: app
         )
     }
+    
+    static var isVisible: Bool {
+        (try? ProductsScreen().isLoaded) ?? false
+    }
 
     @discardableResult
     public func tapCardReaderManuals() throws -> CardReaderManualsScreen {
         cardReaderManualsButton.tap()
         return try CardReaderManualsScreen()
+    }
+
+    @discardableResult
+    public func verifyPaymentsScreenLoaded() throws -> PaymentsScreen {
+        XCTAssertTrue(isLoaded)
+        return self
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -19,10 +19,6 @@ public final class PaymentsScreen: ScreenObject {
             app: app
         )
     }
-    
-    static var isVisible: Bool {
-        (try? ProductsScreen().isLoaded) ?? false
-    }
 
     @discardableResult
     public func tapCardReaderManuals() throws -> CardReaderManualsScreen {

--- a/WooCommerce/UITestsFoundation/XCTest+Extensions.swift
+++ b/WooCommerce/UITestsFoundation/XCTest+Extensions.swift
@@ -47,18 +47,6 @@ extension XCTestCase {
         }
     }
 
-    public func waitForElementToNotExist(element: XCUIElement, timeout: TimeInterval? = nil) {
-        let notExistsPredicate = NSPredicate(format: "exists == false")
-        let expectation = XCTNSPredicateExpectation(predicate: notExistsPredicate,
-                                                    object: element)
-
-        let timeoutValue = timeout ?? 30
-        guard XCTWaiter().wait(for: [expectation], timeout: timeoutValue) == .completed else {
-            XCTFail("\(element) still exists after \(timeoutValue) seconds.")
-            return
-        }
-    }
-
     public func getRandomPhrase() -> String {
         var wordArray: [String] = []
         let phraseLength = Int.random(in: 3...6)
@@ -109,6 +97,18 @@ extension XCTestCase {
 }
 
 extension XCUIElement {
+
+    public func waitForElementToNotExist(element: XCUIElement, timeout: TimeInterval? = nil) {
+        let notExistsPredicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: notExistsPredicate,
+                                                    object: element)
+
+        let timeoutValue = timeout ?? 30
+        guard XCTWaiter().wait(for: [expectation], timeout: timeoutValue) == .completed else {
+            XCTFail("\(element) still exists after \(timeoutValue) seconds.")
+            return
+        }
+    }
 
     public func scroll(byDeltaX deltaX: CGFloat, deltaY: CGFloat) {
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1274,7 +1274,7 @@
 		80C362732779A7EF005CEAD3 /* products_reviews_all.json in Resources */ = {isa = PBXBuildFile; fileRef = 80C362722779A7EF005CEAD3 /* products_reviews_all.json */; };
 		80CA638929C05E7B002E6BE6 /* PaymentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CA638829C05E7B002E6BE6 /* PaymentsTests.swift */; };
 		80CA638C29C06029002E6BE6 /* PaymentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CA638B29C06029002E6BE6 /* PaymentsScreen.swift */; };
-		80CC80E729DE74D400CA1687 /* ExternalAppScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */; };
+		80CC80E829DEA3C700CA1687 /* ExternalAppScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */; };
 		80D9300329C8660C008865D8 /* CardReaderManualsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D9300229C8660C008865D8 /* CardReaderManualsScreen.swift */; };
 		80DA4F1C29CC505800BDF3BF /* products_search_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 80DA4F1B29CC505800BDF3BF /* products_search_results.json */; };
 		80E6FC6D276312D50086CD67 /* products.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00C923E9BD5500157A78 /* products.json */; };
@@ -10751,7 +10751,7 @@
 				02DEA23328810B7A0057FC40 /* LoginOnboardingScreen.swift in Sources */,
 				3F0CF2FE270420DD00EF3D71 /* ScreenObject+Extension.swift in Sources */,
 				3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */,
-				80CC80E729DE74D400CA1687 /* ExternalAppScreen.swift in Sources */,
+				80CC80E829DEA3C700CA1687 /* ExternalAppScreen.swift in Sources */,
 				3F0CF3002704490A00EF3D71 /* OrderSearchScreen.swift in Sources */,
 				DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */,
 				3F0CF3012704490A00EF3D71 /* ReviewsScreen.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1275,6 +1275,7 @@
 		80CA638929C05E7B002E6BE6 /* PaymentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CA638829C05E7B002E6BE6 /* PaymentsTests.swift */; };
 		80CA638C29C06029002E6BE6 /* PaymentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CA638B29C06029002E6BE6 /* PaymentsScreen.swift */; };
 		80CC80E829DEA3C700CA1687 /* ExternalAppScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */; };
+		80CC80F229DFC3E400CA1687 /* files.json in Resources */ = {isa = PBXBuildFile; fileRef = 80CC80F129DFC3E400CA1687 /* files.json */; };
 		80D9300329C8660C008865D8 /* CardReaderManualsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D9300229C8660C008865D8 /* CardReaderManualsScreen.swift */; };
 		80DA4F1C29CC505800BDF3BF /* products_search_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 80DA4F1B29CC505800BDF3BF /* products_search_results.json */; };
 		80E6FC6D276312D50086CD67 /* products.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00C923E9BD5500157A78 /* products.json */; };
@@ -3462,6 +3463,7 @@
 		80CA638829C05E7B002E6BE6 /* PaymentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsTests.swift; sourceTree = "<group>"; };
 		80CA638B29C06029002E6BE6 /* PaymentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsScreen.swift; sourceTree = "<group>"; };
 		80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalAppScreen.swift; sourceTree = "<group>"; };
+		80CC80F129DFC3E400CA1687 /* files.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = files.json; sourceTree = "<group>"; };
 		80D9300229C8660C008865D8 /* CardReaderManualsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsScreen.swift; sourceTree = "<group>"; };
 		80DA4F1B29CC505800BDF3BF /* products_search_results.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_search_results.json; sourceTree = "<group>"; };
 		80E6FC6E276325F60086CD67 /* Clibsodium.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Clibsodium.xcframework; path = ../Pods/Sodium/Clibsodium.xcframework; sourceTree = "<group>"; };
@@ -8471,6 +8473,7 @@
 				CCFC00D623E9BD5500157A78 /* me */,
 				CCFC00D923E9BD5500157A78 /* notifications */,
 				CCFC00DC23E9BD5500157A78 /* stats */,
+				80CC80F129DFC3E400CA1687 /* files.json */,
 			);
 			path = mappings;
 			sourceTree = "<group>";
@@ -10480,6 +10483,7 @@
 				800A5BAE27586876009DE2CD /* products_2131.json in Resources */,
 				800A5BAC27586642009DE2CD /* products_2130.json in Resources */,
 				C0CE1F84282AB1590019138E /* countries.json in Resources */,
+				80CC80F229DFC3E400CA1687 /* files.json in Resources */,
 				80AD2CA627859B4400A63DE8 /* reports_leaderboards_stats_day.json in Resources */,
 				80C362732779A7EF005CEAD3 /* products_reviews_all.json in Resources */,
 				800A5BC7275889ED009DE2CD /* reports_revenue_stats_month.json in Resources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1274,6 +1274,7 @@
 		80C362732779A7EF005CEAD3 /* products_reviews_all.json in Resources */ = {isa = PBXBuildFile; fileRef = 80C362722779A7EF005CEAD3 /* products_reviews_all.json */; };
 		80CA638929C05E7B002E6BE6 /* PaymentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CA638829C05E7B002E6BE6 /* PaymentsTests.swift */; };
 		80CA638C29C06029002E6BE6 /* PaymentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CA638B29C06029002E6BE6 /* PaymentsScreen.swift */; };
+		80CC80E729DE74D400CA1687 /* ExternalAppScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */; };
 		80D9300329C8660C008865D8 /* CardReaderManualsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D9300229C8660C008865D8 /* CardReaderManualsScreen.swift */; };
 		80DA4F1C29CC505800BDF3BF /* products_search_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 80DA4F1B29CC505800BDF3BF /* products_search_results.json */; };
 		80E6FC6D276312D50086CD67 /* products.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00C923E9BD5500157A78 /* products.json */; };
@@ -3460,6 +3461,7 @@
 		80C362722779A7EF005CEAD3 /* products_reviews_all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = products_reviews_all.json; sourceTree = "<group>"; };
 		80CA638829C05E7B002E6BE6 /* PaymentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsTests.swift; sourceTree = "<group>"; };
 		80CA638B29C06029002E6BE6 /* PaymentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsScreen.swift; sourceTree = "<group>"; };
+		80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalAppScreen.swift; sourceTree = "<group>"; };
 		80D9300229C8660C008865D8 /* CardReaderManualsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsScreen.swift; sourceTree = "<group>"; };
 		80DA4F1B29CC505800BDF3BF /* products_search_results.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_search_results.json; sourceTree = "<group>"; };
 		80E6FC6E276325F60086CD67 /* Clibsodium.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Clibsodium.xcframework; path = ../Pods/Sodium/Clibsodium.xcframework; sourceTree = "<group>"; };
@@ -9902,6 +9904,7 @@
 				F9BB249623F4B1C60068A420 /* Products */,
 				F9BB249923F501FB0068A420 /* Settings */,
 				F997172F23DBCEB200592D8E /* TabNavComponent.swift */,
+				80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -10748,6 +10751,7 @@
 				02DEA23328810B7A0057FC40 /* LoginOnboardingScreen.swift in Sources */,
 				3F0CF2FE270420DD00EF3D71 /* ScreenObject+Extension.swift in Sources */,
 				3FF314EA26FC751B0012E68E /* XCTest+Extensions.swift in Sources */,
+				80CC80E729DE74D400CA1687 /* ExternalAppScreen.swift in Sources */,
 				3F0CF3002704490A00EF3D71 /* OrderSearchScreen.swift in Sources */,
 				DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */,
 				3F0CF3012704490A00EF3D71 /* ReviewsScreen.swift in Sources */,

--- a/WooCommerce/WooCommerceUITests/Mocks/__files/links.html
+++ b/WooCommerce/WooCommerceUITests/Mocks/__files/links.html
@@ -7,6 +7,6 @@
     <h1>TESTING LINKS</h1>
     <h2>Universal Links</h2>
     <!-- Add universal links into this list for testing -->
-    <p><a href="https://woocommerce.com/mobile/payments">Payments</a></p>
+    <p><a href="https://woocommerce.com/mobile/payments">https://woocommerce.com/mobile/payments</a></p>
 </body>
 </html>

--- a/WooCommerce/WooCommerceUITests/Mocks/__files/links.html
+++ b/WooCommerce/WooCommerceUITests/Mocks/__files/links.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>TESTING LINKS</title>
+</head>
+<body>
+    <h1>TESTING LINKS</h1>
+    <h2>Universal Links</h2>
+    <!-- Add universal links into this list for testing -->
+    <p><a href="https://woocommerce.com/mobile/payments">Payments</a></p>
+</body>
+</html>

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/files.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/files.json
@@ -1,0 +1,13 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPattern": "/.*([A-z0-9]*\\.[A-z]{1,6})"
+    },
+    "response": {
+        "status": 200,
+        "bodyFileName": "../__files{{request.url}}",
+        "headers": {
+            "Content-Type": "text/html"
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/README.md
+++ b/WooCommerce/WooCommerceUITests/README.md
@@ -63,9 +63,12 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
     - [ ] New order results in a push notification
     - [ ] Orders push notification opens the correct order
     - [ ] Reviews push notification opens the correct review
-7. Settings
+7. Universal Links and Deeplinks
+    - [x] Universal Link to Payments screen
+    - [ ] Universal Link to an Order
+8. Settings
     - [ ] Contact support
-8. Payments
+9. Payments
     - [ ] Make a Simple payment
     - [ ] Make a Tap to Pay on iPhone payment
     - [ ] Manage Card Reader - Connect/Disconnect Reader

--- a/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
@@ -19,4 +19,11 @@ final class PaymentsTests: XCTestCase {
             .tapChipperManual()
             .verifyChipperManualLoadedOnWebView()
     }
+
+    func test_load_payments_universal_link() throws {
+        let paymentsLink = "https://woocommerce.com/mobile/payments"
+
+        ExternalAppScreen().openUniversalLinkFromRemindersApp(link: paymentsLink)
+        try PaymentsScreen().verifyPaymentsScreenLoaded()
+    }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
@@ -21,9 +21,7 @@ final class PaymentsTests: XCTestCase {
     }
 
     func test_load_payments_universal_link() throws {
-        let paymentsLink = "https://woocommerce.com/mobile/payments"
-
-        ExternalAppScreen().openUniversalLinkFromRemindersApp(link: paymentsLink)
+        ExternalAppScreen().openUniversalLinkFromSafariApp(link: "Payments")
         try PaymentsScreen().verifyPaymentsScreenLoaded()
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
@@ -21,7 +21,7 @@ final class PaymentsTests: XCTestCase {
     }
 
     func test_load_payments_universal_link() throws {
-        ExternalAppScreen().openUniversalLinkFromSafariApp(link: "Payments")
+        try ExternalAppScreen().openUniversalLinkFromSafariApp(linkedScreen: "payments")
         try PaymentsScreen().verifyPaymentsScreenLoaded()
     }
 }


### PR DESCRIPTION
## Description
This is an updated PR based on the [previous PR](https://github.com/woocommerce/woocommerce-ios/pull/9384) that was closed due to test flakiness. In this implementation, we are utilizing Wiremock to create an HTML file and open the file, which lists a list of universal links (h/t to @tiagomar for this amazing [PoC](https://github.com/wordpress-mobile/WordPress-iOS/pull/20485) the Wiremock implementation is based off).

## Testing instructions
Test should pass locally and in CI, and there shouldn't be any test flakiness from repeated runs.