### PR TITLE
[Subscriptions] Add analytics events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -402,6 +402,12 @@ extension WooAnalyticsEvent {
         static func componentsTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productDetailViewComponentsTapped, properties: [:])
         }
+
+        /// Tracks when the merchant taps the Subscriptions row (applicable for subscription-type products only).
+        ///
+        static func subscriptionsTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDetailsViewSubscriptionsTapped, properties: [:])
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -628,6 +628,12 @@ extension WooAnalyticsEvent {
         static func pluginsNotSyncedYet() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .pluginsNotSyncedYet, properties: [:])
         }
+
+        /// Tracked when subscriptions are displayed in order details.
+        ///
+        static func subscriptionsShown() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderDetailsSubscriptionsShown, properties: [:])
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -392,6 +392,7 @@ public enum WooAnalyticsStat: String {
     case collectPaymentTapped = "payments_flow_order_collect_payment_tapped"
     case orderViewCustomFieldsTapped = "order_view_custom_fields_tapped"
     case orderDetailWaitingTimeLoaded = "order_detail_waiting_time_loaded"
+    case orderDetailsSubscriptionsShown = "order_details_subscriptions_shown"
 
     // MARK: Order List Sorting/Filtering
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -574,6 +574,7 @@ public enum WooAnalyticsStat: String {
     case productDetailPreviewFailed = "product_detail_preview_failed"
     case productDetailViewBundledProductsTapped = "product_detail_view_bundled_products_tapped"
     case productDetailViewComponentsTapped = "product_details_view_components_tapped"
+    case productDetailsViewSubscriptionsTapped = "product_details_view_subscriptions_tapped"
 
     // MARK: Edit Product Variation Events
     //

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -610,7 +610,9 @@ extension OrderDetailsViewModel {
                 switch result {
                 case .success(let subscriptions):
                     self?.dataSource.orderSubscriptions = subscriptions
-                    // TODO: 9238 - Add analytics
+                    if subscriptions.isNotEmpty {
+                        ServiceLocator.analytics.track(event: .Orders.subscriptionsShown())
+                    }
                 case .failure(let error):
                     DDLogError("⛔️ Error synchronizing subscriptions: \(error)")
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -459,7 +459,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 guard isActionable else {
                     return
                 }
-                // TODO: Track row tapped
+                ServiceLocator.analytics.track(event: .ProductDetail.subscriptionsTapped())
                 showSubscriptionSettings()
             case .noVariationsWarning:
                 return // This warning is not actionable.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9238
⚠️ Depends on #9536
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds new tracking events for Subscriptions:

* Event name: `order_details_subscriptions_shown`
   * Trigger: When the "Subscriptions" details are shown in order details.
   * Event registration: 1570-gh-tracks-events-registration
* Event name: `product_details_view_subscriptions_tapped`
   * Trigger: When the "Subscriptions" row is tapped in product details.
   * Event registration: 1571-gh-tracks-events-registration

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Prerequisites

1. Install and activate the [Subscriptions extension](https://woocommerce.com/products/woocommerce-subscriptions/) on your store.
2. Create at least one subscription product.
3. Create an order for that subscription product.

### To test

1. Build and run the app.
2. Go to the Orders tab.
3. Open the subscription order. Confirm the event `order_details_subscriptions_shown` is tracked.
4. Go to the Products tab.
5. Open the subscription product.
6. Select the Subscription row. Confirm the event `product_details_view_subscriptions_tapped` is tracked.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
