### PR TITLE
[Gift Cards] Add support for gift cards applied to an order (Networking layer)

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -497,7 +497,8 @@ extension Networking.Order {
             fees: .fake(),
             taxes: .fake(),
             customFields: .fake(),
-            renewalSubscriptionID: .fake()
+            renewalSubscriptionID: .fake(),
+            appliedGiftCards: .fake()
         )
     }
 }
@@ -534,6 +535,17 @@ extension OrderFeeTaxStatus {
     ///
     public static func fake() -> OrderFeeTaxStatus {
         .taxable
+    }
+}
+extension Networking.OrderGiftCard {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.OrderGiftCard {
+        .init(
+            giftCardID: .fake(),
+            code: .fake(),
+            amount: .fake()
+        )
     }
 }
 extension Networking.OrderItem {

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -655,6 +655,7 @@
 		CEC4BF93234E7EE0008D9195 /* refunds-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF92234E7EE0008D9195 /* refunds-all.json */; };
 		CEC4BF95234E7F34008D9195 /* RefundListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */; };
 		CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = CECC759D23D6231900486676 /* order-560-all-refunds.json */; };
+		CEE9187D29F7D636004B23FF /* OrderGiftCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9187C29F7D636004B23FF /* OrderGiftCard.swift */; };
 		CEF88DAB233E911A00BED485 /* order-fully-refunded.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF88DAA233E911A00BED485 /* order-fully-refunded.json */; };
 		CEF88DAD233E95B000BED485 /* OrderRefundCondensed.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF88DAC233E95B000BED485 /* OrderRefundCondensed.swift */; };
 		CEF88DAF233E9F7E00BED485 /* order-details-partially-refunded.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF88DAE233E9F7D00BED485 /* order-details-partially-refunded.json */; };
@@ -1581,6 +1582,7 @@
 		CEC4BF92234E7EE0008D9195 /* refunds-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "refunds-all.json"; sourceTree = "<group>"; };
 		CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundListMapperTests.swift; sourceTree = "<group>"; };
 		CECC759D23D6231900486676 /* order-560-all-refunds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-560-all-refunds.json"; sourceTree = "<group>"; };
+		CEE9187C29F7D636004B23FF /* OrderGiftCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderGiftCard.swift; sourceTree = "<group>"; };
 		CEF88DAA233E911A00BED485 /* order-fully-refunded.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-fully-refunded.json"; sourceTree = "<group>"; };
 		CEF88DAC233E95B000BED485 /* OrderRefundCondensed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderRefundCondensed.swift; sourceTree = "<group>"; };
 		CEF88DAE233E9F7D00BED485 /* order-details-partially-refunded.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-details-partially-refunded.json"; sourceTree = "<group>"; };
@@ -2313,6 +2315,7 @@
 				741B950020EBC8A700DD6E2D /* OrderCouponLine.swift */,
 				D88E228F25AC990A0023F3B1 /* OrderFeeLine.swift */,
 				D88E229325AC9B420023F3B1 /* OrderFeeTaxStatus.swift */,
+				CEE9187C29F7D636004B23FF /* OrderGiftCard.swift */,
 				B5C6FCCE20A3592900A4F8E4 /* OrderItem.swift */,
 				021EAA5525493B3600AA8CCD /* OrderItemAttribute.swift */,
 				CE430671234B9EB20073CBFF /* OrderItemTax.swift */,
@@ -3933,6 +3936,7 @@
 				74046E1B217A684D007DD7BF /* SiteSettingsRemote.swift in Sources */,
 				0359EA1D27AADE000048DE2D /* WCPayChargeMapper.swift in Sources */,
 				B5C6FCCF20A3592900A4F8E4 /* OrderItem.swift in Sources */,
+				CEE9187D29F7D636004B23FF /* OrderGiftCard.swift in Sources */,
 				02C254A025636F6900A04423 /* ShippingLabelRefund.swift in Sources */,
 				26B2F74124C1F2C10065CCC8 /* LeaderboardsRemote.swift in Sources */,
 				CCF48B24262890BB0034EA83 /* ShippingLabelPaymentCardType.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -656,6 +656,7 @@
 		CEC4BF95234E7F34008D9195 /* RefundListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */; };
 		CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */ = {isa = PBXBuildFile; fileRef = CECC759D23D6231900486676 /* order-560-all-refunds.json */; };
 		CEE9187D29F7D636004B23FF /* OrderGiftCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9187C29F7D636004B23FF /* OrderGiftCard.swift */; };
