### PR TITLE
Re-enable and submit profiler questions for free trial store creation

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -48,7 +48,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .storeCreationM2WithInAppPurchasesEnabled:
             return false
         case .storeCreationM3Profiler:
-            return false
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .justInTimeMessagesOnDashboard:
             return true
         case .IPPInAppFeedbackBanner:

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -66,6 +66,8 @@
 		028CB71F2902589E00331C09 /* create-account-error-invalid-email.json in Resources */ = {isa = PBXBuildFile; fileRef = 028CB71D2902589E00331C09 /* create-account-error-invalid-email.json */; };
 		028FA473257E110700F88A48 /* shipping-label-refund-error.json in Resources */ = {isa = PBXBuildFile; fileRef = 028FA471257E110700F88A48 /* shipping-label-refund-error.json */; };
 		028FA474257E110700F88A48 /* shipping-label-refund-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 028FA472257E110700F88A48 /* shipping-label-refund-success.json */; };
+		02935AEE29DFFA74001B793E /* site-enable-trial-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 02935AEC29DFFA74001B793E /* site-enable-trial-success.json */; };
+		02935AEF29DFFA74001B793E /* site-enable-trial-error-already-upgraded.json in Resources */ = {isa = PBXBuildFile; fileRef = 02935AED29DFFA74001B793E /* site-enable-trial-error-already-upgraded.json */; };
 		029BA4F0255D7282006171FD /* ShippingLabelRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */; };
 		029BA4F4255D72EC006171FD /* ShippingLabelPrintData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA4F3255D72EC006171FD /* ShippingLabelPrintData.swift */; };
 		029BA53B255DFABD006171FD /* ShippingLabelPrintDataMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BA53A255DFABD006171FD /* ShippingLabelPrintDataMapper.swift */; };
@@ -968,6 +970,8 @@
 		028CB71D2902589E00331C09 /* create-account-error-invalid-email.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "create-account-error-invalid-email.json"; sourceTree = "<group>"; };
 		028FA471257E110700F88A48 /* shipping-label-refund-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-refund-error.json"; sourceTree = "<group>"; };
 		028FA472257E110700F88A48 /* shipping-label-refund-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-refund-success.json"; sourceTree = "<group>"; };
+		02935AEC29DFFA74001B793E /* site-enable-trial-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-enable-trial-success.json"; sourceTree = "<group>"; };
+		02935AED29DFFA74001B793E /* site-enable-trial-error-already-upgraded.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-enable-trial-error-already-upgraded.json"; sourceTree = "<group>"; };
 		029BA4EF255D7282006171FD /* ShippingLabelRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRemote.swift; sourceTree = "<group>"; };
 		029BA4F3255D72EC006171FD /* ShippingLabelPrintData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintData.swift; sourceTree = "<group>"; };
 		029BA53A255DFABD006171FD /* ShippingLabelPrintDataMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPrintDataMapper.swift; sourceTree = "<group>"; };
@@ -2385,6 +2389,8 @@
 				02B41A93296C04BC00FE3311 /* load-site-plans-no-current-plan.json */,
 				EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */,
 				02B41A8F296BC85800FE3311 /* site-domains.json */,
+				02935AED29DFFA74001B793E /* site-enable-trial-error-already-upgraded.json */,
+				02935AEC29DFFA74001B793E /* site-enable-trial-success.json */,
 				027EB57329C07524003CE551 /* site-launch-error-already-launched.json */,
 				027EB57129C07524003CE551 /* site-launch-error-unauthorized.json */,
 				027EB57229C07524003CE551 /* site-launch-success.json */,
@@ -3248,6 +3254,7 @@
 				DEA6B1C9296D0E8B005AA5E9 /* systemStatusWithPluginsOnly-without-data.json in Resources */,
 				02C4325F298A55D100F14AEE /* domain-contact-info.json in Resources */,
 				EE57C12B297F8F8600BC31E7 /* attribute-term-without-data.json in Resources */,
+				02935AEF29DFFA74001B793E /* site-enable-trial-error-already-upgraded.json in Resources */,
 				314EDF2927C02CC100A56B6F /* stripe-account-complete-empty-descriptor.json in Resources */,
 				DE4D23B629B5EC99003A4B5D /* close-account.json in Resources */,
 				028CB71F2902589E00331C09 /* create-account-error-invalid-email.json in Resources */,
@@ -3454,6 +3461,7 @@
 				743BF8BE21191B63008A9D87 /* site-visits.json in Resources */,
 				CE0A0F1F223998A10075ED8D /* products-load-all.json in Resources */,
 				EE57C1502980F0B700BC31E7 /* shipment_tracking_new-without-data.json in Resources */,
