### PR TITLE
[Subscriptions] Add support for simple and variable subscriptions in Yosemite layer

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1083,6 +1083,21 @@ extension ProductStockStatus {
         .inStock
     }
 }
+extension Networking.ProductSubscription {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.ProductSubscription {
+        .init(
+            length: .fake(),
+            period: .fake(),
+            periodInterval: .fake(),
+            price: .fake(),
+            signUpFee: .fake(),
+            trialLength: .fake(),
+            trialPeriod: .fake()
+        )
+    }
+}
 extension Networking.ProductTag {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -1771,6 +1786,13 @@ extension Networking.StoredProductSettings {
         .init(
             settings: .fake()
         )
+    }
+}
+extension SubscriptionPeriod {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> SubscriptionPeriod {
+        .day
     }
 }
 extension Networking.SystemPlugin {

--- a/Networking/Networking/Model/Product/ProductSubscription.swift
+++ b/Networking/Networking/Model/Product/ProductSubscription.swift
@@ -1,7 +1,8 @@
 import Foundation
+import Codegen
 
 /// Represents the subscription settings extracted from product meta data for a Subscription-type Product.
-public struct ProductSubscription: Decodable, Equatable {
+public struct ProductSubscription: Decodable, Equatable, GeneratedFakeable {
     /// Subscription automatically expires after this number of subscription periods.
     ///
     /// For example, subscription with period of `month` and length of "2" expires after 2 months. Subscription with length of "0" never expires.
@@ -58,7 +59,7 @@ private extension ProductSubscription {
 
 /// Represents all possible subscription periods
 ///
-public enum SubscriptionPeriod: String, Codable {
+public enum SubscriptionPeriod: String, Codable, GeneratedFakeable {
     case day
     case week
     case month

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 		B9AECD462851DBED00E78584 /* Order+CurrencyFormattedValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AECD452851DBED00E78584 /* Order+CurrencyFormattedValues.swift */; };
 		B9AECD482851F28E00E78584 /* Order+CardPresentPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9AECD472851F28E00E78584 /* Order+CardPresentPaymentTests.swift */; };
 		BAB3737927964A9500837B4A /* OrderTaxLine+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB3737827964A9500837B4A /* OrderTaxLine+ReadOnlyConvertible.swift */; };
+		CC24A4F129ED4CEB0009D6DA /* ProductSubscription+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC24A4F029ED4CEB0009D6DA /* ProductSubscription+ReadOnlyConvertible.swift */; };
 		CC2C036C262F316600928C9C /* ShippingLabelAccountSettings+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2C036B262F316600928C9C /* ShippingLabelAccountSettings+ReadOnlyConvertible.swift */; };
 		CC2C0372262F32D800928C9C /* ShippingLabelPaymentMethod+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2C0371262F32D800928C9C /* ShippingLabelPaymentMethod+ReadonlyConvertible.swift */; };
 		CC379B1429C8B593009747B4 /* ProductCompositeComponent+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC379B1329C8B593009747B4 /* ProductCompositeComponent+ReadOnlyConvertible.swift */; };
@@ -780,6 +781,7 @@
 		B9AECD472851F28E00E78584 /* Order+CardPresentPaymentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Order+CardPresentPaymentTests.swift"; sourceTree = "<group>"; };
 		BAB3737827964A9500837B4A /* OrderTaxLine+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderTaxLine+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Yosemite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CC24A4F029ED4CEB0009D6DA /* ProductSubscription+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductSubscription+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CC2C036B262F316600928C9C /* ShippingLabelAccountSettings+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelAccountSettings+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CC2C0371262F32D800928C9C /* ShippingLabelPaymentMethod+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLabelPaymentMethod+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
 		CC379B1329C8B593009747B4 /* ProductCompositeComponent+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductCompositeComponent+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1311,6 +1313,7 @@
 				CE43A90122A072D800A4FF29 /* ProductDownload+ReadOnlyConvertible.swift */,
 				7493750D224988DE007D85D1 /* ProductImage+ReadOnlyConvertible.swift */,
 				D831E2E5230E7149000037D0 /* ProductReview+ReadOnlyConvertible.swift */,
