### PR TITLE
Remove `showsFilters` from `ProductSelectorView` configuration

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -418,8 +418,7 @@ struct AddEditCoupon_Previews: PreviewProvider {
 
 private extension ProductSelectorView.Configuration {
     static let productsForCoupons: Self =
-        .init(showsFilters: true,
-              multipleSelectionsEnabled: true,
+        .init(multipleSelectionsEnabled: true,
               doneButtonTitleSingularFormat: Localization.doneButtonSingular,
               doneButtonTitlePluralFormat: Localization.doneButtonPlural,
               title: Localization.title,

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/UsageDetails/CouponRestrictions.swift
@@ -259,8 +259,7 @@ struct CouponRestrictions_Previews: PreviewProvider {
 
 private extension ProductSelectorView.Configuration {
     static let excludedProductsForCoupons: Self =
-        .init(showsFilters: true,
-              multipleSelectionsEnabled: true,
+        .init(multipleSelectionsEnabled: true,
               doneButtonTitleSingularFormat: Localization.doneButtonSingular,
               doneButtonTitlePluralFormat: Localization.doneButtonPlural,
               title: Localization.title,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -360,7 +360,6 @@ struct OrderForm_Previews: PreviewProvider {
 private extension ProductSelectorView.Configuration {
     static func addProductToOrder() -> ProductSelectorView.Configuration {
         ProductSelectorView.Configuration(
-            showsFilters: true,
             multipleSelectionsEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productMultiSelectionM1),
             searchHeaderBackgroundColor: .listBackground,
             prefersLargeTitle: false,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorNavigationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorNavigationView.swift
@@ -29,7 +29,6 @@ struct ProductSelectorNavigationView_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = ProductSelectorViewModel(siteID: 123)
         let configuration = ProductSelectorView.Configuration(
-            showsFilters: true,
             multipleSelectionsEnabled: true,
             title: "Add Product",
             cancelButtonTitle: "Close",

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -59,7 +59,6 @@ struct ProductSelectorView: View {
                 }
                 .buttonStyle(LinkButtonStyle())
                 .fixedSize()
-                .renderedIf(configuration.showsFilters)
             }
             .padding(.horizontal, insets: safeAreaInsets)
 
@@ -189,7 +188,6 @@ struct ProductSelectorView: View {
 
 extension ProductSelectorView {
     struct Configuration {
-        var showsFilters: Bool = false
         var multipleSelectionsEnabled: Bool = false
         var searchHeaderBackgroundColor: UIColor = .listForeground(modal: false)
         var prefersLargeTitle: Bool = true
@@ -225,7 +223,6 @@ struct AddProduct_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = ProductSelectorViewModel(siteID: 123)
         let configuration = ProductSelectorView.Configuration(
-            showsFilters: true,
             multipleSelectionsEnabled: true,
             title: "Add Product",
             cancelButtonTitle: "Close",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9433 

## Description
The `ProductSelectorView` has a `showsFilters` property which is no longer necessary. This PR removes it from the `Configuration` struct.

## Context
The property was initially used to set the different filter configuration for Order creation product single-selection (filter disabled), and Coupons product multi-selection (filter enabled). Since we've moved to use product multi-selection on Order creation, filters are now always visible.

## Testing instructions
**- Order Creation:** Go to Orders > `+` > `+ Add Products` > Confirm the `Filter` button is rendered
**- Coupons:** Go to Menu > Settings > Experimental Features > Enable `Coupon Management` > Menu > Coupons > `+` > Tap on `Percentage discount` > Tap `All Products` > Confirm the `Filter` button is rendered
