### PR TITLE
[Subscriptions] Add Networking models for subscriptions on an order

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1788,11 +1788,36 @@ extension Networking.StoredProductSettings {
         )
     }
 }
+extension Networking.Subscription {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.Subscription {
+        .init(
+            siteID: .fake(),
+            subscriptionID: .fake(),
+            parentID: .fake(),
+            status: .fake(),
+            currency: .fake(),
+            billingPeriod: .fake(),
+            billingInterval: .fake(),
+            total: .fake(),
+            startDate: .fake(),
+            endDate: .fake()
+        )
+    }
+}
 extension SubscriptionPeriod {
     /// Returns a "ready to use" type filled with fake values.
     ///
     public static func fake() -> SubscriptionPeriod {
         .day
+    }
+}
+extension SubscriptionStatus {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> SubscriptionStatus {
+        .pending
     }
 }
 extension Networking.SystemPlugin {

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -597,6 +597,7 @@
 		CCB2CAA226209A1200285CA0 /* generic_success_data.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA126209A1200285CA0 /* generic_success_data.json */; };
 		CCB2CAA82620ABCC00285CA0 /* shipping-label-create-package-error.json in Resources */ = {isa = PBXBuildFile; fileRef = CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */; };
 		CCB573AA268CCFE90070FBB0 /* ShippingLabelStatusPollingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB573A9268CCFE90070FBB0 /* ShippingLabelStatusPollingResponse.swift */; };
+		CCE5F38F29EFFE3800087332 /* subscription-list.json in Resources */ = {isa = PBXBuildFile; fileRef = CCE5F38E29EFFE3800087332 /* subscription-list.json */; };
 		CCEC5E9129E9BF1400912D6B /* product-variation-subscription.json in Resources */ = {isa = PBXBuildFile; fileRef = CCEC5E9029E9BF1400912D6B /* product-variation-subscription.json */; };
 		CCF434642906BD7200B4475A /* ProductIDMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF434632906BD7200B4475A /* ProductIDMapper.swift */; };
 		CCF434662906C2A400B4475A /* products-ids-only.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF434652906C2A400B4475A /* products-ids-only.json */; };
@@ -1513,6 +1514,7 @@
 		CCB2CAA126209A1200285CA0 /* generic_success_data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = generic_success_data.json; sourceTree = "<group>"; };
 		CCB2CAA72620ABCC00285CA0 /* shipping-label-create-package-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-create-package-error.json"; sourceTree = "<group>"; };
 		CCB573A9268CCFE90070FBB0 /* ShippingLabelStatusPollingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelStatusPollingResponse.swift; sourceTree = "<group>"; };
+		CCE5F38E29EFFE3800087332 /* subscription-list.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "subscription-list.json"; sourceTree = "<group>"; };
 		CCEC5E9029E9BF1400912D6B /* product-variation-subscription.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-variation-subscription.json"; sourceTree = "<group>"; };
 		CCF434632906BD7200B4475A /* ProductIDMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductIDMapper.swift; sourceTree = "<group>"; };
 		CCF434652906C2A400B4475A /* products-ids-only.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-ids-only.json"; sourceTree = "<group>"; };
@@ -2630,6 +2632,7 @@
 				74E30950216E8DCE00ABCE4C /* site-visits-alt.json */,
 				CCA1D6072943804C00B40560 /* site-summary-stats.json */,
 				022902D122E2436300059692 /* stats_module_disabled_error.json */,
+				CCE5F38E29EFFE3800087332 /* subscription-list.json */,
 				45ED4F11239E8C57004F1BE3 /* taxes-classes.json */,
 				EE57C1492980CE4B00BC31E7 /* taxes-classes-without-data.json */,
 				74ABA1C4213F17AA00FFAD30 /* top-performers-day.json */,
@@ -3255,6 +3258,7 @@
 				09885C8027C3FFD200910A62 /* product-variations-bulk-update.json in Resources */,
 				31054734262E36AB00C5C02B /* wcpay-payment-intent-error.json in Resources */,
 				02AF07EE27493AE700B2D81E /* media-upload-to-wordpress-site.json in Resources */,
