### PR TITLE
[Mobile Payments] Show onboarding before Set up Tap to Pay on iPhone

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -292,6 +292,7 @@ public enum WooAnalyticsStat: String {
     case tapToPaySummaryTryPaymentSkipTapped = "tap_to_pay_summary_try_payment_skip_tapped"
     case tapToPaySetupInformationSetUpTapped = "tap_to_pay_set_up_information_set_up_tapped"
     case tapToPaySetupInformationCancelTapped = "tap_to_pay_set_up_information_cancel_tapped"
+    case tapToPaySetupOnboardingCancelTapped = "tap_to_pay_set_up_onboarding_cancel_tapped"
     case tapToPaySetupSuccessDoneTapped = "tap_to_pay_set_up_success_done_tapped"
     case tapToPaySummaryShown = "tap_to_pay_summary_shown"
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderSettingsConnectedViewModel.swift
@@ -276,9 +276,8 @@ final class BluetoothCardReaderSettingsConnectedViewModel: PaymentSettingsFlowPr
 
         let didChange = newShouldShow != shouldShow
 
-        shouldShow = newShouldShow
-
         if didChange {
+            shouldShow = newShouldShow
             didChangeShouldShow?(shouldShow)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayCompleteViewModel.swift
@@ -56,9 +56,8 @@ final class SetUpTapToPayCompleteViewModel: PaymentSettingsFlowPresentedViewMode
 
         let didChange = newShouldShow != shouldShow
 
-        shouldShow = newShouldShow
-
         if didChange {
+            shouldShow = newShouldShow
             didChangeShouldShow?(shouldShow)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -202,14 +202,19 @@ private enum Localization {
         comment: "Settings > Set up Tap to Pay on iPhone > Information > Cancel button")
 }
 
+
+import Combine
+import Yosemite
 struct SetUpTapToPayInformationView_Previews: PreviewProvider {
     static var previews: some View {
         let config = CardPresentConfigurationLoader().configuration
+        let publisher = CardPresentPaymentsOnboardingUseCase().statePublisher
+
         let viewModel = SetUpTapToPayInformationViewModel(
             siteID: 0,
             configuration: config,
             didChangeShouldShow: nil,
-            activePaymentGateway: .wcPay,
+            onboardingStatePublisher: publisher,
             connectionAnalyticsTracker: .init(configuration: config))
         SetUpTapToPayInformationView(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -137,9 +137,8 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
 
         let didChange = newShouldShow != shouldShow
 
-        shouldShow = newShouldShow
-
         if didChange {
+            shouldShow = newShouldShow
             didChangeShouldShow?(shouldShow)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -6,7 +6,7 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
     private(set) var shouldShow: CardReaderSettingsTriState = .isUnknown
     var didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?
     var didUpdate: (() -> Void)?
-    let learnMoreURL: URL
+    private(set) var learnMoreURL: URL
     var dismiss: (() -> Void)?
 
     private let stores: StoresManager
@@ -19,6 +19,7 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
     let connectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker
     let connectivityObserver: ConnectivityObserver
 
+    private let onboardingStatePublisher: Published<CardPresentPaymentOnboardingState>.Publisher
     private let analytics: Analytics = ServiceLocator.analytics
 
     var connectionController: BuiltInCardReaderConnectionController? = nil
@@ -35,7 +36,7 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
     init(siteID: Int64,
          configuration: CardPresentPaymentsConfiguration,
          didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?,
-         activePaymentGateway: CardPresentPaymentsPlugin,
+         onboardingStatePublisher: Published<CardPresentPaymentOnboardingState>.Publisher,
          connectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker,
          connectivityObserver: ConnectivityObserver = ServiceLocator.connectivityObserver,
          stores: StoresManager = ServiceLocator.stores) {
@@ -45,14 +46,26 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
         self.stores = stores
         self.connectionAnalyticsTracker = connectionAnalyticsTracker
         self.connectivityObserver = connectivityObserver
-        self.learnMoreURL = Self.learnMoreURL(for: activePaymentGateway)
+        self.onboardingStatePublisher = onboardingStatePublisher
+        self.learnMoreURL = Self.learnMoreURL(for: .wcPay) // this will be updated when the onboarding state is known
 
+        beginOnboardingStateObservation()
         beginConnectedReaderObservation()
         beginConnectivityObservation()
     }
 
     deinit {
         subscriptions.removeAll()
+    }
+
+    // this is only used for the learn more url...
+    private func beginOnboardingStateObservation() {
+        self.onboardingStatePublisher.share().sink { [weak self] onboardingState in
+            guard case .completed(let plugin) = onboardingState else {
+                return
+            }
+            self?.learnMoreURL = Self.learnMoreURL(for: plugin.preferred)
+        }.store(in: &subscriptions)
     }
 
     /// Set up to observe readers connecting / disconnecting

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayOnboardingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayOnboardingViewController.swift
@@ -11,6 +11,7 @@ final class SetUpTapToPayOnboardingViewController: UIHostingController<SetUpTapT
         let onboardingView = InPersonPaymentsView(viewModel: viewModel)
         super.init(rootView: SetUpTapToPayOnboardingView(onboardingView: onboardingView))
         rootView.cancelTapped = { [weak self] in
+            ServiceLocator.analytics.track(.tapToPaySetupOnboardingCancelTapped)
             self?.dismiss(animated: true)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayOnboardingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayOnboardingViewController.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import Yosemite
+
+final class SetUpTapToPayOnboardingViewController: UIHostingController<SetUpTapToPayOnboardingView>, PaymentSettingsFlowViewModelPresenter {
+
+    private let onWillDisappear: (() -> ())?
+
+    init(viewModel: InPersonPaymentsViewModel,
+         onWillDisappear: (() -> ())?) {
+        self.onWillDisappear = onWillDisappear
+        let onboardingView = InPersonPaymentsView(viewModel: viewModel)
+        super.init(rootView: SetUpTapToPayOnboardingView(onboardingView: onboardingView))
+        rootView.cancelTapped = { [weak self] in
+            self?.dismiss(animated: true)
+        }
+
+        viewModel.showSupport = { [weak self] in
+            guard let self = self else { return }
+            let supportForm = SupportFormHostingController(viewModel: .init())
+            supportForm.show(from: self)
+        }
+
+        viewModel.showURL = { [weak self] url in
+            guard let self = self else { return }
+            WebviewHelper.launch(url, with: self)
+        }
+    }
+
+    convenience init?(viewModel: PaymentSettingsFlowPresentedViewModel) {
+        guard let viewModel = viewModel as? InPersonPaymentsViewModel else {
+            return nil
+        }
+        self.init(viewModel: viewModel, onWillDisappear: nil)
+    }
+
+    @objc required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        onWillDisappear?()
+        super.viewWillDisappear(animated)
+    }
+}
+
+struct SetUpTapToPayOnboardingView: View {
+    @State var onboardingView: InPersonPaymentsView
+    var cancelTapped: (() -> Void)? = nil
+
+    var body: some View {
+        VStack {
+            HStack {
+                Button(Localization.cancelButton) {
+                    cancelTapped?()
+                }
+                .padding(.top)
+
+                Spacer()
+            }
+            .padding()
+
+            Spacer()
+
+            onboardingView
+        }
+    }
+}
+
+private enum Localization {
+    static let cancelButton = NSLocalizedString(
+        "Cancel",
+        comment: "Settings > Set up Tap to Pay on iPhone > Onboarding > Cancel button")
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
@@ -96,9 +96,8 @@ final class SetUpTapToPayTryPaymentPromptViewModel: PaymentSettingsFlowPresented
 
         let didChange = newShouldShow != shouldShow
 
-        shouldShow = newShouldShow
-
         if didChange {
+            shouldShow = newShouldShow
             didChangeShouldShow?(shouldShow)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import Combine
 
 /// Aggregates an ordered list of viewmodels, conforming to the viewmodel provider protocol. Priority is given to
 /// the first viewmodel in the list to return true for shouldShow
@@ -20,14 +21,20 @@ final class SetUpTapToPayViewModelsOrderedList: PaymentSettingsFlowPrioritizedVi
 
     private let cardReaderConnectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker
 
+    private var cancellables = Set<AnyCancellable>()
+
     init(siteID: Int64,
          configuration: CardPresentPaymentsConfiguration,
-         onboardingUseCase: CardPresentPaymentsOnboardingUseCase,
-         activePaymentGateway: CardPresentPaymentsPlugin) {
+         onboardingUseCase: CardPresentPaymentsOnboardingUseCase) {
         /// Initialize dependencies for viewmodels first, then viewmodels
         ///
         cardReaderConnectionAnalyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: configuration)
-        cardReaderConnectionAnalyticsTracker.setGatewayID(gatewayID: activePaymentGateway.gatewayID)
+        onboardingUseCase.statePublisher.share().sink { [weak self] onboardingState in
+            guard case .completed(let plugin) = onboardingState else {
+                return
+            }
+            self?.cardReaderConnectionAnalyticsTracker.setGatewayID(gatewayID: plugin.preferred.gatewayID)
+        }.store(in: &cancellables)
 
         /// Instantiate and add each viewmodel related to setting up Tap to Pay on iPhone to the
         /// array. Viewmodels will be evaluated for shouldShow starting at the top

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
@@ -22,6 +22,7 @@ final class SetUpTapToPayViewModelsOrderedList: PaymentSettingsFlowPrioritizedVi
 
     init(siteID: Int64,
          configuration: CardPresentPaymentsConfiguration,
+         onboardingUseCase: CardPresentPaymentsOnboardingUseCase,
          activePaymentGateway: CardPresentPaymentsPlugin) {
         /// Initialize dependencies for viewmodels first, then viewmodels
         ///
@@ -34,6 +35,15 @@ final class SetUpTapToPayViewModelsOrderedList: PaymentSettingsFlowPrioritizedVi
         /// priority, so viewmodels related to starting set up should come before viewmodels
         /// that expect set up to be completed, etc.
         ///
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhoneMilestone2) {
+            viewModelsAndViews.append(PaymentSettingsFlowViewModelAndView(
+                viewModel: InPersonPaymentsViewModel(useCase: onboardingUseCase,
+                                                     didChangeShouldShow: { [weak self] state in
+                                                         self?.onDidChangeShouldShow(state)
+                                                     }),
+                viewPresenter: InPersonPaymentsViewController.self))
+        }
+
         viewModelsAndViews.append(contentsOf: [
             PaymentSettingsFlowViewModelAndView(
                 viewModel: SetUpTapToPayInformationViewModel(
@@ -42,7 +52,7 @@ final class SetUpTapToPayViewModelsOrderedList: PaymentSettingsFlowPrioritizedVi
                     didChangeShouldShow: { [weak self] state in
                         self?.onDidChangeShouldShow(state)
                     },
-                    activePaymentGateway: activePaymentGateway,
+                    onboardingStatePublisher: onboardingUseCase.statePublisher,
                     connectionAnalyticsTracker: cardReaderConnectionAnalyticsTracker
                 ),
                 viewPresenter: SetUpTapToPayInformationViewController.self

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayViewModelsOrderedList.swift
@@ -48,7 +48,7 @@ final class SetUpTapToPayViewModelsOrderedList: PaymentSettingsFlowPrioritizedVi
                                                      didChangeShouldShow: { [weak self] state in
                                                          self?.onDidChangeShouldShow(state)
                                                      }),
-                viewPresenter: InPersonPaymentsViewController.self))
+                viewPresenter: SetUpTapToPayOnboardingViewController.self))
         }
 
         viewModelsAndViews.append(contentsOf: [

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -34,6 +34,8 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         cardPresentPaymentsOnboardingUseCase.state.isCompleted
     }
 
+    private let setUpFlowOnlyEnabledAfterOnboardingComplete: Bool
+
     /// Main TableView
     ///
     private lazy var tableView: UITableView = {
@@ -64,6 +66,7 @@ final class InPersonPaymentsMenuViewController: UIViewController {
         self.featureFlagService = featureFlagService
         self.cardPresentPaymentsOnboardingUseCase = CardPresentPaymentsOnboardingUseCase()
         self.cashOnDeliveryToggleRowViewModel = InPersonPaymentsCashOnDeliveryToggleRowViewModel()
+        self.setUpFlowOnlyEnabledAfterOnboardingComplete = !featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhoneMilestone2)
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -356,13 +359,15 @@ private extension InPersonPaymentsMenuViewController {
 
     func configureSetUpTapToPayOnIPhone(cell: LeftImageTableViewCell) {
         prepareForReuse(cell)
-        cell.accessoryType = enableSetUpTapToPayOnIPhoneCell ? .disclosureIndicator : .none
-        cell.selectionStyle = enableSetUpTapToPayOnIPhoneCell ? .default : .none
         cell.accessibilityIdentifier = "set-up-tap-to-pay"
         cell.configure(image: .tapToPayOnIPhoneIcon,
                        text: Localization.tapToPayOnIPhone)
 
-        updateEnabledState(in: cell, shouldBeEnabled: enableSetUpTapToPayOnIPhoneCell)
+        if setUpFlowOnlyEnabledAfterOnboardingComplete {
+            cell.accessoryType = enableSetUpTapToPayOnIPhoneCell ? .disclosureIndicator : .none
+            cell.selectionStyle = enableSetUpTapToPayOnIPhoneCell ? .default : .none
+            updateEnabledState(in: cell, shouldBeEnabled: enableSetUpTapToPayOnIPhoneCell)
+        }
     }
 
     func configureTapToPayOnIPhoneFeedback(cell: LeftImageTableViewCell) {
@@ -462,23 +467,26 @@ extension InPersonPaymentsMenuViewController {
     }
 
     func presentSetUpTapToPayOnIPhoneViewController() {
-        if featureFlagService.isFeatureFlagEnabled(.tapToPayOnIPhoneMilestone2) {
-            presentSetUpTapToPayOnIPhoneWithOnboarding()
-        } else {
+        if setUpFlowOnlyEnabledAfterOnboardingComplete {
+            guard enableSetUpTapToPayOnIPhoneCell else {
+                return
+            }
+
             presentSetUpTapToPayOnIPhoneWithoutOnboarding()
+        } else {
+            presentSetUpTapToPayOnIPhoneWithOnboarding()
         }
     }
 
     private func presentSetUpTapToPayOnIPhoneWithoutOnboarding() {
         guard let siteID = stores.sessionManager.defaultStoreID,
-              let activePaymentGateway = pluginState?.preferred else {
+              let _ = pluginState?.preferred else {
             return
         }
 
         let viewModelsAndViews = SetUpTapToPayViewModelsOrderedList(siteID: siteID,
                                                                     configuration: viewModel.cardPresentPaymentsConfiguration,
-                                                                    onboardingUseCase: cardPresentPaymentsOnboardingUseCase,
-                                                                    activePaymentGateway: activePaymentGateway)
+                                                                    onboardingUseCase: cardPresentPaymentsOnboardingUseCase)
         let setUpTapToPayViewController = PaymentSettingsFlowPresentingViewController(viewModelsAndViews: viewModelsAndViews)
         let controller = WooNavigationController(rootViewController: setUpTapToPayViewController)
         controller.navigationBar.isHidden = true
@@ -491,12 +499,9 @@ extension InPersonPaymentsMenuViewController {
             return
         }
 
-        let activePaymentGateway = pluginState?.preferred ?? .wcPay
-
         let viewModelsAndViews = SetUpTapToPayViewModelsOrderedList(siteID: siteID,
                                                                     configuration: viewModel.cardPresentPaymentsConfiguration,
-                                                                    onboardingUseCase: cardPresentPaymentsOnboardingUseCase,
-                                                                    activePaymentGateway: activePaymentGateway)
+                                                                    onboardingUseCase: cardPresentPaymentsOnboardingUseCase)
         let setUpTapToPayViewController = PaymentSettingsFlowPresentingViewController(viewModelsAndViews: viewModelsAndViews)
         let controller = WooNavigationController(rootViewController: setUpTapToPayViewController)
         controller.navigationBar.isHidden = true

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewController.swift
@@ -167,7 +167,8 @@ private extension InPersonPaymentsMenuViewController {
         // That way we avoid triggering the onboarding check again that comes with the presenter.
         let onboardingViewModel = InPersonPaymentsViewModel(useCase: cardPresentPaymentsOnboardingUseCase)
 
-        let onboardingViewController = InPersonPaymentsViewController(viewModel: onboardingViewModel)
+        let onboardingViewController = InPersonPaymentsViewController(viewModel: onboardingViewModel,
+                                                                      onWillDisappear: nil)
         show(onboardingViewController, sender: self)
     }
 
@@ -476,6 +477,7 @@ extension InPersonPaymentsMenuViewController {
 
         let viewModelsAndViews = SetUpTapToPayViewModelsOrderedList(siteID: siteID,
                                                                     configuration: viewModel.cardPresentPaymentsConfiguration,
+                                                                    onboardingUseCase: cardPresentPaymentsOnboardingUseCase,
                                                                     activePaymentGateway: activePaymentGateway)
         let setUpTapToPayViewController = PaymentSettingsFlowPresentingViewController(viewModelsAndViews: viewModelsAndViews)
         let controller = WooNavigationController(rootViewController: setUpTapToPayViewController)
@@ -493,6 +495,7 @@ extension InPersonPaymentsMenuViewController {
 
         let viewModelsAndViews = SetUpTapToPayViewModelsOrderedList(siteID: siteID,
                                                                     configuration: viewModel.cardPresentPaymentsConfiguration,
+                                                                    onboardingUseCase: cardPresentPaymentsOnboardingUseCase,
                                                                     activePaymentGateway: activePaymentGateway)
         let setUpTapToPayViewController = PaymentSettingsFlowPresentingViewController(viewModelsAndViews: viewModelsAndViews)
         let controller = WooNavigationController(rootViewController: setUpTapToPayViewController)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Yosemite
 
-final class InPersonPaymentsViewController: UIHostingController<InPersonPaymentsView>, PaymentSettingsFlowViewModelPresenter {
+final class InPersonPaymentsViewController: UIHostingController<InPersonPaymentsView> {
 
     private let onWillDisappear: (() -> ())?
 
@@ -9,22 +9,15 @@ final class InPersonPaymentsViewController: UIHostingController<InPersonPayments
          onWillDisappear: (() -> ())?) {
         self.onWillDisappear = onWillDisappear
         super.init(rootView: InPersonPaymentsView(viewModel: viewModel))
-        rootView.showSupport = { [weak self] in
+        viewModel.showSupport = { [weak self] in
             guard let self = self else { return }
             let supportForm = SupportFormHostingController(viewModel: .init())
             supportForm.show(from: self)
         }
-        rootView.showURL = { [weak self] url in
+        viewModel.showURL = { [weak self] url in
             guard let self = self else { return }
             WebviewHelper.launch(url, with: self)
         }
-    }
-
-    convenience init?(viewModel: PaymentSettingsFlowPresentedViewModel) {
-        guard let viewModel = viewModel as? InPersonPaymentsViewModel else {
-            return nil
-        }
-        self.init(viewModel: viewModel, onWillDisappear: nil)
     }
 
     @objc required dynamic init?(coder aDecoder: NSCoder) {
@@ -39,9 +32,6 @@ final class InPersonPaymentsViewController: UIHostingController<InPersonPayments
 
 struct InPersonPaymentsView: View {
     @StateObject var viewModel: InPersonPaymentsViewModel
-
-    var showSupport: (() -> Void)? = nil
-    var showURL: ((URL) -> Void)? = nil
     var shouldShowMenuOnCompletion: Bool = true
 
     var body: some View {
@@ -98,13 +88,13 @@ struct InPersonPaymentsView: View {
         .customOpenURL(action: { url in
             switch url {
             case InPersonPaymentsSupportLink.supportURL:
-                showSupport?()
+                viewModel.showSupport?()
             case LearnMoreViewModel.learnMoreURL:
                 if let url = viewModel.learnMoreURL {
-                    showURL?(url)
+                    viewModel.showURL?(url)
                 }
             default:
-                showURL?(url)
+                viewModel.showURL?(url)
             }
         })
         .navigationTitle(Localization.title)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewController.swift
@@ -1,11 +1,12 @@
 import SwiftUI
 import Yosemite
 
-final class InPersonPaymentsViewController: UIHostingController<InPersonPaymentsView> {
+final class InPersonPaymentsViewController: UIHostingController<InPersonPaymentsView>, PaymentSettingsFlowViewModelPresenter {
+
     private let onWillDisappear: (() -> ())?
 
     init(viewModel: InPersonPaymentsViewModel,
-         onWillDisappear: (() -> ())? = nil) {
+         onWillDisappear: (() -> ())?) {
         self.onWillDisappear = onWillDisappear
         super.init(rootView: InPersonPaymentsView(viewModel: viewModel))
         rootView.showSupport = { [weak self] in
@@ -17,6 +18,13 @@ final class InPersonPaymentsViewController: UIHostingController<InPersonPayments
             guard let self = self else { return }
             WebviewHelper.launch(url, with: self)
         }
+    }
+
+    convenience init?(viewModel: PaymentSettingsFlowPresentedViewModel) {
+        guard let viewModel = viewModel as? InPersonPaymentsViewModel else {
+            return nil
+        }
+        self.init(viewModel: viewModel, onWillDisappear: nil)
     }
 
     @objc required dynamic init?(coder aDecoder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -123,7 +123,7 @@ final class InPersonPaymentsViewModel: ObservableObject, PaymentSettingsFlowPres
         case .completed(_):
             return .isFalse
         default:
-            return.isTrue
+            return .isTrue
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -111,9 +111,8 @@ final class InPersonPaymentsViewModel: ObservableObject, PaymentSettingsFlowPres
 
         let didChange = newShouldShow != shouldShow
 
-        shouldShow = newShouldShow
-
         if didChange {
+            shouldShow = newShouldShow
             didChangeShouldShow?(shouldShow)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -9,6 +9,9 @@ final class InPersonPaymentsViewModel: ObservableObject, PaymentSettingsFlowPres
     private let useCase: CardPresentPaymentsOnboardingUseCase
     let stores: StoresManager
 
+    var showSupport: (() -> Void)? = nil
+    var showURL: ((URL) -> Void)? = nil
+
     /// Initializes the view model for a specific site
     ///
     init(stores: StoresManager = ServiceLocator.stores,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -562,6 +562,7 @@
 		038BC38129C4B8AC00EAF565 /* SetUpTapToPayTryPaymentPromptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038BC38029C4B8AC00EAF565 /* SetUpTapToPayTryPaymentPromptViewModel.swift */; };
 		038BC38329C4B8ED00EAF565 /* SetUpTapToPayTryPaymentPromptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038BC38229C4B8ED00EAF565 /* SetUpTapToPayTryPaymentPromptViewController.swift */; };
 		0396CFAD2981476900E91436 /* CardPresentModalBuiltInConnectingFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */; };
+		039B7E6329F136F200E21EF4 /* SetUpTapToPayOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039B7E6229F136F200E21EF4 /* SetUpTapToPayOnboardingViewController.swift */; };
 		039D948D27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */; };
 		039D948F276113490044EF38 /* UIView+SuperviewConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */; };
 		03A6C18428B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A6C18328B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift */; };
@@ -2796,6 +2797,7 @@
 		038BC38029C4B8AC00EAF565 /* SetUpTapToPayTryPaymentPromptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUpTapToPayTryPaymentPromptViewModel.swift; sourceTree = "<group>"; };
 		038BC38229C4B8ED00EAF565 /* SetUpTapToPayTryPaymentPromptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUpTapToPayTryPaymentPromptViewController.swift; sourceTree = "<group>"; };
 		0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInConnectingFailed.swift; sourceTree = "<group>"; };
+		039B7E6229F136F200E21EF4 /* SetUpTapToPayOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUpTapToPayOnboardingViewController.swift; sourceTree = "<group>"; };
 		039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SafeAreaConstraints.swift"; sourceTree = "<group>"; };
 		039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SuperviewConstraints.swift"; sourceTree = "<group>"; };
 		03A6C18328B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift; sourceTree = "<group>"; };
@@ -6324,6 +6326,7 @@
 				314DC4BE268D183600444C9E /* CardReaderSettingsKnownReaderStorage.swift */,
 				ABC353433EABC5F0EC796222 /* CardReaderSettingsSearchingViewController.swift */,
 				0365986A29AFB11E00F297D3 /* SetUpTapToPayInformationViewController.swift */,
+				039B7E6229F136F200E21EF4 /* SetUpTapToPayOnboardingViewController.swift */,
 				038BC37E29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift */,
 				038BC38229C4B8ED00EAF565 /* SetUpTapToPayTryPaymentPromptViewController.swift */,
 				31FC8CE627B47591004B9456 /* CardReaderSettingsDataSource.swift */,
@@ -11892,6 +11895,7 @@
 				2678897C270E6E8B00BD249E /* SimplePaymentsAmount.swift in Sources */,
 				09F5DE5D27CF948000E5A4D2 /* BulkUpdateOptionsModel.swift in Sources */,
 				03076D36290C162E008EE839 /* WebViewSheet.swift in Sources */,
+				039B7E6329F136F200E21EF4 /* SetUpTapToPayOnboardingViewController.swift in Sources */,
 				450C2CBA24D3127500D570DD /* ProductReviewsTableViewCell.swift in Sources */,
 				029D444922F13F8A00DEFA8A /* DashboardUI.swift in Sources */,
 				D8C2A28F231BD00500F503E9 /* ReviewsViewModel.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9370
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

If onboarding is incomplete, a merchant will not be able to complete the Set up Tap to Pay on iPhone flow. Up to now, we’ve prevented the flow from being opened until onboarding is complete, relying on the in-line onboarding offered on the Payments menu.

With the addition of the Universal Link to the Set up Tap to Pay on iPhone flow, that’s no longer sufficient, as we don’t want to make a merchant wait on the menu screen before completing the navigation from their tap on the link.

This change removes the block on opening the set up flow, and shows the onboarding flow when required before set up begins.

N.B. We do not use the existing onboarding presenter, as it was not practical to make the flow seamless when combining it with the PaymentSettingsFlow approach.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a US store on an iPhone XS or newer, on iOS 16+

1. Disable your payment gateway in wp-admin, or use some other method to cause the store to fail onboarding
2. Open the app
3. Navigate to Menu > Payments
4. Immediately tap the `Set up Tap to Pay on iPhone` button – observe that it is not disabled, even though onboarding is incomplete
5. Observe that you are shown onboarding
6. Enable your payment gateway in wp-admin
7. Tap `Refresh after Activating` in the app
8. Observe that the flow continues as expected

Repeat the test with the store already passing onboarding
Observe that you are either shown the loading screen, or immediately the `Set up Tap to Pay` screen, depending whether the onboarding result has loaded or not.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/2472348/233349749-36643afb-b53a-4c14-a736-d266718cb809.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
