### PR TITLE
[Subscriptions] Renewal orders: Add support for requesting specific subscription

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -626,6 +626,7 @@
 		CE0A0F1D22398D520075ED8D /* ProductListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1C22398D520075ED8D /* ProductListMapperTests.swift */; };
 		CE0A0F1F223998A10075ED8D /* products-load-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CE0A0F1E223998A00075ED8D /* products-load-all.json */; };
 		CE12AE9529F29F4F0056DD17 /* order-with-subscription-renewal.json in Resources */ = {isa = PBXBuildFile; fileRef = CE12AE9429F29F4F0056DD17 /* order-with-subscription-renewal.json */; };
+		CE12AE9729F2AB3F0056DD17 /* SubscriptionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12AE9629F2AB3F0056DD17 /* SubscriptionMapper.swift */; };
 		CE12FBD9221F3A6F00C59248 /* OrderStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12FBD8221F3A6F00C59248 /* OrderStatus.swift */; };
 		CE132BBA223851F80029DB6C /* ProductCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE132BB9223851F80029DB6C /* ProductCategory.swift */; };
 		CE132BBC223859710029DB6C /* ProductTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE132BBB223859710029DB6C /* ProductTag.swift */; };
@@ -1552,6 +1553,7 @@
 		CE0A0F1C22398D520075ED8D /* ProductListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListMapperTests.swift; sourceTree = "<group>"; };
 		CE0A0F1E223998A00075ED8D /* products-load-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-load-all.json"; sourceTree = "<group>"; };
 		CE12AE9429F29F4F0056DD17 /* order-with-subscription-renewal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-subscription-renewal.json"; sourceTree = "<group>"; };
+		CE12AE9629F2AB3F0056DD17 /* SubscriptionMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionMapper.swift; sourceTree = "<group>"; };
 		CE12FBD8221F3A6F00C59248 /* OrderStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatus.swift; sourceTree = "<group>"; };
 		CE132BB9223851F80029DB6C /* ProductCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategory.swift; sourceTree = "<group>"; };
 		CE132BBB223859710029DB6C /* ProductTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTag.swift; sourceTree = "<group>"; };
@@ -2789,6 +2791,7 @@
 				DEC51A94274CDA52009F3DF4 /* SitePluginMapper.swift */,
 				74046E1E217A6B70007DD7BF /* SiteSettingsMapper.swift */,
 				DE74F29927E08F5A0002FE59 /* SiteSettingMapper.swift */,
+				CE12AE9629F2AB3F0056DD17 /* SubscriptionMapper.swift */,
 				CCE5F38C29EFFBC400087332 /* SubscriptionListMapper.swift */,
 				B53EF53B21814900003E146F /* SuccessResultMapper.swift */,
 				74A1D26C21189DFE00931DFA /* SiteVisitStatsMapper.swift */,
@@ -3764,6 +3767,7 @@
 				740CF89921937A030023ED3A /* CommentRemote.swift in Sources */,
 				31054702262E04F700C5C02B /* RemotePaymentIntentMapper.swift in Sources */,
 				EE62EE63295AD45E009C965B /* String+URL.swift in Sources */,
+				CE12AE9729F2AB3F0056DD17 /* SubscriptionMapper.swift in Sources */,
 				025CA2C2238EBBAA00B05C81 /* ProductShippingClassListMapper.swift in Sources */,
 				74ABA1CD213F1B6B00FFAD30 /* TopEarnerStats.swift in Sources */,
 				CCAAD10F2683974000909664 /* ShippingLabelPackagePurchase.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -627,6 +627,9 @@
 		CE0A0F1F223998A10075ED8D /* products-load-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CE0A0F1E223998A00075ED8D /* products-load-all.json */; };
 		CE12AE9529F29F4F0056DD17 /* order-with-subscription-renewal.json in Resources */ = {isa = PBXBuildFile; fileRef = CE12AE9429F29F4F0056DD17 /* order-with-subscription-renewal.json */; };
 		CE12AE9729F2AB3F0056DD17 /* SubscriptionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12AE9629F2AB3F0056DD17 /* SubscriptionMapper.swift */; };
