### PR TITLE
Store creation profiler questions: dark mode polishes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ButtonStyles.swift
@@ -268,7 +268,7 @@ private struct SelectableSecondaryButton: View {
                 RoundedRectangle(cornerRadius: Style.defaultCornerRadius)
                     .strokeBorder(
                         Color(borderColor),
-                        lineWidth: Style.defaultBorderWidth
+                        lineWidth: isSelected ? Style.defaultSelectedBorderWidth: Style.defaultBorderWidth
                     )
             )
     }
@@ -374,6 +374,7 @@ private struct PlusButton: View {
 private enum Style {
     static let defaultCornerRadius = CGFloat(8.0)
     static let defaultBorderWidth = CGFloat(1.0)
+    static let defaultSelectedBorderWidth = CGFloat(2.0)
     static let defaultEdgeInsets = EdgeInsets(top: 12, leading: 22, bottom: 12, trailing: 22)
 }
 

--- a/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
+++ b/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
@@ -240,33 +240,35 @@ public extension UIColor {
     /// Selectable Secondary Button Title.
     ///
     static var selectableSecondaryButtonTitle: UIColor {
-        .black
+        .text
     }
 
     /// Selectable Secondary Button Background.
     ///
     static var selectableSecondaryButtonBackground: UIColor {
-        .white
+        .init(light: .white,
+              dark: .tertiarySystemBackground)
     }
 
     /// Selectable Secondary Button Border.
     ///
     static var selectableSecondaryButtonBorder: UIColor {
-        .systemColor(.systemGray3)
+        .init(light: .systemColor(.systemGray3),
+              dark: .clear)
     }
 
     /// Selectable Secondary Button Selected Background.
     ///
     static var selectableSecondaryButtonSelectedBackground: UIColor {
         .init(light: .withColorStudio(.wooCommercePurple, shade: .shade0),
-              dark: .withColorStudio(.wooCommercePurple, shade: .shade10))
+              dark: .tertiarySystemBackground)
     }
 
     /// Selectable Secondary Button Selected Border.
     ///
     static var selectableSecondaryButtonSelectedBorder: UIColor {
         .init(light: .withColorStudio(.wooCommercePurple, shade: .shade50),
-              dark: .withColorStudio(.wooCommercePurple, shade: .shade50))
+              dark: .withColorStudio(.wooCommercePurple, shade: .shade30))
     }
 
     /// Secondary Light Button Background.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9397 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As @itsmeichigo mentioned in this PR comment https://github.com/woocommerce/woocommerce-ios/pull/9422#pullrequestreview-1378645346, the options in the profiler questions have too much of a contrast and are hard to read. After confirming with Ann in a design request p1681384900585949/1681268385.925839-slack-C0354HSNUJH, we now have a design for dark mode HyVloP5FipZzyPVenH2euI-fi-4610_149974. This PR implemented the style updates for the "selectable secondary button" only used in the profiler question options.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Start the store creation flow either from the prologue or the store picker
- Enter a store name --> the category profiler question should be shown
- Tap on an option --> the selected and unselected options should match the design in both dark mode (HyVloP5FipZzyPVenH2euI-fi-4610_149974) and light mode (HyVloP5FipZzyPVenH2euI-fi-3962_142755)
- Continue to the next question 
- Tap on an option that's not "I'm already selling" --> the selected and unselected options should match the design in both dark mode and light mode
- Tap on "I'm already selling" and tap on an option --> the selected and unselected options should match the design in both dark mode and light mode
- Continue to the next question --> in the country question, the selected and unselected options should match the design in both dark mode and light mode

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

question \ mode | dark | light
-- | -- | --
category/industry | ![Simulator Screen Shot - iPhone 14 - 2023-04-18 at 10 27 08](https://user-images.githubusercontent.com/1945542/232656062-2b853372-e696-4a83-82cf-ffe6b94e30f6.png) | ![Simulator Screen Shot - iPhone 14 - 2023-04-18 at 10 29 07](https://user-images.githubusercontent.com/1945542/232656074-9e05de98-db07-4f0c-a0b4-1009820f8870.png)
selling status | ![Simulator Screen Shot - iPhone 14 - 2023-04-18 at 10 37 47](https://user-images.githubusercontent.com/1945542/232656282-555d2fcd-a939-42da-b260-b46706faded7.png) | ![Simulator Screen Shot - iPhone 14 - 2023-04-18 at 10 38 12](https://user-images.githubusercontent.com/1945542/232656300-8cbad8ae-0fea-428a-8696-49d9aeecc0d1.png)
selling platforms | ![Simulator Screen Shot - iPhone 14 - 2023-04-18 at 10 38 00](https://user-images.githubusercontent.com/1945542/232656293-d380d8d7-c81f-4eb8-94ed-a7fe0e0692af.png) | ![Simulator Screen Shot - iPhone 14 - 2023-04-18 at 10 38 16](https://user-images.githubusercontent.com/1945542/232656307-ca9abd27-2e90-45d8-85c8-bdb401bab6f1.png)
country code | ![Simulator Screen Shot - iPhone 14 - 2023-04-18 at 10 37 50](https://user-images.githubusercontent.com/1945542/232656288-a176bd23-483a-416f-a0df-c639a7aa7e23.png) | ![Simulator Screen Shot - iPhone 14 - 2023-04-18 at 10 38 18](https://user-images.githubusercontent.com/1945542/232656309-7c15fac3-fdce-4d27-ad90-2a803e1470be.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.