### PR TITLE
[Free Trial] Track missing free trial tracks

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -75,6 +75,12 @@ extension WooAnalyticsEvent {
             return WooAnalyticsEvent(statName: .siteCreationProfilerData, properties: properties)
         }
 
+        /// Tracked when the "Try For Free" button in the "Summary View" is  tapped.
+        ///
+        static func siteCreationTryForFreeTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .siteCreationTryForFreeTapped, properties: [:])
+        }
+
         /// Tracked when the site creation process takes too much time waiting for the store to be ready.
         ///
         static func siteCreationTimedOut() -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -15,6 +15,7 @@ extension WooAnalyticsEvent {
             static let sellingPlatforms = "ecommerce_platforms"
             static let countryCode = "country_code"
             static let isFreeTrial = "is_free_trial"
+            static let waitingTime = "waiting_time"
         }
 
         /// Tracked when the user taps on the CTA in store picker (logged in to WPCOM) to create a store.
@@ -24,12 +25,13 @@ extension WooAnalyticsEvent {
         }
 
         /// Tracked when a site is created from the store creation flow.
-        static func siteCreated(source: Source, siteURL: String, flow: Flow, isFreeTrial: Bool) -> WooAnalyticsEvent {
+        static func siteCreated(source: Source, siteURL: String, flow: Flow, isFreeTrial: Bool, waitingTime: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .siteCreated,
                               properties: [Key.source: source.rawValue,
                                            Key.url: siteURL,
                                            Key.flow: flow.rawValue,
-                                           Key.isFreeTrial: isFreeTrial])
+                                           Key.isFreeTrial: isFreeTrial,
+                                           Key.waitingTime: waitingTime])
         }
 
         /// Tracked when site creation fails.

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -75,6 +75,18 @@ extension WooAnalyticsEvent {
             return WooAnalyticsEvent(statName: .siteCreationProfilerData, properties: properties)
         }
 
+        /// Tracked when the site creation process takes too much time waiting for the store to be ready.
+        ///
+        static func siteCreationTimedOut() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .siteCreationTimedOut, properties: [:])
+        }
+
+        /// Tracked when the store is jetpack ready, but other store properties are not in sync yet.
+        ///
+        static func siteCreationPropertiesOutOfSync() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .siteCreationPropertiesOutOfSync, properties: [:])
+        }
+
         /// Tracked when the user taps on the CTA in login prologue (logged out) to create a store.
         static func loginPrologueCreateSiteTapped(isFreeTrial: Bool) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .loginPrologueCreateSiteTapped,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -196,6 +196,7 @@ public enum WooAnalyticsStat: String {
     case siteCreationSitePreviewed = "site_creation_site_previewed"
     case siteCreationManageStoreTapped = "site_creation_store_management_opened"
     case siteCreationProfilerData = "site_creation_profiler_data"
+    case siteCreationTryForFreeTapped = "site_creation_try_for_free_tapped"
     case siteCreationTimedOut = "site_creation_timed_out"
     case siteCreationPropertiesOutOfSync = "site_creation_properties_out_of_sync"
     case loginPrologueCreateSiteTapped = "login_prologue_create_site_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -196,6 +196,8 @@ public enum WooAnalyticsStat: String {
     case siteCreationSitePreviewed = "site_creation_site_previewed"
     case siteCreationManageStoreTapped = "site_creation_store_management_opened"
     case siteCreationProfilerData = "site_creation_profiler_data"
+    case siteCreationTimedOut = "site_creation_timed_out"
+    case siteCreationPropertiesOutOfSync = "site_creation_properties_out_of_sync"
     case loginPrologueCreateSiteTapped = "login_prologue_create_site_tapped"
     case signupFormLoginTapped = "signup_login_button_tapped"
     case signupSubmitted = "signup_submitted"

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -409,6 +409,8 @@ private extension StoreCreationCoordinator {
             Task {
                 await self?.createFreeTrialStore(from: navigationController, storeName: storeName)
             }
+
+            self?.analytics.track(event: .StoreCreation.siteCreationTryForFreeTapped())
         })
         navigationController.present(summaryViewController, animated: true)
     }
