### PR TITLE
[Subscriptions] Add support for simple subscriptions in Networking layer

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -842,7 +842,8 @@ extension Networking.Product {
             bundleStockStatus: .fake(),
             bundleStockQuantity: .fake(),
             bundledItems: .fake(),
-            compositeComponents: .fake()
+            compositeComponents: .fake(),
+            subscription: .fake()
         )
     }
 }

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -588,6 +588,7 @@
 		CCA1D6082943804C00B40560 /* site-summary-stats.json in Resources */ = {isa = PBXBuildFile; fileRef = CCA1D6072943804C00B40560 /* site-summary-stats.json */; };
 		CCA1D60A2943809700B40560 /* SiteSummaryStatsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA1D6092943809700B40560 /* SiteSummaryStatsMapperTests.swift */; };
 		CCAAD10F2683974000909664 /* ShippingLabelPackagePurchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCAAD10E2683974000909664 /* ShippingLabelPackagePurchase.swift */; };
+		CCAD671329E6D83C00ADC064 /* ProductSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCAD671229E6D83C00ADC064 /* ProductSubscription.swift */; };
 		CCB2CA9E262091CB00285CA0 /* SuccessDataResultMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB2CA9D262091CB00285CA0 /* SuccessDataResultMapper.swift */; };
 		CCB2CAA226209A1200285CA0 /* generic_success_data.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA126209A1200285CA0 /* generic_success_data.json */; };
 		CCB2CAA82620ABCC00285CA0 /* shipping-label-create-package-error.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */; };
@@ -603,6 +604,7 @@
 		CCF48B382628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF48B372628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json */; };
 		CCF48B802628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48B7F2628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift */; };
 		CCFEB8F429E8504300537456 /* product-subscription.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFEB8F329E8504300537456 /* product-subscription.json */; };
+		CCFEB8F629E8648C00537456 /* ProductMetadataExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFEB8F529E8648C00537456 /* ProductMetadataExtractor.swift */; };
 		CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F12223942D90075ED8D /* ProductImage.swift */; };
 		CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */; };
 		CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */; };
@@ -1497,6 +1499,7 @@
 		CCA1D6072943804C00B40560 /* site-summary-stats.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-summary-stats.json"; sourceTree = "<group>"; };
 		CCA1D6092943809700B40560 /* SiteSummaryStatsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSummaryStatsMapperTests.swift; sourceTree = "<group>"; };
 		CCAAD10E2683974000909664 /* ShippingLabelPackagePurchase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackagePurchase.swift; sourceTree = "<group>"; };
+		CCAD671229E6D83C00ADC064 /* ProductSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSubscription.swift; sourceTree = "<group>"; };
 		CCB2CA9D262091CB00285CA0 /* SuccessDataResultMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuccessDataResultMapper.swift; sourceTree = "<group>"; };
 		CCB2CAA126209A1200285CA0 /* generic_success_data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = generic_success_data.json; sourceTree = "<group>"; };
 		CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-create-package-error.json"; sourceTree = "<group>"; };
@@ -1512,6 +1515,7 @@
 		CCF48B372628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-account-settings-no-payment-methods.json"; sourceTree = "<group>"; };
 		CCF48B7F2628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAccountSettingsMapperTests.swift; sourceTree = "<group>"; };
 		CCFEB8F329E8504300537456 /* product-subscription.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-subscription.json"; sourceTree = "<group>"; };
+		CCFEB8F529E8648C00537456 /* ProductMetadataExtractor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductMetadataExtractor.swift; sourceTree = "<group>"; };
 		CE0A0F12223942D90075ED8D /* ProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImage.swift; sourceTree = "<group>"; };
 		CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttribute.swift; sourceTree = "<group>"; };
 		CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDefaultAttribute.swift; sourceTree = "<group>"; };
@@ -2962,8 +2966,10 @@
 				CE43A8F8229F463000A4FF29 /* ProductDownload.swift */,
 				77CE405F2514CB3E003FF69D /* ProductDownloadDragAndDrop.swift */,
 				CE0A0F12223942D90075ED8D /* ProductImage.swift */,
