### PR TITLE
Used BadgeView on Store Onboarding

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskView.swift
@@ -50,13 +50,7 @@ struct StoreOnboardingTaskView: View {
                                     .redacted(reason: isRedacted ? .placeholder : [])
 
                                 // PRIVATE label.
-                                Text(Localization.privateLabel.uppercased())
-                                    .font(.caption)
-                                    .fontWeight(.bold)
-                                    .foregroundColor(Color(.wooCommercePurple(.shade60)))
-                                    .padding(Layout.PrivateLabel.padding)
-                                    .background(Color(.wooCommercePurple(.shade0)))
-                                    .cornerRadius(Layout.PrivateLabel.cornerRadius)
+                                BadgeView(text: Localization.privateLabel.uppercased())
                                     .renderedIf(!isRedacted && viewModel.task.type == .launchStore && !viewModel.task.isComplete)
                             }
 


### PR DESCRIPTION
# Why

While working on adding the plan badge in the Hub Menu #9463, I reused the app `BadgeView`,  then I noticed that the store creation onboarding task list had an identical badge but had it implemented as a custom label.

This PR replaces that custom label for our general `BadgeView` in order to maintain uniformity across app badges.

# Screenshots

Before | After Light | After Dark
--- | --- | ---
<img width="440" alt="Before" src="https://user-images.githubusercontent.com/562080/232662213-6eadd582-a8dd-4ddf-b7c9-164876a67cff.png"> | <img width="445" alt="after" src="https://user-images.githubusercontent.com/562080/232662211-955f97de-2fc8-4dde-aee8-dfb22c157c6c.png"> | <img width="439" alt="after-dark" src="https://user-images.githubusercontent.com/562080/232662209-a85a41d1-5c55-4b3b-8842-bc0ae501aa43.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
