### PR TITLE
[Free Trial ]Update Hub menu for Non-JP sites

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -29,20 +29,19 @@ struct HubMenu: View {
             // Store Section
             Section {
                 Button {
-                    if viewModel.switchStoreEnabled {
-                        viewModel.presentSwitchStore()
-                    }
+                    viewModel.presentSwitchStore()
                 } label: {
                     Row(title: viewModel.storeTitle,
                         badge: viewModel.planName,
                         description: viewModel.storeURL.host ?? viewModel.storeURL.absoluteString,
                         icon: .remote(viewModel.avatarURL),
-                        chevron: .down,
+                        chevron: viewModel.switchStoreEnabled ? .down : .none,
                         titleAccessibilityID: "store-title",
                         descriptionAccessibilityID: "store-url",
                         chevronAccessibilityID: "switch-store-button")
                     .lineLimit(1)
                 }
+                .disabled(!viewModel.switchStoreEnabled)
             }
 
             // Settings Section
@@ -179,11 +178,14 @@ private extension HubMenu {
         /// Style for the chevron indicator.
         ///
         enum Chevron {
+            case none
             case down
             case leading
 
             var asset: UIImage {
                 switch self {
+                case .none:
+                    return UIImage()
                 case .down:
                     return .chevronDownImage
                 case .leading:
@@ -244,9 +246,10 @@ private extension HubMenu {
 
                         case .remote(let url):
                             KFImage(url)
+                                .placeholder { Image(uiImage: .gravatarPlaceholderImage).resizable() }
                                 .resizable()
-                                .clipShape(Circle())
                                 .frame(width: HubMenu.Constants.avatarSize, height: HubMenu.Constants.avatarSize)
+                                .clipShape(Circle())
                         }
                     }
                 }
@@ -277,6 +280,7 @@ private extension HubMenu {
                     .frame(width: HubMenu.Constants.chevronSize, height: HubMenu.Constants.chevronSize)
                     .foregroundColor(Color(.textSubtle))
                     .accessibilityIdentifier(chevronAccessibilityID ?? "")
+                    .renderedIf(chevron != .none)
             }
             .padding(.vertical, Constants.rowVerticalPadding)
         }


### PR DESCRIPTION
Closes: #9501 

# Why

This PR updates the HUB Menu so the user row is rendered correctly on Non-Jetpack sites.

In particular:
- Shows a default avatar 
- Hides the chevron icon, indicating that the row is capable
- Disables the row (Button) so voice-over does not treat it like a button


# Screenshots

Non Jetpack | Jetpack
---- | ----
<img width="444" alt="Non-JP" src="https://user-images.githubusercontent.com/562080/233210406-4115556a-c36a-4012-b791-1f216829ec2b.png"> | <img width="445" alt="JP" src="https://user-images.githubusercontent.com/562080/233210415-985aefb8-3af9-4073-aa55-3cfd3a4659f7.png">


# Testing

- Log into the app with a non-Jetpack site (You can create one with Jurassic Ninja).
- Go to the hub menu.
- Observe that the user row contains a placeholder avatar.
- Observe that the user row does not contain a chevron button.
- Observe that the user row is not tappable.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
