### PR TITLE
[Mobile Payments] Update IPP minimum charge amounts for UK-based stores

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -127,8 +127,9 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
                         onCompleted: @escaping () -> ()) {
         guard isTotalAmountValid() else {
             let error = totalAmountInvalidError()
-            onFailure(error)
-            return handleTotalAmountInvalidError(totalAmountInvalidError(), onCompleted: onCancel)
+            return handleTotalAmountInvalidError(totalAmountInvalidError(), onCompleted: {
+                onFailure(error)
+            })
         }
 
         preflightController = CardPresentPaymentPreflightController(siteID: siteID,

--- a/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Yosemite/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -65,7 +65,7 @@ public struct CardPresentPaymentsConfiguration {
                 paymentGateways: [WCPayAccount.gatewayID],
                 supportedReaders: [.wisepad3],
                 supportedPluginVersions: [.init(plugin: .wcPay, minimumVersion: "4.4.0")],
-                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
+                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.3"),
                 stripeSmallestCurrencyUnitMultiplier: 100
             )
         default:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

This includes the changes of https://github.com/woocommerce/woocommerce-ios/pull/9431 to be more easily testable. Once that PR is merged, they won't show in the diff

Closes: #9430
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This small PR updates the minimum charge amount for IPP UK charges to 0.30

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Please test that it takes payments until 0.30, but not lower than that. Please also check that the alert is properly updated:

<img src="https://user-images.githubusercontent.com/1864060/231138077-f0e1e559-7aaf-4416-9619-8cf475bd80b9.png" width="375">

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
