### PR TITLE
[Mobile Payments] Bring IPP amount under minimum alert back

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -127,8 +127,9 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
                         onCompleted: @escaping () -> ()) {
         guard isTotalAmountValid() else {
             let error = totalAmountInvalidError()
-            onFailure(error)
-            return handleTotalAmountInvalidError(totalAmountInvalidError(), onCompleted: onCancel)
+            return handleTotalAmountInvalidError(totalAmountInvalidError(), onCompleted: {
+                onFailure(error)
+            })
         }
 
         preflightController = CardPresentPaymentPreflightController(siteID: siteID,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9430
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Because of a bug, we were not showing an alert when the charging card amount was lower than the minimum amount. This PR fixes that.
The reason behind it was that there was that we were calling to dismiss the whole flow before we could show the alert:

`Attempt to present <WooCommerce.CardPresentPaymentsModalViewController: 0x12c8f8200> on <WooCommerce.WooNavigationController: 0x12c957c00> (from <WooCommerce.WooNavigationController: 0x12c957c00>) whose view is not in the window hierarchy.`

Now we wait for the error alert to be shown, and when it's dismissed, we dismiss the flow and notify of the error.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Check that the alert is properly shown:

### Before
![Simulator Screen Recording - iPhone 11 - 2023-04-11 at 09 20 16](https://user-images.githubusercontent.com/3812076/231039088-e1a89b02-3dbc-4af6-a388-895b89e10819.gif)

### After

https://user-images.githubusercontent.com/1864060/231131144-88bfa2a6-f867-43ee-ba37-78e6ad9832f5.mp4

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