+				CCE5F38F29EFFE3800087332 /* subscription-list.json in Resources */,
 				DE4F2A4029750EF400B0701C /* inbox-note-without-data.json in Resources */,
 				45ED4F12239E8C57004F1BE3 /* taxes-classes.json in Resources */,
 				B5A2417B217F98FC00595DEF /* broken-notifications.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -579,6 +579,7 @@
 		CC33754E29C884000006A538 /* ProductCompositeComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC33754D29C884000006A538 /* ProductCompositeComponent.swift */; };
 		CC33755029C88B920006A538 /* product-composite.json in Resources */ = {isa = PBXBuildFile; fileRef = CC33754F29C88B920006A538 /* product-composite.json */; };
 		CC6A1FF5270E042200F6AF4A /* OrderMetaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6A1FF4270E042200F6AF4A /* OrderMetaData.swift */; };
+		CC75108929EFEEF20035FBA4 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC75108829EFEEF20035FBA4 /* Subscription.swift */; };
 		CC75108B29EFF1A90035FBA4 /* SubscriptionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC75108A29EFF1A90035FBA4 /* SubscriptionStatus.swift */; };
 		CC80E3F92948C8BC00D5FF45 /* site-visits-quarter.json in Resources */ = {isa = PBXBuildFile; fileRef = CC80E3F82948C8BC00D5FF45 /* site-visits-quarter.json */; };
 		CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */; };
@@ -1497,6 +1498,7 @@
 		CC33754D29C884000006A538 /* ProductCompositeComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCompositeComponent.swift; sourceTree = "<group>"; };
 		CC33754F29C88B920006A538 /* product-composite.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-composite.json"; sourceTree = "<group>"; };
 		CC6A1FF4270E042200F6AF4A /* OrderMetaData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderMetaData.swift; sourceTree = "<group>"; };
+		CC75108829EFEEF20035FBA4 /* Subscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
 		CC75108A29EFF1A90035FBA4 /* SubscriptionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionStatus.swift; sourceTree = "<group>"; };
 		CC80E3F82948C8BC00D5FF45 /* site-visits-quarter.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-visits-quarter.json"; sourceTree = "<group>"; };
 		CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Extensions.swift"; sourceTree = "<group>"; };
@@ -2322,6 +2324,7 @@
 				CE50345F21B5799F007573C6 /* SitePlan.swift */,
 				45150A9B2683417A006922EA /* StateOfACountry.swift */,
 				311D412B2783BF7400052F64 /* StripeAccount.swift */,
+				CC75108829EFEEF20035FBA4 /* Subscription.swift */,
 				CC75108A29EFF1A90035FBA4 /* SubscriptionStatus.swift */,
 				077F39C7269F2C7E00ABEADC /* SystemPlugin.swift */,
 				3148976F27232982007A86BD /* SystemStatus.swift */,
@@ -3947,6 +3950,7 @@
 				0359EA1327AAC6D00048DE2D /* WCPayCardPaymentDetails.swift in Sources */,
 				CCB2CA9E262091CB00285CA0 /* SuccessDataResultMapper.swift in Sources */,
 				68CB801028D89A0400E169F8 /* CustomerRemote.swift in Sources */,
+				CC75108929EFEEF20035FBA4 /* Subscription.swift in Sources */,
 				DE50295B28C5F99700551736 /* DotcomUser.swift in Sources */,
 				74C8F06820EEB7BD00B6EDC9 /* OrderNotesMapper.swift in Sources */,
 				24F98C582502EA8800F49B68 /* FeatureFlagMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -579,6 +579,7 @@
 		CC33754E29C884000006A538 /* ProductCompositeComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC33754D29C884000006A538 /* ProductCompositeComponent.swift */; };
 		CC33755029C88B920006A538 /* product-composite.json in Resources */ = {isa = PBXBuildFile; fileRef = CC33754F29C88B920006A538 /* product-composite.json */; };
 		CC6A1FF5270E042200F6AF4A /* OrderMetaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6A1FF4270E042200F6AF4A /* OrderMetaData.swift */; };
+		CC75108B29EFF1A90035FBA4 /* SubscriptionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC75108A29EFF1A90035FBA4 /* SubscriptionStatus.swift */; };
 		CC80E3F92948C8BC00D5FF45 /* site-visits-quarter.json in Resources */ = {isa = PBXBuildFile; fileRef = CC80E3F82948C8BC00D5FF45 /* site-visits-quarter.json */; };
 		CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */; };
 		CC851D1425E52AB500249E9C /* Decimal+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */; };
