### PR TITLE
[Store Creation] Handle error from store creation web view

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -194,6 +194,10 @@ extension AuthenticatedWebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         progressBar.setProgress(0, animated: false)
     }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        viewModel.didFailProvisionalNavigation(with: error)
+    }
 }
 
 extension AuthenticatedWebViewController: WKUIDelegate {

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
@@ -29,11 +29,20 @@ protocol AuthenticatedWebViewModel {
 
     /// Handler after receiving response for a navigation
     func decidePolicy(for response: URLResponse) async -> WKNavigationResponsePolicy
+
+    /// Triggered when provisional navigation fails
+    ///
+    func didFailProvisionalNavigation(with error: Error)
 }
 
+/// MARK: Default implementation for the optional methods
+///
 extension AuthenticatedWebViewModel {
-    /// Default implementation for the optional method
     func decidePolicy(for response: URLResponse) async -> WKNavigationResponsePolicy {
         return .allow
+    }
+
+    func didFailProvisionalNavigation(with error: Error) {
+        // NO-OP
     }
 }

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
@@ -35,8 +35,8 @@ protocol AuthenticatedWebViewModel {
     func didFailProvisionalNavigation(with error: Error)
 }
 
-/// MARK: Default implementation for the optional methods
-///
+// MARK: Default implementation for the optional methods
+//
 extension AuthenticatedWebViewModel {
     func decidePolicy(for response: URLResponse) async -> WKNavigationResponsePolicy {
         return .allow

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -270,6 +270,19 @@ private extension StoreCreationCoordinator {
         case .failure(let error):
             analytics.track(event: .StoreCreation.siteCreationFailed(source: source.analyticsValue, error: error, flow: .web, isFreeTrial: false))
             DDLogError("Store creation error: \(error)")
+
+            // Dismiss store creation webview before showing error alert
+            navigationController.dismiss(animated: true) { [weak self] in
+                guard let self else { return }
+
+                // Show error alert
+                let alertController = UIAlertController(title: Localization.StoreCreationErrorAlert.title,
+                                                        message: Localization.StoreCreationErrorAlert.defaultErrorMessage,
+                                                        preferredStyle: .alert)
+                alertController.view.tintColor = .text
+                _ = alertController.addCancelActionWithTitle(Localization.StoreCreationErrorAlert.cancelActionTitle) { _ in }
+                self.navigationController.present(alertController, animated: true)
+            }
         }
     }
 

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -108,7 +108,8 @@ final class StoreCreationCoordinator: Coordinator {
                 let isWebviewFallbackAllowed = featureFlagService.isFeatureFlagEnabled(.storeCreationM2WithInAppPurchasesEnabled) == false
                 navigationController.dismiss(animated: true) { [weak self] in
                     guard let self else { return }
-                    if isWebviewFallbackAllowed {
+                    if error is PlanPurchaseError,
+                       isWebviewFallbackAllowed {
                         self.startStoreCreationM1()
                     } else {
                         self.showIneligibleUI(from: self.navigationController, error: error)

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -104,7 +104,7 @@ final class StoreCreationCoordinator: Coordinator {
                 }
 
                 startStoreCreationM2(from: storeCreationNavigationController, planToPurchase: product)
-            } catch {
+            } catch let error as PlanPurchaseError {
                 let isWebviewFallbackAllowed = featureFlagService.isFeatureFlagEnabled(.storeCreationM2WithInAppPurchasesEnabled) == false
                 navigationController.dismiss(animated: true) { [weak self] in
                     guard let self else { return }
@@ -113,6 +113,18 @@ final class StoreCreationCoordinator: Coordinator {
                     } else {
                         self.showIneligibleUI(from: self.navigationController, error: error)
                     }
+                }
+            } catch {
+                navigationController.dismiss(animated: true) { [weak self] in
+                    guard let self else { return }
+
+                    // Show error alert
+                    let alertController = UIAlertController(title: Localization.StoreCreationErrorAlert.title,
+                                                            message: Localization.StoreCreationErrorAlert.defaultErrorMessage,
+                                                            preferredStyle: .alert)
+                    alertController.view.tintColor = .text
+                    alertController.addCancelActionWithTitle(Localization.StoreCreationErrorAlert.cancelActionTitle) { _ in }
+                    self.navigationController.present(alertController, animated: true)
                 }
             }
         }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -108,8 +108,7 @@ final class StoreCreationCoordinator: Coordinator {
                 let isWebviewFallbackAllowed = featureFlagService.isFeatureFlagEnabled(.storeCreationM2WithInAppPurchasesEnabled) == false
                 navigationController.dismiss(animated: true) { [weak self] in
                     guard let self else { return }
-                    if error is PlanPurchaseError,
-                       isWebviewFallbackAllowed {
+                    if isWebviewFallbackAllowed {
                         self.startStoreCreationM1()
                     } else {
                         self.showIneligibleUI(from: self.navigationController, error: error)

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -119,12 +119,7 @@ final class StoreCreationCoordinator: Coordinator {
                     guard let self else { return }
 
                     // Show error alert
-                    let alertController = UIAlertController(title: Localization.StoreCreationErrorAlert.title,
-                                                            message: Localization.StoreCreationErrorAlert.defaultErrorMessage,
-                                                            preferredStyle: .alert)
-                    alertController.view.tintColor = .text
-                    alertController.addCancelActionWithTitle(Localization.StoreCreationErrorAlert.cancelActionTitle) { _ in }
-                    self.navigationController.present(alertController, animated: true)
+                    self.showStoreCreationDefaultErrorAlert(from: self.navigationController)
                 }
             }
         }
@@ -237,6 +232,16 @@ private extension StoreCreationCoordinator {
 
         navigationController.present(alert, animated: true)
     }
+
+    /// Shows an alert with default error message
+    func showStoreCreationDefaultErrorAlert(from navigationController: UINavigationController) {
+        let alertController = UIAlertController(title: Localization.StoreCreationErrorAlert.title,
+                                                message: Localization.StoreCreationErrorAlert.defaultErrorMessage,
+                                                preferredStyle: .alert)
+        alertController.view.tintColor = .text
+        alertController.addCancelActionWithTitle(Localization.StoreCreationErrorAlert.cancelActionTitle) { _ in }
+        navigationController.present(alertController, animated: true)
+    }
 }
 
 // MARK: - Store creation M1
@@ -288,12 +293,7 @@ private extension StoreCreationCoordinator {
                 guard let self else { return }
 
                 // Show error alert
-                let alertController = UIAlertController(title: Localization.StoreCreationErrorAlert.title,
-                                                        message: Localization.StoreCreationErrorAlert.defaultErrorMessage,
-                                                        preferredStyle: .alert)
-                alertController.view.tintColor = .text
-                alertController.addCancelActionWithTitle(Localization.StoreCreationErrorAlert.cancelActionTitle) { _ in }
-                self.navigationController.present(alertController, animated: true)
+                self.showStoreCreationDefaultErrorAlert(from: self.navigationController)
             }
         }
     }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationCoordinator.swift
@@ -292,7 +292,7 @@ private extension StoreCreationCoordinator {
                                                         message: Localization.StoreCreationErrorAlert.defaultErrorMessage,
                                                         preferredStyle: .alert)
                 alertController.view.tintColor = .text
-                _ = alertController.addCancelActionWithTitle(Localization.StoreCreationErrorAlert.cancelActionTitle) { _ in }
+                alertController.addCancelActionWithTitle(Localization.StoreCreationErrorAlert.cancelActionTitle) { _ in }
                 self.navigationController.present(alertController, animated: true)
             }
         }

--- a/WooCommerce/Classes/Authentication/Store Creation/StoreCreationWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/StoreCreationWebViewModel.swift
@@ -29,6 +29,10 @@ final class StoreCreationWebViewModel: AuthenticatedWebViewModel {
         handleCompletionIfPossible(navigationURL.absoluteString)
         return .allow
     }
+
+    func didFailProvisionalNavigation(with error: Error) {
+        handleError(error)
+    }
 }
 
 enum StoreCreationError: Error {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9395
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Handles the error from store creation web view and shows an error alert. 

## Testing instructions

1. Get Started
2. Enter WPCom account and login
3. Go offline
4. Tap `Add a Store` -> `Create a new store`
6. Notice that an error alert is shown that store creation failed.

## Screenshots

<img src="https://user-images.githubusercontent.com/524475/233629839-55834dbe-4f46-42dd-b3da-982987f2686e.png" width="320"/>

https://user-images.githubusercontent.com/524475/233629068-54795b98-5218-4d38-867d-b5962dad053e.mp4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
