### PR TITLE
[UI Tests] - Update add products tests

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -41,17 +41,32 @@ public final class SingleProductScreen: ScreenObject {
         return self
     }
 
-    public func verifyNewProductScreenLoaded(productName: String) {
+    public func verifyPublishedProductScreenLoaded(productType: String, productName: String) {
+        let priceLabel = NSPredicate(format: "label == 'Price'")
+        let addVariationLabel = NSPredicate(format: "label == 'Add variations'")
+
+        // common fields on a published product screen
         XCTAssertTrue(app.buttons["save-product-button"].exists)
         XCTAssertTrue(app.staticTexts["TIP"].exists)
         XCTAssertTrue(app.textViews[productName].exists)
+
+        // different product types displays different fields on the published product screen
+        // this is to validate that the correct screens are displayed
+        switch productType {
+        case "physical", "virtual":
+            XCTAssertTrue(app.staticTexts.containing(priceLabel).firstMatch.exists)
+        case "variable":
+            XCTAssertTrue(app.staticTexts.containing(addVariationLabel).firstMatch.exists)
+        default:
+            fatalError("Product Type \(productType) doesn't exist!")
+        }
     }
 
     public func verifyProductTypeScreenLoaded(productType: String) throws -> Self {
         let addPriceLabel = NSPredicate(format: "label == 'Add Price'")
         let inventoryLabel = NSPredicate(format: "label == 'Inventory'")
-        let productTypeLabel = NSPredicate(format: "label ==[c] '\(productType)'")
         let addVariationLabel = NSPredicate(format: "label == 'Add variations'")
+        let productTypeLabel = NSPredicate(format: "label ==[c] '\(productType)'")
 
         // the common fields on add product screen
         XCTAssertTrue(app.cells["product-review-cell"].exists)

--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -82,7 +82,7 @@ public final class SingleProductScreen: ScreenObject {
             XCTAssertTrue(app.staticTexts.containing(addVariationLabel).firstMatch.exists)
             XCTAssertTrue(app.staticTexts.containing(inventoryLabel).firstMatch.exists)
         default:
-            fatalError("Product Type \(productType) doesn't exist!")
+            XCTFail("Product Type \(productType) doesn't exist!")
         }
         return self
     }

--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -42,9 +42,6 @@ public final class SingleProductScreen: ScreenObject {
     }
 
     public func verifyPublishedProductScreenLoaded(productType: String, productName: String) {
-        let priceLabel = NSPredicate(format: "label == 'Price'")
-        let addVariationLabel = NSPredicate(format: "label == 'Add variations'")
-
         // common fields on a published product screen
         XCTAssertTrue(app.buttons["save-product-button"].exists)
         XCTAssertTrue(app.staticTexts["TIP"].exists)
@@ -54,19 +51,16 @@ public final class SingleProductScreen: ScreenObject {
         // this is to validate that the correct screens are displayed
         switch productType {
         case "physical", "virtual":
-            XCTAssertTrue(app.staticTexts.containing(priceLabel).firstMatch.exists)
+            XCTAssertTrue(app.staticTexts["Price"].exists)
         case "variable":
-            XCTAssertTrue(app.staticTexts.containing(addVariationLabel).firstMatch.exists)
+            XCTAssertTrue(app.staticTexts["Add variations"].exists)
         default:
             fatalError("Product Type \(productType) doesn't exist!")
         }
     }
 
     public func verifyProductTypeScreenLoaded(productType: String) throws -> Self {
-        let addPriceLabel = NSPredicate(format: "label == 'Add Price'")
-        let inventoryLabel = NSPredicate(format: "label == 'Inventory'")
         let productTypeLabel = NSPredicate(format: "label ==[c] '\(productType)'")
-        let addVariationLabel = NSPredicate(format: "label == 'Add variations'")
 
         // the common fields on add product screen
         XCTAssertTrue(app.cells["product-review-cell"].exists)
@@ -76,11 +70,11 @@ public final class SingleProductScreen: ScreenObject {
         // this is to validate that the correct screens are displayed
         switch productType {
         case "physical", "virtual":
-            XCTAssertTrue(app.staticTexts.containing(addPriceLabel).firstMatch.exists)
-            XCTAssertTrue(app.staticTexts.containing(inventoryLabel).firstMatch.exists)
+            XCTAssertTrue(app.staticTexts["Add Price"].exists)
+            XCTAssertTrue(app.staticTexts["Inventory"].exists)
         case "variable":
-            XCTAssertTrue(app.staticTexts.containing(addVariationLabel).firstMatch.exists)
-            XCTAssertTrue(app.staticTexts.containing(inventoryLabel).firstMatch.exists)
+            XCTAssertTrue(app.staticTexts["Add variations"].exists)
+            XCTAssertTrue(app.staticTexts["Inventory"].exists)
         default:
             XCTFail("Product Type \(productType) doesn't exist!")
         }

--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -50,7 +50,7 @@ public final class SingleProductScreen: ScreenObject {
         XCTAssertTrue(app.staticTexts["TIP"].exists)
         XCTAssertTrue(app.textViews[productName].exists)
 
-        // different product types displays different fields on the published product screen
+        // different product types display different fields on the published product screen
         // this is to validate that the correct screens are displayed
         switch productType {
         case "physical", "virtual":
@@ -65,14 +65,14 @@ public final class SingleProductScreen: ScreenObject {
     public func verifyProductTypeScreenLoaded(productType: String) throws -> Self {
         let addPriceLabel = NSPredicate(format: "label == 'Add Price'")
         let inventoryLabel = NSPredicate(format: "label == 'Inventory'")
-        let addVariationLabel = NSPredicate(format: "label == 'Add variations'")
         let productTypeLabel = NSPredicate(format: "label ==[c] '\(productType)'")
+        let addVariationLabel = NSPredicate(format: "label == 'Add variations'")
 
         // the common fields on add product screen
         XCTAssertTrue(app.cells["product-review-cell"].exists)
         XCTAssertTrue(app.staticTexts.containing(productTypeLabel).firstMatch.exists)
 
-        // different product types displays different fields on add product screen
+        // different product types display different fields on add product screen
         // this is to validate that the correct screens are displayed
         switch productType {
         case "physical", "virtual":

--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -55,7 +55,7 @@ public final class SingleProductScreen: ScreenObject {
         case "variable":
             XCTAssertTrue(app.staticTexts["Add variations"].exists)
         default:
-            fatalError("Product Type \(productType) doesn't exist!")
+            XCTFail("Product Type \(productType) doesn't exist!")
         }
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1258,7 +1258,6 @@
 		800A5BC8275889ED009DE2CD /* reports_revenue_stats_year.json in Resources */ = {isa = PBXBuildFile; fileRef = 800A5BC4275889EC009DE2CD /* reports_revenue_stats_year.json */; };
 		800A5BCB2759CE4B009DE2CD /* ProductsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800A5BCA2759CE4B009DE2CD /* ProductsTests.swift */; };
 		803B0A4629CC2CE20051EFD6 /* ProductSearchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803B0A4529CC2CE20051EFD6 /* ProductSearchScreen.swift */; };
-		806062F229432BB8006BB1F9 /* products_add_new.json in Resources */ = {isa = PBXBuildFile; fileRef = 806062F129432BB8006BB1F9 /* products_add_new.json */; };
 		80AD2CA22782B4EB00A63DE8 /* products_list_1.json in Resources */ = {isa = PBXBuildFile; fileRef = 80AD2CA12782B4EB00A63DE8 /* products_list_1.json */; };
 		80AD2CA427858BAB00A63DE8 /* StatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AD2CA327858BAB00A63DE8 /* StatsTests.swift */; };
 		80AD2CA627859B4400A63DE8 /* reports_leaderboards_stats_day.json in Resources */ = {isa = PBXBuildFile; fileRef = 80AD2CA527859B4400A63DE8 /* reports_leaderboards_stats_day.json */; };
@@ -1276,6 +1275,11 @@
 		80CA638C29C06029002E6BE6 /* PaymentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CA638B29C06029002E6BE6 /* PaymentsScreen.swift */; };
 		80CC80E829DEA3C700CA1687 /* ExternalAppScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */; };
 		80CC80F229DFC3E400CA1687 /* files.json in Resources */ = {isa = PBXBuildFile; fileRef = 80CC80F129DFC3E400CA1687 /* files.json */; };
+		80CC810329E673AB00CA1687 /* products_add_new_physical_2129.json in Resources */ = {isa = PBXBuildFile; fileRef = 80CC810229E673AB00CA1687 /* products_add_new_physical_2129.json */; };
+		80CC810529E6748C00CA1687 /* products_add_new_virtual_2123.json in Resources */ = {isa = PBXBuildFile; fileRef = 80CC810429E6748C00CA1687 /* products_add_new_virtual_2123.json */; };
+		80CC810729E6763F00CA1687 /* products_add_new_variable_2131.json in Resources */ = {isa = PBXBuildFile; fileRef = 80CC810629E6763F00CA1687 /* products_add_new_variable_2131.json */; };
+		80CC810B29E6800F00CA1687 /* products_add_new_grouped_2130.json in Sources */ = {isa = PBXBuildFile; fileRef = 80CC810A29E6800F00CA1687 /* products_add_new_grouped_2130.json */; };
+		80CC810D29E683CE00CA1687 /* products_add_new_external_2132.json in Resources */ = {isa = PBXBuildFile; fileRef = 80CC810C29E683CE00CA1687 /* products_add_new_external_2132.json */; };
 		80D9300329C8660C008865D8 /* CardReaderManualsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D9300229C8660C008865D8 /* CardReaderManualsScreen.swift */; };
 		80DA4F1C29CC505800BDF3BF /* products_search_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 80DA4F1B29CC505800BDF3BF /* products_search_results.json */; };
 		80E6FC6D276312D50086CD67 /* products.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFC00C923E9BD5500157A78 /* products.json */; };
@@ -3451,7 +3455,6 @@
 		800A5BC4275889EC009DE2CD /* reports_revenue_stats_year.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = reports_revenue_stats_year.json; sourceTree = "<group>"; };
 		800A5BCA2759CE4B009DE2CD /* ProductsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTests.swift; sourceTree = "<group>"; };
 		803B0A4529CC2CE20051EFD6 /* ProductSearchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchScreen.swift; sourceTree = "<group>"; };
-		806062F129432BB8006BB1F9 /* products_add_new.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_add_new.json; sourceTree = "<group>"; };
 		80AD2CA12782B4EB00A63DE8 /* products_list_1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_list_1.json; sourceTree = "<group>"; };
 		80AD2CA327858BAB00A63DE8 /* StatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTests.swift; sourceTree = "<group>"; };
 		80AD2CA527859B4400A63DE8 /* reports_leaderboards_stats_day.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reports_leaderboards_stats_day.json; sourceTree = "<group>"; };
@@ -3469,6 +3472,11 @@
 		80CA638B29C06029002E6BE6 /* PaymentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsScreen.swift; sourceTree = "<group>"; };
 		80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalAppScreen.swift; sourceTree = "<group>"; };
 		80CC80F129DFC3E400CA1687 /* files.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = files.json; sourceTree = "<group>"; };
+		80CC810229E673AB00CA1687 /* products_add_new_physical_2129.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_add_new_physical_2129.json; sourceTree = "<group>"; };
+		80CC810429E6748C00CA1687 /* products_add_new_virtual_2123.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_add_new_virtual_2123.json; sourceTree = "<group>"; };
+		80CC810629E6763F00CA1687 /* products_add_new_variable_2131.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_add_new_variable_2131.json; sourceTree = "<group>"; };
+		80CC810A29E6800F00CA1687 /* products_add_new_grouped_2130.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_add_new_grouped_2130.json; sourceTree = "<group>"; };
+		80CC810C29E683CE00CA1687 /* products_add_new_external_2132.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_add_new_external_2132.json; sourceTree = "<group>"; };
 		80D9300229C8660C008865D8 /* CardReaderManualsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsScreen.swift; sourceTree = "<group>"; };
 		80DA4F1B29CC505800BDF3BF /* products_search_results.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = products_search_results.json; sourceTree = "<group>"; };
 		80E6FC6E276325F60086CD67 /* Clibsodium.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Clibsodium.xcframework; path = ../Pods/Sodium/Clibsodium.xcframework; sourceTree = "<group>"; };
@@ -8564,8 +8572,12 @@
 				80AD2CA12782B4EB00A63DE8 /* products_list_1.json */,
 				80B8D3442785A08900FE6E6B /* products_list_2.json */,
 				80B8D3482785A0A900FE6E6B /* products_list_3.json */,
-				806062F129432BB8006BB1F9 /* products_add_new.json */,
 				80DA4F1B29CC505800BDF3BF /* products_search_results.json */,
+				80CC810429E6748C00CA1687 /* products_add_new_virtual_2123.json */,
+				80CC810229E673AB00CA1687 /* products_add_new_physical_2129.json */,
+				80CC810A29E6800F00CA1687 /* products_add_new_grouped_2130.json */,
+				80CC810629E6763F00CA1687 /* products_add_new_variable_2131.json */,
+				80CC810C29E683CE00CA1687 /* products_add_new_external_2132.json */,
 			);
 			path = products;
 			sourceTree = "<group>";
