### PR TITLE
Product description AI: feature flag and eligibility check

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -91,6 +91,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .subscriptionProducts:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .productDescriptionAI:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -191,4 +191,8 @@ public enum FeatureFlag: Int {
     /// Enables subscription product settings in product details
     ///
     case subscriptionProducts
+
+    /// Enables generating product description using AI.
+    ///
+    case productDescriptionAI
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormAIEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormAIEligibilityChecker.swift
@@ -1,0 +1,25 @@
+import protocol Experiments.FeatureFlagService
+import struct Yosemite.Site
+
+/// AI-assisted features for product editing/creation.
+enum ProductFormAIFeature: Equatable {
+    case description
+}
+
+/// Checks the eligible AI features for product editing/creation.
+final class ProductFormAIEligibilityChecker {
+    private let site: Site?
+    private let featureFlagService: FeatureFlagService
+
+    init(site: Site?, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+        self.site = site
+        self.featureFlagService = featureFlagService
+    }
+
+    /// Checks if an AI feature is enabled.
+    /// - Parameter feature: AI-assisted feature.
+    /// - Returns: Whether the feature is supported.
+    func isFeatureEnabled(_ feature: ProductFormAIFeature) -> Bool {
+        site?.isWordPressComStore == true && featureFlagService.isFeatureFlagEnabled(.productDescriptionAI)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -172,6 +172,8 @@
 		023EC2E424DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023EC2E324DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift */; };
 		023EC2E624DAB1270021DA91 /* EditableProductVariationModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023EC2E524DAB1270021DA91 /* EditableProductVariationModelTests.swift */; };
 		0240B3AC230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0240B3AB230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift */; };
+		0242CFB629F278010080F500 /* ProductFormAIEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0242CFB529F278010080F500 /* ProductFormAIEligibilityChecker.swift */; };
+		0242CFB829F278B70080F500 /* ProductFormAIEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0242CFB729F278B70080F500 /* ProductFormAIEligibilityCheckerTests.swift */; };
 		0245465B24EE7637004F531C /* ProductFormEventLoggerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0245465A24EE7637004F531C /* ProductFormEventLoggerProtocol.swift */; };
 		0245465D24EE779D004F531C /* ProductFormEventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0245465C24EE779D004F531C /* ProductFormEventLogger.swift */; };
 		0245465F24EE9106004F531C /* ProductVariationFormEventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0245465E24EE9106004F531C /* ProductVariationFormEventLogger.swift */; };
@@ -2405,6 +2407,8 @@
 		023EC2E324DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductInventorySettingsViewModel+VariationTests.swift"; sourceTree = "<group>"; };
 		023EC2E524DAB1270021DA91 /* EditableProductVariationModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableProductVariationModelTests.swift; sourceTree = "<group>"; };
 		0240B3AB230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4ChartAxisHelper.swift; sourceTree = "<group>"; };
+		0242CFB529F278010080F500 /* ProductFormAIEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormAIEligibilityChecker.swift; sourceTree = "<group>"; };
+		0242CFB729F278B70080F500 /* ProductFormAIEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormAIEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		0245465A24EE7637004F531C /* ProductFormEventLoggerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormEventLoggerProtocol.swift; sourceTree = "<group>"; };
 		0245465C24EE779D004F531C /* ProductFormEventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormEventLogger.swift; sourceTree = "<group>"; };
 		0245465E24EE9106004F531C /* ProductVariationFormEventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormEventLogger.swift; sourceTree = "<group>"; };
@@ -4637,6 +4641,7 @@
 				2688644225D471C700821BA5 /* EditAttributesViewModelTests.swift */,
 				022C658B2863BBAC00EC35A9 /* ProductFormViewController+ProductImageUploaderTests.swift */,
 				0247F50F286E7D26009C177E /* ProductVariationFormViewModel+ImageUploaderTests.swift */,
+				0242CFB729F278B70080F500 /* ProductFormAIEligibilityCheckerTests.swift */,
 			);
 			path = "Edit Product";
 			sourceTree = "<group>";
@@ -4741,6 +4746,7 @@
 				0245465C24EE779D004F531C /* ProductFormEventLogger.swift */,
 				0245465E24EE9106004F531C /* ProductVariationFormEventLogger.swift */,
 				02AAD54425023A8300BA1E26 /* ProductFormRemoteActionUseCase.swift */,
+				0242CFB529F278010080F500 /* ProductFormAIEligibilityChecker.swift */,
 			);
 			path = "Edit Product";
 			sourceTree = "<group>";
@@ -11604,6 +11610,7 @@
 				AEE085B52897C871007ACE20 /* LinkedProductsPromoCampaign.swift in Sources */,
 				933A27372222354600C2143A /* Logging.swift in Sources */,
 				0290E26F238E3CE400B5C466 /* ListSelectorViewController.swift in Sources */,
