### PR TITLE
Product description AI: feature integration

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -7,6 +7,9 @@ final class AztecEditorViewController: UIViewController, Editor {
     var onContentSave: OnContentSave?
 
     private var content: String
+    private var productName: String?
+
+    private let product: ProductFormDataModel
 
     private let viewProperties: EditorViewProperties
 
@@ -105,10 +108,12 @@ final class AztecEditorViewController: UIViewController, Editor {
     private var bottomSheetPresenter: BottomSheetPresenter?
 
     required init(content: String?,
+                  product: ProductFormDataModel,
                   viewProperties: EditorViewProperties,
                   textViewAttachmentDelegate: TextViewAttachmentDelegate = AztecTextViewAttachmentHandler(),
                   isAIGenerationEnabled: Bool) {
         self.content = content ?? ""
+        self.product = product
         self.textViewAttachmentDelegate = textViewAttachmentDelegate
         self.viewProperties = viewProperties
         self.isAIGenerationEnabled = isAIGenerationEnabled
@@ -133,11 +138,7 @@ final class AztecEditorViewController: UIViewController, Editor {
                                                  placeholderView: placeholderLabel)
         disableLinkTapRecognizer(from: editorView.richTextView)
 
-        setHTML(content)
-
-        // getHTML() from the Rich Text View removes the HTML tags
-        // so we align the original content to the value of the Rich Text View
-        content = getHTML()
+        updateContent()
 
         refreshPlaceholderVisibility()
         handleSwipeBackGesture()
@@ -282,7 +283,7 @@ extension AztecEditorViewController {
     @objc private func saveButtonTapped() {
         let content = getHTML()
         ServiceLocator.analytics.track(.aztecEditorDoneButtonTapped)
-        onContentSave?(content)
+        onContentSave?(content, productName)
     }
 
     override func shouldPopOnBackButton() -> Bool {
@@ -345,9 +346,16 @@ private extension AztecEditorViewController {
         })
         bottomSheetPresenter = presenter
 
-        // TODO: 9465 - show product description generation in the bottom sheet
-        let controller = UIViewController()
-        controller.view.backgroundColor = .primaryButtonBackground
+        let controller = ProductDescriptionGenerationHostingController(viewModel:
+                .init(siteID: product.siteID,
+                      name: product.name,
+                      description: product.description ?? "")) { [weak self] output in
+            guard let self else { return }
+            self.content = output.description
+            self.productName = output.name
+            self.updateContent()
+            self.dismissDescriptionGenerationBottomSheetIfNeeded()
+        }
 
         view.endEditing(true)
         presenter.present(controller, from: self, onDismiss: { [weak self] in
@@ -357,5 +365,13 @@ private extension AztecEditorViewController {
 
     func dismissDescriptionGenerationBottomSheetIfNeeded() {
         bottomSheetPresenter?.dismiss(onDismiss: {})
+    }
+
+    func updateContent() {
+        setHTML(content)
+
+        // getHTML() from the Rich Text View removes the HTML tags
+        // so we align the original content to the value of the Rich Text View
+        content = getHTML()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -340,7 +340,7 @@ private extension AztecEditorViewController {
         let presenter = BottomSheetPresenter(configure: { bottomSheet in
             var sheet = bottomSheet
             sheet.prefersEdgeAttachedInCompactHeight = true
-            sheet.largestUndimmedDetentIdentifier = .large
+            sheet.largestUndimmedDetentIdentifier = .none
             sheet.prefersGrabberVisible = true
             sheet.detents = [.medium(), .large()]
         })

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -349,13 +349,14 @@ private extension AztecEditorViewController {
         let controller = ProductDescriptionGenerationHostingController(viewModel:
                 .init(siteID: product.siteID,
                       name: product.name,
-                      description: product.description ?? "")) { [weak self] output in
+                      description: product.description ?? "",
+                      onApply: { [weak self] output in
             guard let self else { return }
             self.content = output.description
             self.productName = output.name
             self.updateContent()
             self.dismissDescriptionGenerationBottomSheetIfNeeded()
-        }
+        }))
 
         view.endEditing(true)
         presenter.present(controller, from: self, onDismiss: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
@@ -1,7 +1,7 @@
 import Yosemite
 
 protocol Editor {
-    typealias OnContentSave = (_ content: String) -> Void
+    typealias OnContentSave = (_ content: String, _ productName: String?) -> Void
     var onContentSave: OnContentSave? { get }
 }
 
@@ -18,6 +18,7 @@ final class EditorFactory {
                                                   placeholderText: Localization.placeholderText(product: product),
                                                   showSaveChangesActionSheet: true)
         let editor = AztecEditorViewController(content: product.description,
+                                               product: product,
                                                viewProperties: viewProperties,
                                                isAIGenerationEnabled: isAIGenerationEnabled)
         editor.onContentSave = onContentSave
@@ -30,6 +31,7 @@ final class EditorFactory {
                                                   placeholderText: Localization.placeholderText(product: product),
                                                   showSaveChangesActionSheet: true)
         let editor = AztecEditorViewController(content: product.shortDescription,
+                                               product: product,
                                                viewProperties: viewProperties,
                                                isAIGenerationEnabled: false)
         editor.onContentSave = onContentSave

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Output data from the AI-generated product description flow.
-struct ProductDescriptionGenerationOutput {
+struct ProductDescriptionGenerationOutput: Equatable {
     /// The user can enter or update the product name when polishing the AI-generated product generation.
     let name: String
 

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -12,10 +12,8 @@ struct ProductDescriptionGenerationOutput {
 /// Hosting controller for `ProductDescriptionGenerationView`.
 ///
 final class ProductDescriptionGenerationHostingController: UIHostingController<ProductDescriptionGenerationView> {
-    init(viewModel: ProductDescriptionGenerationViewModel,
-         onUpdate: @escaping (ProductDescriptionGenerationOutput) -> Void) {
-        super.init(rootView: ProductDescriptionGenerationView(viewModel: viewModel,
-                                                              onUpdate: onUpdate))
+    init(viewModel: ProductDescriptionGenerationViewModel) {
+        super.init(rootView: ProductDescriptionGenerationView(viewModel: viewModel))
     }
 
     @available(*, unavailable)
@@ -28,12 +26,8 @@ final class ProductDescriptionGenerationHostingController: UIHostingController<P
 struct ProductDescriptionGenerationView: View {
     @ObservedObject private var viewModel: ProductDescriptionGenerationViewModel
 
-    private let onUpdate: (_ output: ProductDescriptionGenerationOutput) -> Void
-
-    init(viewModel: ProductDescriptionGenerationViewModel,
-         onUpdate: @escaping (_ output: ProductDescriptionGenerationOutput) -> Void) {
+    init(viewModel: ProductDescriptionGenerationViewModel) {
         self.viewModel = viewModel
-        self.onUpdate = onUpdate
     }
 
     var body: some View {
@@ -101,7 +95,7 @@ struct ProductDescriptionGenerationView: View {
 
                         // CTA to apply the generated text.
                         Button(Localization.insertGeneratedText) {
-                            onUpdate(.init(name: viewModel.name, description: suggestedText))
+                            viewModel.applyToProduct()
                         }
                         .buttonStyle(PrimaryButtonStyle())
                         .fixedSize(horizontal: true, vertical: false)
@@ -193,8 +187,8 @@ struct ProductDescriptionGenerationView_Previews: PreviewProvider {
                       name: "Potted cactus",
                       description: "low-maintenance, decorative plant that improves indoor air quality and provides health benefits",
                       stores: ProductDescriptionGenerationPreviewStores(result:
-                            .success("These unique plants thrive in harsh environments and require very little care."))),
-                                         onUpdate: { _ in })
+                            .success("These unique plants thrive in harsh environments and require very little care.")),
+                      onApply: { _ in }))
         .previewDisplayName("Pre-filled name and features with success")
 
         ProductDescriptionGenerationView(viewModel:
@@ -202,8 +196,8 @@ struct ProductDescriptionGenerationView_Previews: PreviewProvider {
                       name: "",
                       description: "",
                       stores: ProductDescriptionGenerationPreviewStores(result:
-                            .failure(ProductDownloadFileError.emptyFileName))),
-                                         onUpdate: { _ in })
+                            .failure(ProductDownloadFileError.emptyFileName)),
+                      onApply: { _ in }))
         .previewDisplayName("Empty name and features with failure")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -37,8 +37,13 @@ struct ProductDescriptionGenerationView: View {
                     Text(Localization.title)
                         .headlineStyle()
 
-                    TextField(Localization.productNamePlaceholder, text: $viewModel.name)
-                        .subheadlineStyle()
+                    if #available(iOS 16.0, *) {
+                        TextField(Localization.productNamePlaceholder, text: $viewModel.name, axis: .vertical)
+                            .subheadlineStyle()
+                    } else {
+                        TextField(Localization.productNamePlaceholder, text: $viewModel.name)
+                            .subheadlineStyle()
+                    }
                 }
 
                 // Since there is no placeholder support in `TextEditor`, a workaround is to
@@ -56,7 +61,7 @@ struct ProductDescriptionGenerationView: View {
 
                     if viewModel.features.isEmpty {
                         Text(Localization.productDescriptionPlaceholder)
-                            .foregroundColor(Color(.textSubtle))
+                            .foregroundColor(Color(.placeholderText))
                             .bodyStyle()
                             .padding(insets: Layout.productFeaturesPlaceholderInsets)
                             // Allows gestures to pass through to the `TextEditor`.

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -1,0 +1,211 @@
+import SwiftUI
+
+/// Output data from the AI-generated product description flow.
+struct ProductDescriptionGenerationOutput {
+    /// The user can enter or update the product name when polishing the AI-generated product generation.
+    let name: String
+
+    /// AI-generated product description.
+    let description: String
+}
+
+/// Hosting controller for `ProductDescriptionGenerationView`.
+///
+final class ProductDescriptionGenerationHostingController: UIHostingController<ProductDescriptionGenerationView> {
+    init(viewModel: ProductDescriptionGenerationViewModel,
+         onUpdate: @escaping (ProductDescriptionGenerationOutput) -> Void) {
+        super.init(rootView: ProductDescriptionGenerationView(viewModel: viewModel,
+                                                              onUpdate: onUpdate))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// Allows the user to generate a product description using Jetpack AI given the product name and features.
+struct ProductDescriptionGenerationView: View {
+    @ObservedObject private var viewModel: ProductDescriptionGenerationViewModel
+
+    private let onUpdate: (_ output: ProductDescriptionGenerationOutput) -> Void
+
+    init(viewModel: ProductDescriptionGenerationViewModel,
+         onUpdate: @escaping (_ output: ProductDescriptionGenerationOutput) -> Void) {
+        self.viewModel = viewModel
+        self.onUpdate = onUpdate
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Layout.defaultSpacing) {
+                VStack(alignment: .leading, spacing: Layout.titleAndProductNameSpacing) {
+                    Text(Localization.title)
+                        .headlineStyle()
+
+                    TextField(Localization.productNamePlaceholder, text: $viewModel.name)
+                        .subheadlineStyle()
+                }
+
+                // Since there is no placeholder support in `TextEditor`, a workaround is to
+                // use a ZStack with an optional `Text` on top that passes through the gestures.
+                ZStack(alignment: .topLeading) {
+                    TextEditor(text: $viewModel.features)
+                        .bodyStyle()
+                        .foregroundColor(.secondary)
+                        .background(.clear)
+                        .padding(insets: Layout.productFeaturesInsets)
+                        .frame(minHeight: Layout.minimuEditorSize, maxHeight: .infinity)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
+                        )
+
+                    if viewModel.features.isEmpty {
+                        Text(Localization.productDescriptionPlaceholder)
+                            .foregroundColor(Color(.textSubtle))
+                            .bodyStyle()
+                            .padding(insets: Layout.productFeaturesPlaceholderInsets)
+                            // Allows gestures to pass through to the `TextEditor`.
+                            .allowsHitTesting(false)
+                    }
+                }
+
+                if let suggestedText = viewModel.suggestedText {
+                    Text(suggestedText)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .textSelection(.enabled)
+                        .padding(Layout.suggestedTextInsets)
+                        .background(
+                            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                                .foregroundColor(.init(uiColor: .secondarySystemBackground))
+                        )
+                }
+
+                HStack(alignment: .center, spacing: Layout.defaultSpacing) {
+                    if let suggestedText = viewModel.suggestedText {
+                        // CTA to copy the generated text.
+                        Button {
+                            UIPasteboard.general.string = suggestedText
+                        } label: {
+                            Label(Localization.copyGeneratedText, systemImage: "doc.on.doc")
+                        }.buttonStyle(PlainButtonStyle())
+
+                        Spacer()
+
+                        // CTA to start or stop text generation based on the current state.
+                        Button {
+                            viewModel.toggleDescriptionGeneration()
+                        } label: {
+                            Image(systemName: viewModel.isGenerationInProgress ? "pause.circle": "arrow.counterclockwise")
+                        }.buttonStyle(PlainButtonStyle())
+
+                        // CTA to apply the generated text.
+                        Button(Localization.insertGeneratedText) {
+                            onUpdate(.init(name: viewModel.name, description: suggestedText))
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                        .fixedSize(horizontal: true, vertical: false)
+                    } else {
+                        // CTA to generate text for the first pass.
+                        Button(Localization.generateText) {
+                            viewModel.generateDescription()
+                        }
+                        .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isGenerationInProgress))
+                        .disabled(viewModel.isGenerationEnabled == false)
+                    }
+                }
+
+                if let errorMessage = viewModel.errorMessage {
+                    Text(errorMessage)
+                        .font(.footnote)
+                        .errorStyle()
+                }
+            }.padding(insets: Layout.insets)
+        }
+    }
+}
+
+// MARK: Constants
+private extension ProductDescriptionGenerationView {
+    enum Layout {
+        static let insets: EdgeInsets = .init(top: 24, leading: 16, bottom: 16, trailing: 16)
+        static let defaultSpacing: CGFloat = 16
+        static let titleAndProductNameSpacing: CGFloat = 2
+        static let minimuNameEditorSize: CGFloat = 30
+        static let minimuEditorSize: CGFloat = 76
+        static let cornerRadius: CGFloat = 8
+        static let productFeaturesInsets: EdgeInsets = .init(top: 10, leading: 10, bottom: 10, trailing: 10)
+        static let productFeaturesPlaceholderInsets: EdgeInsets = .init(top: 18, leading: 16, bottom: 18, trailing: 16)
+        static let suggestedTextInsets: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+    }
+}
+
+private extension ProductDescriptionGenerationView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Write product description",
+            comment: "Title in the product description AI generator view."
+        )
+        static let productNamePlaceholder = NSLocalizedString(
+            "Enter product name",
+            comment: "Product name placeholder in the product description AI generator view."
+        )
+        static let productDescriptionPlaceholder = NSLocalizedString(
+            "Describe your product features",
+            comment: "Product features placeholder in the product description AI generator view."
+        )
+        static let copyGeneratedText = NSLocalizedString(
+            "Copy",
+            comment: "Button title to copy generated text in the product description AI generator view."
+        )
+        static let insertGeneratedText = NSLocalizedString("Apply",
+                                                           comment: "Button title to insert AI-generated product description.")
+        static let generateText = NSLocalizedString("Generate",
+                                                    comment: "Button title to generate product description with Jetpack AI.")
+    }
+}
+
+#if DEBUG
+
+import Yosemite
+
+final class ProductDescriptionGenerationPreviewStores: DefaultStoresManager {
+    private let result: Result<String, Error>
+
+    init(result: Result<String, Error>) {
+        self.result = result
+        super.init(sessionManager: ServiceLocator.stores.sessionManager)
+    }
+
+    override func dispatch(_ action: Action) {
+        if let action = action as? ProductAction {
+            if case let .generateProductDescription(_, _, _, _, completion) = action {
+                completion(result)
+            }
+        }
+    }
+}
+
+struct ProductDescriptionGenerationView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProductDescriptionGenerationView(viewModel:
+                .init(siteID: 0,
+                      name: "Potted cactus",
+                      description: "low-maintenance, decorative plant that improves indoor air quality and provides health benefits",
+                      stores: ProductDescriptionGenerationPreviewStores(result:
+                            .success("These unique plants thrive in harsh environments and require very little care."))),
+                                         onUpdate: { _ in })
+        .previewDisplayName("Pre-filled name and features with success")
+
+        ProductDescriptionGenerationView(viewModel:
+                .init(siteID: 0,
+                      name: "",
+                      description: "",
+                      stores: ProductDescriptionGenerationPreviewStores(result:
+                            .failure(ProductDownloadFileError.emptyFileName))),
+                                         onUpdate: { _ in })
+        .previewDisplayName("Empty name and features with failure")
+    }
+}
+
+#endif

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -42,7 +42,6 @@ final class ProductDescriptionGenerationViewModel: ObservableObject {
     }
 
     /// Generates product description async.
-    @MainActor
     func generateDescription() {
         isGenerationInProgress = true
         errorMessage = nil
@@ -53,7 +52,6 @@ final class ProductDescriptionGenerationViewModel: ObservableObject {
     }
 
     /// Stops or starts product description generation, depending on whether it is in progress.
-    @MainActor
     func toggleDescriptionGeneration() {
         if isGenerationInProgress {
             task?.cancel()

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -25,17 +25,20 @@ final class ProductDescriptionGenerationViewModel: ObservableObject {
 
     private let siteID: Int64
     private let stores: StoresManager
+    private let onApply: (_ output: ProductDescriptionGenerationOutput) -> Void
 
     private var task: Task<Void, Error>?
 
     init(siteID: Int64,
          name: String,
          description: String,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         onApply: @escaping (ProductDescriptionGenerationOutput) -> Void) {
         self.name = name
         self.features = description
         self.siteID = siteID
         self.stores = stores
+        self.onApply = onApply
     }
 
     /// Generates product description async.
@@ -58,6 +61,11 @@ final class ProductDescriptionGenerationViewModel: ObservableObject {
         } else {
             generateDescription()
         }
+    }
+
+    /// Applies the generated product description and product name to the product.
+    func applyToProduct() {
+        onApply(.init(name: name, description: suggestedText ?? ""))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Yosemite
+
+/// View model for `ProductDescriptionGenerationView`.
+final class ProductDescriptionGenerationViewModel: ObservableObject {
+    /// Product name, editable.
+    @Published var name: String
+
+    /// Product features, editable. The default value is the pre-existing product description.
+    @Published var features: String
+
+    /// AI-generated product description.
+    @Published private(set) var suggestedText: String?
+
+    /// Error message from generating product description.
+    @Published private(set) var errorMessage: String?
+
+    /// Whether product description generation API request is still in progress.
+    @Published private(set) var isGenerationInProgress: Bool = false
+
+    /// Whether the text generation CTA is enabled.
+    var isGenerationEnabled: Bool {
+        name.isNotEmpty && features.isNotEmpty
+    }
+
+    private let siteID: Int64
+    private let stores: StoresManager
+
+    private var task: Task<Void, Error>?
+
+    init(siteID: Int64,
+         name: String,
+         description: String,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.name = name
+        self.features = description
+        self.siteID = siteID
+        self.stores = stores
+    }
+
+    /// Generates product description async.
+    @MainActor
+    func generateDescription() {
+        isGenerationInProgress = true
+        errorMessage = nil
+        task = Task { @MainActor in
+            let result = await generateProductDescription()
+            handleGenerationResult(result)
+        }
+    }
+
+    /// Stops or starts product description generation, depending on whether it is in progress.
+    @MainActor
+    func toggleDescriptionGeneration() {
+        if isGenerationInProgress {
+            task?.cancel()
+            isGenerationInProgress = false
+        } else {
+            generateDescription()
+        }
+    }
+}
+
+private extension ProductDescriptionGenerationViewModel {
+    @MainActor
+    func generateProductDescription() async -> Result<String, Error> {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(ProductAction.generateProductDescription(siteID: siteID,
+                                                                     name: name,
+                                                                     features: features,
+                                                                     languageCode: Locale.current.identifier) { result in
+                continuation.resume(returning: result)
+            })
+        }
+    }
+
+    @MainActor
+    func handleGenerationResult(_ result: Result<String, Error>) {
+        switch result {
+        case let .success(text):
+            suggestedText = text
+        case let .failure(error):
+            errorMessage = error.localizedDescription
+            DDLogError("Error generating product description: \(error)")
+        }
+        isGenerationInProgress = false
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1172,8 +1172,12 @@ private extension ProductFormViewController {
     func editProductDescription() {
         let isAIGenerationEnabled = aiEligibilityChecker.isFeatureEnabled(.description)
         let editorViewController = EditorFactory().productDescriptionEditor(product: product,
-                                                                            isAIGenerationEnabled: isAIGenerationEnabled) { [weak self] content in
-            self?.onEditProductDescriptionCompletion(newDescription: content)
+                                                                            isAIGenerationEnabled: isAIGenerationEnabled) { [weak self] content, productName in
+            guard let self else { return }
+            if let productName {
+                self.onEditProductNameCompletion(newName: productName)
+            }
+            self.onEditProductDescriptionCompletion(newDescription: content)
         }
         navigationController?.pushViewController(editorViewController, animated: true)
     }
@@ -1363,7 +1367,7 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
     func editShortDescription() {
-        let editorViewController = EditorFactory().productShortDescriptionEditor(product: product) { [weak self] content in
+        let editorViewController = EditorFactory().productShortDescriptionEditor(product: product) { [weak self] content, _ in
             self?.onEditShortDescriptionCompletion(newShortDescription: content)
         }
         navigationController?.pushViewController(editorViewController, animated: true)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -497,6 +497,8 @@
 		02EA6BFC2435EC3500FFF90A /* MockImageDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EA6BFB2435EC3500FFF90A /* MockImageDownloader.swift */; };
 		02EAA4C8290F992B00918DAB /* LoggedOutStoreCreationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAA4C7290F992B00918DAB /* LoggedOutStoreCreationCoordinator.swift */; };
 		02EAA4CA2911004B00918DAB /* TextFieldStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAA4C92911004B00918DAB /* TextFieldStyles.swift */; };
+		02EAF5BE29FA04750058071C /* ProductDescriptionGenerationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAF5BD29FA04750058071C /* ProductDescriptionGenerationView.swift */; };
+		02EAF5C029FA04850058071C /* ProductDescriptionGenerationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAF5BF29FA04850058071C /* ProductDescriptionGenerationViewModel.swift */; };
 		02ECD1DF24FF48D000735BE5 /* PaginationTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ECD1DE24FF48D000735BE5 /* PaginationTracker.swift */; };
 		02ECD1E124FF496200735BE5 /* PaginationTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ECD1E024FF496200735BE5 /* PaginationTrackerTests.swift */; };
 		02ECD1E424FF5E0B00735BE5 /* AddProductCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ECD1E324FF5E0B00735BE5 /* AddProductCoordinator.swift */; };
@@ -2743,6 +2745,8 @@
 		02EA6BFB2435EC3500FFF90A /* MockImageDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageDownloader.swift; sourceTree = "<group>"; };
 		02EAA4C7290F992B00918DAB /* LoggedOutStoreCreationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedOutStoreCreationCoordinator.swift; sourceTree = "<group>"; };
 		02EAA4C92911004B00918DAB /* TextFieldStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldStyles.swift; sourceTree = "<group>"; };
+		02EAF5BD29FA04750058071C /* ProductDescriptionGenerationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionGenerationView.swift; sourceTree = "<group>"; };
+		02EAF5BF29FA04850058071C /* ProductDescriptionGenerationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionGenerationViewModel.swift; sourceTree = "<group>"; };
 		02ECD1DE24FF48D000735BE5 /* PaginationTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationTracker.swift; sourceTree = "<group>"; };
 		02ECD1E024FF496200735BE5 /* PaginationTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationTrackerTests.swift; sourceTree = "<group>"; };
 		02ECD1E324FF5E0B00735BE5 /* AddProductCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductCoordinator.swift; sourceTree = "<group>"; };
@@ -5677,6 +5681,15 @@
 			path = Dashboard;
 			sourceTree = "<group>";
 		};
+		02EAF5BC29FA04660058071C /* AI */ = {
+			isa = PBXGroup;
+			children = (
+				02EAF5BD29FA04750058071C /* ProductDescriptionGenerationView.swift */,
+				02EAF5BF29FA04850058071C /* ProductDescriptionGenerationViewModel.swift */,
+			);
+			path = AI;
+			sourceTree = "<group>";
+		};
 		02ECD1E224FF5DDD00735BE5 /* Add Product */ = {
 			isa = PBXGroup;
 			children = (
@@ -7334,6 +7347,7 @@
 		74EC34A3225FE1F3004BBC2E /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				02EAF5BC29FA04660058071C /* AI */,
 				DE4FB771280E758D003D20D6 /* ProductSelector */,
 				0279F0DD252DC1060098D7DE /* Product Loader */,
 				02ECD1E224FF5DDD00735BE5 /* Add Product */,
@@ -11612,6 +11626,7 @@
 				B946881A29BA2AC6000646B0 /* WooAnalyticsEvent+Spotlight.swift in Sources */,
 				0235BFD9246E959500778909 /* ProductFormActionsFactory.swift in Sources */,
 				024EFA6923FCC10B00F36918 /* Product+Media.swift in Sources */,
+				02EAF5BE29FA04750058071C /* ProductDescriptionGenerationView.swift in Sources */,
 				CC857C7729B25FAF00E19D1E /* FooterNotice.swift in Sources */,
 				0202B68D23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift in Sources */,
 				2677B559299F322300862180 /* SupportForm+Presentation.swift in Sources */,
@@ -11763,6 +11778,7 @@
 				74AAF6A5212A04A900C612B0 /* ChartMarker.swift in Sources */,
 				CE32B11520BF8779006FBCF4 /* ButtonTableViewCell.swift in Sources */,
 				CCFBBCF829C4C8010081B595 /* ComponentSettings.swift in Sources */,
+				02EAF5C029FA04850058071C /* ProductDescriptionGenerationViewModel.swift in Sources */,
 				025FDD3223717D2900824006 /* EditorFactory.swift in Sources */,
 				45D1CF4723BAC89A00945A36 /* ProductTaxStatusListSelectorCommand.swift in Sources */,
 				453DBF9023882814006762A5 /* ProductImagesFlowLayout.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -499,6 +499,7 @@
 		02EAA4CA2911004B00918DAB /* TextFieldStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAA4C92911004B00918DAB /* TextFieldStyles.swift */; };
 		02EAF5BE29FA04750058071C /* ProductDescriptionGenerationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAF5BD29FA04750058071C /* ProductDescriptionGenerationView.swift */; };
 		02EAF5C029FA04850058071C /* ProductDescriptionGenerationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAF5BF29FA04850058071C /* ProductDescriptionGenerationViewModel.swift */; };
+		02EAF5C329FA30FF0058071C /* ProductDescriptionGenerationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAF5C229FA30FF0058071C /* ProductDescriptionGenerationViewModelTests.swift */; };
 		02ECD1DF24FF48D000735BE5 /* PaginationTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ECD1DE24FF48D000735BE5 /* PaginationTracker.swift */; };
 		02ECD1E124FF496200735BE5 /* PaginationTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ECD1E024FF496200735BE5 /* PaginationTrackerTests.swift */; };
 		02ECD1E424FF5E0B00735BE5 /* AddProductCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ECD1E324FF5E0B00735BE5 /* AddProductCoordinator.swift */; };
