### PR TITLE
[UI Tests] - Add contact support UI test

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Login/HelpScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/HelpScreen.swift
@@ -3,6 +3,11 @@ import XCTest
 
 public final class HelpScreen: ScreenObject {
 
+    // "Help" screen elements
+    private let helpNavigationBarGetter: (XCUIApplication) -> XCUIElement = {
+        $0.navigationBars["Help"]
+    }
+
     private let contactSupportButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.staticTexts["Contact Support"]
     }
@@ -11,37 +16,37 @@ public final class HelpScreen: ScreenObject {
         $0.textFields["Email"]
     }
 
-    private let helpListFirstOptionGetter: (XCUIApplication) -> XCUIElement = {
-        $0.scrollViews.element.staticTexts.element(boundBy: 1)
-    }
-
-    private let helpNavigationBarGetter: (XCUIApplication) -> XCUIElement = {
-        $0.navigationBars["Help"]
-    }
-
-    private let messageTextFieldGetter: (XCUIApplication) -> XCUIElement = {
-        $0.scrollViews.element.textViews.element(boundBy: 0)
-    }
-
     private let okButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["OK"]
+    }
+
+    // "Contact Support" screen elements
+    private let helpListFirstOptionGetter: (XCUIApplication) -> XCUIElement = {
+        $0.scrollViews.element.staticTexts.element(boundBy: 1)
     }
 
     private let subjectTextFieldGetter: (XCUIApplication) -> XCUIElement = {
         $0.scrollViews.element.textFields.element(boundBy: 0)
     }
 
+    private let messageTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.scrollViews.element.textViews.element(boundBy: 0)
+    }
+
     private let submitButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Submit Support Request"]
     }
 
+    // "Help" screen elements
+    private var helpNavigationBar: XCUIElement { helpNavigationBarGetter(app) }
     private var contactSupportButton: XCUIElement { contactSupportButtonGetter(app) }
     private var emailTextField: XCUIElement { emailTextFieldGetter(app) }
-    private var helpListFirstOption: XCUIElement { helpListFirstOptionGetter(app) }
-    private var helpNavigationBar: XCUIElement { helpNavigationBarGetter(app) }
-    private var messageTextField: XCUIElement { messageTextFieldGetter(app) }
     private var okButton: XCUIElement { okButtonGetter(app) }
+
+    // "Contact Support" screen elements
+    private var helpListFirstOption: XCUIElement { helpListFirstOptionGetter(app) }
     private var subjectTextField: XCUIElement { subjectTextFieldGetter(app) }
