### PR TITLE
[Free Trial] Improve Free Trial Banner voiceover experience

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/FreeTrialBanner.swift
@@ -34,6 +34,7 @@ struct FreeTrialBanner: View {
 
             HStack(alignment: .center) {
                 Image(uiImage: .infoOutlineImage)
+                    .accessibilityHidden(true)
 
                 AdaptiveStack(verticalAlignment: .center, spacing: Layout.spacing) {
                     Text(mainText)
@@ -43,6 +44,7 @@ struct FreeTrialBanner: View {
                         .underline(true)
                         .linkStyle()
                         .onTapGesture(perform: onUpgradeNowTapped)
+                        .accessibilityAddTraits(.isButton)
                 }
             }
             .padding()


### PR DESCRIPTION
Closes: #9359 

# Why

This PR improves the Free Trial Banner voiceover dictation. In particular it:
- Hides the info icon from voice over.
- Adds the button trait to the "Upgrade Now" button.

# Demo 🔊

https://user-images.githubusercontent.com/562080/232659976-c00ad7c3-a5d2-4bec-9b74-46f50341bf1a.mov

# Testing Step

- Launch the app with a free trial store.
- Run voice over
- Check that the info icon is not mentioned
- Check that the "Upgrade Now" link is announced as a button.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
