### PR TITLE
[Free Trial] Render plan names correcly

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
@@ -120,9 +120,11 @@ private extension UpgradesViewModel {
             }
         }
 
-        // For non-free trials plans  remove any mention to WPCom.
-        let toRemove = "WordPress.com"
-        let sanitizedName = plan.name.replacingOccurrences(of: toRemove, with: "").trimmingCharacters(in: .whitespacesAndNewlines)
+        // For non-free trials plans  remove any mention to WPCom or Woo Express.
+        let toRemove = ["WordPress.com", "Woo Express:"]
+        let sanitizedName = toRemove.reduce(plan.name) { planName, prefixToRemove in
+            planName.replacingOccurrences(of: prefixToRemove, with: "").trimmingCharacters(in: .whitespacesAndNewlines)
+        }
 
         if daysLeft > 0 {
             return sanitizedName

--- a/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Upgrades/UpgradesViewModelTests.swift
@@ -105,6 +105,35 @@ final class UpgradesViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.errorNotice)
     }
 
+    func test_WooExpress_is_removed_from_plan_name() {
+        // Given
+        let expireDate = Date().addingDays(300)
+        let plan = WPComSitePlan(id: "another-id",
+                                 hasDomainCredit: false,
+                                 expiryDate: expireDate,
+                                 name: "Woo Express: Essential")
+
+        let session = SessionManager.testingInstance
+        let stores = MockStoresManager(sessionManager: session)
+        session.defaultSite = sampleSite
+        stores.whenReceivingAction(ofType: PaymentAction.self) { action in
+            switch action {
+            case .loadSiteCurrentPlan(_, let completion):
+                completion(.success(plan))
+            default:
+                break
+            }
+        }
+        let synchronizer = StorePlanSynchronizer(stores: stores)
+        let viewModel = UpgradesViewModel(stores: stores, storePlanSynchronizer: synchronizer)
+
+        // When
+        viewModel.loadPlan()
+
+        // Then
+        XCTAssertEqual(viewModel.planName, NSLocalizedString("Essential", comment: ""))
+    }
+
     func test_error_fetching_plan_has_correct_view_model_values() {
         // Given
         let session = SessionManager.testingInstance


### PR DESCRIPTION
Closes: #9446 

Previously plans were named "WordPress.com {something}" so we removed locally the "WordPress.com" prefix to only show the specific plan name to the user.

Now, plan names have been renamed to the following format: "Woo Express: {Something}".

This PR adds some code to remove the "Woo Express:" prefix to new plan names. The legacy "WordPress.com" is still in place to properly render already purchased plans under the previous name.

# Screenshot

Before | After
--- | ---
<img width="462" alt="before" src="https://user-images.githubusercontent.com/562080/232374236-cf359f9a-ce18-4b12-aa45-3587a38a3ff5.png"> |  <img width="462" alt="after" src="https://user-images.githubusercontent.com/562080/232374240-9f2b5caa-e752-4a39-b425-90bb5705c4c8.png">

# Testing Steps

- Open the app with a store with a WPCom purchased plan.
- Go to Hub -> Upgrades
- See that there are no mentions of "Woo Express" or "WordPress.com" in the plan name.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