+		CE12AE9929F2AC2F0056DD17 /* subscription.json in Resources */ = {isa = PBXBuildFile; fileRef = CE12AE9829F2AC2F0056DD17 /* subscription.json */; };
+		CE12AE9B29F2AC3C0056DD17 /* subscription-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE12AE9A29F2AC3C0056DD17 /* subscription-without-data.json */; };
+		CE12AE9D29F2AD1C0056DD17 /* SubscriptionMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12AE9C29F2AD1C0056DD17 /* SubscriptionMapperTests.swift */; };
 		CE12FBD9221F3A6F00C59248 /* OrderStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12FBD8221F3A6F00C59248 /* OrderStatus.swift */; };
 		CE132BBA223851F80029DB6C /* ProductCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE132BB9223851F80029DB6C /* ProductCategory.swift */; };
 		CE132BBC223859710029DB6C /* ProductTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE132BBB223859710029DB6C /* ProductTag.swift */; };
@@ -1554,6 +1557,9 @@
 		CE0A0F1E223998A00075ED8D /* products-load-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-load-all.json"; sourceTree = "<group>"; };
 		CE12AE9429F29F4F0056DD17 /* order-with-subscription-renewal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-subscription-renewal.json"; sourceTree = "<group>"; };
 		CE12AE9629F2AB3F0056DD17 /* SubscriptionMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionMapper.swift; sourceTree = "<group>"; };
+		CE12AE9829F2AC2F0056DD17 /* subscription.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = subscription.json; sourceTree = "<group>"; };
+		CE12AE9A29F2AC3C0056DD17 /* subscription-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "subscription-without-data.json"; sourceTree = "<group>"; };
+		CE12AE9C29F2AD1C0056DD17 /* SubscriptionMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionMapperTests.swift; sourceTree = "<group>"; };
 		CE12FBD8221F3A6F00C59248 /* OrderStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatus.swift; sourceTree = "<group>"; };
 		CE132BB9223851F80029DB6C /* ProductCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategory.swift; sourceTree = "<group>"; };
 		CE132BBB223859710029DB6C /* ProductTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTag.swift; sourceTree = "<group>"; };
@@ -2657,6 +2663,8 @@
 				74E30950216E8DCE00ABCE4C /* site-visits-alt.json */,
 				CCA1D6072943804C00B40560 /* site-summary-stats.json */,
 				022902D122E2436300059692 /* stats_module_disabled_error.json */,
+				CE12AE9829F2AC2F0056DD17 /* subscription.json */,
+				CE12AE9A29F2AC3C0056DD17 /* subscription-without-data.json */,
 				CCE5F38E29EFFE3800087332 /* subscription-list.json */,
 				CCE5F39429F0034400087332 /* subscription-list-without-data.json */,
 				45ED4F11239E8C57004F1BE3 /* taxes-classes.json */,
@@ -2955,6 +2963,7 @@
 				74002D692118B26000A63C19 /* SiteVisitStatsMapperTests.swift */,
 				CCA1D6092943809700B40560 /* SiteSummaryStatsMapperTests.swift */,
 				CCE5F39029F000AC00087332 /* SubscriptionListMapperTests.swift */,
+				CE12AE9C29F2AD1C0056DD17 /* SubscriptionMapperTests.swift */,
 				45ED4F0F239E8A54004F1BE3 /* TaxClassListMapperTest.swift */,
 				74ABA1D4213F26B300FFAD30 /* TopEarnerStatsMapperTests.swift */,
 				D8FBFF0E22D3B25E006E3336 /* WooAPIVersionTests.swift */,
@@ -3295,6 +3304,7 @@
 				B5A2417B217F98FC00595DEF /* broken-notifications.json in Resources */,
 				3158A4A32729F42500C3CFA8 /* wcpay-account-dev-test.json in Resources */,
 				DE50296328C609DE00551736 /* jetpack-user-not-connected.json in Resources */,
