### PR TITLE
Account creation: Optimizations with separate fields and navigation to login if possible

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -84,8 +84,8 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 6.0.0'
-#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+#  pod 'WordPressAuthenticator', '~> 6.0.0'
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '95dfb1b9b4c47b29d2755cd3df376bb46a8e37c7'
 #   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -85,8 +85,8 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
 #  pod 'WordPressAuthenticator', '~> 6.0.0'
-   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '95dfb1b9b4c47b29d2755cd3df376bb46a8e37c7'
-#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
+#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   wordpress_shared

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -39,7 +39,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (6.0.0):
+  - WordPressAuthenticator (6.1.0-beta.1):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -83,7 +83,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 6.0.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `95dfb1b9b4c47b29d2755cd3df376bb46a8e37c7`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.12.5)
   - Wormholy (~> 1.6.6)
@@ -114,7 +114,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressShared
     - WordPressUI
     - Wormholy
@@ -127,6 +126,16 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
+
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :commit: 95dfb1b9b4c47b29d2755cd3df376bb46a8e37c7
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: 95dfb1b9b4c47b29d2755cd3df376bb46a8e37c7
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -149,7 +158,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: b93b797eae278f7cda42693a652329173f1d5423
+  WordPressAuthenticator: e632aa8afeb4583d0c7c0818e2add2bffce47ef2
   WordPressKit: 47e8e0fc39df87d0b8f84c1a4a67868414e9a925
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -164,6 +173,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: acee7d21f87d18c5c4a806a6f3adc22fe5bdeb0d
+PODFILE CHECKSUM: bb8a73076a58380f173a8457332880b2adf9b80a
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -83,7 +83,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `95dfb1b9b4c47b29d2755cd3df376bb46a8e37c7`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `trunk`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.12.5)
   - Wormholy (~> 1.6.6)
@@ -129,12 +129,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: 95dfb1b9b4c47b29d2755cd3df376bb46a8e37c7
+    :branch: trunk
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: 95dfb1b9b4c47b29d2755cd3df376bb46a8e37c7
+    :commit: eba1abd0e7755cca4f0e9064a104cada657cd3b3
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -173,6 +173,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: bb8a73076a58380f173a8457332880b2adf9b80a
+PODFILE CHECKSUM: 1e3ef3081423f883866741eef178eec8e615d385
 
 COCOAPODS: 1.11.3

--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -100,6 +100,11 @@ struct AuthenticationConstants {
         comment: "The hint button's title text to help users find their store address."
     )
 
