### PR TITLE
[Mobile Payments ]Refactor IPP Onboarding checks

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -337,7 +337,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
                 return .codPaymentGatewayNotSetUp(plugin: plugin)
             }
         }
-        guard !isInUndefinedState(account: account) else {
+        guard canCollectCardPresentPayments(account: account) else {
             return .genericError
         }
 
@@ -474,8 +474,9 @@ private extension CardPresentPaymentsOnboardingUseCase {
         return codGateway.enabled
     }
 
-    func isInUndefinedState(account: PaymentGatewayAccount) -> Bool {
-        account.wcpayStatus == .unknown
+    func canCollectCardPresentPayments(account: PaymentGatewayAccount) -> Bool {
+        account.wcpayStatus == .complete ||
+        account.wcpayStatus == .restrictedSoon
     }
 
     func isNetworkError(_ error: Error) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -337,7 +337,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
                 return .codPaymentGatewayNotSetUp(plugin: plugin)
             }
         }
-        guard canCollectCardPresentPayments(account: account) else {
+        guard accountStatusAllowedForCardPresentPayments(account: account) else {
             return .genericError
         }
 
@@ -474,7 +474,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         return codGateway.enabled
     }
 
-    func canCollectCardPresentPayments(account: PaymentGatewayAccount) -> Bool {
+    func accountStatusAllowedForCardPresentPayments(account: PaymentGatewayAccount) -> Bool {
         account.wcpayStatus == .complete ||
         account.wcpayStatus == .restrictedSoon
     }

--- a/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
@@ -374,6 +374,18 @@ class CurrencyFormatterTests: XCTestCase {
         XCTAssertEqual(amount, expectedResult)
     }
 
+    func testFormatHumanReadableWorksUsingLowerCaseCountryCode() {
+        let inputValue = "105.01"
+        let expectedResult = "£105.01"
+        let locale = sampleLocale
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings)
+            .formatHumanReadableAmount(inputValue,
+                                       with: "gbp",
+                                       roundSmallNumbers: false,
+                                       locale: locale)
+        XCTAssertEqual(amount, expectedResult)
+    }
+
     func testFormatHumanReadableWithRoundingWorksUsingSmallNegativeDecimalValue() {
         let inputValue = "-76.64"
         let expectedResult = "-$76"

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -840,6 +840,25 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .stripeAccountPendingRequirement(plugin: .wcPay, deadline: nil))
     }
 
+    func test_onboarding_when_account_is_restricted_soon_with_pending_requirements_skipped_for_wcpay_plugin_returns_complete() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .restrictedSoon, hasPendingRequirements: true)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
+                                                           stores: stores,
+                                                           cardPresentPaymentOnboardingStateCache: onboardingStateCache)
+
+        useCase.skipPendingRequirements()
+        useCase.updateState()
+
+        let state = useCase.state
+        // Then
+        XCTAssertEqual(state, .completed(plugin: CardPresentPaymentsPluginState(preferred: .wcPay, available: [.wcPay])))
+    }
+
     func test_onboarding_returns_overdue_requirements_when_account_is_restricted_with_overdue_requirements_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)

--- a/WooFoundation/WooFoundation/Currency/CurrencyFormatter.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencyFormatter.swift
@@ -266,7 +266,7 @@ public class CurrencyFormatter {
     public func formatAmount(_ amount: NSDecimalNumber, with currency: String? = nil, locale: Locale = .current, numberOfDecimals: Int? = nil) -> String? {
         let currency = currency ?? currencySettings.currencyCode.rawValue
         // Get the currency code
-        let code = CurrencyCode(rawValue: currency) ?? currencySettings.currencyCode
+        let code = CurrencyCode(rawValue: currency.uppercased()) ?? currencySettings.currencyCode
         // Grab the read-only currency options. These are set by the user in Site > Settings.
         let symbol = currencySettings.symbol(from: code)
         let separator = currencySettings.decimalSeparator


### PR DESCRIPTION
… statuses that can collect payments

<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we refactor the onboarding checks for In-Person Payments to allow payments only if the WCPay status is complete or restricted soon (with pending requirements skipped). This is different than the default last approach, where we only checked if the status was unknown to stop the flow.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
With a store where WCPay status is restricted soon, check that you can take payments. Check also if the status is complete.

@joshheald I invited you to my store where status is restricted soon, feel free to use it if necessary.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
