### PR TITLE
[Subscriptions] Add Subscription row to product details

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -91,6 +91,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .IPPUKExpansion:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .subscriptionProducts:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -187,4 +187,8 @@ public enum FeatureFlag: Int {
     /// Enables UK-based stores taking In-Person Payments
     ///
     case IPPUKExpansion
+
+    /// Enables subscription product settings in product details
+    ///
+    case subscriptionProducts
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -116,6 +116,8 @@ private extension DefaultProductFormTableViewModel {
                 return .bundledProducts(viewModel: bundledProductsRow(product: product, isActionable: actionable), isActionable: actionable)
             case .components(let actionable):
                 return .components(viewModel: componentsRow(product: product, isActionable: actionable), isActionable: actionable)
+            case .subscription(let actionable):
+                return .subscription(viewModel: subscriptionRow(product: product, isActionable: actionable), isActionable: actionable)
             default:
                 assertionFailure("Unexpected action in the settings section: \(action)")
                 return nil
@@ -555,6 +557,25 @@ private extension DefaultProductFormTableViewModel {
                                                         details: details,
                                                         isActionable: isActionable)
     }
+
+    // MARK: Subscription products only
+
+    func subscriptionRow(product: ProductFormDataModel, isActionable: Bool) -> ProductFormSection.SettingsRow.ViewModel {
+        let icon = UIImage.priceImage
+        let title = Localization.subscriptionTitle
+
+        var subscriptionDetails = [String]()
+        // TODO: 8952 - Replace with real price and expiry data
+        subscriptionDetails.append(String.localizedStringWithFormat(Localization.subscriptionPriceFormat, "$60.00 every 4 months"))
+        subscriptionDetails.append(String.localizedStringWithFormat(Localization.subscriptionExpiryFormat, "12 months"))
+
+        let details = subscriptionDetails.isEmpty ? nil: subscriptionDetails.joined(separator: "\n")
+
+        return ProductFormSection.SettingsRow.ViewModel(icon: icon,
+                                                        title: title,
+                                                        details: details,
+                                                        isActionable: isActionable)
+    }
 }
 
 private extension DefaultProductFormTableViewModel {
@@ -761,5 +782,12 @@ private extension DefaultProductFormTableViewModel {
                                                                comment: "Format of the number of components in singular form")
         static let pluralComponentsFormat = NSLocalizedString("%ld components",
                                                               comment: "Format of the number of components in plural form")
+
+        // Subscription
+        static let subscriptionTitle = NSLocalizedString("Subscription", comment: "Title for Subscription row in the product form screen.")
+        static let subscriptionPriceFormat = NSLocalizedString("Regular price: %@",
+                                                               comment: "Format of the regular price on the Subscription row")
+        static let subscriptionExpiryFormat = NSLocalizedString("Expire after: %@",
+                                                                comment: "Format of the expiry details on the Subscription row")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -175,6 +175,10 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
         product.compositeComponents
     }
 
+    var subscription: ProductSubscription? {
+        product.subscription
+    }
+
     func isStockStatusEnabled() -> Bool {
         // Only a variable product's stock status is not editable.
         productType != .variable

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -186,6 +186,10 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
         []
     }
 