+				02935AEE29DFFA74001B793E /* site-enable-trial-success.json in Resources */,
 				D8A284F425FBB48D0019A84B /* product-attribute-terms.json in Resources */,
 				74E30951216E8DCE00ABCE4C /* site-visits-alt.json in Resources */,
 				74ABA1C5213F17AA00FFAD30 /* top-performers-day.json in Resources */,

--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -82,12 +82,12 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
                     "woocommerce_onboarding_profile": [
                         "industry": [
                             [
-                                "slug": profilerData.categoryGroup, // TODO: we need to clarify this list from Ghidorah
-                                "detail": profilerData.category // Only populated when it's a subcategory
+                                "slug": profilerData.categoryGroup,
+                                "detail": profilerData.category
                             ].compactMapValues { $0 }
                         ],
                         "is_store_country_set": true,
-                        "selling_venues": profilerData.sellingStatus?.rawValue,
+                        "selling_venues": profilerData.sellingStatus?.rawValue as Any?,
                         "other_platform": profilerData.sellingPlatforms as Any?
                     ].compactMapValues { $0 }
                 ]
@@ -174,7 +174,7 @@ public extension SiteCreationResponse {
     }
 }
 
-/// Data from the site creation profiler questions.
+/// Answers from the site creation profiler questions.
 public struct SiteProfilerData {
     public let name: String
     public let category: String?

--- a/Networking/Networking/Remote/SiteRemote.swift
+++ b/Networking/Networking/Remote/SiteRemote.swift
@@ -15,7 +15,7 @@ public protocol SiteRemoteProtocol {
 
     /// Enables a free trial plan for a site.
     ///
-    func enableFreeTrial(siteID: Int64) async throws
+    func enableFreeTrial(siteID: Int64, profilerData: SiteProfilerData?) async throws
 }
 
 /// Site: Remote Endpoints
@@ -72,9 +72,28 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
         return try await enqueue(request)
     }
 
-    public func enableFreeTrial(siteID: Int64) async throws {
+    public func enableFreeTrial(siteID: Int64, profilerData: SiteProfilerData?) async throws {
         let path = Path.enableFreeTrial(siteID: siteID)
-        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path)
+        let parameters: [String: Any]? = profilerData.map { profilerData in
+            [
+                "wpcom_woocommerce_onboarding": [
+                    "blogname": profilerData.name,
+                    "woocommerce_default_country": profilerData.countryCode,
+                    "woocommerce_onboarding_profile": [
+                        "industry": [
+                            [
+                                "slug": profilerData.categoryGroup, // TODO: we need to clarify this list from Ghidorah
+                                "detail": profilerData.category // Only populated when it's a subcategory
+                            ].compactMapValues { $0 }
+                        ],
+                        "is_store_country_set": true,
+                        "selling_venues": profilerData.sellingStatus?.rawValue,
+                        "other_platform": profilerData.sellingPlatforms as Any?
+                    ].compactMapValues { $0 }
+                ]
+            ]
+        }
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters)
         return try await enqueue(request)
     }
 }
@@ -152,6 +171,42 @@ public extension SiteCreationResponse {
             case url
             case siteSlug = "site_slug"
         }
+    }
+}
+
+/// Data from the site creation profiler questions.
+public struct SiteProfilerData {
+    public let name: String
+    public let category: String?
+    public let categoryGroup: String?
+    public let sellingStatus: SellingStatus?
+    public let sellingPlatforms: String?
+    public let countryCode: String
+
+    /// Selling status options.
+    /// Its raw value is the value to be sent to the backend.
+    /// https://github.com/Automattic/woocommerce.com/blob/trunk/themes/woo/start/config/options.json
+    public enum SellingStatus: String {
+        /// Just starting my business.
+        case justStarting = "no"
+        /// Already selling, but not online.
+        case alreadySellingButNotOnline = "brick-mortar"
+        /// Already selling online.
+        case alreadySellingOnline = "other"
+    }
+
+    public init(name: String,
+                category: String?,
+                categoryGroup: String?,
+                sellingStatus: SiteProfilerData.SellingStatus?,
+                sellingPlatforms: String?,
+                countryCode: String) {
+        self.name = name
+        self.category = category
+        self.categoryGroup = categoryGroup
+        self.sellingStatus = sellingStatus
+        self.sellingPlatforms = sellingPlatforms
+        self.countryCode = countryCode
     }
 }
 

