### PR TITLE
[Mobile Payments] Add tests for IPP Onboarding shouldShow logic

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -26,6 +26,15 @@ protocol CardPresentPaymentsOnboardingUseCaseProtocol {
     /// Update the onboarding state with the latest synced values.
     ///
     func updateState()
+
+    /// Pending requirements can be skipped so the merchant can continue to collect payments.
+    /// Eventually, these become overdue requirements, which cannot be skipped
+    ///
+    func skipPendingRequirements()
+
+    func selectPlugin(_ selectedPlugin: CardPresentPaymentsPlugin)
+
+    func clearPluginSelection()
 }
 
 final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingUseCaseProtocol, ObservableObject {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -6,7 +6,7 @@ final class InPersonPaymentsViewModel: ObservableObject, PaymentSettingsFlowPres
     @Published var state: CardPresentPaymentOnboardingState
     var userIsAdministrator: Bool
     var learnMoreURL: URL? = nil
-    private let useCase: CardPresentPaymentsOnboardingUseCase
+    private let useCase: CardPresentPaymentsOnboardingUseCaseProtocol
     let stores: StoresManager
 
     var showSupport: (() -> Void)? = nil
@@ -16,7 +16,7 @@ final class InPersonPaymentsViewModel: ObservableObject, PaymentSettingsFlowPres
     ///
     init(stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         useCase: CardPresentPaymentsOnboardingUseCase = CardPresentPaymentsOnboardingUseCase(),
+         useCase: CardPresentPaymentsOnboardingUseCaseProtocol = CardPresentPaymentsOnboardingUseCase(),
          didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)? = nil) {
         self.stores = stores
         self.useCase = useCase
@@ -24,7 +24,7 @@ final class InPersonPaymentsViewModel: ObservableObject, PaymentSettingsFlowPres
         state = useCase.state
         userIsAdministrator = ServiceLocator.stores.sessionManager.defaultRoles.contains(.administrator)
 
-        useCase.$state
+        useCase.statePublisher
             .share()
             // Debounce values to prevent the loading screen flashing when there is no connection
             .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
@@ -132,7 +132,7 @@ final class InPersonPaymentsViewModel: ObservableObject, PaymentSettingsFlowPres
 
 private extension InPersonPaymentsViewModel {
     var countryCode: String {
-        useCase.configurationLoader.configuration.countryCode
+        CardPresentConfigurationLoader().configuration.countryCode
     }
 
     func trackState(_ state: CardPresentPaymentOnboardingState) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -564,6 +564,7 @@
 		0396CFAD2981476900E91436 /* CardPresentModalBuiltInConnectingFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */; };
 		039B7E6329F136F200E21EF4 /* SetUpTapToPayOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039B7E6229F136F200E21EF4 /* SetUpTapToPayOnboardingViewController.swift */; };
 		039B7E6529F167DB00E21EF4 /* UniversalLinkRouter+JustInTimeMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039B7E6429F167DB00E21EF4 /* UniversalLinkRouter+JustInTimeMessages.swift */; };
+		039B7E6729F2855B00E21EF4 /* InPersonPaymentsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039B7E6629F2855B00E21EF4 /* InPersonPaymentsViewModelTests.swift */; };
 		039D948D27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */; };
 		039D948F276113490044EF38 /* UIView+SuperviewConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */; };
 		03A6C18428B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A6C18328B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift */; };
@@ -2800,6 +2801,7 @@
 		0396CFAC2981476800E91436 /* CardPresentModalBuiltInConnectingFailed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPresentModalBuiltInConnectingFailed.swift; sourceTree = "<group>"; };
 		039B7E6229F136F200E21EF4 /* SetUpTapToPayOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUpTapToPayOnboardingViewController.swift; sourceTree = "<group>"; };
 		039B7E6429F167DB00E21EF4 /* UniversalLinkRouter+JustInTimeMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UniversalLinkRouter+JustInTimeMessages.swift"; sourceTree = "<group>"; };
+		039B7E6629F2855B00E21EF4 /* InPersonPaymentsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsViewModelTests.swift; sourceTree = "<group>"; };
 		039D948C27610C6F0044EF38 /* UIView+SafeAreaConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SafeAreaConstraints.swift"; sourceTree = "<group>"; };
 		039D948E276113490044EF38 /* UIView+SuperviewConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SuperviewConstraints.swift"; sourceTree = "<group>"; };
 		03A6C18328B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift; sourceTree = "<group>"; };
@@ -5754,6 +5756,7 @@
 				03A6C18228B52ADB00AADF23 /* Onboarding Errors */,
 				03EF24FF28C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift */,
 				03EF250328C6283B006A033E /* InPersonPaymentsMenuViewModelTests.swift */,
