### PR TITLE
Product description AI: native bottom sheet from CTA in Aztec editor

### DIFF
--- a/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetPresenter.swift
@@ -12,19 +12,15 @@ extension UISheetPresentationController: BottomSheetConfigurable {}
 
 /// Handles presentation and dismissal of a bottom sheet natively.
 final class BottomSheetPresenter: NSObject {
+    typealias ConfigureBottomSheet = (BottomSheetConfigurable) -> Void
+
     private var viewController: UIViewController?
     private var onDismiss: (() -> Void)?
 
-    private let configure: ((BottomSheetConfigurable) -> Void)
+    private let configure: ConfigureBottomSheet
 
     /// - Parameter configure: Customizations of the bottom sheet with a default implementation.
-    init(configure: @escaping ((BottomSheetConfigurable) -> Void) = { bottomSheet in
-        var sheet = bottomSheet
-        sheet.prefersEdgeAttachedInCompactHeight = true
-        sheet.largestUndimmedDetentIdentifier = .large
-        sheet.prefersGrabberVisible = false
-        sheet.detents = [.medium()]
-    }) {
+    init(configure: @escaping ConfigureBottomSheet = Defaults.config) {
         self.configure = configure
     }
 
@@ -69,5 +65,17 @@ private extension BottomSheetPresenter {
         onDismiss?()
         onDismiss = nil
         viewController = nil
+    }
+}
+
+private extension BottomSheetPresenter {
+    enum Defaults {
+        static let config: ConfigureBottomSheet = { bottomSheet in
+            var sheet = bottomSheet
+            sheet.prefersEdgeAttachedInCompactHeight = true
+            sheet.largestUndimmedDetentIdentifier = .large
+            sheet.prefersGrabberVisible = false
+            sheet.detents = [.medium()]
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetPresenter.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+/// Based on `UISheetPresentationController`'s properties for bottom sheet customizations.
+protocol BottomSheetConfigurable {
+    var prefersEdgeAttachedInCompactHeight: Bool { get set }
+    var largestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier? { get set }
+    var prefersGrabberVisible: Bool { get set }
+    var detents: [UISheetPresentationController.Detent] { get set }
+}
+
+extension UISheetPresentationController: BottomSheetConfigurable {}
+
+/// Handles presentation and dismissal of a bottom sheet natively.
+final class BottomSheetPresenter: NSObject {
+    private var viewController: UIViewController?
+    private var onDismiss: (() -> Void)?
+
+    private let configure: ((BottomSheetConfigurable) -> Void)
+
+    /// - Parameter configure: Customizations of the bottom sheet with a default implementation.
+    init(configure: @escaping ((BottomSheetConfigurable) -> Void) = { bottomSheet in
+        var sheet = bottomSheet
+        sheet.prefersEdgeAttachedInCompactHeight = true
+        sheet.largestUndimmedDetentIdentifier = .large
+        sheet.prefersGrabberVisible = false
+        sheet.detents = [.medium()]
+    }) {
+        self.configure = configure
+    }
+
+    /// Presents a view controller in a bottom sheet.
+    /// - Parameters:
+    ///   - viewController: View controller to present in a bottom sheet.
+    ///   - sourceViewController: View controller that presents the bottom sheet.
+    ///   - onDismiss: Called when the bottom sheet is dismissed interactively (dragging down gesture).
+    func present(_ viewController: UIViewController,
+                 from sourceViewController: UIViewController,
+                 onDismiss: (() -> Void)? = nil) {
+        self.viewController = viewController
+        self.onDismiss = onDismiss
+        if let sheet = viewController.sheetPresentationController {
+            configure(sheet)
+        }
+        viewController.presentationController?.delegate = self
+        sourceViewController.present(viewController, animated: true)
+    }
+
+    /// Dismisses the previously presented bottom sheet.
+    func dismiss(onDismiss: (() -> Void)? = nil) {
+        viewController?.dismiss(animated: true) { [weak self] in
+            guard let self else { return }
+            self.viewController = nil
+            onDismiss?()
+        }
+    }
+}
+
+extension BottomSheetPresenter: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        onDismiss?()
+        onDismiss = nil
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetPresenter.swift
@@ -46,7 +46,12 @@ final class BottomSheetPresenter: NSObject {
     }
 
     /// Dismisses the previously presented bottom sheet.
-    func dismiss() {
+    /// - Parameter onDismiss: Called when the bottom sheet is dismissed. If non-nil, the `onDismiss` from the `present` call is
+    ///   replaced by the new callback.
+    func dismiss(onDismiss: (() -> Void)? = nil) {
+        if let onDismiss {
+            self.onDismiss = onDismiss
+        }
         viewController?.dismiss(animated: true) { [weak self] in
             self?.onDismissCompletion()
         }

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetPresenter.swift
@@ -46,18 +46,23 @@ final class BottomSheetPresenter: NSObject {
     }
 
     /// Dismisses the previously presented bottom sheet.
-    func dismiss(onDismiss: (() -> Void)? = nil) {
+    func dismiss() {
         viewController?.dismiss(animated: true) { [weak self] in
-            guard let self else { return }
-            self.viewController = nil
-            onDismiss?()
+            self?.onDismissCompletion()
         }
     }
 }
 
 extension BottomSheetPresenter: UIAdaptivePresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        onDismissCompletion()
+    }
+}
+
+private extension BottomSheetPresenter {
+    func onDismissCompletion() {
         onDismiss?()
         onDismiss = nil
+        viewController = nil
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -51,7 +51,7 @@ final class AztecEditorViewController: UIViewController, Editor {
     }()
 
     private lazy var aiActionView: UIView = AztecAIViewFactory().aiButtonNextToFormatBar { [weak self] in
-        self?.showProductGeneratorBottomSheet()
+        self?.showDescriptionGenerationBottomSheet()
     }
 
     /// Aztec's Format Bar (toolbar above the keyboard)
@@ -102,6 +102,7 @@ final class AztecEditorViewController: UIViewController, Editor {
     private let textViewAttachmentDelegate: TextViewAttachmentDelegate
 
     private let isAIGenerationEnabled: Bool
+    private var bottomSheetPresenter: BottomSheetPresenter?
 
     required init(content: String?,
                   viewProperties: EditorViewProperties,
@@ -150,6 +151,11 @@ final class AztecEditorViewController: UIViewController, Editor {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         richTextView.becomeFirstResponder()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        dismissDescriptionGenerationBottomSheetIfNeeded()
     }
 }
 
@@ -328,7 +334,27 @@ extension AztecEditorViewController: UITextViewDelegate {
 }
 
 private extension AztecEditorViewController {
-    func showProductGeneratorBottomSheet() {
-        // TODO: 9465 - show bottom sheet
+    func showDescriptionGenerationBottomSheet() {
+        let presenter = BottomSheetPresenter(configure: { bottomSheet in
+            var sheet = bottomSheet
+            sheet.prefersEdgeAttachedInCompactHeight = true
+            sheet.largestUndimmedDetentIdentifier = .large
+            sheet.prefersGrabberVisible = true
+            sheet.detents = [.medium(), .large()]
+        })
+        bottomSheetPresenter = presenter
+
+        // TODO: 9465 - show product description generation in the bottom sheet
+        let controller = UIViewController()
+        controller.view.backgroundColor = .primaryButtonBackground
+
+        view.endEditing(true)
+        presenter.present(controller, from: self) { [weak self] in
+            self?.richTextView.becomeFirstResponder()
+        }
+    }
+
+    func dismissDescriptionGenerationBottomSheetIfNeeded() {
+        bottomSheetPresenter?.dismiss()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -328,6 +328,7 @@ extension AztecEditorViewController: UITextViewDelegate {
     }
 
     func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
+        dismissDescriptionGenerationBottomSheetIfNeeded()
         textView.inputAccessoryView = createInputAccessoryView()
         return true
     }

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -349,12 +349,12 @@ private extension AztecEditorViewController {
         controller.view.backgroundColor = .primaryButtonBackground
 
         view.endEditing(true)
-        presenter.present(controller, from: self) { [weak self] in
+        presenter.present(controller, from: self, onDismiss: { [weak self] in
             self?.richTextView.becomeFirstResponder()
-        }
+        })
     }
 
     func dismissDescriptionGenerationBottomSheetIfNeeded() {
-        bottomSheetPresenter?.dismiss()
+        bottomSheetPresenter?.dismiss(onDismiss: {})
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -440,6 +440,7 @@
 		02C887712450285100E4470F /* BottomButtonContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C887702450285100E4470F /* BottomButtonContainerView.swift */; };
 		02C88775245036D400E4470F /* FilterProductListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C88774245036D400E4470F /* FilterProductListViewModel.swift */; };
 		02CA3C9729F8E54D0079E2FF /* BottomSheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA3C9629F8E54D0079E2FF /* BottomSheetPresenter.swift */; };
+		02CA3C9A29F8EB6A0079E2FF /* BottomSheetPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA3C9929F8EB6A0079E2FF /* BottomSheetPresenterTests.swift */; };
 		02CA63DA23D1ADD100BBF148 /* CameraCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D623D1ADD100BBF148 /* CameraCaptureCoordinator.swift */; };
 		02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */; };
 		02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */; };
@@ -2685,6 +2686,7 @@
 		02C887702450285100E4470F /* BottomButtonContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonContainerView.swift; sourceTree = "<group>"; };
 		02C88774245036D400E4470F /* FilterProductListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModel.swift; sourceTree = "<group>"; };
 		02CA3C9629F8E54D0079E2FF /* BottomSheetPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetPresenter.swift; sourceTree = "<group>"; };
+		02CA3C9929F8EB6A0079E2FF /* BottomSheetPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetPresenterTests.swift; sourceTree = "<group>"; };
 		02CA63D623D1ADD100BBF148 /* CameraCaptureCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraCaptureCoordinator.swift; sourceTree = "<group>"; };
 		02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingCoordinator.swift; sourceTree = "<group>"; };
 		02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceMediaLibraryPicker.swift; sourceTree = "<group>"; };
@@ -5568,6 +5570,14 @@
 				02C887702450285100E4470F /* BottomButtonContainerView.swift */,
 			);
 			path = BottomButtonContainer;
+			sourceTree = "<group>";
+		};
+		02CA3C9829F8EB580079E2FF /* BottomSheet */ = {
+			isa = PBXGroup;
+			children = (
+				02CA3C9929F8EB6A0079E2FF /* BottomSheetPresenterTests.swift */,
+			);
+			path = BottomSheet;
 			sourceTree = "<group>";
 		};
 		02CE43052769946A0006EAEF /* SKU Scanner */ = {
@@ -9393,6 +9403,7 @@
 		D816DDBA22265D8000903E59 /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				02CA3C9829F8EB580079E2FF /* BottomSheet */,
 				DEF8CF0B29A76F6200800A60 /* JetpackSetup */,
 				02645D8027BA20950065DC68 /* Inbox */,
 				BAA34C1E2787494300846F3C /* Reviews */,
@@ -12320,6 +12331,7 @@
 				02ADC7CE23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift in Sources */,
 				45C8B25B231521510002FA77 /* CustomerNoteTableViewCellTests.swift in Sources */,
 				B5980A6721AC91AA00EBF596 /* BundleWooTests.swift in Sources */,
+				02CA3C9A29F8EB6A0079E2FF /* BottomSheetPresenterTests.swift in Sources */,
 				026D4A24280461960090164F /* LegacyCollectOrderPaymentUseCaseTests.swift in Sources */,
 				D88D5A3D230B5E85007B6E01 /* ServiceLocatorTests.swift in Sources */,
 				269098BA27D6922E001FEB07 /* FeesInputTransformerTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -439,6 +439,7 @@
 		02C8876E24501FAC00E4470F /* FilterListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02C8876C24501FAC00E4470F /* FilterListViewController.xib */; };
 		02C887712450285100E4470F /* BottomButtonContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C887702450285100E4470F /* BottomButtonContainerView.swift */; };
 		02C88775245036D400E4470F /* FilterProductListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C88774245036D400E4470F /* FilterProductListViewModel.swift */; };