@@ -10512,6 +10524,7 @@
 				800A5BB827586A96009DE2CD /* products_reviews_6156.json in Resources */,
 				D8CD0605258B384E00B52D63 /* oauth2_token-error.json in Resources */,
 				800A5BAE27586876009DE2CD /* products_2131.json in Resources */,
+				80CC810D29E683CE00CA1687 /* products_add_new_external_2132.json in Resources */,
 				800A5BAC27586642009DE2CD /* products_2130.json in Resources */,
 				C0CE1F84282AB1590019138E /* countries.json in Resources */,
 				80CC80F229DFC3E400CA1687 /* files.json in Resources */,
@@ -10530,10 +10543,12 @@
 				C0A37CB8282957EB00E0826D /* orders_3337_add_customer_details.json in Resources */,
 				800A5BBE27586AEF009DE2CD /* products_reviews_6163.json in Resources */,
 				FE6BCDFC26A9D0E700D96FE2 /* users_me.json in Resources */,
+				80CC810329E673AB00CA1687 /* products_add_new_physical_2129.json in Resources */,
 				CCF27B3A280EF98F00B755E1 /* orders_3337.json in Resources */,
 				CC5C278B27EE314F00B25D2A /* orders_3337_create_order.json in Resources */,
 				800A5BA027562EE5009DE2CD /* orders_processing.json in Resources */,
 				80AD2CA22782B4EB00A63DE8 /* products_list_1.json in Resources */,