@@ -1496,6 +1497,7 @@
 		CC33754D29C884000006A538 /* ProductCompositeComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCompositeComponent.swift; sourceTree = "<group>"; };
 		CC33754F29C88B920006A538 /* product-composite.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-composite.json"; sourceTree = "<group>"; };
 		CC6A1FF4270E042200F6AF4A /* OrderMetaData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderMetaData.swift; sourceTree = "<group>"; };
+		CC75108A29EFF1A90035FBA4 /* SubscriptionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionStatus.swift; sourceTree = "<group>"; };
 		CC80E3F82948C8BC00D5FF45 /* site-visits-quarter.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-visits-quarter.json"; sourceTree = "<group>"; };
 		CC851D0525E51ADF00249E9C /* Decimal+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Extensions.swift"; sourceTree = "<group>"; };
 		CC851D1325E52AB500249E9C /* Decimal+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+ExtensionsTests.swift"; sourceTree = "<group>"; };
@@ -2320,6 +2322,7 @@
 				CE50345F21B5799F007573C6 /* SitePlan.swift */,
 				45150A9B2683417A006922EA /* StateOfACountry.swift */,
 				311D412B2783BF7400052F64 /* StripeAccount.swift */,
+				CC75108A29EFF1A90035FBA4 /* SubscriptionStatus.swift */,
 				077F39C7269F2C7E00ABEADC /* SystemPlugin.swift */,
 				3148976F27232982007A86BD /* SystemStatus.swift */,
 				DEC51AE527684717009F3DF4 /* SystemStatusDetails */,
@@ -3777,6 +3780,7 @@
 				029C9E5C291507A40013E5EE /* UnauthenticatedRequest.swift in Sources */,
 				93D8BBFB226BBC5100AD2EB3 /* AccountSettings.swift in Sources */,
 				B53EF53821813806003E146F /* DotcomError.swift in Sources */,
