### PR TITLE
[UI Tests] - Add Learn More link test

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Payments/CardReaderManualsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/CardReaderManualsScreen.swift
@@ -33,7 +33,7 @@ public final class CardReaderManualsScreen: ScreenObject {
     }
 
     @discardableResult
-    public func verifyChipperManualLoadedOnWebView() throws -> Self {
+    public func verifyChipperManualLoadedInWebView() throws -> Self {
         let chipperManualPredicate = NSPredicate(format: "label CONTAINS[c] %@", "ChipperTM 2X BT")
         let chipperManualText = app.webViews.textViews.containing(chipperManualPredicate).element
 

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -10,8 +10,18 @@ public final class PaymentsScreen: ScreenObject {
         $0.cells["card-reader-manuals"]
     }
 
+    private let learnMoreButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Learn more about In‑Person Payments"]
+    }
+
+    private let IPPDocumentationHeaderTextGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["Getting started with In-Person Payments with WooCommerce Payments"]
+    }
+
     private var collectPaymentButton: XCUIElement { collectPaymentButtonGetter(app) }
     private var cardReaderManualsButton: XCUIElement { cardReaderManualsButtonGetter(app) }
+    private var learnMoreButton: XCUIElement { learnMoreButtonGetter(app) }
+    private var IPPDocumentationHeaderText: XCUIElement { IPPDocumentationHeaderTextGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -26,9 +36,18 @@ public final class PaymentsScreen: ScreenObject {
         return try CardReaderManualsScreen()
     }
 
+    public func tapLearnMoreIPPLink() throws -> Self {
+        learnMoreButton.tap()
+        return self
+    }
+
     @discardableResult
     public func verifyPaymentsScreenLoaded() throws -> PaymentsScreen {
         XCTAssertTrue(isLoaded)
         return self
+    }
+
+    public func verifyIPPDocumentationLoadedOnWebView() throws {
+        XCTAssertTrue(IPPDocumentationHeaderText.waitForExistence(timeout: 10), "IPP Documentation not displayed on WebView!")
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -47,7 +47,7 @@ public final class PaymentsScreen: ScreenObject {
         return self
     }
 
-    public func verifyIPPDocumentationLoadedOnWebView() throws {
+    public func verifyIPPDocumentationLoadedInWebView() throws {
         XCTAssertTrue(IPPDocumentationHeaderText.waitForExistence(timeout: 10), "IPP Documentation not displayed on WebView!")
     }
 }

--- a/WooCommerce/WooCommerceUITests/README.md
+++ b/WooCommerce/WooCommerceUITests/README.md
@@ -74,7 +74,7 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
     - [ ] Make a Tap to Pay on iPhone payment
     - [ ] Manage Card Reader - Connect/Disconnect Reader
     - [x] Card Reader Manual (Chipper) loads
-    - [ ] Learn More link loads
+    - [x] Learn More link loads
 
 ## Running tests
 

--- a/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
@@ -19,4 +19,11 @@ final class PaymentsTests: XCTestCase {
             .tapChipperManual()
             .verifyChipperManualLoadedOnWebView()
     }
+
+    func test_load_learn_more_link() throws {
+        try TabNavComponent().goToMenuScreen()
+            .goToPaymentsScreen()
+            .tapLearnMoreIPPLink()
+            .verifyIPPDocumentationLoadedOnWebView()
+    }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
@@ -18,11 +18,11 @@ final class PaymentsTests: XCTestCase {
     func test_load_chipper_card_reader_manual() throws {
         try PaymentsScreen().tapCardReaderManuals()
             .tapChipperManual()
-            .verifyChipperManualLoadedOnWebView()
+            .verifyChipperManualLoadedInWebView()
     }
 
     func test_load_learn_more_link() throws {
         try PaymentsScreen().tapLearnMoreIPPLink()
-            .verifyIPPDocumentationLoadedOnWebView()
+            .verifyIPPDocumentationLoadedInWebView()
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/PaymentsTests.swift
@@ -10,20 +10,19 @@ final class PaymentsTests: XCTestCase {
         app.launchArguments = ["logout-at-launch", "disable-animations", "mocked-wpcom-api", "-ui_testing"]
         app.launch()
         try LoginFlow.login()
+
+        try TabNavComponent().goToMenuScreen()
+            .goToPaymentsScreen()
     }
 
     func test_load_chipper_card_reader_manual() throws {
-        try TabNavComponent().goToMenuScreen()
-            .goToPaymentsScreen()
-            .tapCardReaderManuals()
+        try PaymentsScreen().tapCardReaderManuals()
             .tapChipperManual()
             .verifyChipperManualLoadedOnWebView()
     }
 
     func test_load_learn_more_link() throws {
-        try TabNavComponent().goToMenuScreen()
-            .goToPaymentsScreen()
-            .tapLearnMoreIPPLink()
+        try PaymentsScreen().tapLearnMoreIPPLink()
             .verifyIPPDocumentationLoadedOnWebView()
     }
 }


### PR DESCRIPTION
## Description
This PR adds a simple test on payments to validate the learn more about IPP link that's being displayed on payments work as expected. This link is being displayed in a few places and making sure that the link works is pretty important because IPP is a feature that we want merchants to use more of and this link is the first step of that process. 

The flow of the test: 
Go to payments > Tap on Learn More link > Validate that WebView is displayed with the correct header

## Testing instructions
New test `test_load_learn_more_link()` should work as expected
