### PR TITLE
[Mobile Payments] Open Universal Links from Just in Time Messages

### DIFF
--- a/WooCommerce/Classes/JustInTimeMessages/UniversalLinkRouter+JustInTimeMessages.swift
+++ b/WooCommerce/Classes/JustInTimeMessages/UniversalLinkRouter+JustInTimeMessages.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Combine
+
+extension UniversalLinkRouter {
+    static func justInTimeMessagesUniversalLinkRouter(tabBarController: MainTabBarController?,
+                                                      urlOpener: URLOpener) -> UniversalLinkRouter {
+        UniversalLinkRouter(routes: Self.defaultRoutes(tabBarController: tabBarController),
+                            bouncingURLOpener: urlOpener,
+                            analyticsTracker: nil)
+    }
+}
+
+struct JustInTimeMessagesURLOpener: URLOpener {
+    let navigationTitle: String
+    var showWebViewSheetSubject: PassthroughSubject<WebViewSheetViewModel?, Never>
+
+    func open(_ url: URL) {
+        let webViewModel = WebViewSheetViewModel(
+            url: url,
+            navigationTitle: navigationTitle,
+            authenticated: needsAuthenticatedWebView(url: url))
+        showWebViewSheetSubject.send(webViewModel)
+    }
+}
+
+private extension JustInTimeMessagesURLOpener {
+    func needsAuthenticatedWebView(url: URL) -> Bool {
+        guard let host = url.host else {
+            return false
+        }
+        return Constants.trustedDomains.contains(host)
+    }
+
+    enum Constants {
+        static let trustedDomains = ["woocommerce.com", "wordpress.com"]
+    }
+}

--- a/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
+++ b/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
@@ -7,14 +7,18 @@ import UIKit
 struct UniversalLinkRouter {
     private let matcher: RouteMatcher
     private let bouncingURLOpener: URLOpener
+    private let analyticsTracker: UniversalLinkRouterAnalyticsTracking?
 
     /// The order of the passed Route array matters, as given two routes that handle a path only the first
     /// will be called to perform its action. If no route matches the path it uses the `bouncingURLOpener` to
     /// open it e.g to be opened in web when the app cannot handle the link
     ///
-    init(routes: [Route], bouncingURLOpener: URLOpener = ApplicationURLOpener()) {
+    init(routes: [Route],
+         bouncingURLOpener: URLOpener = ApplicationURLOpener(),
+         analyticsTracker: UniversalLinkRouterAnalyticsTracking? = UniversalLinkAnalyticsTracker(analytics: ServiceLocator.analytics)) {
         matcher = RouteMatcher(routes: routes)
         self.bouncingURLOpener = bouncingURLOpener
+        self.analyticsTracker = analyticsTracker
     }
 
     static func defaultUniversalLinkRouter(tabBarController: MainTabBarController) -> UniversalLinkRouter {
@@ -23,18 +27,41 @@ struct UniversalLinkRouter {
 
     /// Add your route here if you want it to be considered when matching for an incoming universal link.
     /// As we only perform one action to avoid conflicts, order matters (only the first matched route will be called to perform its action)
+    /// If `tabBarController: nil` is passed, some routes will not work, e.g. Payments related routes, which require the tab bar for navigation.
     ///
-    private static func defaultRoutes(tabBarController: MainTabBarController) -> [Route] {
-        return [OrderDetailsRoute(), PaymentsRoute(deepLinkForwarder: tabBarController)]
+    static func defaultRoutes(tabBarController: MainTabBarController?) -> [Route] {
+        let routes = [OrderDetailsRoute()]
+        guard let tabBarController = tabBarController else {
+            DDLogWarn("⛔️ Unable to create tab bar dependent Universal Link routes, some links will not be handled")
+            return routes
+        }
+        return routes + [PaymentsRoute(deepLinkForwarder: tabBarController)]
     }
 
     func handle(url: URL) {
         guard let matchedRoute = matcher.firstRouteMatching(url),
               matchedRoute.performAction() else {
-            ServiceLocator.analytics.track(event: WooAnalyticsEvent.universalLinkFailed(with: url))
+            analyticsTracker?.trackUniversalLinkFailure(url: url)
             return bouncingURLOpener.open(url)
         }
 
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.universalLinkOpened(with: matchedRoute.subPath))
+        analyticsTracker?.trackUniversalLinkOpened(subPath: matchedRoute.subPath)
+    }
+}
+
+protocol UniversalLinkRouterAnalyticsTracking {
+    func trackUniversalLinkFailure(url: URL)
+    func trackUniversalLinkOpened(subPath: String)
+}
+
+struct UniversalLinkAnalyticsTracker: UniversalLinkRouterAnalyticsTracking {
+    let analytics: Analytics
+
+    func trackUniversalLinkFailure(url: URL) {
+        analytics.track(event: WooAnalyticsEvent.universalLinkFailed(with: url))
+    }
+
+    func trackUniversalLinkOpened(subPath: String) {
+        analytics.track(event: WooAnalyticsEvent.universalLinkOpened(with: subPath))
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -563,6 +563,7 @@
 		038BC38329C4B8ED00EAF565 /* SetUpTapToPayTryPaymentPromptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038BC38229C4B8ED00EAF565 /* SetUpTapToPayTryPaymentPromptViewController.swift */; };
 		0396CFAD2981476900E91436 /* CardPresentModalBuiltInConnectingFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */; };
 		039B7E6329F136F200E21EF4 /* SetUpTapToPayOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039B7E6229F136F200E21EF4 /* SetUpTapToPayOnboardingViewController.swift */; };
+		039B7E6529F167DB00E21EF4 /* UniversalLinkRouter+JustInTimeMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039B7E6429F167DB00E21EF4 /* UniversalLinkRouter+JustInTimeMessages.swift */; };
 		039D948D27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */; };
 		039D948F276113490044EF38 /* UIView+SuperviewConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */; };
 		03A6C18428B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A6C18328B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift */; };
