### PR TITLE
Remove `shouldUpdateOrDeleteZeroQuantities` usage from `RemoteOrderSynchronizer`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -22,7 +22,6 @@ struct ProductInputTransformer {
     /// Adds, deletes, or updates order items based on the given product input.
     ///
     static func update(input: OrderSyncProductInput, on order: Order) -> Order {
-        // If the input's quantity is 0 or less, delete the item if required.
         guard input.quantity > 0 else {
             return remove(input: input, from: order)
         }
@@ -48,7 +47,6 @@ struct ProductInputTransformer {
             updateOrderItems(from: order, with: input, orderItems: &updatedOrderItems)
         }
 
-        // If the input's quantity is 0 or less, delete the item if required.
         // We perform a second loop for deletions so we don't attempt to access to overflown indexes
         for input in inputs {
             guard input.quantity > 0 else {
@@ -91,7 +89,6 @@ private extension ProductInputTransformer {
     ///
     /// - Returns: An array of Order Item entities
     private static func updateOrderItems(from input: OrderSyncProductInput, order: Order) -> [OrderItem] {
-        // If the input's quantity is 0 or less, delete the item if required.
         guard input.quantity > 0 else {
             return remove(input: input, from: order).items
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformer.swift
@@ -19,17 +19,11 @@ struct ProductInputTransformer {
         }
     }
 
-    enum UpdateOrDelete {
-        case update
-        case delete
-    }
-
     /// Adds, deletes, or updates order items based on the given product input.
-    /// When `shouldUpdateOrDeleteZeroQuantities` value is `.update`, items with `.zero` quantities will be updated instead of being deleted.
     ///
-    static func update(input: OrderSyncProductInput, on order: Order, shouldUpdateOrDeleteZeroQuantities: UpdateOrDelete) -> Order {
+    static func update(input: OrderSyncProductInput, on order: Order) -> Order {
         // If the input's quantity is 0 or less, delete the item if required.
-        guard input.quantity > 0 || shouldUpdateOrDeleteZeroQuantities == .update else {
+        guard input.quantity > 0 else {
             return remove(input: input, from: order)
         }
 
@@ -45,10 +39,9 @@ struct ProductInputTransformer {
     /// - Parameters:
     ///   - inputs: Array of product types the OrderSynchronizer supports
     ///   - order: Represents an Order entity.
-    ///   - shouldUpdateOrDeleteZeroQuantities: When its value is `.update`, items with `.zero` quantities will be updated instead of being deleted.
     ///
     /// - Returns: An Order entity.
-    static func updateMultipleItems(with inputs: [OrderSyncProductInput], on order: Order, shouldUpdateOrDeleteZeroQuantities: UpdateOrDelete) -> Order {
+    static func updateMultipleItems(with inputs: [OrderSyncProductInput], on order: Order) -> Order {
         var updatedOrderItems = order.items
 
         for input in inputs {
@@ -58,7 +51,7 @@ struct ProductInputTransformer {
         // If the input's quantity is 0 or less, delete the item if required.
         // We perform a second loop for deletions so we don't attempt to access to overflown indexes
         for input in inputs {
-            guard input.quantity > 0 || shouldUpdateOrDeleteZeroQuantities == .update else {
+            guard input.quantity > 0 else {
                 updatedOrderItems.removeAll(where: { $0.itemID == input.id })
                 return order.copy(items: updatedOrderItems)
             }
@@ -95,12 +88,11 @@ private extension ProductInputTransformer {
     /// - Parameters:
     ///   - input: Types of products the synchronizer supports
     ///   - order: Represents an Order entity.
-    ///   - shouldUpdateOrDeleteZeroQuantities: When its value is `.update`, items with `.zero` quantities will be updated instead of being deleted.
     ///
     /// - Returns: An array of Order Item entities
-    private static func updateOrderItems(from input: OrderSyncProductInput, order: Order, shouldUpdateOrDeleteZeroQuantities: UpdateOrDelete) -> [OrderItem] {
+    private static func updateOrderItems(from input: OrderSyncProductInput, order: Order) -> [OrderItem] {
         // If the input's quantity is 0 or less, delete the item if required.
-        guard input.quantity > 0 || shouldUpdateOrDeleteZeroQuantities == .update else {
+        guard input.quantity > 0 else {
             return remove(input: input, from: order).items
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -139,7 +139,7 @@ private extension RemoteOrderSynchronizer {
             .map { [weak self] productInput, order -> Order in
                 guard let self = self else { return order }
                 let localInput = self.replaceInputWithLocalIDIfNeeded(productInput)
-                let updatedOrder = ProductInputTransformer.update(input: localInput, on: order, shouldUpdateOrDeleteZeroQuantities: .update)
+                let updatedOrder = ProductInputTransformer.update(input: localInput, on: order)
                 // Calculate order total locally while order is being synced
                 return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
             }
@@ -157,10 +157,7 @@ private extension RemoteOrderSynchronizer {
                     self.replaceInputWithLocalIDIfNeeded($0)
                 }
 
-                let updatedOrder = ProductInputTransformer.updateMultipleItems(
-                    with: localInputs,
-                    on: order,
-                    shouldUpdateOrDeleteZeroQuantities: .update)
+                let updatedOrder = ProductInputTransformer.updateMultipleItems(with: localInputs, on: order)
 
                 return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ProductInputTransformerTests.swift
@@ -20,7 +20,7 @@ class ProductInputTransformerTests: XCTestCase {
         let originalOrder = OrderFactory.emptyNewOrder
 
         // When
-        let updatedOrder = ProductInputTransformer.update(input: input, on: originalOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
+        let updatedOrder = ProductInputTransformer.update(input: input, on: originalOrder)
 
         // Then
         let item = try XCTUnwrap(updatedOrder.items.first)
@@ -44,10 +44,7 @@ class ProductInputTransformerTests: XCTestCase {
         let originalOrder = OrderFactory.emptyNewOrder
 
         // When
-        let updatedOrder = ProductInputTransformer.updateMultipleItems(
-            with: input,
-            on: originalOrder,
-            shouldUpdateOrDeleteZeroQuantities: .delete)
+        let updatedOrder = ProductInputTransformer.updateMultipleItems(with: input, on: originalOrder)
 
         // Then
         let items = try XCTUnwrap(updatedOrder.items)
@@ -73,7 +70,7 @@ class ProductInputTransformerTests: XCTestCase {
         let originalOrder = OrderFactory.emptyNewOrder
 
         // When
-        let updatedOrder = ProductInputTransformer.update(input: input, on: originalOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
+        let updatedOrder = ProductInputTransformer.update(input: input, on: originalOrder)
 
         // Then
         let item = try XCTUnwrap(updatedOrder.items.first)
@@ -101,10 +98,7 @@ class ProductInputTransformerTests: XCTestCase {
         let originalOrder = OrderFactory.emptyNewOrder
 
         // When
-        let updatedOrder = ProductInputTransformer.updateMultipleItems(
-            with: input,
-            on: originalOrder,
-            shouldUpdateOrDeleteZeroQuantities: .delete)
+        let updatedOrder = ProductInputTransformer.updateMultipleItems(with: input, on: originalOrder)
 
         // Then
         let items = try XCTUnwrap(updatedOrder.items)
@@ -128,11 +122,11 @@ class ProductInputTransformerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let input1 = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 1)
-        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
+        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder)
 
         // When
         let input2 = OrderSyncProductInput(id: sampleInputID + 1, product: .product(product), quantity: 1)
-        let update2 = ProductInputTransformer.update(input: input2, on: update1, shouldUpdateOrDeleteZeroQuantities: .delete)
+        let update2 = ProductInputTransformer.update(input: input2, on: update1)
 
         // Then
         XCTAssertEqual(update2.items.count, 2)
@@ -142,11 +136,11 @@ class ProductInputTransformerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "9.99")
         let input1 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
-        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
+        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder)
 
         // When
         let input2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 2)
-        let update2 = ProductInputTransformer.update(input: input2, on: update1, shouldUpdateOrDeleteZeroQuantities: .delete)
+        let update2 = ProductInputTransformer.update(input: input2, on: update1)
 
         // Then
         let item = try XCTUnwrap(update2.items.first)
@@ -162,13 +156,11 @@ class ProductInputTransformerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID, price: "9.99")
         let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
-        let initialOrder = ProductInputTransformer.updateMultipleItems(with: [productInput],
-                                                                       on: OrderFactory.emptyNewOrder,
-                                                                       shouldUpdateOrDeleteZeroQuantities: .delete)
+        let initialOrder = ProductInputTransformer.updateMultipleItems(with: [productInput], on: OrderFactory.emptyNewOrder)
 
         // When
         let productInput2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 2)
-        let updatedOrder = ProductInputTransformer.updateMultipleItems(with: [productInput2], on: initialOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
+        let updatedOrder = ProductInputTransformer.updateMultipleItems(with: [productInput2], on: initialOrder)
 
         // Then
         // Confirm that we still have only 1 item
@@ -192,7 +184,7 @@ class ProductInputTransformerTests: XCTestCase {
 
         // When
         let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2)
-        let updatedOrder = ProductInputTransformer.update(input: input, on: order, shouldUpdateOrDeleteZeroQuantities: .update)
+        let updatedOrder = ProductInputTransformer.update(input: input, on: order)
 
         // Then
         let updatedItem = try XCTUnwrap(updatedOrder.items.first)
@@ -209,7 +201,7 @@ class ProductInputTransformerTests: XCTestCase {
 
         // When
         let input = OrderSyncProductInput(id: sampleInputID, product: .product(product), quantity: 2)
-        let updatedOrder = ProductInputTransformer.updateMultipleItems(with: [input], on: order, shouldUpdateOrDeleteZeroQuantities: .update)
+        let updatedOrder = ProductInputTransformer.updateMultipleItems(with: [input], on: order)
 
         // Then
         let updatedItem = try XCTUnwrap(updatedOrder.items.first)
@@ -222,11 +214,11 @@ class ProductInputTransformerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let input1 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
-        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, shouldUpdateOrDeleteZeroQuantities: .delete)
+        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder)
 
         // When
         let input2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0)
-        let update2 = ProductInputTransformer.update(input: input2, on: update1, shouldUpdateOrDeleteZeroQuantities: .delete)
+        let update2 = ProductInputTransformer.update(input: input2, on: update1)
 
         // Then
         XCTAssertEqual(update2.items.count, 0)
@@ -236,50 +228,12 @@ class ProductInputTransformerTests: XCTestCase {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
-        let initialOrderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput],
-                                                                             on: OrderFactory.emptyNewOrder,
-                                                                             shouldUpdateOrDeleteZeroQuantities: .delete)
+        let initialOrderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput], on: OrderFactory.emptyNewOrder)
 
         // When
         let productInput2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0)
-        let orderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput2],
-                                                                      on: initialOrderUpdate,
-                                                                      shouldUpdateOrDeleteZeroQuantities: .delete)
+        let orderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput2], on: initialOrderUpdate)
         // Then
         XCTAssertEqual(orderUpdate.items.count, 0)
-    }
-
-    func test_sending_a_zero_quantity_update_product_input_does_not_delete_item_on_order() throws {
-        // Given
-        let product = Product.fake().copy(productID: sampleProductID)
-        let input1 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
-        let update1 = ProductInputTransformer.update(input: input1, on: OrderFactory.emptyNewOrder, shouldUpdateOrDeleteZeroQuantities: .update)
-
-        // When
-        let input2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0)
-        let update2 = ProductInputTransformer.update(input: input2, on: update1, shouldUpdateOrDeleteZeroQuantities: .update)
-
-        // Then
-        let item = try XCTUnwrap(update2.items.first)
-        XCTAssertEqual(item.quantity, input2.quantity)
-    }
-
-    func test_order_when_updateMultipleItems_with_zero_quantity_product_input_and_updates_zero_quantities_then_updates_item_on_order() throws {
-        // Given
-        let product = Product.fake().copy(productID: sampleProductID)
-        let productInput = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 1)
-        let initialOrderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput],
-                                                                             on: OrderFactory.emptyNewOrder,
-                                                                             shouldUpdateOrDeleteZeroQuantities: .update)
-
-        // When
-        let productInput2 = OrderSyncProductInput(id: sampleProductID, product: .product(product), quantity: 0)
-        let orderUpdate = ProductInputTransformer.updateMultipleItems(with: [productInput2],
-                                                                      on: initialOrderUpdate,
-                                                                      shouldUpdateOrDeleteZeroQuantities: .update)
-
-        // Then
-        let item = try XCTUnwrap(orderUpdate.items.first)
-        XCTAssertEqual(item.quantity, productInput2.quantity)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -240,7 +240,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertEqual(item.quantity, updatedInput.quantity)
     }
 
-    func test_sending_delete_product_input_updates_local_order() throws {
+    func test_sending_delete_product_input_updates_local_order_with_zero_order_items() throws {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
@@ -253,11 +253,11 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         synchronizer.setProduct.send(updatedInput)
 
         // Then
-        XCTAssertEqual(synchronizer.order.items.count, 1)
-        XCTAssertEqual(synchronizer.order.items[0].quantity, .zero)
+        XCTAssertEqual(synchronizer.order.items.count, 0)
+        XCTAssertTrue(synchronizer.order.items.isEmpty)
     }
 
-    func test_sending_delete_productID_input_updates_local_order() throws {
+    func test_sending_delete_productID_input_updates_local_order_with_zero_order_items() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
@@ -269,8 +269,8 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         synchronizer.setProduct.send(updatedInput)
 
         // Then
-        XCTAssertEqual(synchronizer.order.items.count, 1)
-        XCTAssertEqual(synchronizer.order.items[0].quantity, .zero)
+        XCTAssertEqual(synchronizer.order.items.count, 0)
+        XCTAssertTrue(synchronizer.order.items.isEmpty)
     }
 
     func test_sending_addresses_input_updates_local_order() throws {


### PR DESCRIPTION
Closes: #9381
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR removes the usage of `shouldUpdateOrDeleteZeroQuantities` , which is not used anymore by the [ProductInputTransformer](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/ViewRelated/Orders/Order%20Creation/Synchronizer/ProductInputTransformer.swift), this will always remove inputs from an Order if `quantity > 0`, or remove them otherwise.

## Testing instructions
- Unit Tests should pass