### PR TITLE
Update StripeTerminal to 2.19.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -51,7 +51,7 @@ def cocoa_lumberjack
 end
 
 def stripe_terminal
-  pod 'StripeTerminal', '~> 2.18'
+  pod 'StripeTerminal', '~> 2.19.1'
 end
 
 def networking_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,7 +33,7 @@ PODS:
   - Sentry/Core (7.31.5)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
-  - StripeTerminal (2.18.0)
+  - StripeTerminal (2.19.1)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (2.2.0)
   - WordPress-Aztec-iOS (1.11.0)
@@ -81,7 +81,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 4.2.2)
   - Kingfisher (~> 7.6.2)
   - Sourcery (~> 1.0.3)
-  - StripeTerminal (~> 2.18)
+  - StripeTerminal (~> 2.19.1)
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `trunk`)
   - WordPressShared (~> 2.1)
@@ -153,7 +153,7 @@ SPEC CHECKSUMS:
   Sentry: 4c9babff9034785067c896fd580b1f7de44da020
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
-  StripeTerminal: 2259c7f6a304d13d016a8bd3aae82beeb79bf305
+  StripeTerminal: 93e18a93c6f92e51ceedc5b78ab3075327075a80
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
@@ -173,6 +173,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 1e3ef3081423f883866741eef178eec8e615d385
+PODFILE CHECKSUM: 444e43974af6f3595aadb19afa3bd94e928b1f02
 
 COCOAPODS: 1.11.3

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 13.4
 -----
-
+- [Internal] Payments: Update StripeTerminal pod to 2.19.1 [https://github.com/woocommerce/woocommerce-ios/pull/9537]
 
 13.3
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

[StripeTerminal 2.19.1](https://github.com/stripe/stripe-terminal-ios/releases/tag/v2.19.1) fixes various edge case bugs with Tap to Pay on iPhone and WisePad 3 readers, compared to 2.18.0 which we are currently on.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run through various IPP payments using Tap to Pay and Bluetooth readers



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
