### PR TITLE
[Free Trial] Hide Free Trial banner when there is no internet connection.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -201,10 +201,13 @@ final class HubMenuViewModel: ObservableObject {
     /// Observe the current site's plan name and assign it to the `planName` published property.
     ///
     private func observePlanName() {
-        ServiceLocator.storePlanSynchronizer.$planState.map { planState in
+        ServiceLocator.storePlanSynchronizer.$planState.map { [weak self] planState in
+            guard let self else { return "" }
             switch planState {
             case .loaded(let plan):
                 return WPComPlanNameSanitizer.getPlanName(from: plan).uppercased()
+            case .loading, .failed:
+                return self.planName // Do not override the plan name when loading or failed(most likely no connected to the internet)
             default:
                 return ""
             }


### PR DESCRIPTION
Closes: #9161 

# Why

This PR 
- Hides the free trial banner when there is no internet connection
- Reloads the free trial banner visibility when we gain an internet connection
- Fixes a bug that was hiding the plan badge on the hub menu when the plan was reloading or when there was no internet connection.

# Demo

https://user-images.githubusercontent.com/562080/233549994-fde43634-14ce-4f97-9c70-f8f358ce942f.mov

# Tests

- Launch the app with a free trial site
- Turn off connectivity
- See that the free trial banner disappears and that the no internet connection banner appears
- Turn on connectivity
- See that the free trial banner appears and that the no internet connection banner dissappears

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