+				CE12AE9929F2AC2F0056DD17 /* subscription.json in Resources */,
 				31104E142630DDA700587C1E /* wcpay-account-wrong-json.json in Resources */,
 				3158FE7C26129E2100E566B9 /* wcpay-account-restricted-pending.json in Resources */,
 				DE34051B28BDF12C00CF0D97 /* jetpack-connection-url.json in Resources */,
@@ -3382,6 +3392,7 @@
 				B505F6D520BEE4E700BB1B69 /* me.json in Resources */,
 				D865CE63278CA1DA002C8520 /* stripe-payment-intent-requires-capture.json in Resources */,
 				02A26F1B2744F5FC008E4EDB /* wc-site-settings-partial.json in Resources */,
+				CE12AE9B29F2AC3C0056DD17 /* subscription-without-data.json in Resources */,
 				028FA474257E110700F88A48 /* shipping-label-refund-success.json in Resources */,
 				DE74F29C27E0A1D00002FE59 /* setting-coupon.json in Resources */,
 				EE8A86F1286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json in Resources */,
@@ -4182,6 +4193,7 @@
 				B5C6FCCD20A34B8300A4F8E4 /* OrderListMapperTests.swift in Sources */,
 				B518663520A0A2E800037A38 /* Constants.swift in Sources */,
 				EEA658422966C41A00112DF0 /* ProductIDMapperTests.swift in Sources */,
+				CE12AE9D29F2AD1C0056DD17 /* SubscriptionMapperTests.swift in Sources */,
 				D8FBFF1E22D51F39006E3336 /* OrderStatsMapperV4Tests.swift in Sources */,
 				02E7FFCB256218F600C53030 /* ShippingLabelRemoteTests.swift in Sources */,
 				DE50296528C60A8000551736 /* JetpackUserMapperTests.swift in Sources */,

--- a/Networking/Networking/Mapper/SubscriptionMapper.swift
+++ b/Networking/Networking/Mapper/SubscriptionMapper.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Mapper: `Subscription`
+///
+struct SubscriptionMapper: Mapper {
+    /// Site we're parsing `Subscription` for
+    /// We're injecting this field by copying it in after parsing responses, because `siteID` is not returned in any of the Subscription endpoints.
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert a dictionary into `Subscription`.
+    ///
+    func map(response: Data) throws -> Subscription {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(SubscriptionEnvelope.self, from: response).subscription
+        } else {
+            return try decoder.decode(Subscription.self, from: response)
+        }
+    }
+}
+
+
+/// SubscriptionEnvelope Disposable Entity:
+/// Load Subscription endpoint returns the subscription in the `data` key.
+/// This entity allows us to parse all the things with JSONDecoder.
+///
+private struct SubscriptionEnvelope: Decodable {
+    let subscription: Subscription
+
+    private enum CodingKeys: String, CodingKey {
+        case subscription = "data"
+    }
+}

