### PR TITLE
[Mobile Payments] Retrieve popular and last sold products remotely

### DIFF
--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -63,14 +63,14 @@ public enum ProductAction: Action {
         pageSize: Int = ProductsRemote.Default.pageSize,
         onCompletion: (Result<(products: [Product], hasNextPage: Bool), Error>) -> Void)
 
-    /// Retrieve cached popular products, that is, those that were included
-    /// in a completed order most often, in descending order.
+    /// Retrieve popular products, that is, those that were included
+    /// in a completed cached order most often, in descending order.
     ///
-    case retrievePopularCachedProducts(siteID: Int64, onCompletion: ([Product]) -> Void)
+    case retrievePopularCachedProducts(siteID: Int64, limit: Int, onCompletion: ([Product]) -> Void)
 
-    /// Retrieve the recently sold products in cache sorted by paid date
+    /// Retrieve the recently sold products in cached orders sorted by paid date
     /// 
-    case retrieveRecentlySoldCachedProducts(siteID: Int64, onCompletion: ([Product]) -> Void)
+    case retrieveRecentlySoldCachedProducts(siteID: Int64, limit: Int, onCompletion: ([Product]) -> Void)
 
     /// Deletes all of the cached products.
     ///

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -66,11 +66,11 @@ public enum ProductAction: Action {
     /// Retrieve popular products, that is, those that were included
     /// in a completed cached order most often, in descending order.
     ///
-    case retrievePopularCachedProducts(siteID: Int64, limit: Int, onCompletion: ([Product]) -> Void)
+    case retrievePopularCachedProducts(siteID: Int64, limit: Int, excludedProductIDs: [Int64] = [], onCompletion: ([Product]) -> Void)
 
     /// Retrieve the last sold products in cached orders sorted by paid date
     /// 
-    case retrieveLastSoldCachedProducts(siteID: Int64, limit: Int, onCompletion: ([Product]) -> Void)
+    case retrieveLastSoldCachedProducts(siteID: Int64, limit: Int, excludedProductIDs: [Int64] = [], onCompletion: ([Product]) -> Void)
 
     /// Deletes all of the cached products.
     ///

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -68,9 +68,9 @@ public enum ProductAction: Action {
     ///
     case retrievePopularCachedProducts(siteID: Int64, limit: Int, onCompletion: ([Product]) -> Void)
 
-    /// Retrieve the recently sold products in cached orders sorted by paid date
+    /// Retrieve the last sold products in cached orders sorted by paid date
     /// 
-    case retrieveRecentlySoldCachedProducts(siteID: Int64, limit: Int, onCompletion: ([Product]) -> Void)
+    case retrieveLastSoldCachedProducts(siteID: Int64, limit: Int, onCompletion: ([Product]) -> Void)
 
     /// Deletes all of the cached products.
     ///

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -48,8 +48,8 @@ public class ProductStore: Store {
             retrieveProducts(siteID: siteID, productIDs: productIDs, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         case .retrievePopularCachedProducts(let siteID, let limit, let onCompletion):
             retrievePopularCachedProducts(siteID: siteID, limit: limit, onCompletion: onCompletion)
-        case .retrieveRecentlySoldCachedProducts(let siteID, let limit, let onCompletion):
-            retrieveRecentlySoldCachedProducts(siteID: siteID, limit: limit, onCompletion: onCompletion)
+        case .retrieveLastSoldCachedProducts(let siteID, let limit, let onCompletion):
+            retrieveLastSoldCachedProducts(siteID: siteID, limit: limit, onCompletion: onCompletion)
         case let.searchProductsInCache(siteID, keyword, pageSize, onCompletion):
             searchInCache(siteID: siteID, keyword: keyword, pageSize: pageSize, onCompletion: onCompletion)
         case let .searchProducts(siteID,
@@ -360,7 +360,7 @@ private extension ProductStore {
         }
     }
 
-    func retrieveRecentlySoldCachedProducts(siteID: Int64, limit: Int, onCompletion: @escaping ([Product]) -> Void) {
+    func retrieveLastSoldCachedProducts(siteID: Int64, limit: Int, onCompletion: @escaping ([Product]) -> Void) {
         let completedStorageOrders = sharedDerivedStorage.allObjects(ofType: StorageOrder.self,
                                                       matching: completedOrdersPredicate(from: siteID),
                                                       sortedBy: [NSSortDescriptor(key: #keyPath(StorageOrder.datePaid), ascending: false)])

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -46,10 +46,10 @@ public class ProductStore: Store {
             retrieveProduct(siteID: siteID, productID: productID, onCompletion: onCompletion)
         case .retrieveProducts(let siteID, let productIDs, let pageNumber, let pageSize, let onCompletion):
             retrieveProducts(siteID: siteID, productIDs: productIDs, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
-        case .retrievePopularCachedProducts(let siteID, let onCompletion):
-            retrievePopularCachedProducts(siteID: siteID, onCompletion: onCompletion)
-        case .retrieveRecentlySoldCachedProducts(let siteID, let onCompletion):
-            retrieveRecentlySoldCachedProducts(siteID: siteID, onCompletion: onCompletion)
+        case .retrievePopularCachedProducts(let siteID, let limit, let onCompletion):
+            retrievePopularCachedProducts(siteID: siteID, limit: limit, onCompletion: onCompletion)
+        case .retrieveRecentlySoldCachedProducts(let siteID, let limit, let onCompletion):
+            retrieveRecentlySoldCachedProducts(siteID: siteID, limit: limit, onCompletion: onCompletion)
         case let.searchProductsInCache(siteID, keyword, pageSize, onCompletion):
             searchInCache(siteID: siteID, keyword: keyword, pageSize: pageSize, onCompletion: onCompletion)
         case let .searchProducts(siteID,
@@ -323,7 +323,7 @@ private extension ProductStore {
         }
     }
 
-    func retrievePopularCachedProducts(siteID: Int64, onCompletion: @escaping ([Product]) -> Void) {
+    func retrievePopularCachedProducts(siteID: Int64, limit: Int, onCompletion: @escaping ([Product]) -> Void) {
         // Get completed orders
         let completedStorageOrders = sharedDerivedStorage.allObjects(ofType: StorageOrder.self,
                                                       matching: completedOrdersPredicate(from: siteID),
@@ -334,17 +334,33 @@ private extension ProductStore {
         // Get product ids sorted by occurence
         let completedOrdersItems = completedOrders.flatMap { $0.items }
         let productIDCountDictionary = completedOrdersItems.reduce(into: [:]) { counts, orderItem in counts[orderItem.productID, default: 0] += 1 }
+
         let sortedByOccurenceProductIDs = productIDCountDictionary
-            .sorted { $0.value > $1.value }
+            .sorted {
+                // if the count is the same let's sort it by product id just to avoid randomly sorted sequences
+                if $0.value == $1.value {
+                    return $0.key > $1.key
+                }
+
+                return $0.value > $1.value
+
+            }
             .map { $0.key }
             .uniqued()
 
-        // Retrieve products from product ids and finish
-        let products = retrieveProducts(from: sortedByOccurenceProductIDs)
-        onCompletion(products)
+        retrieveProducts(siteID: siteID,
+                         productIDs: Array(sortedByOccurenceProductIDs.prefix(limit)),
+                         pageNumber: Default.firstPageNumber,
+                         pageSize: limit) { result in
+            if case let .success((products, _)) = result {
+                onCompletion(products)
+            } else {
+                onCompletion([])
+            }
+        }
     }
 
-    func retrieveRecentlySoldCachedProducts(siteID: Int64, onCompletion: @escaping ([Product]) -> Void) {
+    func retrieveRecentlySoldCachedProducts(siteID: Int64, limit: Int, onCompletion: @escaping ([Product]) -> Void) {
         let completedStorageOrders = sharedDerivedStorage.allObjects(ofType: StorageOrder.self,
                                                       matching: completedOrdersPredicate(from: siteID),
                                                       sortedBy: [NSSortDescriptor(key: #keyPath(StorageOrder.datePaid), ascending: false)])
@@ -356,8 +372,17 @@ private extension ProductStore {
             .map { $0.productID }
             .uniqued()
 
-        let products = retrieveProducts(from: productIDs)
-        onCompletion(products)
+        retrieveProducts(siteID: siteID,
+                         productIDs: Array(productIDs.prefix(limit)),
+                         pageNumber: Default.firstPageNumber,
+                         pageSize: limit) { result in
+
+            if case let .success((products, _)) = result {
+                onCompletion(products)
+            } else {
+                onCompletion([])
+            }
+        }
     }
 
     func completedOrdersPredicate(from siteID: Int64) -> NSPredicate {
@@ -365,17 +390,6 @@ private extension ProductStore {
         let sitePredicate = NSPredicate(format: "siteID == %lld", siteID)
 
         return NSCompoundPredicate(andPredicateWithSubpredicates: [completedOrderPredicate, sitePredicate])
-    }
-
-    func retrieveProducts(from productIDs: [Int64]) -> [Product] {
-        productIDs
-            .compactMap {
-                let predicate = NSPredicate(format: "productID == %lld", $0)
-                let product = sharedDerivedStorage.allObjects(ofType: StorageProduct.self,
-                                                          matching: predicate,
-                                                          sortedBy: nil).first
-                return product
-            }.map { $0.toReadOnly() }
     }
 
     /// Adds a product.

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -821,9 +821,9 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertTrue(cachedPopularProducts.isEmpty)
     }
 
-    // MARK: - ProductAction.retrieveRecentlySoldCachedProducts
+    // MARK: - ProductAction.retrieveLastSoldCachedProducts
 
-    func test_retrieveRecentlySoldCachedProducts_when_there_are_several_sold_products_loads_them_remotely_with_the_limit() {
+    func test_retrieveLastSoldCachedProducts_when_there_are_several_sold_products_loads_them_remotely_with_the_limit() {
         let productIDs: [Int64] = [1, 2, 3, 4, 5, 6]
         let limit = 3
         let expectedProducts: [Yosemite.Product] = .init(repeating: Product.fake(), count: 25)
@@ -836,7 +836,7 @@ final class ProductStoreTests: XCTestCase {
 
         // When
         let cachedLastSoldProducts: [Yosemite.Product] = waitFor { promise in
-            let action = ProductAction.retrieveRecentlySoldCachedProducts(siteID: self.sampleSiteID, limit: limit, onCompletion: { result in
+            let action = ProductAction.retrieveLastSoldCachedProducts(siteID: self.sampleSiteID, limit: limit, onCompletion: { result in
                 promise(result)
             })
 
@@ -846,14 +846,14 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(expectedProducts, cachedLastSoldProducts)
     }
 
-    func test_retrieveRecentlySoldCachedProducts_when_there_are_several_sold_products_but_orders_are_not_completed_returns_empty_array() {
+    func test_retrieveLastSoldCachedProducts_when_there_are_several_sold_products_but_orders_are_not_completed_returns_empty_array() {
         preparePopularProductsSamples(with: sampleSiteID, productIDs: [1, 2, 3], orderStatus: .pending)
 
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         // When
         let cachedPopularProducts: [Yosemite.Product] = waitFor { promise in
-            let action = ProductAction.retrieveRecentlySoldCachedProducts(siteID: self.sampleSiteID, limit: 5, onCompletion: { result in
+            let action = ProductAction.retrieveLastSoldCachedProducts(siteID: self.sampleSiteID, limit: 5, onCompletion: { result in
                 promise(result)
             })
 
@@ -863,14 +863,14 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertTrue(cachedPopularProducts.isEmpty)
     }
 
-    func test_retrieveRecentlySoldCachedProducts_when_there_are_several_sold_products_but_siteID_is_different_returns_empty_array() {
+    func test_retrieveLastSoldCachedProducts_when_there_are_several_sold_products_but_siteID_is_different_returns_empty_array() {
         preparePopularProductsSamples(with: sampleSiteID, productIDs: [1, 2, 3])
 
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         // When
         let cachedPopularProducts: [Yosemite.Product] = waitFor { promise in
-            let action = ProductAction.retrieveRecentlySoldCachedProducts(siteID: 555, limit: 5, onCompletion: { result in
+            let action = ProductAction.retrieveLastSoldCachedProducts(siteID: 555, limit: 5, onCompletion: { result in
                 promise(result)
             })
 


### PR DESCRIPTION


<!-- Remember about a good descriptive title. -->

Part of: #9190 #9189
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In the context of sorting products by popularity and last sold, with this PR we improve the retrieval of Popular and last sold products by requesting them remotely instead of just locally as before. 
The reason behind that is that every time we query products on the Product Multi-selector or Products List we [delete](https://github.com/woocommerce/woocommerce-ios/blob/ba274f3534111c2320b18839c471fef822c15ed2/Yosemite/Yosemite/Actions/ProductAction.swift#L48) all products in the database so we just show those requested, which removes also cached Popular and last sold products. With this PR we load them remotely so we can cache them again.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
As this is not called yet by any UI code, please make sure that unit tests pass.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
