### PR TITLE
Shipping Label: Save store phone number and retrieve it when populating original address

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [***] Payments: UK-based stores merchants can take In-Person Payments. [https://github.com/woocommerce/woocommerce-ios/pull/9496]
 - [*] Store creation free trial flow now includes 3 profiler questions again with updated options: store category, selling status, and store country. [https://github.com/woocommerce/woocommerce-ios/pull/9513]
+- [*] Shipping Labels: Origin address's phone number is now saved locally and pre-populated in the creation form. [https://github.com/woocommerce/woocommerce-ios/pull/9520]
 - [Internal] Almost all mappers have been updated to only decode without the data envelope if it's not available. Please do a smoke test to ensure that all features still work as before. [https://github.com/woocommerce/woocommerce-ios/pull/9510]
 - [Internal] Store onboarding: Mark "Launch your store" task as complete if the store is already public. This is a workaround for a backend issue which marks "Launch your store" task incomplete for already live stores. [https://github.com/woocommerce/woocommerce-ios/pull/9507]
 - [*] Payments: Added Universal Link support for Set up Tap to Pay on iPhone, and to open Universal Links from Just in Time Messages, to more easily navigate to app features. [https://github.com/woocommerce/woocommerce-ios/pull/9518]

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -26,6 +26,7 @@ extension UserDefaults {
         case notificationsLastSeenTime
         case notificationsMarkAsReadCount
         case completedAllStoreOnboardingTasks
+        case storePhoneNumber
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -26,7 +26,8 @@ final class ShippingLabelFormViewController: UIViewController {
     init(order: Order) {
         viewModel = ShippingLabelFormViewModel(order: order,
                                                originAddress: nil,
-                                               destinationAddress: order.shippingAddress)
+                                               destinationAddress: order.shippingAddress,
+                                               userDefaults: .standard)
         super.init(nibName: nil, bundle: nil)
         ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "started"])
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -152,6 +152,8 @@ final class ShippingLabelFormViewModel {
 
     private let storageManager: StorageManagerType
 
+    private let userDefaults: UserDefaults
+
     /// Closure to notify the `ViewController` when the view model properties change.
     ///
     var onChange: (() -> (Void))?
@@ -168,7 +170,8 @@ final class ShippingLabelFormViewModel {
          originAddress: Address?,
          destinationAddress: Address?,
          stores: StoresManager = ServiceLocator.stores,
-         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         userDefaults: UserDefaults = .standard) {
 
         self.siteID = order.siteID
         self.order = order
@@ -181,11 +184,13 @@ final class ShippingLabelFormViewModel {
             ShippingLabelFormViewModel.getDefaultOriginAddress(accountSettings: accountSettings,
                                                                company: company,
                                                                siteAddress: SiteAddress(),
-                                                               account: defaultAccount)
+                                                               account: defaultAccount,
+                                                               userDefaults: userDefaults)
         self.destinationAddress = ShippingLabelFormViewModel.getDestinationAddress(order: order, address: destinationAddress)
 
         self.stores = stores
         self.storageManager = storageManager
+        self.userDefaults = userDefaults
 
         state.sections = generateInitialSections()
         syncShippingLabelAccountSettings()
@@ -196,8 +201,8 @@ final class ShippingLabelFormViewModel {
 
     func handleOriginAddressValueChanges(address: ShippingLabelAddress?, validated: Bool) {
         originAddress = address
-        let dateState: ShippingLabelFormViewController.DataState = validated ? .validated : .pending
-        updateRowState(type: .shipFrom, dataState: dateState, displayMode: .editable)
+        let dataState: ShippingLabelFormViewController.DataState = validated ? .validated : .pending
+        updateRowState(type: .shipFrom, dataState: dataState, displayMode: .editable)
 
         // We reset the carrier and rates selected because if the address change
         // the carrier and rate change accordingly
@@ -205,7 +210,8 @@ final class ShippingLabelFormViewModel {
 
         updateRowsForCustomsIfNeeded()
 
-        if dateState == .validated {
+        if dataState == .validated, let address {
+            userDefaults[.storePhoneNumber] = address.phone
             ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "origin_address_complete"])
         }
     }
@@ -557,7 +563,8 @@ private extension ShippingLabelFormViewModel {
     static func getDefaultOriginAddress(accountSettings: AccountSettings?,
                                         company: String?,
                                         siteAddress: SiteAddress,
-                                        account: Account?) -> ShippingLabelAddress? {
+                                        account: Account?,
+                                        userDefaults: UserDefaults) -> ShippingLabelAddress? {
         let address = Address(firstName: accountSettings?.firstName ?? "",
                               lastName: accountSettings?.lastName ?? "",
                               company: company ?? "",
@@ -567,7 +574,7 @@ private extension ShippingLabelFormViewModel {
                               state: siteAddress.state,
                               postcode: siteAddress.postalCode,
                               country: siteAddress.countryCode,
-                              phone: "",
+                              phone: userDefaults[.storePhoneNumber] ?? "",
                               email: account?.email)
         return fromAddressToShippingLabelAddress(address: address)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -691,7 +691,7 @@ private extension ShippingLabelFormViewModel {
                       value: item.value,
                       weight: item.weight,
                       hsTariffNumber: "",
-                      originCountry: SiteAddress().countryCode,
+                      originCountry: originAddress?.country ?? SiteAddress().countryCode,
                       productID: item.productOrVariationID)
             }
             return ShippingLabelCustomsForm(packageID: package.id, packageName: packageName, items: items)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -171,7 +171,7 @@ final class ShippingLabelFormViewModel {
          destinationAddress: Address?,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
-         userDefaults: UserDefaults = .standard) {
+         userDefaults: UserDefaults) {
 
         self.siteID = order.siteID
         self.order = order

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -61,6 +61,21 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(originAddress?.postcode, "94121-2303")
     }
 
+    func test_store_phone_number_is_pre_populated_in_origin_address_if_saved_locally() {
+        // Given
+        let expectedPhoneNumber = "0123456789"
+        userDefaults[.storePhoneNumber] = expectedPhoneNumber
+
+        // When
+        let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                                    originAddress: nil,
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
+
+        // Then
+        XCTAssertEqual(shippingLabelFormViewModel.originAddress?.phone, expectedPhoneNumber)
+    }
+
     func test_handleOriginAddressValueChanges_returns_updated_ShippingLabelAddress() {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -44,7 +44,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // When
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: address,
-                                                                    destinationAddress: nil)
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
 
         // Then
         let originAddress = shippingLabelFormViewModel.originAddress
@@ -64,7 +65,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
-                                                                    destinationAddress: nil)
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
         let expectedShippingAddress = ShippingLabelAddress(company: "Automattic Inc.",
                                                            name: "Skylar Ferry",
                                                            phone: "12345",
@@ -86,7 +88,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
-                                                                    destinationAddress: nil)
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
         let expectedShippingAddress = ShippingLabelAddress(company: "Automattic Inc.",
                                                            name: "Skylar Ferry",
                                                            phone: "12345",
@@ -144,7 +147,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
-                                                                    destinationAddress: nil)
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
         let expectedShippingAddress = ShippingLabelAddress(company: "Automattic Inc.",
                                                            name: "Skylar Ferry",
                                                            phone: "12345",
@@ -166,7 +170,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
-                                                                    destinationAddress: nil)
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
         let expectedShippingAddress = ShippingLabelAddress(company: "Automattic Inc.",
                                                            name: "Skylar Ferry",
                                                            phone: "12345",
@@ -200,7 +205,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
-                                                                    destinationAddress: nil)
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
         let expectedPackageResponse = ShippingLabelPackagesResponse.fake()
 
         // When
@@ -214,7 +220,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
-                                                                    destinationAddress: nil)
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
         let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, items: [])
@@ -230,7 +237,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
-                                                                    destinationAddress: nil)
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
         let expectedPackageID = "my-package-id"
         let expectedPackageWeight = "55"
         let selectedPackage = ShippingLabelPackageAttributes(packageID: expectedPackageID, totalWeight: expectedPackageWeight, items: [])
@@ -261,7 +269,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
-                                                                    destinationAddress: nil)
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
         let expectedPackageWeight = "55"
         let selectedPackage = ShippingLabelPackageAttributes(packageID: "my-package-id", totalWeight: expectedPackageWeight, items: [])
 
@@ -300,7 +309,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
-                                                                    destinationAddress: nil)
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
 
         shippingLabelFormViewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"),
                                                                    validated: true)
@@ -330,7 +340,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
-                                                                    destinationAddress: nil)
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
         XCTAssertTrue(shippingLabelFormViewModel.selectedRates.isEmpty)
 
         // When
@@ -351,7 +362,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
-                                                                    destinationAddress: nil)
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
         let expectedShippingAddress = MockShippingLabelAddress.sampleAddress()
         let currentRows = shippingLabelFormViewModel.state.sections.first?.rows
         XCTAssertEqual(currentRows?[0].type, .shipFrom)