+		02CA3C9729F8E54D0079E2FF /* BottomSheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA3C9629F8E54D0079E2FF /* BottomSheetPresenter.swift */; };
 		02CA63DA23D1ADD100BBF148 /* CameraCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D623D1ADD100BBF148 /* CameraCaptureCoordinator.swift */; };
 		02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */; };
 		02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */; };
@@ -2683,6 +2684,7 @@
 		02C8876C24501FAC00E4470F /* FilterListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FilterListViewController.xib; sourceTree = "<group>"; };
 		02C887702450285100E4470F /* BottomButtonContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonContainerView.swift; sourceTree = "<group>"; };
 		02C88774245036D400E4470F /* FilterProductListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModel.swift; sourceTree = "<group>"; };
+		02CA3C9629F8E54D0079E2FF /* BottomSheetPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetPresenter.swift; sourceTree = "<group>"; };
 		02CA63D623D1ADD100BBF148 /* CameraCaptureCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraCaptureCoordinator.swift; sourceTree = "<group>"; };
 		02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingCoordinator.swift; sourceTree = "<group>"; };
 		02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceMediaLibraryPicker.swift; sourceTree = "<group>"; };
@@ -4871,6 +4873,7 @@
 			children = (
 				0235595624496C08004BE2B8 /* ListSelector */,
 				DE3877E1283CCBC20075D87E /* BottomSheetListSelector.swift */,