--- a/Networking/Networking/Remote/SubscriptionsRemote.swift
+++ b/Networking/Networking/Remote/SubscriptionsRemote.swift
@@ -2,6 +2,9 @@ import Foundation
 
 /// Protocol for `SubscriptionsRemote` mainly used for mocking.
 public protocol SubscriptionsRemoteProtocol {
+    func loadSubscription(siteID: Int64,
+                          subscriptionID: Int64,
+                          completion: @escaping (Result<Subscription, Error>) -> Void)
     func loadSubscriptions(siteID: Int64,
                            orderID: Int64,
                            completion: @escaping (Result<[Subscription], Error>) -> Void)
@@ -10,6 +13,26 @@ public protocol SubscriptionsRemoteProtocol {
 /// Subscriptions: Remote Endpoints
 ///
 public final class SubscriptionsRemote: Remote, SubscriptionsRemoteProtocol {
+
+    /// Retrieves a specific `Subscription`.
+    ///
+    /// - Parameters:
+    ///     - siteID: Remote ID of the site that owns the subscriptions.
+    ///     - subscriptionID: Remote ID of the subscription.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func loadSubscription(siteID: Int64, subscriptionID: Int64, completion: @escaping (Result<Subscription, Error>) -> Void) {
+        let path = "\(Path.subscriptions)/\(subscriptionID)"
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: [:],
+                                     availableAsRESTRequest: true)
+        let mapper = SubscriptionMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 
     /// Retrieves all `Subscriptions` for a parent `Order`.
     ///

--- a/Networking/NetworkingTests/Mapper/SubscriptionMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SubscriptionMapperTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import Networking
+
+final class SubscriptionMapperTests: XCTestCase {
+
+    private let sampleSiteID: Int64 = 12983476
+
+    func test_Subscription_map_parses_subscription_in_response() throws {
+        // Given
+        let subscription = try mapLoadSubscriptionResponseWithDataEnvelope()
+
+        // Then
+        XCTAssertNotNil(subscription)
+    }
+
+    func test_Subscription_map_parses_subscription_in_response_without_data_envelope() throws {
+        // Given
+        let subscription = try mapLoadSubscriptionResponseWithoutDataEnvelope()
+
+        // Then
+        XCTAssertNotNil(subscription)
+    }
+
+    func test_Subscription_map_includes_siteID_in_parsed_result() throws {
+        // Given
+        let subscription = try mapLoadSubscriptionResponseWithDataEnvelope()
+
+        // Then
+        XCTAssertEqual(subscription.siteID, sampleSiteID)
+    }
+
+    func test_Subscription_map_parses_all_fields_in_result() throws {
+        // Given
+        let subscription = try mapLoadSubscriptionResponseWithDataEnvelope()
+
+        // Then
+        let expectedSubscription = Subscription(siteID: sampleSiteID,
+                                                subscriptionID: 282,
+                                                parentID: 281,
+                                                status: .active,
+                                                currency: "USD",
+                                                billingPeriod: .week,
+                                                billingInterval: "1",
+                                                total: "14.50",
+                                                startDate: DateFormatter.dateFromString(with: "2023-01-31T16:29:46"),
+                                                endDate: DateFormatter.dateFromString(with: "2023-04-25T16:29:46"))
+
+        assertEqual(expectedSubscription, subscription)
+    }
+
+}
+
+// MARK: - Test Helpers
+///
+private extension SubscriptionMapperTests {
+
+    /// Returns the SubscriptionMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapSubscription(from filename: String) throws -> Subscription {
+        guard let response = Loader.contentsOf(filename) else {
+            throw FileNotFoundError()
+        }
+
+        return try SubscriptionMapper(siteID: sampleSiteID).map(response: response)
+    }
+
+    /// Returns the SubscriptionMapper output from `subscription.json`
+    ///
+    func mapLoadSubscriptionResponseWithDataEnvelope() throws -> Subscription {
+        return try mapSubscription(from: "subscription")
+    }
+
+    /// Returns the SubscriptionMapper output from `subscription-without-data.json`
+    ///
+    func mapLoadSubscriptionResponseWithoutDataEnvelope() throws -> Subscription {
+        return try mapSubscription(from: "subscription-without-data")
+    }
+
+    struct FileNotFoundError: Error {}
+}

--- a/Networking/NetworkingTests/Remote/SubscriptionsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SubscriptionsRemoteTests.swift
@@ -15,9 +15,69 @@ final class SubscriptionsRemoteTests: XCTestCase {
     ///
     private let sampleOrderID: Int64 = 12345
 
+    /// Sample Subscription ID
+    ///
+    private let sampleSubscriptionID: Int64 = 282
+
     override func setUp() {
         super.setUp()
         network.removeAllSimulatedResponses()
+    }
+
+    // MARK: - Load Subscription tests
+
+    /// Verifies that loadSubscription properly parses the `subscription` sample response.
+    ///
+    func test_loadSubscription_returns_parsed_subscription() throws {
+        // Given
+        let remote = SubscriptionsRemote(network: network)
+
+        network.simulateResponse(requestUrlSuffix: "subscriptions/\(sampleSubscriptionID)", filename: "subscription")
+
+        // When
+        let result = waitFor { promise in
+            remote.loadSubscription(siteID: self.sampleSiteID, subscriptionID: self.sampleSubscriptionID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssert(result.isSuccess)
+        let subscription = try XCTUnwrap(result.get())
+        let expectedSubscription = Subscription(siteID: sampleSiteID,
+                                                subscriptionID: sampleSubscriptionID,
+                                                parentID: 281,
+                                                status: .active,
+                                                currency: "USD",
+                                                billingPeriod: .week,
+                                                billingInterval: "1",
+                                                total: "14.50",
+                                                startDate: DateFormatter.dateFromString(with: "2023-01-31T16:29:46"),
+                                                endDate: DateFormatter.dateFromString(with: "2023-04-25T16:29:46"))
+
+        assertEqual(expectedSubscription, subscription)
+    }
+
+    /// Verifies that loadSubscription properly relays Networking Layer errors.
+    ///
+    func test_loadSubscription_properly_relays_networking_errors() throws {
+        // Given
+        let remote = SubscriptionsRemote(network: network)
+
+        let error = NetworkError.unacceptableStatusCode(statusCode: 403)
+        network.simulateError(requestUrlSuffix: "subscriptions/\(sampleSubscriptionID)", error: error)
+
+        // When
+        let result = waitFor { promise in
+            remote.loadSubscription(siteID: self.sampleSiteID, subscriptionID: self.sampleSubscriptionID) { (result) in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        let resultError = try XCTUnwrap(result.failure as? NetworkError)
+        XCTAssertEqual(resultError, .unacceptableStatusCode(statusCode: 403))
     }
 
     // MARK: - Load Subscriptions tests

--- a/Networking/NetworkingTests/Responses/subscription-without-data.json
+++ b/Networking/NetworkingTests/Responses/subscription-without-data.json
@@ -1,0 +1,238 @@
+{
+    "id": 282,
+    "parent_id": 281,
+    "status": "active",
+    "currency": "USD",
+    "version": "7.6.0",
+    "prices_include_tax": false,
+    "date_created": "2023-01-31T16:20:44",
+    "date_modified": "2023-04-18T18:16:11",
+    "discount_total": "0.00",
+    "discount_tax": "0.00",
+    "shipping_total": "0.00",
+    "shipping_tax": "0.00",
+    "cart_tax": "0.00",
+    "total": "14.50",
+    "total_tax": "0.00",
+    "customer_id": 27375286,
+    "order_key": "wc_order_PStHmyhQCqbBN",
+    "billing": {
+        "first_name": "Brooks",
+        "last_name": "Hane",
+        "company": "",
+        "address_1": "885 Susanna Ridges",
+        "address_2": "978 Powlowski Lock",
+        "city": "Ferryville",
+        "state": "DF",
+        "postcode": "01234",
+        "country": "MX",
+        "email": "your.email+fakedata38165@gmail.com",
+        "phone": "536-297-3865"
+    },
+    "shipping": {
+        "first_name": "Brooks",
+        "last_name": "Hane",
+        "company": "",
+        "address_1": "885 Susanna Ridges",
+        "address_2": "978 Powlowski Lock",
+        "city": "Ferryville",
+        "state": "DF",
+        "postcode": "01234",
+        "country": "MX",
+        "phone": "536-297-3865"
+    },
+    "payment_method": "woocommerce_payments",
+    "payment_method_title": "Credit card / debit card",
+    "customer_ip_address": "192.0.123.2",
+    "customer_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+    "created_via": "store-api",
+    "customer_note": "",
+    "date_completed": null,
+    "date_paid": "2023-04-18T18:16:11",
+    "number": "282",
+    "meta_data": [
+        {
+            "id": 7240,
+            "key": "_shipping_hash",
+            "value": "9d4568c009d203ab10e33ea9953a0264"
+        },
+        {
+            "id": 7241,
+            "key": "_coupons_hash",
+            "value": "d751713988987e9331980363e24189ce"
+        },
+        {
+            "id": 7242,
+            "key": "_fees_hash",
+            "value": "d751713988987e9331980363e24189ce"
+        },
+        {
+            "id": 7243,
+            "key": "_taxes_hash",
+            "value": "d751713988987e9331980363e24189ce"
+        },
+        {
+            "id": 7244,
+            "key": "is_vat_exempt",
+            "value": "no"
+        },
+        {
+            "id": 7245,
+            "key": "_customer_ip_country",
+            "value": "US"
+        },
+        {
+            "id": 7246,
+            "key": "_customer_self_declared_country",
+            "value": "false"
+        },
+        {
+            "id": 7264,
+            "key": "_payment_method_id",
+            "value": "pm_1MU8TnFmpgWy4LrlAwUzFd6t"
+        },
+        {
+            "id": 7265,
+            "key": "_stripe_customer_id",
+            "value": "cus_NEbhgaeylNVXDP"
+        },
+        {
+            "id": 9232,
+            "key": "_new_order_tracking_complete",
+            "value": "yes"
+        }
+    ],
+    "line_items": [
+        {
+            "id": 568,
+            "name": "Polo",
+            "product_id": 26,
+            "variation_id": 0,
+            "quantity": 1,
+            "tax_class": "clothing-20010",
+            "subtotal": "14.50",
+            "subtotal_tax": "0.00",
+            "total": "14.50",
+            "total_tax": "0.00",
+            "taxes": [],
+            "meta_data": [
+                {
+                    "id": 4942,
+                    "key": "As a Gift",
+                    "value": "No",
+                    "display_key": "As a Gift",
+                    "display_value": "No"
+                },
+                {
+                    "id": 4943,
+                    "key": "_pao_ids",
+                    "value": [
+                        {
+                            "key": "As a Gift",
+                            "value": "No"
+                        }
+                    ],
+                    "display_key": "_pao_ids",
+                    "display_value": [
+                        {
+                            "key": "As a Gift",
+                            "value": "No"
+                        }
+                    ]
+                },
+                {
+                    "id": 4944,
+                    "key": "_prl_conversion",
+                    "value": "1",
+                    "display_key": "_prl_conversion",
+                    "display_value": "1"
+                },
+                {
+                    "id": 4945,
+                    "key": "_prl_conversion_time",
+                    "value": "1675182546",
+                    "display_key": "_prl_conversion_time",
+                    "display_value": "1675182546"
+                },
+                {
+                    "id": 4946,
+                    "key": "_wcsatt_scheme",
+                    "value": "1_week_12",
+                    "display_key": "_wcsatt_scheme",
+                    "display_value": "1_week_12"
+                }
+            ],
+            "sku": "woo-polo",
+            "price": 14.5,
+            "image": {
+                "id": "55",
+                "src": "https://superlativecentaur.wpcomstaging.com/wp-content/uploads/2023/01/polo-2.jpg"
+            },
+            "parent_name": null
+        }
+    ],
+    "tax_lines": [],
+    "shipping_lines": [
+        {
+            "id": 567,
+            "method_title": "Free shipping",
+            "method_id": "free_shipping",
+            "instance_id": "9",
+            "total": "0.00",
+            "total_tax": "0.00",
+            "taxes": [],
+            "meta_data": [
+                {
+                    "id": 4932,
+                    "key": "Items",
+                    "value": "Polo &times; 1",
+                    "display_key": "Items",
+                    "display_value": "Polo &times; 1"
+                }
+            ]
+        }
+    ],
+    "fee_lines": [],
+    "coupon_lines": [],
+    "payment_url": "https://superlativecentaur.wpcomstaging.com/checkout/order-pay/282/?pay_for_order=true&key=wc_order_PStHmyhQCqbBN",
+    "is_editable": true,
+    "needs_payment": false,
+    "needs_processing": true,
+    "date_created_gmt": "2023-01-31T16:20:44",
+    "date_modified_gmt": "2023-04-18T17:16:11",
+    "date_completed_gmt": null,
+    "date_paid_gmt": "2023-04-18T17:16:11",
+    "billing_period": "week",
+    "billing_interval": "1",
+    "start_date_gmt": "2023-01-31T16:29:46",
+    "trial_end_date_gmt": "",
+    "next_payment_date_gmt": "",
+    "last_payment_date_gmt": "2023-04-18T17:16:08",
+    "cancelled_date_gmt": "",
+    "end_date_gmt": "2023-04-25T16:29:46",
+    "resubscribed_from": "",
+    "resubscribed_subscription": "",
+    "removed_line_items": [],
+    "_links": {
+        "self": [
+            {
+                "href": "https://superlativecentaur.wpcomstaging.com/wp-json/wc/v3/subscriptions/282"
+            }
+        ],
+        "collection": [
+            {
+                "href": "https://superlativecentaur.wpcomstaging.com/wp-json/wc/v3/subscriptions"
+            }
+        ],
+        "customer": [
+            {
+                "href": "https://superlativecentaur.wpcomstaging.com/wp-json/wc/v3/customers/27375286"
+            }
+        ],
+        "up": [
+            {
+                "href": "https://superlativecentaur.wpcomstaging.com/wp-json/wc/v3/orders/281"
+            }
+        ]
+    }
+}

--- a/Networking/NetworkingTests/Responses/subscription.json
+++ b/Networking/NetworkingTests/Responses/subscription.json
@@ -1,0 +1,240 @@
+{
+    "data": {
+        "id": 282,
+        "parent_id": 281,
+        "status": "active",
+        "currency": "USD",
+        "version": "7.6.0",
+        "prices_include_tax": false,
+        "date_created": "2023-01-31T16:20:44",
+        "date_modified": "2023-04-18T18:16:11",
+        "discount_total": "0.00",
+        "discount_tax": "0.00",
+        "shipping_total": "0.00",
+        "shipping_tax": "0.00",
+        "cart_tax": "0.00",
+        "total": "14.50",
+        "total_tax": "0.00",
+        "customer_id": 27375286,
+        "order_key": "wc_order_PStHmyhQCqbBN",
+        "billing": {
+            "first_name": "Brooks",
+            "last_name": "Hane",
+            "company": "",
+            "address_1": "885 Susanna Ridges",
+            "address_2": "978 Powlowski Lock",
+            "city": "Ferryville",
+            "state": "DF",
+            "postcode": "01234",
+            "country": "MX",
+            "email": "your.email+fakedata38165@gmail.com",
+            "phone": "536-297-3865"
+        },
+        "shipping": {
+            "first_name": "Brooks",
+            "last_name": "Hane",
+            "company": "",
+            "address_1": "885 Susanna Ridges",
+            "address_2": "978 Powlowski Lock",
+            "city": "Ferryville",
+            "state": "DF",
+            "postcode": "01234",
+            "country": "MX",
+            "phone": "536-297-3865"
+        },
+        "payment_method": "woocommerce_payments",
+        "payment_method_title": "Credit card / debit card",
+        "customer_ip_address": "192.0.123.2",
+        "customer_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+        "created_via": "store-api",
+        "customer_note": "",
+        "date_completed": null,
+        "date_paid": "2023-04-18T18:16:11",
+        "number": "282",
+        "meta_data": [
+            {
+                "id": 7240,
+                "key": "_shipping_hash",
+                "value": "9d4568c009d203ab10e33ea9953a0264"
+            },
+            {
+                "id": 7241,
+                "key": "_coupons_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 7242,
+                "key": "_fees_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 7243,
+                "key": "_taxes_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 7244,
+                "key": "is_vat_exempt",
+                "value": "no"
+            },
+            {
+                "id": 7245,
+                "key": "_customer_ip_country",
+                "value": "US"
+            },
+            {
+                "id": 7246,
+                "key": "_customer_self_declared_country",
+                "value": "false"
+            },
+            {
+                "id": 7264,
+                "key": "_payment_method_id",
+                "value": "pm_1MU8TnFmpgWy4LrlAwUzFd6t"
+            },
+            {
+                "id": 7265,
+                "key": "_stripe_customer_id",
+                "value": "cus_NEbhgaeylNVXDP"
+            },
+            {
+                "id": 9232,
+                "key": "_new_order_tracking_complete",
+                "value": "yes"
+            }
+        ],
+        "line_items": [
+            {
+                "id": 568,
+                "name": "Polo",
+                "product_id": 26,
+                "variation_id": 0,
+                "quantity": 1,
+                "tax_class": "clothing-20010",
+                "subtotal": "14.50",
+                "subtotal_tax": "0.00",
+                "total": "14.50",
+                "total_tax": "0.00",
+                "taxes": [],
+                "meta_data": [
+                    {
+                        "id": 4942,
+                        "key": "As a Gift",
+                        "value": "No",
+                        "display_key": "As a Gift",
+                        "display_value": "No"
+                    },
+                    {
+                        "id": 4943,
+                        "key": "_pao_ids",
+                        "value": [
+                            {
+                                "key": "As a Gift",
+                                "value": "No"
+                            }
+                        ],
+                        "display_key": "_pao_ids",
+                        "display_value": [
+                            {
+                                "key": "As a Gift",
+                                "value": "No"
+                            }
+                        ]
+                    },
+                    {
+                        "id": 4944,
+                        "key": "_prl_conversion",
+                        "value": "1",
+                        "display_key": "_prl_conversion",
+                        "display_value": "1"
+                    },
+                    {
+                        "id": 4945,
+                        "key": "_prl_conversion_time",
+                        "value": "1675182546",
+                        "display_key": "_prl_conversion_time",
+                        "display_value": "1675182546"
+                    },
+                    {
+                        "id": 4946,
+                        "key": "_wcsatt_scheme",
+                        "value": "1_week_12",
+                        "display_key": "_wcsatt_scheme",
+                        "display_value": "1_week_12"
+                    }
+                ],
+                "sku": "woo-polo",
+                "price": 14.5,
+                "image": {
+                    "id": "55",
+                    "src": "https://example.com/wp-content/uploads/2023/01/polo-2.jpg"
+                },
+                "parent_name": null
+            }
+        ],
+        "tax_lines": [],
+        "shipping_lines": [
+            {
+                "id": 567,
+                "method_title": "Free shipping",
+                "method_id": "free_shipping",
+                "instance_id": "9",
+                "total": "0.00",
+                "total_tax": "0.00",
+                "taxes": [],
+                "meta_data": [
+                    {
+                        "id": 4932,
+                        "key": "Items",
+                        "value": "Polo &times; 1",
+                        "display_key": "Items",
+                        "display_value": "Polo &times; 1"
+                    }
+                ]
+            }
+        ],
+        "fee_lines": [],
+        "coupon_lines": [],
+        "payment_url": "https://example.com/checkout/order-pay/282/?pay_for_order=true&key=wc_order_PStHmyhQCqbBN",
+        "is_editable": true,
+        "needs_payment": false,
+        "needs_processing": true,
+        "date_created_gmt": "2023-01-31T16:20:44",
+        "date_modified_gmt": "2023-04-18T17:16:11",
+        "date_completed_gmt": null,
+        "date_paid_gmt": "2023-04-18T17:16:11",
+        "billing_period": "week",
+        "billing_interval": "1",
+        "start_date_gmt": "2023-01-31T16:29:46",
+        "trial_end_date_gmt": "",
+        "next_payment_date_gmt": "",
+        "last_payment_date_gmt": "2023-04-18T17:16:08",
+        "cancelled_date_gmt": "",
+        "end_date_gmt": "2023-04-25T16:29:46",
+        "resubscribed_from": "",
+        "resubscribed_subscription": "",
+        "removed_line_items": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/subscriptions/282"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/subscriptions"
+                }
+            ],
+            "customer": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/customers/27375286"
+                }
+            ],
+            "up": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/orders/281"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9310
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support in the Networking layer for fetching a specific subscription:

* Adds support for the required Subscriptions endpoint, to fetch a specific subscription using the subscription ID.
* Adds a `SubscriptionMapper` to map the subscription from the response.
* Adds mock API responses and unit tests for the new endpoint and mapper.

Along with the changes in #9528, we can use this to fetch the subscription associated with a subscription renewal order.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Confirm unit tests pass.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
