### PR TITLE
[UI Tests] - Update if condition check from exists to isHittable

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -31,6 +31,6 @@ public final class ExternalAppScreen {
         safari.buttons["Go"].tap()
 
         // Tap on the universal link
-        if safari.staticTexts["TESTING LINKS"].exists { safari.links[universalLink].tap() }
+        if safari.links[universalLink].isHittable { safari.links[universalLink].tap() }
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -30,7 +30,10 @@ public final class ExternalAppScreen {
         safari.typeText("http://localhost:8282/links.html")
         safari.buttons["Go"].tap()
 
-        // Tap on the universal link
-        if safari.links[universalLink].isHittable { safari.links[universalLink].tap() }
+        // Tap on the universal link and fail test immediately if link is not hittable
+        guard safari.links[universalLink].isHittable else {
+            return XCTFail("\(universalLink) is not displayed!")
+        }
+        safari.links[universalLink].tap()
     }
 }


### PR DESCRIPTION
## Description
I've seen some flakiness when testing out [an unmerged branch](https://buildkite.com/automattic/woocommerce-ios/builds/12575#01879359-906e-403e-beb6-97f2e3df3b44/559-6898), and the test looks to be stuck on the safari screen. I haven't been able to reproduce this locally (could be because of slowness in CI?), but updating the check so that it looks for the link itself and making sure that it's hittable before tapping on it might be able to solve it. 

I did face some odd behavior when testing locally repeatedly. When the test runs too many times (usually, this happens after >10 test runs), the test fails when the redirection does not happen, and the link redirects to the below screenshot instead:

<img src="https://user-images.githubusercontent.com/17252150/232986105-1fa4e1af-106b-47e4-be68-a1876b478eb9.png" width="25%" height="25%" />

I think it's safe to let the test fail when 👆 happens because it looks like a redirection issue. 

## Testing instructions
Universal links UI tests should work locally and in CI.

