### PR TITLE
[Subscriptions] Show real subscription details for simple subscription products

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1432,6 +1432,36 @@ extension Networking.ProductReview {
     }
 }
 
+extension Networking.ProductSubscription {
+    public func copy(
+        length: CopiableProp<String> = .copy,
+        period: CopiableProp<SubscriptionPeriod> = .copy,
+        periodInterval: CopiableProp<String> = .copy,
+        price: CopiableProp<String> = .copy,
+        signUpFee: CopiableProp<String> = .copy,
+        trialLength: CopiableProp<String> = .copy,
+        trialPeriod: CopiableProp<SubscriptionPeriod> = .copy
+    ) -> Networking.ProductSubscription {
+        let length = length ?? self.length
+        let period = period ?? self.period
+        let periodInterval = periodInterval ?? self.periodInterval
+        let price = price ?? self.price
+        let signUpFee = signUpFee ?? self.signUpFee
+        let trialLength = trialLength ?? self.trialLength
+        let trialPeriod = trialPeriod ?? self.trialPeriod
+
+        return Networking.ProductSubscription(
+            length: length,
+            period: period,
+            periodInterval: periodInterval,
+            price: price,
+            signUpFee: signUpFee,
+            trialLength: trialLength,
+            trialPeriod: trialPeriod
+        )
+    }
+}
+
 extension Networking.ProductVariation {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Product/ProductSubscription.swift
+++ b/Networking/Networking/Model/Product/ProductSubscription.swift
@@ -2,7 +2,7 @@ import Foundation
 import Codegen
 
 /// Represents the subscription settings extracted from product meta data for a Subscription-type Product.
-public struct ProductSubscription: Decodable, Equatable, GeneratedFakeable {
+public struct ProductSubscription: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
     /// Subscription automatically expires after this number of subscription periods.
     ///
     /// For example, subscription with period of `month` and length of "2" expires after 2 months. Subscription with length of "0" never expires.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -565,9 +565,14 @@ private extension DefaultProductFormTableViewModel {
         let title = Localization.subscriptionTitle
 
         var subscriptionDetails = [String]()
-        // TODO: 8952 - Replace with real price and expiry data
-        subscriptionDetails.append(String.localizedStringWithFormat(Localization.subscriptionPriceFormat, "$60.00 every 4 months"))
-        subscriptionDetails.append(String.localizedStringWithFormat(Localization.subscriptionExpiryFormat, "12 months"))
+
+        if let priceDescription = product.subscription?.priceDescription() {
+            subscriptionDetails.append(String.localizedStringWithFormat(Localization.subscriptionPriceFormat, priceDescription))
+        }
+
+        if let expiryDescription = product.subscription?.expiryDescription {
+            subscriptionDetails.append(String.localizedStringWithFormat(Localization.subscriptionExpiryFormat, expiryDescription))
+        }
 
         let details = subscriptionDetails.isEmpty ? nil: subscriptionDetails.joined(separator: "\n")
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1720,10 +1720,13 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
     func showSubscriptionSettings() {
-        let viewModel = SubscriptionSettingsViewModel(price: "$60.00 every 4 months",
-                                                      expiresAfter: "12 months",
-                                                      signupFee: "$5.00",
-                                                      freeTrial: "No trial period") // TODO: 8952 - Replace with real data
+        guard let product = product as? EditableProductModel, let subscription = product.subscription else {
+            return
+        }
+        let viewModel = SubscriptionSettingsViewModel(price: subscription.priceDescription() ?? "",
+                                                      expiresAfter: subscription.expiryDescription,
+                                                      signupFee: subscription.signupFeeDescription(),
+                                                      freeTrial: subscription.trialDescription)
         let viewController = SubscriptionSettingsViewController(viewModel: viewModel)
         show(viewController, sender: self)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UI.swift
@@ -39,6 +39,19 @@ extension ProductSubscription {
 
         return String.localizedStringWithFormat(Localization.priceFormat, formattedPrice, billingFrequency)
     }
+
+    /// Localized string describing the subscription signup fee.
+    ///
+    /// Example: "No signup fee" or "$5.00"
+    ///
+    func signupFeeDescription(currencySettings: CurrencySettings = ServiceLocator.currencySettings) -> String {
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        guard let formattedPrice = currencyFormatter.formatAmount(self.signUpFee) else {
+            return Localization.noSignupFee
+        }
+
+        return formattedPrice
+    }
 }
 
 private extension ProductSubscription {
@@ -47,6 +60,7 @@ private extension ProductSubscription {
                                                    comment: "Description of the subscription price for a product, with the price and billing frequency. " +
                                                    "Reads like: '$60.00 every 2 months'.")
         static let neverExpire = NSLocalizedString("Never expire", comment: "Display label when a subscription never expires.")
+        static let noSignupFee = NSLocalizedString("No signup fee", comment: "Display label when a subscription has no signup fee.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UI.swift
@@ -1,0 +1,83 @@
+import Yosemite
+import WooFoundation
+
+extension ProductSubscription {
+
+    /// Localized string describing when the subscription expires.
+    ///
+    /// Example: "Never expires" or "6 months" or "1 year"
+    ///
+    var expiryDescription: String {
+        switch self.length {
+        case "", "0":
+            return Localization.neverExpire
+        case "1":
+            return "1 \(self.period.descriptionSingular)"
+        default:
+            return "\(self.length) \(self.period.descriptionPlural)"
+        }
+    }
+
+    /// Localized string describing the subscription price, billing interval, and period.
+    ///
+    /// Example: "$50.00 every year" or "$10.00 every 2 weeks"
+    ///
+    func priceDescription(currencySettings: CurrencySettings = ServiceLocator.currencySettings) -> String? {
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        guard let formattedPrice = currencyFormatter.formatAmount(self.price) else {
+            return nil
+        }
+
+        let billingFrequency = {
+            switch self.periodInterval {
+            case "1":
+                return self.period.descriptionSingular
+            default:
+                return "\(self.periodInterval) \(self.period.descriptionPlural)"
+            }
+        }()
+
+        return String.localizedStringWithFormat(Localization.priceFormat, formattedPrice, billingFrequency)
+    }
+}
+
+private extension ProductSubscription {
+    enum Localization {
+        static let priceFormat = NSLocalizedString("%1$@ every %2$@",
+                                                   comment: "Description of the subscription price for a product, with the price and billing frequency. " +
+                                                   "Reads like: '$60.00 every 2 months'.")
+        static let neverExpire = NSLocalizedString("Never expire", comment: "Display label when a subscription never expires.")
+    }
+}
+
+extension SubscriptionPeriod {
+    /// Returns the localized singular text version of the Enum
+    ///
+    var descriptionSingular: String {
+        switch self {
+        case .day:
+            return NSLocalizedString("day", comment: "Display label for a product's subscription period when it is a single day.")
+        case .week:
+            return NSLocalizedString("week", comment: "Display label for a product's subscription period when it is a single week.")
+        case .month:
+            return NSLocalizedString("month", comment: "Display label for a product's subscription period when it is a single month.")
+        case .year:
+            return NSLocalizedString("year", comment: "Display label for a product's subscription period when it is a single year.")
+        }
+    }
+
+    /// Returns the localized plural text version of the Enum
+    ///
+    var descriptionPlural: String {
+        switch self {
+        case .day:
+            return NSLocalizedString("days", comment: "Display label for a product's subscription period, e.g. '7 days'.")
+        case .week:
+            return NSLocalizedString("weeks", comment: "Display label for a product's subscription period, e.g. '4 weeks'.")
+        case .month:
+            return NSLocalizedString("months", comment: "Display label for a product's subscription period, e.g. '12 months'.")
+        case .year:
+            return NSLocalizedString("years", comment: "Display label for a product's subscription period, e.g. '2 years'.")
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UI.swift
@@ -18,6 +18,21 @@ extension ProductSubscription {
         }
     }
 
+    /// Localized string describing the subscription trial period.
+    ///
+    /// Example: "No trial period" or "12 months"
+    ///
+    var trialDescription: String {
+        switch self.trialLength {
+        case "", "0":
+            return Localization.noTrial
+        case "1":
+            return "1 \(self.trialPeriod.descriptionSingular)"
+        default:
+            return "\(self.trialLength) \(self.trialPeriod.descriptionPlural)"
+        }
+    }
+
     /// Localized string describing the subscription price, billing interval, and period.
     ///
     /// Example: "$50.00 every year" or "$10.00 every 2 weeks"
@@ -61,6 +76,7 @@ private extension ProductSubscription {
                                                    "Reads like: '$60.00 every 2 months'.")
         static let neverExpire = NSLocalizedString("Never expire", comment: "Display label when a subscription never expires.")
         static let noSignupFee = NSLocalizedString("No signup fee", comment: "Display label when a subscription has no signup fee.")
+        static let noTrial = NSLocalizedString("No trial period", comment: "Display label when a subscription has no trial period.")
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1640,7 +1640,9 @@
 		CCDC49ED24000533003166BA /* TestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49EC24000533003166BA /* TestCredentials.swift */; };
 		CCE4CD172667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */; };
 		CCE4CD282669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */; };
+		CCE64E3E29EEA9DA00C1C937 /* ProductSubscription+UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE64E3D29EEA9DA00C1C937 /* ProductSubscription+UITests.swift */; };
 		CCE73D2329ED8DAC0064E797 /* SubscriptionSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE73D2229ED8DAC0064E797 /* SubscriptionSettingsViewModel.swift */; };
+		CCE73D2529EDAB5C0064E797 /* ProductSubscription+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE73D2429EDAB5C0064E797 /* ProductSubscription+UI.swift */; };
 		CCE785C829C1E8280003977F /* BundledProductsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE785C729C1E8280003977F /* BundledProductsListViewModelTests.swift */; };
 		CCE785CA29C1F9170003977F /* ProductBundleItemStockStatus+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE785C929C1F9170003977F /* ProductBundleItemStockStatus+UI.swift */; };
 		CCEC256A27B581E800EF9FA3 /* ProductVariationFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEC256927B581E800EF9FA3 /* ProductVariationFormatter.swift */; };
