### PR TITLE
[Gift Cards] Add support for gift cards applied to an order (Yosemite layer)

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -119,6 +119,13 @@ public extension StorageType {
         return firstObject(ofType: OrderMetaData.self, matching: predicate)
     }
 
+    /// Retrieves the Stored Order Gift Cards.
+    ///
+    func loadOrderGiftCard(siteID: Int64, giftCardID: Int64) -> OrderGiftCard? {
+        let predicate = \OrderGiftCard.order?.siteID == siteID && \OrderGiftCard.giftCardID == giftCardID
+        return firstObject(ofType: OrderGiftCard.self, matching: predicate)
+    }
+
     // MARK: - Stats
 
     /// Retrieves the Stored TopEarnerStats.

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -360,6 +360,7 @@
 		CE4FD4562350FD4800A16B31 /* Refund+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4FD4552350FD4800A16B31 /* Refund+ReadOnlyConvertible.swift */; };
 		CE5F9A7A22B2D455001755E8 /* Array+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F9A7922B2D455001755E8 /* Array+Helpers.swift */; };
 		CECC504023675DF4004540EA /* RefundStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC503F23675DF4004540EA /* RefundStoreTests.swift */; };
+		CEE9188C29F7F68C004B23FF /* OrderGiftCard+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9188B29F7F68C004B23FF /* OrderGiftCard+ReadOnlyConvertible.swift */; };
 		D4CBAE5C26D401BC00BBE6D1 /* AnnouncementsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CBAE5B26D401BC00BBE6D1 /* AnnouncementsStoreTests.swift */; };
 		D4CBAE6026D440FA00BBE6D1 /* MockAnnouncementsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CBAE5F26D440FA00BBE6D1 /* MockAnnouncementsRemote.swift */; };
 		D4CBAE6226D4460900BBE6D1 /* AnnouncementsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CBAE6126D4460800BBE6D1 /* AnnouncementsStore.swift */; };
@@ -811,6 +812,7 @@
 		CE4FD4552350FD4800A16B31 /* Refund+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Refund+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CE5F9A7922B2D455001755E8 /* Array+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Helpers.swift"; sourceTree = "<group>"; };
 		CECC503F23675DF4004540EA /* RefundStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundStoreTests.swift; sourceTree = "<group>"; };
+		CEE9188B29F7F68C004B23FF /* OrderGiftCard+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderGiftCard+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D4CBAE5B26D401BC00BBE6D1 /* AnnouncementsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsStoreTests.swift; sourceTree = "<group>"; };
 		D4CBAE5F26D440FA00BBE6D1 /* MockAnnouncementsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnnouncementsRemote.swift; sourceTree = "<group>"; };
 		D4CBAE6126D4460800BBE6D1 /* AnnouncementsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsStore.swift; sourceTree = "<group>"; };
@@ -1295,6 +1297,7 @@
 				74D7F29A20F6A7FB0058B2F0 /* Order+ReadOnlyConvertible.swift */,
 				74685D4F20F7F3CE008958C1 /* OrderCoupon+ReadOnlyConvertible.swift */,
 				D88E234425AE0EB90023F3B1 /* OrderFeeLine+ReadOnlyConvertible.swift */,
+				CEE9188B29F7F68C004B23FF /* OrderGiftCard+ReadOnlyConvertible.swift */,
 				74685D4D20F7EFA7008958C1 /* OrderItem+ReadOnlyConvertible.swift */,
 				021EAA5B25493E9300AA8CCD /* OrderItemAttribute+ReadOnlyConvertible.swift */,
 				CE4FD44F2350F27C00A16B31 /* OrderItemTax+ReadOnlyConvertible.swift */,
@@ -2141,6 +2144,7 @@
 				B9AECD3C2850F3C600E78584 /* OrderCardPresentPaymentEligibilityStore.swift in Sources */,
 				45AB8B1724AA4B3D00B5B36E /* ProductTagStore.swift in Sources */,
 				02137903270ABDDE006430F7 /* MockAnnouncementsActionHandler.swift in Sources */,
