### PR TITLE
[Subscriptions] Renewal orders: Add renewalSubscriptionID to Order

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -496,7 +496,8 @@ extension Networking.Order {
             refunds: .fake(),
             fees: .fake(),
             taxes: .fake(),
-            customFields: .fake()
+            customFields: .fake(),
+            renewalSubscriptionID: .fake()
         )
     }
 }

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -625,6 +625,7 @@
 		CE0A0F1B223989670075ED8D /* ProductsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1A223989670075ED8D /* ProductsRemote.swift */; };
 		CE0A0F1D22398D520075ED8D /* ProductListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1C22398D520075ED8D /* ProductListMapperTests.swift */; };
 		CE0A0F1F223998A10075ED8D /* products-load-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CE0A0F1E223998A00075ED8D /* products-load-all.json */; };
+		CE12AE9529F29F4F0056DD17 /* order-with-subscription-renewal.json in Resources */ = {isa = PBXBuildFile; fileRef = CE12AE9429F29F4F0056DD17 /* order-with-subscription-renewal.json */; };
 		CE12FBD9221F3A6F00C59248 /* OrderStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12FBD8221F3A6F00C59248 /* OrderStatus.swift */; };
 		CE132BBA223851F80029DB6C /* ProductCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE132BB9223851F80029DB6C /* ProductCategory.swift */; };
 		CE132BBC223859710029DB6C /* ProductTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE132BBB223859710029DB6C /* ProductTag.swift */; };
@@ -1550,6 +1551,7 @@
 		CE0A0F1A223989670075ED8D /* ProductsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsRemote.swift; sourceTree = "<group>"; };
 		CE0A0F1C22398D520075ED8D /* ProductListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListMapperTests.swift; sourceTree = "<group>"; };
 		CE0A0F1E223998A00075ED8D /* products-load-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-load-all.json"; sourceTree = "<group>"; };
+		CE12AE9429F29F4F0056DD17 /* order-with-subscription-renewal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-subscription-renewal.json"; sourceTree = "<group>"; };
 		CE12FBD8221F3A6F00C59248 /* OrderStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatus.swift; sourceTree = "<group>"; };
 		CE132BB9223851F80029DB6C /* ProductCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategory.swift; sourceTree = "<group>"; };
 		CE132BBB223859710029DB6C /* ProductTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTag.swift; sourceTree = "<group>"; };
@@ -2535,6 +2537,7 @@
 				0272E3F4254AA48F00436277 /* order-with-line-item-attributes.json */,
 				0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */,
 				A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */,
+				CE12AE9429F29F4F0056DD17 /* order-with-subscription-renewal.json */,
 				261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */,
 				0313651A28AE60E000EEE571 /* payment-gateway-cod.json */,
 				261CF2CA255C50010090D8D3 /* payment-gateway-list-half.json */,
@@ -3538,6 +3541,7 @@
 				453305F52459ED2700264E50 /* site-post-update.json in Resources */,
 				CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */,
 				02E7FFCF25621C7900C53030 /* shipping-label-print.json in Resources */,
