### PR TITLE
[Store onboarding] Show PRIVATE label only if task is incomplete.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -57,7 +57,7 @@ struct StoreOnboardingTaskView: View {
                                     .padding(Layout.PrivateLabel.padding)
                                     .background(Color(.wooCommercePurple(.shade0)))
                                     .cornerRadius(Layout.PrivateLabel.cornerRadius)
-                                    .renderedIf(!isRedacted && viewModel.task.type == .launchStore)
+                                    .renderedIf(!isRedacted && viewModel.task.type == .launchStore && !viewModel.task.isComplete)
                             }
 
                             // Task subtitle.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9418 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Stops showing the `PRIVATE` label in the "Launch your store" task if the task is already completed. 

Internal - p1681137456956839-slack-C045CUK1Y3U

Targeting `release/13.1` as a beta fix because, 
- This is a contained change with minimum impact area. 
- This is a user-reported issue.

## Testing instructions

**To test this, we have to create a new store using credits and launch it.**

- Launch and login into the app
- Create a new store from the store picker screen. Menu -> Switch Store -> + Add a Store -> Create a new store
- You will see the "Launch your store" task with `PRIVATE` label on the Dashboard screen
- Tap on the "Launch your store" task and "Upgrade plan" using credits
- From the Dashboard, pull down to refresh to reload the tasks
- You can see the "Launch your store" task with `PRIVATE` label as the store is not launched yet. (We have only purchased a plan)
- Tap on the "Launch your store" task and tap "Publish My Store" to launch the store
- From the Dashboard, tap on "View all" button to view all onboarding tasks
- Validate that you don't see the `PRIVATE` label on the "Launch your store" task as the store is launched now. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Before | Now |
|--------|--------|
| ![Before](https://user-images.githubusercontent.com/524475/231025821-ecb3c6ec-c74d-44ff-975f-0375a8531aa2.png) | ![Now](https://user-images.githubusercontent.com/524475/231025813-318d51f2-aef8-4407-8185-a5365f55c6ef.png) | 


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.