### PR TITLE
[Subscriptions] Add Yosemite support for fetching subscription for renewal order

### DIFF
--- a/Yosemite/YosemiteTests/Stores/SubscriptionStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SubscriptionStoreTests.swift
@@ -24,6 +24,10 @@ final class SubscriptionStoreTests: XCTestCase {
     ///
     private let sampleOrderID: Int64 = 12345
 
+    /// Sample Subscription ID
+    ///
+    private let sampleSubscriptionID: Int64 = 282
+
     override func setUp() {
         super.setUp()
         network = MockNetwork()
@@ -33,7 +37,57 @@ final class SubscriptionStoreTests: XCTestCase {
 
     // MARK: - loadSubscriptions
 
-    func test_loadSubscriptions_returns_subscriptions_on_success() throws {
+    func test_loadSubscriptions_returns_specific_subscription_for_renewal_order_on_success() throws {
+        // Given
+        network.simulateResponse(requestUrlSuffix: "subscriptions/\(sampleSubscriptionID)", filename: "subscription")
+        let store = SubscriptionStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let renewalOrder = Order.fake().copy(siteID: self.sampleSiteID, renewalSubscriptionID: "\(sampleSubscriptionID)")
+        let result: Result<[Subscription], Error> = waitFor { promise in
+            let action = SubscriptionAction.loadSubscriptions(for: renewalOrder) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let subscription = try XCTUnwrap(result.get().first)
+        let expectedSubscription = Subscription(siteID: sampleSiteID,
+                                                subscriptionID: sampleSubscriptionID,
+                                                parentID: 281,
+                                                status: .active,
+                                                currency: "USD",
+                                                billingPeriod: .week,
+                                                billingInterval: "1",
+                                                total: "14.50",
+                                                startDate: DateFormatter.dateFromString(with: "2023-01-31T16:29:46"),
+                                                endDate: DateFormatter.dateFromString(with: "2023-04-25T16:29:46"))
+        assertEqual(expectedSubscription, subscription)
+    }
+
+    func test_loadSubscriptions_returns_errors_for_renewal_order_on_failure() {
+        // Given
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "subscriptions/\(sampleSubscriptionID)", error: error)
+        let store = SubscriptionStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let renewalOrder = Order.fake().copy(siteID: self.sampleSiteID, renewalSubscriptionID: "\(sampleSubscriptionID)")
+        let result: Result<[Subscription], Error> = waitFor { promise in
+            let action = SubscriptionAction.loadSubscriptions(for: renewalOrder) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, error)
+    }
+
+    func test_loadSubscriptions_returns_subscriptions_for_non_renewal_order_on_success() throws {
         // Given
         network.simulateResponse(requestUrlSuffix: "subscriptions", filename: "subscription-list")
         let store = SubscriptionStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
@@ -52,7 +106,7 @@ final class SubscriptionStoreTests: XCTestCase {
         assertEqual(2, subscriptions.count)
     }
 
-    func test_loadSubscriptions_returns_errors_on_failure() {
+    func test_loadSubscriptions_returns_errors_for_non_renewal_order_on_failure() {
         // Given
         let error = NetworkError.unacceptableStatusCode(statusCode: 500)
         network.simulateError(requestUrlSuffix: "subscriptions", error: error)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9310
⚠️ Depends on #9528, #9530
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support in the Yosemite layer for fetching the subscription associated with a subscription renewal order.

With the Subscriptions extension, there are two ways to get the subscriptions associated with an order:

1. If the order is the initial (parent) subscription order, we can fetch all of the subscriptions related to that order from the subscriptions endpoint, using the order ID. `SubscriptionStore` already supports this scenario.
2. If the order is a subscription renewal order, the subscription ID is stored as metadata on the order. We can fetch the subscription from the subscriptions endpoint, using the subscription ID.

With this PR, `SubscriptionStore.loadSubscriptions(for:)` supports both scenarios. If the order is a renewal order (has a `renewalSubscriptionID`) we fetch the subscription using the subscription ID; otherwise, we load all subscriptions for that order.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Confirm unit tests pass. This action is not yet being used in the app.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