+				80CC810529E6748C00CA1687 /* products_add_new_virtual_2123.json in Resources */,
 				80B8D34127859C6F00FE6E6B /* reports_leaderboards_stats_month.json in Resources */,
 				800A5BC6275889ED009DE2CD /* reports_revenue_stats_hour.json in Resources */,
 				800A5BB027586898009DE2CD /* products_2132.json in Resources */,
@@ -10542,11 +10557,11 @@
 				CC2A08022862400100510C4B /* orders_3337_add_shipping.json in Resources */,
 				800A5BC027586AFC009DE2CD /* products_reviews_6164.json in Resources */,
 				800A5BC5275889ED009DE2CD /* reports_revenue_stats_day.json in Resources */,
+				80CC810729E6763F00CA1687 /* products_add_new_variable_2131.json in Resources */,
 				800A5B972755BA02009DE2CD /* status.json in Resources */,
 				800A5BC8275889ED009DE2CD /* reports_revenue_stats_year.json in Resources */,
 				CC2A08062863222500510C4B /* orders_3337_add_fee.json in Resources */,
 				800A5BBC27586AE1009DE2CD /* products_reviews_6162.json in Resources */,
-				806062F229432BB8006BB1F9 /* products_add_new.json in Resources */,
 				800A5B6127548F53009DE2CD /* sites_posts_password.json in Resources */,
 				800A5BB427586A0E009DE2CD /* products_reviews_6155.json in Resources */,
 				800A5B5F27548F31009DE2CD /* site_info_wordpress_com.json in Resources */,