+    static let forgotPassword = NSLocalizedString(
+        "Forgot password?",
+        comment: "Button to see instructions for resetting password of a WPCom account."
+    )
+
     /// Footer for Terms of Service of Sign In With Apple and Sign In with Google
     //
     static let signupTermsOfService = NSLocalizedString(

--- a/WooCommerce/Classes/Authentication/Store Creation/LoggedOutStoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/LoggedOutStoreCreationCoordinator.swift
@@ -50,7 +50,7 @@ private extension LoggedOutStoreCreationCoordinator {
         guard !isExisting else {
             /// Navigates to login with the existing email address.
             let command = NavigateToEnterAccount(signInSource: signInSource, email: email)
-            command.execute(from: navigationController)
+            command.execute(from: navigationController.topViewController ?? navigationController)
             return
         }
         /// Navigates to password field for account creation

--- a/WooCommerce/Classes/Authentication/Store Creation/LoggedOutStoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/LoggedOutStoreCreationCoordinator.swift
@@ -54,8 +54,8 @@ private extension LoggedOutStoreCreationCoordinator {
             return
         }
         /// Navigates to password field for account creation
-        let passwordView = AccountCreationFormHostingController(field: .password(email: email),
-                                                                viewModel: .init(),
+        let passwordView = AccountCreationFormHostingController(field: .password,
+                                                                viewModel: .init(email: email),
                                                                 signInSource: signInSource,
                                                                 completion: { [weak self] in
             guard let self else { return }

--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -94,6 +94,7 @@ extension WordPressAuthenticator {
                                                                   enterYourSiteAddressButtonTitle: AuthenticationConstants.enterYourSiteAddressButtonTitle,
                                                                   signInWithSiteCredentialsButtonTitle: AuthenticationConstants.signInWithSiteCredsButtonTitle,
                                                                   findSiteButtonTitle: AuthenticationConstants.findYourStoreAddressButtonTitle,
+                                                                  resetPasswordButtonTitle: AuthenticationConstants.forgotPassword,
                                                                   signupTermsOfService: AuthenticationConstants.signupTermsOfService,
                                                                   whatIsWPComLinkTitle: AuthenticationConstants.whatIsWPComLinkTitle,
                                                                   siteCreationButtonTitle: AuthenticationConstants.createSiteButtonTitle,

--- a/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
@@ -72,7 +72,16 @@ final class AccountCreationFormViewModel: ObservableObject {
 
             await handleSuccess(data: data)
         } catch let error as CreateAccountError {
-            analytics.track(event: .StoreCreation.signupFailed(error: error))
+            /// Skip tracking if the password field is yet to be presented.
+            let shouldSkipTrackingError: Bool = {
+                guard case .invalidPassword = error else {
+                    return false
+                }
+                return emailSubmissionHandler != nil
+            }()
+            if !shouldSkipTrackingError {
+                analytics.track(event: .StoreCreation.signupFailed(error: error))
+            }
             handleFailure(error: error)
 
             throw error

--- a/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
@@ -29,12 +29,14 @@ final class AccountCreationFormViewModel: ObservableObject {
     private let emailSubmissionHandler: ((_ email: String, _ isExisting: Bool) -> Void)?
     private var subscriptions: Set<AnyCancellable> = []
 
-    init(debounceDuration: Double = Constants.fieldDebounceDuration,
+    init(email: String = "",
+         debounceDuration: Double = Constants.fieldDebounceDuration,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          emailSubmissionHandler: ((_ email: String, _ isExisting: Bool) -> Void)? = nil) {
         self.stores = stores
         self.analytics = analytics
+        self.email = email
         self.emailSubmissionHandler = emailSubmissionHandler
 
         $email

--- a/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Authentication/AccountCreationFormViewModel.swift
@@ -28,9 +28,11 @@ final class AccountCreationFormViewModel: ObservableObject {
     private let analytics: Analytics
     private var subscriptions: Set<AnyCancellable> = []
 
-    init(debounceDuration: Double = Constants.fieldDebounceDuration,
+    init(email: String = "",
+         debounceDuration: Double = Constants.fieldDebounceDuration,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
+        self.email = email
         self.stores = stores
         self.analytics = analytics
 
@@ -89,8 +91,6 @@ private extension AccountCreationFormViewModel {
     @MainActor
     func handleFailure(error: CreateAccountError) {
         switch error {
-        case .emailExists:
-            emailErrorMessage = Localization.emailExistsError
         case .invalidEmail:
             emailErrorMessage = Localization.invalidEmailError
         case .invalidPassword(let message):
@@ -119,8 +119,6 @@ private extension AccountCreationFormViewModel {
     }
 
     enum Localization {
-        static let emailExistsError = NSLocalizedString("An account with this email already exists.",
-                                                        comment: "Account creation error when the email is already associated with an existing WP.com account.")
         static let invalidEmailError = NSLocalizedString("Use a working email address, so you can receive our messages.",
                                                          comment: "Account creation error when the email is invalid.")
         static let passwordError = NSLocalizedString("Password must be at least 6 characters.",

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -173,7 +173,7 @@ private extension AccountCreationForm {
         static let passwordFieldPlaceholder = NSLocalizedString("Password", comment: "Placeholder of the password field on the account creation form.")
         static let tosFormat = NSLocalizedString("By continuing, you agree to our %1$@.", comment: "Terms of service format on the account creation form.")
         static let tos = NSLocalizedString("Terms of Service", comment: "Terms of service link on the account creation form.")
-        static let submitButtonTitle = NSLocalizedString("Get started", comment: "Title of the submit button on the account creation form.")
+        static let submitButtonTitle = NSLocalizedString("Continue", comment: "Title of the submit button on the account creation form.")
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -6,8 +6,6 @@ import enum Yosemite.CreateAccountError
 /// Hosting controller that wraps an `AccountCreationForm`.
 final class AccountCreationFormHostingController: UIHostingController<AccountCreationForm> {
     private let analytics: Analytics
-    private let signInSource: SignInSource
-    private let completion: () -> Void
 
     init(field: AccountCreationForm.Field = .email,
          viewModel: AccountCreationFormViewModel,
@@ -15,8 +13,6 @@ final class AccountCreationFormHostingController: UIHostingController<AccountCre
          analytics: Analytics = ServiceLocator.analytics,
          completion: @escaping () -> Void) {
         self.analytics = analytics
-        self.signInSource = signInSource
-        self.completion = completion
         super.init(rootView: AccountCreationForm(field: field, viewModel: viewModel))
 
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController.
@@ -43,7 +39,7 @@ final class AccountCreationFormHostingController: UIHostingController<AccountCre
 struct AccountCreationForm: View {
     enum Field: Equatable {
         case email
-        case password(email: String)
+        case password
     }
 
     /// Triggered when the account is created and the app is authenticated.
@@ -73,9 +69,6 @@ struct AccountCreationForm: View {
     init(field: Field, viewModel: AccountCreationFormViewModel) {
         self.viewModel = viewModel
         self.field = field
-        if case let .password(email) = field {
-            viewModel.email = email
-        }
     }
 
     var body: some View {
@@ -96,33 +89,33 @@ struct AccountCreationForm: View {
 
                 // Form fields.
                 VStack(spacing: Layout.verticalSpacingBetweenFields) {
-                    if case .email = field {
-                        // Email field.
-                        AuthenticationFormFieldView(viewModel: .init(header: Localization.emailFieldTitle,
-                                                                     placeholder: Localization.emailFieldPlaceholder,
-                                                                     keyboardType: .emailAddress,
-                                                                     text: $viewModel.email,
-                                                                     isSecure: false,
-                                                                     errorMessage: viewModel.emailErrorMessage,
-                                                                     isFocused: isFocused))
-                        .autocorrectionDisabled()
-                        .textInputAutocapitalization(.never)
-                        .focused($isFocused)
-                        .disabled(isPerformingTask)
-                    } else {
-                        // Password field.
-                        AuthenticationFormFieldView(viewModel: .init(header: Localization.passwordFieldTitle,
-                                                                     placeholder: Localization.passwordFieldPlaceholder,
-                                                                     keyboardType: .default,
-                                                                     text: $viewModel.password,
-                                                                     isSecure: true,
-                                                                     errorMessage: viewModel.passwordErrorMessage,
-                                                                     isFocused: isFocused))
-                        .autocorrectionDisabled()
-                        .textInputAutocapitalization(.never)
-                        .focused($isFocused)
-                        .disabled(isPerformingTask)
-                    }
+                    // Email field.
+                    AuthenticationFormFieldView(viewModel: .init(header: Localization.emailFieldTitle,
+                                                                 placeholder: Localization.emailFieldPlaceholder,
+                                                                 keyboardType: .emailAddress,
+                                                                 text: $viewModel.email,
+                                                                 isSecure: false,
+                                                                 errorMessage: viewModel.emailErrorMessage,
+                                                                 isFocused: isFocused))
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .focused($isFocused)
+                    .disabled(isPerformingTask)
+                    .renderedIf(field == .email)
+
+                    // Password field.
+                    AuthenticationFormFieldView(viewModel: .init(header: Localization.passwordFieldTitle,
+                                                                 placeholder: Localization.passwordFieldPlaceholder,
+                                                                 keyboardType: .default,
+                                                                 text: $viewModel.password,
+                                                                 isSecure: true,
+                                                                 errorMessage: viewModel.passwordErrorMessage,
+                                                                 isFocused: isFocused))
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .focused($isFocused)
+                    .disabled(isPerformingTask)
+                    .renderedIf(field == .password)
 
                     // Terms of Service link.
                     AttributedText(tosAttributedText, enablesLinkUnderline: true)
@@ -218,7 +211,7 @@ struct AccountCreationForm_Previews: PreviewProvider {
         AccountCreationForm(field: .email, viewModel: .init())
             .preferredColorScheme(.light)
 
-        AccountCreationForm(field: .password(email: "test@example.com"), viewModel: .init())
+        AccountCreationForm(field: .password, viewModel: .init())
             .preferredColorScheme(.dark)
             .dynamicTypeSize(.xxxLarge)
     }

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -70,19 +70,6 @@ struct AccountCreationForm: View {
                         Text(Localization.subtitle)
                             .foregroundColor(Color(.secondaryLabel))
                             .bodyStyle()
-                        HStack(alignment: .firstTextBaseline) {
-                            // Login subtitle label.
-                            Text(Localization.loginSubtitle)
-                                .foregroundColor(Color(.secondaryLabel))
-                                .bodyStyle()
-
-                            // Login button.
-                            Button(Localization.loginButtonTitle) {
-                                loginButtonTapped()
-                            }
-                            .buttonStyle(TextButtonStyle())
-                            .disabled(isPerformingTask)
-                        }
                     }
                 }
 
@@ -140,6 +127,13 @@ struct AccountCreationForm: View {
             }
             .padding(.init(top: 0, leading: Layout.horizontalSpacing, bottom: 0, trailing: Layout.horizontalSpacing))
         }
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button(Localization.loginButtonTitle, action: loginButtonTapped)
+                    .buttonStyle(TextButtonStyle())
+                    .disabled(isPerformingTask)
+            }
+        }
     }
 }
 
@@ -172,7 +166,6 @@ private extension AccountCreationForm {
     enum Localization {
         static let title = NSLocalizedString("Get started in minutes", comment: "Title for the account creation form.")
         static let subtitle = NSLocalizedString("First, let’s create your account.", comment: "Subtitle for the account creation form.")
-        static let loginSubtitle = NSLocalizedString("Already registered?", comment: "Subtitle for the login button on the account creation form.")
         static let loginButtonTitle = NSLocalizedString("Log in", comment: "Title of the login button on the account creation form.")
         static let emailFieldTitle = NSLocalizedString("Your email address", comment: "Title of the email field on the account creation form.")
         static let emailFieldPlaceholder = NSLocalizedString("Email address", comment: "Placeholder of the email field on the account creation form.")

--- a/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Authentication/AccountCreationForm.swift
@@ -100,6 +100,7 @@ struct AccountCreationForm: View {
                     .textInputAutocapitalization(.never)
                     .focused($focusedField, equals: .password)
                     .disabled(isPerformingTask)
+                    .renderedIf(viewModel.shouldShowPasswordField)
 
                     // Terms of Service link.
                     AttributedText(tosAttributedText, enablesLinkUnderline: true)
@@ -109,8 +110,19 @@ struct AccountCreationForm: View {
                         }
                         .safariSheet(url: $tosURL)
                 }
-
-                // CTA to submit the form.
+            }
+            .padding(.init(top: 0, leading: Layout.horizontalSpacing, bottom: 0, trailing: Layout.horizontalSpacing))
+        }
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button(Localization.loginButtonTitle, action: loginButtonTapped)
+                    .buttonStyle(TextButtonStyle())
+                    .disabled(isPerformingTask)
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            // CTA to submit the form.
+            VStack {
                 Button(Localization.submitButtonTitle.localizedCapitalized) {
                     Task { @MainActor in
                         isPerformingTask = true
@@ -124,15 +136,9 @@ struct AccountCreationForm: View {
                 }
                 .buttonStyle(PrimaryLoadingButtonStyle(isLoading: isPerformingTask))
                 .disabled(!(viewModel.isEmailValid && viewModel.isPasswordValid) || isPerformingTask)
+                .padding()
             }
-            .padding(.init(top: 0, leading: Layout.horizontalSpacing, bottom: 0, trailing: Layout.horizontalSpacing))
-        }
-        .toolbar {
-            ToolbarItem(placement: .confirmationAction) {
-                Button(Localization.loginButtonTitle, action: loginButtonTapped)
-                    .buttonStyle(TextButtonStyle())
-                    .disabled(isPerformingTask)
-            }
+            .background(Color(uiColor: .systemBackground))
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/Authentication/AccountCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Authentication/AccountCreationFormViewModelTests.swift
@@ -236,7 +236,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents, ["signup_submitted"])
     }
 
-    func test_createAccount_failure_with_invalid_password_is__tracked_if_emailSubmissionHandler_is_not_available() async {
+    func test_createAccount_failure_with_invalid_password_is_tracked_if_emailSubmissionHandler_is_not_available() async {
         // Given
         viewModel = .init(debounceDuration: 0, stores: stores, analytics: analytics)
         mockAccountCreationFailure(error: .invalidPassword(message: nil))

--- a/WooCommerce/WooCommerceTests/ViewModels/Authentication/AccountCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Authentication/AccountCreationFormViewModelTests.swift
@@ -112,6 +112,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         mockAccountCreationFailure(error: .invalidEmail)
         XCTAssertNil(viewModel.emailErrorMessage)
 
+        // When
         do {
             try await viewModel.createAccount()
 
@@ -119,6 +120,54 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         } catch {
             // Then
             XCTAssertNotNil(viewModel.emailErrorMessage)
+        }
+    }
+
+    func test_emailSubmissionHandler_is_triggered_when_account_creation_fails_with_emailExists() async {
+        // Given
+        var emailExists = false
+        var submittedEmail: String?
+        viewModel = .init(debounceDuration: 0, stores: stores, analytics: analytics, emailSubmissionHandler: { email, exists in
+            emailExists = exists
+            submittedEmail = email
+        })
+        mockAccountCreationFailure(error: .emailExists)
+        viewModel.email = "test@example.com"
+
+        // When
+        do {
+            try await viewModel.createAccount()
+
+            XCTFail("Function should have thrown an error")
+        } catch {
+            // Then
+            XCTAssertNil(viewModel.emailErrorMessage)
+            XCTAssertTrue(emailExists)
+            XCTAssertEqual(submittedEmail, "test@example.com")
+        }
+    }
+
+    func test_emailSubmissionHandler_is_triggered_when_account_creation_fails_with_invalidPassword() async {
+        // Given
+        var emailExists = false
+        var submittedEmail: String?
+        viewModel = .init(debounceDuration: 0, stores: stores, analytics: analytics, emailSubmissionHandler: { email, exists in
+            emailExists = exists
+            submittedEmail = email
+        })
+        mockAccountCreationFailure(error: .invalidPassword(message: ""))
+        viewModel.email = "test@example.com"
+
+        // When
+        do {
+            try await viewModel.createAccount()
+
+            XCTFail("Function should have thrown an error")
+        } catch {
+            // Then
+            XCTAssertNil(viewModel.emailErrorMessage)
+            XCTAssertFalse(emailExists)
+            XCTAssertEqual(submittedEmail, "test@example.com")
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewModels/Authentication/AccountCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Authentication/AccountCreationFormViewModelTests.swift
@@ -222,6 +222,32 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents, ["signup_submitted", "signup_failed"])
     }
+
+    func test_createAccount_failure_with_invalid_password_is_not_tracked_if_emailSubmissionHandler_is_available() async {
+        // Given
+        viewModel = .init(debounceDuration: 0, stores: stores, analytics: analytics, emailSubmissionHandler: { _, _ in })
+        mockAccountCreationFailure(error: .invalidPassword(message: nil))
+        viewModel.email = "test@example.com"
+
+        // When
+        try? await viewModel.createAccount()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents, ["signup_submitted"])
+    }
+
+    func test_createAccount_failure_with_invalid_password_is__tracked_if_emailSubmissionHandler_is_not_available() async {
+        // Given
+        viewModel = .init(debounceDuration: 0, stores: stores, analytics: analytics)
+        mockAccountCreationFailure(error: .invalidPassword(message: nil))
+        viewModel.email = "test@example.com"
+
+        // When
+        try? await viewModel.createAccount()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents, ["signup_submitted", "signup_failed"])
+    }
 }
 
 private extension AccountCreationFormViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Closes #9407 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds optimization to the account creation flow following the latest updates in pecCkj-wI-p2:
- Separates fields email and password during account creation. Since the two screens are almost identical, I reuse the same view and view model, with the new parameter `field` to decide which field to show.
- Handles existing email error by navigating to the login flow. Please also review https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/767 to see the changes in the WordPressAuthenticator library.
- Changes some wording: main CTA button, the title of the password screen, and moves the Log In button to the navigation bar.
- Changes the title of the Reset Password button in the Login flow to Forgot your password?

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- On the prologue screen tap Get Started.
- Enter the email address of an existing email and tap Continue. Notice that the login flow is presented with the input email already populated.
- Navigate back to the account creation screen and change the email to a new one. Tap Continue and notice another screen is displayed with the password field only.
- Enter a valid password and tap Continue. A new account should be created successfully.
- Please feel free to test with invalid input to see if the error cases are still handled correctly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/232018749-ea238227-ea15-470f-b87b-e5ea74129414.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.