### PR TITLE
[Mobile Payments]Refactoring for Product Multi-selection

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -173,7 +173,7 @@ final class EditableOrderViewModel: ObservableObject {
 
     /// View model for the product list
     ///
-    var productSelectorViewModel: ProductSelectorViewModel {
+    lazy var productSelectorViewModel: ProductSelectorViewModel = {
         ProductSelectorViewModel(
             siteID: siteID,
             selectedItemIDs: selectedProductsAndVariationsIDs,
@@ -182,13 +182,13 @@ final class EditableOrderViewModel: ObservableObject {
             stores: stores,
             supportsMultipleSelection: isProductMultiSelectionEnabled,
             toggleAllVariationsOnSelection: false,
-            onProductSelected: { [weak self] product in
+            onProductSelectionStateChanged: { [weak self] product in
                 guard let self = self else { return }
-                self.addProductToOrder(product)
+                self.addOrRemoveProductToOrder(product)
             },
-            onVariationSelected: { [weak self] variation, parentProduct in
+            onVariationSelectionStateChanged: { [weak self] variation, parentProduct in
                 guard let self = self else { return }
-                self.addProductVariationToOrder(variation, parent: parentProduct)
+                self.addOrRemoveProductVariationToOrder(variation, parent: parentProduct)
             }, onMultipleSelectionCompleted: { [weak self] _ in
                 guard let self = self else { return }
                 self.syncOrderItems(products: self.selectedProducts, variations: self.selectedProductVariations)
@@ -200,7 +200,7 @@ final class EditableOrderViewModel: ObservableObject {
                 guard let self = self else { return }
                 self.clearSelectedVariations()
             })
-    }
+    }()
 
     /// View models for each product row in the order.
     ///
@@ -394,14 +394,12 @@ final class EditableOrderViewModel: ObservableObject {
         orderSynchronizer.setProduct.send(input)
 
         if isProductMultiSelectionEnabled {
-            // Updates selected products and selected variations for all items that have been removed directly from the Order
-            // when using multi-selection, for example by tapping the `-` button within the Order view
-            if item.productID != 0 {
-                selectedProducts.removeAll(where: { $0.productID == item.productID })
-            }
             if item.variationID != 0 {
-                selectedProductVariations.removeAll(where: { $0.productVariationID == item.variationID })
+                productSelectorViewModel.changeSelectionStateForVariation(with: item.variationID, productID: item.productID)
+            } else if item.productID != 0 {
+                productSelectorViewModel.changeSelectionStateForProduct(with: item.productID)
             }
+
         }
 
         analytics.track(event: WooAnalyticsEvent.Orders.orderProductRemove(flow: flow.analyticsFlow))
@@ -866,7 +864,7 @@ private extension EditableOrderViewModel {
     // TODO:
     // This method needs to be refactored, to reflect that adds products to Order for single selection,
     // but only selects/unselects for multi-selection: https://github.com/woocommerce/woocommerce-ios/issues/9176
-    func addProductToOrder(_ product: Product) {
+    func addOrRemoveProductToOrder(_ product: Product) {
         // Needed because `allProducts` is only updated at start, so product from new pages are not synced.
         if !allProducts.contains(product) {
             allProducts.append(product)
@@ -894,7 +892,7 @@ private extension EditableOrderViewModel {
     // TODO:
     // This method needs to be refactored, to reflect that adds variations to Order for single selection,
     // but only selects/unselects for multi-selection: https://github.com/woocommerce/woocommerce-ios/issues/9176
-    func addProductVariationToOrder(_ variation: ProductVariation, parent product: Product) {
+    func addOrRemoveProductVariationToOrder(_ variation: ProductVariation, parent product: Product) {
         // Needed because `allProducts` is only updated at start, so product from new pages are not synced.
         if !allProducts.contains(product) {
             allProducts.append(product)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -178,7 +178,7 @@ struct ProductSelectorView: View {
                        viewModel: rowViewModel)
                 .accessibilityHint(configuration.productRowAccessibilityHint)
                 .onTapGesture {
-                    viewModel.selectProduct(rowViewModel.productOrVariationID)
+                    viewModel.changeSelectionStateForProduct(with: rowViewModel.productOrVariationID)
                     if !configuration.multipleSelectionsEnabled {
                         isPresented.toggle()
                     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -64,13 +64,13 @@ final class ProductSelectorViewModel: ObservableObject {
     ///
     let toggleAllVariationsOnSelection: Bool
 
-    /// Closure to be invoked when a product is selected
+    /// Closure to be invoked when a product is selected or deselected
     ///
-    private let onProductSelected: ((Product) -> Void)?
+    private let onProductSelectionStateChanged: ((Product) -> Void)?
 
-    /// Closure to be invoked when a product variation is selected
+    /// Closure to be invoked when a product variation is selected or deselected
     ///
-    private let onVariationSelected: ((ProductVariation, Product) -> Void)?
+    private let onVariationSelectionStateChanged: ((ProductVariation, Product) -> Void)?
 
     /// Closure to be invoked when multiple selection is completed
     ///
@@ -156,8 +156,8 @@ final class ProductSelectorViewModel: ObservableObject {
          analytics: Analytics = ServiceLocator.analytics,
          supportsMultipleSelection: Bool = false,
          toggleAllVariationsOnSelection: Bool = true,
-         onProductSelected: ((Product) -> Void)? = nil,
-         onVariationSelected: ((ProductVariation, Product) -> Void)? = nil,
+         onProductSelectionStateChanged: ((Product) -> Void)? = nil,
+         onVariationSelectionStateChanged: ((ProductVariation, Product) -> Void)? = nil,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil,
          onAllSelectionsCleared: (() -> Void)? = nil,
          onSelectedVariationsCleared: (() -> Void)? = nil) {
@@ -167,8 +167,8 @@ final class ProductSelectorViewModel: ObservableObject {
         self.analytics = analytics
         self.supportsMultipleSelection = supportsMultipleSelection
         self.toggleAllVariationsOnSelection = toggleAllVariationsOnSelection
-        self.onProductSelected = onProductSelected
-        self.onVariationSelected = onVariationSelected
+        self.onProductSelectionStateChanged = onProductSelectionStateChanged
+        self.onVariationSelectionStateChanged = onVariationSelectionStateChanged
         self.onMultipleSelectionCompleted = onMultipleSelectionCompleted
         self.initialSelectedItems = selectedItemIDs
         self.purchasableItemsOnly = purchasableItemsOnly
@@ -200,8 +200,8 @@ final class ProductSelectorViewModel: ObservableObject {
         self.analytics = analytics
         self.supportsMultipleSelection = supportsMultipleSelection
         self.toggleAllVariationsOnSelection = toggleAllVariationsOnSelection
-        self.onProductSelected = nil
-        self.onVariationSelected = nil
+        self.onProductSelectionStateChanged = nil
+        self.onVariationSelectionStateChanged = nil
         self.onMultipleSelectionCompleted = onMultipleSelectionCompleted
         self.initialSelectedItems = selectedItemIDs
         self.purchasableItemsOnly = purchasableItemsOnly
@@ -214,24 +214,34 @@ final class ProductSelectorViewModel: ObservableObject {
         synchronizeProductFilterSearch()
     }
 
-    /// Select a product to add to the order
+    /// Selects or unselects a product to add to the order
     ///
-    func selectProduct(_ productID: Int64) {
+    func changeSelectionStateForProduct(with productID: Int64) {
         guard let selectedProduct = products.first(where: { $0.productID == productID }) else {
             return
         }
-        guard let onProductSelected else {
+        guard let onProductSelectionStateChanged else {
             toggleSelection(productID: productID)
             return
         }
         guard supportsMultipleSelection else {
             // The selector supports single selection only
-            onProductSelected(selectedProduct)
+            onProductSelectionStateChanged(selectedProduct)
             return
         }
         // The selector supports multiple selection. Toggles the item, and triggers the selection
         toggleSelection(productID: productID)
-        onProductSelected(selectedProduct)
+        onProductSelectionStateChanged(selectedProduct)
+    }
+
+    func changeSelectionStateForVariation(with id: Int64, productID: Int64) {
+        getVariationsViewModel(for: productID)?.changeSelectionStateForVariation(with: id)
+
+        if selectedProductVariationIDs.contains(id) {
+            selectedProductVariationIDs = selectedProductVariationIDs.filter { $0 != id }
+        } else {
+            selectedProductVariationIDs.append(id)
+        }
     }
 
     /// Get the view model for a list of product variations to add to the order
@@ -246,7 +256,7 @@ final class ProductSelectorViewModel: ObservableObject {
                                                  selectedProductVariationIDs: selectedItems,
                                                  purchasableItemsOnly: purchasableItemsOnly,
                                                  supportsMultipleSelection: supportsMultipleSelection,
-                                                 onVariationSelected: onVariationSelected,
+                                                 onVariationSelectionStateChanged: onVariationSelectionStateChanged,
                                                  onSelectionsCleared: onSelectedVariationsCleared)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
@@ -54,7 +54,7 @@ struct ProductVariationSelector: View {
                                 .accessibilityHint(Localization.productRowAccessibilityHint)
                                 .padding(Constants.defaultPadding)
                                 .onTapGesture {
-                                    viewModel.selectVariation(rowViewModel.productOrVariationID)
+                                    viewModel.changeSelectionStateForVariation(with: rowViewModel.productOrVariationID)
                                     if !multipleSelectionsEnabled {
                                         isPresented.toggle()
                                     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -55,7 +55,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
 
     /// Closure to be invoked when a product variation is selected
     ///
-    let onVariationSelected: ((ProductVariation, Product) -> Void)?
+    let onVariationSelectionStateChanged: ((ProductVariation, Product) -> Void)?
 
     /// Closure to be invoked when "Clear Selection" is called.
     ///
@@ -121,7 +121,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          supportsMultipleSelection: Bool = false,
-         onVariationSelected: ((ProductVariation, Product) -> Void)? = nil,
+         onVariationSelectionStateChanged: ((ProductVariation, Product) -> Void)? = nil,
          onSelectionsCleared: (() -> Void)? = nil) {
         self.siteID = siteID
         self.productID = productID
@@ -130,7 +130,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         self.storageManager = storageManager
         self.stores = stores
         self.supportsMultipleSelection = supportsMultipleSelection
-        self.onVariationSelected = onVariationSelected
+        self.onVariationSelectionStateChanged = onVariationSelectionStateChanged
         self.selectedProductVariationIDs = selectedProductVariationIDs
         self.purchasableItemsOnly = purchasableItemsOnly
         self.onSelectionsCleared = onSelectionsCleared
@@ -147,7 +147,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      stores: StoresManager = ServiceLocator.stores,
                      supportsMultipleSelection: Bool = false,
-                     onVariationSelected: ((ProductVariation, Product) -> Void)? = nil,
+                     onVariationSelectionStateChanged: ((ProductVariation, Product) -> Void)? = nil,
                      onSelectionsCleared: (() -> Void)? = nil) {
         self.init(siteID: siteID,
                   productID: product.productID,
@@ -158,13 +158,13 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                   storageManager: storageManager,
                   stores: stores,
                   supportsMultipleSelection: supportsMultipleSelection,
-                  onVariationSelected: onVariationSelected,
+                  onVariationSelectionStateChanged: onVariationSelectionStateChanged,
                   onSelectionsCleared: onSelectionsCleared)
     }
 
     /// Select a product variation to add to the order
     ///
-    func selectVariation(_ variationID: Int64) {
+    func changeSelectionStateForVariation(with variationID: Int64) {
 
         // Fetch parent product
         // Needed because the parent product contains the product name & attributes.
@@ -174,18 +174,18 @@ final class ProductVariationSelectorViewModel: ObservableObject {
               let selectedVariation = productVariations.first(where: { $0.productVariationID == variationID }) else {
             return
         }
-        guard let onVariationSelected else {
+        guard let onVariationSelectionStateChanged else {
             toggleSelection(productVariationID: variationID)
             return
         }
         guard supportsMultipleSelection else {
             // The selector supports single selection only
-            onVariationSelected(selectedVariation, parentProduct)
+            onVariationSelectionStateChanged(selectedVariation, parentProduct)
             return
         }
         // The selector supports multiple selection. Toggles the item, and triggers the selection
         toggleSelection(productVariationID: variationID)
-        onVariationSelected(selectedVariation, parentProduct)
+        onVariationSelectionStateChanged(selectedVariation, parentProduct)
     }
 
     /// Unselect all items.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -264,7 +264,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         // When
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
 
         // Then
         XCTAssertTrue(viewModel.productRows.contains(where: { $0.productOrVariationID == sampleProductID }), "Product rows do not contain expected product")
@@ -278,11 +278,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         // When
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         viewModel.productRows[0].incrementQuantity()
 
         // And when another product is added to the order (to confirm the first product's quantity change is retained)
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
 
         // Then
         XCTAssertEqual(viewModel.productRows[safe: 0]?.quantity, 2)
@@ -302,8 +302,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager, featureFlagService: featureFlagService)
 
         // When
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
-        viewModel.productSelectorViewModel.selectProduct(anotherProduct.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: anotherProduct.productID)
         viewModel.productSelectorViewModel.completeMultipleSelection()
         // And when another product is added to the order (to confirm the first product's quantity change is retained)
         viewModel.productRows[0].incrementQuantity()
@@ -319,7 +319,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         // Product quantity is 1
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         XCTAssertEqual(viewModel.productRows[0].quantity, 1)
 
         // When
@@ -333,7 +333,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: sampleProductID, purchasable: true)
         storageManager.insertSampleProduct(readOnlyProduct: product)
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
 
         // When
         let expectedRow = viewModel.productRows[0]
@@ -351,8 +351,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         storageManager.insertProducts([product0, product1])
 
         // Given products are added to order
-        viewModel.productSelectorViewModel.selectProduct(product0.productID)
-        viewModel.productSelectorViewModel.selectProduct(product1.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product0.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product1.productID)
 
         // When
         let expectedRemainingRow = viewModel.productRows[1]
@@ -532,7 +532,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                featureFlagService: featureFlagService)
 
         // When & Then
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         XCTAssertEqual(viewModel.paymentDataViewModel.itemsTotal, "£8.50")
         XCTAssertEqual(viewModel.paymentDataViewModel.orderTotal, "£8.50")
 
@@ -554,7 +554,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                featureFlagService: featureFlagService)
 
         // When
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         let testShippingLine = ShippingLine(shippingID: 0,
                                             methodTitle: "Flat Rate",
                                             methodID: "other",
@@ -592,7 +592,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                featureFlagService: featureFlagService)
 
         // When
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         let testFeeLine = OrderFeeLine(feeID: 0,
                                        name: "Fee",
                                        taxClass: "",
@@ -632,7 +632,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                featureFlagService: featureFlagService)
 
         // When
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         let testCouponLine = OrderCouponLine(couponID: 0, code: "COUPONCODE", discount: "1.5", discountTax: "")
         viewModel.saveCouponLine(testCouponLine)
 
@@ -661,7 +661,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                featureFlagService: featureFlagService)
 
         // When
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         let testShippingLine = ShippingLine(shippingID: 0,
                                             methodTitle: "Flat Rate",
                                             methodID: "other",
@@ -699,7 +699,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                featureFlagService: featureFlagService)
 
         // When
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         let testFeeLine = OrderFeeLine(feeID: 0,
                                        name: "Fee",
                                        taxClass: "",
@@ -739,7 +739,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                featureFlagService: featureFlagService)
 
         // When
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
 
         let testShippingLine = ShippingLine(shippingID: 0,
                                             methodTitle: "Flat Rate",
@@ -866,7 +866,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         // When
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
 
         // Then
         XCTAssertTrue(viewModel.hasChanges)
@@ -945,7 +945,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                featureFlagService: featureFlagService)
 
         // When
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
 
         // Then
         XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderProductAdd.rawValue])
@@ -966,7 +966,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                featureFlagService: featureFlagService)
 
         // When
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         viewModel.productSelectorViewModel.completeMultipleSelection()
 
         // Then
@@ -996,7 +996,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                featureFlagService: featureFlagService)
 
         // When
-        viewModel.productSelectorViewModel.selectProduct(product.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product.productID)
         viewModel.productRows[0].incrementQuantity()
 
         // Then
@@ -1017,7 +1017,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                featureFlagService: featureFlagService)
 
         // Given products are added to order
-        viewModel.productSelectorViewModel.selectProduct(product0.productID)
+        viewModel.productSelectorViewModel.changeSelectionStateForProduct(with: product0.productID)
 
         // When
         let itemToRemove = OrderItem.fake().copy(itemID: viewModel.productRows[0].id)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -434,7 +434,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
                                                    onProductSelected: { selectedProduct = $0.productID })
 
         // When
-        viewModel.selectProduct(product.productID)
+        viewModel.changeSelectionStateForProduct(with: product.productID)
 
         // Then
         XCTAssertEqual(selectedProduct, product.productID)
@@ -451,7 +451,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
                                                  onProductSelected: { selectedProduct = $0.productID })
 
         // When
-        viewModel.selectProduct(product.productID)
+        viewModel.changeSelectionStateForProduct(with: product.productID)
 
         // Then
         XCTAssertEqual(selectedProduct, product.productID)
@@ -496,7 +496,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
                                                  onProductSelected: { _ in })
 
         // When
-        viewModel.selectProduct(product.productID)
+        viewModel.changeSelectionStateForProduct(with: product.productID)
 
         // Then
         let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
@@ -512,8 +512,8 @@ final class ProductSelectorViewModelTests: XCTestCase {
                                                  storageManager: storageManager)
 
         // When
-        viewModel.selectProduct(product.productID)
-        viewModel.selectProduct(product.productID)
+        viewModel.changeSelectionStateForProduct(with: product.productID)
+        viewModel.changeSelectionStateForProduct(with: product.productID)
 
         // Then
         let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
@@ -531,8 +531,8 @@ final class ProductSelectorViewModelTests: XCTestCase {
                                                  onProductSelected: { _ in })
 
         // When
-        viewModel.selectProduct(product.productID)
-        viewModel.selectProduct(product.productID)
+        viewModel.changeSelectionStateForProduct(with: product.productID)
+        viewModel.changeSelectionStateForProduct(with: product.productID)
 
         // Then
         let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
@@ -549,8 +549,8 @@ final class ProductSelectorViewModelTests: XCTestCase {
                                                  supportsMultipleSelection: true)
 
         // When
-        viewModel.selectProduct(product.productID)
-        viewModel.selectProduct(product.productID)
+        viewModel.changeSelectionStateForProduct(with: product.productID)
+        viewModel.changeSelectionStateForProduct(with: product.productID)
 
         // Then
         let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
@@ -659,7 +659,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         })
 
         // When
-        viewModel.selectProduct(simpleProduct.productID)
+        viewModel.changeSelectionStateForProduct(with: simpleProduct.productID)
         viewModel.updateSelectedVariations(productID: variableProduct.productID, selectedVariationIDs: [12])
         viewModel.completeMultipleSelection()
 
@@ -751,7 +751,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
                                                  supportsMultipleSelection: true)
 
         // When
-        viewModel.selectProduct(product.productID)
+        viewModel.changeSelectionStateForProduct(with: product.productID)
         // Confidence check
         let productRow = viewModel.productRows.first(where: { $0.productOrVariationID == product.productID })
         XCTAssertEqual(productRow?.selectedState, .selected)
@@ -944,11 +944,11 @@ final class ProductSelectorViewModelTests: XCTestCase {
             })
 
         // When
-        viewModel.selectProduct(products[0].productID)
+        viewModel.changeSelectionStateForProduct(with: products[0].productID)
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
             switch action {
             case let .synchronizeProducts(_, _, _, _, _, _, _, _, _, _, onCompletion):
-                viewModel.selectProduct(products[1].productID)
+                viewModel.changeSelectionStateForProduct(with: products[1].productID)
                 onCompletion(.success(true))
             default:
                 XCTFail("Unsupported Action")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -431,7 +431,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                    storageManager: storageManager,
-                                                   onProductSelected: { selectedProduct = $0.productID })
+                                                   onProductSelectionStateChanged: { selectedProduct = $0.productID })
 
         // When
         viewModel.changeSelectionStateForProduct(with: product.productID)
@@ -448,7 +448,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
                                                  supportsMultipleSelection: true,
-                                                 onProductSelected: { selectedProduct = $0.productID })
+                                                 onProductSelectionStateChanged: { selectedProduct = $0.productID })
 
         // When
         viewModel.changeSelectionStateForProduct(with: product.productID)
@@ -493,7 +493,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
                                                  supportsMultipleSelection: true,
-                                                 onProductSelected: { _ in })
+                                                 onProductSelectionStateChanged: { _ in })
 
         // When
         viewModel.changeSelectionStateForProduct(with: product.productID)
@@ -528,7 +528,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
                                                  supportsMultipleSelection: false,
-                                                 onProductSelected: { _ in })
+                                                 onProductSelectionStateChanged: { _ in })
 
         // When
         viewModel.changeSelectionStateForProduct(with: product.productID)
@@ -939,7 +939,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let viewModel = ProductSelectorViewModel(
             siteID: sampleSiteID,
             storageManager: storageManager,
-            onProductSelected: {
+            onProductSelectionStateChanged: {
                 selectedProduct = $0.productID
             })
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductVariationSelectorViewModelTests.swift
@@ -205,7 +205,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.notice, ProductVariationSelectorViewModel.NoticeFactory.productVariationSyncNotice(retryAction: {}))
     }
 
-    func test_selectVariation_invokes_onVariationSelected_closure_for_existing_variation() {
+    func test_selectVariation_invokes_onVariationSelectionStateChanged_closure_for_existing_variation() {
         // Given
         var selectedVariationID: Int64?
         var selectedProductID: Int64?
@@ -218,13 +218,13 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
         let viewModel = ProductVariationSelectorViewModel(siteID: sampleSiteID,
                                                             product: product,
                                                             storageManager: storageManager,
-                                                            onVariationSelected: { variation, product in
+                                                            onVariationSelectionStateChanged: { variation, product in
             selectedVariationID = variation.productVariationID
             selectedProductID = product.productID
         })
 
         // When
-        viewModel.selectVariation(productVariation.productVariationID)
+        viewModel.changeSelectionStateForVariation(with: productVariation.productVariationID)
 
         // Then
         XCTAssertEqual(selectedVariationID, productVariation.productVariationID)
@@ -242,7 +242,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
                                                           storageManager: storageManager)
 
         // When
-        viewModel.selectVariation(productVariation.productVariationID)
+        viewModel.changeSelectionStateForVariation(with: productVariation.productVariationID)
 
         // Then
         let row = viewModel.productVariationRows.first(where: { $0.productOrVariationID == productVariation.productVariationID })
@@ -261,7 +261,7 @@ final class ProductVariationSelectorViewModelTests: XCTestCase {
                                                           storageManager: storageManager)
 
         // When
-        viewModel.selectVariation(productVariation.productVariationID)
+        viewModel.changeSelectionStateForVariation(with: productVariation.productVariationID)
         // Confidence check
         let row = viewModel.productVariationRows.first(where: { $0.productOrVariationID == productVariation.productVariationID })
         XCTAssertEqual(row?.selectedState, .selected)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we refactor the Product Multi-selection code in the Editable Order context to make it more readable and efficient. The changes are:
- Make the `productSelectorViewModel` property in the `EditableOrderViewModel` lazy. That means that we do not have to create a new one every time is referenced from outside (e.g., from the view), but we have to pass any event so it keeps updated. That will also help when adding the top products to the list in the context of the Sorting products by popularity project.
- Rename functions and closures to be more specific. Instead of `selectProduct` we use `changeSelectionState` because we can also handle deselection.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Test the product multi-selection feature and ensure that everything works as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