@@ -385,7 +397,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: nil,
-                                                                    destinationAddress: nil)
+                                                                    destinationAddress: nil,
+                                                                    userDefaults: userDefaults)
         let expectedShippingAddress = MockShippingLabelAddress.sampleAddress()
 
         // When
@@ -423,7 +436,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: originAddress,
                                                                     destinationAddress: nil,
-                                                                    stores: storesManager)
+                                                                    stores: storesManager,
+                                                                    userDefaults: userDefaults)
 
         // When
         shippingLabelFormViewModel.validateAddress(type: .origin) { validationState, validationSuccess in
@@ -465,7 +479,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                                     originAddress: originAddress,
                                                                     destinationAddress: nil,
-                                                                    stores: storesManager)
+                                                                    stores: storesManager,
+                                                                    userDefaults: userDefaults)
 
         // When
         shippingLabelFormViewModel.validateAddress(type: .origin) { _, _ in }
@@ -487,8 +502,9 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
     func test_handlePaymentMethodValueChanges_returns_updated_data_and_state_with_no_selected_payment_method() {
         // Given
         let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
-                                                                    originAddress: nil,
-                                                                    destinationAddress: nil)
+                                                   originAddress: nil,
+                                                   destinationAddress: nil,
+                                                   userDefaults: userDefaults)
         let expectedPaymentMethodID: Int64 = 0
         let expectedEmailReceiptsSetting = true
         let settings = ShippingLabelAccountSettings.fake().copy(selectedPaymentMethodID: expectedPaymentMethodID,
@@ -508,8 +524,9 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
     func test_handlePaymentMethodValueChanges_returns_updated_data_and_state_with_selected_payment_method() {
         // Given
         let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
-                                                                    originAddress: nil,
-                                                                    destinationAddress: nil)
+                                                   originAddress: nil,
+                                                   destinationAddress: nil,
+                                                   userDefaults: userDefaults)
         let expectedPaymentMethodID: Int64 = 12345
         let expectedEmailReceiptsSetting = false
         let settings = ShippingLabelAccountSettings.fake().copy(selectedPaymentMethodID: expectedPaymentMethodID,
@@ -530,7 +547,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Given
         let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                    originAddress: nil,
-                                                   destinationAddress: nil)
+                                                   destinationAddress: nil,
+                                                   userDefaults: userDefaults)
         let settings = ShippingLabelAccountSettings.fake().copy()
 
         // When
