### PR TITLE
REST API: Update tracking event for application password authorization web view

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2210,6 +2210,27 @@ extension WooAnalyticsEvent {
     }
 }
 
+/// Mark: - Application password authorization in web view
+///
+extension WooAnalyticsEvent {
+    enum ApplicationPasswordAuthorization {
+        enum Key: String {
+            case step
+        }
+
+        enum Step: String {
+            case initial
+            case login
+            case authorization
+        }
+
+        static func webViewShown(step: Step) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .applicationPasswordAuthorizationWebViewShown,
+                              properties: [Key.step.rawValue: step.rawValue])
+        }
+    }
+}
+
 // MARK: - Free Trial
 //
 extension WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2210,8 +2210,8 @@ extension WooAnalyticsEvent {
     }
 }
 
-/// Mark: - Application password authorization in web view
-///
+// MARK: - Application password authorization in web view
+//
 extension WooAnalyticsEvent {
     enum ApplicationPasswordAuthorization {
         enum Key: String {

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
@@ -172,7 +172,7 @@ private extension ApplicationPasswordAuthorizationWebViewController {
         if url.absoluteString == authorizationURL {
             analytics.track(event: .ApplicationPasswordAuthorization.webViewShown(step: webViewInitialLoad ? .initial : .authorization))
             webViewInitialLoad = false
-        } else if url.absoluteString.contains("redirect_to") {
+        } else if url.absoluteString.contains(Constants.Query.redirect) {
             analytics.track(event: .ApplicationPasswordAuthorization.webViewShown(step: .login))
         }
 
@@ -225,6 +225,7 @@ private extension ApplicationPasswordAuthorizationWebViewController {
             static let appName = "app_name"
             static let appID = "app_id"
             static let successURL = "success_url"
+            static let redirect = "redirect_to"
         }
     }
     enum Localization {

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
@@ -169,6 +169,11 @@ private extension ApplicationPasswordAuthorizationWebViewController {
         guard let url else {
             return
         }
+        /// We need to track the web view steps based on these assumptions:
+        /// - First, the web view is loaded with the authorization URL that we built from the previous steps.
+        /// - Since the web view is not authenticated initially, the page will redirect to the login page, hence the `redirect-to` query.
+        /// We based on this query to detect the login page. The value of this query should be same as the initial URL.
+        /// - After login completes, the page will redirect to the initial URL.
         if url.absoluteString == authorizationURL {
             analytics.track(event: .ApplicationPasswordAuthorization.webViewShown(step: webViewInitialLoad ? .initial : .authorization))
             webViewInitialLoad = false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9400 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new property `step` to the `application_password_authorization_web_view` event to better understand user behavior when handling the authorization request. Since the authorization URL redirects to the login page, we need to track three steps:
- When the web view first opens, `step` should be `initial`.
- When the login page is displayed, `step` should be `login`. Since we cannot safely infer the admin URL of a site, the trick is to check for the `redirect_to` query.
- When the web view redirects to the authorization URL the second time, this means the login succeeds, so `step` should be `authorization`.

We will build funnels based on these steps to see where the most drop-off happen.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Prerequisite: make sure that you have access to a self-hosted store without Jetpack.
- Log out of the app if needed.
- Attempt to log in to your test store with incorrect credentials. On the error alert, select Try again with wp-admin.
- When the web view is displayed, notice in Xcode: 🔵 Tracked application_password_authorization_web_view_shown, properties: [AnyHashable("step"): "initial"].
- When the login page is shown, notice in Xcode: 🔵 Tracked application_password_authorization_web_view_shown, properties: [AnyHashable("step"): "login"].
- Log in with the correct credentials. When the authorization page is displayed, notice in Xcode console: 🔵 Tracked application_password_authorization_web_view_shown, properties: [AnyHashable("step"): "authorization"].

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
