### PR TITLE
[Gift Cards] Add gift cards section to order details

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -93,6 +93,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .productDescriptionAI:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .readOnlyGiftCards:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -195,4 +195,8 @@ public enum FeatureFlag: Int {
     /// Enables generating product description using AI.
     ///
     case productDescriptionAI
+
+    /// Enables read-only support for the Gift Cards extension
+    ///
+    case readOnlyGiftCards
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1210,7 +1210,7 @@ extension OrderDetailsDataSource {
 
         let giftCards: Section? = {
             // Gift Cards section is hidden if there are no gift cards for the order.
-            guard appliedGiftCards.isNotEmpty else {
+            guard appliedGiftCards.isNotEmpty && featureFlags.isFeatureFlagEnabled(.readOnlyGiftCards) else {
                 return nil
             }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -241,6 +241,12 @@ final class OrderDetailsDataSource: NSObject {
         }
     }
 
+    /// Gift Cards applied to an Order
+    ///
+    private var appliedGiftCards: [OrderGiftCard] {
+        order.appliedGiftCards
+    }
+
     private lazy var currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
 
     private let imageService: ImageService = ServiceLocator.imageService
@@ -441,6 +447,8 @@ private extension OrderDetailsDataSource {
             configureCustomFields(cell: cell)
         case let cell as OrderSubscriptionTableViewCell where row == .subscriptions:
             configureSubscriptions(cell: cell, at: indexPath)
+        case let cell as TitleAndValueTableViewCell where row == .giftCards:
+            configureGiftCards(cell: cell, at: indexPath)
         default:
             fatalError("Unidentified customer info row type")
         }
@@ -863,6 +871,17 @@ private extension OrderDetailsDataSource {
         cell.configure(cellViewModel)
     }
 
+    private func configureGiftCards(cell: TitleAndValueTableViewCell, at indexPath: IndexPath) {
+        guard let giftCard = giftCard(at: indexPath) else {
+            return
+        }
+
+        let negativeAmount = -giftCard.amount
+        let formattedAmount = currencyFormatter.formatAmount(negativeAmount.description)
+        cell.updateUI(title: giftCard.code, value: formattedAmount)
+        cell.apply(style: .boldValue)
+    }
+
     private func configureTracking(cell: OrderTrackingTableViewCell, at indexPath: IndexPath) {
         guard let tracking = orderTracking(at: indexPath) else {
             return
@@ -1189,6 +1208,16 @@ extension OrderDetailsDataSource {
             return Section(category: .subscriptions, title: Title.subscriptions, rows: rows)
         }()
 
+        let giftCards: Section? = {
+            // Gift Cards section is hidden if there are no gift cards for the order.
+            guard appliedGiftCards.isNotEmpty else {
+                return nil
+            }
+
+            let rows: [Row] = Array(repeating: .giftCards, count: appliedGiftCards.count)
+            return Section(category: .giftCards, title: Title.giftCards, rows: rows)
+        }()
+
         let tracking: Section? = {
             // Tracking section is hidden if there are non-empty non-refunded shipping labels.
             guard shippingLabels.nonRefunded.isEmpty else {
@@ -1236,6 +1265,7 @@ extension OrderDetailsDataSource {
                     [payment,
                      customerInformation,
                      subscriptions,
+                     giftCards,
                      tracking,
                      addTracking,
                      notes]).compactMap { $0 }
@@ -1304,6 +1334,15 @@ extension OrderDetailsDataSource {
         }
 
         return orderSubscriptions[orderIndex]
+    }
+
+    func giftCard(at indexPath: IndexPath) -> OrderGiftCard? {
+        let orderIndex = indexPath.row
+        guard appliedGiftCards.indices.contains(orderIndex) else {
+            return nil
+        }
+
+        return appliedGiftCards[orderIndex]
     }
 
     func orderTracking(at indexPath: IndexPath) -> ShipmentTracking? {
@@ -1424,6 +1463,7 @@ extension OrderDetailsDataSource {
         static let product = NSLocalizedString("Product", comment: "Product section title if there is only one product.")
         static let refundedProducts = NSLocalizedString("Refunded Products", comment: "Section title")
         static let subscriptions = NSLocalizedString("Subscriptions", comment: "Subscriptions section title")
+        static let giftCards = NSLocalizedString("Gift Cards", comment: "Gift Cards section title")
         static let tracking = NSLocalizedString("Tracking", comment: "Order tracking section title")
         static let customerNote = NSLocalizedString("Customer Provided Note", comment: "Customer note section title")
         static let shippingAddress = NSLocalizedString("Shipping Details",
@@ -1470,6 +1510,7 @@ extension OrderDetailsDataSource {
             case payment
             case customerInformation
             case subscriptions
+            case giftCards
             case tracking
             case addTracking
             case notes
@@ -1559,6 +1600,7 @@ extension OrderDetailsDataSource {
         case refund
         case netAmount
         case subscriptions
+        case giftCards
         case tracking
         case trackingAdd
         case collectCardPaymentButton
@@ -1641,6 +1683,8 @@ extension OrderDetailsDataSource {
                 return WooBasicTableViewCell.reuseIdentifier
             case .subscriptions:
                 return OrderSubscriptionTableViewCell.reuseIdentifier
+            case .giftCards:
+                return TitleAndValueTableViewCell.reuseIdentifier
             }
         }
     }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -322,7 +322,8 @@ extension OrderDetailsViewModel {
             IssueRefundTableViewCell.self,
             ImageAndTitleAndTextTableViewCell.self,
             WCShipInstallTableViewCell.self,
-            OrderSubscriptionTableViewCell.self
+            OrderSubscriptionTableViewCell.self,
+            TitleAndValueTableViewCell.self
         ]
 
         for cellClass in cells {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndValueTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndValueTableViewCell.swift
@@ -15,6 +15,8 @@ final class TitleAndValueTableViewCell: UITableViewCell {
         case nonSelectable
         /// Title and value will use headline (bold) styles.
         case headline
+        /// Title uses body style and value uses headline (bold) style.
+        case boldValue
 
         fileprivate static let `default` = Self.regular
     }
@@ -57,6 +59,9 @@ extension TitleAndValueTableViewCell {
             valueLabel.textColor = .textTertiary
         case .headline:
             titleLabel.applyHeadlineStyle()
+            valueLabel.applyHeadlineStyle()
+        case .boldValue:
+            titleLabel.applyBodyStyle()
             valueLabel.applyHeadlineStyle()
         }
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -21,6 +21,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isIPPUKExpansionEnabled: Bool
     private let isReadOnlySubscriptionsEnabled: Bool
     private let isProductDescriptionAIEnabled: Bool
+    private let isReadOnlyGiftCardsEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -40,7 +41,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isTapToPayOnIPhoneMilestone2On: Bool = false,
          isIPPUKExpansionEnabled: Bool = false,
          isReadOnlySubscriptionsEnabled: Bool = false,
-         isProductDescriptionAIEnabled: Bool = false) {
+         isProductDescriptionAIEnabled: Bool = false,
+         isReadOnlyGiftCardsEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -60,6 +62,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isIPPUKExpansionEnabled = isIPPUKExpansionEnabled
         self.isReadOnlySubscriptionsEnabled = isReadOnlySubscriptionsEnabled
         self.isProductDescriptionAIEnabled = isProductDescriptionAIEnabled
+        self.isReadOnlyGiftCardsEnabled = isReadOnlyGiftCardsEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -102,6 +105,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isReadOnlySubscriptionsEnabled
         case .productDescriptionAI:
             return isProductDescriptionAIEnabled
+        case .readOnlyGiftCards:
+            return isReadOnlyGiftCardsEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -590,6 +590,36 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let subscriptionSection = section(withCategory: .subscriptions, from: dataSource)
         XCTAssertNil(subscriptionSection)
     }
+
+    func test_giftCards_section_is_visible_when_order_has_gift_cards() throws {
+        // Given
+        let order = Order.fake().copy(appliedGiftCards: [.init(giftCardID: 2, code: "SU9F-MGB5-KS5V-EZFT", amount: 20)])
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let giftCardsSection = section(withCategory: .giftCards, from: dataSource)
+        XCTAssertNotNil(giftCardsSection)
+    }
+
+    func test_giftCards_section_is_hidden_when_order_has_no_gift_cards() throws {
+        // Given
+        let order = Order.fake()
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let giftCardsSection = section(withCategory: .giftCards, from: dataSource)
+        XCTAssertNil(giftCardsSection)
+    }
 }
 
 // MARK: - Test Data

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -596,7 +596,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = Order.fake().copy(appliedGiftCards: [.init(giftCardID: 2, code: "SU9F-MGB5-KS5V-EZFT", amount: 20)])
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration)
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                featureFlags: MockFeatureFlagService(isReadOnlyGiftCardsEnabled: true))
 
         // When
         dataSource.reloadSections()
@@ -611,7 +612,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = Order.fake()
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration)
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                featureFlags: MockFeatureFlagService(isReadOnlyGiftCardsEnabled: true))
 
         // When
         dataSource.reloadSections()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8958
⚠️ Depends on #9554
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are adding read-only support for the [Gift Cards](https://woocommerce.com/products/gift-cards/) extension in order details, to display any gift cards applied to an order (used for payment on the order).

This adds a Gift Cards section to order details, showing the gift card and amount of the gift card applied to the order. (Gift cards will be added to the Payments section in another PR.)

### Changes

* Adds a feature flag for the read-only gift cards support.
* Updates `TitleAndValueTableViewCell` to add a style with a regular title and bold value.
* Adds the gift cards section and rows to `OrderDetailsDataSource`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Prerequisites

1. Install and activate the [Gift Cards](https://woocommerce.com/products/gift-cards/) extension on your store.
2. Create a gift card product.
3. Create an order to purchase a gift card, and make a note of the gift card code.
4. Create an order and apply the gift card to the order.

### To test

1. Build and run the app.
2. Go to the Orders tab.
3. Open the order where you applied the gift card and confirm a Gift Cards section appears, with the gift card code and the amount of the gift card used for that order.

You can also open another order (where no gift card was applied) and confirm the Gift Cards section does not appear.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/8658164/234593257-3cbfb18b-f710-479f-b732-525eb2e25f5a.png" width="300px">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
