### PR TITLE
[Gift Cards] Request gift_cards field from Orders endpoint

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -343,7 +343,7 @@ public extension OrdersRemote {
             "id", "parent_id", "number", "status", "currency", "customer_id", "customer_note", "date_created_gmt", "date_modified_gmt", "date_paid_gmt",
             "discount_total", "discount_tax", "shipping_total", "shipping_tax", "total", "total_tax", "payment_method", "payment_method_title",
             "payment_url", "line_items", "shipping", "billing", "coupon_lines", "shipping_lines", "refunds", "fee_lines", "order_key", "tax_lines", "meta_data",
-            "is_editable", "needs_payment", "needs_processing"
+            "is_editable", "needs_payment", "needs_processing", "gift_cards"
         ]
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8957
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a small fix to the Networking layer changes in #9548, to support gift cards in orders. Those gift cards are part of the response from the Orders API endpoint, but we need to add the `gift_cards` field to the list of fields we request when getting orders from that endpoint (when loading all orders or a single order).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
One way to test this is to check the response with Wormholy:

1. Build and run the app.
2. Select a store with the Gift Cards extension installed and activated.
3. Open the Orders tab to load all orders.
4. Go to the Hub menu > Settings > Launch Wormholy Debug.
5. Select the request to the orders endpoint (`/wc/v3/orders`) and view the response body.
6. Confirm the orders response includes the `gift_cards` field for each order.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
