### PR TITLE
[Subscriptions] Add UI to display subscription settings for a subscription product

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/SubscriptionSettings.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/SubscriptionSettings.swift
@@ -27,34 +27,51 @@ struct SubscriptionSettings: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading) {
-                TitleAndSubtitleRow(title: "Subscription price", subtitle: "$60.00 every 4 months")
+                // Subscription price
+                TitleAndSubtitleRow(title: Localization.priceTitle, subtitle: "$60.00 every 4 months")
                 Divider()
                     .padding(.leading)
                     .padding(.trailing, insets: -safeAreaInsets)
 
-                TitleAndSubtitleRow(title: "Expire after", subtitle: "12 months")
+                // Expire after
+                TitleAndSubtitleRow(title: Localization.expiryTitle, subtitle: "12 months")
                 Divider()
                     .padding(.leading)
                     .padding(.trailing, insets: -safeAreaInsets)
 
-                TitleAndSubtitleRow(title: "Signup fee", subtitle: "$5.00")
+                // Signup fee
+                TitleAndSubtitleRow(title: Localization.signupFeeTitle, subtitle: "$5.00")
                 Divider()
                     .padding(.leading)
                     .padding(.trailing, insets: -safeAreaInsets)
 
-                TitleAndSubtitleRow(title: "Free trial", subtitle: "No trial period")
+                // Free trial
+                TitleAndSubtitleRow(title: Localization.freeTrialTitle, subtitle: "No trial period")
             }
             .padding(.horizontal, insets: safeAreaInsets)
             .addingTopAndBottomDividers()
             .background(Color(.listForeground(modal: false)))
 
-            FooterNotice(infoText: "You can edit subscription settings in the web dashboard")
+            FooterNotice(infoText: Localization.infoNotice)
                 .padding(.horizontal, insets: safeAreaInsets)
         }
         .ignoresSafeArea(edges: .horizontal)
         .background(
             Color(.listBackground).edgesIgnoringSafeArea(.all)
         )