@@ -12555,6 +12570,7 @@
 				80AD2CA427858BAB00A63DE8 /* StatsTests.swift in Sources */,
 				800A5BCB2759CE4B009DE2CD /* ProductsTests.swift in Sources */,
 				800A5B9E275623FC009DE2CD /* LoginFlow.swift in Sources */,
+				80CC810B29E6800F00CA1687 /* products_add_new_grouped_2130.json in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WooCommerce/WooCommerceUITests/Flows/MockDataReader.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/MockDataReader.swift
@@ -39,8 +39,14 @@ class GetMocks {
         return updatedData
     }
 
-    static func readNewProductData() throws -> ProductData {
-        let originalData = try JSONDecoder().decode(NewProductMock.self, from: self.getMockData(test: ProductsTests.self, filename: "products_add_new"))
+    static func readNewProductData(productType: String) throws -> ProductData {
+        let file = [
+            "physical": "products_add_new_physical_2129",
+            "virtual": "products_add_new_virtual_2123",
+            "variable": "products_add_new_variable_2131"
+        ]
+
+        let originalData = try JSONDecoder().decode(NewProductMock.self, from: self.getMockData(test: ProductsTests.self, filename: file[productType]!))
 
         return try XCTUnwrap(originalData.response.jsonBody.data)
     }

--- a/WooCommerce/WooCommerceUITests/Flows/MockDataReader.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/MockDataReader.swift
@@ -18,6 +18,12 @@ class GetMocks {
         2132: "rose gold shades"
     ]
 
+    private static let file = [
+        "physical": "products_add_new_physical_2129",
+        "virtual": "products_add_new_virtual_2123",
+        "variable": "products_add_new_variable_2131"
+    ]
+
     static func getMockData(test: AnyClass, filename file: String) -> Data {
         let json = Bundle(for: test).url(forResource: file, withExtension: "json")!
 
@@ -40,12 +46,6 @@ class GetMocks {
     }
 
     static func readNewProductData(productType: String) throws -> ProductData {
-        let file = [
-            "physical": "products_add_new_physical_2129",
-            "virtual": "products_add_new_virtual_2123",
-            "variable": "products_add_new_variable_2131"
-        ]
-
         let originalData = try JSONDecoder().decode(NewProductMock.self, from: self.getMockData(test: ProductsTests.self, filename: file[productType]!))
 
         return try XCTUnwrap(originalData.response.jsonBody.data)

--- a/WooCommerce/WooCommerceUITests/Flows/ProductFlow.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/ProductFlow.swift
@@ -4,7 +4,7 @@ import XCTest
 class ProductFlow {
 
     static func addAndVerifyNewProduct(productType: String) throws {
-        let product = try GetMocks.readNewProductData()
+        let product = try GetMocks.readNewProductData(productType: productType)
 
         try TabNavComponent().goToProductsScreen()
             .tapAddProduct()
@@ -12,6 +12,6 @@ class ProductFlow {
             .verifyProductTypeScreenLoaded(productType: productType)
             .addProductTitle(productTitle: product.name)
             .publishProduct()
-            .verifyNewProductScreenLoaded(productName: product.name)
+            .verifyPublishedProductScreenLoaded(productType: productType, productName: product.name)
     }
 }

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/products/products_add_new_external_2132.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/products/products_add_new_external_2132.json
@@ -1,0 +1,133 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "bodyPatterns": [
+            {
+                "matches": ".*path=/wc/v3/products%26_method%3Dpost"
+            },
+            {
+                "contains": "name%22%3A%22Rose%20Gold%20shades"
+            }
+        ]
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 2132,
+                "name": "Rose Gold shades",
+                "slug": "rose-gold-shades",
+                "permalink": "https:\/\/automatticwidgets.wpcomstaging.com\/product\/rose-gold-shades\/",
+                "date_created": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{now format=customformat}}",
+                "date_created_gmt": "{{now format=customformat}}",
+                "date_modified": "{{now format=customformat}}",
+                "date_modified_gmt": "{{now format=customformat}}",
+                "type": "external",
+                "status": "publish",
+                "featured": false,
+                "catalog_visibility": "visible",
+                "description": "external product",
+                "short_description": "",
+                "sku": "",
+                "price": "140",
+                "regular_price": "140",
+                "sale_price": "",
+                "date_on_sale_from": null,
+                "date_on_sale_from_gmt": null,
+                "date_on_sale_to": null,
+                "date_on_sale_to_gmt": null,
+                "on_sale": false,
+                "purchasable": false,
+                "virtual": false,
+                "total_sales": 0,
+                "downloadable": false,
+                "downloads": [],
+                "download_limit": -1,
+                "download_expiry": -1,
+                "external_url": "",
+                "button_text": "",
+                "tax_status": "taxable",
+                "tax_class": "",
+                "manage_stock": false,
+                "stock_quantity": null,
+                "backorders": "no",
+                "backorders_allowed": false,
+                "backordered": false,
+                "low_stock_amount": null,
+                "sold_individually": false,
+                "weight": "",
+                "dimensions": {
+                    "length": "",
+                    "width": "",
+                    "height": ""
+                },
+                "shipping_required": true,
+                "shipping_taxable": true,
+                "shipping_class": "",
+                "shipping_class_id": 0,
+                "reviews_allowed": true,
+                "average_rating": "0",
+                "rating_count": 0,
+                "upsell_ids": [],
+                "cross_sell_ids": [],
+                "parent_id": 0,
+                "purchase_note": "",
+                "categories": [],
+                "tags": [],
+                "images": [
+                    {
+                        "id": 2128,
+                        "date_created": "2020-01-28T09:52:59",
+                        "date_created_gmt": "2020-01-28T09:52:59",
+                        "date_modified": "2020-01-28T09:52:59",
+                        "date_modified_gmt": "2020-01-28T09:52:59",
+                        "src": "https://i1.wp.com/automatticwidgets.wpcomstaging.com/wp-content/uploads/2020/01/Mask-Group.png?fit=201%2C201&ssl=1",
+                        "name": "Mask Group",
+                        "alt": ""
+                    }
+                ],
+                "attributes": [],
+                "default_attributes": [],
+                "variations": [],
+                "grouped_products": [],
+                "menu_order": 0,
+                "price_html": "",
+                "related_ids": [],
+                "meta_data": [{
+                    "id": 2662,
+                    "key": "_product_addons",
+                    "value": []
+                }, {
+                    "id": 2663,
+                    "key": "_product_addons_exclude_global",
+                    "value": "0"
+                }, {
+                    "id": 2679,
+                    "key": "_wpas_done_all",
+                    "value": "1"
+                }, {
+                    "id": 4048,
+                    "key": "_last_editor_used_jetpack",
+                    "value": "classic-editor"
+                }],
+                "stock_status": "outofstock",
+                "has_options": false,
+                "jetpack_likes_enabled": true,
+                "_links": {
+                    "self": [
+                        {
+                            "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products\/2132"
+                        }
+                    ],
+                    "collection": [
+                        {
+                            "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/products/products_add_new_grouped_2130.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/products/products_add_new_grouped_2130.json
@@ -1,0 +1,133 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "bodyPatterns": [
+            {
+                "matches": ".*path=/wc/v3/products%26_method%3Dpost"
+            },
+            {
+                "contains": "name%22%3A%22Black%20Coral%20shades"
+            }
+        ]
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 2130,
+                "name": "Black Coral shades",
+                "slug": "black-coral-shades",
+                "permalink": "https:\/\/automatticwidgets.wpcomstaging.com\/product\/black-coral-shades\/",
+                "date_created": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{now format=customformat}}",
+                "date_created_gmt": "{{now format=customformat}}",
+                "date_modified": "{{now format=customformat}}",
+                "date_modified_gmt": "{{now format=customformat}}",
+                "type": "grouped",
+                "status": "publish",
+                "featured": false,
+                "catalog_visibility": "visible",
+                "description": "grouped product",
+                "short_description": "",
+                "sku": "",
+                "price": "150",
+                "regular_price": "150",
+                "sale_price": "",
+                "date_on_sale_from": null,
+                "date_on_sale_from_gmt": null,
+                "date_on_sale_to": null,
+                "date_on_sale_to_gmt": null,
+                "on_sale": false,
+                "purchasable": false,
+                "virtual": false,
+                "total_sales": 0,
+                "downloadable": false,
+                "downloads": [],
+                "download_limit": -1,
+                "download_expiry": -1,
+                "external_url": "",
+                "button_text": "",
+                "tax_status": "taxable",
+                "tax_class": "",
+                "manage_stock": false,
+                "stock_quantity": null,
+                "backorders": "no",
+                "backorders_allowed": false,
+                "backordered": false,
+                "low_stock_amount": null,
+                "sold_individually": false,
+                "weight": "",
+                "dimensions": {
+                    "length": "",
+                    "width": "",
+                    "height": ""
+                },
+                "shipping_required": true,
+                "shipping_taxable": true,
+                "shipping_class": "",
+                "shipping_class_id": 0,
+                "reviews_allowed": true,
+                "average_rating": "0",
+                "rating_count": 0,
+                "upsell_ids": [],
+                "cross_sell_ids": [],
+                "parent_id": 0,
+                "purchase_note": "",
+                "categories": [],
+                "tags": [],
+                "images": [
+                    {
+                        "id": 2128,
+                        "date_created": "2020-01-28T09:52:59",
+                        "date_created_gmt": "2020-01-28T09:52:59",
+                        "date_modified": "2020-01-28T09:52:59",
+                        "date_modified_gmt": "2020-01-28T09:52:59",
+                        "src": "https://i1.wp.com/automatticwidgets.wpcomstaging.com/wp-content/uploads/2020/01/Mask-Group.png?fit=201%2C201&ssl=1",
+                        "name": "Mask Group",
+                        "alt": ""
+                    }
+                ],
+                "attributes": [],
+                "default_attributes": [],
+                "variations": [],
+                "grouped_products": [],
+                "menu_order": 0,
+                "price_html": "",
+                "related_ids": [],
+                "meta_data": [{
+                    "id": 2618,
+                    "key": "_product_addons",
+                    "value": []
+                }, {
+                    "id": 2619,
+                    "key": "_product_addons_exclude_global",
+                    "value": "0"
+                }, {
+                    "id": 2635,
+                    "key": "_wpas_done_all",
+                    "value": "1"
+                }, {
+                    "id": 4050,
+                    "key": "_last_editor_used_jetpack",
+                    "value": "classic-editor"
+                }],
+                "stock_status": "onbackorder",
+                "has_options": false,
+                "jetpack_likes_enabled": true,
+                "_links": {
+                    "self": [
+                        {
+                            "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products\/2130"
+                        }
+                    ],
+                    "collection": [
+                        {
+                            "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/products/products_add_new_physical_2129.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/products/products_add_new_physical_2129.json
@@ -1,0 +1,138 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "bodyPatterns": [
+            {
+                "matches": ".*path=/wc/v3/products%26_method%3Dpost"
+            },
+            {
+                "contains": "name%22%3A%22Akoya%20Pearl%20shades"
+            }
+        ]
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 2129,
+                "name": "Akoya Pearl shades",
+                "slug": "akoya-pearl-shades",
+                "permalink": "https:\/\/automatticwidgets.wpcomstaging.com\/product\/akoya-pearl-shades\/",
+                "date_created": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{now format=customformat}}",
+                "date_created_gmt": "{{now format=customformat}}",
+                "date_modified": "{{now format=customformat}}",
+                "date_modified_gmt": "{{now format=customformat}}",
+                "type": "simple",
+                "status": "publish",
+                "featured": false,
+                "catalog_visibility": "visible",
+                "description": "simple physical product",
+                "short_description": "",
+                "sku": "",
+                "price": "110",
+                "regular_price": "110",
+                "sale_price": "",
+                "date_on_sale_from": null,
+                "date_on_sale_from_gmt": null,
+                "date_on_sale_to": null,
+                "date_on_sale_to_gmt": null,
+                "on_sale": false,
+                "purchasable": true,
+                "total_sales": 0,
+                "virtual": false,
+                "downloadable": false,
+                "downloads": [],
+                "download_limit": -1,
+                "download_expiry": -1,
+                "external_url": "",
+                "button_text": "",
+                "tax_status": "taxable",
+                "tax_class": "",
+                "manage_stock": false,
+                "stock_quantity": null,
+                "backorders": "no",
+                "backorders_allowed": false,
+                "backordered": false,
+                "low_stock_amount": null,
+                "sold_individually": false,
+                "weight": "",
+                "dimensions": {
+                    "length": "",
+                    "width": "",
+                    "height": ""
+                },
+                "shipping_required": true,
+                "shipping_taxable": true,
+                "shipping_class": "",
+                "shipping_class_id": 0,
+                "reviews_allowed": true,
+                "average_rating": "0",
+                "rating_count": 0,
+                "upsell_ids": [],
+                "cross_sell_ids": [],
+                "parent_id": 0,
+                "purchase_note": "",
+                "categories": [],
+                "tags": [],
+                "images": [
+                    {
+                        "id": 2127,
+                        "date_created": "2020-01-28T09:52:58",
+                        "date_created_gmt": "2020-01-28T09:52:58",
+                        "date_modified": "2020-01-28T09:52:58",
+                        "date_modified_gmt": "2020-01-28T09:52:58",
+                        "src": "https://i0.wp.com/automatticwidgets.wpcomstaging.com/wp-content/uploads/2020/01/Mask-Group-2.png?fit=200%2C201&ssl=1",
+                        "name": "Mask Group-2",
+                        "alt": ""
+                    }
+                ],
+                "attributes": [],
+                "default_attributes": [],
+                "variations": [],
+                "grouped_products": [],
+                "menu_order": 0,
+                "price_html": "",
+                "related_ids": [],
+                "meta_data": [
+                    {
+                        "id": 2596,
+                        "key": "_product_addons",
+                        "value": []
+                    },
+                    {
+                        "id": 2597,
+                        "key": "_product_addons_exclude_global",
+                        "value": "0"
+                    },
+                    {
+                        "id": 2613,
+                        "key": "_wpas_done_all",
+                        "value": "1"
+                    },
+                    {
+                        "id": 4051,
+                        "key": "_last_editor_used_jetpack",
+                        "value": "classic-editor"
+                    }
+                ],
+                "stock_status": "instock",
+                "has_options": false,
+                "jetpack_likes_enabled": true,
+                "_links": {
+                    "self": [
+                        {
+                            "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products\/2129"
+                        }
+                    ],
+                    "collection": [
+                        {
+                            "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/products/products_add_new_variable_2131.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/products/products_add_new_variable_2131.json
@@ -1,0 +1,133 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "bodyPatterns": [
+            {
+                "matches": ".*path=/wc/v3/products%26_method%3Dpost"
+            },
+            {
+                "contains": "name%22%3A%22Colorado%20shades"
+            }
+        ]
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 2131,
+                "name": "Colorado shades",
+                "slug": "colorado-shades",
+                "permalink": "https:\/\/automatticwidgets.wpcomstaging.com\/product\/colorado-shades\/",
+                "date_created": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{now format=customformat}}",
+                "date_created_gmt": "{{now format=customformat}}",
+                "date_modified": "{{now format=customformat}}",
+                "date_modified_gmt": "{{now format=customformat}}",
+                "type": "variable",
+                "status": "publish",
+                "featured": false,
+                "catalog_visibility": "visible",
+                "description": "variable product",
+                "short_description": "",
+                "sku": "",
+                "price": "140",
+                "regular_price": "140",
+                "sale_price": "",
+                "date_on_sale_from": null,
+                "date_on_sale_from_gmt": null,
+                "date_on_sale_to": null,
+                "date_on_sale_to_gmt": null,
+                "on_sale": false,
+                "purchasable": false,
+                "virtual": false,
+                "total_sales": 0,
+                "downloadable": false,
+                "downloads": [],
+                "download_limit": -1,
+                "download_expiry": -1,
+                "external_url": "",
+                "button_text": "",
+                "tax_status": "taxable",
+                "tax_class": "",
+                "manage_stock": false,
+                "stock_quantity": null,
+                "backorders": "no",
+                "backorders_allowed": false,
+                "backordered": false,
+                "low_stock_amount": null,
+                "sold_individually": false,
+                "weight": "",
+                "dimensions": {
+                    "length": "",
+                    "width": "",
+                    "height": ""
+                },
+                "shipping_required": true,
+                "shipping_taxable": true,
+                "shipping_class": "",
+                "shipping_class_id": 0,
+                "reviews_allowed": true,
+                "average_rating": "0",
+                "rating_count": 0,
+                "upsell_ids": [],
+                "cross_sell_ids": [],
+                "parent_id": 0,
+                "purchase_note": "",
+                "categories": [],
+                "tags": [],
+                "images": [
+                    {
+                        "id": 2128,
+                        "date_created": "2020-01-28T09:52:59",
+                        "date_created_gmt": "2020-01-28T09:52:59",
+                        "date_modified": "2020-01-28T09:52:59",
+                        "date_modified_gmt": "2020-01-28T09:52:59",
+                        "src": "https://i1.wp.com/automatticwidgets.wpcomstaging.com/wp-content/uploads/2020/01/Mask-Group.png?fit=201%2C201&ssl=1",
+                        "name": "Mask Group",
+                        "alt": ""
+                    }
+                ],
+                "attributes": [],
+                "default_attributes": [],
+                "variations": [],
+                "grouped_products": [],
+                "menu_order": 0,
+                "price_html": "",
+                "related_ids": [],
+                "meta_data": [{
+                    "id": 2640,
+                    "key": "_product_addons",
+                    "value": []
+                }, {
+                    "id": 2641,
+                    "key": "_product_addons_exclude_global",
+                    "value": "0"
+                }, {
+                    "id": 2657,
+                    "key": "_wpas_done_all",
+                    "value": "1"
+                }, {
+                    "id": 4049,
+                    "key": "_last_editor_used_jetpack",
+                    "value": "classic-editor"
+                }],
+                "stock_status": "instock",
+                "has_options": false,
+                "jetpack_likes_enabled": true,
+                "_links": {
+                    "self": [
+                        {
+                            "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products\/2131"
+                        }
+                    ],
+                    "collection": [
+                        {
+                            "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/products/products_add_new_virtual_2123.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/products/products_add_new_virtual_2123.json
@@ -1,0 +1,138 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "bodyPatterns": [
+            {
+                "matches": ".*path=/wc/v3/products%26_method%3Dpost"
+            },
+            {
+                "contains": "name%22%3A%22Malaya%20shades"
+            }
+        ]
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 2123,
+                "name": "Malaya shades",
+                "slug": "malaya-shades",
+                "permalink": "https:\/\/automatticwidgets.wpcomstaging.com\/product\/malaya-shades\/",
+                "date_created": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{now format=customformat}}",
+                "date_created_gmt": "{{now format=customformat}}",
+                "date_modified": "{{now format=customformat}}",
+                "date_modified_gmt": "{{now format=customformat}}",
+                "type": "simple",
+                "status": "publish",
+                "featured": false,
+                "catalog_visibility": "visible",
+                "description": "simple virtual product",
+                "short_description": "",
+                "sku": "",
+                "price": "140",
+                "regular_price": "140",
+                "sale_price": "",
+                "date_on_sale_from": null,
+                "date_on_sale_from_gmt": null,
+                "date_on_sale_to": null,
+                "date_on_sale_to_gmt": null,
+                "on_sale": false,
+                "purchasable": true,
+                "virtual": true,
+                "total_sales": 0,
+                "downloadable": false,
+                "downloads": [],
+                "download_limit": -1,
+                "download_expiry": -1,
+                "external_url": "",
+                "button_text": "",
+                "tax_status": "taxable",
+                "tax_class": "",
+                "manage_stock": false,
+                "stock_quantity": null,
+                "backorders": "no",
+                "backorders_allowed": false,
+                "backordered": false,
+                "low_stock_amount": null,
+                "sold_individually": false,
+                "weight": "",
+                "dimensions": {
+                    "length": "",
+                    "width": "",
+                    "height": ""
+                },
+                "shipping_required": true,
+                "shipping_taxable": true,
+                "shipping_class": "",
+                "shipping_class_id": 0,
+                "reviews_allowed": true,
+                "average_rating": "0",
+                "rating_count": 0,
+                "upsell_ids": [],
+                "cross_sell_ids": [],
+                "parent_id": 0,
+                "purchase_note": "",
+                "categories": [],
+                "tags": [],
+                "images": [
+                    {
+                        "id": 2128,
+                        "date_created": "2020-01-28T09:52:59",
+                        "date_created_gmt": "2020-01-28T09:52:59",
+                        "date_modified": "2020-01-28T09:52:59",
+                        "date_modified_gmt": "2020-01-28T09:52:59",
+                        "src": "https://i1.wp.com/automatticwidgets.wpcomstaging.com/wp-content/uploads/2020/01/Mask-Group.png?fit=201%2C201&ssl=1",
+                        "name": "Mask Group",
+                        "alt": ""
+                    }
+                ],
+                "attributes": [],
+                "default_attributes": [],
+                "variations": [],
+                "grouped_products": [],
+                "menu_order": 0,
+                "price_html": "",
+                "related_ids": [],
+                "meta_data": [
+                    {
+                        "id": 2574,
+                        "key": "_product_addons",
+                        "value": []
+                    },
+                    {
+                        "id": 2575,
+                        "key": "_product_addons_exclude_global",
+                        "value": "0"
+                    },
+                    {
+                        "id": 2591,
+                        "key": "_wpas_done_all",
+                        "value": "1"
+                    },
+                    {
+                        "id": 4047,
+                        "key": "_last_editor_used_jetpack",
+                        "value": "classic-editor"
+                    }
+                ],
+                "stock_status": "instock",
+                "has_options": false,
+                "jetpack_likes_enabled": true,
+                "_links": {
+                    "self": [
+                        {
+                            "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products\/2123"
+                        }
+                    ],
+                    "collection": [
+                        {
+                            "href": "https:\/\/automatticwidgets.wpcomstaging.com\/wp-json\/wc\/v3\/products"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
This PR updates the existing add product types UI tests. I realized after we were using only 1 mock file with `"type": "simple",` and validating only the product name on the published product screen. While this is correct for physical and virtual products, this still passed on variable test because it was only checking the product name even though the incorrect product screen was displayed on the UI. 

To fix this, I created a different mock file for each product type (`physical`, `virtual`, `variable`, `grouped` and `external`) that will be called for the different product types. I also renamed `verifyNewProductScreenLoaded` to `verifyPublishedProductScreenLoaded` and added a unique validation per screen, intentionally keeping it at one assertion type per type so that it doesn't take long but enough info that the correct page is displayed.

Note: A lot of file changes because of the mock files. Code changes (and updates to `WooCommerce/WooCommerce.xcodeproj/project.pbxproj`) are in https://github.com/woocommerce/woocommerce-ios/pull/9441/commits/3bf4e1a27c78c06b9ae19a9dd34e853c68714288, mock file additions are in https://github.com/woocommerce/woocommerce-ios/pull/9441/commits/efd3ac9b9922ec14d80f68245e810c88f33bbbe0 

## Testing instructions
Products-related tests should work as expected.
