### PR TITLE
[Product Multi-Selection] Sync order original state when closed without saving changes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -213,11 +213,11 @@ final class EditableOrderViewModel: ObservableObject {
 
     /// Keeps track of selected/unselected Products, if any
     ///
-    @Published private var selectedProducts: [Product] = []
+    @Published private(set) var selectedProducts: [Product] = []
 
     /// Keeps track of selected/unselected Product Variations, if any
     ///
-    @Published private var selectedProductVariations: [ProductVariation] = []
+    @Published private(set) var selectedProductVariations: [ProductVariation] = []
 
     /// Keeps track of all selected Products and Product Variations IDs
     ///
@@ -252,6 +252,12 @@ final class EditableOrderViewModel: ObservableObject {
     /// Representation of payment data display properties
     ///
     @Published private(set) var paymentDataViewModel = PaymentDataViewModel()
+
+    /// Syncs initial selected state for all items in an Order
+    ///
+    func syncSelectionState() {
+        syncInitialSelectedState()
+    }
 
     /// Saves a shipping line.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -285,6 +285,7 @@ private struct ProductsSection: View {
                         viewModel: viewModel.productSelectorViewModel)
                     .onDisappear {
                         viewModel.productSelectorViewModel.clearSearchAndFilters()
+                        viewModel.syncSelectionState()
                         navigationButtonID = UUID()
                     }
                 })

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1538,10 +1538,10 @@ final class EditableOrderViewModelTests: XCTestCase {
         viewModel.productSelectorViewModel.selectProduct(anotherProduct.productID)
         viewModel.productSelectorViewModel.completeMultipleSelection()
 
-        // Confidence check: New selectedProducts selectedProducts state (2 items)
+        // Confidence check: Confirms updated selectedProducts state (2 items)
         XCTAssertEqual(viewModel.selectedProducts.count, 2)
 
-        // Confidence check: Clear selection without saving updates, updates selectedProducts state (0 items)
+        // Confidence check: Confirms updated selectedProducts state after clearing selections (0 items)
         viewModel.productSelectorViewModel.clearSelection()
         XCTAssertEqual(viewModel.selectedProducts.count, 0)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9388 

## Description
This PR addresses a bug with product selection state where products would appear unselected if we attempt to edit an existing order, tap the clear selection button, and exit the order without saving changes. By staying in the Order editing view without navigating elsewhere, and attempting to add products again, would show all products as unselected.

We fix this by calling the order synchronizer when the product selector is closed, so we're sure to keep the state up-to-date.

## Changes
* Calls the existing `syncInitialSelectedState()` method on product selector `onDisappear()`
* Marks `selectedProducts` and `selectedProductVariations` as `private(set)`

While making these `private(set)` is not necessary for production logic, having them publicly gettable improves greatly the confidence of keeping the correct state through the whole multi-selection flow via unit tests (for example avoiding the exact scenario we're fixing with this PR), so I'd vote to keep this access control and I can add further tests for testing both selection and clear selection logic as part of a different PR.

## Testing instructions
- Go to Orders > Select any existing order with products on it > Tap on `Edit`
- Tap `+ Add Products` > See products are already selected
- Tap on `Clear Selection` > See products are unselected > Tap the `Close` button to exit the selector without saving changes (not the `Done` button)
- Tap `+ Add Products` again > See products are still selected


![Simulator Screen Recording - iPhone 11 - 2023-04-12 at 15 17 31](https://user-images.githubusercontent.com/3812076/231396413-65234134-b76f-41d7-98ca-fa7bcd423e40.gif)