+				039B7E6629F2855B00E21EF4 /* InPersonPaymentsViewModelTests.swift */,
 			);
 			path = "In-Person Payments";
 			sourceTree = "<group>";
@@ -12548,6 +12551,7 @@
 				02279590237A5DC900787C63 /* AztecUnorderedListFormatBarCommandTests.swift in Sources */,
 				B958A7D128B5281800823EEF /* UniversalLinkRouterTests.swift in Sources */,
 				B5F571AB21BEECB60010D1B8 /* NoteWooTests.swift in Sources */,
+				039B7E6729F2855B00E21EF4 /* InPersonPaymentsViewModelTests.swift in Sources */,
 				03EF250428C6283B006A033E /* InPersonPaymentsMenuViewModelTests.swift in Sources */,
 				45DB706C26161F970064A6CF /* DecimalWooTests.swift in Sources */,
 				CCE4CD172667EBB100E09FD4 /* ShippingLabelPaymentMethodsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/MockCardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/MockCardPresentPaymentsOnboardingUseCase.swift
@@ -22,6 +22,23 @@ final class MockCardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboard
         // No op
     }
 
+    var skipPendingRequirementsWasCalled = false
+    func skipPendingRequirements() {
+        skipPendingRequirementsWasCalled = true
+    }
+
+    var selectPluginWasCalled = false
+    var spySelectedPlugin: CardPresentPaymentsPlugin? = nil
+    func selectPlugin(_ selectedPlugin: CardPresentPaymentsPlugin) {
+        selectPluginWasCalled = true
+        spySelectedPlugin = selectedPlugin
+    }
+
+    var clearPluginSelectionWasCalled = false
+    func clearPluginSelection() {
+        clearPluginSelectionWasCalled = true
+    }
+
     // MARK: Convenience Initializer
     init(initial: CardPresentPaymentOnboardingState, publisher: AnyPublisher<CardPresentPaymentOnboardingState, Never>? = nil) {
         self.state = initial

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModelTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+import Combine
+@testable import WooCommerce
+import Yosemite
+
+final class InPersonPaymentsViewModelTests: XCTestCase {
+    private var sut: InPersonPaymentsViewModel!
+    private var onboardingUseCase: MockCardPresentPaymentsOnboardingUseCase!
+    private var stateSubject: CurrentValueSubject<CardPresentPaymentOnboardingState, Never>!
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func setUp() {
+        stateSubject = CurrentValueSubject<CardPresentPaymentOnboardingState, Never>(.loading)
+        onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(
+            initial: .noConnectionError,
+            publisher: stateSubject.eraseToAnyPublisher())
+        sut = InPersonPaymentsViewModel(useCase: onboardingUseCase)
+    }
+
+    override func tearDown() {
+        _ = cancellables.map { $0.cancel() }
+        cancellables = []
+    }
+
+    func test_when_created_shouldShow_isUnknown() {
+        // Given, When
+        // `setUp` has created the `sut`
+
+        // Then
+        assertEqual(.isUnknown, sut.shouldShow)
+    }
+
+    func test_when_onboarding_state_changes_to_loading_shouldShow_isTrue() {
+        // Given
+        waitFor { [weak self] promise in
+            guard let self = self else { return }
+            /// When the View Model receives an _onboarding_ state, it debounces, so goes async.
+            /// Waiting for the View Model's state to change at the end of this means we're done with
+            /// the shouldShow changes too. We ignore the first state, as it comes from `sut.init`
+            self.sut.$state.dropFirst(1).sink { _ in
+                promise(())
+            }.store(in: &self.cancellables)
+
+            // When
+            self.stateSubject.send(.loading)
+        }
+
+        // Then
+        assertEqual(.isTrue, sut.shouldShow)
+    }
+
+    func test_when_onboarding_state_changes_to_loading_didChangeShouldShow_is_called_with_newShouldShow_isTrue() {
+        // Given
+        let receivedShouldShow = waitFor { [weak self] promise in
+            guard let self = self else { return }
+            self.sut.didChangeShouldShow = { newShouldShow in
+                promise(newShouldShow)
+            }
+
+            // When
+            self.stateSubject.send(.loading)
+        }
+
+        // Then
+        assertEqual(.isTrue, receivedShouldShow)
+    }
+
+    func test_when_onboarding_state_changes_to_completed_shouldShow_isFalse() {
+        // Given
+        waitFor { [weak self] promise in
+            guard let self = self else { return }
+            /// When the View Model receives an _onboarding_ state, it debounces, so goes async.
+            /// Waiting for the View Model's state to change at the end of this means we're done with
+            /// the shouldShow changes too. We ignore the first state, as it comes from `sut.init`
+            self.sut.$state.dropFirst(1).sink { _ in
+                promise(())
+            }.store(in: &self.cancellables)
+
+            // When
+            self.stateSubject.send(.completed(plugin: .wcPayOnly))
+        }
+
+        // Then
+        assertEqual(.isFalse, sut.shouldShow)
+    }
+
+    func test_when_onboarding_state_changes_to_completed_didChangeShouldShow_is_called_with_newShouldShow_isFalse() {
+        // Given
+        let receivedShouldShow = waitFor { [weak self] promise in
+            guard let self = self else { return }
+            self.sut.didChangeShouldShow = { newShouldShow in
+                promise(newShouldShow)
+            }
+
+            // When
+            self.stateSubject.send(.completed(plugin: .stripeOnly))
+        }
+
+        // Then
+        assertEqual(.isFalse, receivedShouldShow)
+    }
+
+    func test_when_onboarding_state_changes_to_error_shouldShow_isTrue() {
+        // Given
+        waitFor { [weak self] promise in
+            guard let self = self else { return }
+            self.sut.$state.dropFirst(1).sink { _ in
+                promise(())
+            }.store(in: &self.cancellables)
+
+            // When
+            self.stateSubject.send(.pluginNotInstalled)
+        }
+
+        // Then
+        assertEqual(.isTrue, sut.shouldShow)
+    }
+
+    func test_when_onboarding_state_changes_to_error_didChangeShouldShow_is_called_with_newShouldShow_isTrue() {
+        // Given
+        let receivedShouldShow = waitFor { [weak self] promise in
+            guard let self = self else { return }
+            self.sut.didChangeShouldShow = { newShouldShow in
+                promise(newShouldShow)
+            }
+
+            // When
+            self.stateSubject.send(.stripeAccountPendingRequirement(plugin: .wcPay, deadline: nil))
+        }
+
+        // Then
+        assertEqual(.isTrue, receivedShouldShow)
+    }
+
+    func test_when_onboarding_state_changes_to_completed_after_an_error_didChangeShouldShow_is_called_with_newShouldShow_isFalse() {
+        // Given
+        stateSubject.send(.noConnectionError)
+
+        let receivedShouldShow = waitFor { [weak self] promise in
+            guard let self = self else { return }
+            self.sut.didChangeShouldShow = { newShouldShow in
+                promise(newShouldShow)
+            }
+
+            // When
+            self.stateSubject.send(.completed(plugin: .stripeOnly))
+        }
+
+        // Then
+        assertEqual(.isFalse, receivedShouldShow)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9370
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In #9515 we added the Onboarding flow at the start of Set up Tap to Pay on iPhone, which is a `PaymentSettingsFlow`. There were no unit tests for the new display logic in the original PR.

When the In Person Payments Onboarding screens are presented within a `PaymentSettingsFlow`, e.g. before Set up Tap to Pay on iPhone, the logic for setting `shouldShow` and calling `didChangeShouldShow` determines whether the overall onboarding screen is displayed or not.

This adds tests for this logic. When the `shouldShow` tri-state `isTrue`, and it’s the first screen in the flow saying it `shouldShow`, the `InPersonPaymentsViewController` will be displayed. We want to return `isTrue` when there’s a loading or error status in Onboarding, and `isFalse` when it’s completed.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run unit tests


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
