### PR TITLE
REST API: Update mappers for orders

### DIFF
--- a/Networking/Networking/Mapper/CountryListMapper.swift
+++ b/Networking/Networking/Mapper/CountryListMapper.swift
@@ -5,14 +5,15 @@ import Foundation
 ///
 struct CountryListMapper: Mapper {
 
+    let siteID: Int64
+
     /// (Attempts) to convert an instance of Data into an array of Country Entities.
     ///
     func map(response: Data) throws -> [Country] {
-        do {
-            return try JSONDecoder().decode(CountryListEnvelope.self, from: response).data
-        } catch {
+        guard siteID != WooConstants.placeholderSiteID else {
             return try JSONDecoder().decode([Country].self, from: response)
         }
+        return try JSONDecoder().decode(CountryListEnvelope.self, from: response).data
     }
 }
 

--- a/Networking/Networking/Mapper/NewShipmentTrackingMapper.swift
+++ b/Networking/Networking/Mapper/NewShipmentTrackingMapper.swift
@@ -22,12 +22,10 @@ struct NewShipmentTrackingMapper: Mapper {
             .siteID: siteID,
             .orderID: orderID
         ]
-
-        do {
-            return try decoder.decode(NewShipmentTrackingMapperEnvelope.self, from: response).shipmentTracking
-        } catch {
+        guard siteID != WooConstants.placeholderSiteID else {
             return try decoder.decode(ShipmentTracking.self, from: response)
         }
+        return try decoder.decode(NewShipmentTrackingMapperEnvelope.self, from: response).shipmentTracking
     }
 }
 

--- a/Networking/Networking/Mapper/OrderListMapper.swift
+++ b/Networking/Networking/Mapper/OrderListMapper.swift
@@ -21,11 +21,10 @@ struct OrderListMapper: Mapper {
             .siteID: siteID
         ]
 
-        do {
-            return try decoder.decode(OrderListEnvelope.self, from: response).orders
-        } catch {
+        guard siteID != WooConstants.placeholderSiteID else {
             return try decoder.decode([Order].self, from: response)
         }
+        return try decoder.decode(OrderListEnvelope.self, from: response).orders
     }
 }
 

--- a/Networking/Networking/Mapper/OrderMapper.swift
+++ b/Networking/Networking/Mapper/OrderMapper.swift
@@ -20,11 +20,10 @@ struct OrderMapper: Mapper {
         decoder.userInfo = [
             .siteID: siteID
         ]
-        do {
-            return try decoder.decode(OrderEnvelope.self, from: response).order
-        } catch {
+        guard siteID != WooConstants.placeholderSiteID else {
             return try decoder.decode(Order.self, from: response)
         }
+        return try decoder.decode(OrderEnvelope.self, from: response).order
     }
 }
 

--- a/Networking/Networking/Mapper/OrderNoteMapper.swift
+++ b/Networking/Networking/Mapper/OrderNoteMapper.swift
@@ -3,7 +3,9 @@ import Foundation
 
 /// Mapper: OrderNote (Singular)
 ///