@@ -545,7 +563,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // Given
         let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
                                                    originAddress: nil,
-                                                   destinationAddress: nil)
+                                                   destinationAddress: nil,
+                                                   userDefaults: userDefaults)
         let paymentMethod = ShippingLabelPaymentMethod.fake().copy(paymentMethodID: 12345, cardDigits: "4242")
         let settings = ShippingLabelAccountSettings.fake().copy(paymentMethods: [paymentMethod], selectedPaymentMethodID: 12345)
 
@@ -564,7 +583,11 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         insert(country1)
         insert(country2)
 
-        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: nil, destinationAddress: nil, storageManager: storageManager)
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                   originAddress: nil,
+                                                   destinationAddress: nil,
+                                                   storageManager: storageManager,
+                                                   userDefaults: userDefaults)
 
         // When
         let filteredCountries = viewModel.filteredCountries(for: .origin)
@@ -580,7 +603,11 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         insert(country1)
         insert(country2)
 
-        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: nil, destinationAddress: nil, storageManager: storageManager)
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                   originAddress: nil,
+                                                   destinationAddress: nil,
+                                                   storageManager: storageManager,
+                                                   userDefaults: userDefaults)
 
         // When
         let filteredCountries = viewModel.filteredCountries(for: .destination)
@@ -615,7 +642,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                          email: nil)
 
         // When
