### PR TITLE
Disable flaky test

### DIFF
--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -59,6 +59,9 @@
       }
     },
     {
+      "skippedTests" : [
+        "ProductStoreTests\/test_retrieveRecentlySoldCachedProducts_when_there_are_several_sold_products_returns_them_sorted()"
+      ],
       "target" : {
         "containerPath" : "container:..\/Yosemite\/Yosemite.xcodeproj",
         "identifier" : "B5C9DDFD2087FEC0006B910A",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9406
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

`ProductStoreTests.test_retrieveRecentlySoldCachedProducts_when_there_are_several_sold_products_returns_them_sorted` is flaky, meaning that it crashes randomly. With this PR we disable it so stops affecting other flows until we find a definitive solution.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Please check that the unit test is skipped when running the whole suite.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
