### PR TITLE
[Subscriptions] Add support for variable subscriptions in Networking layer

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1149,7 +1149,8 @@ extension Networking.ProductVariation {
             dimensions: .fake(),
             shippingClass: .fake(),
             shippingClassID: .fake(),
-            menuOrder: .fake()
+            menuOrder: .fake(),
+            subscription: .fake()
         )
     }
 }

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -593,6 +593,7 @@
 		CCB2CAA226209A1200285CA0 /* generic_success_data.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA126209A1200285CA0 /* generic_success_data.json */; };
 		CCB2CAA82620ABCC00285CA0 /* shipping-label-create-package-error.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */; };
 		CCB573AA268CCFE90070FBB0 /* ShippingLabelStatusPollingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB573A9268CCFE90070FBB0 /* ShippingLabelStatusPollingResponse.swift */; };
+		CCEC5E9129E9BF1400912D6B /* product-variation-subscription.json in Resources */ = {isa = PBXBuildFile; fileRef = CCEC5E9029E9BF1400912D6B /* product-variation-subscription.json */; };
 		CCF434642906BD7200B4475A /* ProductIDMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF434632906BD7200B4475A /* ProductIDMapper.swift */; };
 		CCF434662906C2A400B4475A /* products-ids-only.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF434652906C2A400B4475A /* products-ids-only.json */; };
 		CCF4346A2906C9C300B4475A /* products-ids-only-empty.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF434692906C9C300B4475A /* products-ids-only-empty.json */; };
@@ -1504,6 +1505,7 @@
 		CCB2CAA126209A1200285CA0 /* generic_success_data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = generic_success_data.json; sourceTree = "<group>"; };
 		CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-create-package-error.json"; sourceTree = "<group>"; };
 		CCB573A9268CCFE90070FBB0 /* ShippingLabelStatusPollingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelStatusPollingResponse.swift; sourceTree = "<group>"; };
+		CCEC5E9029E9BF1400912D6B /* product-variation-subscription.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-variation-subscription.json"; sourceTree = "<group>"; };
 		CCF434632906BD7200B4475A /* ProductIDMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductIDMapper.swift; sourceTree = "<group>"; };
 		CCF434652906C2A400B4475A /* products-ids-only.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-ids-only.json"; sourceTree = "<group>"; };
 		CCF434692906C9C300B4475A /* products-ids-only-empty.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-ids-only-empty.json"; sourceTree = "<group>"; };
@@ -2540,6 +2542,7 @@
 				EE57C133297F985A00BC31E7 /* product-variations-bulk-create-without-data.json */,
 				EE57C132297F985A00BC31E7 /* product-variations-bulk-update-without-data.json */,
 				451274A525276C82009911FF /* product-variation.json */,
+				CCEC5E9029E9BF1400912D6B /* product-variation-subscription.json */,
 				CE0A0F1E223998A00075ED8D /* products-load-all.json */,
 				EEA6583D2966B41E00112DF0 /* products-load-all-without-data.json */,
 				2676F4CF290B0EC700C7A15B /* product-id-only.json */,
@@ -3437,6 +3440,7 @@
 				268B68FD24C87E37007EBF1D /* leaderboards-year-alt.json in Resources */,
 				74A1D264211898F000931DFA /* site-visits-week.json in Resources */,
 				EE57C127297F8E5E00BC31E7 /* product-attribute-terms-without-data.json in Resources */,