-        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: originAddress, destinationAddress: destinationAddress)
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                   originAddress: originAddress,
+                                                   destinationAddress: destinationAddress,
+                                                   userDefaults: userDefaults)
 
         // Then
         XCTAssertFalse(viewModel.customsFormRequired)
@@ -647,7 +677,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                          email: nil)
 
         // When
-        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: originAddress, destinationAddress: destinationAddress)
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                   originAddress: originAddress,
+                                                   destinationAddress: destinationAddress,
+                                                   userDefaults: userDefaults)
 
         // Then
         XCTAssertTrue(viewModel.customsFormRequired)
@@ -679,7 +712,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                          email: nil)
 
         // When
-        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: originAddress, destinationAddress: destinationAddress)
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                   originAddress: originAddress,
+                                                   destinationAddress: destinationAddress,
+                                                   userDefaults: userDefaults)
 
         // Then
         XCTAssertTrue(viewModel.customsFormRequired)
@@ -711,7 +747,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                          email: nil)
 
         // When
-        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: originAddress, destinationAddress: destinationAddress)
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                   originAddress: originAddress,
+                                                   destinationAddress: destinationAddress,
+                                                   userDefaults: userDefaults)
 
         // Then
         XCTAssertTrue(viewModel.customsFormRequired)
@@ -743,7 +782,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                          email: nil)
 
         // When
-        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: originAddress, destinationAddress: destinationAddress)
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                   originAddress: originAddress,
+                                                   destinationAddress: destinationAddress,
+                                                   userDefaults: userDefaults)
 
         // Then
         let firstSection = viewModel.state.sections.first
@@ -777,7 +819,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                          email: nil)
 
         // When
-        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: originAddress, destinationAddress: destinationAddress)
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                   originAddress: originAddress,
+                                                   destinationAddress: destinationAddress,
+                                                   userDefaults: userDefaults)
 
         // Then
         let firstSection = viewModel.state.sections.first
@@ -810,7 +855,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                          email: nil)
 
         // When
-        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: originAddress, destinationAddress: destinationAddress)
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                   originAddress: originAddress,
+                                                   destinationAddress: destinationAddress,
+                                                   userDefaults: userDefaults)
         let newAddress = MockShippingLabelAddress.sampleAddress(country: "US", state: "NY")
         viewModel.handleDestinationAddressValueChanges(address: newAddress, validated: true)
 
@@ -844,7 +892,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                          email: nil)
 
         // When
-        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: originAddress, destinationAddress: destinationAddress)
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                   originAddress: originAddress,
+                                                   destinationAddress: destinationAddress,
+                                                   userDefaults: userDefaults)
         let newAddress = MockShippingLabelAddress.sampleAddress(country: "VN", state: "")
         viewModel.handleDestinationAddressValueChanges(address: newAddress, validated: true)
 