+				02CA3C9629F8E54D0079E2FF /* BottomSheetPresenter.swift */,
 			);
 			path = BottomSheet;
 			sourceTree = "<group>";
@@ -11402,6 +11405,7 @@
 				26771A14256FFA8700EE030E /* IssueRefundCoordinatingController.swift in Sources */,
 				027A2E162513356100DA6ACB /* AppleIDCredentialChecker.swift in Sources */,
 				26B98758273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift in Sources */,
+				02CA3C9729F8E54D0079E2FF /* BottomSheetPresenter.swift in Sources */,
 				4524CD9E242D01FD00B2F20A /* ProductStatusSettingListSelectorCommand.swift in Sources */,
 				02F6800325807C9B00C3BAD2 /* ShippingLabelPaperSizeOptionListView.swift in Sources */,
 				02E8B17723E2C49000A43403 /* InProgressProductImageCollectionViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/BottomSheet/BottomSheetPresenterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/BottomSheet/BottomSheetPresenterTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import WooCommerce
+
+final class BottomSheetPresenterTests: XCTestCase {
+    func test_sheet_customizations_are_set_to_sheetPresentationController() throws {
+        // Given
+        let presenter = BottomSheetPresenter { bottomSheet in
+            var sheet = bottomSheet
+            sheet.prefersEdgeAttachedInCompactHeight = false
+            sheet.largestUndimmedDetentIdentifier = nil
+            sheet.prefersGrabberVisible = false
+            sheet.detents = [.large()]
+        }
+        let viewController = UIViewController()
+
+        // When
+        presenter.present(viewController, from: .init())
+
+        // Then
+        XCTAssertTrue(viewController.sheetPresentationController?.prefersEdgeAttachedInCompactHeight == false)
+        XCTAssertNil(viewController.sheetPresentationController?.largestUndimmedDetentIdentifier)
+        XCTAssertTrue(viewController.sheetPresentationController?.prefersGrabberVisible == false)
+        XCTAssertEqual(viewController.sheetPresentationController?.detents, [.large()])
+    }
+
+    func test_dismiss_sheet_invokes_onDismiss() throws {
+        // Given
+        let presenter = BottomSheetPresenter()
+        let viewController = UIViewController()
+
+        // When
+        waitFor { promise in
+            presenter.present(viewController, from: .init()) {
+                // Then
+                promise(())
+            }
+            presenter.dismiss()
+        }
+    }
+
+    func test_interactively_dismissing_sheet_invokes_onDismiss() throws {
+        // Given
+        let presenter = BottomSheetPresenter()
+        let viewController = UIViewController()
+
+        // When
+        waitFor { promise in
+            presenter.present(viewController, from: .init()) {
+                // Then
+                promise(())
+            }
+            presenter.presentationControllerDidDismiss(UIPresentationController(presentedViewController: .init(), presenting: nil))
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/BottomSheet/BottomSheetPresenterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/BottomSheet/BottomSheetPresenterTests.swift
@@ -23,7 +23,7 @@ final class BottomSheetPresenterTests: XCTestCase {
         XCTAssertEqual(viewController.sheetPresentationController?.detents, [.large()])
     }
 
-    func test_dismiss_sheet_invokes_onDismiss() throws {
+    func test_dismiss_sheet_invokes_onDismiss_from_present() throws {
         // Given
         let presenter = BottomSheetPresenter()
         let viewController = UIViewController()
@@ -35,6 +35,23 @@ final class BottomSheetPresenterTests: XCTestCase {
                 promise(())
             }
             presenter.dismiss()
+        }
+    }
+
+    func test_dismiss_sheet_invokes_onDismiss_from_dismiss() throws {
+        // Given
+        let presenter = BottomSheetPresenter()
+        let viewController = UIViewController()
+
+        // When
+        waitFor { promise in
+            presenter.present(viewController, from: .init(), onDismiss: {
+                XCTFail("The onDismiss of the present call should not be invoked.")
+            })
+            presenter.dismiss(onDismiss: {
+                // Then
+                promise(())
+            })
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/BottomSheet/BottomSheetPresenterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/BottomSheet/BottomSheetPresenterTests.swift
@@ -17,10 +17,11 @@ final class BottomSheetPresenterTests: XCTestCase {
         presenter.present(viewController, from: .init())
 
         // Then
-        XCTAssertTrue(viewController.sheetPresentationController?.prefersEdgeAttachedInCompactHeight == false)
-        XCTAssertNil(viewController.sheetPresentationController?.largestUndimmedDetentIdentifier)
-        XCTAssertTrue(viewController.sheetPresentationController?.prefersGrabberVisible == false)
-        XCTAssertEqual(viewController.sheetPresentationController?.detents, [.large()])
+        let sheetPresentationController = try XCTUnwrap(viewController.sheetPresentationController)
+        XCTAssertTrue(sheetPresentationController.prefersEdgeAttachedInCompactHeight == false)
+        XCTAssertNil(sheetPresentationController.largestUndimmedDetentIdentifier)
+        XCTAssertTrue(sheetPresentationController.prefersGrabberVisible == false)
+        XCTAssertEqual(sheetPresentationController.detents, [.large()])
     }
 
     func test_dismiss_sheet_invokes_onDismiss_from_present() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9465 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

We used to have our custom implementation of bottom sheet, but now we can start using the [native bottom sheet with UIKit](https://developer.apple.com/documentation/uikit/uisheetpresentationcontroller) in iOS 15 since our app is iOS 15+. One limitation is that the custom detents (the resting height of the sheet) doesn't support "content height" out of the box for most of the pre-existing bottom sheet use cases. For product description AI, we don't need the sheet to fit to content height and we can start adopting the native bottom sheet.

## How

A presenter `BottomSheetPresenter` was created, with a `configure` function in the initializer to customize the sheet. In order to abstract the implementation detail (`UISheetPresentationController`), the customizations are through a protocol `BottomSheetConfigurable` with the common properties that we customize. When presenting a view controller in a bottom sheet, a closure `onDismiss` can be passed and is called when the sheet is programmatically or interactively dismissed by the user. Some basic test cases were added for `BottomSheetPresenter`.

For the first use case, the AI CTA in Aztec editor `AztecEditorViewController`, a blank view controller was presented for testing. This CTA is behind a feature flag.

In the next PR, the product description AI content will be shown in the bottom sheet.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in to a WPCOM store if needed
- Go to the Products tab
- Create a product if needed
- Tap on an editable product
- Tap on the product description row
- Tap on the magic wand CTA above the keyboard --> a blank bottom sheet should be presented
- Feel free to rotate, drag up the sheet to expand to fullscreen
- Drag down the bottom sheet to dismiss --> the keyboard should be presented again
- Tap on the magic wand CTA above the keyboard again
- Tap `Done` or `<` to navigate back to the product form --> the bottom sheet should be dismissed

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

iPhone | iPad - portrait | iPad - landscape
-- | -- | --
![Simulator Screen Shot - iPhone 14 - 2023-04-26 at 13 47 09](https://user-images.githubusercontent.com/1945542/234481735-e885a2d1-93ce-43a3-8ee9-1a2c0d11b505.png) | ![Simulator Screen Shot - iPad (9th generation) - 2023-04-26 at 13 52 04](https://user-images.githubusercontent.com/1945542/234481720-93fae7e1-8a21-4c0c-931f-c3d83821e4cb.png) | ![Simulator Screen Shot - iPad (9th generation) - 2023-04-26 at 13 52 06](https://user-images.githubusercontent.com/1945542/234481725-201ab1b1-1489-4c72-9907-b0d7b8f1bbdc.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