+		CEE9188129F7DC23004B23FF /* order-with-gift-cards.json in Resources */ = {isa = PBXBuildFile; fileRef = CEE9188029F7DC23004B23FF /* order-with-gift-cards.json */; };
 		CEF88DAB233E911A00BED485 /* order-fully-refunded.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF88DAA233E911A00BED485 /* order-fully-refunded.json */; };
 		CEF88DAD233E95B000BED485 /* OrderRefundCondensed.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF88DAC233E95B000BED485 /* OrderRefundCondensed.swift */; };
 		CEF88DAF233E9F7E00BED485 /* order-details-partially-refunded.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF88DAE233E9F7D00BED485 /* order-details-partially-refunded.json */; };
@@ -1583,6 +1584,7 @@
 		CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundListMapperTests.swift; sourceTree = "<group>"; };
 		CECC759D23D6231900486676 /* order-560-all-refunds.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-560-all-refunds.json"; sourceTree = "<group>"; };
 		CEE9187C29F7D636004B23FF /* OrderGiftCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderGiftCard.swift; sourceTree = "<group>"; };
+		CEE9188029F7DC23004B23FF /* order-with-gift-cards.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-gift-cards.json"; sourceTree = "<group>"; };
 		CEF88DAA233E911A00BED485 /* order-fully-refunded.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-fully-refunded.json"; sourceTree = "<group>"; };
 		CEF88DAC233E95B000BED485 /* OrderRefundCondensed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderRefundCondensed.swift; sourceTree = "<group>"; };
 		CEF88DAE233E9F7D00BED485 /* order-details-partially-refunded.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-details-partially-refunded.json"; sourceTree = "<group>"; };
@@ -2541,6 +2543,7 @@
 				0272E3FA254AABB800436277 /* order-with-line-item-attributes-before-API-support.json */,
 				A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */,
 				CE12AE9429F29F4F0056DD17 /* order-with-subscription-renewal.json */,
+				CEE9188029F7DC23004B23FF /* order-with-gift-cards.json */,
 				261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */,
 				0313651A28AE60E000EEE571 /* payment-gateway-cod.json */,
 				261CF2CA255C50010090D8D3 /* payment-gateway-list-half.json */,
@@ -3545,6 +3548,7 @@
 				CECC759E23D6231A00486676 /* order-560-all-refunds.json in Resources */,
 				02E7FFCF25621C7900C53030 /* shipping-label-print.json in Resources */,
 				CE12AE9529F29F4F0056DD17 /* order-with-subscription-renewal.json in Resources */,
