### PR TITLE
Jetpack connection: Fix regression issues for Jetpack connection during the WPCom login flow.

### DIFF
--- a/Networking/Networking/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Networking/Networking/CookieNonce/CookieNonceAuthenticator.swift
@@ -155,7 +155,7 @@ private extension CookieNonceAuthenticator {
     }
 
     func buildNonceRequestURL(base: URL) -> URL? {
-        URL(string: "admin-ajax.php?action=rest-nonce", relativeTo: base)
+        URL(string: base.absoluteString + "/admin-ajax.php?action=rest-nonce")
     }
 }
 

--- a/Networking/Networking/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Networking/Networking/CookieNonce/CookieNonceAuthenticator.swift
@@ -155,7 +155,7 @@ private extension CookieNonceAuthenticator {
     }
 
     func buildNonceRequestURL(base: URL) -> URL? {
-        URL(string: base.absoluteString + "/admin-ajax.php?action=rest-nonce")
+        URL(string: base.absoluteString.removingSuffix("/") + "/admin-ajax.php?action=rest-nonce")
     }
 }
 

--- a/Networking/Networking/Remote/JetpackConnectionRemote.swift
+++ b/Networking/Networking/Remote/JetpackConnectionRemote.swift
@@ -49,12 +49,65 @@ public final class JetpackConnectionRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    /// Registers Jetpack site connection by requesting the input URL while disabling automatic redirection,
+    /// and returns the URL in the requested redirection.
+    /// To simplify redirection manipulation, we'll use a `URLSession` here instead of `Network`.
+    ///
+    public func registerJetpackSiteConnection(with url: URL, completion: @escaping (Result<URL, Error>) -> Void) {
+
+        let configuration = URLSessionConfiguration.default
+        for cookie in network.session.configuration.httpCookieStorage?.cookies ?? [] {
+            configuration.httpCookieStorage?.setCookie(cookie)
+        }
+
+        let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+        do {
+            let request = try URLRequest(url: url, method: .get)
+            let task = session.dataTask(with: request) { [weak self] data, response, error in
+                if let result = self?.accountConnectionURL {
+                    DispatchQueue.main.async {
+                        completion(.success(result))
+                    }
+                    return
+                }
+                // We don't expect any response here since we'll cancel the task as soon as a redirect request is received.
+                // So always complete with a failure here.
+                let returnedError = error ?? ConnectionError.accountConnectionURLNotFound
+                DispatchQueue.main.async {
+                    completion(.failure(returnedError))
+                }
+                return
+            }
+            task.resume()
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
     /// Fetches the user connection state with the site's Jetpack.
     ///
     public func fetchJetpackUser(completion: @escaping (Result<JetpackUser, Error>) -> Void) {
         let request = RESTRequest(siteURL: siteURL, method: .get, path: Path.jetpackConnectionUser)
         let mapper = JetpackUserMapper()
         enqueue(request, mapper: mapper, completion: completion)
+    }
+}
+
+// MARK: - URLSessionDataDelegate conformance
+//
+extension JetpackConnectionRemote: URLSessionDataDelegate {
+    public func urlSession(_ session: URLSession,
+                           task: URLSessionTask,
+                           willPerformHTTPRedirection response: HTTPURLResponse,
+                           newRequest request: URLRequest) async -> URLRequest? {
+        // Disables redirection if the request is to load the Jetpack account connection URL
+        if let url = request.url,
+            url.absoluteString.hasPrefix(Constants.jetpackAccountConnectionURL) {
+            accountConnectionURL = url
+            task.cancel()
+            return nil
+        }
+        return request
     }
 }
 

--- a/Podfile
+++ b/Podfile
@@ -85,7 +85,7 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
 #  pod 'WordPressAuthenticator', '~> 6.0.0'
-   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'b0eedc43ecd8226d4d4c065b16bf43cbff2b5133'
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '075d308a039525f119a717641b03d2f74a8815af'
 #   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -84,8 +84,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 6.0.0'
-#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+#  pod 'WordPressAuthenticator', '~> 6.0.0'
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'b0eedc43ecd8226d4d4c065b16bf43cbff2b5133'
 #   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -39,7 +39,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (6.0.0):
+  - WordPressAuthenticator (6.0.1-beta.1):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -83,7 +83,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 6.0.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `b0eedc43ecd8226d4d4c065b16bf43cbff2b5133`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.12.5)
   - Wormholy (~> 1.6.6)
@@ -114,7 +114,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressShared
     - WordPressUI
     - Wormholy
