### PR TITLE
[Mobile Payments] Use passed currency on receipts

### DIFF
--- a/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
@@ -374,6 +374,18 @@ class CurrencyFormatterTests: XCTestCase {
         XCTAssertEqual(amount, expectedResult)
     }
 
+    func testFormatHumanReadableWorksUsingLowerCaseCountryCode() {
+        let inputValue = "105.01"
+        let expectedResult = "£105.01"
+        let locale = sampleLocale
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings)
+            .formatHumanReadableAmount(inputValue,
+                                       with: "gbp",
+                                       roundSmallNumbers: false,
+                                       locale: locale)
+        XCTAssertEqual(amount, expectedResult)
+    }
+
     func testFormatHumanReadableWithRoundingWorksUsingSmallNegativeDecimalValue() {
         let inputValue = "-76.64"
         let expectedResult = "-$76"

--- a/WooFoundation/WooFoundation/Currency/CurrencyFormatter.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencyFormatter.swift
@@ -266,7 +266,7 @@ public class CurrencyFormatter {
     public func formatAmount(_ amount: NSDecimalNumber, with currency: String? = nil, locale: Locale = .current, numberOfDecimals: Int? = nil) -> String? {
         let currency = currency ?? currencySettings.currencyCode.rawValue
         // Get the currency code
-        let code = CurrencyCode(rawValue: currency) ?? currencySettings.currencyCode
+        let code = CurrencyCode(rawValue: currency.uppercased()) ?? currencySettings.currencyCode
         // Grab the read-only currency options. These are set by the user in Site > Settings.
         let symbol = currencySettings.symbol(from: code)
         let separator = currencySettings.decimalSeparator


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

Merge after #9487 

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

UK In-Person Payments receipts were showing with $ signs.

This was due to the currency code used from the API being `gbp` instead of `GBP`, which meant it didn’t match the `CurrencyCode.rawValue` when checked.

All our `CurrencyCode` values are upper case, so it seems reasonable to convert anything that’s passed in to upper case as well, to avoid this issue in future.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Take an In-Person Payment using a UK WCPay store
2. When the payment is complete, view the receipt (from the print, email, or order details buttons)
3. Observe that all the amounts have a £ symbol, not a $


1. Repeat with a US/CA store
2. Observe that the amounts have a $ symbol

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![image](https://user-images.githubusercontent.com/2472348/232852678-35fdeab6-4a07-4620-90df-15bb13e9eb5b.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
