### PR TITLE
[Product Multi-selection] Sync items selected state when view is closed without saving changes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -195,6 +195,7 @@ final class EditableOrderViewModel: ObservableObject {
             }, onAllSelectionsCleared: { [weak self] in
                 guard let self = self else { return }
                 self.clearAllSelectedItems()
+                self.trackClearAllSelectedItemsTapped()
             }, onSelectedVariationsCleared: { [weak self] in
                 guard let self = self else { return }
                 self.clearSelectedVariations()
@@ -369,9 +370,12 @@ final class EditableOrderViewModel: ObservableObject {
     /// Clears selected products and variations
     ///
     private func clearAllSelectedItems() {
-        analytics.track(event: WooAnalyticsEvent.Orders.orderCreationProductSelectorClearSelectionButtonTapped(productType: .product))
         selectedProducts.removeAll()
         selectedProductVariations.removeAll()
+    }
+
+    private func trackClearAllSelectedItemsTapped() {
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCreationProductSelectorClearSelectionButtonTapped(productType: .product))
     }
 
     /// Clears selected variations

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1205,9 +1205,6 @@ private extension EditableOrderViewModel {
     /// Syncs initial selected state for all items in the Order
     ///
     func syncInitialSelectedState() {
-        selectedProducts = []
-        selectedProductVariations = []
-
         let _ = orderSynchronizer.order.items.map { item in
             if item.variationID != 0 {
                 if let variation = allProductVariations.first(where: { $0.productVariationID == item.variationID }) {
@@ -1224,11 +1221,11 @@ private extension EditableOrderViewModel {
     /// Syncs initial selected state for all items in the Order when clearing selections
     ///
     func syncClearSelectionState() {
-        if flow == .creation {
+        selectedProducts = []
+        selectedProductVariations = []
+
+        if flow == .creation && orderSynchronizer.order.items.count == .zero {
             syncInitialSelectedState()
-        } else {
-            selectedProducts = []
-            selectedProductVariations = []
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1214,6 +1214,9 @@ private extension EditableOrderViewModel {
     /// Syncs initial selected state for all items in the Order
     ///
     func syncInitialSelectedState() {
+        selectedProducts = []
+        selectedProductVariations = []
+
         let _ = orderSynchronizer.order.items.map { item in
             if item.variationID != 0 {
                 if let variation = allProductVariations.first(where: { $0.productVariationID == item.variationID }) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -195,7 +195,6 @@ final class EditableOrderViewModel: ObservableObject {
             }, onAllSelectionsCleared: { [weak self] in
                 guard let self = self else { return }
                 self.clearAllSelectedItems()
-                self.syncClearSelectionState()
             }, onSelectedVariationsCleared: { [weak self] in
                 guard let self = self else { return }
                 self.clearSelectedVariations()
@@ -1225,14 +1224,6 @@ private extension EditableOrderViewModel {
                     selectedProducts.append(product)
                 }
             }
-        }
-    }
-
-    /// Syncs initial selected state for all items in the Order when clearing selections
-    ///
-    func syncClearSelectionState() {
-        if flow == .creation && orderSynchronizer.order.items.count == .zero {
-            syncInitialSelectedState()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1221,9 +1221,6 @@ private extension EditableOrderViewModel {
     /// Syncs initial selected state for all items in the Order when clearing selections
     ///
     func syncClearSelectionState() {
-        selectedProducts = []
-        selectedProductVariations = []
-
         if flow == .creation && orderSynchronizer.order.items.count == .zero {
             syncInitialSelectedState()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -199,6 +199,9 @@ final class EditableOrderViewModel: ObservableObject {
             }, onSelectedVariationsCleared: { [weak self] in
                 guard let self = self else { return }
                 self.clearSelectedVariations()
+            }, onCloseButtonTapped: { [weak self] in
+                guard let self = self else { return }
+                self.syncOrderItemSelectionStateOnDismiss()
             })
     }
 
@@ -377,6 +380,13 @@ final class EditableOrderViewModel: ObservableObject {
     private func clearSelectedVariations() {
         analytics.track(event: WooAnalyticsEvent.Orders.orderCreationProductSelectorClearSelectionButtonTapped(productType: .variation))
         selectedProductVariations.removeAll()
+    }
+
+    /// Synchronizes the item selection state by clearing all items, then retrieving the latest saved state
+    ///
+    func syncOrderItemSelectionStateOnDismiss() {
+        clearAllSelectedItems()
+        syncInitialSelectedState()
     }
 
     /// Selects an order item by setting the `selectedProductViewModel`.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -127,7 +127,7 @@ struct ProductSelectorView: View {
                     Button(cancelButtonTitle) {
                         isPresented.toggle()
                         if !isPresented {
-                            viewModel.cancelButtonTapped()
+                            viewModel.closeButtonTapped()
                         }
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -127,7 +127,7 @@ struct ProductSelectorView: View {
                     Button(cancelButtonTitle) {
                         isPresented.toggle()
                         if !isPresented {
-                            viewModel.clearSelection()
+                            viewModel.cancelButtonTapped()
                         }
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -146,6 +146,8 @@ final class ProductSelectorViewModel: ObservableObject {
     ///
     private let onSelectedVariationsCleared: (() -> Void)?
 
+    private let onCloseButtonTapped: (() -> Void)?
+
     /// Initializer for single selection
     ///
     init(siteID: Int64,
@@ -160,7 +162,8 @@ final class ProductSelectorViewModel: ObservableObject {
          onVariationSelected: ((ProductVariation, Product) -> Void)? = nil,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil,
          onAllSelectionsCleared: (() -> Void)? = nil,
-         onSelectedVariationsCleared: (() -> Void)? = nil) {
+         onSelectedVariationsCleared: (() -> Void)? = nil,
+         onCloseButtonTapped: (() -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
@@ -174,6 +177,7 @@ final class ProductSelectorViewModel: ObservableObject {
         self.purchasableItemsOnly = purchasableItemsOnly
         self.onAllSelectionsCleared = onAllSelectionsCleared
         self.onSelectedVariationsCleared = onSelectedVariationsCleared
+        self.onCloseButtonTapped = onCloseButtonTapped
 
         configureSyncingCoordinator()
         configureProductsResultsController()
@@ -193,7 +197,8 @@ final class ProductSelectorViewModel: ObservableObject {
          toggleAllVariationsOnSelection: Bool = true,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil,
          onAllSelectionsCleared: (() -> Void)? = nil,
-         onSelectedVariationsCleared: (() -> Void)? = nil) {
+         onSelectedVariationsCleared: (() -> Void)? = nil,
+         onCloseButtonTapped: (() -> Void)? = nil) {
         self.siteID = siteID
         self.storageManager = storageManager
         self.stores = stores
@@ -207,6 +212,7 @@ final class ProductSelectorViewModel: ObservableObject {
         self.purchasableItemsOnly = purchasableItemsOnly
         self.onAllSelectionsCleared = onAllSelectionsCleared
         self.onSelectedVariationsCleared = onSelectedVariationsCleared
+        self.onCloseButtonTapped = onCloseButtonTapped
 
         configureSyncingCoordinator()
         configureProductsResultsController()
@@ -301,6 +307,12 @@ final class ProductSelectorViewModel: ObservableObject {
         let allIDs = selectedProductIDs + selectedProductVariationIDs
         analytics.track(event: WooAnalyticsEvent.Orders.orderCreationProductSelectorConfirmButtonTapped(productCount: allIDs.count))
         onMultipleSelectionCompleted?(allIDs)
+    }
+
+    /// Triggers completion closure when the close button is tapped
+    ///
+    func closeButtonTapped() {
+        onCloseButtonTapped?()
     }
 
     /// Unselect all items.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: https://github.com/woocommerce/woocommerce-ios/issues/9388

## Description
This PR addresses a bug with item selected state when a merchant attempts to edit an existing order by tapping on `Clear selection`, and then tapping `Close`, exiting the order without saving changes. 

This would cause the items to appear as unselected the next time they try to edit the order again, despite having items in their order, and is only fixed if they navigate outside the Order form.

We fix this by clearing any unsaved selection when a merchant taps on the `Done` button, and then synchronizing which items are selected based on the existing order. So we keep the selected item state up-to-date to the latest order state.

## Changes
- Adds a `onCloseButtonTapped` closure to the `ProductSelectorViewModel`, this will be invoked when the merchant taps on the "Close" button.
- This will call the method `syncOrderItemSelectionStateOnDismiss()` which clears any selection that hasn't been saved, and then retrieves the latest selected state from the order synchronizer.
- We also decouple clearing selected items from its event tracking, so we can re-use the clearing logic as needed without invoking the specific tracking event of a merchant tapping the button.

## Testing instructions
- Go to Orders > Tap `+ Add Products` > Select some > Tap on `Done` to save the Order
- Tap `+ Add Products` again > See products are already selected
- Tap on `Clear Selection` > See products are unselected > Tap the `Close` button to exit the selector without saving changes (not the `Done` button)
- Tap `+ Add Products again` > See products are still selected

## Screenshots
![Simulator Screen Recording - iPhone 11 - 2023-04-12 at 15 17 31](https://user-images.githubusercontent.com/3812076/231396413-65234134-b76f-41d7-98ca-fa7bcd423e40.gif)