+				CCEC5E9129E9BF1400912D6B /* product-variation-subscription.json in Resources */,
 				027EB57429C07524003CE551 /* site-launch-error-unauthorized.json in Resources */,
 				B53EF53621813681003E146F /* generic_success.json in Resources */,
 				31054718262E2F5E00C5C02B /* wcpay-payment-intent-requires-confirmation.json in Resources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1469,7 +1469,8 @@ extension Networking.ProductVariation {
         dimensions: CopiableProp<ProductDimensions> = .copy,
         shippingClass: NullableCopiableProp<String> = .copy,
         shippingClassID: CopiableProp<Int64> = .copy,
-        menuOrder: CopiableProp<Int64> = .copy
+        menuOrder: CopiableProp<Int64> = .copy,
+        subscription: NullableCopiableProp<ProductSubscription> = .copy
     ) -> Networking.ProductVariation {
         let siteID = siteID ?? self.siteID
         let productID = productID ?? self.productID
@@ -1507,6 +1508,7 @@ extension Networking.ProductVariation {
         let shippingClass = shippingClass ?? self.shippingClass
         let shippingClassID = shippingClassID ?? self.shippingClassID
         let menuOrder = menuOrder ?? self.menuOrder
+        let subscription = subscription ?? self.subscription
 
         return Networking.ProductVariation(
             siteID: siteID,
@@ -1544,7 +1546,8 @@ extension Networking.ProductVariation {
             dimensions: dimensions,
             shippingClass: shippingClass,
             shippingClassID: shippingClassID,
-            menuOrder: menuOrder
+            menuOrder: menuOrder,
+            subscription: subscription
         )
     }
 }

--- a/Networking/Networking/Model/Product/ProductType.swift
+++ b/Networking/Networking/Model/Product/ProductType.swift
@@ -9,6 +9,7 @@ public enum ProductType: Codable, Hashable, GeneratedFakeable {
     case affiliate
     case variable
     case subscription
+    case variableSubscription
     case bundle
     case composite
     case custom(String) // in case there are extensions modifying product types
@@ -33,6 +34,8 @@ extension ProductType: RawRepresentable {
             self = .variable
         case Keys.subscription:
             self = .subscription
+        case Keys.variableSubscription:
+            self = .variableSubscription
         case Keys.bundle:
             self = .bundle
         case Keys.composite:
@@ -51,6 +54,7 @@ extension ProductType: RawRepresentable {
         case .affiliate:            return Keys.affiliate
         case .variable:             return Keys.variable
         case .subscription:         return Keys.subscription
+        case .variableSubscription: return Keys.variableSubscription
         case .bundle:               return Keys.bundle
         case .composite:            return Keys.composite
         case .custom(let payload):  return payload
@@ -70,7 +74,9 @@ extension ProductType: RawRepresentable {
         case .variable:
             return NSLocalizedString("Variable", comment: "Display label for variable product type.")
         case .subscription:
-            return NSLocalizedString("Subscription", comment: "Display label for subscription product type.")
+            return NSLocalizedString("Subscription", comment: "Display label for simple subscription product type.")
+        case .variableSubscription:
+            return NSLocalizedString("Variable Subscription", comment: "Display label for variable subscription product type.")
         case .bundle:
             return NSLocalizedString("Bundle", comment: "Display label for bundle product type.")
         case .composite:
@@ -85,11 +91,12 @@ extension ProductType: RawRepresentable {
 /// Enum containing the 'Known' ProductType Keys
 ///
 private enum Keys {
-    static let simple       = "simple"
-    static let grouped      = "grouped"
-    static let affiliate    = "external"
-    static let variable     = "variable"
-    static let subscription = "subscription"
-    static let bundle       = "bundle"
-    static let composite    = "composite"
+    static let simple               = "simple"
+    static let grouped              = "grouped"
+    static let affiliate            = "external"
+    static let variable             = "variable"
+    static let subscription         = "subscription"
+    static let variableSubscription = "variable-subscription"
+    static let bundle               = "bundle"
+    static let composite            = "composite"
 }

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -56,6 +56,9 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
 
     public let menuOrder: Int64
 
+    /// Subscription settings. Applicable to variations in variable subscription-type products only.
+    public let subscription: ProductSubscription?
+
     /// Computed Properties
     ///
     /// Whether the product variation has an integer (or nil) stock quantity.
@@ -106,7 +109,8 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
                 dimensions: ProductDimensions,
                 shippingClass: String?,
                 shippingClassID: Int64,
-                menuOrder: Int64) {
+                menuOrder: Int64,
+                subscription: ProductSubscription?) {
         self.siteID = siteID
         self.productID = productID
         self.productVariationID = productVariationID
@@ -143,6 +147,7 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
         self.shippingClass = shippingClass
         self.shippingClassID = shippingClassID
         self.menuOrder = menuOrder
+        self.subscription = subscription
     }
 
     /// The public initializer for ProductVariation.
@@ -249,6 +254,9 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
         let shippingClassID = try container.decode(Int64.self, forKey: .shippingClassID)
         let menuOrder = try container.decode(Int64.self, forKey: .menuOrder)
 
+        // Subscription settings for subscription variations
+        let subscription = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?.extractProductSubscription()
+
         self.init(siteID: siteID,
                   productID: productID,
                   productVariationID: productVariationID,
@@ -284,7 +292,8 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
                   dimensions: dimensions,
                   shippingClass: shippingClass,
                   shippingClassID: shippingClassID,
-                  menuOrder: menuOrder)
+                  menuOrder: menuOrder,
+                  subscription: subscription)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -393,6 +402,8 @@ private extension ProductVariation {
 
         case attributes
         case menuOrder          = "menu_order"
+
+        case metadata           = "meta_data"
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
@@ -145,7 +145,8 @@ private extension ProductVariationMapperTests {
                                                               height: ""),
                                 shippingClass: "",
                                 shippingClassID: 0,
-                                menuOrder: 1)
+                                menuOrder: 1,
+                                subscription: nil)
     }
 
     func sampleProductVariationAttributes() -> [ProductVariationAttribute] {

--- a/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
@@ -41,6 +41,23 @@ final class ProductVariationMapperTests: XCTestCase {
         XCTAssertTrue(productVariation.purchasable)
         XCTAssertEqual(productVariation.permalink, "")
     }
+
+    /// Test that the fields for variations of a subscription product are properly parsed.
+    ///
+    func test_subscription_variations_are_properly_parsed() throws {
+        // Given
+        let productVariation = try XCTUnwrap(mapLoadSubscriptionVariationResponse())
+        let subscriptionSettings = try XCTUnwrap(productVariation.subscription)
+
+        // Then
+        XCTAssertEqual(subscriptionSettings.length, "0")
+        XCTAssertEqual(subscriptionSettings.period, .week)
+        XCTAssertEqual(subscriptionSettings.periodInterval, "1")
+        XCTAssertEqual(subscriptionSettings.price, "5")
+        XCTAssertEqual(subscriptionSettings.signUpFee, "")
+        XCTAssertEqual(subscriptionSettings.trialLength, "0")
+        XCTAssertEqual(subscriptionSettings.trialPeriod, .month)
+    }
 }
 
 /// Private Helpers
@@ -72,6 +89,12 @@ private extension ProductVariationMapperTests {
     ///
     func mapLoadProductVariationResponseWithAlternativeTypes() -> ProductVariation? {
         return mapProductVariation(from: "product-variation-alternative-types")
+    }
+
+    /// Returns the ProductVariationMapper output upon receiving `product-variation-subscription`
+    ///
+    func mapLoadSubscriptionVariationResponse() -> ProductVariation? {
+        return mapProductVariation(from: "product-variation-subscription")
     }
 }
 

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -434,7 +434,8 @@ private extension ProductVariationsRemoteTests {
                                                               height: ""),
                                 shippingClass: "",
                                 shippingClassID: 0,
-                                menuOrder: 1)
+                                menuOrder: 1,
+                                subscription: nil)
     }
 
     func sampleProductVariationAttributes() -> [ProductVariationAttribute] {

--- a/Networking/NetworkingTests/Responses/product-variation-subscription.json
+++ b/Networking/NetworkingTests/Responses/product-variation-subscription.json
@@ -1,0 +1,180 @@
+{
+    "data": {
+        "id": 204,
+        "name": "Coffee Subscription (Choose your grind) - Whole bean, Weekly",
+        "slug": "coffee-subscription-your-choice-weekly-whole-bean",
+        "permalink": "https://example.com/product/coffee-subscription-choose-your-grind/?attribute_grind=Whole+bean&attribute_frequency=Weekly",
+        "date_created": "2023-01-24T18:24:06",
+        "date_created_gmt": "2023-01-24T18:24:06",
+        "date_modified": "2023-04-05T18:08:12",
+        "date_modified_gmt": "2023-04-05T17:08:12",
+        "type": "subscription_variation",
+        "status": "publish",
+        "featured": false,
+        "catalog_visibility": "visible",
+        "description": "",
+        "short_description": "",
+        "sku": "",
+        "price": "5",
+        "regular_price": "5",
+        "sale_price": "",
+        "date_on_sale_from": null,
+        "date_on_sale_from_gmt": null,
+        "date_on_sale_to": null,
+        "date_on_sale_to_gmt": null,
+        "on_sale": false,
+        "purchasable": true,
+        "total_sales": "0",
+        "virtual": false,
+        "downloadable": false,
+        "downloads": [],
+        "download_limit": -1,
+        "download_expiry": -1,
+        "external_url": "",
+        "button_text": "",
+        "tax_status": "taxable",
+        "tax_class": "",
+        "manage_stock": false,
+        "stock_quantity": null,
+        "backorders": "no",
+        "backorders_allowed": false,
+        "backordered": false,
+        "low_stock_amount": null,
+        "sold_individually": false,
+        "weight": "",
+        "dimensions": {
+            "length": "",
+            "width": "",
+            "height": ""
+        },
+        "shipping_required": true,
+        "shipping_taxable": true,
+        "shipping_class": "",
+        "shipping_class_id": 0,
+        "reviews_allowed": false,
+        "average_rating": "0.00",
+        "rating_count": 0,
+        "upsell_ids": [],
+        "cross_sell_ids": [],
+        "parent_id": 200,
+        "purchase_note": "",
+        "categories": [],
+        "tags": [],
+        "images": [
+            {
+                "id": 199,
+                "date_created": "2023-01-24T18:16:07",
+                "date_created_gmt": "2023-01-24T18:16:07",
+                "date_modified": "2023-01-27T10:55:09",
+                "date_modified_gmt": "2023-01-27T10:55:09",
+                "src": "https://example.com/wp-content/uploads/2023/01/coffee-beans.jpg",
+                "name": "coffee-beans",
+                "alt": ""
+            }
+        ],
+        "attributes": [
+            {
+                "id": 0,
+                "name": "Grind",
+                "option": "Whole bean"
+            },
+            {
+                "id": 0,
+                "name": "Frequency",
+                "option": "Weekly"
+            }
+        ],
+        "default_attributes": [],
+        "variations": [],
+        "grouped_products": [],
+        "menu_order": 1,
+        "price_html": "<span class=\"woocommerce-Price-amount amount\"><bdi><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>5.00</bdi></span> <span class=\"subscription-details\"> / week</span>",
+        "related_ids": [],
+        "meta_data": [
+            {
+                "id": 4464,
+                "key": "_subscription_period",
+                "value": "week"
+            },
+            {
+                "id": 4465,
+                "key": "_subscription_period_interval",
+                "value": "1"
+            },
+            {
+                "id": 4466,
+                "key": "_subscription_length",
+                "value": "0"
+            },
+            {
+                "id": 4467,
+                "key": "_subscription_trial_period",
+                "value": "month"
+            },
+            {
+                "id": 4685,
+                "key": "_subscription_sign_up_fee",
+                "value": ""
+            },
+            {
+                "id": 4686,
+                "key": "_subscription_price",
+                "value": "5"
+            },
+            {
+                "id": 4687,
+                "key": "_subscription_trial_length",
+                "value": "0"
+            },
+            {
+                "id": 4688,
+                "key": "_subscription_payment_sync_date",
+                "value": "0"
+            }
+        ],
+        "stock_status": "instock",
+        "has_options": true,
+        "composite_virtual": false,
+        "composite_layout": "",
+        "composite_add_to_cart_form_location": "",
+        "composite_editable_in_cart": false,
+        "composite_sold_individually_context": "",
+        "composite_shop_price_calc": "",
+        "composite_components": [],
+        "composite_scenarios": [],
+        "bundled_by": [],
+        "bundle_stock_status": "instock",
+        "bundle_stock_quantity": null,
+        "bundle_virtual": false,
+        "bundle_layout": "",
+        "bundle_add_to_cart_form_location": "",
+        "bundle_editable_in_cart": false,
+        "bundle_sold_individually_context": "",
+        "bundle_item_grouping": "",
+        "bundle_min_size": "",
+        "bundle_max_size": "",
+        "bundled_items": [],
+        "bundle_sell_ids": [],
+        "jetpack_publicize_connections": [],
+        "jetpack_sharing_enabled": true,
+        "jetpack_likes_enabled": true,
+        "brands": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products/204"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products"
+                }
+            ],
+            "up": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products/200"
+                }
+            ]
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommand.swift
@@ -145,9 +145,11 @@ public enum BottomSheetProductType: Hashable {
         case .grouped:
             self = .grouped
         case .subscription:
-            // We need to be aware of subscriptions for Payments
-            // but we don't handle them in the UI yet
+            // We do not yet support product editing or creation for subscriptions
             self = .custom("subscription")
+        case .variableSubscription:
+            // We do not yet support product editing or creation for variable subscriptions
+            self = .custom("variable-subscription")
         case .bundle:
             // We do not yet support product editing or creation for bundles
             self = .custom("bundle")

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductVariation.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductVariation.swift
@@ -40,6 +40,7 @@ final class MockProductVariation {
                                                               height: ""),
                                 shippingClass: "",
                                 shippingClassID: 0,
-                                menuOrder: 1)
+                                menuOrder: 1,
+                                subscription: nil)
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/ProductVariation+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductVariation+ReadOnlyConvertible.swift
@@ -104,7 +104,8 @@ extension Storage.ProductVariation: ReadOnlyConvertible {
                                 dimensions: productDimensions,
                                 shippingClass: shippingClass,
                                 shippingClassID: shippingClassID,
-                                menuOrder: menuOrder)
+                                menuOrder: menuOrder,
+                                subscription: nil) // TODO: Convert the subscription
     }
 }
 

--- a/Yosemite/YosemiteTests/Mocks/MockProductVariation.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockProductVariation.swift
@@ -47,7 +47,8 @@ final class MockProductVariation {
                                                               height: ""),
                                 shippingClass: "",
                                 shippingClassID: 0,
-                                menuOrder: 1)
+                                menuOrder: 1,
+                                subscription: nil)
 
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -1012,7 +1012,8 @@ private extension ProductVariationStoreTests {
                                                               height: ""),
                                 shippingClass: "",
                                 shippingClassID: 0,
-                                menuOrder: 8)
+                                menuOrder: 8,
+                                subscription: nil)
     }
 
     func sampleOrder(items: [Yosemite.OrderItem]) -> Yosemite.Order {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9392
⚠️ Depends on #9456; please review that PR first.
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support for variable subscription products in the Networking layer, based on the changes in #9456. The subscription data is included in the meta data for each variation of a variable subscription product.

### Changes

Most of the changes are the JSON mock file for a subscription variation, or adding the `subscription` property to related mocks.. 

Significant changes:

* Updates the `ProductVariation` model to include an optional `subscription` property with the variation's `ProductSubscription` data (extracted from its meta data). This will be `nil` for variations of non-subscription-type products.
* Adds the variable subscription type to the `ProductType` model.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Open the Products tab and confirm your full product list loads without any decoding errors.
3. Open a variable product, select Variations, and confirm the variations list loads without any decoding errors. (Note that variable subscription products do not yet include the Variations row in product details; you can check this with a regular variable product.)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
