### PR TITLE
Update UI tests to account for new Simulator behavior in Xcode 14.3

### DIFF
--- a/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Login/PasswordScreen.swift
@@ -40,6 +40,13 @@ public final class PasswordScreen: ScreenObject {
             waitFor(element: continueButton, predicate: "isEnabled == true")
         }
 
+        // As of Xcode 14.3, the Simulator might ask to save the password which, of course, we don't want to do.
+        if app.buttons["Save Password"].waitForExistence(timeout: 5) {
+            // There should be no need to wait for this button to exist since it's part of the same
+            // alert where "Save Password" is.
+            app.buttons["Not Now"].tap()
+        }
+
         return self
     }
 


### PR DESCRIPTION

## Description
Without this, the UI tests will hang after logging in on Xcode 14.3 because the Simulator will ask to save the password.

<img width="400" alt="Screenshot 2023-04-26 at 9 25 42 pm" src="https://user-images.githubusercontent.com/1218433/234561710-d36fa6dc-b4c4-4fc0-b12e-dee434d77a97.png">


See also https://github.com/wordpress-mobile/WordPress-iOS/pull/20583


## Testing instructions
Run on Xcode 14.3 locally and verify the test proceed after logging in.



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
