### PR TITLE
[Subscriptions] Add support for retrieving subscriptions in the Yosemite layer

### DIFF
--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -72,6 +72,7 @@ class AuthenticatedState: StoresManagerState {
                       storageManager: storageManager,
                       network: network),
             StatsStoreV4(dispatcher: dispatcher, storageManager: storageManager, network: network),
+            SubscriptionStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             SystemStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             TaxClassStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             TelemetryStore(dispatcher: dispatcher, storageManager: storageManager, network: network),

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -341,6 +341,8 @@
 		CC6A054628773F75002C144E /* OrderMetaData+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6A054528773F75002C144E /* OrderMetaData+ReadOnlyConvertible.swift */; };
 		CC80E40C294B454A00D5FF45 /* SiteSummaryStats+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC80E40B294B454A00D5FF45 /* SiteSummaryStats+ReadOnlyConvertible.swift */; };
 		CCCF3A8129C07DD9001D3507 /* ProductBundleItem+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCF3A8029C07DD9001D3507 /* ProductBundleItem+ReadOnlyConvertible.swift */; };
+		CCE5F39B29F015BD00087332 /* SubscriptionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE5F39A29F015BD00087332 /* SubscriptionAction.swift */; };
+		CCE5F39D29F0165900087332 /* SubscriptionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE5F39C29F0165900087332 /* SubscriptionStore.swift */; };
 		CE01014F2368C41600783459 /* Refund+ReadOnlyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01014E2368C41600783459 /* Refund+ReadOnlyType.swift */; };
 		CE0DB6C0233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0DB6BF233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift */; };
 		CE12FBDB221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12FBDA221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift */; };
@@ -788,6 +790,8 @@
 		CC6A054528773F75002C144E /* OrderMetaData+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderMetaData+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CC80E40B294B454A00D5FF45 /* SiteSummaryStats+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SiteSummaryStats+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CCCF3A8029C07DD9001D3507 /* ProductBundleItem+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductBundleItem+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		CCE5F39A29F015BD00087332 /* SubscriptionAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionAction.swift; sourceTree = "<group>"; };
+		CCE5F39C29F0165900087332 /* SubscriptionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionStore.swift; sourceTree = "<group>"; };
 		CE01014E2368C41600783459 /* Refund+ReadOnlyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Refund+ReadOnlyType.swift"; sourceTree = "<group>"; };
 		CE0DB6BF233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderRefundCondensed+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CE12FBDA221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatus+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1445,6 +1449,7 @@
 				D4CBAE6126D4460800BBE6D1 /* AnnouncementsStore.swift */,
 				74D7FFF9221F01E90008CC0E /* ShipmentStore.swift */,
 				D8C11A4F22DF2D9400D4A88D /* StatsStoreV4.swift */,
+				CCE5F39C29F0165900087332 /* SubscriptionStore.swift */,
 				025CA2C9238F515600B05C81 /* ProductShippingClassStore.swift */,
 				026CF625237D8EFB009563D4 /* ProductVariationStore.swift */,
 				45010692239A6C9F00E24722 /* TaxClassStore.swift */,
@@ -1701,6 +1706,7 @@
 				7492FADE217FB11D00ED2C69 /* SettingAction.swift */,
 				74643EE0221F567E00EDC51A /* ShipmentAction.swift */,
 				D8C11A5122DF2DA200D4A88D /* StatsActionV4.swift */,
+				CCE5F39A29F015BD00087332 /* SubscriptionAction.swift */,
 				026CF627237D8F30009563D4 /* ProductVariationAction.swift */,
 				025CA2CB238F518600B05C81 /* ProductShippingClassAction.swift */,
 				029BA55A255E0D39006171FD /* ShippingLabelAction.swift */,
@@ -2016,6 +2022,7 @@
 				03FBDA222631521100ACE257 /* CouponAction.swift in Sources */,
 				CE4FD4562350FD4800A16B31 /* Refund+ReadOnlyConvertible.swift in Sources */,
 				CE3B7AD92229C3570050FE4B /* OrderStatus+ReadOnlyType.swift in Sources */,
+				CCE5F39B29F015BD00087332 /* SubscriptionAction.swift in Sources */,
 				CC80E40C294B454A00D5FF45 /* SiteSummaryStats+ReadOnlyConvertible.swift in Sources */,
 				026CF62C237D92DC009563D4 /* ProductVariationAttribute+ReadOnlyConvertible.swift in Sources */,
 				247CE7AB2582DB9300F9D9D1 /* String+Extensions.swift in Sources */,