+				CCFEB8F529E8648C00537456 /* ProductMetadataExtractor.swift */,
 				CE227092228DD44C00C0626C /* ProductStatus.swift */,
 				CE17C6B0229462C000AACE1C /* ProductStockStatus.swift */,
+				CCAD671229E6D83C00ADC064 /* ProductSubscription.swift */,
 				CE6BFEE92236E191005C79FB /* ProductType.swift */,
 				CE132BBB223859710029DB6C /* ProductTag.swift */,
 				456F71D324CB1E2400472EC1 /* ProductTagFromBatchCreation.swift */,
@@ -3628,6 +3634,7 @@
 				DE4D23B829B5F909003A4B5D /* Announcement.swift in Sources */,
 				CEF88DAD233E95B000BED485 /* OrderRefundCondensed.swift in Sources */,
 				EE54C8A729486B6800A9BF61 /* ApplicationPasswordMapper.swift in Sources */,
+				CCFEB8F629E8648C00537456 /* ProductMetadataExtractor.swift in Sources */,
 				FE28F6E426842848004465C7 /* UserMapper.swift in Sources */,
 				CE430670234B99F50073CBFF /* RefundsRemote.swift in Sources */,
 				B56C1EB620EA757B00D749F9 /* SiteListMapper.swift in Sources */,
@@ -3760,6 +3767,7 @@
 				DE2E8E9F295310C5002E4B14 /* WordPressSiteMapper.swift in Sources */,
 				B59325CC217E2B4C000B0E8E /* NoteListMapper.swift in Sources */,
 				B505F6CD20BEE37E00BB1B69 /* AccountMapper.swift in Sources */,
+				CCAD671329E6D83C00ADC064 /* ProductSubscription.swift in Sources */,
 				EE57C1152979371B00BC31E7 /* ApplicationPassword.swift in Sources */,
 				B554FA8F2180BC7000C54DFF /* NoteHashListMapper.swift in Sources */,
 				B556FD69211CE2EC00B5DAE7 /* NetworkError.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -602,6 +602,7 @@
 		CCF48B2C2628AE160034EA83 /* shipping-label-account-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF48B2B2628AE160034EA83 /* shipping-label-account-settings.json */; };
 		CCF48B382628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF48B372628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json */; };
 		CCF48B802628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48B7F2628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift */; };
+		CCFEB8F429E8504300537456 /* product-subscription.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFEB8F329E8504300537456 /* product-subscription.json */; };
 		CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F12223942D90075ED8D /* ProductImage.swift */; };
 		CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */; };
 		CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */; };
@@ -1510,6 +1511,7 @@
 		CCF48B2B2628AE160034EA83 /* shipping-label-account-settings.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-account-settings.json"; sourceTree = "<group>"; };
 		CCF48B372628AEAE0034EA83 /* shipping-label-account-settings-no-payment-methods.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-label-account-settings-no-payment-methods.json"; sourceTree = "<group>"; };
 		CCF48B7F2628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAccountSettingsMapperTests.swift; sourceTree = "<group>"; };
+		CCFEB8F329E8504300537456 /* product-subscription.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-subscription.json"; sourceTree = "<group>"; };
 		CE0A0F12223942D90075ED8D /* ProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImage.swift; sourceTree = "<group>"; };
 		CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttribute.swift; sourceTree = "<group>"; };
 		CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDefaultAttribute.swift; sourceTree = "<group>"; };
@@ -2507,6 +2509,7 @@
 				CC01CE5729B0EBED004FF537 /* product-bundle.json */,
 				CC33754F29C88B920006A538 /* product-composite.json */,
 				02DD6491248A3EC00082523E /* product-external.json */,
+				CCFEB8F329E8504300537456 /* product-subscription.json */,
 				4524CD9B242CEFAB00B2F20A /* product-on-sale-with-empty-sale-price.json */,
 				025CA2C7238F4FF400B05C81 /* product-shipping-classes-load-all.json */,
 				020220E123966CD900290165 /* product-shipping-classes-load-one.json */,
@@ -3451,6 +3454,7 @@
 				D865CE6E278CC19A002C8520 /* stripe-location.json in Resources */,
 				DEA6B1C4296C0F45005AA5E9 /* payment-gateway-cod-without-data.json in Resources */,
 				CEC4BF93234E7EE0008D9195 /* refunds-all.json in Resources */,