@@ -2747,6 +2748,7 @@
 		02EAA4C92911004B00918DAB /* TextFieldStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldStyles.swift; sourceTree = "<group>"; };
 		02EAF5BD29FA04750058071C /* ProductDescriptionGenerationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionGenerationView.swift; sourceTree = "<group>"; };
 		02EAF5BF29FA04850058071C /* ProductDescriptionGenerationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionGenerationViewModel.swift; sourceTree = "<group>"; };
+		02EAF5C229FA30FF0058071C /* ProductDescriptionGenerationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionGenerationViewModelTests.swift; sourceTree = "<group>"; };
 		02ECD1DE24FF48D000735BE5 /* PaginationTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationTracker.swift; sourceTree = "<group>"; };
 		02ECD1E024FF496200735BE5 /* PaginationTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationTrackerTests.swift; sourceTree = "<group>"; };
 		02ECD1E324FF5E0B00735BE5 /* AddProductCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductCoordinator.swift; sourceTree = "<group>"; };
@@ -5138,6 +5140,7 @@
 				26F94E32267AA3DD00DB6CCF /* Addons */,
 				02077F70253816B1005A78EF /* Actions Factory */,
 				024F1450250B658F0003030A /* Add Product */,
+				02EAF5C129FA30D70058071C /* AI */,
 				02A9A494244D848F00757B99 /* BottomSheetListSelector */,
 				7E7C5F892719AEAF00315B61 /* Categories */,
 				0248B3522457CF1500A271A4 /* Filters */,