+				CE12AE9529F29F4F0056DD17 /* order-with-subscription-renewal.json in Resources */,
 				74ABA1CB213F19FE00FFAD30 /* top-performers-week.json in Resources */,
 				456930AD2652AF00009ED69D /* shipping-label-carriers-and-rates-success.json in Resources */,
 				B524194721AC643900D6FC0A /* device-settings.json in Resources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -525,7 +525,8 @@ extension Networking.Order {
         refunds: CopiableProp<[OrderRefundCondensed]> = .copy,
         fees: CopiableProp<[OrderFeeLine]> = .copy,
         taxes: CopiableProp<[OrderTaxLine]> = .copy,
-        customFields: CopiableProp<[OrderMetaData]> = .copy
+        customFields: CopiableProp<[OrderMetaData]> = .copy,
+        renewalSubscriptionID: NullableCopiableProp<String> = .copy
     ) -> Networking.Order {
         let siteID = siteID ?? self.siteID
         let orderID = orderID ?? self.orderID
@@ -561,6 +562,7 @@ extension Networking.Order {
         let fees = fees ?? self.fees
         let taxes = taxes ?? self.taxes
         let customFields = customFields ?? self.customFields
+        let renewalSubscriptionID = renewalSubscriptionID ?? self.renewalSubscriptionID
 
         return Networking.Order(
             siteID: siteID,
@@ -596,7 +598,8 @@ extension Networking.Order {
             refunds: refunds,
             fees: fees,
             taxes: taxes,
-            customFields: customFields
+            customFields: customFields,
+            renewalSubscriptionID: renewalSubscriptionID
         )
     }
 }

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -48,6 +48,10 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
 
     public let customFields: [OrderMetaData]
 
+    /// Subscription ID if this is a subscription renewal order (Subscriptions extension only)
+    ///
+    public let renewalSubscriptionID: String?
+
     /// Order struct initializer.
     ///
     public init(siteID: Int64,
@@ -83,7 +87,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                 refunds: [OrderRefundCondensed],
                 fees: [OrderFeeLine],
                 taxes: [OrderTaxLine],
-                customFields: [OrderMetaData]) {
+                customFields: [OrderMetaData],
+                renewalSubscriptionID: String?) {
 
         self.siteID = siteID
         self.orderID = orderID
@@ -124,6 +129,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         self.taxes = taxes
 
         self.customFields = customFields
+        self.renewalSubscriptionID = renewalSubscriptionID
     }
 
 
@@ -202,6 +208,9 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         // Filter out metadata if the key is prefixed with an underscore (internal meta keys) or the value is empty
         let customFields = allOrderMetaData?.filter({ !$0.key.hasPrefix("_") && !$0.value.isEmpty }) ?? []
 
+        // Subscriptions extension
+        let renewalSubscriptionID = allOrderMetaData?.first(where: { $0.key == "_subscription_renewal" })?.value
+
         self.init(siteID: siteID,
                   orderID: orderID,
                   parentID: parentID,
@@ -235,7 +244,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                   refunds: refunds,
                   fees: fees,
                   taxes: taxes,
-                  customFields: customFields)
+                  customFields: customFields,
+                  renewalSubscriptionID: renewalSubscriptionID)
     }
 
     public static var empty: Order {
@@ -272,7 +282,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                   refunds: [],
                   fees: [],
                   taxes: [],
-                  customFields: [])
+                  customFields: [],
+                  renewalSubscriptionID: nil)
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -379,6 +379,12 @@ final class OrderMapperTests: XCTestCase {
         let expectedCustomField = OrderMetaData(metadataID: 18148, key: "Viewed Currency", value: "USD")
         XCTAssertEqual(customField, expectedCustomField)
     }
+
+    func test_order_renewal_subscription_id_is_parsed_successfully() throws {
+        let order = try XCTUnwrap(mapLoadOrderWithSubscriptionRenewal())
+
+        XCTAssertEqual(order.renewalSubscriptionID, "282")
+    }
 }
 
 
@@ -455,6 +461,12 @@ private extension OrderMapperTests {
     ///
     func mapLoadOrderWithChargeResponse() -> Order? {
         return mapOrder(from: "order-with-charge")
+    }
+
+    /// Returns the Order output upon receiving `order-with-subscription-renewal`
+    ///
+    func mapLoadOrderWithSubscriptionRenewal() -> Order? {
+        return mapOrder(from: "order-with-subscription-renewal")
     }
 
 }

--- a/Networking/NetworkingTests/Responses/order-with-subscription-renewal.json
+++ b/Networking/NetworkingTests/Responses/order-with-subscription-renewal.json
@@ -1,0 +1,284 @@
+{
+    "data": {
+        "id": 526,
+        "parent_id": 0,
+        "status": "processing",
+        "currency": "USD",
+        "version": "7.6.0",
+        "prices_include_tax": false,
+        "date_created": "2023-04-18T18:16:08",
+        "date_modified": "2023-04-18T18:16:10",
+        "discount_total": "0.00",
+        "discount_tax": "0.00",
+        "shipping_total": "0.00",
+        "shipping_tax": "0.00",
+        "cart_tax": "0.00",
+        "total": "14.50",
+        "total_tax": "0.00",
+        "customer_id": 27375286,
+        "order_key": "wc_order_ApPuB8FVJAD6A",
+        "billing": {
+            "first_name": "Brooks",
+            "last_name": "Hane",
+            "company": "",
+            "address_1": "885 Susanna Ridges",
+            "address_2": "978 Powlowski Lock",
+            "city": "Ferryville",
+            "state": "DF",
+            "postcode": "01234",
+            "country": "MX",
+            "email": "your.email+fakedata38165@gmail.com",
+            "phone": "536-297-3865"
+        },
+        "shipping": {
+            "first_name": "Brooks",
+            "last_name": "Hane",
+            "company": "",
+            "address_1": "885 Susanna Ridges",
+            "address_2": "978 Powlowski Lock",
+            "city": "Ferryville",
+            "state": "DF",
+            "postcode": "01234",
+            "country": "MX",
+            "phone": "536-297-3865"
+        },
+        "payment_method": "woocommerce_payments",
+        "payment_method_title": "Credit card / debit card",
+        "transaction_id": "pi_3MyI8TFmpgWy4Lrl0rLQ6JZD",
+        "customer_ip_address": "192.0.123.2",
+        "customer_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+        "created_via": "subscription",
+        "customer_note": "",
+        "date_completed": null,
+        "date_paid": "2023-04-18T18:16:11",
+        "cart_hash": "",
+        "number": "526",
+        "meta_data": [
+            {
+                "id": 15647,
+                "key": "_shipping_hash",
+                "value": "9d4568c009d203ab10e33ea9953a0264"
+            },
+            {
+                "id": 15648,
+                "key": "_coupons_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 15649,
+                "key": "_fees_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 15650,
+                "key": "_taxes_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 15651,
+                "key": "is_vat_exempt",
+                "value": "no"
+            },
+            {
+                "id": 15652,
+                "key": "_customer_ip_country",
+                "value": "US"
+            },
+            {
+                "id": 15653,
+                "key": "_customer_self_declared_country",
+                "value": "false"
+            },
+            {
+                "id": 15654,
+                "key": "_payment_method_id",
+                "value": "pm_1MU8TnFmpgWy4LrlAwUzFd6t"
+            },
+            {
+                "id": 15655,
+                "key": "_stripe_customer_id",
+                "value": "cus_NEbhgaeylNVXDP"
+            },
+            {
+                "id": 15674,
+                "key": "_subscription_renewal",
+                "value": "282"
+            },
+            {
+                "id": 15677,
+                "key": "_wcpay_mode",
+                "value": "test"
+            },
+            {
+                "id": 15678,
+                "key": "_intent_id",
+                "value": "pi_3MyI8TFmpgWy4Lrl0rLQ6JZD"
+            },
+            {
+                "id": 15679,
+                "key": "_charge_id",
+                "value": "ch_3MyI8TFmpgWy4Lrl0SvjrkuP"
+            },
+            {
+                "id": 15680,
+                "key": "_intention_status",
+                "value": "succeeded"
+            },
+            {
+                "id": 15681,
+                "key": "_wcpay_intent_currency",
+                "value": "usd"
+            },
+            {
+                "id": 15685,
+                "key": "_wc_points_earned",
+                "value": "15"
+            },
+            {
+                "id": 15686,
+                "key": "_prl_conversion_saved",
+                "value": "yes"
+            },
+            {
+                "id": 15687,
+                "key": "_wcpay_transaction_fee",
+                "value": "1.03"
+            },
+            {
+                "id": 15688,
+                "key": "_automatewoo_order_created",
+                "value": "1"
+            },
+            {
+                "id": 15689,
+                "key": "_new_order_tracking_complete",
+                "value": "yes"
+            }
+        ],
+        "line_items": [
+            {
+                "id": 1052,
+                "name": "Polo",
+                "product_id": 26,
+                "variation_id": 0,
+                "quantity": 1,
+                "tax_class": "clothing-20010",
+                "subtotal": "14.50",
+                "subtotal_tax": "0.00",
+                "total": "14.50",
+                "total_tax": "0.00",
+                "taxes": [],
+                "meta_data": [
+                    {
+                        "id": 9198,
+                        "key": "As a Gift",
+                        "value": "No",
+                        "display_key": "As a Gift",
+                        "display_value": "No"
+                    },
+                    {
+                        "id": 9199,
+                        "key": "_pao_ids",
+                        "value": [
+                            {
+                                "key": "As a Gift",
+                                "value": "No"
+                            }
+                        ],
+                        "display_key": "_pao_ids",
+                        "display_value": [
+                            {
+                                "key": "As a Gift",
+                                "value": "No"
+                            }
+                        ]
+                    },
+                    {
+                        "id": 9200,
+                        "key": "_prl_conversion",
+                        "value": "1",
+                        "display_key": "_prl_conversion",
+                        "display_value": "1"
+                    },
+                    {
+                        "id": 9201,
+                        "key": "_prl_conversion_time",
+                        "value": "1675182546",
+                        "display_key": "_prl_conversion_time",
+                        "display_value": "1675182546"
+                    },
+                    {
+                        "id": 9202,
+                        "key": "_wcsatt_scheme",
+                        "value": "1_week_12",
+                        "display_key": "_wcsatt_scheme",
+                        "display_value": "1_week_12"
+                    }
+                ],
+                "sku": "woo-polo",
+                "price": 14.5,
+                "image": {
+                    "id": "55",
+                    "src": "https://example.com/wp-content/uploads/2023/01/polo-2.jpg"
+                },
+                "parent_name": null,
+                "composite_parent": "",
+                "composite_children": [],
+                "bundled_by": "",
+                "bundled_item_title": "",
+                "bundled_items": []
+            }
+        ],
+        "tax_lines": [],
+        "shipping_lines": [
+            {
+                "id": 1053,
+                "method_title": "Free shipping",
+                "method_id": "free_shipping",
+                "instance_id": "9",
+                "total": "0.00",
+                "total_tax": "0.00",
+                "taxes": [],
+                "meta_data": [
+                    {
+                        "id": 9208,
+                        "key": "Items",
+                        "value": "Polo &times; 1",
+                        "display_key": "Items",
+                        "display_value": "Polo &times; 1"
+                    }
+                ]
+            }
+        ],
+        "fee_lines": [],
+        "coupon_lines": [],
+        "refunds": [],
+        "payment_url": "https://example.com/checkout/order-pay/526/?pay_for_order=true&key=wc_order_ApPuB8FVJAD6A&subscription_renewal=true",
+        "is_editable": false,
+        "needs_payment": false,
+        "needs_processing": true,
+        "date_created_gmt": "2023-04-18T17:16:08",
+        "date_modified_gmt": "2023-04-18T17:16:10",
+        "date_completed_gmt": null,
+        "date_paid_gmt": "2023-04-18T17:16:11",
+        "gift_cards": [],
+        "currency_symbol": "$",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/orders/526"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/orders"
+                }
+            ],
+            "customer": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/customers/27375286"
+                }
+            ]
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -492,7 +492,8 @@ struct EditAddressForm_Previews: PreviewProvider {
                                    refunds: [],
                                    fees: [],
                                    taxes: [],
-                                   customFields: [])
+                                   customFields: [],
+                                   renewalSubscriptionID: nil)
 
     static let sampleAddress = Address(firstName: "Johnny",
                                        lastName: "Appleseed",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -475,7 +475,8 @@ extension ShippingLabelPackagesFormViewModel {
                      refunds: [],
                      fees: [],
                      taxes: [],
-                     customFields: [])
+                     customFields: [],
+                     renewalSubscriptionID: nil)
     }
 
     static func sampleAddress() -> Address {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
@@ -39,7 +39,8 @@ enum ShippingLabelSampleData {
                      refunds: [],
                      fees: [],
                      taxes: [],
-                     customFields: [])
+                     customFields: [],
+                     renewalSubscriptionID: nil)
     }
 
     static func samplePackageDetails() -> ShippingLabelPackagesResponse {

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -363,7 +363,8 @@ extension MockObjectGraph {
             refunds: [],
             fees: [],
             taxes: [],
-            customFields: []
+            customFields: [],
+            renewalSubscriptionID: nil
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -111,7 +111,8 @@ extension Storage.Order: ReadOnlyConvertible {
                      refunds: orderRefunds,
                      fees: orderFeeLines,
                      taxes: orderTaxLines,
-                     customFields: orderCustomFields)
+                     customFields: orderCustomFields,
+                     renewalSubscriptionID: nil)
 
     }
 

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -41,7 +41,8 @@ public enum OrderFactory {
               refunds: [],
               fees: [simplePaymentFee(feeID: 0, amount: amount, taxable: taxable)],
               taxes: [],
-              customFields: [])
+              customFields: [],
+              renewalSubscriptionID: nil)
     }
 
     /// Creates a fee line suitable to be used within a simple payments order.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9310
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With the Subscriptions extension, there are two ways to get the subscriptions associated with an order:

1. If the order is the initial subscription order, we can fetch all of the subscriptions related to that order from the subscriptions endpoint, using the order ID. (This is already supported.)
2. If the order is a subscription renewal order, the subscription ID is stored as metadata on the order. We can fetch the subscription from the subscriptions endpoint, using the subscription ID.

This PR is part of adding support for renewal orders. It adds `renewalSubscriptionID` to the `Order` model, to capture that subscription ID for renewal orders. Another PR will add the necessary endpoint to request the subscription using the subscription ID.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Confirm tests pass. You can also build and run the app to confirm orders still load in the Orders tab.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
