### PR TITLE
Login: Attempt fixing crash on login onboarding

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [Internal] Almost all mappers have been updated to only decode without the data envelope if it's not available. Please do a smoke test to ensure that all features still work as before. [https://github.com/woocommerce/woocommerce-ios/pull/9510]
 - [Internal] Store onboarding: Mark "Launch your store" task as complete if the store is already public. This is a workaround for a backend issue which marks "Launch your store" task incomplete for already live stores. [https://github.com/woocommerce/woocommerce-ios/pull/9507]
 - [*] Payments: Added Universal Link support for Set up Tap to Pay on iPhone, and to open Universal Links from Just in Time Messages, to more easily navigate to app features. [https://github.com/woocommerce/woocommerce-ios/pull/9518]
+- [*] Login: Potentially fixed the crash on the onboarding screen. [https://github.com/woocommerce/woocommerce-ios/pull/9523]
 
 13.2
 -----

--- a/WooCommerce/Classes/Authentication/Prologue/LoginProloguePageViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginProloguePageViewController.swift
@@ -37,7 +37,7 @@ final class LoginProloguePageViewController: UIPageViewController {
             return false
         }
         pageControl.currentPage = currentPage + 1
-        handlePageControlValueChanged(sender: pageControl)
+        setViewControllers([pages[pageControl.currentPage]], direction: .forward, animated: true)
         return true
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Potentially closes: #9479 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The crash log in #9479 indicates that the crash happened when the user tapped the Next button - the `handlePageControlValueChanged` method failed to determine the correct direction of the scroll.

I cannot reproduce the crash to really fix it, but I think the call to `handlePageControlValueChanged` is unnecessary. This method calculates the current page - which is already available in `goToNextPageIfPossible`. Maybe the crash happened because the calculation failed.

This PR attempts to fix the crash by calling `setViewControllers` directly with the `.forward` direction instead of triggering `handlePageControlValueChanged`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Reinstall the app.
- Tap the Next button on the onboarding screen. The app should not crash.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
