### PR TITLE
Attempt fixing web view login issue by using navigation delegate

### DIFF
--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
@@ -230,10 +230,6 @@ extension ApplicationPasswordAuthorizationWebViewController: WKNavigationDelegat
         DDLogInfo("✅ Application password authorized")
         return .cancel
     }
-
-    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-        progressBar.setProgress(0, animated: false)
-    }
 }
 
 private extension ApplicationPasswordAuthorizationWebViewController {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9483 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR attempts fixing the web view login redirect on physical devices as reported in p1681805697351039-slack-C046HDZL87J.

In the current implementation, I observe the change of URL in the web view to detect the success URL. I notice that right after the web view redirects to this URL, it navigates to the authorization URL again. I have no good explanation for why this happens, but it doesn't look like the expected behavior to me. For some reason, the redirect works fine when the app is built in debug mode, but not in alpha and production builds.

In an attempt to fix the redirect, in this PR, the redirect is detected with a navigational delegate method of the web view. Instead of letting the web view navigate to the success URL, the delegate method cancels the navigation and handles authentication immediately. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Important: Please make sure to test with the installable (alpha) build for this PR. Debug build always works fine for the redirect.
- On the prologue screen, select Log In and proceed with the address of a self-hosted store without Jetpack.
- Enter incorrect credentials for the site.
- On the error alert, select Try again in WP-Admin.
- On the web view, enter the correct credentials for the site.
- Tap the approve button when the authorization page loads.
- Notice that you can log in successfully.

Please ignore the missing progress bar - I fixed it in dfda327a387019225790bf3966196d9f2a9e43bc. The installable build is not triggered again so it's outdated, you can test the progress bar in the debug build if needed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/232794488-ad43d775-d5ad-44e5-ac61-a21b380515db.mov



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.