### PR TITLE
Login: Restore social logins for WPCom login flow

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -85,8 +85,8 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
 #  pod 'WordPressAuthenticator', '~> 6.0.0'
-#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'f4199f843f6480af54d9d307796850a7ecfebf4e'
+#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   wordpress_shared

--- a/Podfile
+++ b/Podfile
@@ -85,8 +85,8 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
 #  pod 'WordPressAuthenticator', '~> 6.0.0'
-   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'f4199f843f6480af54d9d307796850a7ecfebf4e'
-#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
+#   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'trunk'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   wordpress_shared

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -39,7 +39,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (6.1.0):
+  - WordPressAuthenticator (6.2.0-beta.1):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -83,7 +83,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `trunk`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `f4199f843f6480af54d9d307796850a7ecfebf4e`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.12.5)
   - Wormholy (~> 1.6.6)
@@ -129,12 +129,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :branch: trunk
+    :commit: f4199f843f6480af54d9d307796850a7ecfebf4e
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: 1ebe6f64508658370b25014185105fd6fb7a3617
+    :commit: f4199f843f6480af54d9d307796850a7ecfebf4e
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -158,7 +158,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 9956582dabc0e98fc6f22ef960c52d8a3480b2d8
+  WordPressAuthenticator: 022b4354e9de3e43b1dc763e5fc88fe65497bc67
   WordPressKit: b65a51863982d8166897bea8b753f1fc51732aad
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -173,6 +173,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 1e3ef3081423f883866741eef178eec8e615d385
+PODFILE CHECKSUM: 88fbd80edc2e378787350959954039b0a19823d6
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -83,7 +83,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 2.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `f4199f843f6480af54d9d307796850a7ecfebf4e`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `trunk`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.12.5)
   - Wormholy (~> 1.6.6)
@@ -129,12 +129,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: f4199f843f6480af54d9d307796850a7ecfebf4e
+    :branch: trunk
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: f4199f843f6480af54d9d307796850a7ecfebf4e
+    :commit: 37872e28975c89e1c7b95d361d25ca7ffee88aa9
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -173,6 +173,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 88fbd80edc2e378787350959954039b0a19823d6
+PODFILE CHECKSUM: 1e3ef3081423f883866741eef178eec8e615d385
 
 COCOAPODS: 1.11.3

--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -26,7 +26,6 @@ extension WordPressAuthenticator {
                                                                 enableSignupWithGoogle: false,
                                                                 enableUnifiedAuth: true,
                                                                 continueWithSiteAddressFirst: false,
-                                                                enableSiteCredentialsLoginForSelfHostedSites: true,
                                                                 isWPComLoginRequiredForSiteCredentialsLogin: false,
                                                                 isWPComMagicLinkPreferredToPassword: isWPComMagicLinkPreferredToPassword,
                                                                 isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen:

--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -41,8 +41,7 @@ extension WordPressAuthenticator {
                                                                 enableManualSiteCredentialLogin: true,
                                                                 enableManualErrorHandlingForSiteCredentialLogin: isManualErrorHandlingEnabled,
                                                                 useEnterEmailAddressAsStepValueForGetStartedVC: true,
-                                                                enableSiteAddressLoginOnlyInPrologue: true,
-                                                                enableSiteCredentialLoginForJetpackSites: false)
+                                                                enableSiteAddressLoginOnlyInPrologue: true)
 
         let systemGray3LightModeColor = UIColor(red: 199/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1)
         let systemLabelLightModeColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #9549 
Please also review https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/771

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously in #7298 we added two configs `enableSiteCredentialsLoginForSelfHostedSites`. This decides whether to show the "Log In with Site Credential" button when a user enters the site address login flow.

With our recent changes to the login flow, we are keeping the site address login flow as the default and either navigating to site credential login or WPCom login based on whether the input site has Jetpack installed and configured. We then added a new configure for the authenticator as part of #8845 - but this is unnecessary. This change also creates a new variant of the WPCom login screen with only the Continue button.

To restore the missing social login buttons, this PR removes the custom value for `enableSiteCredentialsLoginForSelfHostedSites` (the default one is `false`). This also removes the redundant config `enableSiteCredentialLoginForJetpackSites` to reduce ambiguity. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log out of the app if needed.
- On the prologue screen, select Log In.
- Enter the address of a Jetpack site.
- On the WPCom login screen, notice that the social login buttons are present.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/5533851/234257802-2374a579-ed75-432b-afc0-f463161962f9.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