--- a/Networking/NetworkingTests/Extensions/MockNetwork+Path.swift
+++ b/Networking/NetworkingTests/Extensions/MockNetwork+Path.swift
@@ -4,18 +4,23 @@ import XCTest
 extension MockNetwork {
     /// Returns the parameters ("\(key)=\(value)") for the WC API query in the first network request URL.
     var queryParameters: [String]? {
+        queryParametersDictionary?.map { "\($0.key)=\($0.value)" }
+    }
+
+    /// Returns the parameters dictionary for the WC API query in the first network request URL.
+    var queryParametersDictionary: [String: Any]? {
         guard let request = requestsForResponseData.first,
-            let urlRequest = try? request.asURLRequest(),
-            let url = urlRequest.url,
-            requestsForResponseData.count == 1 else {
-                return nil
+              let urlRequest = try? request.asURLRequest(),
+              let url = urlRequest.url,
+              requestsForResponseData.count == 1 else {
+            return nil
         }
         guard let urlComponents = URLComponents(string: url.absoluteString) else {
             return nil
         }
 
         if let dotcomRequest = request as? DotcomRequest {
-            return dotcomRequest.parameters?.map { "\($0.key)=\($0.value)" }
+            return dotcomRequest.parameters
         }
 
         let parameters = urlComponents.queryItems
@@ -25,6 +30,6 @@ extension MockNetwork {
               let queryDictionary = try? JSONSerialization.jsonObject(with: queryData) as? [String: String] else {
             return nil
         }
-        return queryDictionary.map({ $0.0 + "=" + $0.1 })
+        return queryDictionary
     }
 }

--- a/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteRemoteTests.swift
@@ -163,6 +163,24 @@ final class SiteRemoteTests: XCTestCase {
         XCTAssertEqual(profilerIndustryDictionary, [["slug": "other"]])
     }
 
+    func test_enableFreeTrial_with_nil_industry_data_does_not_contain_industry_parameters() async throws {
+        // When
+        try? await remote.enableFreeTrial(siteID: 134, profilerData: .init(name: "Woo shop",
+                                                                           // Both industry (category) data are nil.
+                                                                           category: nil,
+                                                                           categoryGroup: nil,
+                                                                           sellingStatus: .alreadySellingOnline,
+                                                                           sellingPlatforms: "wordPress",
+                                                                           countryCode: "US"))
+
+        // Then
+        let parameterDictionary = try XCTUnwrap(network.queryParametersDictionary)
+        let onboardingDictionary = try XCTUnwrap(parameterDictionary["wpcom_woocommerce_onboarding"] as? [String: Any])
+        let profilerDictionary = try XCTUnwrap(onboardingDictionary["woocommerce_onboarding_profile"] as? [String: Any])
+        let profilerIndustryDictionary = try XCTUnwrap(profilerDictionary["industry"] as? [[String: String]])
+        XCTAssertEqual(profilerIndustryDictionary, [[:]])
+    }
+
     func test_enableFreeTrial_with_nil_selling_status_does_not_contain_selling_status_parameters() async throws {
         // When
         try? await remote.enableFreeTrial(siteID: 134, profilerData: .init(name: "Woo shop",

--- a/Networking/NetworkingTests/Responses/site-enable-trial-error-already-upgraded.json
+++ b/Networking/NetworkingTests/Responses/site-enable-trial-error-already-upgraded.json
@@ -1,0 +1,4 @@
+{
+    "error": "no-upgrades-permitted",
+    "message": "You cannot add WordPress.com eCommerce Trial when you already have paid upgrades"
+}

--- a/Networking/NetworkingTests/Responses/site-enable-trial-success.json
+++ b/Networking/NetworkingTests/Responses/site-enable-trial-success.json
@@ -1,0 +1,3 @@
+{
+    "success": true
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -1,4 +1,5 @@
 import enum Yosemite.CreateAccountError
+import struct Yosemite.SiteProfilerData
 
 extension WooAnalyticsEvent {
     enum StoreCreation {
@@ -68,7 +69,7 @@ extension WooAnalyticsEvent {
             let properties = [
                 Key.category: category?.value,
                 Key.categoryGroup: category?.groupValue,
-                Key.sellingStatus: sellingStatus?.sellingStatus.rawValue,
+                Key.sellingStatus: sellingStatus?.sellingStatus.analyticsValue,
                 Key.sellingPlatforms: sellingStatus?.sellingPlatforms?.map { $0.rawValue }.sorted().joined(separator: ","),
                 Key.countryCode: countryCode?.rawValue
             ].compactMapValues({ $0 })
@@ -157,6 +158,19 @@ private extension CreateAccountError {
             return "PASSWORD_INVALID"
         default:
             return "\(self)"
+        }
+    }
+}
+
+private extension SiteProfilerData.SellingStatus {
+    var analyticsValue: String {
+        switch self {
+        case .justStarting:
+            return "im_just_starting_my_business"
+        case .alreadySellingButNotOnline:
+            return "im_already_selling_but_not_online"
+        case .alreadySellingOnline:
+            return "im_already_selling_online"
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Selling Status/StoreCreationSellingStatusQuestionViewModel.swift
@@ -1,20 +1,11 @@
 import Combine
 import Foundation
+import struct Yosemite.SiteProfilerData
 
 /// View model for `StoreCreationSellingStatusQuestionView`, an optional profiler question about store selling status in the store creation flow.
 @MainActor
 final class StoreCreationSellingStatusQuestionViewModel: StoreCreationProfilerQuestionViewModel, ObservableObject {
-    /// Selling status options.
-    /// Its raw value is the value to be sent to the backend.
-    /// https://github.com/Automattic/woocommerce.com/blob/trunk/themes/woo/start/config/options.json
-    enum SellingStatus: String {
-        /// Just starting my business.
-        case justStarting = "im_just_starting_my_business"
-        /// Already selling, but not online.
-        case alreadySellingButNotOnline = "im_already_selling_but_not_online"
-        /// Already selling online.
-        case alreadySellingOnline = "im_already_selling_online"
-    }
+    typealias SellingStatus = SiteProfilerData.SellingStatus
 
     let topHeader: String
 

--- a/Yosemite/Yosemite/Actions/SiteAction.swift
+++ b/Yosemite/Yosemite/Actions/SiteAction.swift
@@ -21,7 +21,7 @@ public enum SiteAction: Action {
 
     /// Enables a free trial plan for a site.
     ///
-    case enableFreeTrial(siteID: Int64, completion: (Result<Void, Error>) -> Void)
+    case enableFreeTrial(siteID: Int64, profilerData: SiteProfilerData?, completion: (Result<Void, Error>) -> Void)
 }
 
 /// The result of site creation including necessary site information.

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -129,6 +129,7 @@ public typealias SiteAPI = Networking.SiteAPI
 public typealias Post = Networking.Post
 public typealias SitePlugin = Networking.SitePlugin
 public typealias SitePluginStatusEnum = Networking.SitePluginStatusEnum
+public typealias SiteProfilerData = Networking.SiteProfilerData
 public typealias SiteSetting = Networking.SiteSetting
 public typealias SiteSettingGroup = Networking.SiteSettingGroup
 public typealias SiteSummaryStats = Networking.SiteSummaryStats

--- a/Yosemite/Yosemite/Stores/SiteStore.swift
+++ b/Yosemite/Yosemite/Stores/SiteStore.swift
@@ -44,8 +44,8 @@ public final class SiteStore: Store {
             createSite(name: name, flow: flow, completion: completion)
         case let .launchSite(siteID, completion):
             launchSite(siteID: siteID, completion: completion)
-        case let .enableFreeTrial(siteID, completion):
-            enableFreeTrial(siteID: siteID, completion: completion)
+        case let .enableFreeTrial(siteID, profilerData, completion):
+            enableFreeTrial(siteID: siteID, profilerData: profilerData, completion: completion)
         }
     }
 }
@@ -85,10 +85,10 @@ private extension SiteStore {
         }
     }
 
-    func enableFreeTrial(siteID: Int64, completion: @escaping (Result<Void, Error>) -> Void) {
+    func enableFreeTrial(siteID: Int64, profilerData: SiteProfilerData?, completion: @escaping (Result<Void, Error>) -> Void) {
         Task { @MainActor in
             do {
-                try await remote.enableFreeTrial(siteID: siteID)
+                try await remote.enableFreeTrial(siteID: siteID, profilerData: profilerData)
                 completion(.success(()))
             } catch {
                 completion(.failure(error))

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
@@ -22,6 +22,11 @@ final class MockSiteRemote {
     func whenLaunchingSite(thenReturn result: Result<Void, Error>) {
         launchSiteResult = result
     }
+
+    /// Returns the value when `enableFreeTrial` is called.
+    func whenEnablingFreeTrialResult(thenReturn result: Result<Void, Error>) {
+        enableFreeTrialResult = result
+    }
 }
 
 extension MockSiteRemote: SiteRemoteProtocol {
@@ -43,7 +48,7 @@ extension MockSiteRemote: SiteRemoteProtocol {
         return try result.get()
     }
 
-    func enableFreeTrial(siteID: Int64) async throws {
+    func enableFreeTrial(siteID: Int64, profilerData: SiteProfilerData?) async throws {
         guard let result = enableFreeTrialResult else {
             XCTFail("Could not find result for enabling a trial.")
             throw NetworkError.notFound

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
@@ -24,7 +24,7 @@ final class MockSiteRemote {
     }
 
     /// Returns the value when `enableFreeTrial` is called.
-    func whenEnablingFreeTrialResult(thenReturn result: Result<Void, Error>) {
+    func whenEnablingFreeTrial(thenReturn result: Result<Void, Error>) {
         enableFreeTrialResult = result
     }
 }

--- a/Yosemite/YosemiteTests/Stores/SiteStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SiteStoreTests.swift
@@ -198,4 +198,47 @@ final class SiteStoreTests: XCTestCase {
         let error = try XCTUnwrap(result.failure)
         XCTAssertEqual(error, .unexpected(description: "WordPress API Error: [unauthorized] "))
     }
+
+    // MARK: - `enableFreeTrial`
+
+    func test_enableFreeTrial_returns_success_on_success() throws {
+        // Given
+        remote.whenEnablingFreeTrial(thenReturn: .success(()))
+
+        // When
+        let result = waitFor { promise in
+            self.store.onAction(SiteAction.enableFreeTrial(siteID: 134, profilerData: .init(name: "",
+                                                                                            category: nil,
+                                                                                            categoryGroup: nil,
+                                                                                            sellingStatus: nil,
+                                                                                            sellingPlatforms: nil,
+                                                                                            countryCode: "US")) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+    }
+
+    func test_enableFreeTrial_returns_error_on_failure() throws {
+        // Given
+        remote.whenEnablingFreeTrial(thenReturn: .failure(DotcomError.unknown(code: "error", message: nil)))
+
+        // When
+        let result = waitFor { promise in
+            self.store.onAction(SiteAction.enableFreeTrial(siteID: 134, profilerData: .init(name: "",
+                                                                                            category: nil,
+                                                                                            categoryGroup: nil,
+                                                                                            sellingStatus: nil,
+                                                                                            sellingPlatforms: nil,
+                                                                                            countryCode: "US")) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure)
+        XCTAssertEqual(error as? DotcomError, .unknown(code: "error", message: nil))
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9397 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, we disabled the profiler questions because we didn't have an endpoint to submit the answers. With the latest addition of the [free trial endpoint](https://github.com/Automattic/wp-calypso/blob/67f5d8a68562920e2912a8f6c5a3c33b7a5773b6/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx#L44), it allows us to submit the profiler data as a parameter in the request body. The API spec is in pe5sF9-1pZ-p2#comment-2025:

```json
{
    "wpcom_woocommerce_onboarding": {
        "blogname": "test trial", // from the store name question
        "woocommerce_default_country": "TW", // from the country code question
        "woocommerce_onboarding_profile": {
            "industry": [
                {
                    "slug": "fashion-apparel-accessories", // The industry group, which we're updating the options as another subtask
                    "detail": "" // Only populated when it's a subcategory
                }
            ],
            "is_store_country_set": true,
            "selling_venues": "no"|"brick-mortar"|"other", // from the selling status question
            "other_platform": "amazon", // from the selling status followup question if the merchant is already selling online
            "skipped": true // seems to be always true, we can probably ignore this field
        }
    }
}
```

## Implementation

- Re-enable the feature flag `storeCreationM3Profiler`
- Add a parameter `profilerData: SiteProfilerData?` to `SiteRemote.enableFreeTrial` to include the profiler data in the request body. It's optional because of the feature flag where the value is `nil` when the flag is disabled
- Moved `SellingStatus` enum from the UI layer to the Networking layer, and updated the analytics value in Tracks
- In `StoreCreationCoordinator`, passed the profiler data from user answers
- Added a few test cases, focusing on the body parameters with nullable profiler answers

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Start the store creation flow either from the prologue or the store picker
- Enter a store name --> the category profiler question should be shown
- Tap on an option, or skip --> the selling status profiler question should be shown
- Tap on any option and complete the followup question if needed --> the country profiler question should be shown
- Continue with a country --> the free trial modal should be shown
- Continue with creating a store with free trial --> the in-progress UI should be shown. after about a minute, the store should be created and logged-in
- Tap on the onboarding task `Tell us more about your store` --> the store location should show the country previously selected in the profiler question

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/1945542/230807910-a3247132-3145-4872-9dfc-0d1287b100af.mov




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.