### PR TITLE
[Composite Products] Release read-only support for composite products

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -88,7 +88,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .manualErrorHandlingForSiteCredentialLogin:
             return true
         case .compositeProducts:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .IPPUKExpansion:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [Internal] Store creation: New loading screen added for create store flow. [https://github.com/woocommerce/woocommerce-ios/pull/9383]
 - [*] Payments: Add account type field to receipts [https://github.com/woocommerce/woocommerce-ios/pull/9416]
 - [*] Products can now be filtered within Order creation [https://github.com/woocommerce/woocommerce-ios/pull/9258]
+- [*] Products: Adds read-only support for the Composite Products extension in the Products list, including a list of components in product details. [https://github.com/woocommerce/woocommerce-ios/pull/9455]
 
 
 13.1


### PR DESCRIPTION
## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This enables the composite products feature flag, to release read-only support for composite products.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

If possible, please follow the mini test plan (internal ref: pe5pgL-2F1-p2):

### Prerequisites

1. Install and activate the Composite Products extension on your store.
2. Create one or several Composite Products. Some ideas for the components in a composite product: 
   * Add a component with product options (Component Options > Select products).
   * Add a component with category options (Component Options > Select categories).
   * Add a component with a single component option.
   * Add a component with no default option.
   * Add a component with or without a name, description, or image.

### To test

- Test that all of your products, including composite products, load in the product list on the Products tab.
- Test that you can open the product details for a composite product, with read-only support for components, price, and inventory.
- Test that a “Components” row appears in product details for composite products, and it shows the correct number of components.
- Test that tapping “Components” opens a list with each component and its image.
- Test that tapping on a component opens the read-only component settings, showing the component image, title, description, component options, and default option.
- Test that the component options display an image and product name (for product options) or just a category name (for category options).
- Disable your internet connection and test that you see an error notice when you open the component settings screen for a component. Re-enable your internet connection and test that the "Retry" action loads your component options and default option.
- Test that you can change the editable details on your composite product (e.g., title, description) and that the changes are saved/published correctly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/8658164/232025203-64312267-e464-4c96-b3d8-59cf77abcaca.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.