-class OrderNoteMapper: Mapper {
+struct OrderNoteMapper: Mapper {
+
+    let siteID: Int64
 
     /// (Attempts) to convert a dictionary into a single OrderNote
     ///
@@ -11,11 +13,10 @@ class OrderNoteMapper: Mapper {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
 
-        do {
-            return try decoder.decode(OrderNoteEnvelope.self, from: response).orderNote
-        } catch {
+        guard siteID != WooConstants.placeholderSiteID else {
             return try decoder.decode(OrderNote.self, from: response)
         }
+        return try decoder.decode(OrderNoteEnvelope.self, from: response).orderNote
     }
 }
 

--- a/Networking/Networking/Mapper/OrderNotesMapper.swift
+++ b/Networking/Networking/Mapper/OrderNotesMapper.swift
@@ -3,7 +3,9 @@ import Foundation
 
 /// Mapper: OrderNotes
 ///
-class OrderNotesMapper: Mapper {
+struct OrderNotesMapper: Mapper {
+
+    let siteID: Int64
 
     /// (Attempts) to convert a dictionary into [OrderNote].
     ///
@@ -11,11 +13,10 @@ class OrderNotesMapper: Mapper {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
 
-        do {
-            return try decoder.decode(OrderNotesEnvelope.self, from: response).orderNotes
-        } catch {
+        guard siteID != WooConstants.placeholderSiteID else {
             return try decoder.decode([OrderNote].self, from: response)
         }
+        return try decoder.decode(OrderNotesEnvelope.self, from: response).orderNotes
     }
 }
 

--- a/Networking/Networking/Mapper/RefundListMapper.swift
+++ b/Networking/Networking/Mapper/RefundListMapper.swift
@@ -27,11 +27,10 @@ struct RefundListMapper: Mapper {
             .orderID: orderID
         ]
 
-        do {
-            return try decoder.decode(RefundsEnvelope.self, from: response).refunds
-        } catch {
+        guard siteID != WooConstants.placeholderSiteID else {
             return try decoder.decode([Refund].self, from: response)
         }
+        return try decoder.decode(RefundsEnvelope.self, from: response).refunds
     }
 }
 

--- a/Networking/Networking/Mapper/RefundMapper.swift
+++ b/Networking/Networking/Mapper/RefundMapper.swift
@@ -27,11 +27,11 @@ struct RefundMapper: Mapper {
             .orderID: orderID
         ]
 
-        do {
-            return try decoder.decode(RefundEnvelope.self, from: response).refund
-        } catch {
+        guard siteID != WooConstants.placeholderSiteID else {
             return try decoder.decode(Refund.self, from: response)
         }
+
+        return try decoder.decode(RefundEnvelope.self, from: response).refund
     }
 
     /// (Attempts) to encode a Refund object into JSONEncoded data.

--- a/Networking/Networking/Remote/DataRemote.swift
+++ b/Networking/Networking/Remote/DataRemote.swift
@@ -13,7 +13,7 @@ public final class DataRemote: Remote {
                                      siteID: siteID,
                                      path: Path.countries,
                                      availableAsRESTRequest: true)
-        let mapper = CountryListMapper()
+        let mapper = CountryListMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }
 }

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -96,7 +96,7 @@ public class OrdersRemote: Remote {
                                      path: path,
                                      parameters: nil,
                                      availableAsRESTRequest: true)
-        let mapper = OrderNotesMapper()
+        let mapper = OrderNotesMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -275,7 +275,7 @@ public class OrdersRemote: Remote {
         let parameters = [ParameterKeys.note: note,
                           ParameterKeys.customerNote: String(isCustomerNote),
                           ParameterKeys.addedByUser: String(true)] // This will always be true when creating notes in-app
-        let mapper = OrderNoteMapper()
+        let mapper = OrderNoteMapper(siteID: siteID)
 
         let request = JetpackRequest(wooApiVersion: .mark3,
                                      method: .post,

--- a/Networking/NetworkingTests/Mapper/CountryListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CountryListMapperTests.swift
@@ -43,23 +43,23 @@ private extension CountryListMapperTests {
 
     /// Returns the CountryListMapperTests output upon receiving `filename` (Data Encoded)
     ///
-    func mapCountries(from filename: String) -> [Country]? {
+    func mapCountries(siteID: Int64, from filename: String) -> [Country]? {
         guard let response = Loader.contentsOf(filename) else {
             return nil
         }
 
-        return try! CountryListMapper().map(response: response)
+        return try! CountryListMapper(siteID: siteID).map(response: response)
     }
 
     /// Returns the [Country] output upon receiving `countries`
     ///
     func mapCountriesResponse() -> [Country]? {
-        return mapCountries(from: "countries")
+        return mapCountries(siteID: 123, from: "countries")
     }
 
     /// Returns the [Country] output upon receiving `countries-without-data`
     ///
     func mapCountriesResponseWithoutDataEnvelope() -> [Country]? {
-        return mapCountries(from: "countries-without-data")
+        return mapCountries(siteID: -1, from: "countries-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/NewShipmentTrackingMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/NewShipmentTrackingMapperTests.swift
@@ -28,7 +28,7 @@ final class NewShipmentTrackingMapperTests: XCTestCase {
     func test_tracking_fields_are_properly_parsed_when_response_has_no_data_envelope() throws {
         let shipmentTracking = try mapLoadShipmentTrackingResponseWithoutDataEnvelope()
         let shipmentTrackingShipDate = DateFormatter.Defaults.yearMonthDayDateFormatter.date(from: "2019-03-12")
-        XCTAssertEqual(shipmentTracking.siteID, dummySiteID)
+        XCTAssertEqual(shipmentTracking.siteID, WooConstants.placeholderSiteID)
         XCTAssertEqual(shipmentTracking.orderID, dummyOrderID)
         XCTAssertEqual(shipmentTracking.trackingID, "f2e7783b40837b9e1ec503a149dab4a1")
         XCTAssertEqual(shipmentTracking.trackingNumber, "123456781234567812345678")
@@ -45,24 +45,24 @@ private extension NewShipmentTrackingMapperTests {
 
     /// Returns the NewShipmentTrackingMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapShipmentTracking(from filename: String) throws -> ShipmentTracking {
+    func mapShipmentTracking(siteID: Int64, from filename: String) throws -> ShipmentTracking {
         guard let response = Loader.contentsOf(filename) else {
             throw ParsingError.unableToLoadFile
         }
 
-        return try! NewShipmentTrackingMapper(siteID: dummySiteID, orderID: dummyOrderID).map(response: response)
+        return try! NewShipmentTrackingMapper(siteID: siteID, orderID: dummyOrderID).map(response: response)
     }
 
     /// Returns the NewShipmentTrackingMapper output upon receiving `shipment_tracking_new`
     ///
     func mapLoadShipmentTrackingResponse() throws -> ShipmentTracking {
-        try mapShipmentTracking(from: "shipment_tracking_new")
+        try mapShipmentTracking(siteID: dummySiteID, from: "shipment_tracking_new")
     }
 
     /// Returns the NewShipmentTrackingMapper output upon receiving `shipment_tracking_new-without-data`
     ///
     func mapLoadShipmentTrackingResponseWithoutDataEnvelope() throws -> ShipmentTracking {
-        try mapShipmentTracking(from: "shipment_tracking_new-without-data")
+        try mapShipmentTracking(siteID: WooConstants.placeholderSiteID, from: "shipment_tracking_new-without-data")
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/OrderListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderListMapperTests.swift
@@ -171,35 +171,35 @@ private extension OrderListMapperTests {
 
     /// Returns the [Order] output upon receiving `filename` (Data Encoded)
     ///
-    func mapOrders(from filename: String) -> [Order] {
+    func mapOrders(siteID: Int64, from filename: String) -> [Order] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! OrderListMapper(siteID: dummySiteID).map(response: response)
+        return try! OrderListMapper(siteID: siteID).map(response: response)
     }
 
     /// Returns the [Order] output upon receiving `orders-load-all`
     ///
     func mapLoadAllOrdersResponse() -> [Order] {
-        return mapOrders(from: "orders-load-all")
+        return mapOrders(siteID: dummySiteID, from: "orders-load-all")
     }
 
     /// Returns the [Order] output upon receiving `orders-load-all-without-data`
     ///
     func mapLoadAllOrdersResponseWithoutDataEnvelope() -> [Order] {
-        return mapOrders(from: "orders-load-all-without-data")
+        return mapOrders(siteID: WooConstants.placeholderSiteID, from: "orders-load-all-without-data")
     }
 
     /// Returns the [Order] output upon receiving `broken-order`
     ///
     func mapLoadBrokenOrderResponse() -> [Order] {
-        return mapOrders(from: "broken-orders")
+        return mapOrders(siteID: dummySiteID, from: "broken-orders")
     }
 
     /// Returns the [Order] output upon receiving `broken-orders-mark-2`
     ///
     func mapLoadBrokenOrdersResponseMarkII() -> [Order] {
-        return mapOrders(from: "broken-orders-mark-2")
+        return mapOrders(siteID: dummySiteID, from: "broken-orders-mark-2")
     }
 }

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -55,7 +55,7 @@ final class OrderMapperTests: XCTestCase {
         let dateModified = DateFormatter.Defaults.dateTimeFormatter.date(from: "2018-04-03T23:05:14")
         let datePaid = DateFormatter.Defaults.dateTimeFormatter.date(from: "2018-04-03T23:05:14")
 
-        XCTAssertEqual(order.siteID, dummySiteID)
+        XCTAssertEqual(order.siteID, WooConstants.placeholderSiteID)
         XCTAssertEqual(order.orderID, 963)
         XCTAssertEqual(order.parentID, 0)
         XCTAssertEqual(order.customerID, 11)
@@ -388,73 +388,73 @@ private extension OrderMapperTests {
 
     /// Returns the Order output upon receiving `filename` (Data Encoded)
     ///
-    func mapOrder(from filename: String) -> Order? {
+    func mapOrder(siteID: Int64, from filename: String) -> Order? {
         guard let response = Loader.contentsOf(filename) else {
             return nil
         }
 
-        return try! OrderMapper(siteID: dummySiteID).map(response: response)
+        return try! OrderMapper(siteID: siteID).map(response: response)
     }
 
     /// Returns the Order output upon receiving `order`
     ///
     func mapLoadOrderResponse() -> Order? {
-        return mapOrder(from: "order")
+        return mapOrder(siteID: dummySiteID, from: "order")
     }
 
     /// Returns the Order output upon receiving `order-without-data`
     ///
     func mapLoadOrderResponseWithoutDataEnvelope() -> Order? {
-        return mapOrder(from: "order-without-data")
+        return mapOrder(siteID: WooConstants.placeholderSiteID, from: "order-without-data")
     }
 
     /// Returns the Order output upon receiving `broken-order`
     ///
     func mapLoadBrokenOrderResponse() -> Order? {
-        return mapOrder(from: "broken-order")
+        return mapOrder(siteID: dummySiteID, from: "broken-order")
     }
 
     /// Returns the Order output upon receiving `order-fully-refunded`
     ///
     func mapLoadFullyRefundedOrderResponse() -> Order? {
-        return mapOrder(from: "order-fully-refunded")
+        return mapOrder(siteID: dummySiteID, from: "order-fully-refunded")
     }
 
     /// Returns the Order output upon receiving `order-details-partially-refunded`
     ///
     func mapLoadPartiallRefundedOrderResponse() -> Order? {
-        return mapOrder(from: "order-details-partially-refunded")
+        return mapOrder(siteID: dummySiteID, from: "order-details-partially-refunded")
     }
 
     /// Returns the Order output upon receiving `order-with-line-item-attributes`
     ///
     func mapLoadOrderWithLineItemAttributesResponse() -> Order? {
-        return mapOrder(from: "order-with-line-item-attributes")
+        return mapOrder(siteID: dummySiteID, from: "order-with-line-item-attributes")
     }
 
     /// Returns the Order output upon receiving `order-with-faulty-attributes`
     /// Where the `value` to `_measurement_data` is not a `string` but a `JSON object`
     ///
     func mapLoadOrderWithFaultyAttributesResponse() -> Order? {
-        return mapOrder(from: "order-with-faulty-attributes")
+        return mapOrder(siteID: dummySiteID, from: "order-with-faulty-attributes")
     }
 
     /// Returns the Order output upon receiving `order-with-line-item-attributes-before-API-support`
     ///
     func mapLoadOrderWithLineItemAttributesBeforeAPISupportResponse() -> Order? {
-        return mapOrder(from: "order-with-line-item-attributes-before-API-support")
+        return mapOrder(siteID: dummySiteID, from: "order-with-line-item-attributes-before-API-support")
     }
 
     /// Returns the Order output upon receiving `order-with-deleted-refunds`
     ///
     func mapLoadOrderWithDeletedRefundsResponse() -> Order? {
-        return mapOrder(from: "order-with-deleted-refunds")
+        return mapOrder(siteID: dummySiteID, from: "order-with-deleted-refunds")
     }
 
     /// Returns the Order output upon receiving `order-with-charge`
     ///
     func mapLoadOrderWithChargeResponse() -> Order? {
-        return mapOrder(from: "order-with-charge")
+        return mapOrder(siteID: dummySiteID, from: "order-with-charge")
     }
 
 }

--- a/Networking/NetworkingTests/Mapper/OrderNotesMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderNotesMapperTests.swift
@@ -79,29 +79,29 @@ private extension OrderNotesMapperTests {
 
     /// Returns the [OrderNote] output upon receiving `filename` (Data Encoded)
     ///
-    func mapNotes(from filename: String) -> [OrderNote] {
+    func mapNotes(siteID: Int64, from filename: String) -> [OrderNote] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! OrderNotesMapper().map(response: response)
+        return try! OrderNotesMapper(siteID: siteID).map(response: response)
     }
 
     /// Returns the [OrderNote] output upon receiving `order-notes`
     ///
     func mapLoadAllOrderNotesResponse() -> [OrderNote] {
-        return mapNotes(from: "order-notes")
+        return mapNotes(siteID: 123, from: "order-notes")
     }
 
     /// Returns the [OrderNote] output upon receiving `order-notes-without-data`
     ///
     func mapLoadAllOrderNotesResponseWithoutDataEnvelope() -> [OrderNote] {
-        return mapNotes(from: "order-notes-without-data")
+        return mapNotes(siteID: WooConstants.placeholderSiteID, from: "order-notes-without-data")
     }
 
     /// Returns the [OrderNote] output upon receiving `broken-order`
     ///
     func mapLoadBrokenOrderNotesResponse() -> [OrderNote] {
-        return mapNotes(from: "broken-notes")
+        return mapNotes(siteID: 123, from: "broken-notes")
     }
 }

--- a/Networking/NetworkingTests/Mapper/RefundListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/RefundListMapperTests.swift
@@ -18,11 +18,12 @@ final class RefundListMapperTests: XCTestCase {
     ///
     func test_Refund_fields_are_properly_parsed() {
         let result = [mapLoadAllRefundsResponse(), mapLoadAllRefundsResponseWithoutDataEnvelope()]
-        for refunds in result {
+        for (index, refunds) in result.enumerated() {
+            let expectedSiteID: Int64 = index == 0 ? dummySiteID : WooConstants.placeholderSiteID
             XCTAssertEqual(refunds.count, 2)
 
             let firstRefund = refunds[0]
-            XCTAssertEqual(firstRefund.siteID, dummySiteID)
+            XCTAssertEqual(firstRefund.siteID, expectedSiteID)
             XCTAssertEqual(firstRefund.orderID, orderID)
             XCTAssertEqual(firstRefund.refundID, 590)
 
@@ -37,7 +38,7 @@ final class RefundListMapperTests: XCTestCase {
             }
 
             let secondRefund = refunds[1]
-            XCTAssertEqual(secondRefund.siteID, dummySiteID)
+            XCTAssertEqual(secondRefund.siteID, expectedSiteID)
             XCTAssertEqual(secondRefund.orderID, orderID)
             XCTAssertEqual(secondRefund.refundID, 562)
 
@@ -117,23 +118,23 @@ private extension RefundListMapperTests {
 
     /// Returns the RefundListMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapRefunds(from filename: String) -> [Refund] {
+    func mapRefunds(siteID: Int64, from filename: String) -> [Refund] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! RefundListMapper(siteID: dummySiteID, orderID: orderID).map(response: response)
+        return try! RefundListMapper(siteID: siteID, orderID: orderID).map(response: response)
     }
 
     /// Returns the RefundListMapper output upon receiving `refunds-all`
     ///
     func mapLoadAllRefundsResponse() -> [Refund] {
-        return mapRefunds(from: "refunds-all")
+        return mapRefunds(siteID: dummySiteID, from: "refunds-all")
     }
 
     /// Returns the RefundListMapper output upon receiving `refunds-all-without-data`
     ///
     func mapLoadAllRefundsResponseWithoutDataEnvelope() -> [Refund] {
-        return mapRefunds(from: "refunds-all-without-data")
+        return mapRefunds(siteID: WooConstants.placeholderSiteID, from: "refunds-all-without-data")
     }
 }

--- a/Networking/NetworkingTests/Mapper/RefundMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/RefundMapperTests.swift
@@ -18,13 +18,13 @@ final class RefundMapperTests: XCTestCase {
     ///
     func test_Refund_fields_are_properly_parsed() {
         let results = [mapLoadRefundResponse(), mapLoadRefundResponseWithoutDataEnvelope()]
-        for refund in results {
+        for (index, refund) in results.enumerated() {
             guard let refund else {
                 XCTFail("No mock file found.")
                 return
             }
-
-            XCTAssertEqual(refund.siteID, dummySiteID)
+            let expectedSiteID: Int64 = index == 0 ? dummySiteID : WooConstants.placeholderSiteID
+            XCTAssertEqual(refund.siteID, expectedSiteID)
             XCTAssertEqual(refund.refundID, 562)
 
             let dateCreated = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-10-01T19:33:46")
@@ -149,24 +149,24 @@ private extension RefundMapperTests {
 
     /// Returns the RefundMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapRefund(from filename: String) -> Refund? {
+    func mapRefund(siteID: Int64, from filename: String) -> Refund? {
         guard let response = Loader.contentsOf(filename) else {
             return nil
         }
 
-        return try! RefundMapper(siteID: dummySiteID, orderID: orderID).map(response: response)
+        return try? RefundMapper(siteID: siteID, orderID: orderID).map(response: response)
     }
 
     /// Returns the RefundsMapper output upon receiving `refund-single`
     ///
     func mapLoadRefundResponse() -> Refund? {
-        return mapRefund(from: "refund-single")
+        return mapRefund(siteID: dummySiteID, from: "refund-single")
     }
 
     /// Returns the RefundsMapper output upon receiving `refund-single-without-data`
     ///
     func mapLoadRefundResponseWithoutDataEnvelope() -> Refund? {
-        return mapRefund(from: "refund-single-without-data")
+        return mapRefund(siteID: WooConstants.placeholderSiteID, from: "refund-single-without-data")
     }
 
     /// Creates a dummy refund with items and taxes

--- a/WooCommerce/WooCommerceTests/Model/OrderNoteWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/OrderNoteWooTests.swift
@@ -40,6 +40,6 @@ private extension OrderNoteWooTests {
     ///
     func mapOrderNotes(from filename: String) throws -> [OrderNote] {
         let response = Loader.contentsOf(filename)!
-        return try OrderNotesMapper().map(response: response)
+        return try OrderNotesMapper(siteID: 123).map(response: response)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9304 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, we decoded models with data envelopes by default and fell back to decoding without the envelope if the default method fails. This causes incorrect tracking of errors when there are decoding failures happening to Jetpack sites.

This PR updates the mappers related to the Orders feature of the app. The goal is to throw the correct error from the decoding failures, so I applied the same rule for all mappers: if the current site ID is the constant -1, it means the site is not Jetpack site and the mappers will always decode without the data envelope. Otherwise, data envelope is expected in the response.

This leads to the addition of `siteID` in a few mappers that don't already have the property. Unit tests have been updated to match the new behavior.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in with an application password to a self-hosted Woo store without Jetpack and confirm that all order-related features work as expected: order list, order detail, order refund, order creation and edit.
- Log in to a Jetpack site with a WPCom account and confirm that all order-related features work as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