@@ -5686,6 +5689,14 @@
 			children = (
 				02EAF5BD29FA04750058071C /* ProductDescriptionGenerationView.swift */,
 				02EAF5BF29FA04850058071C /* ProductDescriptionGenerationViewModel.swift */,
+			);
+			path = AI;
+			sourceTree = "<group>";
+		};
+		02EAF5C129FA30D70058071C /* AI */ = {
+			isa = PBXGroup;
+			children = (
+				02EAF5C229FA30FF0058071C /* ProductDescriptionGenerationViewModelTests.swift */,
 			);
 			path = AI;
 			sourceTree = "<group>";
@@ -12462,6 +12473,7 @@
 				B541B2132189E7FD008FE7C1 /* ScannerWooTests.swift in Sources */,
 				CC4B252D27CFE443008D2E6E /* OrderTotalsCalculatorTests.swift in Sources */,
 				DEF8CF1A29AC6E5900800A60 /* AdminRoleRequiredViewModelTests.swift in Sources */,
+				02EAF5C329FA30FF0058071C /* ProductDescriptionGenerationViewModelTests.swift in Sources */,
 				B57C5C9A21B80E7100FF82B2 /* DataWooTests.swift in Sources */,
 				B53A56A42112483E000776C9 /* Constants.swift in Sources */,
 				2667BFE72530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductDescriptionGenerationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/AI/ProductDescriptionGenerationViewModelTests.swift
@@ -1,0 +1,184 @@
+import Combine
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+@MainActor
+final class ProductDescriptionGenerationViewModelTests: XCTestCase {
+    private var stores: MockStoresManager!
+    private var subscriptions: Set<AnyCancellable> = []
+
+    override func setUp() {
+        super.setUp()
+
+        stores = MockStoresManager(sessionManager: .testingInstance)
+    }
+
+    override func tearDown() {
+        stores = nil
+
+        super.tearDown()
+    }
+
+    // MARK: - `suggestedText`
+
+    func test_suggestedText_is_set_after_generateDescription_success() throws {
+        // Given
+        mockGeneratedDescription(result: .success("Must buy"))
+
+        let viewModel = ProductDescriptionGenerationViewModel(siteID: 6, name: "", description: "", stores: stores, onApply: { _ in })
+        XCTAssertNil(viewModel.suggestedText)
+
+        // When
+        viewModel.generateDescription()
+
+        // Then
+        waitUntil {
+            viewModel.suggestedText == "Must buy"
+        }
+    }
+
+    // MARK: - `errorMessage`
+
+    func test_errorMessage_is_set_after_generateDescription_failure() throws {
+        // Given
+        mockGeneratedDescription(result: .failure(TestError.generationFailure))
+
+        let viewModel = ProductDescriptionGenerationViewModel(siteID: 6, name: "", description: "", stores: stores, onApply: { _ in })
+
+        // When
+        viewModel.generateDescription()
+
+        // Then
+        waitUntil {
+            viewModel.errorMessage == "Generation error"
+        }
+    }
+
+    // MARK: - `onApply`
+
+    func test_applyToProductonApply_invokes_onApply_with_generated_description_and_updated_product_name() throws {
+        // Given
+        mockGeneratedDescription(result: .success("Must buy"))
+
+        var productContent: ProductDescriptionGenerationOutput?
+        let viewModel = ProductDescriptionGenerationViewModel(siteID: 6,
+                                                              name: "",
+                                                              description: "Durable",
+                                                              stores: stores,
+                                                              onApply: { content in
+            productContent = content
+        })
+
+        // When
+        viewModel.name = "Fun"
+        viewModel.generateDescription()
+        waitUntil {
+            viewModel.isGenerationInProgress == false
+        }
+        viewModel.applyToProduct()
+
+        // Then
+        XCTAssertEqual(productContent, .init(name: "Fun", description: "Must buy"))
+    }
+
+    // MARK: - `isGenerationInProgress`
+
+    func test_isGenerationInProgress_becomes_true_when_generating_description() throws {
+        // Given
+        let viewModel = ProductDescriptionGenerationViewModel(siteID: 6, name: "", description: "", onApply: { _ in })
+        XCTAssertFalse(viewModel.isGenerationInProgress)
+
+        // When
+        viewModel.generateDescription()
+
+        // Then
+        XCTAssertTrue(viewModel.isGenerationInProgress)
+    }
+
+    func test_isGenerationInProgress_becomes_true_then_false_when_toggling_description_twice() throws {
+        // Given
+        let viewModel = ProductDescriptionGenerationViewModel(siteID: 6, name: "", description: "", onApply: { _ in })
+
+        // When toggling generation
+        viewModel.toggleDescriptionGeneration()
+
+        // Then `isGenerationInProgress` becomes `true`
+        XCTAssertTrue(viewModel.isGenerationInProgress)
+
+        // When toggling generation again
+        viewModel.toggleDescriptionGeneration()
+
+        // Then `isGenerationInProgress` becomes `true`
+        XCTAssertFalse(viewModel.isGenerationInProgress)
+    }
+
+    func test_isGenerationInProgress_becomes_false_when_toggling_description_completes() throws {
+        // Given
+        let viewModel = ProductDescriptionGenerationViewModel(siteID: 6, name: "", description: "", stores: stores, onApply: { _ in })
+        mockGeneratedDescription(result: .success(""))
+
+        var isGenerationInProgressValues: [Bool] = []
+        viewModel.$isGenerationInProgress.sink { value in
+            isGenerationInProgressValues.append(value)
+        }.store(in: &subscriptions)
+
+        XCTAssertEqual(isGenerationInProgressValues, [false])
+
+        // When
+        viewModel.toggleDescriptionGeneration()
+
+        // Then
+        waitUntil {
+            isGenerationInProgressValues == [false, true, false]
+        }
+    }
+
+    // MARK: - `isGenerationEnabled`
+
+    func test_isGenerationEnabled_is_false_when_product_name_is_empty() throws {
+        // Given
+        let viewModel = ProductDescriptionGenerationViewModel(siteID: 6, name: "", description: "a product", onApply: { _ in })
+
+        // Then
+        XCTAssertFalse(viewModel.isGenerationEnabled)
+    }
+
+    func test_isGenerationEnabled_is_false_when_product_description_is_empty() throws {
+        // Given
+        let viewModel = ProductDescriptionGenerationViewModel(siteID: 6, name: "Woo plate", description: "", onApply: { _ in })
+
+        // Then
+        XCTAssertFalse(viewModel.isGenerationEnabled)
+    }
+
+    func test_isGenerationEnabled_is_true_when_product_name_and_description_are_not_empty() throws {
+        // Given
+        let viewModel = ProductDescriptionGenerationViewModel(siteID: 6, name: "Woo", description: "a product", onApply: { _ in })
+
+        // Then
+        XCTAssertTrue(viewModel.isGenerationEnabled)
+    }
+}
+
+private extension ProductDescriptionGenerationViewModelTests {
+    func mockGeneratedDescription(result: Result<String, Error>) {
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            guard case let .generateProductDescription(_, _, _, _, completion) = action else {
+                return XCTFail("Unexpected action: \(action)")
+            }
+            completion(result)
+        }
+    }
+}
+
+private enum TestError: LocalizedError {
+    case generationFailure
+
+    var errorDescription: String? {
+        switch self {
+        case .generationFailure:
+            return "Generation error"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9465 
<!-- Id number of the GitHub issue this PR addresses. -->

Apology for the 500+ diffs, the unit tests were a bit long with coverage on a few different properties.

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After previous PRs for https://github.com/woocommerce/woocommerce-ios/issues/9465, this PR integrated the bottom sheet with the product description AI flow.

## The flow

There are two input fields:

- Product name
- Product features with default value as the pre-existing product description

There is only 1 CTA in the beginning to generate a product description, when the product name & features are non-empty.

After a description is generated, there are 3 CTAs:
- Copy generated description
- Toggle description generation (start/stop)
- Apply the generated description and the latest name to the product

## How

`ProductDescriptionGenerationView` is the main SwiftUI view, with a view model `ProductDescriptionGenerationViewModel` to supply observable data and handle user interactions. To integrate the view with the bottom sheet, `ProductDescriptionGenerationHostingController ` is shown for the CTA in the bottom sheet in `AztecEditorViewController`. Since the product name can also be updated to polish the description, the product name is also added to `Editor.OnContentSave`. When applying the content to the product, `ProductFormViewController` updated its name and description accordingly.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in to a WPCOM store if needed
- Go to the Products tab
- Create a product if needed
- Tap on an editable product
- Tap on the product description row
- Tap on the magic wand CTA above the keyboard --> a bottom sheet should be shown, the product name and features should be pre-filled with the pre-existing name and description
- Enter or update the product name
- Enter or update the product features
- Tap `Generate` --> a spinner should be shown in the button, and after a while (30-60 seconds from my testing), some generated text should be shown below in gray with 3 CTAs: `Copy`, retry icon, and `Apply`
- Tap `Copy` and try pasting the content somewhere in or outside of the app --> the generated text should be in the pasteboard
- Tap the retry icon in the middle --> the icon should become a pause button. after a while, the generated text should be replaced above
- Tap the retry icon again, and immediately tap again  --> the icon should go back to the retry icon
- Tap `Apply` --> the product description should be replaced with the generated text
- Tap `Done` --> the product form should have the updated product name and generated text as its description, with the `Save` CTA enabled
- Tap `Save` --> the product name & description should be saved remotely

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://user-images.githubusercontent.com/1945542/234768978-3dc53b86-92b2-49ec-a567-ce6f50f94eb4.mov


Initial state | After generation
-- | --
![Simulator Screen Shot - iPhone 14 - 2023-04-27 at 13 13 50](https://user-images.githubusercontent.com/1945542/234768951-3af58e7d-a46e-4aaf-bc4d-c616bb6d8f44.png) | ![Simulator Screen Shot - iPhone 14 - 2023-04-27 at 13 13 54](https://user-images.githubusercontent.com/1945542/234768956-417c8093-29ff-4e79-b25f-0da68ccc7f66.png)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
