### PR TITLE
[Subscriptions] Add support for variable subscription products in product details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -143,8 +143,6 @@ private extension DefaultProductFormTableViewModel {
                 return .status(viewModel: variationStatusRow(productVariation: productVariation, isEditable: editable), isEditable: editable)
             case .noPriceWarning:
                 return .noPriceWarning(viewModel: noPriceWarningRow(isActionable: false))
-            case .subscription(let actionable):
-                return .subscription(viewModel: subscriptionRow(product: productVariation, isActionable: actionable), isActionable: actionable)
             default:
                 assertionFailure("Unexpected action in the settings section: \(action)")
                 return nil
@@ -562,7 +560,7 @@ private extension DefaultProductFormTableViewModel {
                                                         isActionable: isActionable)
     }
 
-    // MARK: Subscription products and product variations only
+    // MARK: Subscription products only
 
     func subscriptionRow(product: ProductFormDataModel, isActionable: Bool) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.priceImage

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -118,6 +118,8 @@ private extension DefaultProductFormTableViewModel {
                 return .components(viewModel: componentsRow(product: product, isActionable: actionable), isActionable: actionable)
             case .subscription(let actionable):
                 return .subscription(viewModel: subscriptionRow(product: product, isActionable: actionable), isActionable: actionable)
+            case .noVariationsWarning:
+                return .noVariationsWarning(viewModel: noVariationsWarningRow())
             default:
                 assertionFailure("Unexpected action in the settings section: \(action)")
                 return nil
@@ -141,6 +143,8 @@ private extension DefaultProductFormTableViewModel {
                 return .status(viewModel: variationStatusRow(productVariation: productVariation, isEditable: editable), isEditable: editable)
             case .noPriceWarning:
                 return .noPriceWarning(viewModel: noPriceWarningRow(isActionable: false))
+            case .subscription(let actionable):
+                return .subscription(viewModel: subscriptionRow(product: productVariation, isActionable: actionable), isActionable: actionable)
             default:
                 assertionFailure("Unexpected action in the settings section: \(action)")
                 return nil
@@ -558,7 +562,7 @@ private extension DefaultProductFormTableViewModel {
                                                         isActionable: isActionable)
     }
 
-    // MARK: Subscription products only
+    // MARK: Subscription products and product variations only
 
     func subscriptionRow(product: ProductFormDataModel, isActionable: Bool) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.priceImage
@@ -575,6 +579,16 @@ private extension DefaultProductFormTableViewModel {
                                                         title: title,
                                                         details: details,
                                                         isActionable: isActionable)
+    }
+
+    // MARK: Variable Subscription products only
+
+    func noVariationsWarningRow() -> ProductFormSection.SettingsRow.WarningViewModel {
+        let icon = UIImage.infoOutlineImage
+        let title = Localization.noVariationsWarningTitle
+        return ProductFormSection.SettingsRow.WarningViewModel(icon: icon,
+                                                               title: title,
+                                                               isActionable: false)
     }
 }
 
@@ -789,5 +803,10 @@ private extension DefaultProductFormTableViewModel {
                                                                comment: "Format of the regular price on the Subscription row")
         static let subscriptionExpiryFormat = NSLocalizedString("Expire after: %@",
                                                                 comment: "Format of the expiry details on the Subscription row")
