### PR TITLE
Product description AI: Yosemite action

### DIFF
--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		026CF62C237D92DC009563D4 /* ProductVariationAttribute+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CF62B237D92DC009563D4 /* ProductVariationAttribute+ReadOnlyConvertible.swift */; };
 		026D52C0238235930092AE05 /* ProductVariationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026D52BF238235930092AE05 /* ProductVariationStoreTests.swift */; };
 		0271E1662509CF0100633F7A /* AnyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0271E1652509CF0100633F7A /* AnyError.swift */; };
+		027CC11129F7AAEA00614B6E /* MockGenerativeContentRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027CC11029F7AAEA00614B6E /* MockGenerativeContentRemote.swift */; };
 		028BCE2422DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BCE2322DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift */; };
 		029249E8274B8AEE002E9C34 /* MockMediaRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029249E7274B8AEE002E9C34 /* MockMediaRemote.swift */; };
 		029B00A7230D64E800B0AE66 /* StatsTimeRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029B00A6230D64E800B0AE66 /* StatsTimeRangeTests.swift */; };
@@ -503,6 +504,7 @@
 		026CF62B237D92DC009563D4 /* ProductVariationAttribute+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariationAttribute+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		026D52BF238235930092AE05 /* ProductVariationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationStoreTests.swift; sourceTree = "<group>"; };
 		0271E1652509CF0100633F7A /* AnyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyError.swift; sourceTree = "<group>"; };
+		027CC11029F7AAEA00614B6E /* MockGenerativeContentRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGenerativeContentRemote.swift; sourceTree = "<group>"; };
 		028BCE2322DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteVisitStatsStoreErrorTests.swift; sourceTree = "<group>"; };
 		029249E7274B8AEE002E9C34 /* MockMediaRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaRemote.swift; sourceTree = "<group>"; };
 		029B00A6230D64E800B0AE66 /* StatsTimeRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeTests.swift; sourceTree = "<group>"; };
@@ -1247,6 +1249,7 @@
 				02616F932921E1CD0095BC00 /* MockSiteRemote.swift */,
 				02F2722E292F18FD00C36419 /* MockPaymentRemote.swift */,
 				EEB4E2CC29B04CE900371C3C /* MockStoreOnboardingTasksRemote.swift */,
+				027CC11029F7AAEA00614B6E /* MockGenerativeContentRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -2299,6 +2302,7 @@
 				029249E8274B8AEE002E9C34 /* MockMediaRemote.swift in Sources */,
 				022F00C72472963E008CD97F /* NotificationCountStoreTests.swift in Sources */,
 				578CE7882475D70F00492EBF /* RetrieveProductReviewFromNoteUseCaseTests.swift in Sources */,
+				027CC11129F7AAEA00614B6E /* MockGenerativeContentRemote.swift in Sources */,
 				02FF056723DEB2180058E6E7 /* MediaStoreTests.swift in Sources */,
 				B5C9DE272087FF20006B910A /* MockAcountStore.swift in Sources */,
 				312DB64D268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -107,4 +107,8 @@ public enum ProductAction: Action {
     /// Creates a product using the provided template type.
     ///
     case createTemplateProduct(siteID: Int64, template: ProductsRemote.TemplateType, onCompletion: (Result<Product, Error>) -> Void)
+
+    /// Generates a product description with Jetpack AI given the name, features, and language code.
+    ///
+    case generateProductDescription(siteID: Int64, name: String, features: String, languageCode: String, completion: (Result<String, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -499,7 +499,9 @@ private extension ProductStore {
         "Product name: \(name)\nFeatures: \(features)\nLanguage: \(languageCode)"
         Task {
             let result = await Result { try await generativeContentRemote.generateText(siteID: siteID, base: prompt) }
-            completion(result)
+            await MainActor.run {
+                completion(result)
+            }
         }
     }
 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGenerativeContentRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGenerativeContentRemote.swift
@@ -1,0 +1,27 @@
+import Networking
+import XCTest
+
+/// Mock for `GenerativeContentRemote`.
+///
+final class MockGenerativeContentRemote {
+    private(set) var generateTextBase: String?
+
+    /// The results to return in `generateText`.
+    private var generateTextResult: Result<String, Error>?
+
+    /// Returns the value when `generateText` is called.
+    func whenGeneratingText(thenReturn result: Result<String, Error>) {
+        generateTextResult = result
+    }
+}
+
+extension MockGenerativeContentRemote: GenerativeContentRemoteProtocol {
+    func generateText(siteID: Int64, base: String) async throws -> String {
+        generateTextBase = base
+        guard let result = generateTextResult else {
+            XCTFail("Could not find result for generating text.")
+            throw NetworkError.notFound
+        }
+        return try result.get()
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9465 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As i1 of AI-generated product description POC pe5sF9-1oI-p2, we're enabling merchants to generate a product description from the product name and features. This PR just contains the Yosemite changes, a new action `ProductAction.generateProductDescription` to generate text from a curated prompt after some testing on my end. This prompt surely isn't perfect, and please feel free to suggest any improvements after testing the integration in a future PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just CI is sufficient, as the new action isn't used in the app. If you're interested in testing how it works, you can also test a [separate branch](https://github.com/woocommerce/woocommerce-ios/compare/feat/9465-product-description-gen-feature-flag?expand=1) including the PR changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.