### PR TITLE
[Subscription] Disable generating and bulk editing variations for variable subscriptions

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -171,8 +171,9 @@ private extension ProductVariationsViewController {
     /// Shows or hides the "more" navigation bar button.
     ///
     func showOrHideMoreActionsNavigationBarButton() {
-        guard resultsController.fetchedObjects.isNotEmpty else {
+        guard resultsController.fetchedObjects.isNotEmpty && viewModel.shouldAllowBulkEditing(for: product) else {
             // Do not display the "more" button with the bulk update option if we do not have any variations
+            // or if the view model does not allow it
             hideMoreActionsNavigationBarButton()
             return
         }
@@ -284,6 +285,10 @@ private extension ProductVariationsViewController {
 //
 private extension ProductVariationsViewController {
     func configureTopStackView() {
+        guard viewModel.shouldAllowGeneration(for: product) else {
+            return
+        }
+
         addTopButton(title: Localization.generateVariationAction,
                      insets: .init(top: 16, left: 16, bottom: 8, right: 16),
                      hasBottomBorder: true,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -286,6 +286,10 @@ private extension ProductVariationsViewController {
 private extension ProductVariationsViewController {
     func configureTopStackView() {
         guard viewModel.shouldAllowGeneration(for: product) else {
+            // Hide top stack view by reducing its height to 0.
+            // Otherwise, a blank space is shown where the "Generate Variation" button would be.
+            let zeroHeight = topStackView.heightAnchor.constraint(equalToConstant: 0)
+            topStackView.addConstraint(zeroHeight)
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewModel.swift
@@ -58,4 +58,20 @@ extension ProductVariationsViewModel {
     func shouldShowAttributeGuide(for product: Product) -> Bool {
         product.attributesForVariations.isEmpty
     }
+
+    /// Defines if screen should show the options to generate new variations.
+    ///
+    /// Generating variations is currently disabled for variable subscription products.
+    ///
+    func shouldAllowGeneration(for product: Product) -> Bool {
+        product.productType != .variableSubscription
+    }
+
+    /// Defines if screen should allow bulk editing.
+    ///
+    /// Bulk editing is currently disabled for variable subscription products.
+    ///
+    func shouldAllowBulkEditing(for product: Product) -> Bool {
+        product.productType != .variableSubscription
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationsViewModelTests.swift
@@ -114,4 +114,14 @@ final class ProductVariationsViewModelTests: XCTestCase {
         XCTAssertTrue(product.existsRemotely)
         XCTAssertEqual(viewModel.formType, .readonly)
     }
+
+    func test_generating_and_bulk_editing_variations_not_allowed_for_variable_subscription_products() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: ProductType.variableSubscription.rawValue)
+        let viewModel = ProductVariationsViewModel(formType: .edit)
+
+        // Then
+        XCTAssertFalse(viewModel.shouldAllowGeneration(for: product))
+        XCTAssertFalse(viewModel.shouldAllowBulkEditing(for: product))
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9394
⚠️ Depends on #9488
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are only adding read-only support for variable subscription products. When you tap to view the variations list, you should only see a list of the existing variations. This PR disables the options to generate or bulk edit variations on the variations list for variable subscription products.

### Changes

* Adds checks in the view model to disallow generating and bulk editing variations if the product type is Variable Subscription.
* Hides the top stack view (with the "Generate New Variation" button) if `shouldAllowGeneration(for:)` is `false`.
* Hides the "more" menu (with the "Bulk Update" button) if `shouldAllowBulkEditing(for:)` is `false`.

Note: This PR doesn't change the variations list behavior for the empty state. This is because you can't open the variations list for variable subscription products if there are no variations. It also doesn't update the variation detail screen (when you select a variation); this will be updated in another PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Prerequisites

1. Install and activate the [Subscriptions extension](https://woocommerce.com/products/woocommerce-subscriptions/) on your store.
2. Create at least one product with the Variable Subscription product type.
3. Add at least one variation to the product.

### To test

1. Build and run the app.
2. Go to the Products tab.
4. Open a variable subscription product and select Variations.
5. Confirm the Variations list loads with no options to create or bulk edit the variations.

You can also open a core variable product (not a subscription) to confirm it continues to show the generating and bulk editing options as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-04-18 at 18 51 24](https://user-images.githubusercontent.com/8658164/232863096-8925265d-757f-4fb2-a2d9-ae5e1d2fe029.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-04-18 at 18 47 01](https://user-images.githubusercontent.com/8658164/232863109-67081ee9-9617-48c4-abaa-ae5d82822552.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