+				CEE9188129F7DC23004B23FF /* order-with-gift-cards.json in Resources */,
 				74ABA1CB213F19FE00FFAD30 /* top-performers-week.json in Resources */,
 				456930AD2652AF00009ED69D /* shipping-label-carriers-and-rates-success.json in Resources */,
 				B524194721AC643900D6FC0A /* device-settings.json in Resources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -526,7 +526,8 @@ extension Networking.Order {
         fees: CopiableProp<[OrderFeeLine]> = .copy,
         taxes: CopiableProp<[OrderTaxLine]> = .copy,
         customFields: CopiableProp<[OrderMetaData]> = .copy,
-        renewalSubscriptionID: NullableCopiableProp<String> = .copy
+        renewalSubscriptionID: NullableCopiableProp<String> = .copy,
+        appliedGiftCards: CopiableProp<[OrderGiftCard]> = .copy
     ) -> Networking.Order {
         let siteID = siteID ?? self.siteID
         let orderID = orderID ?? self.orderID
@@ -563,6 +564,7 @@ extension Networking.Order {
         let taxes = taxes ?? self.taxes
         let customFields = customFields ?? self.customFields
         let renewalSubscriptionID = renewalSubscriptionID ?? self.renewalSubscriptionID
+        let appliedGiftCards = appliedGiftCards ?? self.appliedGiftCards
 
         return Networking.Order(
             siteID: siteID,
@@ -599,7 +601,8 @@ extension Networking.Order {
             fees: fees,
             taxes: taxes,
             customFields: customFields,
-            renewalSubscriptionID: renewalSubscriptionID
+            renewalSubscriptionID: renewalSubscriptionID,
+            appliedGiftCards: appliedGiftCards
         )
     }
 }
@@ -654,6 +657,24 @@ extension Networking.OrderFeeLine {
             totalTax: totalTax,
             taxes: taxes,
             attributes: attributes
+        )
+    }
+}
+
+extension Networking.OrderGiftCard {
+    public func copy(
+        giftCardID: CopiableProp<Int64> = .copy,
+        code: CopiableProp<String> = .copy,
+        amount: CopiableProp<Int64> = .copy
+    ) -> Networking.OrderGiftCard {
+        let giftCardID = giftCardID ?? self.giftCardID
+        let code = code ?? self.code
+        let amount = amount ?? self.amount
+
+        return Networking.OrderGiftCard(
+            giftCardID: giftCardID,
+            code: code,
+            amount: amount
         )
     }
 }
@@ -2193,7 +2214,7 @@ extension Networking.Subscription {
         billingInterval: CopiableProp<String> = .copy,
         total: CopiableProp<String> = .copy,
         startDate: CopiableProp<Date> = .copy,
-        endDate: CopiableProp<Date> = .copy
+        endDate: NullableCopiableProp<Date> = .copy
     ) -> Networking.Subscription {
         let siteID = siteID ?? self.siteID
         let subscriptionID = subscriptionID ?? self.subscriptionID

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -52,6 +52,10 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
     ///
     public let renewalSubscriptionID: String?
 
+    /// Gift cards applied to an order (Gift Cards extension only)
+    ///
+    public let appliedGiftCards: [OrderGiftCard]
+
     /// Order struct initializer.
     ///
     public init(siteID: Int64,
@@ -88,7 +92,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                 fees: [OrderFeeLine],
                 taxes: [OrderTaxLine],
                 customFields: [OrderMetaData],
-                renewalSubscriptionID: String?) {
+                renewalSubscriptionID: String?,
+                appliedGiftCards: [OrderGiftCard]) {
 
         self.siteID = siteID
         self.orderID = orderID
@@ -130,6 +135,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
 
         self.customFields = customFields
         self.renewalSubscriptionID = renewalSubscriptionID
+        self.appliedGiftCards = appliedGiftCards
     }
 
 
@@ -211,6 +217,9 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         // Subscriptions extension
         let renewalSubscriptionID = allOrderMetaData?.first(where: { $0.key == "_subscription_renewal" })?.value
 
+        // Gift Cards extension
+        let appliedGiftCards = try container.decodeIfPresent([OrderGiftCard].self, forKey: .giftCards) ?? []
+
         self.init(siteID: siteID,
                   orderID: orderID,
                   parentID: parentID,
@@ -245,7 +254,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                   fees: fees,
                   taxes: taxes,
                   customFields: customFields,
-                  renewalSubscriptionID: renewalSubscriptionID)
+                  renewalSubscriptionID: renewalSubscriptionID,
+                  appliedGiftCards: appliedGiftCards)
     }
 
     public static var empty: Order {
@@ -283,7 +293,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                   fees: [],
                   taxes: [],
                   customFields: [],
-                  renewalSubscriptionID: nil)
+                  renewalSubscriptionID: nil,
+                  appliedGiftCards: [])
     }
 }
 
@@ -329,6 +340,7 @@ internal extension Order {
         case feeLines           = "fee_lines"
         case taxLines           = "tax_lines"
         case metadata           = "meta_data"
+        case giftCards          = "gift_cards"
     }
 }
 

--- a/Networking/Networking/Model/OrderGiftCard.swift
+++ b/Networking/Networking/Model/OrderGiftCard.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Codegen
+
+/// OrderGiftCard entity: Represents a gift card applied to an order.
+///
+public struct OrderGiftCard: Codable, Equatable, GeneratedFakeable, GeneratedCopiable {
+
+    /// Remote ID for the gift card
+    ///
+    public let giftCardID: Int64
+
+    /// Gift card code
+    ///
+    public let code: String
+
+    /// Amount applied to the order
+    ///
+    public let amount: Int64
+
+    /// OrderGiftCard struct initializer.
+    ///
+    public init(giftCardID: Int64, code: String, amount: Int64) {
+        self.giftCardID = giftCardID
+        self.code = code
+        self.amount = amount
+    }
+}
+
+/// Defines all of the OrderGiftCard's CodingKeys.
+///
+private extension OrderGiftCard {
+
+    enum CodingKeys: String, CodingKey {
+        case giftCardID = "id"
+        case code       = "code"
+        case amount     = "amount"
+    }
+}

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -385,6 +385,19 @@ final class OrderMapperTests: XCTestCase {
 
         XCTAssertEqual(order.renewalSubscriptionID, "282")
     }
+
+    func test_order_applied_gift_cards_are_parsed_successfully() throws {
+        // Given
+        let order = try XCTUnwrap(mapLoadOrderWithGiftCards())
+
+        // When
+        let giftCard = try XCTUnwrap(order.appliedGiftCards.first)
+
+        // Then
+        XCTAssertEqual(giftCard.giftCardID, 2)
+        XCTAssertEqual(giftCard.code, "SU9F-MGB5-KS5V-EZFT")
+        XCTAssertEqual(giftCard.amount, 20)
+    }
 }
 
 
@@ -467,6 +480,12 @@ private extension OrderMapperTests {
     ///
     func mapLoadOrderWithSubscriptionRenewal() -> Order? {
         return mapOrder(from: "order-with-subscription-renewal")
+    }
+
+    /// Returns the Order output upon receiving `order-with-gift-cards`
+    ///
+    func mapLoadOrderWithGiftCards() -> Order? {
+        return mapOrder(from: "order-with-gift-cards")
     }
 
 }

--- a/Networking/NetworkingTests/Responses/order-with-gift-cards.json
+++ b/Networking/NetworkingTests/Responses/order-with-gift-cards.json
@@ -1,0 +1,278 @@
+{
+    "data": {
+        "id": 459,
+        "parent_id": 0,
+        "status": "processing",
+        "currency": "USD",
+        "version": "7.5.1",
+        "prices_include_tax": false,
+        "date_created": "2023-03-29T04:21:20",
+        "date_modified": "2023-03-29T04:23:02",
+        "discount_total": "0.00",
+        "discount_tax": "0.00",
+        "shipping_total": "10.00",
+        "shipping_tax": "0.00",
+        "cart_tax": "0.00",
+        "total": "4.00",
+        "total_tax": "0.00",
+        "customer_id": 27375286,
+        "order_key": "wc_order_boLXJYDMOOhSp",
+        "billing": {
+            "first_name": "Tyrel",
+            "last_name": "Senger",
+            "company": "",
+            "address_1": "8412 Dicki Creek",
+            "address_2": "481 General Crossroad",
+            "city": "Denesikton",
+            "state": "Louisiana",
+            "postcode": "903851780",
+            "country": "BB",
+            "email": "your.email+fakedata99085@gmail.com",
+            "phone": "724-024-2595"
+        },
+        "shipping": {
+            "first_name": "Tyrel",
+            "last_name": "Senger",
+            "company": "",
+            "address_1": "8412 Dicki Creek",
+            "address_2": "481 General Crossroad",
+            "city": "Denesikton",
+            "state": "Louisiana",
+            "postcode": "903851780",
+            "country": "BB",
+            "phone": "1234567898"
+        },
+        "payment_method": "woocommerce_payments",
+        "payment_method_title": "Visa credit card",
+        "transaction_id": "pi_3MqpbEFmpgWy4Lrl0vJo4TIn",
+        "customer_ip_address": "189.147.41.13",
+        "customer_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36",
+        "created_via": "store-api",
+        "customer_note": "",
+        "date_completed": null,
+        "date_paid": "2023-03-29T04:23:02",
+        "cart_hash": "dde03e176e78380de9549352abdfbe4a",
+        "number": "459",
+        "meta_data": [
+            {
+                "id": 12849,
+                "key": "_shipping_hash",
+                "value": "9d4568c009d203ab10e33ea9953a0264"
+            },
+            {
+                "id": 12850,
+                "key": "_coupons_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 12851,
+                "key": "_fees_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 12852,
+                "key": "_taxes_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 12853,
+                "key": "is_vat_exempt",
+                "value": "no"
+            },
+            {
+                "id": 12855,
+                "key": "_customer_ip_country",
+                "value": "MX"
+            },
+            {
+                "id": 12856,
+                "key": "_customer_self_declared_country",
+                "value": "false"
+            },
+            {
+                "id": 12858,
+                "key": "_payment_method_id",
+                "value": "pm_1MU8TnFmpgWy4LrlAwUzFd6t"
+            },
+            {
+                "id": 12859,
+                "key": "_stripe_customer_id",
+                "value": "cus_NEbhgaeylNVXDP"
+            },
+            {
+                "id": 12861,
+                "key": "_wcpay_mode",
+                "value": "test"
+            },
+            {
+                "id": 12862,
+                "key": "_intent_id",
+                "value": "pi_3MqpbEFmpgWy4Lrl0vJo4TIn"
+            },
+            {
+                "id": 12863,
+                "key": "_charge_id",
+                "value": "ch_3MqpbEFmpgWy4Lrl0XY98kur"
+            },
+            {
+                "id": 12864,
+                "key": "_intention_status",
+                "value": "succeeded"
+            },
+            {
+                "id": 12865,
+                "key": "_wcpay_intent_currency",
+                "value": "usd"
+            },
+            {
+                "id": 12869,
+                "key": "_wc_points_earned",
+                "value": "36"
+            },
+            {
+                "id": 12871,
+                "key": "_automatewoo_order_created",
+                "value": "1"
+            },
+            {
+                "id": 12872,
+                "key": "_new_order_tracking_complete",
+                "value": "yes"
+            },
+            {
+                "id": 12873,
+                "key": "_wc_connect_destination_normalized",
+                "value": "1"
+            }
+        ],
+        "line_items": [
+            {
+                "id": 921,
+                "name": "Beanie with Logo",
+                "product_id": 36,
+                "variation_id": 0,
+                "quantity": 1,
+                "tax_class": "clothing-20010",
+                "subtotal": "18.00",
+                "subtotal_tax": "0.00",
+                "total": "18.00",
+                "total_tax": "0.00",
+                "taxes": [],
+                "meta_data": [
+                    {
+                        "id": 8166,
+                        "key": "As a Gift",
+                        "value": "No",
+                        "display_key": "As a Gift",
+                        "display_value": "No"
+                    },
+                    {
+                        "id": 8167,
+                        "key": "_pao_ids",
+                        "value": [
+                            {
+                                "key": "As a Gift",
+                                "value": "No"
+                            }
+                        ],
+                        "display_key": "_pao_ids",
+                        "display_value": [
+                            {
+                                "key": "As a Gift",
+                                "value": "No"
+                            }
+                        ]
+                    },
+                    {
+                        "id": 8168,
+                        "key": "_wcsatt_scheme",
+                        "value": "0",
+                        "display_key": "_wcsatt_scheme",
+                        "display_value": "0"
+                    },
+                    {
+                        "id": 8189,
+                        "key": "_reduced_stock",
+                        "value": "1",
+                        "display_key": "_reduced_stock",
+                        "display_value": "1"
+                    }
+                ],
+                "sku": "Woo-beanie-logo",
+                "price": 18,
+                "image": {
+                    "id": "59",
+                    "src": "https://example.com/wp-content/uploads/2023/01/beanie-with-logo-1.jpg"
+                },
+                "parent_name": null,
+                "composite_parent": "",
+                "composite_children": [],
+                "bundled_by": "",
+                "bundled_item_title": "",
+                "bundled_items": []
+            }
+        ],
+        "tax_lines": [],
+        "shipping_lines": [
+            {
+                "id": 923,
+                "method_title": "Flat rate",
+                "method_id": "flat_rate",
+                "instance_id": "3",
+                "total": "10.00",
+                "total_tax": "0.00",
+                "taxes": [],
+                "meta_data": [
+                    {
+                        "id": 8180,
+                        "key": "Items",
+                        "value": "Beanie with Logo &times; 1",
+                        "display_key": "Items",
+                        "display_value": "Beanie with Logo &times; 1"
+                    }
+                ]
+            }
+        ],
+        "fee_lines": [],
+        "coupon_lines": [],
+        "refunds": [],
+        "payment_url": "https://example.com/checkout/order-pay/459/?pay_for_order=true&key=wc_order_boLXJYDMOOhSp",
+        "is_editable": false,
+        "needs_payment": false,
+        "needs_processing": true,
+        "date_created_gmt": "2023-03-29T03:21:20",
+        "date_modified_gmt": "2023-03-29T03:23:02",
+        "date_completed_gmt": null,
+        "date_paid_gmt": "2023-03-29T03:23:02",
+        "gift_cards": [
+            {
+                "id": 2,
+                "code": "SU9F-MGB5-KS5V-EZFT",
+                "amount": 20
+            },
+            {
+                "id": 4,
+                "code": "NZR8-BMP8-XJZ2-ZKS9",
+                "amount": 4
+            }
+        ],
+        "currency_symbol": "$",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/orders/459"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/orders"
+                }
+            ],
+            "customer": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/customers/27375286"
+                }
+            ]
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -493,7 +493,8 @@ struct EditAddressForm_Previews: PreviewProvider {
                                    fees: [],
                                    taxes: [],
                                    customFields: [],
-                                   renewalSubscriptionID: nil)
+                                   renewalSubscriptionID: nil,
+                                   appliedGiftCards: [])
 
     static let sampleAddress = Address(firstName: "Johnny",
                                        lastName: "Appleseed",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -476,7 +476,8 @@ extension ShippingLabelPackagesFormViewModel {
                      fees: [],
                      taxes: [],
                      customFields: [],
-                     renewalSubscriptionID: nil)
+                     renewalSubscriptionID: nil,
+                     appliedGiftCards: [])
     }
 
     static func sampleAddress() -> Address {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
@@ -40,7 +40,8 @@ enum ShippingLabelSampleData {
                      fees: [],
                      taxes: [],
                      customFields: [],
-                     renewalSubscriptionID: nil)
+                     renewalSubscriptionID: nil,
+                     appliedGiftCards: [])
     }
 
     static func samplePackageDetails() -> ShippingLabelPackagesResponse {

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -364,7 +364,8 @@ extension MockObjectGraph {
             fees: [],
             taxes: [],
             customFields: [],
-            renewalSubscriptionID: nil
+            renewalSubscriptionID: nil,
+            appliedGiftCards: []
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -112,7 +112,8 @@ extension Storage.Order: ReadOnlyConvertible {
                      fees: orderFeeLines,
                      taxes: orderTaxLines,
                      customFields: orderCustomFields,
-                     renewalSubscriptionID: nil)
+                     renewalSubscriptionID: nil,
+                     appliedGiftCards: [])
 
     }
 

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -42,7 +42,8 @@ public enum OrderFactory {
               fees: [simplePaymentFee(feeID: 0, amount: amount, taxable: taxable)],
               taxes: [],
               customFields: [],
-              renewalSubscriptionID: nil)
+              renewalSubscriptionID: nil,
+              appliedGiftCards: [])
     }
 
     /// Creates a fee line suitable to be used within a simple payments order.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8957
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are adding read-only support for the [Gift Cards](https://woocommerce.com/products/gift-cards/) extension in order details, to display any gift cards applied to an order (used for payment on the order).

This PR adds support in the Networking layer for gift cards applied to an order.

### Changes
* Adds an `OrderGiftCard` entity to represent a gift card applied to an order. (This does not include full details about the gift card; it represents the summary details included in the Order API response.)
* Adds an `appliedGiftCards` property to the `Order` entity, to represent all gift cards applied to an order.
* Updates the generated `fake()` and `copy()` methods, and adds the new property as needed where `Order` is used.
* Adds a mock API response and unit test for mapping an Order with applied gift cards.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Confirm tests pass and there are no issues loading the order list on the Orders tab in the app.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