@@ -692,7 +694,6 @@ private extension StoreCreationCoordinator {
             // in the WPCOM `/me/sites` response.
             .retry(10)
             .replaceError(with: nil)
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] site in
                 guard let self else { return }
                 guard let site else {

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -762,6 +762,8 @@ private extension StoreCreationCoordinator {
         alertController.view.tintColor = .text
         _ = alertController.addCancelActionWithTitle(Localization.WaitingForJetpackSite.TimeoutAlert.cancelActionTitle) { _ in }
         navigationController.present(alertController, animated: true)
+
+        analytics.track(event: .StoreCreation.siteCreationTimedOut())
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -226,6 +226,10 @@ private extension StoreCreationCoordinator {
 
 private extension StoreCreationCoordinator {
     func observeSiteURLsFromStoreCreation() {
+
+        // Timestamp when we start observing times. Needed to track the store creating waiting duration.
+        let waitingTimeStart = Date()
+
         possibleSiteURLsFromStoreCreationSubscription = $possibleSiteURLsFromStoreCreation
             .filter { $0.isEmpty == false }
             .removeDuplicates()
@@ -243,7 +247,7 @@ private extension StoreCreationCoordinator {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] site in
                 guard let self, let site else { return }
-                self.analytics.track(event: .StoreCreation.siteCreated(source: self.source.analyticsValue, siteURL: site.url, flow: .web, isFreeTrial: false))
+                self.trackSiteCreatedEvent(site: site, flow: .web, timeAtStart: waitingTimeStart)
                 self.continueWithSelectedSite(site: site)
             }
     }
@@ -662,6 +666,10 @@ private extension StoreCreationCoordinator {
         ///
         var haveTrackedOutOfSyncEvent = false
 
+        /// Timestamp when we start observing times. Needed to track the store creating waiting duration.
+        ///
+        let waitingTimeStart = Date()
+
         jetpackSiteSubscription = $siteIDFromStoreCreation
             .compactMap { $0 }
             .removeDuplicates()
@@ -673,16 +681,6 @@ private extension StoreCreationCoordinator {
             .receive(on: DispatchQueue.main)
             .handleEvents(receiveCompletion: { [weak self] output in
                 guard let self else { return }
-
-                // Track when a properties out of sync event occur, but only track it once.
-                if self.isPropertiesOutOfSyncError(output) && !haveTrackedOutOfSyncEvent {
-                    self.analytics.track(event: .StoreCreation.siteCreationPropertiesOutOfSync())
-                    haveTrackedOutOfSyncEvent = true
-                }
-            })
-            .handleEvents(receiveCompletion: { [weak self] output in
-                guard let self else { return }
-                self.storeCreationProgressViewModel?.incrementProgress()
 
                 // Track when a properties out of sync event occur, but only track it once.
                 if self.isPropertiesOutOfSyncError(output) && !haveTrackedOutOfSyncEvent {
@@ -705,13 +703,12 @@ private extension StoreCreationCoordinator {
                     return
                 }
 
+
+                self.trackSiteCreatedEvent(site: site, flow: .native, timeAtStart: waitingTimeStart)
+
                 /// Free trial stores should land directly on the dashboard and not show any success view.
                 ///
                 if self.isFreeTrialCreation {
-                    self.analytics.track(event: .StoreCreation.siteCreated(source: self.source.analyticsValue,
-                                                                           siteURL: site.url,
-                                                                           flow: .native,
-                                                                           isFreeTrial: true))
                     self.continueWithSelectedSite(site: site)
                 } else {
                     self.showSuccessView(from: navigationController, site: site)
@@ -778,7 +775,6 @@ private extension StoreCreationCoordinator {
 
     @MainActor
     func showSuccessView(from navigationController: UINavigationController, site: Site) {
-        analytics.track(event: .StoreCreation.siteCreated(source: source.analyticsValue, siteURL: site.url, flow: .native, isFreeTrial: false))
         guard let url = URL(string: site.url) else {
             return continueWithSelectedSite(site: site)
         }
@@ -802,6 +798,17 @@ private extension StoreCreationCoordinator {
         navigationController.present(alertController, animated: true)
 
         analytics.track(event: .StoreCreation.siteCreationTimedOut())
+    }
+
+    /// Tracks when a store has been successfully created.
+    ///
+    func trackSiteCreatedEvent(site: Site, flow: WooAnalyticsEvent.StoreCreation.Flow, timeAtStart: Date) {
+        let waitingTime = "\(Date().timeIntervalSince(timeAtStart))"
+        analytics.track(event: .StoreCreation.siteCreated(source: source.analyticsValue,
+                                                          siteURL: site.url,
+                                                          flow: flow,
+                                                          isFreeTrial: isFreeTrialCreation,
+                                                          waitingTime: waitingTime))
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationWebViewModel.swift
@@ -36,6 +36,7 @@ enum StoreCreationError: Error {
     case invalidCompletionPath
     case newSiteUnavailable
     case newSiteIsNotJetpackSite
+    case newSiteIsNotFullySynced
 }
 
 private extension StoreCreationWebViewModel {


### PR DESCRIPTION
Closes: #9378 #9423 #9424 

# Why 

This PR adds tracks for the following events:

- When the site creation process reaches a state where the store has jetpack installed but other store properties are still out of sync. `site_creation_properties_out_of_sync`.   **One important bit here is that this event should only be tracked once per site creation process.**

- When the site creation process ends without the store fully reflecting its jetpack installation. 
`site_creation_timed_out `

- When the "Try For Free" button is tapped on the summary view. `site_creation_try_for_free_tapped`

- Adds a `waiting_time` property to the `login_woocommerce_site_created` event.

# Events

- https://github.com/Automattic/tracks-events-registration/pull/1531
- https://github.com/Automattic/tracks-events-registration/pull/1532
- https://github.com/Automattic/tracks-events-registration/pull/1550

# Screenshots

<img width="1500" alt="Screenshot 2023-04-11 at 9 07 47 AM" src="https://user-images.githubusercontent.com/562080/231191387-b83b16c6-e210-435f-bf8b-653da83bb959.png">


# Testing Steps

- Launch the app on a WPcom account
- Go to the site picker, scroll down, and tap on "+ add a store"
- Enter the store name
- Tap the "Try For Free" button
- Inspect the Xcode logs and search for the `site_creation_try_for_free_tapped` event.
- Wait for the store to be created
- Inspect the Xcode logs and search for the `login_woocommerce_site_created` event and search for the `waiting_time` property.
- Inspect the Xcode logs and search for the `site_creation_properties_out_of_sync` event.
- Make sure that the event is only logged once.

**Note: The `site_creation_properties_out_of_sync` event may not be tracked if the site never reaches the out-of-sync state(which is a good thing)**

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
