### PR TITLE
[UI Tests] - Reduce retry from default to 2

### DIFF
--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -19,6 +19,7 @@
     "environmentVariableEntries" : [
 
     ],
+    "maximumTestRepetitions" : 2,
     "testRepetitionMode" : "retryOnFailure"
   },
   "testTargets" : [


### PR DESCRIPTION
## Description
This PR contains no functional changes, this updates the retry from the default value of 3 to 2 as discussed in pdcxQM-24i-p2#comment-1898

## Testing instructions
All tests should still work as expected