### PR TITLE
[Free Trial] Add Plan Name Badge

### DIFF
--- a/WooCommerce/Classes/Model/WPComPlanNameSanitizer.swift
+++ b/WooCommerce/Classes/Model/WPComPlanNameSanitizer.swift
@@ -1,0 +1,31 @@
+import Foundation
+import struct Yosemite.WPComSitePlan
+
+/// Type to help sanitize and format a WPCom site plan name.
+///
+struct WPComPlanNameSanitizer {
+    /// Removes any occurrences of `WordPress.com` and `Woo Express:` from the site's name.
+    /// Free Trial's sites have an special handling!
+    ///
+    static func getPlanName(from plan: WPComSitePlan) -> String {
+        // Handle the "Free trial" case specially.
+        if plan.isFreeTrial {
+            return Localization.freeTrial
+        }
+
+        // For non-free trials plans remove any mention to WPCom or Woo Express.
+        let toRemove = ["WordPress.com", "Woo Express:"]
+        let sanitizedName = toRemove.reduce(plan.name) { planName, prefixToRemove in
+            planName.replacingOccurrences(of: prefixToRemove, with: "").trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return sanitizedName
+    }
+}
+
+// MARK: Constants
+private extension WPComPlanNameSanitizer {
+    enum Localization {
+        static let freeTrial = NSLocalizedString("Free Trial", comment: "Plan name for an active free trial")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -261,7 +261,7 @@ private extension HubMenu {
                             .accessibilityIdentifier(titleAccessibilityID ?? "")
 
                         if let badge, badge.isNotEmpty {
-                            BadgeView(text: badge) // TODO: Adjust for dark mode
+                            BadgeView(text: badge)
                         }
                     }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -34,7 +34,7 @@ struct HubMenu: View {
                     }
                 } label: {
                     Row(title: viewModel.storeTitle,
-                        badge: "FREE TRIAL",
+                        badge: viewModel.planName,
                         description: viewModel.storeURL.host ?? viewModel.storeURL.absoluteString,
                         icon: .remote(viewModel.avatarURL),
                         chevron: .down,
@@ -260,8 +260,8 @@ private extension HubMenu {
                             .headlineStyle()
                             .accessibilityIdentifier(titleAccessibilityID ?? "")
 
-                        if let badge {
-                            BadgeView(text: badge)
+                        if let badge, badge.isNotEmpty {
+                            BadgeView(text: badge) // TODO: Adjust for dark mode
                         }
                     }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -34,6 +34,7 @@ struct HubMenu: View {
                     }
                 } label: {
                     Row(title: viewModel.storeTitle,
+                        badge: "FREE TRIAL",
                         description: viewModel.storeURL.host ?? viewModel.storeURL.absoluteString,
                         icon: .remote(viewModel.avatarURL),
                         chevron: .down,
@@ -51,6 +52,7 @@ struct HubMenu: View {
                         handleTap(menu: menu)
                     } label: {
                         Row(title: menu.title,
+                            badge: nil,
                             description: menu.description,
                             icon: .local(menu.icon),
                             chevron: .leading)
@@ -67,6 +69,7 @@ struct HubMenu: View {
                         handleTap(menu: menu)
                     } label: {
                         Row(title: menu.title,
+                            badge: nil,
                             description: menu.description,
                             icon: .local(menu.icon),
                             chevron: .leading)
@@ -193,6 +196,10 @@ private extension HubMenu {
         ///
         let title: String
 
+        /// Optional badge text. Render next to `title`
+        ///
+        let badge: String?
+
         /// Row Description
         ///
         let description: String
@@ -208,6 +215,8 @@ private extension HubMenu {
         var titleAccessibilityID: String?
         var descriptionAccessibilityID: String?
         var chevronAccessibilityID: String?
+
+        @Environment(\.sizeCategory) private var sizeCategory
 
         var body: some View {
             HStack(spacing: HubMenu.Constants.padding) {
@@ -245,9 +254,16 @@ private extension HubMenu {
 
                 // Title & Description
                 VStack(alignment: .leading, spacing: HubMenu.Constants.topBarSpacing) {
-                    Text(title)
-                        .headlineStyle()
-                        .accessibilityIdentifier(titleAccessibilityID ?? "")
+
+                    AdaptiveStack(horizontalAlignment: .leading, spacing: Constants.badgeSpacing(sizeCategory: sizeCategory)) {
+                        Text(title)
+                            .headlineStyle()
+                            .accessibilityIdentifier(titleAccessibilityID ?? "")
+
+                        if let badge {
+                            BadgeView(text: badge)
+                        }
+                    }
 
                     Text(description)
                         .subheadlineStyle()
@@ -278,6 +294,12 @@ private extension HubMenu {
         static let chevronSize: CGFloat = 20
         static let iconSize: CGFloat = 20
         static let trackingOptionKey = "option"
+
+        /// Spacing for the badge view in the avatar row.
+        ///
+        static func badgeSpacing(sizeCategory: ContentSizeCategory) -> CGFloat {
+            sizeCategory.isAccessibilityCategory ? .zero : 4
+        }
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -204,7 +204,7 @@ final class HubMenuViewModel: ObservableObject {
         ServiceLocator.storePlanSynchronizer.$planState.map { planState in
             switch planState {
             case .loaded(let plan):
-                return plan.name.capitalized
+                return WPComPlanNameSanitizer.getPlanName(from: plan).uppercased()
             default:
                 return ""
             }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -31,6 +31,8 @@ final class HubMenuViewModel: ObservableObject {
 
     @Published private(set) var storeTitle = Localization.myStore
 
+    @Published private(set) var planName = ""
+
     @Published private(set) var storeURL = WooConstants.URLs.blog.asURL()
 
     @Published private(set) var woocommerceAdminURL = WooConstants.URLs.blog.asURL()
@@ -71,6 +73,7 @@ final class HubMenuViewModel: ObservableObject {
         self.generalAppSettings = generalAppSettings
         self.switchStoreEnabled = stores.isAuthenticatedWithoutWPCom == false
         observeSiteForUIUpdates()
+        observePlanName()
     }
 
     func viewDidAppear() {
@@ -193,6 +196,20 @@ final class HubMenuViewModel: ObservableObject {
                 return true
             }
             .assign(to: &$shouldAuthenticateAdminPage)
+    }
+
+    /// Observe the current site's plan name and assign it to the `planName` published property.
+    ///
+    private func observePlanName() {
+        ServiceLocator.storePlanSynchronizer.$planState.map { planState in
+            switch planState {
+            case .loaded(let plan):
+                return plan.name.capitalized
+            default:
+                return ""
+            }
+        }
+        .assign(to: &$planName)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
@@ -27,14 +27,15 @@ struct BadgeView: View {
 
     var body: some View {
         Text(text)
+            .bold()
             .foregroundColor(Color(.textBrand))
+            .captionStyle()
             .padding(.leading, Layout.horizontalPadding)
             .padding(.trailing, Layout.horizontalPadding)
             .padding(.top, Layout.verticalPadding)
             .padding(.bottom, Layout.verticalPadding)
             .background(RoundedRectangle(cornerRadius: Layout.cornerRadius)
                 .fill(Color(.withColorStudio(.wooCommercePurple, shade: .shade0))))
-            .font(.system(size: 12, weight: .bold))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
@@ -35,7 +35,8 @@ struct BadgeView: View {
             .padding(.top, Layout.verticalPadding)
             .padding(.bottom, Layout.verticalPadding)
             .background(RoundedRectangle(cornerRadius: Layout.cornerRadius)
-                .fill(Color(.withColorStudio(.wooCommercePurple, shade: .shade0))))
+                .fill(Color(.wooCommercePurple(.shade0)))
+            )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesViewModel.swift
@@ -110,22 +110,12 @@ private extension UpgradesViewModel {
     /// Free Trial's have an special handling!
     ///
     static func getPlanName(from plan: WPComSitePlan) -> String {
-        // Handle the "Free trial" case specially.
         let daysLeft = daysLeft(for: plan)
-        if plan.isFreeTrial {
-            if daysLeft > 0 {
-                return Localization.freeTrial
-            } else {
-                return Localization.trialEnded
-            }
+        if plan.isFreeTrial, daysLeft <= 0 {
+            return Localization.trialEnded
         }
 
-        // For non-free trials plans  remove any mention to WPCom or Woo Express.
-        let toRemove = ["WordPress.com", "Woo Express:"]
-        let sanitizedName = toRemove.reduce(plan.name) { planName, prefixToRemove in
-            planName.replacingOccurrences(of: prefixToRemove, with: "").trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-
+        let sanitizedName = WPComPlanNameSanitizer.getPlanName(from: plan)
         if daysLeft > 0 {
             return sanitizedName
         } else {
@@ -204,7 +194,6 @@ private extension UpgradesViewModel {
 // MARK: Definitions
 private extension UpgradesViewModel {
     enum Localization {
-        static let freeTrial = NSLocalizedString("Free Trial", comment: "Plan name for an active free trial")
         static let trialEnded = NSLocalizedString("Trial ended", comment: "Plan name for an expired free trial")
         static let trialEndedInfo = NSLocalizedString("Your free trial has ended and you have limited access to all the features. " +
                                                       "Subscribe to Woo Express Performance Plan now.",

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -663,6 +663,7 @@
 		262EB5B3298D66FE009DCC36 /* SupportDataSourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262EB5B2298D66FE009DCC36 /* SupportDataSourcesTests.swift */; };
 		26309F17277D0AEA0012797F /* SafeAreaInsetsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26309F16277D0AEA0012797F /* SafeAreaInsetsKey.swift */; };
 		2631D4F829ED0B5C00F13F20 /* WPComPlanNameSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2631D4F729ED0B5C00F13F20 /* WPComPlanNameSanitizer.swift */; };
+		2631D4FA29ED108400F13F20 /* WPComPlanNameSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2631D4F929ED108400F13F20 /* WPComPlanNameSanitizer.swift */; };
 		263491D5299C923400594566 /* SupportFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263491D4299C923300594566 /* SupportFormViewModelTests.swift */; };
 		263C4CC02963784900CA7E05 /* ProductVariationGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */; };
 		263E37E12641AD8300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; };
@@ -2883,6 +2884,7 @@
 		262EB5B2298D66FE009DCC36 /* SupportDataSourcesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataSourcesTests.swift; sourceTree = "<group>"; };
 		26309F16277D0AEA0012797F /* SafeAreaInsetsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeAreaInsetsKey.swift; sourceTree = "<group>"; };
 		2631D4F729ED0B5C00F13F20 /* WPComPlanNameSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPlanNameSanitizer.swift; sourceTree = "<group>"; };
+		2631D4F929ED108400F13F20 /* WPComPlanNameSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPlanNameSanitizer.swift; sourceTree = "<group>"; };
 		263491D4299C923300594566 /* SupportFormViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportFormViewModelTests.swift; sourceTree = "<group>"; };
 		263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationGenerator.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
@@ -8116,6 +8118,7 @@
 				DE001322279A793A00EB0350 /* CouponWooTests.swift */,
 				E1068057285C787100668B46 /* BetaFeaturesTests.swift */,
 				EE0EE7A728B74EF300F6061E /* CustomHelpCenterContentTests.swift */,
+				2631D4F929ED108400F13F20 /* WPComPlanNameSanitizer.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -12343,6 +12346,7 @@
 				023EC2E424DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift in Sources */,
 				CCB366AF274518EC007D437A /* EditableOrderViewModelTests.swift in Sources */,
 				020BE76B23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift in Sources */,
+				2631D4FA29ED108400F13F20 /* WPComPlanNameSanitizer.swift in Sources */,
 				D83F5937225B402E00626E75 /* TitleAndEditableValueTableViewCellTests.swift in Sources */,
 				773077F3251E954300178696 /* ProductDownloadFileViewModelTests.swift in Sources */,
 				2602A64A27BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -662,6 +662,7 @@
 		262EB5B0298C7C3A009DCC36 /* SupportFormsDataSources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262EB5AF298C7C3A009DCC36 /* SupportFormsDataSources.swift */; };
 		262EB5B3298D66FE009DCC36 /* SupportDataSourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262EB5B2298D66FE009DCC36 /* SupportDataSourcesTests.swift */; };
 		26309F17277D0AEA0012797F /* SafeAreaInsetsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26309F16277D0AEA0012797F /* SafeAreaInsetsKey.swift */; };
+		2631D4F829ED0B5C00F13F20 /* WPComPlanNameSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2631D4F729ED0B5C00F13F20 /* WPComPlanNameSanitizer.swift */; };
 		263491D5299C923400594566 /* SupportFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263491D4299C923300594566 /* SupportFormViewModelTests.swift */; };
 		263C4CC02963784900CA7E05 /* ProductVariationGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */; };
 		263E37E12641AD8300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; };
@@ -2881,6 +2882,7 @@
 		262EB5AF298C7C3A009DCC36 /* SupportFormsDataSources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportFormsDataSources.swift; sourceTree = "<group>"; };
 		262EB5B2298D66FE009DCC36 /* SupportDataSourcesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataSourcesTests.swift; sourceTree = "<group>"; };
 		26309F16277D0AEA0012797F /* SafeAreaInsetsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeAreaInsetsKey.swift; sourceTree = "<group>"; };
+		2631D4F729ED0B5C00F13F20 /* WPComPlanNameSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPlanNameSanitizer.swift; sourceTree = "<group>"; };
 		263491D4299C923300594566 /* SupportFormViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportFormViewModelTests.swift; sourceTree = "<group>"; };
 		263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationGenerator.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryTests.swift; sourceTree = "<group>"; };
@@ -7894,6 +7896,7 @@
 				E1E649E82846188C0070B194 /* BetaFeature.swift */,
 				EE0EE7A528B7415200F6061E /* CustomHelpCenterContent.swift */,
 				26C98F9729C1246F00F96503 /* WPComSitePlan+FreeTrial.swift */,
+				2631D4F729ED0B5C00F13F20 /* WPComPlanNameSanitizer.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -11572,6 +11575,7 @@
 				D8752EF7265E60F4008ACC80 /* PaymentCaptureCelebration.swift in Sources */,
 				EE6B2AD129DC522300048A8F /* StoreCreationProgressView.swift in Sources */,
 				B58B4AB62108F11C00076FDD /* Notice.swift in Sources */,
+				2631D4F829ED0B5C00F13F20 /* WPComPlanNameSanitizer.swift in Sources */,
 				CE4296B920A5E9E400B2AFBD /* CNContact+Helpers.swift in Sources */,
 				0211252825773F220075AD2A /* Models+Copiable.generated.swift in Sources */,
 				4596853F2540669900D17B90 /* DownloadableFileSource.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Model/WPComPlanNameSanitizer.swift
+++ b/WooCommerce/WooCommerceTests/Model/WPComPlanNameSanitizer.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class WPComPlanNameSanitizerTests: XCTestCase {
+
+    func test_free_trial_plan_is_sanitized() {
+        // Given
+        let freeTrialID = "1052"
+        let plan = WPComSitePlan(id: freeTrialID, hasDomainCredit: false, expiryDate: Date())
+
+        // When
+        let sanitized = WPComPlanNameSanitizer.getPlanName(from: plan)
+
+        XCTAssertEqual(sanitized, NSLocalizedString("Free Trial", comment: ""))
+    }
+
+    func test_wpcom_plan_is_sanitized() {
+        // Given
+        let plan = WPComSitePlan(id: "123", hasDomainCredit: false, name: "WordPress.com Business")
+
+        // When
+        let sanitized = WPComPlanNameSanitizer.getPlanName(from: plan)
+
+        XCTAssertEqual(sanitized, NSLocalizedString("Business", comment: ""))
+    }
+
+    func test_wooExpress_plan_is_sanitized() {
+        // Given
+        let plan = WPComSitePlan(id: "123", hasDomainCredit: false, name: "Woo Express: Performance")
+
+        // When
+        let sanitized = WPComPlanNameSanitizer.getPlanName(from: plan)
+
+        XCTAssertEqual(sanitized, NSLocalizedString("Performance", comment: ""))
+    }
+
+    func test_any_other_plan_is_not_sanitized() {
+        // Given
+        let plan = WPComSitePlan(id: "123", hasDomainCredit: false, name: "Plus")
+
+        // When
+        let sanitized = WPComPlanNameSanitizer.getPlanName(from: plan)
+
+        XCTAssertEqual(sanitized, NSLocalizedString("Plus", comment: ""))
+    }
+}


### PR DESCRIPTION
Closes: #9436 

# Why

This PR adds a the plan name badge next to the store name in the Hub Menu.

# How

- Extract plan name sanitizer logic from the `UpgradesViewModel` into a new `WPComPlanNameSanitizer` type

- Update `HubMenuViewModel` to observe the store plan name from the `StorePlanSynchronizer`

- Update `BadgeView` to support dynamic fonts and correct dark colors.

- Update `HubMenu` to render the plan name badge when required.

# Screenshots

 Free Trial | Big Font
---- | ----
<img width="438" alt="free" src="https://user-images.githubusercontent.com/562080/232393573-ac4e792d-e48b-4e52-a034-78719d25ab3a.png"> | <img width="438" alt="free-big-font" src="https://user-images.githubusercontent.com/562080/232393575-6d60a5bf-75e3-4519-891c-4a8b0b680e1c.png">
Plan | Dark 
<img width="440" alt="wp-plan" src="https://user-images.githubusercontent.com/562080/232393577-1d288782-a2a9-4d66-94f1-01bbe05d434c.png"> | <img width="448" alt="dark" src="https://user-images.githubusercontent.com/562080/232393576-0087918d-3fcf-4aa4-8a06-48a8217e4f1a.png">


 # Testing

- Launch the app with a Free Trial Store
- Go to the Hub
- See the Free trial Badge next to the name

----

- Launch the app with a WPCom plan store
- Go to the Hub
- See the plan name Badge next to the name

----

- Launch  the app with a non-wp store
- Go to the Hub
- See the **NO** Badge next to the name



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
