### PR TITLE
[Mobile Payments] Add account type to receipts

### DIFF
--- a/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Hardware/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -171,12 +171,22 @@ private extension ReceiptRenderer {
         }
 
         /// According to the documentation, only `Application name` and `AID`
-        /// are required in the US.
+        /// are required in the US, but since `Account type` is required in other countries,
+        /// we add it if we have it.
         /// https://stripe.com/docs/terminal/checkout/receipts#custom
-        return """
+        let baseRequiredItems = """
                \(Localization.applicationName): \(emv.applicationPreferredName.htmlStripped())<br/>
                \(Localization.aid): \(emv.dedicatedFileName.htmlStripped())
                """
+
+        guard let accountType = emv.accountType else {
+            return baseRequiredItems
+        }
+
+        return baseRequiredItems + """
+            <br/>
+            \(Localization.accountType): \(accountType.htmlStripped())
+            """
     }
 
     private func cardIconCSS() -> String {

--- a/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
+++ b/Hardware/HardwareTests/AirPrintReceipt/ReceiptRendererTest.swift
@@ -6,7 +6,7 @@ import CryptoKit
 
 final class ReceiptRendererTest: XCTestCase {
     func test_TextWithoutHtmlSymbols() {
-        let expectedResultWithoutHtmlSymbolsMd5Description = "MD5 digest: dcf62ae7ac29fc305c280193887350b6"
+        let expectedResultWithoutHtmlSymbolsMd5Description = "MD5 digest: 16568a76909a0e2279356d334b31355e"
         let content = generateReceiptContent()
 
         let renderer = ReceiptRenderer(content: content)
@@ -18,7 +18,7 @@ final class ReceiptRendererTest: XCTestCase {
     }
 
     func test_TextWithHtmlSymbols() {
-        let expectedResultWithHtmlSymbolsMd5Description = "MD5 digest: 40083b7f6ef076c8d84f8fca79611823"
+        let expectedResultWithHtmlSymbolsMd5Description = "MD5 digest: d4dde7c09e3f6a3e8eab05027c65422a"
         let stringWithHtml = "<tt><table></table></footer>"
         let content = generateReceiptContent(stringToAppend: stringWithHtml)
 
@@ -31,7 +31,7 @@ final class ReceiptRendererTest: XCTestCase {
     }
 
     func test_TextWithVariationsSymbols() {
-        let expectedResultWithHtmlSymbolsMd5Description = "MD5 digest: a30f786359ebb6197b58fe1eaddbb04f"
+        let expectedResultWithHtmlSymbolsMd5Description = "MD5 digest: dedd63a1cb5d6977d372935979a270c0"
         let attributeOne = ReceiptLineAttribute(name: "name_attr_1", value: "value_attr_1")
         let attributeTwo = ReceiptLineAttribute(name: "name_attr_2", value: "value_attr_2")
         let content = generateReceiptContent(attributes: [attributeOne, attributeTwo])

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 13.2
 -----
+- [**] Payments: UK merchants can collect In-Person Payments [https://github.com/woocommerce/woocommerce-ios/pull/9415]
 
 
 13.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [Internal] Store creation: New loading screen added for create store flow. [https://github.com/woocommerce/woocommerce-ios/pull/9383]
 - [**] Payments: UK merchants can collect In-Person Payments [https://github.com/woocommerce/woocommerce-ios/pull/9415]
+- [*] Payments: Add account type field to receipts [https://github.com/woocommerce/woocommerce-ios/pull/9416]
 
 
 13.1

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -475,7 +475,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func isInUndefinedState(account: PaymentGatewayAccount) -> Bool {
-        account.wcpayStatus != .complete
+        account.wcpayStatus == .unknown
     }
 
     func isNetworkError(_ error: Error) -> Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -122,7 +122,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         // Given
         setupCountry(country: .ca)
         setupStripePlugin(status: .active, version: .minimumSupportedVersion)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionCanadaUK)
+        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionCanada)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
@@ -137,7 +137,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_wcpay_plugin_unsupported_version_for_canada_when_version_unsupported() {
         // Given
         setupCountry(country: .ca)
-        setupWCPayPlugin(status: .active, version: .unsupportedVersionCanadaUK)
+        setupWCPayPlugin(status: .active, version: .unsupportedVersionCanada)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
@@ -152,7 +152,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_does_not_return_plugin_unsupported_version_for_canada_when_version_is_supported() {
         // Given
         setupCountry(country: .ca)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionCanadaUK)
+        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionCanada)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
@@ -210,9 +210,9 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
 
     func test_onboarding_returns_setup_not_completed_stripe_when_stripe_and_wcPay_plugins_are_installed_in_UK() {
         // Given
-        setupCountry(country: .ca)
+        setupCountry(country: .gb)
         setupStripePlugin(status: .active, version: .minimumSupportedVersion)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionCanadaUK)
+        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionUK)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
@@ -227,7 +227,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_returns_wcpay_plugin_unsupported_version_for_uk_when_version_unsupported() {
         // Given
         setupCountry(country: .gb)
-        setupWCPayPlugin(status: .active, version: .unsupportedVersionCanadaUK)
+        setupWCPayPlugin(status: .active, version: .unsupportedVersionUK)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
@@ -242,7 +242,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
     func test_onboarding_does_not_return_plugin_unsupported_version_for_uk_when_version_is_supported() {
         // Given
         setupCountry(country: .gb)
-        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionCanadaUK)
+        setupWCPayPlugin(status: .active, version: .minimumSupportedVersionUK)
 
         // When
         let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
@@ -266,7 +266,7 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         let state = useCase.state
 
         // Then
-        XCTAssertNotEqual(state, .countryNotSupported(countryCode: "CA"))
+        XCTAssertNotEqual(state, .countryNotSupported(countryCode: "GB"))
     }
 
 
@@ -1118,9 +1118,11 @@ private extension CardPresentPaymentsOnboardingUseCaseTests {
     enum WCPayPluginVersion: String {
         case unsupportedVersionWithPatch = "2.4.2"
         case unsupportedVersionWithoutPatch = "3.2"
-        case unsupportedVersionCanadaUK = "3.9.0"
+        case unsupportedVersionCanada = "3.9.0"
+        case unsupportedVersionUK = "4.3.0"
         case minimumSupportedVersion = "3.2.1" // Should match `CardPresentPaymentsConfiguration` `minimumSupportedPluginVersion` for the US
-        case minimumSupportedVersionCanadaUK = "4.0.0" // Should match `CardPresentPaymentsConfiguration` `minimumSupportedPluginVersion` for Canada and UK
+        case minimumSupportedVersionCanada = "4.0.0" // Should match `CardPresentPaymentsConfiguration` `minimumSupportedPluginVersion` for Canada
+        case minimumSupportedVersionUK = "4.4.0" // Should match `CardPresentPaymentsConfiguration` `minimumSupportedPluginVersion` for UK
         case supportedVersionWithPatch = "3.2.5"
         case supportedVersionWithoutPatch = "3.3"
     }

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -57,6 +57,17 @@ public struct CardPresentPaymentsConfiguration {
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
                 stripeSmallestCurrencyUnitMultiplier: 100
             )
+        case "GB":
+            self.init(
+                countryCode: country,
+                paymentMethods: [.cardPresent],
+                currencies: [.GBP],
+                paymentGateways: [WCPayAccount.gatewayID],
+                supportedReaders: [.wisepad3],
+                supportedPluginVersions: [.init(plugin: .wcPay, minimumVersion: "4.0.0")],
+                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
+                stripeSmallestCurrencyUnitMultiplier: 100
+            )
         default:
             self.init(
                 countryCode: country,

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -64,7 +64,7 @@ public struct CardPresentPaymentsConfiguration {
                 currencies: [.GBP],
                 paymentGateways: [WCPayAccount.gatewayID],
                 supportedReaders: [.wisepad3],
-                supportedPluginVersions: [.init(plugin: .wcPay, minimumVersion: "4.0.0")],
+                supportedPluginVersions: [.init(plugin: .wcPay, minimumVersion: "4.4.0")],
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
                 stripeSmallestCurrencyUnitMultiplier: 100
             )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

⚠️  Please review https://github.com/woocommerce/woocommerce-ios/pull/9415 first

Closes: #9413
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In the context of the IPP UK Expansion, we add the Account Type to the receipt with this PR, which is only optional in US –[required elsewhere](https://href.li/?https://stripe.com/docs/terminal/features/receipts)-.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Collect a payment with card, ideally with an UK-based store.
2. After the payment was successful, tap on print receipt.
3. When the receipt is shown, please make sure that the Account type is shown together with the value (debit or credit).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://user-images.githubusercontent.com/1864060/230925692-fd7c21fe-d1f7-474f-84a1-ef5b795e4015.PNG" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