+    }
+}
+
+private extension SubscriptionSettings {
+    enum Localization {
+        static let title = NSLocalizedString("Subscription", comment: "Title for the subscription settings in a subscription product.")
+        static let infoNotice = NSLocalizedString("You can edit subscription settings in the web dashboard",
+                                                  comment: "Info notice at the bottom of the subscription settings screen.")
+        static let priceTitle = NSLocalizedString("Subscription price",
+                                                  comment: "Label for the subscription price setting in the subscription settings screen.")
+        static let expiryTitle = NSLocalizedString("Expire after", comment: "Label for the expiry setting in the subscription settings screen.")
+        static let signupFeeTitle = NSLocalizedString("Signup fee", comment: "Label for the signup fee setting in the subscription settings screen.")
+        static let freeTrialTitle = NSLocalizedString("Free trial", comment: "Label for the free trial setting in the subscription settings screen.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/SubscriptionSettings.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/SubscriptionSettings.swift
@@ -5,8 +5,8 @@ import SwiftUI
 /// Hosting controller that wraps a `SubscriptionSettings` view.
 ///
 final class SubscriptionSettingsViewController: UIHostingController<SubscriptionSettings> {
-    init() {
-        super.init(rootView: SubscriptionSettings())
+    init(viewModel: SubscriptionSettingsViewModel) {
+        super.init(rootView: SubscriptionSettings(viewModel: viewModel))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -20,6 +20,10 @@ final class SubscriptionSettingsViewController: UIHostingController<Subscription
 ///
 struct SubscriptionSettings: View {
 
+    /// View model that directs the view content.
+    ///
+    let viewModel: SubscriptionSettingsViewModel
+
     /// Environment safe areas
     ///
     @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
@@ -28,25 +32,25 @@ struct SubscriptionSettings: View {
         ScrollView {
             VStack(alignment: .leading) {
                 // Subscription price
-                TitleAndSubtitleRow(title: Localization.priceTitle, subtitle: "$60.00 every 4 months")
+                TitleAndSubtitleRow(title: Localization.priceTitle, subtitle: viewModel.priceDescription)
                 Divider()
                     .padding(.leading)
                     .padding(.trailing, insets: -safeAreaInsets)
 
                 // Expire after
-                TitleAndSubtitleRow(title: Localization.expiryTitle, subtitle: "12 months")
+                TitleAndSubtitleRow(title: Localization.expiryTitle, subtitle: viewModel.expiryDescription)
                 Divider()
                     .padding(.leading)
                     .padding(.trailing, insets: -safeAreaInsets)
 
                 // Signup fee
-                TitleAndSubtitleRow(title: Localization.signupFeeTitle, subtitle: "$5.00")
+                TitleAndSubtitleRow(title: Localization.signupFeeTitle, subtitle: viewModel.signupFeeDescription)
                 Divider()
                     .padding(.leading)
                     .padding(.trailing, insets: -safeAreaInsets)
 
                 // Free trial
-                TitleAndSubtitleRow(title: Localization.freeTrialTitle, subtitle: "No trial period")
+                TitleAndSubtitleRow(title: Localization.freeTrialTitle, subtitle: viewModel.freeTrialDescription)
             }
             .padding(.horizontal, insets: safeAreaInsets)
             .addingTopAndBottomDividers()
@@ -76,7 +80,13 @@ private extension SubscriptionSettings {
 }
 
 struct SubscriptionSettings_Previews: PreviewProvider {
+
+    static let viewModel = SubscriptionSettingsViewModel(price: "$60.00 every 4 months",
+                                                         expiresAfter: "12 months",
+                                                         signupFee: "$5.00",
+                                                         freeTrial: "No trial period")
+
     static var previews: some View {
-        SubscriptionSettings()
+        SubscriptionSettings(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/SubscriptionSettings.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/SubscriptionSettings.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+// MARK: Hosting Controller
+
+/// Hosting controller that wraps a `SubscriptionSettings` view.
+///
+final class SubscriptionSettingsViewController: UIHostingController<SubscriptionSettings> {
+    init() {
+        super.init(rootView: SubscriptionSettings())
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: Views
+
+/// Renders the subscription settings for a subscription product.
+///
+struct SubscriptionSettings: View {
+
+    /// Environment safe areas
+    ///
+    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                TitleAndSubtitleRow(title: "Subscription price", subtitle: "$60.00 every 4 months")
+                Divider()
+                    .padding(.leading)
+                    .padding(.trailing, insets: -safeAreaInsets)
+
+                TitleAndSubtitleRow(title: "Expire after", subtitle: "12 months")
+                Divider()
+                    .padding(.leading)
+                    .padding(.trailing, insets: -safeAreaInsets)
+
+                TitleAndSubtitleRow(title: "Signup fee", subtitle: "$5.00")
+                Divider()
+                    .padding(.leading)
+                    .padding(.trailing, insets: -safeAreaInsets)
+
+                TitleAndSubtitleRow(title: "Free trial", subtitle: "No trial period")
+            }
+            .padding(.horizontal, insets: safeAreaInsets)
+            .addingTopAndBottomDividers()
+            .background(Color(.listForeground(modal: false)))
+
+            FooterNotice(infoText: "You can edit subscription settings in the web dashboard")
+                .padding(.horizontal, insets: safeAreaInsets)
+        }
+        .ignoresSafeArea(edges: .horizontal)
+        .background(
+            Color(.listBackground).edgesIgnoringSafeArea(.all)
+        )
+    }
+}
+
+struct SubscriptionSettings_Previews: PreviewProvider {
+    static var previews: some View {
+        SubscriptionSettings()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/SubscriptionSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/SubscriptionSettingsViewModel.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// ViewModel for `SubscriptionSettings`
+///
+final class SubscriptionSettingsViewModel {
+
+    /// Description of the subscription price, billing interval, and period.
+    ///
+    let priceDescription: String
+
+    /// Description of the length of time after which the subscription expires.
+    ///
+    let expiryDescription: String
+
+    /// Description of the subscription signup fee.
+    ///
+    let signupFeeDescription: String
+
+    /// Description of the subscription free trial period.
+    ///
+    let freeTrialDescription: String
+
+    init(price: String,
+         expiresAfter: String,
+         signupFee: String,
+         freeTrial: String) {
+        self.priceDescription = price
+        self.expiryDescription = expiresAfter
+        self.signupFeeDescription = signupFee
+        self.freeTrialDescription = freeTrial
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1636,6 +1636,7 @@
 		CCDC49ED24000533003166BA /* TestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49EC24000533003166BA /* TestCredentials.swift */; };
 		CCE4CD172667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */; };
 		CCE4CD282669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */; };
+		CCE73D2329ED8DAC0064E797 /* SubscriptionSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE73D2229ED8DAC0064E797 /* SubscriptionSettingsViewModel.swift */; };
 		CCE785C829C1E8280003977F /* BundledProductsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE785C729C1E8280003977F /* BundledProductsListViewModelTests.swift */; };
 		CCE785CA29C1F9170003977F /* ProductBundleItemStockStatus+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE785C929C1F9170003977F /* ProductBundleItemStockStatus+UI.swift */; };
 		CCEC256A27B581E800EF9FA3 /* ProductVariationFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEC256927B581E800EF9FA3 /* ProductVariationFormatter.swift */; };
@@ -3861,6 +3862,7 @@
 		CCDC49F1240060F3003166BA /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UnitTests.xctestplan; path = WooCommerceTests/UnitTests.xctestplan; sourceTree = SOURCE_ROOT; };
 		CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
 		CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsTopBanner.swift; sourceTree = "<group>"; };
+		CCE73D2229ED8DAC0064E797 /* SubscriptionSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionSettingsViewModel.swift; sourceTree = "<group>"; };
 		CCE785C729C1E8280003977F /* BundledProductsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledProductsListViewModelTests.swift; sourceTree = "<group>"; };
 		CCE785C929C1F9170003977F /* ProductBundleItemStockStatus+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductBundleItemStockStatus+UI.swift"; sourceTree = "<group>"; };
 		CCEC256927B581E800EF9FA3 /* ProductVariationFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormatter.swift; sourceTree = "<group>"; };
@@ -8340,6 +8342,7 @@
 			isa = PBXGroup;
 			children = (
 				CC24A4F329ED6FF70009D6DA /* SubscriptionSettings.swift */,
+				CCE73D2229ED8DAC0064E797 /* SubscriptionSettingsViewModel.swift */,
 			);
 			path = Subscription;
 			sourceTree = "<group>";
@@ -11756,6 +11759,7 @@
 				4515262E2577D56C0076B03C /* AddAttributeViewController.swift in Sources */,
 				57EBC92024EEE61800C1D45B /* WooAnalyticsEvent.swift in Sources */,
 				57CDABB9252E9BEB00BED88C /* ButtonTableFooterView.swift in Sources */,
+				CCE73D2329ED8DAC0064E797 /* SubscriptionSettingsViewModel.swift in Sources */,
 				021940E8291FDBF90090354E /* StoreCreationSummaryView.swift in Sources */,
 				0201E4292945B8B600C793C7 /* StoreCreationCategoryQuestionView.swift in Sources */,
 				B946881829B8DDC2000646B0 /* ProductsViewController+Activity.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1568,6 +1568,7 @@
 		CC13C0CD278E086D00C0B5B5 /* ProductVariationSelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13C0CC278E086D00C0B5B5 /* ProductVariationSelectorViewModelTests.swift */; };
 		CC1AB56827FC5822003DEF43 /* OrderStatusScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1AB56727FC5821003DEF43 /* OrderStatusScreen.swift */; };
 		CC200BB127847DE300EC5884 /* OrderPaymentSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC200BB027847DE300EC5884 /* OrderPaymentSection.swift */; };
+		CC24A4F429ED6FF70009D6DA /* SubscriptionSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC24A4F329ED6FF70009D6DA /* SubscriptionSettings.swift */; };
 		CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */; };
 		CC254F3026C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */; };
 		CC254F3226C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC254F3126C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift */; };