+
+        // No variations warning row (read-only variable subscription)
+        static let noVariationsWarningTitle =
+            NSLocalizedString("You can only add variable subscriptions in the web dashboard",
+                              comment: "Title of the no variations warning row in the product form when a variable subscription product has no variations.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -82,7 +82,8 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
              .attributes,
              .bundledProducts,
              .components,
-             .subscription:
+             .subscription,
+             .noVariationsWarning:
             return [ImageAndTitleAndTextTableViewCell.self]
         case .reviews:
             return [ProductReviewsTableViewCell.self]
@@ -114,7 +115,8 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
              .attributes,
              .bundledProducts,
              .components,
-             .subscription:
+             .subscription,
+             .noVariationsWarning:
             return ImageAndTitleAndTextTableViewCell.self
         case .reviews:
             return ProductReviewsTableViewCell.self

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -265,7 +265,8 @@ private extension ProductFormTableViewDataSource {
             configureReviews(cell: cell, viewModel: viewModel, ratingCount: ratingCount, averageRating: averageRating)
         case .status(let viewModel, _):
             configureSettingsRowWithASwitch(cell: cell, viewModel: viewModel)
-        case .noPriceWarning(let viewModel):
+        case .noPriceWarning(let viewModel),
+             .noVariationsWarning(let viewModel):
             configureWarningRow(cell: cell, viewModel: viewModel)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -47,6 +47,7 @@ enum ProductFormSection: Equatable {
         case bundledProducts(viewModel: ViewModel, isActionable: Bool)
         case components(viewModel: ViewModel, isActionable: Bool)
         case subscription(viewModel: ViewModel, isActionable: Bool)
+        case noVariationsWarning(viewModel: WarningViewModel)
 
         struct ViewModel {
             let icon: UIImage

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -461,6 +461,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 }
                 // TODO: Track row tapped
                 showSubscriptionSettings()
+            case .noVariationsWarning:
+                return // This warning is not actionable.
             }
         case .optionsCTA(let rows):
             let row = rows[indexPath.row]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -765,6 +765,75 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
         assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
     }
+
+    func test_view_model_for_variable_subscription_product_with_feature_flag_disabled() {
+        // Arrange
+        let product = Fixtures.variableSubscriptionProduct
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isSubscriptionProductsEnabled: false)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.reviews,
+                                                                       .inventorySettings(editable: false),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: false)]
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
+        assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
+    }
+
+    func test_view_model_for_variable_subscription_product_with_no_variations_and_feature_flag_enabled() {
+        // Arrange
+        let product = Fixtures.variableSubscriptionProduct
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isSubscriptionProductsEnabled: true)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.noVariationsWarning,
+                                                                       .reviews,
+                                                                       .inventorySettings(editable: false),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: false)]
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
+        assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
+    }
+
+    func test_view_model_for_variable_subscription_product_with_variations_and_feature_flag_enabled() {
+        // Arrange
+        let product = Fixtures.variableSubscriptionProduct.copy(attributes: [.fake().copy(variation: true)], variations: [123])
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isSubscriptionProductsEnabled: true)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.variations(hideSeparator: false),
+                                                                       .attributes(editable: true),
+                                                                       .reviews,
+                                                                       .inventorySettings(editable: false),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: false)]
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
+        assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
+    }
 }
 
 private extension ProductFormActionsFactoryTests {
@@ -820,6 +889,9 @@ private extension ProductFormActionsFactoryTests {
 
         // Subscription product with price and subscription
         static let subscriptionProduct = affiliateProduct.copy(productTypeKey: ProductType.subscription.rawValue, regularPrice: "2", subscription: .fake())
+
+        // Variable subscription product with no variations or variation attributes
+        static let variableSubscriptionProduct = affiliateProduct.copy(productTypeKey: ProductType.variableSubscription.rawValue)
 
         // Non-core product, missing price/short description/categories/tags
         static let nonCoreProductWithoutPrice = affiliateProduct.copy(productTypeKey: "other", regularPrice: "")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9394
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support in the product details screen for variable subscription products. It adds two rows:

* The Variations row if the product has variations, or a warning if it doesn't.
* The Attributes row if the product has attributes to use for variations.

For now, selecting the Variations row opens the same variation list and variation details as core variable products. This will be updated in another PR with the expected behavior for variable subscription products.

### Changes

* Adds a view model for the no variations warning in `DefaultProductFormTableViewModel`. This warning directs users to the web dashboard to add new variations for a variable subscription product.
* Defines the rows to show for Variable Subscription products in `ProductFormActionsFactory`. These are the same as before (for non-core products), with the addition of the variations row or warning and the attributes row.
* Adds unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Prerequisites

1. Install and activate the [Subscriptions extension](https://woocommerce.com/products/woocommerce-subscriptions/) on your store.
2. Create at least one product with the Variable Subscription product type.

### To test

1. Build and run the app.
2. Go to the Products tab.
3. Open a variable subscription product and confirm the expected row appear in product details.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-04-18 at 17 39 42](https://user-images.githubusercontent.com/8658164/232848950-b5f89199-6173-4b2e-a659-43f3a58fb652.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-04-18 at 17 38 13](https://user-images.githubusercontent.com/8658164/232848989-ea72c467-ba00-40a8-a885-a43dee89f0da.png)
![Simulator Screen Shot - iPhone 14 Pro - 2023-04-18 at 17 39 51](https://user-images.githubusercontent.com/8658164/232848969-bf8c6856-124f-4e38-ac4a-413eb63f2a20.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-04-18 at 17 38 24](https://user-images.githubusercontent.com/8658164/232849001-e3f1f520-6cd9-46bf-9109-064253ce8317.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