+    private var messageTextField: XCUIElement { messageTextFieldGetter(app) }
     private var submitButton: XCUIElement { submitButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {

--- a/WooCommerce/UITestsFoundation/Screens/Login/HelpScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/HelpScreen.swift
@@ -74,6 +74,7 @@ public final class HelpScreen: ScreenObject {
 
     public func verifySubmitButtonDisabled() throws -> Self {
         XCTAssertTrue(!submitButton.isEnabled)
+
         return self
     }
 

--- a/WooCommerce/UITestsFoundation/Screens/Login/HelpScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/HelpScreen.swift
@@ -1,0 +1,83 @@
+import ScreenObject
+import XCTest
+
+public final class HelpScreen: ScreenObject {
+
+    private let contactSupportButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["Contact Support"]
+    }
+
+    private let emailTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["Email"]
+    }
+
+    private let helpListFirstOptionGetter: (XCUIApplication) -> XCUIElement = {
+        $0.scrollViews.element.staticTexts.element(boundBy: 1)
+    }
+
+    private let helpNavigationBarGetter: (XCUIApplication) -> XCUIElement = {
+        $0.navigationBars["Help"]
+    }
+
+    private let messageTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.scrollViews.element.textViews.element(boundBy: 0)
+    }
+
+    private let okButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["OK"]
+    }
+
+    private let subjectTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.scrollViews.element.textFields.element(boundBy: 0)
+    }
+
+    private let submitButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Submit Support Request"]
+    }
+
+    private var contactSupportButton: XCUIElement { contactSupportButtonGetter(app) }
+    private var emailTextField: XCUIElement { emailTextFieldGetter(app) }
+    private var helpListFirstOption: XCUIElement { helpListFirstOptionGetter(app) }
+    private var helpNavigationBar: XCUIElement { helpNavigationBarGetter(app) }
+    private var messageTextField: XCUIElement { messageTextFieldGetter(app) }
+    private var okButton: XCUIElement { okButtonGetter(app) }
+    private var subjectTextField: XCUIElement { subjectTextFieldGetter(app) }
+    private var submitButton: XCUIElement { submitButtonGetter(app) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetter: helpNavigationBarGetter,
+            app: app
+        )
+    }
+
+    public func tapContactSupport() throws -> Self {
+        contactSupportButton.tap()
+
+        return self
+    }
+
+    public func addEmail(email: String) throws -> Self {
+        emailTextField.enterText(text: email)
+        okButton.tap()
+
+        return self
+    }
+
+    public func addSupportContent(subject: String, message: String) throws -> Self {
+        helpListFirstOption.tap()
+        subjectTextField.enterText(text: subject)
+        messageTextField.enterText(text: message)
+
+        return self
+    }
+
+    public func verifySubmitButtonDisabled() throws -> Self {
+        XCTAssertTrue(!submitButton.isEnabled)
+        return self
+    }
+
+    public func verifySubmitButtonEnabled() throws {
+        XCTAssertTrue(submitButton.isEnabled)
+    }
+}

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
@@ -10,9 +10,14 @@ public final class LoginSiteAddressScreen: ScreenObject {
     private let siteAddressFieldGetter: (XCUIApplication) -> XCUIElement = {
         $0.textFields["Site address"]
     }
+    
+    private let helpButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["authenticator-help-button"]
+    }
 
     private var nextButton: XCUIElement { nextButtonGetter(app) }
     private var siteAddressField: XCUIElement { siteAddressFieldGetter(app) }
+    private var helpButton: XCUIElement { helpButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -29,5 +34,11 @@ public final class LoginSiteAddressScreen: ScreenObject {
         nextButton.tap()
 
         return try GetStartedScreen()
+    }
+
+    public func tapHelpButton() throws -> HelpScreen {
+        helpButton.tap()
+
+        return try HelpScreen()
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
@@ -10,7 +10,7 @@ public final class LoginSiteAddressScreen: ScreenObject {
     private let siteAddressFieldGetter: (XCUIApplication) -> XCUIElement = {
         $0.textFields["Site address"]
     }
-    
+
     private let helpButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["authenticator-help-button"]
     }

--- a/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PrologueScreen.swift
@@ -11,12 +11,12 @@ public final class PrologueScreen: ScreenObject {
         $0.buttons["Prologue Continue Button"]
     }
 
-    private let selectSiteButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let logInButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Prologue Self Hosted Button"]
     }
 
     private var continueButton: XCUIElement { continueButtonGetter(app) }
-    private var selectSiteButton: XCUIElement { selectSiteButtonGetter(app) }
+    private var logInButton: XCUIElement { logInButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -34,8 +34,8 @@ public final class PrologueScreen: ScreenObject {
         return try GetStartedScreen()
     }
 
-    public func tapSiteAddress() throws -> LoginSiteAddressScreen {
-        selectSiteButton.tap()
+    public func tapLogIn() throws -> LoginSiteAddressScreen {
+        logInButton.tap()
         return try LoginSiteAddressScreen()
     }
 
@@ -46,7 +46,7 @@ public final class PrologueScreen: ScreenObject {
     }
 
     public func isSiteAddressLoginAvailable() throws -> Bool {
-        selectSiteButton.waitForExistence(timeout: 1)
+        logInButton.waitForExistence(timeout: 1)
     }
 
     public func isWPComLoginAvailable() throws -> Bool {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1271,6 +1271,9 @@
 		80C3627127745737005CEAD3 /* ReviewDataStructs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C3627027745737005CEAD3 /* ReviewDataStructs.swift */; };
 		80C362732779A7EF005CEAD3 /* products_reviews_all.json in Resources */ = {isa = PBXBuildFile; fileRef = 80C362722779A7EF005CEAD3 /* products_reviews_all.json */; };
 		80C5D4E129E90DAC00352EC7 /* UniversalLinksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C5D4E029E90DAC00352EC7 /* UniversalLinksTests.swift */; };
+		80C5D4E329ECFFE400352EC7 /* SupportsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C5D4E229ECFFE400352EC7 /* SupportsTests.swift */; };
+		80C5D4E529ED003B00352EC7 /* HelpScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C5D4E429ED003B00352EC7 /* HelpScreen.swift */; };
+		80C5D4E729ED0C5E00352EC7 /* TestStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C5D4E629ED0C5E00352EC7 /* TestStrings.swift */; };
 		80CA638929C05E7B002E6BE6 /* PaymentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CA638829C05E7B002E6BE6 /* PaymentsTests.swift */; };
 		80CA638C29C06029002E6BE6 /* PaymentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CA638B29C06029002E6BE6 /* PaymentsScreen.swift */; };
 		80CC80E829DEA3C700CA1687 /* ExternalAppScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */; };