+				0242CFB629F278010080F500 /* ProductFormAIEligibilityChecker.swift in Sources */,
 				B5D1AFB820BC510200DB0E8C /* UIImage+Woo.swift in Sources */,
 				B5980A6121AC878900EBF596 /* UIDevice+Woo.swift in Sources */,
 				EEADF624281A421A001B40F1 /* DefaultShippingValueLocalizer.swift in Sources */,
@@ -12286,6 +12293,7 @@
 				DE7842EF26F079A60030C792 /* NumberFormatter+LocalizedTests.swift in Sources */,
 				5768315126694ADC00FDFB6C /* AuthenticationManagerTests.swift in Sources */,
 				D82DFB4C225F303200EFE2CB /* EmptyListMessageWithActionTests.swift in Sources */,
+				0242CFB829F278B70080F500 /* ProductFormAIEligibilityCheckerTests.swift in Sources */,
 				E10DFC78267331590083AFF2 /* ApplicationLogViewModelTests.swift in Sources */,
 				0298431225936DFC00979CAE /* ShippingLabelsTopBannerFactoryTests.swift in Sources */,
 				57B374B6245B331100D58BE0 /* EmptyStateViewControllerTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -19,6 +19,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let jetpackSetupWithApplicationPassword: Bool
     private let isTapToPayOnIPhoneMilestone2On: Bool
     private let isIPPUKExpansionEnabled: Bool
+    private let isProductDescriptionAIEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -36,7 +37,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isFreeTrial: Bool = false,
          jetpackSetupWithApplicationPassword: Bool = false,
          isTapToPayOnIPhoneMilestone2On: Bool = false,
-         isIPPUKExpansionEnabled: Bool = false) {
+         isIPPUKExpansionEnabled: Bool = false,
+         isProductDescriptionAIEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -54,6 +56,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.jetpackSetupWithApplicationPassword = jetpackSetupWithApplicationPassword
         self.isTapToPayOnIPhoneMilestone2On = isTapToPayOnIPhoneMilestone2On
         self.isIPPUKExpansionEnabled = isIPPUKExpansionEnabled
+        self.isProductDescriptionAIEnabled = isProductDescriptionAIEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -92,6 +95,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isTapToPayOnIPhoneMilestone2On
         case .IPPUKExpansion:
             return isIPPUKExpansionEnabled
+        case .productDescriptionAI:
+            return isProductDescriptionAIEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormAIEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormAIEligibilityCheckerTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import WooCommerce
+
+final class ProductFormAIEligibilityCheckerTests: XCTestCase {
+    // MARK: - Product description
+
+    func test_description_feature_is_enabled_when_site_is_wpcom() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIEnabled: true)
+        let checker = ProductFormAIEligibilityChecker(site: .fake().copy(isWordPressComStore: true), featureFlagService: featureFlagService)
+
+        // When
+        let isDescriptionAIEnabled = checker.isFeatureEnabled(.description)
+
+        // Then
+        XCTAssertTrue(isDescriptionAIEnabled)
+    }
+
+    func test_description_feature_is_disabled_when_site_is_not_wpcom() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIEnabled: true)
+        let checker = ProductFormAIEligibilityChecker(site: .fake().copy(isWordPressComStore: false), featureFlagService: featureFlagService)
+
+        // When
+        let isDescriptionAIEnabled = checker.isFeatureEnabled(.description)
+
+        // Then
+        XCTAssertFalse(isDescriptionAIEnabled)
+    }
+
+    func test_description_feature_is_disabled_when_site_is_nil() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIEnabled: true)
+        let checker = ProductFormAIEligibilityChecker(site: nil, featureFlagService: featureFlagService)
+
+        // When
+        let isDescriptionAIEnabled = checker.isFeatureEnabled(.description)
+
+        // Then
+        XCTAssertFalse(isDescriptionAIEnabled)
+    }
+
+    func test_description_feature_is_disabled_when_site_is_wpcom_and_feature_flag_is_off() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIEnabled: false)
+        let checker = ProductFormAIEligibilityChecker(site: .fake().copy(isWordPressComStore: true), featureFlagService: featureFlagService)
+
+        // When
+        let isDescriptionAIEnabled = checker.isFeatureEnabled(.description)
+
+        // Then
+        XCTAssertFalse(isDescriptionAIEnabled)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9465 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The feature flag gets merge conflicts often from new flags on `trunk`, so I'm PR'ing the feature flag and an eligibility checker to set the foundation for the AI-assisted product description in future PRs.

- A new feature flag `productDescriptionAI` was added
- `ProductFormAIEligibilityChecker` was created to check if a product form AI feature is enabled: right now, Jetpack AI is only available to simple and atomic sites

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just CI is sufficient for the new unit tests, the feature flag and the eligibility checker aren't used yet.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
