### PR TITLE
[Gift Cards] Release read-only support for gift cards

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -94,7 +94,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .productDescriptionAI:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .readOnlyGiftCards:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 13.4
 -----
 - [Internal] Payments: Update StripeTerminal pod to 2.19.1 [https://github.com/woocommerce/woocommerce-ios/pull/9537]
+- [**] Adds read-only support for the Gift Cards extension in order details. [https://github.com/woocommerce/woocommerce-ios/pull/9558]
 
 13.3
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8958
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This releases read-only support for the Gift Cards extension. It adds gift cards to order details, to display any gift cards applied to an order (used for payment on the order).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Confirm the change in this PR makes the feature available to all users. If you have time, you can test the feature with the test plan in pe5pgL-2DB-p2.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/8658164/234612379-a547d752-6705-4ce2-b8f0-157a6e28155b.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.