### PR TITLE
Product description AI: CTA in Aztec editor

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Text.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Text.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+extension UIImage {
+    /// Creates an image from the given text and size.
+    /// - Parameters:
+    ///   - text: Text to be shown in the image. The font size is scaled to fit the size.
+    ///   - size: The size of the image.
+    /// - Returns: An image with the given text and size, if available.
+    static func image(fromText text: String, size: CGSize) -> UIImage? {
+        let attributedString = NSAttributedString(string: text,
+                                                  attributes: [
+                                                    .font: UIFont.systemFont(ofSize: min(size.width, size.height))
+                                                  ])
+
+        // Renders the attributed string to an image.
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        attributedString.draw(in: CGRect(origin: .zero, size: size))
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return image
+    }
+}

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -362,6 +362,12 @@ extension UIImage {
         return UIImage(named: "icon-fixed-product-discount")!
     }
 
+    /// Magic wand icon
+    ///
+    static func magicWandIcon(size: CGSize = .init(width: 24, height: 24)) -> UIImage {
+        .image(fromText: "🪄", size: size)!
+    }
+
     /// Percentage discount icon
     ///
     static var percentageDiscountIcon: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecAIViewFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecAIViewFactory.swift
@@ -1,6 +1,4 @@
-import Aztec
-import Gridicons
-import WordPressEditor
+import UIKit
 
 /// Creates Jetpack AI CTAs in Aztec editor.
 struct AztecAIViewFactory {

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecAIViewFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecAIViewFactory.swift
@@ -8,22 +8,14 @@ struct AztecAIViewFactory {
     func aiButtonNextToFormatBar(onTap: @escaping () -> Void) -> UIView {
         let configuration: UIButton.Configuration = {
             var configuration = UIButton.Configuration.filled()
-            configuration.image = .magicWandIcon(size: .init(width: 16, height: 20))
+            configuration.image = .magicWandIcon(size: Layout.AIButton.imageSize)
             configuration.imagePadding = 0
             configuration.background.backgroundColor = .tertiaryLabel
-            configuration.contentInsets = .init(
-                top: 0,
-                leading: 4,
-                bottom: 0,
-                trailing: 4
-            )
+            configuration.contentInsets = Layout.AIButton.contentInsets
             return configuration
         }()
         let button = UIButton(type: .system)
-        button.accessibilityLabel = NSLocalizedString(
-            "Generate product description with AI",
-            comment: "Accessibility label to generate product description with Jetpack AI from the Aztec editor."
-        )
+        button.accessibilityLabel = Localization.aiButtonAccessibilityLabel
         button.configuration = configuration
         button.on(.touchUpInside) { _ in
             onTap()
@@ -34,16 +26,16 @@ struct AztecAIViewFactory {
         containerView.addSubview(button)
         button.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            button.widthAnchor.constraint(equalToConstant: 24),
-            button.heightAnchor.constraint(equalToConstant: 24),
+            button.widthAnchor.constraint(equalToConstant: Layout.AIButton.size.width),
+            button.heightAnchor.constraint(equalToConstant: Layout.AIButton.size.height),
             button.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
-            button.leadingAnchor.constraint(equalTo: containerView.safeLeadingAnchor, constant: 20),
-            button.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -20),
-            containerView.heightAnchor.constraint(equalToConstant: 44)
+            button.leadingAnchor.constraint(equalTo: containerView.safeLeadingAnchor, constant: Layout.AIButton.horizontalMargin),
+            button.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -Layout.AIButton.horizontalMargin),
+            containerView.heightAnchor.constraint(equalToConstant: Layout.AIButton.containerHeight)
         ])
 
-        let topBorder = UIView.createBorderView(height: 1, color: .divider)
-        let bottomBorder = UIView.createBorderView(height: 1, color: .divider)
+        let topBorder = UIView.createBorderView(height: Layout.borderWidth, color: .divider)
+        let bottomBorder = UIView.createBorderView(height: Layout.borderWidth, color: .divider)
         [topBorder, bottomBorder].forEach {
             containerView.addSubview($0)
             NSLayoutConstraint.activate([
@@ -57,8 +49,8 @@ struct AztecAIViewFactory {
             containerView.bottomAnchor.constraint(equalTo: bottomBorder.bottomAnchor)
         ])
 
-        let verticalBorder = UIView.createSeparatorView(height: 24,
-                                                        width: 1,
+        let verticalBorder = UIView.createSeparatorView(height: Layout.AIButton.size.height,
+                                                        width: Layout.borderWidth,
                                                         color: .divider)
         containerView.addSubview(verticalBorder)
         NSLayoutConstraint.activate([
@@ -67,5 +59,26 @@ struct AztecAIViewFactory {
         ])
 
         return containerView
+    }
+}
+
+private extension AztecAIViewFactory {
+    enum Localization {
+        static let aiButtonAccessibilityLabel = NSLocalizedString(
+            "Generate product description with AI",
+            comment: "Accessibility label to generate product description with Jetpack AI from the Aztec editor."
+        )
+    }
+
+    enum Layout {
+        enum AIButton {
+            static let contentInsets: NSDirectionalEdgeInsets = .init(top: 0, leading: 4, bottom: 0, trailing: 4)
+            static let imageSize: CGSize = .init(width: 16, height: 20)
+            static let size: CGSize = .init(width: 24, height: 24)
+            static let horizontalMargin: CGFloat = 20
+            static let containerHeight: CGFloat = 44
+        }
+
+        static let borderWidth: CGFloat = 1
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecAIViewFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecAIViewFactory.swift
@@ -1,0 +1,73 @@
+import Aztec
+import Gridicons
+import WordPressEditor
+
+/// Creates Jetpack AI CTAs in Aztec editor.
+struct AztecAIViewFactory {
+    /// Returns a view that contains a CTA for the Jetpack AI action to be shown next to the Aztec format bar.
+    /// - Parameter onTap: Called when the CTA is tapped.
+    /// - Returns: View that contains the Jetpack AI CTA.
+    func aiButtonNextToFormatBar(onTap: @escaping () -> Void) -> UIView {
+        let configuration: UIButton.Configuration = {
+            var configuration = UIButton.Configuration.filled()
+            configuration.image = .magicWandIcon(size: .init(width: 16, height: 20))
+            configuration.imagePadding = 0
+            configuration.background.backgroundColor = .tertiaryLabel
+            configuration.contentInsets = .init(
+                top: 0,
+                leading: 4,
+                bottom: 0,
+                trailing: 4
+            )
+            return configuration
+        }()
+        let button = UIButton(type: .system)
+        button.accessibilityLabel = NSLocalizedString(
+            "Generate product description with AI",
+            comment: "Accessibility label to generate product description with Jetpack AI from the Aztec editor."
+        )
+        button.configuration = configuration
+        button.on(.touchUpInside) { _ in
+            onTap()
+        }
+
+        let containerView = UIView(frame: .zero)
+        containerView.backgroundColor = .systemColor(.secondarySystemBackground)
+        containerView.addSubview(button)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            button.widthAnchor.constraint(equalToConstant: 24),
+            button.heightAnchor.constraint(equalToConstant: 24),
+            button.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+            button.leadingAnchor.constraint(equalTo: containerView.safeLeadingAnchor, constant: 20),
+            button.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -20),
+            containerView.heightAnchor.constraint(equalToConstant: 44)
+        ])
+
+        let topBorder = UIView.createBorderView(height: 1, color: .divider)
+        let bottomBorder = UIView.createBorderView(height: 1, color: .divider)
+        [topBorder, bottomBorder].forEach {
+            containerView.addSubview($0)
+            NSLayoutConstraint.activate([
+                containerView.leadingAnchor.constraint(equalTo: $0.leadingAnchor),
+                containerView.trailingAnchor.constraint(equalTo: $0.trailingAnchor)
+            ])
+        }
+
+        NSLayoutConstraint.activate([
+            containerView.topAnchor.constraint(equalTo: topBorder.topAnchor),
+            containerView.bottomAnchor.constraint(equalTo: bottomBorder.bottomAnchor)
+        ])
+
+        let verticalBorder = UIView.createSeparatorView(height: 24,
+                                                        width: 1,
+                                                        color: .divider)
+        containerView.addSubview(verticalBorder)
+        NSLayoutConstraint.activate([
+            verticalBorder.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+            verticalBorder.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
+        ])
+
+        return containerView
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -50,6 +50,10 @@ final class AztecEditorViewController: UIViewController, Editor {
         return AztecFormatBarFactory()
     }()
 
+    private lazy var generatorActionView: UIView = AztecAIViewFactory().aiButtonNextToFormatBar { [weak self] in
+        self?.showProductGeneratorBottomSheet()
+    }
+
     /// Aztec's Format Bar (toolbar above the keyboard)
     ///
     private lazy var formatBar: Aztec.FormatBar = {
@@ -97,12 +101,16 @@ final class AztecEditorViewController: UIViewController, Editor {
 
     private let textViewAttachmentDelegate: TextViewAttachmentDelegate
 
+    private let isAIGenerationEnabled: Bool
+
     required init(content: String?,
                   viewProperties: EditorViewProperties,
-                  textViewAttachmentDelegate: TextViewAttachmentDelegate = AztecTextViewAttachmentHandler()) {
+                  textViewAttachmentDelegate: TextViewAttachmentDelegate = AztecTextViewAttachmentHandler(),
+                  isAIGenerationEnabled: Bool) {
         self.content = content ?? ""
         self.textViewAttachmentDelegate = textViewAttachmentDelegate
         self.viewProperties = viewProperties
+        self.isAIGenerationEnabled = isAIGenerationEnabled
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -186,6 +194,26 @@ private extension AztecEditorViewController {
             return
         }
         recognizer.isEnabled = false
+    }
+
+    func createInputAccessoryView() -> UIView {
+        guard isAIGenerationEnabled else {
+            return formatBar
+        }
+
+        let stackView = UIStackView(arrangedSubviews: [generatorActionView, formatBar])
+        stackView.spacing = 0
+        stackView.axis = .horizontal
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        let accessoryView = InputAccessoryView()
+        accessoryView.addSubview(stackView)
+        accessoryView.pinSubviewToAllEdges(stackView)
+        accessoryView.translatesAutoresizingMaskIntoConstraints = false
+
+        accessoryView.sizeToFit()
+
+        return accessoryView
     }
 }
 
@@ -294,7 +322,13 @@ extension AztecEditorViewController: UITextViewDelegate {
     }
 
     func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
-        textView.inputAccessoryView = formatBar
+        textView.inputAccessoryView = createInputAccessoryView()
         return true
+    }
+}
+
+private extension AztecEditorViewController {
+    func showProductGeneratorBottomSheet() {
+        // TODO: 9465 - show bottom sheet
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -50,7 +50,7 @@ final class AztecEditorViewController: UIViewController, Editor {
         return AztecFormatBarFactory()
     }()
 
-    private lazy var generatorActionView: UIView = AztecAIViewFactory().aiButtonNextToFormatBar { [weak self] in
+    private lazy var aiActionView: UIView = AztecAIViewFactory().aiButtonNextToFormatBar { [weak self] in
         self?.showProductGeneratorBottomSheet()
     }
 
@@ -201,7 +201,7 @@ private extension AztecEditorViewController {
             return formatBar
         }
 
-        let stackView = UIStackView(arrangedSubviews: [generatorActionView, formatBar])
+        let stackView = UIStackView(arrangedSubviews: [aiActionView, formatBar])
         stackView.spacing = 0
         stackView.axis = .horizontal
         stackView.translatesAutoresizingMaskIntoConstraints = false

--- a/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
@@ -12,11 +12,14 @@ final class EditorFactory {
     // MARK: - Editor: Instantiation
 
     func productDescriptionEditor(product: ProductFormDataModel,
+                                  isAIGenerationEnabled: Bool,
                                   onContentSave: @escaping Editor.OnContentSave) -> Editor & UIViewController {
         let viewProperties = EditorViewProperties(navigationTitle: Localization.productDescriptionTitle,
                                                   placeholderText: Localization.placeholderText(product: product),
                                                   showSaveChangesActionSheet: true)
-        let editor = AztecEditorViewController(content: product.description, viewProperties: viewProperties)
+        let editor = AztecEditorViewController(content: product.description,
+                                               viewProperties: viewProperties,
+                                               isAIGenerationEnabled: isAIGenerationEnabled)
         editor.onContentSave = onContentSave
         return editor
     }
@@ -26,7 +29,9 @@ final class EditorFactory {
         let viewProperties = EditorViewProperties(navigationTitle: Localization.productShortDescriptionTitle,
                                                   placeholderText: Localization.placeholderText(product: product),
                                                   showSaveChangesActionSheet: true)
-        let editor = AztecEditorViewController(content: product.shortDescription, viewProperties: viewProperties)
+        let editor = AztecEditorViewController(content: product.shortDescription,
+                                               viewProperties: viewProperties,
+                                               isAIGenerationEnabled: false)
         editor.onContentSave = onContentSave
         return editor
     }

--- a/WooCommerce/Classes/ViewRelated/Keyboard/InputAccessoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/InputAccessoryView.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+/// Allows a text input's `inputAccessoryView` to use Auto Layout subviews above the keyboard.
+/// The main view can be added to its subview, and pins to its edges.
+///
+final class InputAccessoryView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        // Required to make the view grow vertically.
+        autoresizingMask = .flexibleHeight
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var intrinsicContentSize: CGSize {
+        // Calculates intrinsic content size that fits to content.
+        let contentSize = sizeThatFits(CGSize(width: bounds.width, height: .greatestFiniteMagnitude))
+        return CGSize(width: bounds.width, height: contentSize.height)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -66,6 +66,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
     private let showGroupedTableViewAppearance: Bool
 
+    private let aiEligibilityChecker: ProductFormAIEligibilityChecker
+
     init(viewModel: ViewModel,
          eventLogger: ProductFormEventLoggerProtocol,
          productImageActionHandler: ProductImageActionHandler,
@@ -88,6 +90,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                                                                   productImageStatuses: productImageActionHandler.productImageStatuses,
                                                                   productUIImageLoader: productUIImageLoader)
         self.showGroupedTableViewAppearance = showGroupedTableViewAppearance
+        self.aiEligibilityChecker = .init(site: ServiceLocator.stores.sessionManager.defaultSite)
         super.init(nibName: "ProductFormViewController", bundle: nil)
         updateDataSourceActions()
     }
@@ -1167,7 +1170,9 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
     func editProductDescription() {
-        let editorViewController = EditorFactory().productDescriptionEditor(product: product) { [weak self] content in
+        let isAIGenerationEnabled = aiEligibilityChecker.isFeatureEnabled(.description)
+        let editorViewController = EditorFactory().productDescriptionEditor(product: product,
+                                                                            isAIGenerationEnabled: isAIGenerationEnabled) { [weak self] content in
             self?.onEditProductDescriptionCompletion(newDescription: content)
         }
         navigationController?.pushViewController(editorViewController, animated: true)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -450,6 +450,9 @@
 		02CEBB8024C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */; };
 		02CEBB8224C98861002EDF35 /* ProductFormDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */; };
 		02CEBB8424C99A10002EDF35 /* Product+ShippingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */; };
+		02D29A8E29F7C26000473D6D /* InputAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D29A8D29F7C26000473D6D /* InputAccessoryView.swift */; };
+		02D29A9029F7C2DA00473D6D /* AztecAIViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D29A8F29F7C2DA00473D6D /* AztecAIViewFactory.swift */; };
+		02D29A9229F7C39200473D6D /* UIImage+Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D29A9129F7C39200473D6D /* UIImage+Text.swift */; };
 		02D3B68529657061009BF0BC /* SupportButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D3B68429657061009BF0BC /* SupportButton.swift */; };
 		02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */; };
 		02D681A929C358BA00348510 /* StoreOnboardingPaymentsSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D681A829C358BA00348510 /* StoreOnboardingPaymentsSetupView.swift */; };