@@ -2221,6 +2228,7 @@
 				03FBDA3E2632E29600ACE257 /* Coupon+ReadOnlyConvertible.swift in Sources */,
 				02E4F5E423CD5628003B0010 /* NSOrderedSet+Array.swift in Sources */,
 				749737672141CC8C0008C490 /* TopEarnerStats+ReadOnlyType.swift in Sources */,
+				CCE5F39D29F0165900087332 /* SubscriptionStore.swift in Sources */,
 				7493751222498B2C007D85D1 /* ProductTag+ReadOnlyConvertible.swift in Sources */,
 				E109876C284F6EEB002EBB05 /* CardPresentPaymentsPluginState.swift in Sources */,
 				03FBDA26263296A100ACE257 /* CouponStore.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		CC6A054628773F75002C144E /* OrderMetaData+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6A054528773F75002C144E /* OrderMetaData+ReadOnlyConvertible.swift */; };
 		CC80E40C294B454A00D5FF45 /* SiteSummaryStats+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC80E40B294B454A00D5FF45 /* SiteSummaryStats+ReadOnlyConvertible.swift */; };
 		CCCF3A8129C07DD9001D3507 /* ProductBundleItem+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCF3A8029C07DD9001D3507 /* ProductBundleItem+ReadOnlyConvertible.swift */; };
+		CCE24F8829F025BB00B416BC /* SubscriptionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE24F8729F025BB00B416BC /* SubscriptionStoreTests.swift */; };
 		CCE5F39B29F015BD00087332 /* SubscriptionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE5F39A29F015BD00087332 /* SubscriptionAction.swift */; };
 		CCE5F39D29F0165900087332 /* SubscriptionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE5F39C29F0165900087332 /* SubscriptionStore.swift */; };
 		CE01014F2368C41600783459 /* Refund+ReadOnlyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01014E2368C41600783459 /* Refund+ReadOnlyType.swift */; };
@@ -790,6 +791,7 @@
 		CC6A054528773F75002C144E /* OrderMetaData+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderMetaData+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CC80E40B294B454A00D5FF45 /* SiteSummaryStats+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SiteSummaryStats+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CCCF3A8029C07DD9001D3507 /* ProductBundleItem+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductBundleItem+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		CCE24F8729F025BB00B416BC /* SubscriptionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionStoreTests.swift; sourceTree = "<group>"; };
 		CCE5F39A29F015BD00087332 /* SubscriptionAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionAction.swift; sourceTree = "<group>"; };
 		CCE5F39C29F0165900087332 /* SubscriptionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionStore.swift; sourceTree = "<group>"; };
 		CE01014E2368C41600783459 /* Refund+ReadOnlyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Refund+ReadOnlyType.swift"; sourceTree = "<group>"; };
@@ -1510,6 +1512,7 @@
 				453305FA245AEDCB00264E50 /* SitePostStoreTests.swift */,
 				028BCE2322DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift */,
 				D8C11A5922DFC21600D4A88D /* StatsStoreV4Tests.swift */,
+				CCE24F8729F025BB00B416BC /* SubscriptionStoreTests.swift */,
 				026D52BF238235930092AE05 /* ProductVariationStoreTests.swift */,
 				025CA2CF238F54E800B05C81 /* ProductShippingClassStoreTests.swift */,
 				45ED4F15239E939A004F1BE3 /* TaxClassStoreTests.swift */,
@@ -2373,6 +2376,7 @@
 				02F2722D292F18BF00C36419 /* PaymentStoreTests.swift in Sources */,
 				02FF056923DECD5B0058E6E7 /* MediaImageExporterTests.swift in Sources */,
 				0202B6972387AFBF00F3EBE0 /* MockInMemoryStorage.swift in Sources */,