+				CEE9188C29F7F68C004B23FF /* OrderGiftCard+ReadOnlyConvertible.swift in Sources */,
 				247CE8342582F20100F9D9D1 /* MockAppSettingsActionHandler.swift in Sources */,
 				025CA2CA238F515600B05C81 /* ProductShippingClassStore.swift in Sources */,
 				0366EADF29082B3100B51755 /* JustInTimeMessageStore.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -54,6 +54,7 @@ public typealias OrderStatusEnum = Networking.OrderStatusEnum
 public typealias OrderCouponLine = Networking.OrderCouponLine
 public typealias OrderFeeLine = Networking.OrderFeeLine
 public typealias OrderFeeTaxStatus = Networking.OrderFeeTaxStatus
+public typealias OrderGiftCard = Networking.OrderGiftCard
 public typealias OrderMetaData = Networking.OrderMetaData
 public typealias OrderNote = Networking.OrderNote
 public typealias OrderTaxLine = Networking.OrderTaxLine

--- a/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -37,6 +37,7 @@ extension Storage.Order: ReadOnlyConvertible {
         paymentMethodTitle = order.paymentMethodTitle
         paymentURL = order.paymentURL as NSURL?
         chargeID = order.chargeID
+        renewalSubscriptionID = order.renewalSubscriptionID
 
         if let billingAddress = order.billingAddress {
             billingFirstName = billingAddress.firstName
@@ -77,6 +78,7 @@ extension Storage.Order: ReadOnlyConvertible {
         let orderFeeLines = fees?.map { $0.toReadOnly() } ?? [Yosemite.OrderFeeLine]()
         let orderTaxLines = taxes?.map { $0.toReadOnly() } ?? [Yosemite.OrderTaxLine]()
         let orderCustomFields = customFields?.map { $0.toReadOnly() } ?? [Yosemite.OrderMetaData]()
+        let orderGiftCards = appliedGiftCards?.map { $0.toReadOnly() } ?? [Yosemite.OrderGiftCard]()
 
         return Order(siteID: siteID,
                      orderID: orderID,
@@ -112,8 +114,8 @@ extension Storage.Order: ReadOnlyConvertible {
                      fees: orderFeeLines,
                      taxes: orderTaxLines,
                      customFields: orderCustomFields,
-                     renewalSubscriptionID: nil,
-                     appliedGiftCards: [])
+                     renewalSubscriptionID: renewalSubscriptionID,
+                     appliedGiftCards: orderGiftCards)
 
     }
 

--- a/Yosemite/Yosemite/Model/Storage/OrderGiftCard+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderGiftCard+ReadOnlyConvertible.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Storage
+
+
+// MARK: - Storage.OrderGiftCard: ReadOnlyConvertible
+//
+extension Storage.OrderGiftCard: ReadOnlyConvertible {
+
+    /// Updates the Storage.OrderGiftCard with the ReadOnly.
+    ///
+    public func update(with giftCard: Yosemite.OrderGiftCard) {
+        giftCardID = giftCard.giftCardID
+        code = giftCard.code
+        amount = giftCard.amount
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.OrderGiftCard {
+        OrderGiftCard(giftCardID: giftCardID,
+                      code: code ?? "",
+                      amount: amount)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8957
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are adding read-only support for the [Gift Cards](https://woocommerce.com/products/gift-cards/) extension in order details, to display any gift cards applied to an order (used for payment on the order).

This PR adds support in the Yosemite layer for gift cards applied to an order.

### Changes

* Adds a Storage extension to load a stored gift card for a given order.
* Adds and updates the ReadOnlyConvertible methods for `Order` and `OrderGiftCard`.
* Updates `OrdersUpsertUseCase` to handle gift cards when upserting an `Order`.
* Adds unit tests for upserting orders with gift cards.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Confirm unit tests pass and orders can still be loaded and viewed as expected in the app. We aren't yet using gift cards in the UI layer.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