@@ -2689,6 +2692,9 @@
 		02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryProtocol.swift; sourceTree = "<group>"; };
 		02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormDataModel.swift; sourceTree = "<group>"; };
 		02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ShippingTests.swift"; sourceTree = "<group>"; };
+		02D29A8D29F7C26000473D6D /* InputAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputAccessoryView.swift; sourceTree = "<group>"; };
+		02D29A8F29F7C2DA00473D6D /* AztecAIViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecAIViewFactory.swift; sourceTree = "<group>"; };
+		02D29A9129F7C39200473D6D /* UIImage+Text.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Text.swift"; sourceTree = "<group>"; };
 		02D3B68429657061009BF0BC /* SupportButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportButton.swift; sourceTree = "<group>"; };
 		02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Dot.swift"; sourceTree = "<group>"; };
 		02D681A829C358BA00348510 /* StoreOnboardingPaymentsSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingPaymentsSetupView.swift; sourceTree = "<group>"; };
@@ -5052,6 +5058,7 @@
 				0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */,
 				024DF3062372C18D006658FE /* AztecUIConfigurator.swift */,
 				024DF3082372CA00006658FE /* EditorViewProperties.swift */,
+				02D29A8F29F7C2DA00473D6D /* AztecAIViewFactory.swift */,
 			);
 			path = Editor;
 			sourceTree = "<group>";