+				CCE24F8829F025BB00B416BC /* SubscriptionStoreTests.swift in Sources */,
 				028BCE2422DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift in Sources */,
 				5758EB3324DC9631009ED8A6 /* InAppFeedbackCardVisibilityUseCaseTests.swift in Sources */,
 				B5F2AE9520EBAD6000FEDC59 /* ResultsControllerTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/SubscriptionAction.swift
+++ b/Yosemite/Yosemite/Actions/SubscriptionAction.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum SubscriptionAction: Action {
+
+    /// Retrieves all Subscriptions for a given Order.
+    ///
+    case loadSubscriptions(for: Order, completion: (Result<[Subscription], Error>) -> Void)
+}

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -137,6 +137,7 @@ public typealias SiteSummaryStats = Networking.SiteSummaryStats
 public typealias SiteVisitStats = Networking.SiteVisitStats
 public typealias SiteVisitStatsItem = Networking.SiteVisitStatsItem
 public typealias StateOfACountry = Networking.StateOfACountry
+public typealias Subscription = Networking.Subscription
 public typealias SubscriptionPeriod = Networking.SubscriptionPeriod
 public typealias SystemPlugin = Networking.SystemPlugin
 public typealias SystemStatus = Networking.SystemStatus

--- a/Yosemite/Yosemite/Stores/SubscriptionStore.swift
+++ b/Yosemite/Yosemite/Stores/SubscriptionStore.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Storage
+import Networking
+
+/// Implements `SubscriptionAction` actions
+///
+public final class SubscriptionStore: Store {
+    private let remote: SubscriptionsRemoteProtocol
+
+    public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
+        self.remote = SubscriptionsRemote(network: network)
+        super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    }
+
+    init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, remote: SubscriptionsRemoteProtocol) {
+        self.remote = remote
+        super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    }
+
+    /// Registers for supported Actions.
+    override public func registerSupportedActions(in dispatcher: Dispatcher) {
+        dispatcher.register(processor: self, for: SubscriptionAction.self)
+    }
+
+    /// Receives and executes Actions.
+    override public func onAction(_ action: Action) {
+        guard let action = action as? SubscriptionAction else {
+            assertionFailure("SubscriptionStore received an unsupported action")
+            return
+        }
+
+        switch action {
+        case .loadSubscriptions(let order, let completion):
+            loadSubscriptions(siteID: order.siteID, orderID: order.orderID, completion: completion)
+        }
+    }
+}
+
+private extension SubscriptionStore {
+
+    /// Retrieves all Subscriptions for a given Order.
+    ///
+    func loadSubscriptions(siteID: Int64, orderID: Int64, completion: @escaping (Result<[Subscription], Error>) -> Void) {
+        remote.loadSubscriptions(siteID: siteID, orderID: orderID) { result in
+            switch result {
+            case .success(let response):
+                completion(.success(response))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/SubscriptionStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SubscriptionStoreTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import Networking
+import Yosemite
+
+final class SubscriptionStoreTests: XCTestCase {
+
+    /// Mock Dispatcher
+    ///
+    private var dispatcher: Dispatcher!
+
+    /// Mock Storage Manager
+    ///
+    private var storageManager: MockStorageManager!
+
+    /// Mock Network
+    ///
+    private var network: MockNetwork!
+
+    /// Sample Site ID
+    ///
+    private let sampleSiteID: Int64 = 1234
+
+    /// Sample Order ID
+    ///
+    private let sampleOrderID: Int64 = 12345
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork()
+        storageManager = MockStorageManager()
+        dispatcher = Dispatcher()
+    }
+
+    // MARK: - loadSubscriptions
+
+    func test_loadSubscriptions_returns_subscriptions_on_success() throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "subscriptions", filename: "subscription-list")
+        let store = SubscriptionStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let result: Result<[Subscription], Error> = waitFor { promise in
+            let action = SubscriptionAction.loadSubscriptions(for: Order.fake()) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let subscriptions = try XCTUnwrap(result.get())
+        assertEqual(2, subscriptions.count)
+    }
+
+    func test_loadSubscriptions_returns_errors_on_failure() {
+        // Given
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "subscriptions", error: error)
+        let store = SubscriptionStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let result: Result<[Subscription], Error> = waitFor { promise in
+            let action = SubscriptionAction.loadSubscriptions(for: Order.fake()) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, error)
+    }
+
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8949
⚠️ Depends on #9504
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds support in the Yosemite layer for retrieving the subscriptions for an order. For now, we aren't persisting these subscriptions in storage; they will be requested when an order is opened in order details, and the retrieved subscriptions will be passed directly to the UI layer to be displayed there.

### Changes

* Adds `SubscriptionAction` with an action to load subscriptions for an order.
* Adds `SubscriptionStore` to call the remote endpoint to retrieve the subscriptions for an order.
* Adds unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Confirm unit tests pass. This action is not yet being used in the app.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
