### PR TITLE
[Subscriptions] Add support for subscriptions with no end date

### DIFF
--- a/Networking/Networking/Model/Subscription.swift
+++ b/Networking/Networking/Model/Subscription.swift
@@ -31,7 +31,7 @@ public struct Subscription: Decodable, Equatable, GeneratedFakeable, GeneratedCo
     public let startDate: Date
 
     /// The subscription's end date in GMT.
-    public let endDate: Date
+    public let endDate: Date?
 
     /// Subscription struct initializer.
     ///
@@ -44,7 +44,7 @@ public struct Subscription: Decodable, Equatable, GeneratedFakeable, GeneratedCo
                 billingInterval: String,
                 total: String,
                 startDate: Date,
-                endDate: Date) {
+                endDate: Date?) {
         self.siteID = siteID
         self.subscriptionID = subscriptionID
         self.parentID = parentID
@@ -74,7 +74,7 @@ public struct Subscription: Decodable, Equatable, GeneratedFakeable, GeneratedCo
         let billingInterval = try container.decode(String.self, forKey: .billingInterval)
         let total = try container.decode(String.self, forKey: .total)
         let startDate = try container.decode(Date.self, forKey: .startDate)
-        let endDate = try container.decode(Date.self, forKey: .endDate)
+        let endDate = try? container.decode(Date.self, forKey: .endDate)
 
         self.init(siteID: siteID,
                   subscriptionID: subscriptionID,

--- a/Networking/NetworkingTests/Responses/subscription-list.json
+++ b/Networking/NetworkingTests/Responses/subscription-list.json
@@ -449,7 +449,7 @@
             "next_payment_date_gmt": "",
             "last_payment_date_gmt": "2023-04-18T17:16:08",
             "cancelled_date_gmt": "",
-            "end_date_gmt": "2023-04-25T16:29:46",
+            "end_date_gmt": "",
             "resubscribed_from": "",
             "resubscribed_subscription": "",
             "removed_line_items": [],


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
While testing subscriptions, I realized that we're missing support in order details for purchased subscriptions with no end date. (These are subscriptions that are set to "Never expire" in the subscription product settings.)

This PR adds support in the `Subscription` model for a subscription with no end date (an empty string in the API response).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Confirm tests pass.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