@@ -854,7 +905,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
 
     func test_updateRowsForCustomsIfNeeded_updates_row_states_correctly_when_phone_number_is_missing_in_both_origin_address_only() {
         // Given
-        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: nil, destinationAddress: nil)
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                   originAddress: nil,
+                                                   destinationAddress: nil,
+                                                   userDefaults: userDefaults)
         viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "US", state: "CA"), validated: true)
         viewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "US", state: "NY"), validated: true)
 
@@ -882,7 +936,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
 
     func test_updateRowsForCustomsIfNeeded_updates_row_states_correctly_when_phone_number_is_missing_in_both_origin_and_destination_addresses() {
         // Given
-        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(), originAddress: nil, destinationAddress: nil)
+        let viewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),
+                                                   originAddress: nil,
+                                                   destinationAddress: nil,
+                                                   userDefaults: userDefaults)
         viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "US", state: "CA"), validated: true)
         viewModel.handleDestinationAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(country: "US", state: "NY"), validated: true)
 
@@ -912,7 +969,10 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         let expectedProductID: Int64 = 123
         let orderItem = OrderItem.fake().copy(productID: expectedProductID)
         let order = MockOrders().makeOrder(items: [orderItem])
-        let viewModel = ShippingLabelFormViewModel(order: order, originAddress: nil, destinationAddress: nil)
+        let viewModel = ShippingLabelFormViewModel(order: order,
+                                                   originAddress: nil,
+                                                   destinationAddress: nil,
+                                                   userDefaults: userDefaults)
 
         // When
         viewModel.handleOriginAddressValueChanges(address: MockShippingLabelAddress.sampleAddress(phone: "0123456789", country: "US"), validated: true)
@@ -931,7 +991,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(defaultForms.first?.items.first?.description, item.name)
         XCTAssertEqual(defaultForms.first?.items.first?.hsTariffNumber, "")
         XCTAssertEqual(defaultForms.first?.items.first?.value, item.value)
-        XCTAssertEqual(defaultForms.first?.items.first?.originCountry, "")
+        XCTAssertEqual(defaultForms.first?.items.first?.originCountry, "US")
     }
 
     func test_getDestinationAddress_uses_shipping_phone_if_available() {
@@ -942,7 +1002,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // When
         let viewModel = ShippingLabelFormViewModel(order: Order.fake().copy(billingAddress: billingAddress),
                                                    originAddress: nil,
-                                                   destinationAddress: shippingAddress)
+                                                   destinationAddress: shippingAddress,
+                                                   userDefaults: userDefaults)
 
         // Then
         XCTAssertEqual(viewModel.destinationAddress?.phone, shippingAddress.phone)
@@ -955,7 +1016,8 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         // When
         let viewModel = ShippingLabelFormViewModel(order: Order.fake().copy(billingAddress: billingAddress),
                                                    originAddress: nil,
-                                                   destinationAddress: Address.fake())
+                                                   destinationAddress: Address.fake(),
+                                                   userDefaults: userDefaults)
 
         // Then
         XCTAssertEqual(viewModel.destinationAddress?.phone, billingAddress.phone)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: https://github.com/woocommerce/woomobile-private/issues/280
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR enhances the experience of creating shipping labels by saving the store phone number locally so that users have to enter it only once.

Since the API endpoint for retrieving store's phone number is not available yet, for now we are only saving the number locally using `UserDefaults`.

The solution is saving the phone number when the user submits an original address that is validated.
When the shipping label form is initialized, we also look for the phone number in `UserDefaults` and pre-populate the origin address if it's available.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Pre-requisite: make sure that your test store has been set up for shipping labels.
- In the Orders tab, select an order that is eligible for creating shipping labels.
- At first, since phone number is not available, you'll be asked to enter the number for the origin address.
- Enter a phone number and submit. 
- Navigate to the Order list and then back to the previous order's shipping label creation form.
- Notice that you are no longer asked for a phone number for the origin address.
- Tap on the Orgin Address form, notice that the pre-populated phone number matches the one you entered in the previous step.
- When you update this number, it should be saved locally again and used for future labels.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/233541983-0c18d545-a91c-4a2f-abc7-66c6e5873628.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