@@ -3468,6 +3471,9 @@
 		80C3627027745737005CEAD3 /* ReviewDataStructs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDataStructs.swift; sourceTree = "<group>"; };
 		80C362722779A7EF005CEAD3 /* products_reviews_all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = products_reviews_all.json; sourceTree = "<group>"; };
 		80C5D4E029E90DAC00352EC7 /* UniversalLinksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalLinksTests.swift; sourceTree = "<group>"; };
+		80C5D4E229ECFFE400352EC7 /* SupportsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportsTests.swift; sourceTree = "<group>"; };
+		80C5D4E429ED003B00352EC7 /* HelpScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpScreen.swift; sourceTree = "<group>"; };
+		80C5D4E629ED0C5E00352EC7 /* TestStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStrings.swift; sourceTree = "<group>"; };
 		80CA638829C05E7B002E6BE6 /* PaymentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsTests.swift; sourceTree = "<group>"; };
 		80CA638B29C06029002E6BE6 /* PaymentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsScreen.swift; sourceTree = "<group>"; };
 		80CC80E629DE74D400CA1687 /* ExternalAppScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalAppScreen.swift; sourceTree = "<group>"; };
@@ -8420,6 +8426,7 @@
 			isa = PBXGroup;
 			children = (
 				CCDC49EC24000533003166BA /* TestCredentials.swift */,
+				80C5D4E629ED0C5E00352EC7 /* TestStrings.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -8434,6 +8441,7 @@
 				80AD2CA327858BAB00A63DE8 /* StatsTests.swift */,
 				80CA638829C05E7B002E6BE6 /* PaymentsTests.swift */,
 				80C5D4E029E90DAC00352EC7 /* UniversalLinksTests.swift */,
+				80C5D4E229ECFFE400352EC7 /* SupportsTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -9969,6 +9977,7 @@
 				D8F3A9782588659E0085859B /* GetStartedScreen.swift */,
 				D8F3A97E258865BD0085859B /* PasswordScreen.swift */,
 				02DEA23228810B7A0057FC40 /* LoginOnboardingScreen.swift */,
+				80C5D4E429ED003B00352EC7 /* HelpScreen.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -10815,6 +10824,7 @@
 				80D9300329C8660C008865D8 /* CardReaderManualsScreen.swift in Sources */,
 				80ECB4E229D2A51A00C62EEC /* ProductFilterScreen.swift in Sources */,
 				3F0CF3112704490A00EF3D71 /* ProductsScreen.swift in Sources */,
+				80C5D4E529ED003B00352EC7 /* HelpScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12567,8 +12577,10 @@
 				80C5D4E129E90DAC00352EC7 /* UniversalLinksTests.swift in Sources */,
 				80089F182949B92D0078C671 /* ProductFlow.swift in Sources */,
 				800A5B58275483D6009DE2CD /* OrdersTests.swift in Sources */,
+				80C5D4E729ED0C5E00352EC7 /* TestStrings.swift in Sources */,
 				80AD2CA427858BAB00A63DE8 /* StatsTests.swift in Sources */,
 				800A5BCB2759CE4B009DE2CD /* ProductsTests.swift in Sources */,