@@ -3791,6 +3792,7 @@
 		CC13C0CC278E086D00C0B5B5 /* ProductVariationSelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationSelectorViewModelTests.swift; sourceTree = "<group>"; };
 		CC1AB56727FC5821003DEF43 /* OrderStatusScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusScreen.swift; sourceTree = "<group>"; };
 		CC200BB027847DE300EC5884 /* OrderPaymentSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentSection.swift; sourceTree = "<group>"; };
+		CC24A4F329ED6FF70009D6DA /* SubscriptionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionSettings.swift; sourceTree = "<group>"; };
 		CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonView.swift; sourceTree = "<group>"; };
 		CC254F2F26C2A53D005F3C82 /* ShippingLabelAddNewPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackage.swift; sourceTree = "<group>"; };
 		CC254F3126C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAddNewPackageViewModel.swift; sourceTree = "<group>"; };
@@ -4686,6 +4688,7 @@
 				45E9A6E124DAE18E00A600E8 /* Reviews */,
 				CC01CE5B29B2342E004FF537 /* Bundled Products */,
 				CCFBBCF229C4B8820081B595 /* Composite Product Components */,
+				CC24A4F229ED6FC00009D6DA /* Subscription */,
 				02162724237963AF000208D2 /* ProductFormViewController.swift */,
 				02162725237963AF000208D2 /* ProductFormViewController.xib */,
 				45912FE22526642200982948 /* ProductFormViewController+Helpers.swift */,
