### PR TITLE
[Subscriptions] Add subscription settings to subscription variation details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -570,12 +570,9 @@ private extension DefaultProductFormTableViewModel {
 
         var subscriptionDetails = [String]()
 
-        if let priceDescription = product.subscription?.priceDescription() {
-            subscriptionDetails.append(String.localizedStringWithFormat(Localization.subscriptionPriceFormat, priceDescription))
-        }
-
-        if let expiryDescription = product.subscription?.expiryDescription {
-            subscriptionDetails.append(String.localizedStringWithFormat(Localization.subscriptionExpiryFormat, expiryDescription))
+        if let subscription = product.subscription {
+            subscriptionDetails.append(String.localizedStringWithFormat(Localization.subscriptionPriceFormat, subscription.priceDescription()))
+            subscriptionDetails.append(String.localizedStringWithFormat(Localization.subscriptionExpiryFormat, subscription.expiryDescription))
         }
 
         let details = subscriptionDetails.isEmpty ? nil: subscriptionDetails.joined(separator: "\n")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -143,6 +143,8 @@ private extension DefaultProductFormTableViewModel {
                 return .status(viewModel: variationStatusRow(productVariation: productVariation, isEditable: editable), isEditable: editable)
             case .noPriceWarning:
                 return .noPriceWarning(viewModel: noPriceWarningRow(isActionable: false))
+            case .subscription(let actionable):
+                return .subscription(viewModel: subscriptionRow(product: productVariation, isActionable: actionable), isActionable: actionable)
             default:
                 assertionFailure("Unexpected action in the settings section: \(action)")
                 return nil
@@ -560,7 +562,7 @@ private extension DefaultProductFormTableViewModel {
                                                         isActionable: isActionable)
     }
 
-    // MARK: Subscription products only
+    // MARK: Subscription products and variations only
 
     func subscriptionRow(product: ProductFormDataModel, isActionable: Bool) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.priceImage

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1725,7 +1725,7 @@ private extension ProductFormViewController {
         guard let subscription = product.subscription else {
             return
         }
-        let viewModel = SubscriptionSettingsViewModel(price: subscription.priceDescription() ?? "",
+        let viewModel = SubscriptionSettingsViewModel(price: subscription.priceDescription(),
                                                       expiresAfter: subscription.expiryDescription,
                                                       signupFee: subscription.signupFeeDescription(),
                                                       freeTrial: subscription.trialDescription)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1722,7 +1722,7 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
     func showSubscriptionSettings() {
-        guard let product = product as? EditableProductModel, let subscription = product.subscription else {
+        guard let subscription = product.subscription else {
             return
         }
         let viewModel = SubscriptionSettingsViewModel(price: subscription.priceDescription() ?? "",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UI.swift
@@ -37,10 +37,10 @@ extension ProductSubscription {
     ///
     /// Example: "$50.00 every year" or "$10.00 every 2 weeks"
     ///
-    func priceDescription(currencySettings: CurrencySettings = ServiceLocator.currencySettings) -> String? {
+    func priceDescription(currencySettings: CurrencySettings = ServiceLocator.currencySettings) -> String {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
-        guard let formattedPrice = currencyFormatter.formatAmount(self.price) else {
-            return nil
+        guard self.price.isNotEmpty, let formattedPrice = currencyFormatter.formatAmount(self.price) else {
+            return Localization.noPrice
         }
 
         let billingFrequency = {
@@ -74,6 +74,7 @@ private extension ProductSubscription {
         static let priceFormat = NSLocalizedString("%1$@ every %2$@",
                                                    comment: "Description of the subscription price for a product, with the price and billing frequency. " +
                                                    "Reads like: '$60.00 every 2 months'.")
+        static let noPrice = NSLocalizedString("No price set", comment: "Display label when a subscription has no price.")
         static let neverExpire = NSLocalizedString("Never expire", comment: "Display label when a subscription never expires.")
         static let noSignupFee = NSLocalizedString("No signup fee", comment: "Display label when a subscription has no signup fee.")
         static let noTrial = NSLocalizedString("No trial period", comment: "Display label when a subscription has no trial period.")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactoryTests.swift
@@ -141,6 +141,31 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
+
+    func test_actions_for_a_subscription_ProductVariation() {
+        // Arrange
+        let productVariation = Fixtures.subscriptionProductVariation
+        let model = EditableProductVariationModel(productVariation: productVariation)
+
+        // Action
+        let factory = ProductVariationFormActionsFactory(productVariation: model, editable: true)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .variationName, .description(editable: true)]
+        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [
+            .subscription(actionable: true),
+            .attributes(editable: true),
+            .status(editable: true),
+            .shippingSettings(editable: true),
+            .inventorySettings(editable: true)
+        ]
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
+        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
+    }
 }
 
 private extension ProductVariationFormActionsFactoryTests {
@@ -177,5 +202,7 @@ private extension ProductVariationFormActionsFactoryTests {
         static let physicalProductVariationEnabledAndMissingPrice = MockProductVariation().productVariation()
             .copy(image: nil, status: .published, sku: "uks", regularPrice: nil, virtual: false, downloadable: false,
                   weight: "2", dimensions: ProductDimensions(length: "", width: "", height: ""))
+        // downloadable: false, virtual: false, with subscription settings, with inventory/shipping
+        static let subscriptionProductVariation = physicalProductVariationWithImages.copy(subscription: .fake())
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UITests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Subscription/ProductSubscription+UITests.swift
@@ -26,6 +26,14 @@ final class ProductSubscription_UITests: XCTestCase {
                        String.localizedStringWithFormat(Localization.priceFormat, "$5.00", "2 \(samplePeriod.descriptionPlural)"))
     }
 
+    func test_priceDescription_returns_expected_description_for_no_price_set() {
+        // Given
+        let subscription = ProductSubscription.fake().copy(price: "")
+
+        // Then
+        XCTAssertEqual(subscription.priceDescription(), Localization.noPrice)
+    }
+
     func test_expiryDescription_returns_expected_description_for_singular_subscription_length() {
         // Given
         let subscription = ProductSubscription.fake().copy(length: "1", period: samplePeriod)
@@ -97,6 +105,7 @@ private extension ProductSubscription_UITests {
         static let priceFormat = NSLocalizedString("%1$@ every %2$@",
                                                    comment: "Description of the subscription price for a product, with the price and billing frequency. " +
                                                    "Reads like: '$60.00 every 2 months'.")
+        static let noPrice = NSLocalizedString("No price set", comment: "Display label when a subscription has no price.")
         static let neverExpire = NSLocalizedString("Never expire", comment: "Display label when a subscription never expires.")
         static let noSignupFee = NSLocalizedString("No signup fee", comment: "Display label when a subscription has no signup fee.")
         static let noTrial = NSLocalizedString("No trial period", comment: "Display label when a subscription has no trial period.")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9394
⚠️ Depends on #9490
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds support for variable subscriptions on the variation details screen. When viewing the variation details for a variable subscription, the Price row is replaced with the Subscription row. When tapped, this opens the Subscription settings for that variation.

### Changes

The existing Subscription product details action/row and Subscription settings view are reused for variations, so the changes are mostly to add them to variation details:

* `ProductVariationFormActionsFactory` is updated to include the Subscription action if the variation has a subscription; otherwise, the Price action is included as before.
* `DefaultProductFormTableViewModel` is updated to include the Subscription row in the product variation form.
* A new "No price set" label is returned when the `price` property on a `ProductDescription` is empty. This occurs when a product variation does not have a price set.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Prerequisites

1. Install and activate the [Subscriptions extension](https://woocommerce.com/products/woocommerce-subscriptions/) on your store.
2. Create at least one product with the Variable Subscription product type.
3. Add at least one variation to the product.

### To test

1. Build and run the app.
2. Go to the Products tab.
4. Open a variable subscription product and select Variations.
5. Select a variation.
6. Confirm the Subscription row appears, and no Price row appears. If there is no price set on the variation, confirm the "no price" warning also appears below the Subscription row.

You can also open a core variable product (not a subscription) to confirm the variation details show the same rows as before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
**Variable Subscription Product**

https://user-images.githubusercontent.com/8658164/233014613-1f3479a3-cf87-4cd2-9394-af0ade2c68aa.mp4

**Core Variable Product (no change)**

https://user-images.githubusercontent.com/8658164/233014684-c1a09e2a-0ea7-4aa7-9d67-6db7df1fafaa.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