+				80C5D4E329ECFFE400352EC7 /* SupportsTests.swift in Sources */,
 				800A5B9E275623FC009DE2CD /* LoginFlow.swift in Sources */,
 				80CC810B29E6800F00CA1687 /* products_add_new_grouped_2130.json in Sources */,
 			);

--- a/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/LoginFlow.swift
@@ -26,7 +26,7 @@ class LoginFlow {
     @discardableResult
     static func logInWithSiteAddress() throws -> MyStoreScreen {
         try PrologueScreen()
-            .tapSiteAddress()
+            .tapLogIn()
             .proceedWith(siteUrl: TestCredentials.siteUrl)
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)

--- a/WooCommerce/WooCommerceUITests/README.md
+++ b/WooCommerce/WooCommerceUITests/README.md
@@ -67,7 +67,7 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
     - [x] Universal Link to Payments screen
     - [x] Universal Link to an Order
 8. Settings
-    - [ ] Contact support
+    - [x] Contact support
 9. Payments
     - [ ] Make a Simple payment
     - [ ] Make a Tap to Pay on iPhone payment

--- a/WooCommerce/WooCommerceUITests/README.md
+++ b/WooCommerce/WooCommerceUITests/README.md
@@ -67,7 +67,8 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
     - [x] Universal Link to Payments screen
     - [x] Universal Link to an Order
 8. Settings
-    - [x] Contact support
+    - [x] Contact support - Validate buttons and text fields
+    - [ ] Contact support - Submit support ticket
 9. Payments
     - [ ] Make a Simple payment
     - [ ] Make a Tap to Pay on iPhone payment

--- a/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/LoginTests.swift
@@ -17,7 +17,7 @@ final class LoginTests: XCTestCase {
             return
         }
         try PrologueScreen()
-            .tapSiteAddress()
+            .tapLogIn()
             .proceedWith(siteUrl: TestCredentials.siteUrl)
             .proceedWith(email: TestCredentials.emailAddress)
             .proceedWith(password: TestCredentials.password)

--- a/WooCommerce/WooCommerceUITests/Tests/SupportsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/SupportsTests.swift
@@ -1,0 +1,23 @@
+import UITestsFoundation
+import XCTest
+
+final class SupportTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        app.launchArguments = ["logout-at-launch", "disable-animations", "mocked-wpcom-api", "-ui_testing"]
+        app.launch()
+    }
+
+    // Test ends before tapping the submit button so it doesn't get sent to zendesk
+    func test_load_support_screen() throws {
+        try PrologueScreen().tapLogIn()
+            .tapHelpButton()
+            .tapContactSupport()
+            .addEmail(email: TestCredentials.emailAddress)
+            .verifySubmitButtonDisabled()
+            .addSupportContent(subject: TestStrings.supportSubject, message: TestStrings.supportMessage)
+            .verifySubmitButtonEnabled()
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Utils/TestStrings.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/TestStrings.swift
@@ -1,4 +1,4 @@
-// String used for tests
+// Strings used for tests
 struct TestStrings {
     static let supportSubject: String = "Subject 123~"
     static let supportMessage: String = "Support Message 123 ~!@#$%^&*() مرحبًا 你好 привіт olá"

--- a/WooCommerce/WooCommerceUITests/Utils/TestStrings.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/TestStrings.swift
@@ -1,0 +1,5 @@
+// String used for tests
+struct TestStrings {
+    static let supportSubject: String = "Subject 123~"
+    static let supportMessage: String = "Support Message 123 ~!@#$%^&*() مرحبًا 你好 привіт olá"
+}


### PR DESCRIPTION
## Description
This PR adds a new contact support UI test into the test suite. This test, however, ends before the submit button is clicked so that this doesn't become noise in Zendesk. Right now the test would validate that the text fields can be entered and the verification point is the state of the button. When the text field and area are empty, the `submit` button is disabled, it will be enabled when the fields are no longer empty.

I've also made a naming update of `selectSiteButton` to `logInButton`. After a recent design change, the button is now called `Log In` instead of `Select Site`. The accessibility identifier is not changed so this is only a naming update so that when the new test taps on the `Log In` button to access the help screen, the step is clearer.

## Testing instructions
The new test `test_load_support_screen` should pass/fail as expected.

