### PR TITLE
[Store onboarding] Hide "Launch your store" task for already public stores

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] Payments: Add account type field to receipts [https://github.com/woocommerce/woocommerce-ios/pull/9416]
 - [*] Products can now be filtered within Order creation [https://github.com/woocommerce/woocommerce-ios/pull/9258]
 - [*] Products: Adds read-only support for the Composite Products extension in the Products list, including a list of components in product details. [https://github.com/woocommerce/woocommerce-ios/pull/9455]
+- [Internal] Store onboarding: Mark "Launch your store" task as complete if the store is already public. [https://github.com/woocommerce/woocommerce-ios/pull/9383]
 
 
 13.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,7 @@
 - [*] Payments: Add account type field to receipts [https://github.com/woocommerce/woocommerce-ios/pull/9416]
 - [*] Products can now be filtered within Order creation [https://github.com/woocommerce/woocommerce-ios/pull/9258]
 - [*] Products: Adds read-only support for the Composite Products extension in the Products list, including a list of components in product details. [https://github.com/woocommerce/woocommerce-ios/pull/9455]
-- [Internal] Store onboarding: Mark "Launch your store" task as complete if the store is already public. [https://github.com/woocommerce/woocommerce-ios/pull/9383]
+- [Internal] Store onboarding: Mark "Launch your store" task as complete if the store is already public. [https://github.com/woocommerce/woocommerce-ios/pull/9481]
 
 
 13.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,7 @@
 - [*] Payments: Add account type field to receipts [https://github.com/woocommerce/woocommerce-ios/pull/9416]
 - [*] Products can now be filtered within Order creation [https://github.com/woocommerce/woocommerce-ios/pull/9258]
 - [*] Products: Adds read-only support for the Composite Products extension in the Products list, including a list of components in product details. [https://github.com/woocommerce/woocommerce-ios/pull/9455]
-- [Internal] Store onboarding: Mark "Launch your store" task as complete if the store is already public. [https://github.com/woocommerce/woocommerce-ios/pull/9481]
+- [Internal] Store onboarding: Mark "Launch your store" task as complete if the store is already public. This is a workaround for a backend issue which marks "Launch your store" task incomplete for already live stores. [https://github.com/woocommerce/woocommerce-ios/pull/9481]
 
 
 13.1

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -178,8 +178,8 @@ private extension StoreOnboardingViewModel {
                         guard let self,
                               case .launchStore = task.type,
                               !task.isComplete,
-                              let isBlogPublic = self.stores.sessionManager.defaultSite?.isBlogPublic,
-                              isBlogPublic else {
+                              let isPublic = self.stores.sessionManager.defaultSite?.isPublic,
+                              isPublic else {
                             return task
                         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -172,6 +172,18 @@ private extension StoreOnboardingViewModel {
                         } else {
                             return true
                         }
+                    }).map({ [weak self] task in
+                        // If store is already live and launchStore task is incomplete
+                        // mark the task as complete
+                        guard let self,
+                              case .launchStore = task.type,
+                              !task.isComplete,
+                              let isBlogPublic = self.stores.sessionManager.defaultSite?.isBlogPublic,
+                              isBlogPublic else {
+                            return task
+                        }
+
+                        return StoreOnboardingTask(isComplete: true, type: .launchStore)
                     }))
                 case .failure(let error):
                     return continuation.resume(throwing: error)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -174,7 +174,12 @@ private extension StoreOnboardingViewModel {
                         }
                     }).map({ [weak self] task in
                         // If store is already live and launchStore task is incomplete
-                        // mark the task as complete
+                        // mark the task as complete.
+                        //
+                        // We do this as a workaround because there is an issue with the backend
+                        // and `launchStore` task is marked as `incomplete` for already live stores.
+                        //
+                        // More info at https://github.com/woocommerce/woocommerce-ios/issues/9477
                         guard let self,
                               case .launchStore = task.type,
                               !task.isComplete,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -178,8 +178,7 @@ private extension StoreOnboardingViewModel {
                         guard let self,
                               case .launchStore = task.type,
                               !task.isComplete,
-                              let isPublic = self.stores.sessionManager.defaultSite?.isPublic,
-                              isPublic else {
+                              self.stores.sessionManager.defaultSite?.isPublic == true else {
                             return task
                         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -251,7 +251,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
 
     func test_launch_store_task_is_marked_as_complete_for_already_public_store() async throws {
         // Given
-        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true, isBlogPublic: true)
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true, isPublic: true)
         sessionManager.defaultRoles = [.administrator]
         mockLoadOnboardingTasks(result: .success([
             .init(isComplete: false, type: .addFirstProduct),
@@ -275,7 +275,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
 
     func test_launch_store_task_is_not_marked_as_complete_for_non_public_store() async throws {
         // Given
-        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true, isBlogPublic: false)
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true, isPublic: false)
         sessionManager.defaultRoles = [.administrator]
         mockLoadOnboardingTasks(result: .success([
             .init(isComplete: false, type: .addFirstProduct),
@@ -299,7 +299,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
 
     func test_tasks_other_than_launchStore_type_are_not_marked_as_complete_for_already_public_store() async {
         // Given
-        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true, isBlogPublic: true)
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true, isPublic: true)
         sessionManager.defaultRoles = [.administrator]
         mockLoadOnboardingTasks(result: .success([
             .init(isComplete: false, type: .storeDetails),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -252,7 +252,6 @@ final class StoreOnboardingViewModelTests: XCTestCase {
     func test_launch_store_task_is_marked_as_complete_for_already_public_store() async throws {
         // Given
         sessionManager.defaultSite = .fake().copy(isWordPressComStore: true, isPublic: true)
-        sessionManager.defaultRoles = [.administrator]
         mockLoadOnboardingTasks(result: .success([
             .init(isComplete: false, type: .addFirstProduct),
             .init(isComplete: false, type: .launchStore)
@@ -276,7 +275,6 @@ final class StoreOnboardingViewModelTests: XCTestCase {
     func test_launch_store_task_is_not_marked_as_complete_for_non_public_store() async throws {
         // Given
         sessionManager.defaultSite = .fake().copy(isWordPressComStore: true, isPublic: false)
-        sessionManager.defaultRoles = [.administrator]
         mockLoadOnboardingTasks(result: .success([
             .init(isComplete: false, type: .addFirstProduct),
             .init(isComplete: false, type: .launchStore)
@@ -300,7 +298,6 @@ final class StoreOnboardingViewModelTests: XCTestCase {
     func test_tasks_other_than_launchStore_type_are_not_marked_as_complete_for_already_public_store() async {
         // Given
         sessionManager.defaultSite = .fake().copy(isWordPressComStore: true, isPublic: true)
-        sessionManager.defaultRoles = [.administrator]
         mockLoadOnboardingTasks(result: .success([
             .init(isComplete: false, type: .storeDetails),
             .init(isComplete: false, type: .addFirstProduct),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -249,6 +249,80 @@ final class StoreOnboardingViewModelTests: XCTestCase {
                                                               .init(isComplete: false, type: .customizeDomains)])
     }
 
+    func test_launch_store_task_is_marked_as_complete_for_already_public_store() async throws {
+        // Given
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true, isBlogPublic: true)
+        sessionManager.defaultRoles = [.administrator]
+        mockLoadOnboardingTasks(result: .success([
+            .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .launchStore)
+        ]))
+
+        let sitePlan = WPComSitePlan(hasDomainCredit: false)
+        mockLoadSiteCurrentPlan(result: .success(sitePlan))
+
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: true,
+                                           stores: stores,
+                                           defaults: defaults)
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        let launchStoreTask = try XCTUnwrap(sut.tasksForDisplay.filter({ $0.task.type == .launchStore}).first)
+        XCTAssertTrue(launchStoreTask.isComplete)
+    }
+
+    func test_launch_store_task_is_not_marked_as_complete_for_non_public_store() async throws {
+        // Given
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true, isBlogPublic: false)
+        sessionManager.defaultRoles = [.administrator]
+        mockLoadOnboardingTasks(result: .success([
+            .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .launchStore)
+        ]))
+
+        let sitePlan = WPComSitePlan(hasDomainCredit: false)
+        mockLoadSiteCurrentPlan(result: .success(sitePlan))
+
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: true,
+                                           stores: stores,
+                                           defaults: defaults)
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        let launchStoreTask = try XCTUnwrap(sut.tasksForDisplay.filter({ $0.task.type == .launchStore}).first)
+        XCTAssertFalse(launchStoreTask.isComplete)
+    }
+
+    func test_tasks_other_than_launchStore_type_are_not_marked_as_complete_for_already_public_store() async {
+        // Given
+        sessionManager.defaultSite = .fake().copy(isWordPressComStore: true, isBlogPublic: true)
+        sessionManager.defaultRoles = [.administrator]
+        mockLoadOnboardingTasks(result: .success([
+            .init(isComplete: false, type: .storeDetails),
+            .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: false, type: .customizeDomains),
+            .init(isComplete: false, type: .payments),
+            .init(isComplete: false, type: .woocommercePayments),
+        ]))
+
+        let sitePlan = WPComSitePlan(hasDomainCredit: false)
+        mockLoadSiteCurrentPlan(result: .success(sitePlan))
+
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: true,
+                                           stores: stores,
+                                           defaults: defaults)
+        // When
+        await sut.reloadTasks()
+
+        // Then
+        XCTAssertTrue(sut.tasksForDisplay.filter({ $0.task.isComplete}).isEmpty)
+    }
+
     // MARK: - shouldShowViewAllButton
 
     func test_view_all_button_is_hidden_in_expanded_mode() async {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9477 


## Description

- [ ] ⚠️ Please review https://github.com/woocommerce/woocommerce-ios/pull/9480 as well. 

Marks the "Launch your store" task as complete for already public stores.


## Testing instructions
This is an issue with inconsistent DB in the backend. To reproduce this issue, you need a public site with an invalid "launch_store" task status. 
- You can follow the instructions from this internal discussion here - p1681472876661259/1681200289.275869-slack-CNA89KY6M

or

- I can invite you to the site I created for testing. Please DM me. 

**Steps**
- Launch and login into the app
- Switch to/Select the site with the inconsistent state
- Open the store onboarding task list
- Ensure that the "Launch your store" task is already marked as complete

## Screenshots
| Before | After |
|--------|--------|
| ![Before](https://user-images.githubusercontent.com/524475/232775911-d46dc505-26f9-4ae5-9593-ef7289afaeed.png) | ![After](https://user-images.githubusercontent.com/524475/232775899-4aeb2d9d-2495-4557-a401-2b0b2a8898fc.png) | 


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.