+    var subscription: ProductSubscription? {
+        productVariation.subscription
+    }
+
     // Visibility logic
 
     func allowsMultipleImages() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -307,14 +307,19 @@ private extension ProductFormActionsFactory {
     }
 
     func allSettingsSectionActionsForSubscriptionProduct() -> [ProductFormEditAction] {
-        let shouldShowSubscriptionRow = isSubscriptionProductsEnabled
-        // Only show price settings row if subscriptions row is not shown; otherwise, price is part of subscription details.
-        let shouldShowPriceSettingsRow = product.regularPrice.isNilOrEmpty == false && !shouldShowSubscriptionRow
+        let subscriptionOrPriceRow: ProductFormEditAction? = {
+            if isSubscriptionProductsEnabled {
+                return .subscription(actionable: true)
+            } else if !product.regularPrice.isNilOrEmpty {
+                return .priceSettings(editable: false, hideSeparator: false)
+            } else {
+                return nil
+            }
+        }()
         let shouldShowReviewsRow = product.reviewsAllowed
 
         let actions: [ProductFormEditAction?] = [
-            shouldShowSubscriptionRow ? .subscription(actionable: true) : nil,
-            shouldShowPriceSettingsRow ? .priceSettings(editable: false, hideSeparator: false): nil,
+            subscriptionOrPriceRow,
             shouldShowReviewsRow ? .reviews: nil,
             .inventorySettings(editable: false),
             .categories(editable: editable),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -76,6 +76,9 @@ protocol ProductFormDataModel {
     // Composite Products
     var compositeComponents: [ProductCompositeComponent] { get }
 
+    // Subscription Products
+    var subscription: ProductSubscription? { get }
+
     /// True if a product has been saved remotely.
     var existsRemotely: Bool { get }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -81,7 +81,8 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
              .noPriceWarning,
              .attributes,
              .bundledProducts,
-             .components:
+             .components,
+             .subscription:
             return [ImageAndTitleAndTextTableViewCell.self]
         case .reviews:
             return [ProductReviewsTableViewCell.self]
@@ -112,7 +113,8 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
              .noPriceWarning,
              .attributes,
              .bundledProducts,
-             .components:
+             .components,
+             .subscription:
             return ImageAndTitleAndTextTableViewCell.self
         case .reviews:
             return ProductReviewsTableViewCell.self

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -258,7 +258,8 @@ private extension ProductFormTableViewDataSource {
              .variations(let viewModel),
              .attributes(let viewModel, _),
              .bundledProducts(let viewModel, _),
-             .components(let viewModel, _):
+             .components(let viewModel, _),
+             .subscription(let viewModel, _):
             configureSettings(cell: cell, viewModel: viewModel)
         case .reviews(let viewModel, let ratingCount, let averageRating):
             configureReviews(cell: cell, viewModel: viewModel, ratingCount: ratingCount, averageRating: averageRating)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -46,6 +46,7 @@ enum ProductFormSection: Equatable {
         case attributes(viewModel: ViewModel, isEditable: Bool)
         case bundledProducts(viewModel: ViewModel, isActionable: Bool)
         case components(viewModel: ViewModel, isActionable: Bool)
+        case subscription(viewModel: ViewModel, isActionable: Bool)
 
         struct ViewModel {
             let icon: UIImage

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -455,6 +455,12 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 }
                 ServiceLocator.analytics.track(event: .ProductDetail.componentsTapped())
                 showCompositeComponents()
+            case .subscription(_, let isActionable):
+                guard isActionable else {
+                    return
+                }
+                // TODO: Track row tapped
+                showSubscriptionSettings()
             }
         case .optionsCTA(let rows):
             let row = rows[indexPath.row]
@@ -1706,6 +1712,19 @@ private extension ProductFormViewController {
         }
         let viewModel = ComponentsListViewModel(siteID: product.siteID, components: product.compositeComponents)
         let viewController = ComponentsListViewController(viewModel: viewModel)
+        show(viewController, sender: self)
+    }
+}
+
+// MARK: Action - Show Subscription Settings
+//
+private extension ProductFormViewController {
+    func showSubscriptionSettings() {
+        let viewModel = SubscriptionSettingsViewModel(price: "$60.00 every 4 months",
+                                                      expiresAfter: "12 months",
+                                                      signupFee: "$5.00",
+                                                      freeTrial: "No trial period") // TODO: 8952 - Replace with real data
+        let viewController = SubscriptionSettingsViewController(viewModel: viewModel)
         show(viewController, sender: self)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/SubscriptionSettings.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/SubscriptionSettings.swift
@@ -59,6 +59,8 @@ struct SubscriptionSettings: View {
             FooterNotice(infoText: Localization.infoNotice)
                 .padding(.horizontal, insets: safeAreaInsets)
         }
+        .navigationBarTitle(Localization.title)
+        .navigationBarTitleDisplayMode(.inline)
         .ignoresSafeArea(edges: .horizontal)
         .background(
             Color(.listBackground).edgesIgnoringSafeArea(.all)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -719,6 +719,52 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
         assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
     }
+
+    func test_view_model_for_subscription_product_with_feature_flag_disabled() {
+        // Arrange
+        let product = Fixtures.subscriptionProduct
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isSubscriptionProductsEnabled: false)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: false, hideSeparator: false),
+                                                                       .reviews,
+                                                                       .inventorySettings(editable: false),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: false)]
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
+        assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
+    }
+
+    func test_view_model_for_subscription_product_with_feature_flag_enabled() {
+        // Arrange
+        let product = Fixtures.subscriptionProduct
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isSubscriptionProductsEnabled: true)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.subscription(actionable: true),
+                                                                       .reviews,
+                                                                       .inventorySettings(editable: false),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: false)]
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
+        assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
+    }
 }
 
 private extension ProductFormActionsFactoryTests {
@@ -772,6 +818,9 @@ private extension ProductFormActionsFactoryTests {
         // Composite product with price and composite components
         static let compositeProduct = affiliateProduct.copy(productTypeKey: ProductType.composite.rawValue, regularPrice: "2", compositeComponents: [.fake()])
 
+        // Subscription product with price and subscription
+        static let subscriptionProduct = affiliateProduct.copy(productTypeKey: ProductType.subscription.rawValue, regularPrice: "2", subscription: .fake())
+
         // Non-core product, missing price/short description/categories/tags
         static let nonCoreProductWithoutPrice = affiliateProduct.copy(productTypeKey: "other", regularPrice: "")
 
@@ -791,6 +840,7 @@ private extension ProductFormActionsFactoryTests {
                                    isDownloadableFilesSettingBased: Bool = true,
                                    isBundledProductsEnabled: Bool = false,
                                    isCompositeProductsEnabled: Bool = false,
+                                   isSubscriptionProductsEnabled: Bool = false,
                                    variationsPrice: ProductFormActionsFactory.VariationsPrice = .unknown) -> ProductFormActionsFactory {
             ProductFormActionsFactory(product: product,
                                       formType: formType,
@@ -804,6 +854,7 @@ private extension ProductFormActionsFactoryTests {
                                       isDownloadableFilesSettingBased: isDownloadableFilesSettingBased,
                                       isBundledProductsEnabled: isBundledProductsEnabled,
                                       isCompositeProductsEnabled: isCompositeProductsEnabled,
+                                      isSubscriptionProductsEnabled: isSubscriptionProductsEnabled,
                                       variationsPrice: variationsPrice)
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8952
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a Subscription row to the product details screen for simple subscription products. The Subscription row replaces the Price row, since the subscription price is part of the subscription settings. Selecting the Subscription row opens the Subscription settings view (added in #9470).

For now, both the Subscription row and the Subscription settings view show fake data. This will be updated with real data in another PR.

### Changes

- Adds a `subscriptionProducts` feature flag.
- Adds the `subscription` property to `ProductFormDataModel`.
- Adds the Subscription row view model to `DefaultProductFormTableViewModel`.
- Defines the rows to show for Subscription Products in `ProductFormActionsFactory`. These are the same as before (for non-core products), except that the Price row is replaced with the Subscription row.
- Adds the new row to the Product Form (VC, table data source, etc.).
- Adds unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Prerequisites

1. Install and activate the [Subscriptions extension](https://woocommerce.com/products/woocommerce-subscriptions/) on your store.
2. Create at least one product with the Simple Subscription product type.

### To test

1. Build and run the app.
2. Go to the Products tab.
3. Open a subscription product and confirm the new Subscription row appears as expected.
4. Tap the Subscription row and confirm it opens the Subscription settings view.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![SubscriptionDetails-Before](https://user-images.githubusercontent.com/8658164/232790350-9f8e4009-7013-43a1-8d8d-6e6580f569cd.png)|![SubscriptionDetails-After](https://user-images.githubusercontent.com/8658164/232790366-bee14f74-ecd0-45fe-9db8-a974a7b81f50.png)

https://user-images.githubusercontent.com/8658164/232805477-4b106ca6-226b-4a35-bbc6-70cde68a58b2.mp4




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