@@ -127,6 +126,16 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
+
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :commit: b0eedc43ecd8226d4d4c065b16bf43cbff2b5133
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: b0eedc43ecd8226d4d4c065b16bf43cbff2b5133
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -149,7 +158,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: b93b797eae278f7cda42693a652329173f1d5423
+  WordPressAuthenticator: 3b05690984590e0c97e44fec89bd06ab16a2da1f
   WordPressKit: 47e8e0fc39df87d0b8f84c1a4a67868414e9a925
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -164,6 +173,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: acee7d21f87d18c5c4a806a6f3adc22fe5bdeb0d
+PODFILE CHECKSUM: 2d9f33ba482029bbf524c6901f99d021cb861913
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -83,7 +83,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `b0eedc43ecd8226d4d4c065b16bf43cbff2b5133`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `075d308a039525f119a717641b03d2f74a8815af`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.12.5)
   - Wormholy (~> 1.6.6)
@@ -129,12 +129,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: b0eedc43ecd8226d4d4c065b16bf43cbff2b5133
+    :commit: 075d308a039525f119a717641b03d2f74a8815af
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: b0eedc43ecd8226d4d4c065b16bf43cbff2b5133
+    :commit: 075d308a039525f119a717641b03d2f74a8815af
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -173,6 +173,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 2d9f33ba482029bbf524c6901f99d021cb861913
+PODFILE CHECKSUM: ba17fdc169d3e046fa3b3de13b3cb5b9ffb71741
 
 COCOAPODS: 1.11.3

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -256,7 +256,7 @@ private extension WrongAccountErrorViewModel {
     ///
     func fetchJetpackConnectionURL(onCompletion: ((URL) -> Void)? = nil) {
         primaryButtonLoading = true
-        let action = JetpackConnectionAction.fetchJetpackConnectionURL { [weak self] result in
+        let action = JetpackConnectionAction.fetchAccountConnectionURL { [weak self] result in
             guard let self = self else { return }
             self.primaryButtonLoading = false
             switch result {

--- a/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
@@ -139,7 +139,7 @@ final class WrongAccountErrorViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
-            case .fetchJetpackConnectionURL(let completion):
+            case .fetchAccountConnectionURL(let completion):
                 completion(.success(expectedURL))
             default:
                 break
@@ -311,7 +311,7 @@ final class WrongAccountErrorViewModelTests: XCTestCase {
         var completed = false
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
-            case .fetchJetpackConnectionURL(let completion):
+            case .fetchAccountConnectionURL(let completion):
                 let error = NSError(domain: "Test", code: 123)
                 completion(.failure(error))
                 completed = true

--- a/Yosemite/Yosemite/Actions/JetpackConnectionAction.swift
+++ b/Yosemite/Yosemite/Actions/JetpackConnectionAction.swift
@@ -12,8 +12,11 @@ public enum JetpackConnectionAction: Action {
     case installJetpackPlugin(completion: (Result<Void, Error>) -> Void)
     /// Updates Jetpack the plugin for the current site.
     case activateJetpackPlugin(completion: (Result<Void, Error>) -> Void)
-    /// Fetches the URL used for setting up Jetpack connection.
+    /// Fetches the URL used for setting up Jetpack site or account connection.
     case fetchJetpackConnectionURL(completion: (Result<URL, Error>) -> Void)
+    /// Fetches the URL used for account connection only.
+    /// Site registration will be handled automatically with cookie-nonce.
+    case fetchAccountConnectionURL(completion: (Result<URL, Error>) -> Void)
     /// Fetches the user connection state with the given site's Jetpack.
     case fetchJetpackUser(completion: (Result<JetpackUser, Error>) -> Void)
     /// Fetches the WPCom account with the given network

--- a/Yosemite/Yosemite/Stores/JetpackConnectionStore.swift
+++ b/Yosemite/Yosemite/Stores/JetpackConnectionStore.swift
@@ -56,11 +56,17 @@ private extension JetpackConnectionStore {
     }
 
     func retrieveJetpackPluginDetails(completion: @escaping (Result<SitePlugin, Error>) -> Void) {
-        jetpackConnectionRemote?.retrieveJetpackPluginDetails(completion: completion)
+        guard let remote = jetpackConnectionRemote else {
+            return completion(.failure(ConnectionError.notAuthenticated))
+        }
+        remote.retrieveJetpackPluginDetails(completion: completion)
     }
 
     func installJetpackPlugin(completion: @escaping (Result<Void, Error>) -> Void) {
-        jetpackConnectionRemote?.installJetpackPlugin(completion: { result in
+        guard let remote = jetpackConnectionRemote else {
+            return completion(.failure(ConnectionError.notAuthenticated))
+        }
+        remote.installJetpackPlugin(completion: { result in
             switch result {
             case .success:
                 completion(.success(()))
@@ -71,7 +77,10 @@ private extension JetpackConnectionStore {
     }
 
     func activateJetpackPlugin(completion: @escaping (Result<Void, Error>) -> Void) {
-        jetpackConnectionRemote?.activateJetpackPlugin(completion: { result in
+        guard let remote = jetpackConnectionRemote else {
+            return completion(.failure(ConnectionError.notAuthenticated))
+        }
+        remote.activateJetpackPlugin(completion: { result in
             switch result {
             case .success:
                 completion(.success(()))
@@ -82,12 +91,17 @@ private extension JetpackConnectionStore {
     }
 
     func fetchJetpackConnectionURL(completion: @escaping (Result<URL, Error>) -> Void) {
-        jetpackConnectionRemote?.fetchJetpackConnectionURL(completion: completion)
+        guard let remote = jetpackConnectionRemote else {
+            return completion(.failure(ConnectionError.notAuthenticated))
+        }
+        remote.fetchJetpackConnectionURL(completion: completion)
     }
 
     func fetchAccountConnectionURL(completion: @escaping (Result<URL, Error>) -> Void) {
-        jetpackConnectionRemote?.fetchJetpackConnectionURL { [weak self] result in
-            guard let self else { return }
+        guard let remote = jetpackConnectionRemote else {
+            return completion(.failure(ConnectionError.notAuthenticated))
+        }
+        remote.fetchJetpackConnectionURL { result in
             switch result {
             case .success(let url):
                 // If we get the account connection URL, return it immediately.
@@ -95,7 +109,7 @@ private extension JetpackConnectionStore {
                     return completion(.success(url))
                 }
                 // Otherwise, request the url with redirection disabled and retrieve the URL in LOCATION header
-                self.jetpackConnectionRemote?.registerJetpackSiteConnection(with: url, completion: completion)
+                remote.registerJetpackSiteConnection(with: url, completion: completion)
             case .failure(let error):
                 completion(.failure(error))
             }
@@ -103,7 +117,10 @@ private extension JetpackConnectionStore {
     }
 
     func fetchJetpackUser(completion: @escaping (Result<JetpackUser, Error>) -> Void) {
-        jetpackConnectionRemote?.fetchJetpackUser(completion: completion)
+        guard let remote = jetpackConnectionRemote else {
+            return completion(.failure(ConnectionError.notAuthenticated))
+        }
+        remote.fetchJetpackUser(completion: completion)
     }
 
     func loadWPComAccount(network: Network, onCompletion: @escaping (Account?) -> Void) {
@@ -124,6 +141,9 @@ private extension JetpackConnectionStore {
 // MARK: - Enums
 //
 private extension JetpackConnectionStore {
+    enum ConnectionError: Error {
+        case notAuthenticated
+    }
     enum Constants {
         static let jetpackAccountConnectionURL = "https://jetpack.wordpress.com/jetpack.authorize"
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #9427 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the regression issues of the Jetpack connection flow for users logged in with WPCom accounts that are not connected to the entered site's Jetpack. The fixes include:
- Integrated the fix in the authenticator library to make sure that `completionHandler` is prioritized in site credential login if it's available (more information in https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/768).
- Restored the logic for site registration with cookie-nonce that was removed in #9113. `JetpackConnectionAction` and store were updated with a new action to fetch the account connection URL only, with the site registration handled under the hood.
- Fixed issue building the nonce-retrieval URL for cookie-nonce authentication.
- Hid the web view login entry point in the error alert for users logged in with WPCom.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure that you have access to a self-hosted Woo store without Jetpack.
- Install and activate Jetpack on your site. Proceed to finish setup Jetpack, but stop at the step for connecting your WPCom account.
- On the app, enter the address of your test site. Since your site has Jetpack connection, you are then asked for WPCom credentials.
- After logging in successfully, notice that you see the wrong account error screen.
- Tap Connect Jetpack, the site credential login screen should then be displayed.
- Enter incorrect credentials and tap Continue. Notice that the error alert doesn't have the entry point to the web view login flow.
- Enter the correct credentials, the login screen should be dismissed after the login succeeds.
- There should be a loading indicator on the Connect Jetpack button for fetching the connection URL. When this completes, a web view should be displayed for connecting Jetpack.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/231398937-beee8547-0a2b-4785-8d46-855c987dfa2f.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