@@ -3870,7 +3872,9 @@
 		CCDC49F1240060F3003166BA /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UnitTests.xctestplan; path = WooCommerceTests/UnitTests.xctestplan; sourceTree = SOURCE_ROOT; };
 		CCE4CD162667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
 		CCE4CD272669324300E09FD4 /* ShippingLabelPaymentMethodsTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaymentMethodsTopBanner.swift; sourceTree = "<group>"; };
+		CCE64E3D29EEA9DA00C1C937 /* ProductSubscription+UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductSubscription+UITests.swift"; sourceTree = "<group>"; };
 		CCE73D2229ED8DAC0064E797 /* SubscriptionSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionSettingsViewModel.swift; sourceTree = "<group>"; };
+		CCE73D2429EDAB5C0064E797 /* ProductSubscription+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductSubscription+UI.swift"; sourceTree = "<group>"; };
 		CCE785C729C1E8280003977F /* BundledProductsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledProductsListViewModelTests.swift; sourceTree = "<group>"; };
 		CCE785C929C1F9170003977F /* ProductBundleItemStockStatus+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductBundleItemStockStatus+UI.swift"; sourceTree = "<group>"; };
 		CCEC256927B581E800EF9FA3 /* ProductVariationFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormatter.swift; sourceTree = "<group>"; };
@@ -4588,6 +4592,7 @@
 		020B2F9723BDF2D000BD79AD /* Edit Product */ = {
 			isa = PBXGroup;
 			children = (
+				CCE64E3C29EEA9C500C1C937 /* Subscription */,
 				CC09A91029CB1AB700D6C4AD /* Composite Products */,
 				CCE785C629C1E80D0003977F /* Bundled Products */,
 				455208592582907C001CF873 /* Add Product Variation */,
@@ -8355,6 +8360,7 @@
 			children = (
 				CC24A4F329ED6FF70009D6DA /* SubscriptionSettings.swift */,
 				CCE73D2229ED8DAC0064E797 /* SubscriptionSettingsViewModel.swift */,
+				CCE73D2429EDAB5C0064E797 /* ProductSubscription+UI.swift */,
 			);
 			path = Subscription;
 			sourceTree = "<group>";
@@ -8471,6 +8477,14 @@
 				F997174823DC0A7800592D8E /* PeriodStatsTable.swift */,
 			);
 			path = MyStore;
+			sourceTree = "<group>";
+		};
+		CCE64E3C29EEA9C500C1C937 /* Subscription */ = {
+			isa = PBXGroup;
+			children = (
+				CCE64E3D29EEA9DA00C1C937 /* ProductSubscription+UITests.swift */,
+			);
+			path = Subscription;
 			sourceTree = "<group>";
 		};
 		CCE785C629C1E80D0003977F /* Bundled Products */ = {
@@ -11174,6 +11188,7 @@
 				02C37B7D2967B72A00F0CF9E /* FreeStagingDomainView.swift in Sources */,
 				457509E4267B9E91005FA2EA /* AggregatedProductListViewController.swift in Sources */,
 				D8815B0D263861A400EDAD62 /* CardPresentModalSuccess.swift in Sources */,
+				CCE73D2529EDAB5C0064E797 /* ProductSubscription+UI.swift in Sources */,
 				0235595524496B6D004BE2B8 /* BottomSheetListSelectorCommand.swift in Sources */,
 				CC666F2627F359590045AF1E /* OrdersTopBannerFactory.swift in Sources */,
 				747AA0892107CEC60047A89B /* AnalyticsProvider.swift in Sources */,
@@ -12533,6 +12548,7 @@
 				B57C5C9921B80E7100FF82B2 /* DictionaryWooTests.swift in Sources */,
 				26F94E34267AA42F00DB6CCF /* ProductAddOnViewModelTests.swift in Sources */,
 				AE7C957F27C417FA007E8E12 /* FeeLineDetailsViewModelTests.swift in Sources */,
+				CCE64E3E29EEA9DA00C1C937 /* ProductSubscription+UITests.swift in Sources */,
 				0290E27E238E5B5C00B5C466 /* ProductStockStatusListSelectorCommandTests.swift in Sources */,
 				028A4655295AD2DA001CF6CE /* StoreCreationSellingStatusQuestionViewModelTests.swift in Sources */,
 				EE81B1382865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UITests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UITests.swift
@@ -50,6 +50,22 @@ final class ProductSubscription_UITests: XCTestCase {
         XCTAssertEqual(subscription.expiryDescription, Localization.neverExpire)
     }
 
+    func test_signupFeeDescription_returns_formatted_signUpFee() {
+        // Given
+        let subscription = ProductSubscription.fake().copy(signUpFee: "5")
+
+        // Then
+        XCTAssertEqual(subscription.signupFeeDescription(currencySettings: currencySettings), "$5.00")
+    }
+
+    func test_signupFeeDescription_returns_expected_description_for_no_signup_fee() {
+        // Given
+        let subscription = ProductSubscription.fake().copy(signUpFee: "")
+
+        // Then
+        XCTAssertEqual(subscription.signupFeeDescription(currencySettings: currencySettings), Localization.noSignupFee)
+    }
+
 }
 
 private extension ProductSubscription_UITests {
@@ -58,5 +74,6 @@ private extension ProductSubscription_UITests {
                                                    comment: "Description of the subscription price for a product, with the price and billing frequency. " +
                                                    "Reads like: '$60.00 every 2 months'.")
         static let neverExpire = NSLocalizedString("Never expire", comment: "Display label when a subscription never expires.")
+        static let noSignupFee = NSLocalizedString("No signup fee", comment: "Display label when a subscription has no signup fee.")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UITests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UITests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+import WooFoundation
+
+final class ProductSubscription_UITests: XCTestCase {
+
+    private let currencySettings = CurrencySettings()
+    private let samplePeriod: SubscriptionPeriod = .month
+
+    func test_priceDescription_returns_expected_description_for_singular_period_interval() {
+        // Given
+        let subscription = ProductSubscription.fake().copy(period: samplePeriod, periodInterval: "1", price: "5")
+
+        // Then
+        XCTAssertEqual(subscription.priceDescription(currencySettings: currencySettings),
+                       String.localizedStringWithFormat(Localization.priceFormat, "$5.00", samplePeriod.descriptionSingular))
+    }
+
+    func test_priceDescription_returns_expected_description_for_plural_period_interval() {
+        // Given
+        let subscription = ProductSubscription.fake().copy(period: samplePeriod, periodInterval: "2", price: "5")
+
+        // Then
+        XCTAssertEqual(subscription.priceDescription(currencySettings: currencySettings),
+                       String.localizedStringWithFormat(Localization.priceFormat, "$5.00", "2 \(samplePeriod.descriptionPlural)"))
+    }
+
+    func test_expiryDescription_returns_expected_description_for_singular_subscription_length() {
+        // Given
+        let subscription = ProductSubscription.fake().copy(length: "1", period: samplePeriod)
+
+        // Then
+        XCTAssertEqual(subscription.expiryDescription, "1 \(samplePeriod.descriptionSingular)")
+    }
+
+    func test_expiryDescription_returns_expected_description_for_plural_subscription_length() {
+        // Given
+        let subscription = ProductSubscription.fake().copy(length: "2", period: samplePeriod)
+
+        // Then
+        XCTAssertEqual(subscription.expiryDescription, "2 \(samplePeriod.descriptionPlural)")
+    }
+
+    func test_expiryDescription_returns_expected_description_for_no_expiry() {
+        // Given
+        let subscription = ProductSubscription.fake().copy(length: "0", period: samplePeriod)
+
+        // Then
+        XCTAssertEqual(subscription.expiryDescription, Localization.neverExpire)
+    }
+
+}
+
+private extension ProductSubscription_UITests {
+    enum Localization {
+        static let priceFormat = NSLocalizedString("%1$@ every %2$@",
+                                                   comment: "Description of the subscription price for a product, with the price and billing frequency. " +
+                                                   "Reads like: '$60.00 every 2 months'.")
+        static let neverExpire = NSLocalizedString("Never expire", comment: "Display label when a subscription never expires.")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UITests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UITests.swift
@@ -66,6 +66,30 @@ final class ProductSubscription_UITests: XCTestCase {
         XCTAssertEqual(subscription.signupFeeDescription(currencySettings: currencySettings), Localization.noSignupFee)
     }
 
+    func test_trialDescription_returns_expected_description_for_singular_trial_length() {
+        // Given
+        let subscription = ProductSubscription.fake().copy(trialLength: "1", trialPeriod: samplePeriod)
+
+        // Then
+        XCTAssertEqual(subscription.trialDescription, "1 \(samplePeriod.descriptionSingular)")
+    }
+
+    func test_trialDescription_returns_expected_description_for_plural_trial_length() {
+        // Given
+        let subscription = ProductSubscription.fake().copy(trialLength: "2", trialPeriod: samplePeriod)
+
+        // Then
+        XCTAssertEqual(subscription.trialDescription, "2 \(samplePeriod.descriptionPlural)")
+    }
+
+    func test_trialDescription_returns_expected_description_for_no_trial() {
+        // Given
+        let subscription = ProductSubscription.fake().copy(trialLength: "0", trialPeriod: samplePeriod)
+
+        // Then
+        XCTAssertEqual(subscription.trialDescription, Localization.noTrial)
+    }
+
 }
 
 private extension ProductSubscription_UITests {
@@ -75,5 +99,6 @@ private extension ProductSubscription_UITests {
                                                    "Reads like: '$60.00 every 2 months'.")
         static let neverExpire = NSLocalizedString("Never expire", comment: "Display label when a subscription never expires.")
         static let noSignupFee = NSLocalizedString("No signup fee", comment: "Display label when a subscription has no signup fee.")
+        static let noTrial = NSLocalizedString("No trial period", comment: "Display label when a subscription has no trial period.")
     }
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -137,6 +137,7 @@ public typealias SiteSummaryStats = Networking.SiteSummaryStats
 public typealias SiteVisitStats = Networking.SiteVisitStats
 public typealias SiteVisitStatsItem = Networking.SiteVisitStatsItem
 public typealias StateOfACountry = Networking.StateOfACountry
+public typealias SubscriptionPeriod = Networking.SubscriptionPeriod
 public typealias SystemPlugin = Networking.SystemPlugin
 public typealias SystemStatus = Networking.SystemStatus
 public typealias TaxClass = Networking.TaxClass


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8952
⚠️ Depends on #9484
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This formats and displays the subscription settings for simple subscription products in the Subscription row in product details and the `SubscriptionSettings` view.

### Changes

* Adds an extension to `ProductSubscription` in the UI layer format and localize the subscription details. This creates four descriptions, for example:
   * Subscription price: "$50.00 every year" or "$10.00 every 2 weeks"
   * Expire after: "Never expires" or "6 months" or "1 year"
   * Signup fee: "No signup fee" or "$5.00"
   * Free trial: "No trial period" or "12 months"
* Updates `DefaultProductFormTableViewModel` to show the real subscription price and expiry descriptions in the Subscription row.
* Updates `ProductFormViewController` to show the real subscription settings descriptions in `SubscriptionSettings`.
* Adds unit tests for the new description strings.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Prerequisites

1. Install and activate the [Subscriptions extension](https://woocommerce.com/products/woocommerce-subscriptions/) on your store.
2. Create at least one product with the Simple Subscription product type, and enter the subscription details on the General product settings tab.

### To test

1. Build and run the app.
2. Go to the Products tab.
3. Open a subscription product and confirm the Subscription row shows the correct data.
4. Tap the Subscription row and confirm it the Subscription settings view shows the correct data.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/8658164/232808265-631f88e0-dc55-4d9c-b16f-bc6cd2c79767.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
