### PR TITLE
[UI Tests] - Use waitForExistence instead of exists to assert button after product creation

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -43,7 +43,7 @@ public final class SingleProductScreen: ScreenObject {
 
     public func verifyPublishedProductScreenLoaded(productType: String, productName: String) {
         // common fields on a published product screen
-        XCTAssertTrue(app.buttons["save-product-button"].exists)
+        XCTAssertTrue(app.buttons["save-product-button"].waitForExistence(timeout: 10), "Save button is not displayed!")
         XCTAssertTrue(app.staticTexts["TIP"].exists)
         XCTAssertTrue(app.textViews[productName].exists)
 


### PR DESCRIPTION
## Description
While [testing parallel test runs in CI](https://buildkite.com/automattic/woocommerce-ios/builds/12617#0187986e-9031-4d8a-99eb-c84cc37ddb48), the product creation tests failed a few times (and usually pass after the retry). I checked the error and screenshot, it was because the `save` button did not exist:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/17252150/233263208-f6aa83e4-2f5e-44ef-92b0-2acbc83e47c9.png">

However, the screenshot says otherwise:
<img width="889" alt="image" src="https://user-images.githubusercontent.com/17252150/233263285-904d24b1-0df3-466c-8b53-ccdae11dc669.png">

The Save button is displayed, but there is the `product published` notice at the bottom of the screen though not sure if that played a part in the failure. Still an assumption, but I also think that some screen loads slower when multiple simulators run tests simultaneously. 

As an attempt to stop this from happening, instead of using `exists,` I've updated it to `waitForExistence` with a 10-second timeout so that it could wait up to 10 seconds for that it to exist.

## Testing instructions
`ProductsTest` should work as expected locally and in CI.