@@ -2798,6 +2799,7 @@
 		038BC38229C4B8ED00EAF565 /* SetUpTapToPayTryPaymentPromptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUpTapToPayTryPaymentPromptViewController.swift; sourceTree = "<group>"; };
 		0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInConnectingFailed.swift; sourceTree = "<group>"; };
 		039B7E6229F136F200E21EF4 /* SetUpTapToPayOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUpTapToPayOnboardingViewController.swift; sourceTree = "<group>"; };
+		039B7E6429F167DB00E21EF4 /* UniversalLinkRouter+JustInTimeMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UniversalLinkRouter+JustInTimeMessages.swift"; sourceTree = "<group>"; };
 		039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SafeAreaConstraints.swift"; sourceTree = "<group>"; };
 		039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SuperviewConstraints.swift"; sourceTree = "<group>"; };
 		03A6C18328B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift; sourceTree = "<group>"; };
@@ -8218,6 +8220,7 @@
 			isa = PBXGroup;
 			children = (
 				B92639FE293E2D4C00A257E0 /* JustInTimeMessagesProvider.swift */,
+				039B7E6429F167DB00E21EF4 /* UniversalLinkRouter+JustInTimeMessages.swift */,
 			);
 			path = JustInTimeMessages;
 			sourceTree = "<group>";
@@ -12040,6 +12043,7 @@
 				CE2A9FC823C3D2D4002BEC1C /* RefundedProductsDataSource.swift in Sources */,
 				5783FB3F25D7369F00B9984B /* WooAnalyticsEventPropertyType.swift in Sources */,
 				CECC759523D6057E00486676 /* OrderItem+Woo.swift in Sources */,
+				039B7E6529F167DB00E21EF4 /* UniversalLinkRouter+JustInTimeMessages.swift in Sources */,
 				03AFDE02282C0B82003B67CD /* InPersonPaymentsCompletedView.swift in Sources */,
 				D449C52626DFBBDB00D75B02 /* WhatsNewFactory.swift in Sources */,
 				028FA46C257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9516
Merge after: #9515 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Originally, the CTA of a Just in Time Message (JITM) would always be opened in a web view, authenticated for WordPress.com if a trusted URL.

We are gradually adding support for Universal Links to the app, and this PR enables the same code to be used to open app screens from supported JITM links.

Any JITM with a `cta.link` value which matches a supported Universal Link will be opened as per that universal link.

### Summary of changes
- Analytics logging within `UniversalLinkRouter` is now customisable/optional, as we don't want to track a failure to open a JITM link in the same way as an externally-opened universal link. JITM links are still tracked in the existing code.
- The `JustInTimeMessageAnnouncementCardViewModel` now uses a `UniversalLinkRouter` to handle taps on the CTA.
- That `UniversalLinkRouter` has a new fallback (bouncing) `URLOpener` which opens bounced links in a web view, as per existing JITMs
- In theory, it's possible to end up with a `URLRouter` which can't handle Payments links, because they require the tab bar controller, which is optional on the AppDelegate. In practice, it's always there, so this won't happen, but we log a warning just in case. This was preferable to other options I tried.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a store which is eligible for an existing JITM, where the JITM has not been dismissed (e.g. US based WCPay with COD enabled and no IPP transactions.)

1. Open the app, and tap the CTA on the JITM – observe that it opens a web view with the expected address
2. Put a breakpoint in Proxyman/Charles on the response to `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/*/rest-api/?json=true&locale=*&path=/jetpack/v4/jitm*` – this will stop when the JITM is returned
3. Pull to refresh the JITM
4. In Proxyman, replace the JITM's CTA with a supported deep link, e.g. `https://woocommerce.com/mobile/payments/tap-to-pay`
5. Execute the edited response
6. Tap the CTA on the updated JITM
7. Observe that the deep link is navigated to correctly

Example full JITM response:
```
{
  "data": [
    {
      "content": {
        "message": "Accept contactless payments on your iPhone",
        "icon": "",
        "iconPath": null,
        "list": [],
        "description": "Tap to Pay on iPhone is quick and simple to set up in WooCommerce Payments — no extra card readers needed.",
        "classes": "",
        "title": "",
        "disclaimer": []
      },
      "CTA": {
        "message": "Purchase a card reader",
        "hook": "",
        "newWindow": true,
        "primary": true,
        "link": "https://woocommerce.com/mobile/payments/tap-to-pay"
      },
      "template": "default",
      "ttl": 300,
      "id": "woomobile_ipp_cod_no_transactions_us",
      "feature_class": "woomobile_ipp",
      "expires": 3628800,
      "max_dismissal": 2,
      "activate_module": null,
      "is_dismissible": true,
      "is_user_created_by_partner": null,
      "message_expiration": null,
      "url": "https://jetpack.com/redirect/?source=jitm-woomobile_ipp_cod_no_transactions_us&#038;site=jheverydaypay.mystagingwebsite.com&#038;u=1",
      "jitm_stats_url": "https://pixel.wp.com/b.gif?v=wpcom2&rand=308290c79e2a62c2939250b01fecc863&x_jetpack-jitm=woomobile_ipp_cod_no_transactions_us"
    }
  ]
}
```

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/233401911-dff09c44-709a-42a6-8b74-25219c38cbd1.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