+				CC75108B29EFF1A90035FBA4 /* SubscriptionStatus.swift in Sources */,
 				CC07865F267799EE00BA9AC1 /* ShippingLabelPurchase.swift in Sources */,
 				45A4B84E25D2E11300776FB4 /* ShippingLabelAddressValidationSuccessMapper.swift in Sources */,
 				CC851D0625E51ADF00249E9C /* Decimal+Extensions.swift in Sources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2176,6 +2176,45 @@ extension Networking.SiteVisitStatsItem {
     }
 }
 
+extension Networking.Subscription {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        subscriptionID: CopiableProp<Int64> = .copy,
+        parentID: CopiableProp<Int64> = .copy,
+        status: CopiableProp<SubscriptionStatus> = .copy,
+        currency: CopiableProp<String> = .copy,
+        billingPeriod: CopiableProp<SubscriptionPeriod> = .copy,
+        billingInterval: CopiableProp<String> = .copy,
+        total: CopiableProp<String> = .copy,
+        startDate: CopiableProp<Date> = .copy,
+        endDate: CopiableProp<Date> = .copy
+    ) -> Networking.Subscription {
+        let siteID = siteID ?? self.siteID
+        let subscriptionID = subscriptionID ?? self.subscriptionID
+        let parentID = parentID ?? self.parentID
+        let status = status ?? self.status
+        let currency = currency ?? self.currency
+        let billingPeriod = billingPeriod ?? self.billingPeriod
+        let billingInterval = billingInterval ?? self.billingInterval
+        let total = total ?? self.total
+        let startDate = startDate ?? self.startDate
+        let endDate = endDate ?? self.endDate
+
+        return Networking.Subscription(
+            siteID: siteID,
+            subscriptionID: subscriptionID,
+            parentID: parentID,
+            status: status,
+            currency: currency,
+            billingPeriod: billingPeriod,
+            billingInterval: billingInterval,
+            total: total,
+            startDate: startDate,
+            endDate: endDate
+        )
+    }
+}
+
 extension Networking.SystemPlugin {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Subscription.swift
+++ b/Networking/Networking/Model/Subscription.swift
@@ -1,8 +1,9 @@
 import Foundation
+import Codegen
 
 /// Represents a Subscription entity
 ///
-public struct Subscription: Decodable, Equatable {
+public struct Subscription: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
     public let siteID: Int64
 
     /// Unique identifier for the Subscription.

--- a/Networking/Networking/Model/Subscription.swift
+++ b/Networking/Networking/Model/Subscription.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Represents a Subscription entity
+///
+public struct Subscription: Decodable, Equatable {
+    public let siteID: Int64
+
+    /// Unique identifier for the Subscription.
+    public let subscriptionID: Int64
+
+    /// Parent/initial order ID for the subscription.
+    public let parentID: Int64
+
+    /// Subscription status. Default is `pending`.
+    public let status: SubscriptionStatus
+
+    /// Currency the subscription was created with, in ISO format.
+    public let currency: String
+
+    /// The subscription's billing period.
+    public let billingPeriod: SubscriptionPeriod
+
+    /// The number of billing periods between subscription renewals.
+    public let billingInterval: String
+
+    /// Grand total.
+    public let total: String
+
+    /// The subscription's start date in GMT.
+    public let startDate: Date
+
+    /// The subscription's end date in GMT.
+    public let endDate: Date
+
+    /// Subscription struct initializer.
+    ///
+    public init(siteID: Int64,
+                subscriptionID: Int64,
+                parentID: Int64,
+                status: SubscriptionStatus,
+                currency: String,
+                billingPeriod: SubscriptionPeriod,
+                billingInterval: String,
+                total: String,
+                startDate: Date,
+                endDate: Date) {
+        self.siteID = siteID
+        self.subscriptionID = subscriptionID
+        self.parentID = parentID
+        self.status = status
+        self.currency = currency
+        self.billingPeriod = billingPeriod
+        self.billingInterval = billingInterval
+        self.total = total
+        self.startDate = startDate
+        self.endDate = endDate
+    }
+
+    /// The public initializer for Subscription.
+    ///
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw SubscriptionDecodingError.missingSiteID
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let subscriptionID = try container.decode(Int64.self, forKey: .subscriptionID)
+        let parentID = try container.decode(Int64.self, forKey: .parentID)
+        let status = try container.decode(SubscriptionStatus.self, forKey: .status)
+        let currency = try container.decode(String.self, forKey: .currency)
+        let billingPeriod = try container.decode(SubscriptionPeriod.self, forKey: .billingPeriod)
+        let billingInterval = try container.decode(String.self, forKey: .billingInterval)
+        let total = try container.decode(String.self, forKey: .total)
+        let startDate = try container.decode(Date.self, forKey: .startDate)
+        let endDate = try container.decode(Date.self, forKey: .endDate)
+
+        self.init(siteID: siteID,
+                  subscriptionID: subscriptionID,
+                  parentID: parentID,
+                  status: status,
+                  currency: currency,
+                  billingPeriod: billingPeriod,
+                  billingInterval: billingInterval,
+                  total: total,
+                  startDate: startDate,
+                  endDate: endDate)
+    }
+}
+
+// MARK: Coding Keys
+//
+internal extension Subscription {
+    enum CodingKeys: String, CodingKey {
+        case subscriptionID     = "id"
+        case parentID           = "parent_id"
+        case status             = "status"
+        case currency           = "currency"
+        case billingPeriod      = "billing_period"
+        case billingInterval    = "billing_interval"
+        case total              = "total"
+        case startDate          = "start_date_gmt"
+        case endDate            = "end_date_gmt"
+    }
+}
+
+// MARK: - Decoding Errors
+//
+enum SubscriptionDecodingError: Error {
+    case missingSiteID
+}

--- a/Networking/Networking/Model/SubscriptionStatus.swift
+++ b/Networking/Networking/Model/SubscriptionStatus.swift
@@ -1,8 +1,9 @@
 import Foundation
+import Codegen
 
 /// Represents all possible subscription statuses
 ///
-public enum SubscriptionStatus: Codable, Equatable {
+public enum SubscriptionStatus: Codable, Equatable, GeneratedFakeable {
     case pending
     case active
     case onHold

--- a/Networking/Networking/Model/SubscriptionStatus.swift
+++ b/Networking/Networking/Model/SubscriptionStatus.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Represents all possible subscription statuses
+///
+public enum SubscriptionStatus: Codable, Equatable {
+    case pending
+    case active
+    case onHold
+    case expired
+    case pendingCancel
+    case cancelled
+    case custom(String)
+}
+
+/// RawRepresentable Conformance
+///
+extension SubscriptionStatus: RawRepresentable {
+
+    /// Designated Initializer.
+    ///
+    public init(rawValue: String) {
+        switch rawValue {
+        case Keys.pending:
+            self = .pending
+        case Keys.active:
+            self = .active
+        case Keys.onHold:
+            self = .onHold
+        case Keys.expired:
+            self = .expired
+        case Keys.pendingCancel:
+            self = .pendingCancel
+        case Keys.cancelled:
+            self = .cancelled
+        default:
+            self = .custom(rawValue)
+        }
+    }
+
+    /// Returns the current enum case's raw value.
+    ///
+    public var rawValue: String {
+        switch self {
+        case .pending:              return Keys.pending
+        case .active:               return Keys.active
+        case .onHold:               return Keys.onHold
+        case .expired:              return Keys.expired
+        case .pendingCancel:        return Keys.pendingCancel
+        case .cancelled:            return Keys.cancelled
+        case .custom(let payload):  return payload
+        }
+    }
+}
+
+
+/// Enum containing the 'Known' SubscriptionStatus Keys
+///
+private enum Keys {
+    static let pending       = "pending"
+    static let active        = "active"
+    static let onHold        = "on-hold"
+    static let expired       = "expired"
+    static let pendingCancel = "pending-cancel"
+    static let cancelled     = "cancelled"
+}

--- a/Networking/NetworkingTests/Responses/subscription-list.json
+++ b/Networking/NetworkingTests/Responses/subscription-list.json
@@ -1,0 +1,242 @@
+{
+    "data": [
+        {
+            "id": 282,
+            "parent_id": 281,
+            "status": "active",
+            "currency": "USD",
+            "version": "7.6.0",
+            "prices_include_tax": false,
+            "date_created": "2023-01-31T16:20:44",
+            "date_modified": "2023-04-18T18:16:11",
+            "discount_total": "0.00",
+            "discount_tax": "0.00",
+            "shipping_total": "0.00",
+            "shipping_tax": "0.00",
+            "cart_tax": "0.00",
+            "total": "14.50",
+            "total_tax": "0.00",
+            "customer_id": 27375286,
+            "order_key": "wc_order_PStHmyhQCqbBN",
+            "billing": {
+                "first_name": "Brooks",
+                "last_name": "Hane",
+                "company": "",
+                "address_1": "885 Susanna Ridges",
+                "address_2": "978 Powlowski Lock",
+                "city": "Ferryville",
+                "state": "DF",
+                "postcode": "01234",
+                "country": "MX",
+                "email": "your.email+fakedata38165@gmail.com",
+                "phone": "536-297-3865"
+            },
+            "shipping": {
+                "first_name": "Brooks",
+                "last_name": "Hane",
+                "company": "",
+                "address_1": "885 Susanna Ridges",
+                "address_2": "978 Powlowski Lock",
+                "city": "Ferryville",
+                "state": "DF",
+                "postcode": "01234",
+                "country": "MX",
+                "phone": "536-297-3865"
+            },
+            "payment_method": "woocommerce_payments",
+            "payment_method_title": "Credit card / debit card",
+            "customer_ip_address": "192.0.123.2",
+            "customer_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+            "created_via": "store-api",
+            "customer_note": "",
+            "date_completed": null,
+            "date_paid": "2023-04-18T18:16:11",
+            "number": "282",
+            "meta_data": [
+                {
+                    "id": 7240,
+                    "key": "_shipping_hash",
+                    "value": "9d4568c009d203ab10e33ea9953a0264"
+                },
+                {
+                    "id": 7241,
+                    "key": "_coupons_hash",
+                    "value": "d751713988987e9331980363e24189ce"
+                },
+                {
+                    "id": 7242,
+                    "key": "_fees_hash",
+                    "value": "d751713988987e9331980363e24189ce"
+                },
+                {
+                    "id": 7243,
+                    "key": "_taxes_hash",
+                    "value": "d751713988987e9331980363e24189ce"
+                },
+                {
+                    "id": 7244,
+                    "key": "is_vat_exempt",
+                    "value": "no"
+                },
+                {
+                    "id": 7245,
+                    "key": "_customer_ip_country",
+                    "value": "US"
+                },
+                {
+                    "id": 7246,
+                    "key": "_customer_self_declared_country",
+                    "value": "false"
+                },
+                {
+                    "id": 7264,
+                    "key": "_payment_method_id",
+                    "value": "pm_1MU8TnFmpgWy4LrlAwUzFd6t"
+                },
+                {
+                    "id": 7265,
+                    "key": "_stripe_customer_id",
+                    "value": "cus_NEbhgaeylNVXDP"
+                },
+                {
+                    "id": 9232,
+                    "key": "_new_order_tracking_complete",
+                    "value": "yes"
+                }
+            ],
+            "line_items": [
+                {
+                    "id": 568,
+                    "name": "Polo",
+                    "product_id": 26,
+                    "variation_id": 0,
+                    "quantity": 1,
+                    "tax_class": "clothing-20010",
+                    "subtotal": "14.50",
+                    "subtotal_tax": "0.00",
+                    "total": "14.50",
+                    "total_tax": "0.00",
+                    "taxes": [],
+                    "meta_data": [
+                        {
+                            "id": 4942,
+                            "key": "As a Gift",
+                            "value": "No",
+                            "display_key": "As a Gift",
+                            "display_value": "No"
+                        },
+                        {
+                            "id": 4943,
+                            "key": "_pao_ids",
+                            "value": [
+                                {
+                                    "key": "As a Gift",
+                                    "value": "No"
+                                }
+                            ],
+                            "display_key": "_pao_ids",
+                            "display_value": [
+                                {
+                                    "key": "As a Gift",
+                                    "value": "No"
+                                }
+                            ]
+                        },
+                        {
+                            "id": 4944,
+                            "key": "_prl_conversion",
+                            "value": "1",
+                            "display_key": "_prl_conversion",
+                            "display_value": "1"
+                        },
+                        {
+                            "id": 4945,
+                            "key": "_prl_conversion_time",
+                            "value": "1675182546",
+                            "display_key": "_prl_conversion_time",
+                            "display_value": "1675182546"
+                        },
+                        {
+                            "id": 4946,
+                            "key": "_wcsatt_scheme",
+                            "value": "1_week_12",
+                            "display_key": "_wcsatt_scheme",
+                            "display_value": "1_week_12"
+                        }
+                    ],
+                    "sku": "woo-polo",
+                    "price": 14.5,
+                    "image": {
+                        "id": "55",
+                        "src": "https://example.com/wp-content/uploads/2023/01/polo-2.jpg"
+                    },
+                    "parent_name": null
+                }
+            ],
+            "tax_lines": [],
+            "shipping_lines": [
+                {
+                    "id": 567,
+                    "method_title": "Free shipping",
+                    "method_id": "free_shipping",
+                    "instance_id": "9",
+                    "total": "0.00",
+                    "total_tax": "0.00",
+                    "taxes": [],
+                    "meta_data": [
+                        {
+                            "id": 4932,
+                            "key": "Items",
+                            "value": "Polo &times; 1",
+                            "display_key": "Items",
+                            "display_value": "Polo &times; 1"
+                        }
+                    ]
+                }
+            ],
+            "fee_lines": [],
+            "coupon_lines": [],
+            "payment_url": "https://example.com/checkout/order-pay/282/?pay_for_order=true&key=wc_order_PStHmyhQCqbBN",
+            "is_editable": true,
+            "needs_payment": false,
+            "needs_processing": true,
+            "date_created_gmt": "2023-01-31T16:20:44",
+            "date_modified_gmt": "2023-04-18T17:16:11",
+            "date_completed_gmt": null,
+            "date_paid_gmt": "2023-04-18T17:16:11",
+            "billing_period": "week",
+            "billing_interval": "1",
+            "start_date_gmt": "2023-01-31T16:29:46",
+            "trial_end_date_gmt": "",
+            "next_payment_date_gmt": "",
+            "last_payment_date_gmt": "2023-04-18T17:16:08",
+            "cancelled_date_gmt": "",
+            "end_date_gmt": "2023-04-25T16:29:46",
+            "resubscribed_from": "",
+            "resubscribed_subscription": "",
+            "removed_line_items": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/subscriptions/282"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/subscriptions"
+                    }
+                ],
+                "customer": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/customers/27375286"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/orders/281"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8949
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We need to support retrieving the subscriptions associated with a specific order on a store. This PR adds Networking models to represent those subscriptions.

### Changes

* Adds a mock API response when subscriptions are requested for an order.
* Adds a `Subscription` model to represent a subscription and the fields we are using.
* Adds a `SubscriptionStatus` model to represent the possible statuses of a subscription. (These statuses can be further modified by other extensions.)
* Adds generated `fake()` and `copy()` methods to use in testing.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
These models aren't yet being used or tested. The required endpoint support and mapper (and related tests) are part of #9504. You can check the tests on that PR to confirm the mock responses can be decoded according to these models.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
