### PR TITLE
Skip refreshing user data if user is authenticated without wpcom

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -61,7 +61,11 @@ public extension WooAnalytics {
             return
         }
 
-        analyticsProvider.refreshUserData()
+        // Skips refreshing user data when user is authenticated without WPCom
+        // since they are still identified with anonymous ID.
+        if ServiceLocator.stores.isAuthenticatedWithoutWPCom == false {
+            analyticsProvider.refreshUserData()
+        }
 
         // Refreshes A/B experiments since `ExPlat.shared` is reset after each `TracksProvider.refreshUserData` call
         // and any A/B test assignments that come back after the shared instance is reset won't be saved for later


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9473 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, event `application_password_authorization_approved` was not logged properly since it was tracked immediately before the app [authenticates](https://github.com/woocommerce/woocommerce-ios/blob/dc51a40a5a18ead6c1138318ad51d0473c47087b/WooCommerce/Classes/Authentication/AuthenticationManager.swift#L690) the user with application password. When authentication state changes, Tracks user data is [refreshed](https://github.com/woocommerce/woocommerce-ios/blob/dc51a40a5a18ead6c1138318ad51d0473c47087b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift#L297), causing the event to be missed.

One thing to note: when a user is authenticated with an application password, they are still identified with their anonymous ID, so refreshing user data is unnecessary. This PR fixes the tracking by skipping the refreshing when the user is detected as authenticated with an application password.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Important: The tracking only fails on physical devices, so please make sure to test with the installable build below.
- On the prologue screen, tap Log In and proceed with the address of a self-hosted Woo store without Jetpack.
- Enter incorrect credentials for the site.
- On the error alert, tap the button to log in with wp-admin.
- Enter the correct credentials on the presented web view.
- Approve the authorization request for application password. Notice that the login succeeds.
- Wait around 5 minutes, then go to Tracks Live View and search for the event name `woocommerceios_application_password_authorization_approved`.
- Select the event that matches the timing of your testing. Look at the properties of the event, make sure that they are correct.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="691" alt="ảnh" src="https://user-images.githubusercontent.com/5533851/232951215-aed94bd5-91b5-43fd-a224-8ebbffa33e7c.png">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