@@ -5147,6 +5154,7 @@
 				024DF3042372ADCD006658FE /* KeyboardScrollable.swift */,
 				6856D3846BBF078CB5D955B9 /* KeyboardFrameAdjustmentProvider.swift */,
 				6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */,
+				02D29A8D29F7C26000473D6D /* InputAccessoryView.swift */,
 			);
 			path = Keyboard;
 			sourceTree = "<group>";
@@ -8891,6 +8899,7 @@
 				028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */,
 				DE4D239729ADF8E3003A4B5D /* WordPressAuthenticator+Woo.swift */,
 				EE2A57D629E399CC009F61E1 /* CaseIterable+Helpers.swift */,
+				02D29A9129F7C39200473D6D /* UIImage+Text.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -11425,6 +11434,7 @@
 				DE1B030D268DD01A00804330 /* ReviewOrderViewController.swift in Sources */,
 				B5FD111621D3F13700560344 /* BordersView.swift in Sources */,
 				0262DA5B23A244830029AF30 /* Product+ShippingSettingsViewModels.swift in Sources */,
+				02D29A8E29F7C26000473D6D /* InputAccessoryView.swift in Sources */,
 				0201E42D2946C23600C793C7 /* OptionalStoreCreationProfilerQuestionView.swift in Sources */,
 				0216272B2379662C000208D2 /* DefaultProductFormTableViewModel.swift in Sources */,
 				45E9A6E424DAE1EA00A600E8 /* ProductReviewsViewController.swift in Sources */,
