### PR TITLE
Release read-only support for Subscriptions

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -90,7 +90,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .IPPUKExpansion:
             return true
         case .readOnlySubscriptions:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .productDescriptionAI:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 13.4
 -----
 - [Internal] Payments: Update StripeTerminal pod to 2.19.1 [https://github.com/woocommerce/woocommerce-ios/pull/9537]
+- [**] Adds read-only support for the Subscriptions extension in order and product details. [https://github.com/woocommerce/woocommerce-ios/pull/9541]
 
 13.3
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This releases read-only support for the Subscriptions extension. It enables support in two places:

1. If an order has an associated subscription (i.e. it is an order to purchase or renew a subscription), a Subscriptions section appears in order details with the details of the subscription.
2. Subscription products (simple or variable) now have a Subscription row showing the subscription settings for the product or variation.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Confirm the change in this PR makes the feature available to all users. If you have time, you can test the feature with the test plan in pe5pgL-2yK-p2.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/8658164/234525657-4560ef7d-593c-4193-8afc-5a80e208c541.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.