### PR TITLE
Set parallelizable to true for UI Tests

### DIFF
--- a/WooCommerce/WooCommerceUITests/UITests.xctestplan
+++ b/WooCommerce/WooCommerceUITests/UITests.xctestplan
@@ -24,6 +24,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "skippedTests" : [
         "StatsTests\/testStatsScreenLoad()"
       ],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1129,8 +1129,9 @@ lane :test_without_building do |options|
 
   inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
 
-  # Excluding unit tests from parallel testing
-  parallel_testing_value = options[:name] == "UnitTests" ? false : true
+  # Only run UI tests in parallel.
+  # At the time of writing with Xcode 14.3, we need to explicitly set this value despite using test plans that configure parallelism.
+  parallel_testing_value = options[:name] == "UITests"
 
   run_tests(
     workspace: 'WooCommerce.xcworkspace',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -50,6 +50,8 @@ COMMON_EXPORT_OPTIONS = { manageAppVersionAndBuildNumber: false }.freeze
 
 TEST_SCHEME = 'WooCommerce'
 
+CONCURRENT_SIMULATORS = 2
+
 # List of `.strings` files manually maintained by developers (as opposed to being automatically extracted from the code)
 # which we will merge into the main `Localizable.strings` file imported by GlotPress, then extract back once we download the translations.
 #
@@ -1127,10 +1129,16 @@ lane :test_without_building do |options|
 
   inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
 
+  # Excluding unit tests from parallel testing
+  parallel_testing_value = options[:name] == "UnitTests" ? false : true
+
   run_tests(
     workspace: 'WooCommerce.xcworkspace',
     scheme: TEST_SCHEME,
     device: options[:device],
+    parallel_testing: parallel_testing_value,
+    concurrent_workers: CONCURRENT_SIMULATORS,
+    max_concurrent_simulators: CONCURRENT_SIMULATORS,
     test_without_building: true,
     xctestrun: xctestrun_path,
     result_bundle: true,


### PR DESCRIPTION
## Description
In an attempt to get tests running faster, this PR turns on parallel testing for UI Tests, setting the number of concurrent simulators for each test run to 2. 

On the test run ensure that tests are running in parallel. This can be validated from the test results logs:


I'm only setting this for UI Test for now for 2 reasons:
1. I know for sure that each UI tests are independent but I'm not sure if that's true for Unit Tests. On a testing branch, when this was first turned on, more than 20 unit tests failed ([testing build](https://buildkite.com/automattic/woocommerce-ios/builds/12206#01873693-f18a-4514-b1a8-59b8a72c4a29)). So looks like there are some investigation is needed before this can be turned on for unit tests 
2. Unit tests are generally faster than UI tests; with this turned on, while this configuration should make tests run faster, we would need to make updates to the test classes to fully utilize it. On UI Test each test class is quite small so whichever combination it ends up with for the test runs, will end in some time savings. For Unit Tests, the split looks like below, so I would recommend looking at how tests are arranged in test classes before turning this on for Unit Tests:
<img width="470" alt="image" src="https://user-images.githubusercontent.com/17252150/233293629-c876fbef-996e-4294-b813-1213bd978af5.png">


## Testing instructions
Tests should run and should be faster than previously (from what I see, without any changes to test classes, adding this makes UI Tests run 1-2 minutes faster, which isn't much but our test suite is also quite small, once it gets bigger this would have more impact)
