### PR TITLE
[Gift Cards] Add gift cards to payments section in order details

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -175,6 +175,32 @@ final class OrderPaymentDetailsViewModel {
         return order.coupons
     }
 
+    /// Gift Cards
+    /// - returns: 'Gift Cards' label and a list of gift card codes, or nil if there are none.
+    ///
+    var giftCardsText: String? {
+        guard order.appliedGiftCards.isNotEmpty else {
+            return nil
+        }
+
+        let codes = order.appliedGiftCards.map { $0.code }.joined(separator: ", ")
+
+        return NSLocalizedString("Gift Cards", comment: "Gift Cards label for payment view") + " (" + codes + ")"
+    }
+
+    /// Gift cards total
+    ///  - returns: Total amount of gift cards applied to the order, expressed in a negative amount.
+    ///
+    var giftCardsValue: String? {
+        let giftCardsTotal = -order.appliedGiftCards.map { $0.amount }.reduce(0, +)
+
+        return currencyFormatter.formatAmount(giftCardsTotal.description, with: order.currency)
+    }
+
+    var shouldHideGiftCards: Bool {
+        giftCardsText == nil
+    }
+
     init(order: Order, refund: Refund? = nil, currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.order = order
         self.refund = refund

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LedgerTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LedgerTableViewCell.swift
@@ -27,6 +27,11 @@ final class LedgerTableViewCell: UITableViewCell {
     @IBOutlet private weak var taxesValue: UILabel!
     private lazy var taxesViews = RowGroup(containerView: taxesView, label: taxesLabel, value: taxesValue)
 
+    @IBOutlet weak var giftCardsView: UIView!
+    @IBOutlet weak var giftCardsLabel: UILabel!
+    @IBOutlet weak var giftCardsValue: UILabel!
+    private lazy var giftCardsViews = RowGroup(containerView: giftCardsView, label: giftCardsLabel, value: giftCardsValue)
+
     @IBOutlet private var totalView: UIView!
     @IBOutlet private weak var totalLabel: UILabel!
     @IBOutlet private weak var totalValue: UILabel!
@@ -60,6 +65,7 @@ final class LedgerTableViewCell: UITableViewCell {
         feesViews.configure(title: Titles.feesLabel, amount: viewModel.feesValue, hidden: viewModel.shouldHideFees)
         shippingViews.configure(title: Titles.shippingLabel, amount: viewModel.shippingValue, hidden: false)
         taxesViews.configure(title: Titles.taxesLabel, amount: viewModel.taxesValue, hidden: viewModel.shouldHideTaxes)
+        giftCardsViews.configure(title: viewModel.giftCardsText, amount: viewModel.giftCardsValue, hidden: viewModel.shouldHideGiftCards)
         totalViews.configure(title: Titles.totalLabel, amount: viewModel.totalValue, hidden: false)
         configureAccessibility()
     }
@@ -72,6 +78,7 @@ final class LedgerTableViewCell: UITableViewCell {
         feesViews.configure(title: nil, amount: nil, hidden: true)
         shippingViews.configure(title: nil, amount: nil, hidden: true)
         taxesViews.configure(title: Titles.tax, amount: viewModel.taxSubtotal, hidden: taxesValue == nil)
+        giftCardsViews.configure(title: nil, amount: nil, hidden: true)
         totalViews.configure(title: Titles.productsRefund, amount: viewModel.productsRefund, hidden: false)
         configureAccessibility()
     }
@@ -82,6 +89,7 @@ final class LedgerTableViewCell: UITableViewCell {
                             feesView,
                             shippingView,
                             taxesView,
+                            giftCardsView,
                             totalView].filter({
                                 $0?.isHidden == false
                             })
@@ -159,6 +167,14 @@ extension LedgerTableViewCell {
         return taxesValue
     }
 
+    func getGiftCardsLabel() -> UILabel {
+        return giftCardsLabel
+    }
+
+    func getGiftCardsValue() -> UILabel {
+        return giftCardsValue
+    }
+
     func getTotalLabel() -> UILabel {
         return totalLabel
     }
@@ -190,6 +206,8 @@ private extension LedgerTableViewCell {
         shippingValue.applyBodyStyle()
         taxesLabel.applyBodyStyle()
         taxesValue.applyBodyStyle()
+        giftCardsLabel.applyBodyStyle()
+        giftCardsValue.applyBodyStyle()
         totalLabel.applyHeadlineStyle()
         totalValue.applyHeadlineStyle()
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LedgerTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LedgerTableViewCell.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,13 +21,13 @@
                         <rect key="frame" x="16" y="19" width="288" height="436"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tfd-et-ehF" userLabel="subtotalView">
-                                <rect key="frame" x="0.0" y="0.0" width="288" height="60.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="51.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="IHU-N8-p4k">
-                                        <rect key="frame" x="0.0" y="0.0" width="288" height="60.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="288" height="51.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SUBTOTAL" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Xb-4v-uVN">
-                                                <rect key="frame" x="0.0" y="0.0" width="84.5" height="60.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="84.5" height="51.5"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <bool key="isElement" value="NO"/>
                                                 </accessibility>
@@ -35,7 +36,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$999.99" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k43-i3-sNC">
-                                                <rect key="frame" x="222" y="0.0" width="66" height="60.5"/>
+                                                <rect key="frame" x="222" y="0.0" width="66" height="51.5"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <bool key="isElement" value="NO"/>
                                                 </accessibility>
@@ -57,13 +58,13 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q5b-zU-7fY" userLabel="discountView">
-                                <rect key="frame" x="0.0" y="64.5" width="288" height="79.5"/>
+                                <rect key="frame" x="0.0" y="55.5" width="288" height="88.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dqG-xo-5BL">
-                                        <rect key="frame" x="0.0" y="0.0" width="288" height="79.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="288" height="88.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DISCOUNT" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LgV-BP-GFN">
-                                                <rect key="frame" x="0.0" y="0.0" width="140" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="85.5" height="20.5"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <bool key="isElement" value="NO"/>
                                                 </accessibility>
@@ -133,13 +134,13 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MYg-Hq-mwx" userLabel="shippingView">
-                                <rect key="frame" x="0.0" y="222" width="288" height="60.5"/>
+                                <rect key="frame" x="0.0" y="222" width="288" height="51.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="5kf-hJ-JoD">
-                                        <rect key="frame" x="0.0" y="0.0" width="288" height="60.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="288" height="51.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SHIPPING" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gTx-ab-CBl">
-                                                <rect key="frame" x="0.0" y="0.0" width="76.5" height="60.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="76.5" height="51.5"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <bool key="isElement" value="NO"/>
                                                 </accessibility>
@@ -148,7 +149,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$0.01" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h6Q-Cf-oXh">
-                                                <rect key="frame" x="246" y="0.0" width="42" height="60.5"/>
+                                                <rect key="frame" x="246" y="0.0" width="42" height="51.5"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <bool key="isElement" value="NO"/>
                                                 </accessibility>
@@ -170,13 +171,13 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BAA-Mv-unS" userLabel="taxesView">
-                                <rect key="frame" x="0.0" y="286.5" width="288" height="60"/>
+                                <rect key="frame" x="0.0" y="277.5" width="288" height="50"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Dmz-oH-Z9g">
-                                        <rect key="frame" x="0.0" y="0.0" width="288" height="60"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="288" height="50"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TAXES" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z9r-YA-aG9">
-                                                <rect key="frame" x="0.0" y="0.0" width="51.5" height="60"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="51.5" height="50"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <bool key="isElement" value="NO"/>
                                                 </accessibility>
@@ -185,7 +186,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$333.33" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pCA-4f-cjt">
-                                                <rect key="frame" x="223" y="0.0" width="65" height="60"/>
+                                                <rect key="frame" x="223" y="0.0" width="65" height="50"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <bool key="isElement" value="NO"/>
                                                 </accessibility>
@@ -206,14 +207,51 @@
                                     <constraint firstItem="Dmz-oH-Z9g" firstAttribute="leading" secondItem="BAA-Mv-unS" secondAttribute="leading" priority="800" id="hQt-g6-22g"/>
                                 </constraints>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="III-2B-8aD" userLabel="giftCardsView">
+                                <rect key="frame" x="0.0" y="331.5" width="288" height="51"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3tg-7T-PUD">
+                                        <rect key="frame" x="0.0" y="0.0" width="288" height="51"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="GIFT CARDS" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bbZ-df-i56" userLabel="Gift Cards Label">
+                                                <rect key="frame" x="0.0" y="0.0" width="96" height="51"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="-$20.00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zsL-OF-M9I" userLabel="Gift Cards Value">
+                                                <rect key="frame" x="226" y="0.0" width="62" height="51"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <accessibility key="accessibilityConfiguration">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="3tg-7T-PUD" secondAttribute="trailing" priority="800" id="D7O-FK-2J4"/>
+                                    <constraint firstItem="3tg-7T-PUD" firstAttribute="leading" secondItem="III-2B-8aD" secondAttribute="leading" priority="800" id="eic-ok-ISH"/>
+                                    <constraint firstAttribute="bottom" secondItem="3tg-7T-PUD" secondAttribute="bottom" priority="800" id="n7d-SU-5KS"/>
+                                    <constraint firstItem="3tg-7T-PUD" firstAttribute="top" secondItem="III-2B-8aD" secondAttribute="top" priority="800" id="vHR-pr-PvM"/>
+                                </constraints>
+                            </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="K4G-Fo-ooM" userLabel="totalView">
-                                <rect key="frame" x="0.0" y="350.5" width="288" height="85.5"/>
+                                <rect key="frame" x="0.0" y="386.5" width="288" height="49.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="firstBaseline" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ehO-OF-bQV">
-                                        <rect key="frame" x="0.0" y="8" width="288" height="73.5"/>
+                                        <rect key="frame" x="0.0" y="8" width="288" height="37.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="$40.00" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Pa-jd-Tcj">
-                                                <rect key="frame" x="0.0" y="53" width="55" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="17" width="55" height="20.5"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <bool key="isElement" value="NO"/>
                                                 </accessibility>
@@ -222,7 +260,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="$40.00" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="awb-Pi-AeE">
-                                                <rect key="frame" x="233" y="53" width="55" height="20.5"/>
+                                                <rect key="frame" x="233" y="17" width="55" height="20.5"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <bool key="isElement" value="NO"/>
                                                 </accessibility>
@@ -277,6 +315,9 @@
                 <outlet property="feesLabel" destination="kuu-gt-Uht" id="5eS-5n-vSe"/>
                 <outlet property="feesValue" destination="om6-u8-QDq" id="G41-wd-Bqo"/>
                 <outlet property="feesView" destination="De3-wg-68K" id="49r-zW-igB"/>
+                <outlet property="giftCardsLabel" destination="bbZ-df-i56" id="CGk-vY-Bwt"/>
+                <outlet property="giftCardsValue" destination="zsL-OF-M9I" id="Ywr-Yg-1kj"/>
+                <outlet property="giftCardsView" destination="III-2B-8aD" id="Efw-Sv-lZ7"/>
                 <outlet property="shippingLabel" destination="gTx-ab-CBl" id="vFS-6X-myF"/>
                 <outlet property="shippingValue" destination="h6Q-Cf-oXh" id="Rnr-Fu-UuX"/>
                 <outlet property="shippingView" destination="MYg-Hq-mwx" id="cUJ-ZU-dkG"/>

--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -16,7 +16,8 @@ final class MockOrders {
                    refunds: [OrderRefundCondensed] = [],
                    fees: [OrderFeeLine] = [],
                    taxes: [OrderTaxLine] = [],
-                   customFields: [OrderMetaData] = []) -> Order {
+                   customFields: [OrderMetaData] = [],
+                   giftCards: [OrderGiftCard] = []) -> Order {
         return Order.fake().copy(siteID: siteID,
                                  orderID: orderID,
                                  customerID: 11,
@@ -43,7 +44,8 @@ final class MockOrders {
                                  refunds: refunds,
                                  fees: fees,
                                  taxes: taxes,
-                                 customFields: customFields)
+                                 customFields: customFields,
+                                 appliedGiftCards: giftCards)
     }
 
     func sampleOrder() -> Order {
@@ -52,6 +54,11 @@ final class MockOrders {
 
     func orderWithFees() -> Order {
         makeOrder(fees: sampleFeeLines())
+    }
+
+    func orderWithFeesAndGiftCards() -> Order {
+        makeOrder(fees: sampleFeeLines(),
+                  giftCards: sampleGiftCards())
     }
 
     func orderPaidWithNoPaymentMethod() -> Order {
@@ -116,6 +123,11 @@ final class MockOrders {
                             totalTax: "",
                             taxes: [],
                             attributes: [])
+    }
+
+    func sampleGiftCards() -> [OrderGiftCard] {
+        let giftCard = OrderGiftCard(giftCardID: 2, code: "SU9F-MGB5-KS5V-EZFT", amount: 20)
+        return [giftCard]
     }
 
     func sampleAddress() -> Address {

--- a/WooCommerce/WooCommerceTests/ViewRelated/LedgerTableViewCellTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/LedgerTableViewCellTests.swift
@@ -9,7 +9,7 @@ final class LedgerTableViewCellTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        order = MockOrders().orderWithFees()
+        order = MockOrders().orderWithFeesAndGiftCards()
         viewModel = OrderPaymentDetailsViewModel(order: order)
 
         let nib = Bundle.main.loadNibNamed("LedgerTableViewCell", owner: self, options: nil)
@@ -78,6 +78,16 @@ final class LedgerTableViewCellTests: XCTestCase {
     func test_total_value_contains_expected_text() {
         let label = cell.getTotalValue()
         XCTAssertEqual(label.text, viewModel.totalValue)
+    }
+
+    func test_giftCards_label_contains_expected_text() {
+        let label = cell.getGiftCardsLabel()
+        XCTAssertEqual(label.text, viewModel.giftCardsText)
+    }
+
+    func test_giftCards_value_contains_expected_text() {
+        let label = cell.getGiftCardsValue()
+        XCTAssertEqual(label.text, viewModel.giftCardsValue)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -15,12 +15,14 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
     private var orderPaidWithNoPaymentMethod: Order!
     private var orderWithAPIRefunds: Order!
     private var orderWithTransientRefunds: Order!
+    private var orderWithGiftCards: Order!
     private var brokenOrderViewModel: OrderPaymentDetailsViewModel!
     private var anotherBrokenOrderViewModel: OrderPaymentDetailsViewModel!
     private var orderWithFeesViewModel: OrderPaymentDetailsViewModel!
     private var orderPaidWithNoPaymentMethodViewModel: OrderPaymentDetailsViewModel!
     private var orderWithAPIRefundsViewModel: OrderPaymentDetailsViewModel!
     private var orderWithTransientRefundsViewModel: OrderPaymentDetailsViewModel!
+    private var orderWithGiftCardsViewModel: OrderPaymentDetailsViewModel!
 
     override func setUp() {
         super.setUp()
@@ -44,6 +46,9 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
 
         orderWithTransientRefunds = MockOrders().orderWithTransientRefunds()
         orderWithTransientRefundsViewModel = OrderPaymentDetailsViewModel(order: orderWithTransientRefunds, refund: MockRefunds.sampleRefund())
+
+        orderWithGiftCards = order.copy(appliedGiftCards: [.fake().copy(code: "ABCD", amount: 5)])
+        orderWithGiftCardsViewModel = OrderPaymentDetailsViewModel(order: orderWithGiftCards)
     }
 
     override func tearDown() {
@@ -186,5 +191,23 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
         let refundAmount = try XCTUnwrap(orderWithTransientRefundsViewModel.refundAmount)
 
         XCTAssertTrue(refundAmount.hasPrefix("-"))
+    }
+
+    func test_giftCards_text_matches_expectation() {
+        let expectedText = NSLocalizedString("Gift Cards", comment: "Gift Cards label for payment view") + " (ABCD)"
+        XCTAssertEqual(orderWithGiftCardsViewModel.giftCardsText, expectedText)
+    }
+
+    func test_giftCards_value_matches_expectation() {
+        let expectedValue = CurrencyFormatter(currencySettings: CurrencySettings()).formatAmount("-5", with: order.currency)!
+        XCTAssertEqual(orderWithGiftCardsViewModel.giftCardsValue, expectedValue)
+    }
+
+    func test_giftCards_is_visible_for_orders_with_giftCard() {
+        XCTAssertFalse(orderWithGiftCardsViewModel.shouldHideGiftCards)
+    }
+
+    func test_giftCards_is_hidden_for_orders_without_giftCard() {
+        XCTAssertTrue(viewModel.shouldHideGiftCards)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8958
⚠️ Depends on #9556
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are adding read-only support for the [Gift Cards](https://woocommerce.com/products/gift-cards/) extension in order details, to display any gift cards applied to an order (used for payment on the order).

This adds a Gift Cards row in the Payment section in order details. It shows the gift card codes applied to the order, and the total amount paid with gift cards.

### Changes

* Adds a `giftCardsView` to `LedgerTableViewCell`, with the text labels for the row.
* Updates `OrderPaymentDetailsViewModel` with the gift card row details.
* Adds unit tests for the cell and view model.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Prerequisites

1. Install and activate the [Gift Cards](https://woocommerce.com/products/gift-cards/) extension on your store.
2. Create a gift card product.
3. Create an order to purchase a gift card, and make a note of the gift card code.
4. Create an order and apply the gift card to the order.

### To test

1. Build and run the app.
2. Go to the Orders tab.
3. Open the order where you applied the gift card and confirm the Gift Cards row appears above the order total in the Payment section.

You can also open another order (where no gift card was applied) and confirm the Gift Cards row does not appear.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/8658164/234599991-4845b841-e503-4ec9-869a-bbdc682fbc0b.png" width="300px">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
