### PR TITLE
[Mobile Payments] IPP UK Expansion Feature Flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -89,6 +89,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .compositeProducts:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .IPPUKExpansion:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -183,4 +183,8 @@ public enum FeatureFlag: Int {
     /// Enables composite product settings in product details
     ///
     case compositeProducts
+
+    /// Enables UK-based stores taking In-Person Payments
+    ///
+    case IPPUKExpansion
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,6 @@
 13.2
 -----
 - [Internal] Store creation: New loading screen added for create store flow. [https://github.com/woocommerce/woocommerce-ios/pull/9383]
-- [**] Payments: UK merchants can collect In-Person Payments [https://github.com/woocommerce/woocommerce-ios/pull/9415]
 - [*] Payments: Add account type field to receipts [https://github.com/woocommerce/woocommerce-ios/pull/9416]
 
 

--- a/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
+++ b/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
@@ -1,17 +1,23 @@
 import Foundation
+import Experiments
 import Yosemite
 
 final class CardPresentConfigurationLoader {
-    init(stores: StoresManager = ServiceLocator.stores) {
+    let shouldReturnConfigurationForGB: Bool
+
+    init(stores: StoresManager = ServiceLocator.stores,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         // This initializer is kept since this is where we'd check for
         // feature flags while developing support for a new country
         // See https://github.com/woocommerce/woocommerce-ios/pull/6954
+
+        shouldReturnConfigurationForGB = featureFlagService.isFeatureFlagEnabled(.IPPUKExpansion)
     }
 
     var configuration: CardPresentPaymentsConfiguration {
         .init(
             country: SiteAddress().countryCode,
-            shouldReturnConfigurationForGB: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPUKExpansion)
+            shouldReturnConfigurationForGB: shouldReturnConfigurationForGB
         )
     }
 }

--- a/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
+++ b/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
@@ -10,7 +10,8 @@ final class CardPresentConfigurationLoader {
 
     var configuration: CardPresentPaymentsConfiguration {
         .init(
-            country: SiteAddress().countryCode
+            country: SiteAddress().countryCode,
+            shouldReturnConfigurationForGB: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.IPPUKExpansion)
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -17,6 +17,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isDashboardStoreOnboardingEnabled: Bool
     private let isFreeTrial: Bool
     private let jetpackSetupWithApplicationPassword: Bool
+    private let isIPPUKExpansionEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -32,7 +33,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isAddCouponToOrderEnabled: Bool = false,
          isDashboardStoreOnboardingEnabled: Bool = false,
          isFreeTrial: Bool = false,
-         jetpackSetupWithApplicationPassword: Bool = false) {
+         jetpackSetupWithApplicationPassword: Bool = false,
+         isIPPUKExpansionEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -48,6 +50,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isDashboardStoreOnboardingEnabled = isDashboardStoreOnboardingEnabled
         self.isFreeTrial = isFreeTrial
         self.jetpackSetupWithApplicationPassword = jetpackSetupWithApplicationPassword
+        self.isIPPUKExpansionEnabled = isIPPUKExpansionEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -82,6 +85,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isFreeTrial
         case .jetpackSetupWithApplicationPassword:
             return jetpackSetupWithApplicationPassword
+        case .IPPUKExpansion:
+            return isIPPUKExpansionEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
@@ -66,6 +66,32 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
         // Then
         XCTAssertFalse(configuration.isSupportedCountry)
     }
+
+    func test_configuration_for_UK_when_enabled_returns_supported() {
+        // Given
+        setupCountry(country: .gb)
+
+        // When
+        let featureFlagService = MockFeatureFlagService(isIPPUKExpansionEnabled: true)
+        let loader = CardPresentConfigurationLoader(stores: stores, featureFlagService: featureFlagService)
+        let configuration = loader.configuration
+
+        // Then
+        XCTAssertTrue(configuration.isSupportedCountry)
+    }
+
+    func test_configuration_for_UK_when_disabled_returns_not_supported() {
+        // Given
+        setupCountry(country: .gb)
+
+        // When
+        let featureFlagService = MockFeatureFlagService(isIPPUKExpansionEnabled: false)
+        let loader = CardPresentConfigurationLoader(stores: stores, featureFlagService: featureFlagService)
+        let configuration = loader.configuration
+
+        // Then
+        XCTAssertFalse(configuration.isSupportedCountry)
+    }
 }
 
 private extension CardPresentConfigurationLoaderTests {
@@ -85,5 +111,6 @@ private extension CardPresentConfigurationLoaderTests {
         case us = "US:CA"
         case ca = "CA:NS"
         case es = "ES"
+        case gb = "GB"
     }
 }

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -29,7 +29,7 @@ public struct CardPresentPaymentsConfiguration {
         self.stripeSmallestCurrencyUnitMultiplier = stripeSmallestCurrencyUnitMultiplier
     }
 
-    public init(country: String) {
+    public init(country: String, shouldReturnConfigurationForGB: Bool = false) {
         /// Changing `minimumVersion` values here? You'll need to also update `CardPresentPaymentsOnboardingUseCaseTests`
         switch country {
         case "US":
@@ -57,7 +57,7 @@ public struct CardPresentPaymentsConfiguration {
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
                 stripeSmallestCurrencyUnitMultiplier: 100
             )
-        case "GB":
+        case "GB" where shouldReturnConfigurationForGB:
             self.init(
                 countryCode: country,
                 paymentMethods: [.cardPresent],


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9426
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add a feature flag to the IPP UK Expansion feature so it can be tested on debug (and alpha) but is not released yet to production. Furthermore, we remove the release note as we hide the functionality to our users.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Run the application with Debug Build Configuration, it should enable you to take payments with a UK-based store.
- Run the application with Release Build Configuration (see screenshot), Card method shouldn't be available for UK-based stores.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="916" alt="Screenshot 2023-04-11 at 10 17 02" src="https://user-images.githubusercontent.com/1864060/231099360-5b95f789-c854-4114-9460-816c064a415c.png">



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