+				CC24A4F029ED4CEB0009D6DA /* ProductSubscription+ReadOnlyConvertible.swift */,
 				7493751122498B2C007D85D1 /* ProductTag+ReadOnlyConvertible.swift */,
 				CE4FD4552350FD4800A16B31 /* Refund+ReadOnlyConvertible.swift */,
 				74D42DBB221C983F00B4977D /* ShipmentTracking+ReadOnlyConvertible.swift */,
@@ -2117,6 +2120,7 @@
 				D831E2E4230E3524000037D0 /* ProductReviewAction.swift in Sources */,
 				02393065291A018600B2632F /* DomainAction.swift in Sources */,
 				D831E2E6230E7149000037D0 /* ProductReview+ReadOnlyConvertible.swift in Sources */,
+				CC24A4F129ED4CEB0009D6DA /* ProductSubscription+ReadOnlyConvertible.swift in Sources */,
 				03101F0129DD7D9D00769CF3 /* CardReaderType+ReadOnlyConvertible.swift in Sources */,
 				CE4FD4502350F27C00A16B31 /* OrderItemTax+ReadOnlyConvertible.swift in Sources */,
 				02FF055123D983F30058E6E7 /* MediaAssetExporter.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -79,6 +79,7 @@ public typealias ProductShippingClass = Networking.ProductShippingClass
 public typealias ProductStatus = Networking.ProductStatus
 public typealias ProductCatalogVisibility = Networking.ProductCatalogVisibility
 public typealias ProductStockStatus = Networking.ProductStockStatus
+public typealias ProductSubscription = Networking.ProductSubscription
 public typealias ProductType = Networking.ProductType
 public typealias ProductCategory = Networking.ProductCategory
 public typealias ProductTag = Networking.ProductTag

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -224,6 +224,7 @@ public typealias StorageProductDefaultAttribute = Storage.ProductDefaultAttribut
 public typealias StorageProductDownload = Storage.ProductDownload
 public typealias StorageProductReview = Storage.ProductReview
 public typealias StorageProductShippingClass = Storage.ProductShippingClass
+public typealias StorageProductSubscription = Storage.ProductSubscription
 public typealias StorageProductTag = Storage.ProductTag
 public typealias StorageRefund = Storage.Refund
 public typealias StorageProductVariation = Storage.ProductVariation

--- a/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
@@ -175,7 +175,7 @@ extension Storage.Product: ReadOnlyConvertible {
                        bundleStockQuantity: bundleStockQuantity as? Int64,
                        bundledItems: bundledItemsArray.map { $0.toReadOnly() },
                        compositeComponents: compositeComponentsArray.map { $0.toReadOnly() },
-                       subscription: nil) // TODO: Convert the subscription
+                       subscription: subscription?.toReadOnly())
     }
 
     // MARK: - Private Helpers

--- a/Yosemite/Yosemite/Model/Storage/ProductSubscription+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductSubscription+ReadOnlyConvertible.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Networking
+import Storage
+
+// MARK: - Storage.ProductSubscription: ReadOnlyConvertible
+//
+extension Storage.ProductSubscription: ReadOnlyConvertible {
+
+    /// Updates the Storage.ProductSubscription with the ReadOnly.
+    ///
+    public func update(with subscription: Yosemite.ProductSubscription) {
+        length = subscription.length
+        period = subscription.period.rawValue
+        periodInterval = subscription.periodInterval
+        price = subscription.price
+        signUpFee = subscription.signUpFee
+        trialLength = subscription.trialLength
+        trialPeriod = subscription.trialPeriod.rawValue
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.ProductSubscription {
+        return ProductSubscription(length: length ?? "0",
+                                   period: SubscriptionPeriod(rawValue: period ?? "day") ?? .day,
+                                   periodInterval: periodInterval ?? "",
+                                   price: price ?? "",
+                                   signUpFee: signUpFee ?? "",
+                                   trialLength: trialLength ?? "0",
+                                   trialPeriod: SubscriptionPeriod(rawValue: trialPeriod ?? "day") ?? .day)
+    }
+}

--- a/Yosemite/Yosemite/Model/Storage/ProductVariation+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductVariation+ReadOnlyConvertible.swift
@@ -105,7 +105,7 @@ extension Storage.ProductVariation: ReadOnlyConvertible {
                                 shippingClass: shippingClass,
                                 shippingClassID: shippingClassID,
                                 menuOrder: menuOrder,
-                                subscription: nil) // TODO: Convert the subscription
+                                subscription: subscription?.toReadOnly())
     }
 }
 

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -592,6 +592,7 @@ extension ProductStore {
             handleProductAddOns(readOnlyProduct, storageProduct, storage)
             handleProductBundledItems(readOnlyProduct, storageProduct, storage)
             handleProductCompositeComponents(readOnlyProduct, storageProduct, storage)
+            handleProductSubscription(readOnlyProduct, storageProduct, storage)
         }
     }
 
@@ -812,6 +813,25 @@ extension ProductStore {
             return storageCompositeComponent
         }
         storageProduct.addToCompositeComponents(NSOrderedSet(array: storageCompositeComponents))
+    }
+
+    /// Updates, inserts, or prunes the provided StorageProduct's subscription using the provided read-only Product's subscription
+    ///
+    func handleProductSubscription(_ readOnlyProduct: Networking.Product, _ storageProduct: Storage.Product, _ storage: StorageType) {
+        guard let readOnlySubscription = readOnlyProduct.subscription else {
+            if let existingStorageSubscription = storageProduct.subscription {
+                storage.deleteObject(existingStorageSubscription)
+            }
+            return
+        }
+
+        if let existingStorageSubscription = storageProduct.subscription {
+            existingStorageSubscription.update(with: readOnlySubscription)
+        } else {
+            let newStorageSubscription = storage.insertNewObject(ofType: Storage.ProductSubscription.self)
+            newStorageSubscription.update(with: readOnlySubscription)
+            storageProduct.subscription = newStorageSubscription
+        }
     }
 }
 

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -406,6 +406,7 @@ private extension ProductVariationStore {
             handleProductDimensions(readOnlyProductVariation, storageProductVariation, storage)
             handleProductVariationAttributes(readOnlyProductVariation, storageProductVariation, storage)
             handleProductImage(readOnlyProductVariation, storageProductVariation, storage)
+            handleProductSubscription(readOnlyProductVariation, storageProductVariation, storage)
         }
     }
 
@@ -460,6 +461,25 @@ private extension ProductVariationStore {
             let newStorageImage = storage.insertNewObject(ofType: Storage.ProductImage.self)
             newStorageImage.update(with: readOnlyImage)
             storageVariation.image = newStorageImage
+        }
+    }
+
+    /// Updates, inserts, or prunes the provided StorageProductVariation's subscription using the provided read-only ProductVariation's subscription
+    ///
+    func handleProductSubscription(_ readOnlyVariation: Networking.ProductVariation, _ storageVariation: Storage.ProductVariation, _ storage: StorageType) {
+        guard let readOnlySubscription = readOnlyVariation.subscription else {
+            if let existingStorageSubscription = storageVariation.subscription {
+                storage.deleteObject(existingStorageSubscription)
+            }
+            return
+        }
+
+        if let existingStorageSubscription = storageVariation.subscription {
+            existingStorageSubscription.update(with: readOnlySubscription)
+        } else {
+            let newStorageSubscription = storage.insertNewObject(ofType: Storage.ProductSubscription.self)
+            newStorageSubscription.update(with: readOnlySubscription)
+            storageVariation.subscription = newStorageSubscription
         }
     }
 

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -91,7 +91,8 @@ final class ProductStoreTests: XCTestCase {
                                                   defaultAttributes: [mockDefaultAttribute],
                                                   addOns: sampleAddOns(),
                                                   bundledItems: [.fake()],
-                                                  compositeComponents: [.fake()])
+                                                  compositeComponents: [.fake()],
+                                                  subscription: .fake())
         remote.whenAddingProduct(siteID: sampleSiteID, thenReturn: .success(expectedProduct))
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
 
@@ -123,6 +124,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductAddOnOption.self), 7)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductBundleItem.self), 1)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductCompositeComponent.self), 1)
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductSubscription.self), 1)
     }
 
     func test_addProduct_returns_error_upon_network_error() {
@@ -175,7 +177,8 @@ final class ProductStoreTests: XCTestCase {
                                                   defaultAttributes: [mockDefaultAttribute],
                                                   addOns: sampleAddOns(),
                                                   bundledItems: [.fake()],
-                                                  compositeComponents: [.fake()])
+                                                  compositeComponents: [.fake()],
+                                                  subscription: .fake())
         remote.whenDeletingProduct(siteID: sampleSiteID, thenReturn: .success(expectedProduct))
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
 
@@ -193,6 +196,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductAddOnOption.self), 7)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductBundleItem.self), 1)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductCompositeComponent.self), 1)
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductSubscription.self), 1)
 
         var result: Result<Yosemite.Product, ProductUpdateError>?
         waitForExpectation { expectation in
@@ -218,6 +222,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductAddOnOption.self), 0)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductBundleItem.self), 0)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductCompositeComponent.self), 0)
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductSubscription.self), 0)
     }
 
     func test_deleteProduct_returns_error_upon_network_error() {
@@ -913,6 +918,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductDownload.self), 0)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductBundleItem.self), 0)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductCompositeComponent.self), 0)
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductSubscription.self), 0)
 
         productStore.upsertStoredProduct(readOnlyProduct: sampleProduct(downloadable: true), in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 1)
@@ -925,6 +931,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductDownload.self), 3)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductBundleItem.self), 0)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductCompositeComponent.self), 0)
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductSubscription.self), 0)
 
         productStore.upsertStoredProduct(readOnlyProduct: sampleProductMutated(), in: viewStorage)
         let storageProduct1 = viewStorage.loadProduct(siteID: sampleSiteID, productID: sampleProductID)
@@ -939,6 +946,7 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductDownload.self), 2)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductBundleItem.self), 2)
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductCompositeComponent.self), 2)
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductSubscription.self), 1)
     }
 
     /// Verifies that `ProductStore.upsertStoredProduct` updates the correct site's product.
@@ -2059,7 +2067,7 @@ private extension ProductStoreTests {
                        bundleStockQuantity: 0,
                        bundledItems: [.fake(), .fake()],
                        compositeComponents: [.fake(), .fake()],
-                       subscription: nil)
+                       subscription: .fake())
     }
 
     func sampleDimensionsMutated() -> Networking.ProductDimensions {

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -317,12 +317,13 @@ final class ProductVariationStoreTests: XCTestCase {
         let remote = MockProductVariationsRemote()
         let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
         let sampleProductVariationID: Int64 = 1275
-        let expectedProductVariation = sampleProductVariation(id: sampleProductVariationID)
+        let expectedProductVariation = sampleProductVariation(id: sampleProductVariationID).copy(subscription: .fake())
         remote.whenLoadingProductVariation(siteID: sampleSiteID,
                                            productID: sampleProductID,
                                            productVariationID: sampleProductVariationID,
                                            thenReturn: .success(expectedProductVariation))
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductVariation.self), 0)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductSubscription.self), 0)
 
         // When
         let result: Result<Yosemite.ProductVariation, Error> = waitFor { promise in
@@ -336,6 +337,7 @@ final class ProductVariationStoreTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductVariation.self), 1)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductSubscription.self), 1)
 
         XCTAssertTrue(result.isSuccess)
         XCTAssertNotNil(try result.get())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8951, #9392
⚠️ Depends on #9468
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support for simple and variable subscription products in the Yosemite layer. With these changes, we handle subscriptions when products or product variations are upserted in storage.

### Changes

- Adds a `ReadOnlyConvertible` extension for `ProductSubscription`.
- Updates `Product+ReadOnlyConvertible` extension to convert the subscription property.
- Updates `ProductVariation+ReadOnlyConvertible` extension to convert the subscription property.
- Updates `ProductStore` to handle `ProductSubscription`s when a product is upserted in storage.
- Updates `ProductVariationStore` to handle `ProductSubscription`s when a product variation is upserted in storage.
- Updates `ProductStore` and `ProductVariationStore` tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
We aren't using the subscription property for products or variations in the UI layer yet. For now, confirm the changes to the tests look reasonable and tests pass.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