@@ -11916,6 +11926,7 @@
 				027F83ED29B046D2002688C6 /* DashboardTopPerformersViewModel.swift in Sources */,
 				260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */,
 				2678897C270E6E8B00BD249E /* SimplePaymentsAmount.swift in Sources */,
+				02D29A9229F7C39200473D6D /* UIImage+Text.swift in Sources */,
 				09F5DE5D27CF948000E5A4D2 /* BulkUpdateOptionsModel.swift in Sources */,
 				03076D36290C162E008EE839 /* WebViewSheet.swift in Sources */,
 				039B7E6329F136F200E21EF4 /* SetUpTapToPayOnboardingViewController.swift in Sources */,
@@ -11997,6 +12008,7 @@
 				3178C1F726409216000D771A /* BluetoothCardReaderSettingsConnectedViewModel.swift in Sources */,
 				DEF8CF1D29AC84BC00800A60 /* WPComEmailLoginView.swift in Sources */,
 				CC6923AC26010D8D002FB669 /* LoginProloguePageViewController.swift in Sources */,
+				02D29A9029F7C2DA00473D6D /* AztecAIViewFactory.swift in Sources */,
 				4515C88D25D6BE540099C8E3 /* ShippingLabelAddressFormViewController.swift in Sources */,
 				CE5F462A23AACA0A006B1A5C /* RefundDetailsDataSource.swift in Sources */,
 				02162726237963AF000208D2 /* ProductFormViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -204,6 +204,17 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.fixedProductDiscountIcon)
     }
 
+    func test_magicWandIcon_is_not_nil() {
+        // Given
+        let size = CGSize(width: 10, height: 20)
+
+        // When
+        let image = UIImage.magicWandIcon(size: size)
+
+        // Then
+        XCTAssertEqual(size, image.size)
+    }
+
     func test_percentage_discount_icon_is_not_nil() {
         XCTAssertNotNil(UIImage.percentageDiscountIcon)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9465 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

With i1 design for AI-generated product description NMncL2ViLjomfLhuyEhVM1-fi-41_18217, we're adding a CTA next to the format bar in the Aztec editor for product description. This CTA is only shown when the site is eligible for product description AI (hosted on WPCOM for now) and the feature flag is enabled.

### Support Auto Layout views in `inputAccessoryView`

In this PR, a horizontal stack view is now used as the product description text view's `inputAccessoryView` with the AI CTA and the format bar. However, a text input's `inputAccessoryView` doesn't support Auto Layout out of the box (you can test it by directly returning the stack view for the `inputAccessoryView`). A new `InputAccessoryView` class was created with manual intrinsic content size calculation for Auto Layout-based subviews.

### Magic wand icon 🪄 

As in the i1 design, we're showing a magic wand emoji in the CTA. Since another CTA in the product creation bottom sheet (design NMncL2ViLjomfLhuyEhVM1-fi-32_11974) requires an image of the magic wand, I decided to make the magic wand an `UIImage` like other icons but by generating an image with the emoji text. This ensures the CTA in the input accessory view to be the same height, since the Aztec format bar has a constant height 44px and does not support dynamic type.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Product description

#### WPCOM store

- Log in to a WPCOM store if needed
- Create a product if needed
- Go to the Products tab, and tap on a product
- Tap on the product description row --> the input accessory view above the keyboard should have a magic wand CTA to the leading edge of the Aztec format bar
- Go back to the product form
- Tap on the Short description row, or `Add more details` > `Short description` --> the input accessory view above the keyboard should **not** have a magic wand CTA to the leading edge of the Aztec format bar

#### Self-hosted store

- Log in to a self-hosted store
- Create a product if needed
- Go to the Products tab, and tap on a product
- Tap on the product description row --> the input accessory view above the keyboard should **not** have a magic wand CTA to the leading edge of the Aztec format bar
- Go back to the product form
- Tap on the Short description row, or `Add more details` > `Short description` --> the input accessory view above the keyboard should **not** have a magic wand CTA to the leading edge of the Aztec format bar

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light | Jetpack AI disabled
-- | -- | --
![Simulator Screen Shot - iPhone 14 - 2023-04-25 at 16 41 28](https://user-images.githubusercontent.com/1945542/234228263-8b12f8bb-9e4f-4927-b7d0-c89969168635.png) | ![Simulator Screen Shot - iPhone 14 - 2023-04-25 at 16 42 55](https://user-images.githubusercontent.com/1945542/234228288-e343c33c-0fc1-41ae-8725-cd0c0a3a0ce2.png) | ![Simulator Screen Shot - iPhone 14 - 2023-04-25 at 16 43 14](https://user-images.githubusercontent.com/1945542/234228300-3ceb9528-0d87-4062-9262-8ad6026532d6.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.