### PR TITLE
[Mobile Payments] Allow In-Person Payments on a UK-based store

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 13.2
 -----
+- [**] Payments: UK merchants can collect In-Person Payments [https://github.com/woocommerce/woocommerce-ios/pull/9415]
 
 
 13.1

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -475,7 +475,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func isInUndefinedState(account: PaymentGatewayAccount) -> Bool {
-        account.wcpayStatus != .complete
+        account.wcpayStatus == .unknown
     }
 
     func isNetworkError(_ error: Error) -> Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -122,7 +122,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .ca)
         setupStripePlugin(status: .active, version: .minimumSupportedVersion)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionCanadaUK)
+        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionCanada)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
@@ -137,7 +137,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_wcpay_plugin_unsupported_version_for_canada_when_version_unsupported() {
         // Given
         setupCountry(country: .ca)
-        setupWCPayPlugin(status: .active, version: .unsupportedVersionCanadaUK)
+        setupWCPayPlugin(status: .active, version: .unsupportedVersionCanada)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
@@ -152,7 +152,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_does_not_return_plugin_unsupported_version_for_canada_when_version_is_supported() {
         // Given
         setupCountry(country: .ca)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionCanadaUK)
+        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionCanada)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
@@ -210,9 +210,9 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
     func test_onboarding_returns_setup_not_completed_stripe_when_stripe_and_wcPay_plugins_are_installed_in_UK() {
         // Given
-        setupCountry(country: .ca)
+        setupCountry(country: .gb)
         setupStripePlugin(status: .active, version: .minimumSupportedVersion)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionCanadaUK)
+        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionUK)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
@@ -227,7 +227,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_wcpay_plugin_unsupported_version_for_uk_when_version_unsupported() {
         // Given
         setupCountry(country: .gb)
-        setupWCPayPlugin(status: .active, version: .unsupportedVersionCanadaUK)
+        setupWCPayPlugin(status: .active, version: .unsupportedVersionUK)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
@@ -242,7 +242,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_does_not_return_plugin_unsupported_version_for_uk_when_version_is_supported() {
         // Given
         setupCountry(country: .gb)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionCanadaUK)
+        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionUK)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
@@ -266,7 +266,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertNotEqual(state, .countryNotSupported(countryCode: "CA"))
+        XCTAssertNotEqual(state, .countryNotSupported(countryCode: "GB"))
     }
 
 
@@ -1118,9 +1118,11 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
     enum WCPayPluginVersion: String {
         case unsupportedVersionWithPatch = "2.4.2"
         case unsupportedVersionWithoutPatch = "3.2"
-        case unsupportedVersionCanadaUK = "3.9.0"
+        case unsupportedVersionCanada = "3.9.0"
+        case unsupportedVersionUK = "4.3.0"
         case minimumSupportedVersion = "3.2.1" // Should match `CardPresentPaymentsConfiguration` `minimumSupportedPluginVersion` for the US
-        case minimumSupportedVersionCanadaUK = "4.0.0" // Should match `CardPresentPaymentsConfiguration` `minimumSupportedPluginVersion` for Canada and UK
+        case minimumSupportedVersionCanada = "4.0.0" // Should match `CardPresentPaymentsConfiguration` `minimumSupportedPluginVersion` for Canada
+        case minimumSupportedVersionUK = "4.4.0" // Should match `CardPresentPaymentsConfiguration` `minimumSupportedPluginVersion` for UK
         case supportedVersionWithPatch = "3.2.5"
         case supportedVersionWithoutPatch = "3.3"
     }

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -57,6 +57,17 @@ public struct CardPresentPaymentsConfiguration {
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
                 stripeSmallestCurrencyUnitMultiplier: 100
             )
+        case "GB":
+            self.init(
+                countryCode: country,
+                paymentMethods: [.cardPresent],
+                currencies: [.GBP],
+                paymentGateways: [WCPayAccount.gatewayID],
+                supportedReaders: [.wisepad3],
+                supportedPluginVersions: [.init(plugin: .wcPay, minimumVersion: "4.0.0")],
+                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
+                stripeSmallestCurrencyUnitMultiplier: 100
+            )
         default:
             self.init(
                 countryCode: country,

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -64,7 +64,7 @@ public struct CardPresentPaymentsConfiguration {
                 currencies: [.GBP],
                 paymentGateways: [WCPayAccount.gatewayID],
                 supportedReaders: [.wisepad3],
-                supportedPluginVersions: [.init(plugin: .wcPay, minimumVersion: "4.0.0")],
+                supportedPluginVersions: [.init(plugin: .wcPay, minimumVersion: "4.4.0")],
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
                 stripeSmallestCurrencyUnitMultiplier: 100
             )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9412 and #9409
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add support for In-Person Payments in the UK, by adding a new configuration that allows to collect payments on a store based in that country.
Furthermore, we fix an issue that was blocking merchants whose WCPay account status was "restricted_soon" to take payments (see video). "restricted_soon" accounts should show the skippable notice and then allow the payment to be collected, same as Android. It is included here because UK test stores return that error when set up.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

On a UK-based store (I invited you to mine) collect a payment with card from orders and simple payments. The payment collection should be successful. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Previous error screen for _restricted soon_ accounts. This is fixed for this PR

https://user-images.githubusercontent.com/1864060/230922858-bc9eb0bf-0968-4162-af05-892075448793.mp4

### Succesful payment on a UK-based store

https://user-images.githubusercontent.com/1864060/230923139-5ae38c44-2149-4300-b179-53e31e8d79e8.mp4

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