@@ -8333,6 +8336,14 @@
 			path = PaymentSection;
 			sourceTree = "<group>";
 		};
+		CC24A4F229ED6FC00009D6DA /* Subscription */ = {
+			isa = PBXGroup;
+			children = (
+				CC24A4F329ED6FF70009D6DA /* SubscriptionSettings.swift */,
+			);
+			path = Subscription;
+			sourceTree = "<group>";
+		};
 		CC254F2E26C2A4E6005F3C82 /* Package Creation */ = {
 			isa = PBXGroup;
 			children = (
@@ -11688,6 +11699,7 @@
 				D8815B132638686200EDAD62 /* CardPresentModalError.swift in Sources */,
 				020ACF88299A809000B3638B /* LearnMoreAttributedText.swift in Sources */,
 				02EAA4CA2911004B00918DAB /* TextFieldStyles.swift in Sources */,
+				CC24A4F429ED6FF70009D6DA /* SubscriptionSettings.swift in Sources */,
 				453DBF8E2387F34A006762A5 /* UICollectionViewCell+Helpers.swift in Sources */,
 				45B9C63E23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift in Sources */,
 				318853362639FC9C00F66A9C /* PaymentSettingsFlowPresentingViewController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8952
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This introduces a new read-only view to display the subscription settings for a subscription product or variation:

* Price (including the billing interval and period)
* Expire after (length of time after which the subscription expires)
* Signup fee
* Free trial

For now, the view model is initialized with the four strings describing the subscription settings. Eventually, these strings will be created based on the product or variation's `ProductSubscription`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
This view isn't yet used anywhere, so take a look at the SwiftUI preview and/or the screenshots below.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Subscription Settings|Large font|Dark/Landscape
-|-|-
![Screenshot 2023-04-17 at 3 58 56 PM](https://user-images.githubusercontent.com/8658164/232525660-cbcb5bbb-4cba-4c70-91c2-d725378a635b.png)|![Screenshot 2023-04-17 at 3 59 41 PM](https://user-images.githubusercontent.com/8658164/232525712-eb17fc6b-a624-49df-8d33-f61bdf0d318e.png)|![Screenshot 2023-04-17 at 3 59 23 PM](https://user-images.githubusercontent.com/8658164/232525745-edd99ed5-365e-4f11-9ba7-b03c08e6ee9c.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