+				CCFEB8F429E8504300537456 /* product-subscription.json in Resources */,
 				D8FBFF1522D3BE09006E3336 /* order-stats-v4-defaults.json in Resources */,
 				7495AACF225D366D00801A89 /* variation-as-product.json in Resources */,
 				0272E3FB254AABB800436277 /* order-with-line-item-attributes-before-API-support.json in Resources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1056,7 +1056,8 @@ extension Networking.Product {
         bundleStockStatus: NullableCopiableProp<ProductStockStatus> = .copy,
         bundleStockQuantity: NullableCopiableProp<Int64> = .copy,
         bundledItems: CopiableProp<[ProductBundleItem]> = .copy,
-        compositeComponents: CopiableProp<[ProductCompositeComponent]> = .copy
+        compositeComponents: CopiableProp<[ProductCompositeComponent]> = .copy,
+        subscription: NullableCopiableProp<ProductSubscription> = .copy
     ) -> Networking.Product {
         let siteID = siteID ?? self.siteID
         let productID = productID ?? self.productID
@@ -1125,6 +1126,7 @@ extension Networking.Product {
         let bundleStockQuantity = bundleStockQuantity ?? self.bundleStockQuantity
         let bundledItems = bundledItems ?? self.bundledItems
         let compositeComponents = compositeComponents ?? self.compositeComponents
+        let subscription = subscription ?? self.subscription
 
         return Networking.Product(
             siteID: siteID,
@@ -1193,7 +1195,8 @@ extension Networking.Product {
             bundleStockStatus: bundleStockStatus,
             bundleStockQuantity: bundleStockQuantity,
             bundledItems: bundledItems,
-            compositeComponents: compositeComponents
+            compositeComponents: compositeComponents,
+            subscription: subscription
         )
     }
 }

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -101,6 +101,11 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
     /// List of components that this product consists of. Applicable to composite-type products only.
     public let compositeComponents: [ProductCompositeComponent]
 
+    // MARK: Subscription Product properties
+
+    /// Subscription settings. Applicable to subscription-type products only.
+    public let subscription: ProductSubscription?
+
     /// Computed Properties
     ///
     public var productStatus: ProductStatus {
@@ -219,7 +224,8 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                 bundleStockStatus: ProductStockStatus?,
                 bundleStockQuantity: Int64?,
                 bundledItems: [ProductBundleItem],
-                compositeComponents: [ProductCompositeComponent]) {
+                compositeComponents: [ProductCompositeComponent],
+                subscription: ProductSubscription?) {
         self.siteID = siteID
         self.productID = productID
         self.name = name
@@ -287,6 +293,7 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         self.bundleStockQuantity = bundleStockQuantity
         self.bundledItems = bundledItems
         self.compositeComponents = compositeComponents
+        self.subscription = subscription
     }
 
     /// The public initializer for Product.
@@ -452,6 +459,8 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         // Composite Product properties
         let compositeComponents = try container.decodeIfPresent([ProductCompositeComponent].self, forKey: .compositeComponents) ?? []
 
+        // Subscription properties
+        let subscription = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?.extractProductSubscription()
 
         self.init(siteID: siteID,
                   productID: productID,
@@ -519,7 +528,8 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                   bundleStockStatus: bundleStockStatus,
                   bundleStockQuantity: bundleStockQuantity,
                   bundledItems: bundledItems,
-                  compositeComponents: compositeComponents)
+                  compositeComponents: compositeComponents,
+                  subscription: subscription)
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Networking/Networking/Model/Product/ProductMetadataExtractor.swift
+++ b/Networking/Networking/Model/Product/ProductMetadataExtractor.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Helper to extract specific data from inside `Product` metadata.
+/// Sample Json:
+/// "meta_data": [
+/// {
+///  "id": 6469,
+///  "key": "_last_editor_used_jetpack",
+///  "value": "classic-editor"
+/// },
+/// {
+///  "id": 6471,
+///  "key": "_subscription_price",
+///  "value": "5"
+/// },
+/// {
+///  "id": 6472,
+///  "key": "_subscription_period",
+///  "value": "month"
+/// }
+/// ]
+///
+internal struct ProductMetadataExtractor: Decodable {
+
+    private typealias DecodableDictionary = [String: AnyDecodable]
+    private typealias AnyDictionary = [String: Any?]
+
+    /// Internal metadata representation
+    ///
+    private let metadata: [DecodableDictionary]
+
+    /// Decode main metadata array as an untyped dictionary.
+    ///
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.metadata = try container.decode([DecodableDictionary].self)
+    }
+
+    /// Searches product metadata for subscription data and converts it to a `ProductSubscription` if possible.
+    ///
+    internal func extractProductSubscription() throws -> ProductSubscription? {
+        let subscriptionMetadata = filterMetadata(with: Constants.subscriptionPrefix)
+
+        guard !subscriptionMetadata.isEmpty else {
+            return nil
+        }
+
+        let keyValueMetadata = getKeyValueDictionary(from: subscriptionMetadata)
+        let jsonData = try convertToJSON(keyValueMetadata)
+        let decoder = JSONDecoder()
+        return try decoder.decode(ProductSubscription.self, from: jsonData)
+    }
+
+    /// Filters product metadata using the provided prefix.
+    ///
+    private func filterMetadata(with prefix: String) -> [DecodableDictionary] {
+        metadata.filter { object in
+            let objectKey = object["key"]?.value as? String ?? ""
+            return objectKey.hasPrefix(prefix)
+        }
+    }
+
+    /// Parses provided metadata to return a dictionary with each metadata object's key and value.
+    ///
+    private func getKeyValueDictionary(from metadata: [DecodableDictionary]) -> AnyDictionary {
+        metadata.reduce(AnyDictionary()) { (dict, object) in
+            var newDict = dict
+            let objectKey = object["key"]?.value as? String ?? ""
+            let objectValue = object["value"]?.value
+            newDict.updateValue(objectValue, forKey: objectKey)
+            return newDict
+        }
+    }
+
+    /// Converts the provided key/value dictionary to `JSON Data` that can be decoded.
+    ///
+    private func convertToJSON(_ keyValueMetadata: AnyDictionary) throws -> Data {
+        // Confirm the provided metadata is valid JSON that can be serialized.
+        guard JSONSerialization.isValidJSONObject(keyValueMetadata) else {
+            throw ProductMetadataExtractorError.invalidJSONObject(keyValueMetadata)
+        }
+
+        return try JSONSerialization.data(withJSONObject: keyValueMetadata)
+    }
+}
+
+// MARK: Constants
+
+private extension ProductMetadataExtractor {
+    enum Constants {
+        static let subscriptionPrefix = "_subscription"
+    }
+}
+
+// MARK: Errors
+
+/// Custom errors that can happen during the `ProductMetadataExtractor` decoding.
+///
+public enum ProductMetadataExtractorError: Error {
+    /// Represents an error when a provided `key/value JSON object` can't be converted to `JSON data`.
+    ///
+    case invalidJSONObject([String: Any?])
+}

--- a/Networking/Networking/Model/Product/ProductSubscription.swift
+++ b/Networking/Networking/Model/Product/ProductSubscription.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Represents the subscription settings extracted from product meta data for a Subscription-type Product.
+public struct ProductSubscription: Decodable, Equatable {
+    /// Subscription automatically expires after this number of subscription periods.
+    ///
+    /// For example, subscription with period of `month` and length of "2" expires after 2 months. Subscription with length of "0" never expires.
+    public let length: String
+
+    /// Subscription period.
+    public let period: String
+
+    /// Subscription billing interval for the subscription period.
+    public let periodInterval: String
+
+    /// Regular price of the subscription.
+    public let price: String
+
+    /// Optional amount to be charged at the outset of the subscription.
+    public let signUpFee: String
+
+    /// Length of the free trial period, if any.
+    public let trialLength: String
+
+    /// Period of the free trial, if any.
+    public let trialPeriod: String
+
+    public init(length: String,
+                period: String,
+                periodInterval: String,
+                price: String,
+                signUpFee: String,
+                trialLength: String,
+                trialPeriod: String) {
+        self.length = length
+        self.period = period
+        self.periodInterval = periodInterval
+        self.price = price
+        self.signUpFee = signUpFee
+        self.trialLength = trialLength
+        self.trialPeriod = trialPeriod
+    }
+}
+
+// MARK: Coding Keys
+//
+private extension ProductSubscription {
+    enum CodingKeys: String, CodingKey {
+        case length         = "_subscription_length"
+        case period         = "_subscription_period"
+        case periodInterval = "_subscription_period_interval"
+        case price          = "_subscription_price"
+        case signUpFee      = "_subscription_sign_up_fee"
+        case trialLength    = "_subscription_trial_length"
+        case trialPeriod    = "_subscription_trial_period"
+    }
+}

--- a/Networking/Networking/Model/Product/ProductSubscription.swift
+++ b/Networking/Networking/Model/Product/ProductSubscription.swift
@@ -8,7 +8,7 @@ public struct ProductSubscription: Decodable, Equatable {
     public let length: String
 
     /// Subscription period.
-    public let period: String
+    public let period: SubscriptionPeriod
 
     /// Subscription billing interval for the subscription period.
     public let periodInterval: String
@@ -16,22 +16,22 @@ public struct ProductSubscription: Decodable, Equatable {
     /// Regular price of the subscription.
     public let price: String
 
-    /// Optional amount to be charged at the outset of the subscription.
+    /// Optional amount to be charged at the outset of the subscription. Empty string if no
     public let signUpFee: String
 
-    /// Length of the free trial period, if any.
+    /// Length of the free trial period. (Length is "0" for no free trial.)
     public let trialLength: String
 
     /// Period of the free trial, if any.
-    public let trialPeriod: String
+    public let trialPeriod: SubscriptionPeriod
 
     public init(length: String,
-                period: String,
+                period: SubscriptionPeriod,
                 periodInterval: String,
                 price: String,
                 signUpFee: String,
                 trialLength: String,
-                trialPeriod: String) {
+                trialPeriod: SubscriptionPeriod) {
         self.length = length
         self.period = period
         self.periodInterval = periodInterval
@@ -54,4 +54,13 @@ private extension ProductSubscription {
         case trialLength    = "_subscription_trial_length"
         case trialPeriod    = "_subscription_trial_period"
     }
+}
+
+/// Represents all possible subscription periods
+///
+public enum SubscriptionPeriod: String, Codable {
+    case day
+    case week
+    case month
+    case year
 }

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -352,12 +352,12 @@ final class ProductMapperTests: XCTestCase {
         // Then
         XCTAssertEqual(product.productType, .subscription)
         XCTAssertEqual(subscriptionSettings.length, "2")
-        XCTAssertEqual(subscriptionSettings.period, "month")
+        XCTAssertEqual(subscriptionSettings.period, .month)
         XCTAssertEqual(subscriptionSettings.periodInterval, "1")
         XCTAssertEqual(subscriptionSettings.price, "5")
         XCTAssertEqual(subscriptionSettings.signUpFee, "")
         XCTAssertEqual(subscriptionSettings.trialLength, "1")
-        XCTAssertEqual(subscriptionSettings.trialPeriod, "week")
+        XCTAssertEqual(subscriptionSettings.trialPeriod, .week)
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -341,6 +341,24 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(compositeComponent.optionIDs, [413, 412])
         XCTAssertEqual(compositeComponent.defaultOptionID, "413")
     }
+
+    /// Test that products with the `subscription` product type are properly parsed.
+    ///
+    func test_subscription_products_are_properly_parsed() throws {
+        // Given
+        let product = try XCTUnwrap(mapLoadSubscriptionProductResponse())
+        let subscriptionSettings = try XCTUnwrap(product.subscription)
+
+        // Then
+        XCTAssertEqual(product.productType, .subscription)
+        XCTAssertEqual(subscriptionSettings.length, "2")
+        XCTAssertEqual(subscriptionSettings.period, "month")
+        XCTAssertEqual(subscriptionSettings.periodInterval, "1")
+        XCTAssertEqual(subscriptionSettings.price, "5")
+        XCTAssertEqual(subscriptionSettings.signUpFee, "")
+        XCTAssertEqual(subscriptionSettings.trialLength, "1")
+        XCTAssertEqual(subscriptionSettings.trialPeriod, "week")
+    }
 }
 
 
@@ -400,5 +418,11 @@ private extension ProductMapperTests {
     ///
     func mapLoadCompositeProductResponse() -> Product? {
         return mapProduct(from: "product-composite")
+    }
+
+    /// Returns the ProductMapper output upon receiving `product-subscription`
+    ///
+    func mapLoadSubscriptionProductResponse() -> Product? {
+        return mapProduct(from: "product-subscription")
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -109,7 +109,8 @@ final class ProductsRemoteTests: XCTestCase {
                                       bundleStockStatus: nil,
                                       bundleStockQuantity: nil,
                                       bundledItems: [],
-                                      compositeComponents: [])
+                                      compositeComponents: [],
+                                      subscription: nil)
         XCTAssertEqual(addedProduct, expectedProduct)
     }
 
@@ -216,7 +217,8 @@ final class ProductsRemoteTests: XCTestCase {
                                       bundleStockStatus: nil,
                                       bundleStockQuantity: nil,
                                       bundledItems: [],
-                                      compositeComponents: [])
+                                      compositeComponents: [],
+                                      subscription: nil)
         XCTAssertEqual(deletedProduct, expectedProduct)
     }
 
@@ -749,7 +751,8 @@ private extension ProductsRemoteTests {
                        bundleStockStatus: .inStock,
                        bundleStockQuantity: nil,
                        bundledItems: [],
-                       compositeComponents: [])
+                       compositeComponents: [],
+                       subscription: nil)
     }
 
     func sampleDimensions() -> Networking.ProductDimensions {

--- a/Networking/NetworkingTests/Responses/product-subscription.json
+++ b/Networking/NetworkingTests/Responses/product-subscription.json
@@ -1,0 +1,202 @@
+{
+    "data": {
+        "id": 198,
+        "name": "Coffee Subscription",
+        "slug": "coffee-subscription",
+        "permalink": "https://example.com/product/coffee-subscription/",
+        "date_created": "2023-01-24T18:14:18",
+        "date_created_gmt": "2023-01-24T18:14:18",
+        "date_modified": "2023-04-08T01:00:50",
+        "date_modified_gmt": "2023-04-08T00:00:50",
+        "type": "subscription",
+        "status": "publish",
+        "featured": false,
+        "catalog_visibility": "visible",
+        "description": "<p>A simple subscription for a regular delivery of the best coffee!</p>\n",
+        "short_description": "",
+        "sku": "",
+        "price": "5",
+        "regular_price": "5",
+        "sale_price": "",
+        "date_on_sale_from": null,
+        "date_on_sale_from_gmt": null,
+        "date_on_sale_to": null,
+        "date_on_sale_to_gmt": null,
+        "on_sale": false,
+        "purchasable": true,
+        "total_sales": 0,
+        "virtual": false,
+        "downloadable": false,
+        "downloads": [],
+        "download_limit": -1,
+        "download_expiry": -1,
+        "external_url": "",
+        "button_text": "",
+        "tax_status": "taxable",
+        "tax_class": "",
+        "manage_stock": false,
+        "stock_quantity": null,
+        "backorders": "no",
+        "backorders_allowed": false,
+        "backordered": false,
+        "low_stock_amount": null,
+        "sold_individually": false,
+        "weight": "",
+        "dimensions": {
+            "length": "",
+            "width": "",
+            "height": ""
+        },
+        "shipping_required": true,
+        "shipping_taxable": true,
+        "shipping_class": "",
+        "shipping_class_id": 0,
+        "reviews_allowed": true,
+        "average_rating": "0.00",
+        "rating_count": 0,
+        "upsell_ids": [],
+        "cross_sell_ids": [],
+        "parent_id": 0,
+        "purchase_note": "",
+        "categories": [],
+        "tags": [
+            {
+                "id": 1407,
+                "name": "coffee",
+                "slug": "coffee"
+            }
+        ],
+        "images": [
+            {
+                "id": 199,
+                "date_created": "2023-01-24T18:16:07",
+                "date_created_gmt": "2023-01-24T18:16:07",
+                "date_modified": "2023-01-27T10:55:09",
+                "date_modified_gmt": "2023-01-27T10:55:09",
+                "src": "https://example.com/wp-content/uploads/2023/01/coffee-beans.jpg",
+                "name": "coffee-beans",
+                "alt": ""
+            }
+        ],
+        "attributes": [],
+        "default_attributes": [],
+        "variations": [],
+        "grouped_products": [],
+        "menu_order": 0,
+        "price_html": "<span class=\"woocommerce-Price-amount amount\"><bdi><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>5.00</bdi></span> <span class=\"subscription-details\"> / month for 2 months</span>",
+        "related_ids": [],
+        "meta_data": [
+            {
+                "id": 4178,
+                "key": "_wpcom_is_markdown",
+                "value": "1"
+            },
+            {
+                "id": 4179,
+                "key": "_last_editor_used_jetpack",
+                "value": "classic-editor"
+            },
+            {
+                "id": 4183,
+                "key": "_product_addons",
+                "value": []
+            },
+            {
+                "id": 4184,
+                "key": "_product_addons_exclude_global",
+                "value": "0"
+            },
+            {
+                "id": 4210,
+                "key": "_subscription_payment_sync_date",
+                "value": "0"
+            },
+            {
+                "id": 4211,
+                "key": "_subscription_price",
+                "value": "5"
+            },
+            {
+                "id": 4215,
+                "key": "_subscription_trial_length",
+                "value": "1"
+            },
+            {
+                "id": 4216,
+                "key": "_subscription_sign_up_fee",
+                "value": ""
+            },
+            {
+                "id": 4217,
+                "key": "_subscription_period",
+                "value": "month"
+            },
+            {
+                "id": 4218,
+                "key": "_subscription_period_interval",
+                "value": "1"
+            },
+            {
+                "id": 4219,
+                "key": "_subscription_length",
+                "value": "2"
+            },
+            {
+                "id": 4220,
+                "key": "_subscription_trial_period",
+                "value": "week"
+            },
+            {
+                "id": 4221,
+                "key": "_subscription_limit",
+                "value": "no"
+            },
+            {
+                "id": 4222,
+                "key": "_subscription_one_time_shipping",
+                "value": "no"
+            }
+        ],
+        "stock_status": "outofstock",
+        "has_options": true,
+        "composite_virtual": false,
+        "composite_layout": "",
+        "composite_add_to_cart_form_location": "",
+        "composite_editable_in_cart": false,
+        "composite_sold_individually_context": "",
+        "composite_shop_price_calc": "",
+        "composite_components": [],
+        "composite_scenarios": [],
+        "bundled_by": [
+            "129"
+        ],
+        "bundle_stock_status": "outofstock",
+        "bundle_stock_quantity": null,
+        "bundle_virtual": false,
+        "bundle_layout": "",
+        "bundle_add_to_cart_form_location": "",
+        "bundle_editable_in_cart": false,
+        "bundle_sold_individually_context": "",
+        "bundle_item_grouping": "",
+        "bundle_min_size": "",
+        "bundle_max_size": "",
+        "bundled_items": [],
+        "bundle_sell_ids": [],
+        "jetpack_publicize_connections": [],
+        "jetpack_sharing_enabled": true,
+        "jetpack_likes_enabled": true,
+        "brands": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products/198"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products"
+                }
+            ]
+        }
+    }
+}

--- a/WooCommerce/Classes/Extensions/Product+SwiftUIPreviewHelpers.swift
+++ b/WooCommerce/Classes/Extensions/Product+SwiftUIPreviewHelpers.swift
@@ -71,7 +71,8 @@ extension Product {
                 bundleStockStatus: nil,
                 bundleStockQuantity: nil,
                 bundledItems: [],
-                compositeComponents: [])
+                compositeComponents: [],
+                subscription: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
@@ -98,6 +98,7 @@ private extension ProductFactory {
                 bundleStockStatus: nil,
                 bundleStockQuantity: nil,
                 bundledItems: [],
-                compositeComponents: [])
+                compositeComponents: [],
+                subscription: nil)
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
@@ -122,7 +122,8 @@ extension MockReviews {
                        bundleStockStatus: nil,
                        bundleStockQuantity: nil,
                        bundledItems: [],
-                       compositeComponents: [])
+                       compositeComponents: [],
+                       subscription: nil)
     }
 
     func sampleDimensions() -> Networking.ProductDimensions {
@@ -272,7 +273,8 @@ extension MockReviews {
                        bundleStockStatus: nil,
                        bundleStockQuantity: nil,
                        bundledItems: [],
-                       compositeComponents: [])
+                       compositeComponents: [],
+                       subscription: nil)
     }
 
     func sampleDimensionsMutated() -> Networking.ProductDimensions {
@@ -397,7 +399,8 @@ extension MockReviews {
                        bundleStockStatus: nil,
                        bundleStockQuantity: nil,
                        bundledItems: [],
-                       compositeComponents: [])
+                       compositeComponents: [],
+                       subscription: nil)
     }
 
     func sampleVariationTypeDimensions() -> Networking.ProductDimensions {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
@@ -168,6 +168,7 @@ private extension Product_ProductFormTests {
                        bundleStockStatus: nil,
                        bundleStockQuantity: nil,
                        bundledItems: [],
-                       compositeComponents: [])
+                       compositeComponents: [],
+                       subscription: nil)
     }
 }

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -311,7 +311,8 @@ extension MockObjectGraph {
             bundleStockStatus: nil,
             bundleStockQuantity: nil,
             bundledItems: [],
-            compositeComponents: []
+            compositeComponents: [],
+            subscription: nil
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
@@ -174,7 +174,8 @@ extension Storage.Product: ReadOnlyConvertible {
                        bundleStockStatus: productBundleStockStatus,
                        bundleStockQuantity: bundleStockQuantity as? Int64,
                        bundledItems: bundledItemsArray.map { $0.toReadOnly() },
-                       compositeComponents: compositeComponentsArray.map { $0.toReadOnly() })
+                       compositeComponents: compositeComponentsArray.map { $0.toReadOnly() },
+                       subscription: nil) // TODO: Convert the subscription
     }
 
     // MARK: - Private Helpers

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1897,7 +1897,8 @@ private extension ProductStoreTests {
                        bundleStockStatus: .inStock,
                        bundleStockQuantity: nil,
                        bundledItems: [],
-                       compositeComponents: [])
+                       compositeComponents: [],
+                       subscription: nil)
     }
 
     func sampleDimensions() -> Networking.ProductDimensions {
@@ -2057,7 +2058,8 @@ private extension ProductStoreTests {
                        bundleStockStatus: .insufficientStock,
                        bundleStockQuantity: 0,
                        bundledItems: [.fake(), .fake()],
-                       compositeComponents: [.fake(), .fake()])
+                       compositeComponents: [.fake(), .fake()],
+                       subscription: nil)
     }
 
     func sampleDimensionsMutated() -> Networking.ProductDimensions {
@@ -2191,7 +2193,8 @@ private extension ProductStoreTests {
                        bundleStockStatus: nil,
                        bundleStockQuantity: nil,
                        bundledItems: [],
-                       compositeComponents: [])
+                       compositeComponents: [],
+                       subscription: nil)
     }
 
     func sampleVariationTypeDimensions() -> Networking.ProductDimensions {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #8951
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support for simple subscription products in the Networking layer. We already support this `subscription` type in `ProductType`, so this adds a property to the `Product` model to represent the subscription settings data for a subscription product.

### Changes

Apologies for the size of the PR. About half of the lines are the JSON mock file for a subscription-type product, or adding the `subscription` property to related mocks.

Significant changes:

* New `ProductSubscription` model. This represents the subscription product settings that are extracted from the `Product` meta data.
* New `ProductMetadataExtractor` helper. This converts the `Product` meta data into a key/value dictionary that can be decoded as a `ProductSubscription`. (This is similar to the approach used to extract add-ons from the meta data in `ProductAddOnEnvelope`, but could be reused to extract any meta data based on a given prefix.)
* Updates the `Product` model to include an optional `subscription` property with the `ProductSubscription` data. This will be nil for non-subscription-type products.

I used this approach (a single `subscription` property with a separate model for the data, instead of individual product properties) to encapsulate the subscription data and make it easier to reuse `ProductMetadataExtractor` and `ProductSubscription` for variable subscription products (support to be added in a future PR). For that product type, the subscription data is formatted the same but included in each product variation's meta data.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Open the Products tab and confirm your full product list loads without any decoding errors.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
