### PR TITLE
[Gift Cards] Add analytics event

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -634,6 +634,12 @@ extension WooAnalyticsEvent {
         static func subscriptionsShown() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderDetailsSubscriptionsShown, properties: [:])
         }
+
+        /// Tracked when gift cards are displayed in order details.
+        ///
+        static func giftCardsShown() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderDetailsGiftCardShown, properties: [:])
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -393,6 +393,7 @@ public enum WooAnalyticsStat: String {
     case orderViewCustomFieldsTapped = "order_view_custom_fields_tapped"
     case orderDetailWaitingTimeLoaded = "order_detail_waiting_time_loaded"
     case orderDetailsSubscriptionsShown = "order_details_subscriptions_shown"
+    case orderDetailsGiftCardShown = "order_details_gift_card_shown"
 
     // MARK: Order List Sorting/Filtering
     //

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -247,6 +247,10 @@ final class OrderDetailsDataSource: NSObject {
         order.appliedGiftCards
     }
 
+    var shouldShowGiftCards: Bool {
+        appliedGiftCards.isNotEmpty && featureFlags.isFeatureFlagEnabled(.readOnlyGiftCards)
+    }
+
     private lazy var currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
 
     private let imageService: ImageService = ServiceLocator.imageService
@@ -1209,8 +1213,7 @@ extension OrderDetailsDataSource {
         }()
 
         let giftCards: Section? = {
-            // Gift Cards section is hidden if there are no gift cards for the order.
-            guard appliedGiftCards.isNotEmpty && featureFlags.isFeatureFlagEnabled(.readOnlyGiftCards) else {
+            guard shouldShowGiftCards else {
                 return nil
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -74,6 +74,7 @@ final class OrderDetailsViewController: UIViewController {
         configureEntityListener()
         configureViewModel()
         updateTopBannerView()
+        trackGiftCardsShown()
 
         // FIXME: this is a hack. https://github.com/woocommerce/woocommerce-ios/issues/1779
         reloadTableViewSectionsAndData()
@@ -579,6 +580,15 @@ private extension OrderDetailsViewController {
         let addOnsController = OrderAddOnsListViewController(viewModel: addOnsViewModel)
         let navigationController = WooNavigationController(rootViewController: addOnsController)
         present(navigationController, animated: true, completion: nil)
+    }
+
+    /// Tracks when the Gift Cards section will be shown.
+    ///
+    func trackGiftCardsShown() {
+        guard viewModel.dataSource.shouldShowGiftCards else {
+            return
+        }
+        ServiceLocator.analytics.track(event: .Orders.giftCardsShown())
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9239
⚠️ Depends on 9557
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds a new tracking event for Gift Cards:

- Event name: `order_details_gift_card_shown`
   - Trigger: When the "Gift Cards" section is shown in order details.
   - Event registration: 1573-gh-tracks-events-registration

This event is tracked each time the order details are opened for an order containing gift cards.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Prerequisites

1. Install and activate the [Gift Cards](https://woocommerce.com/products/gift-cards/) extension on your store.
2. Create a gift card product.
3. Create an order to purchase a gift card, and make a note of the gift card code.
4. Create an order and apply the gift card to the order.

### To test

1. Build and run the app.
2. Go to the Orders tab.
3. Open the order where you applied the gift card and confirm the event is tracked as expected.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
