### PR TITLE
[Mobile Payments] Replace “Built in reader” with “Tap to Pay on iPhone”

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -154,7 +154,7 @@ extension StripeCardReaderService: CardReaderService {
 
     // If we're using the simulated reader, we don't want to check for Bluetooth permissions
     // as the simulator won't have Bluetooth available.
-    // If we're using the built-in reader, bluetooth is not required.
+    // If we're using Tap to Pay on iPhone, bluetooth is not required.
     private func shouldSkipBluetoothCheck(discoveryConfiguration: DiscoveryConfiguration) -> Bool {
         shouldUseSimulatedCardReader || discoveryConfiguration.discoveryMethod == .localMobile
     }

--- a/Hardware/Hardware/CardReader/UnderlyingError.swift
+++ b/Hardware/Hardware/CardReader/UnderlyingError.swift
@@ -149,9 +149,9 @@ public enum UnderlyingError: Error, Equatable {
     /// There was no refund in progress to cancel
     case noRefundInProgress
 
-    // MARK: - Built-in reader related errors
+    // MARK: - Tap to Pay on iPhone related errors
 
-    /// The device must have a passcode in order to use the built-in reader
+    /// The device must have a passcode in order to use Tap to Pay on iPhone
     /// https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorPasscodeNotEnabled
     case passcodeNotEnabled
 
@@ -165,43 +165,43 @@ public enum UnderlyingError: Error, Equatable {
     /// https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorNFCDisabled
     case nfcDisabled
 
-    /// Preparing the built-in reader failed. This is a retriable error
+    /// Preparing Tap to Pay on iPhone failed. This is a retriable error
     /// https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorAppleBuiltInReaderFailedToPrepare
     case appleBuiltInReaderFailedToPrepare
 
-    /// The user cancelled the built-in reader Terms of Service acceptance
+    /// The user cancelled Tap to Pay on iPhone Terms of Service acceptance
     /// https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorAppleBuiltInReaderTOSAcceptanceCanceled
     case appleBuiltInReaderTOSAcceptanceCanceled
 
-    /// The built-in reader Terms of Service have not been accepted. This error is retriable
+    /// Tap to Pay on iPhone Terms of Service have not been accepted. This error is retriable
     /// https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorAppleBuiltInReaderTOSNotYetAccepted
     case appleBuiltInReaderTOSNotYetAccepted
 
-    /// The built-in reader Terms of Service could not be accepted. This may indicate an issue with the Apple ID used.
+    /// Tap to Pay on iPhone Terms of Service could not be accepted. This may indicate an issue with the Apple ID used.
     /// https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorAppleBuiltInReaderTOSAcceptanceFailed
     case appleBuiltInReaderTOSAcceptanceFailed
 
-    /// This (Stripe) merchant account cannot be used with the built-in reader as it has been blocked
+    /// This (Stripe) merchant account cannot be used with Tap to Pay on iPhone as it has been blocked
     /// https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorAppleBuiltInReaderMerchantBlocked
     case appleBuiltInReaderMerchantBlocked
 
-    /// The merchant account is invalid and cannot be used with the built-in reader
+    /// The merchant account is invalid and cannot be used with Tap to Pay on iPhone
     /// https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorAppleBuiltInReaderInvalidMerchant
     case appleBuiltInReaderInvalidMerchant
 
-    /// The built-in reader on this device cannot be used because it has been banned
+    /// Tap to Pay on iPhone on this device cannot be used because it has been banned
     /// https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorAppleBuiltInReaderDeviceBanned
     case appleBuiltInReaderDeviceBanned
 
-    /// The device does not meet the minimum requirements for using the built-in reader
+    /// The device does not meet the minimum requirements for using Tap to Pay on iPhone
     /// https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorUnsupportedMobileDeviceConfiguration
     case unsupportedMobileDeviceConfiguration
 
-    /// The built-in reader cannot be used while the app is in the background
+    /// Tap to Pay on iPhone cannot be used while the app is in the background
     /// https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorReaderNotAccessibleInBackground
     case readerNotAccessibleInBackground
 
-    /// The built-in reader cannot be used during a phone call
+    /// Tap to Pay on iPhone cannot be used during a phone call
     /// https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPError.html#/c:@E@SCPError@SCPErrorCommandNotAllowedDuringCall
     case commandNotAllowedDuringCall
 
@@ -409,60 +409,60 @@ extension UnderlyingError: LocalizedError {
                                      comment: "Error message shown when a refund could not be canceled (likely because " +
                                      "it had already completed)")
 
-            // MARK: - Built-in reader errors
+            // MARK: - Tap to Pay on iPhone errors
         case .passcodeNotEnabled:
             return NSLocalizedString("You need to set a lock screen passcode to use Tap to Pay on iPhone",
-                                     comment: "Error message shown when the built-in reader cannot be used because " +
+                                     comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the device does not have a passcode set.")
         case .appleBuiltInReaderTOSAcceptanceRequiresiCloudSignIn:
             return NSLocalizedString("Please sign in to iCloud on this device to use Tap to Pay on iPhone",
-                                     comment: "Error message shown when the built-in reader cannot be used because " +
+                                     comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the device is not signed in to iCloud.")
         case .nfcDisabled:
             return NSLocalizedString("The app could not enable Tap to Pay on iPhone, because the NFC chip is disabled. " +
                                      "Please contact support for more details.",
-                                     comment: "Error message shown when the built-in reader cannot be used because " +
+                                     comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the device's NFC chipset has been disabled by a device management policy.")
         case .appleBuiltInReaderFailedToPrepare, .readerNotAccessibleInBackground:
             return NSLocalizedString("There was an issue preparing to use Tap to Pay on iPhone – please try again.",
-                                     comment: "Error message shown when the built-in reader cannot be used because " +
+                                     comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "there was some issue with the connection. Retryable.")
         case .appleBuiltInReaderTOSAcceptanceCanceled, .appleBuiltInReaderTOSNotYetAccepted:
             return NSLocalizedString("Please try again, and accept Apple's Terms of Service, so you can use Tap to " +
                                      "Pay on iPhone",
-                                     comment: "Error message shown when the built-in reader cannot be used because " +
+                                     comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the merchant cancelled or did not complete the Terms of Service acceptance flow")
         case .appleBuiltInReaderTOSAcceptanceFailed:
             return NSLocalizedString("Please check your Apple ID is valid, and then try again. A valid Apple ID is " +
                                      "required to accept Apple's Terms of Service",
-                                     comment: "Error message shown when the built-in reader cannot be used because " +
+                                     comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the Terms of Service acceptance flow failed, possibly due to issues with " +
                                      "the Apple ID")
         case .appleBuiltInReaderMerchantBlocked, .appleBuiltInReaderInvalidMerchant, .appleBuiltInReaderDeviceBanned:
             return NSLocalizedString("Please contact support – there was an issue starting Tap to Pay on iPhone",
-                                     comment: "Error message shown when the built-in reader cannot be used because " +
+                                     comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "there is an issue with the merchant account or device")
         case .unsupportedMobileDeviceConfiguration:
             return NSLocalizedString("Please check that your phone meets these requirements: " +
                                      "iPhone XS or newer running iOS 16.0 or above. Contact support if this error " +
                                      "shows on a supported device.",
-                                     comment: "Error message shown when the built-in reader cannot be used because " +
+                                     comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the device does not meet minimum requirements.")
         case .commandNotAllowedDuringCall:
             return NSLocalizedString("Tap to Pay on iPhone cannot be used during a phone call. Please try again after " +
                                      "you finish your call.",
-                                     comment: "Error message shown when the built-in reader cannot be used because " +
+                                     comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "there is a call in progress")
         case .invalidAmount:
             return NSLocalizedString("The amount is not supported for Tap to Pay on iPhone – please try a hardware " +
                                      "reader or another payment method.",
-                                     comment: "Error message shown when the built-in reader cannot be used because " +
-                                     "the amount for payment is not supported by the built in reader.")
+                                     comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
+                                     "the amount for payment is not supported for Tap to Pay on iPhone.")
         case .invalidCurrency:
             return NSLocalizedString("The currency is not supported for Tap to Pay on iPhone – please try a hardware " +
                                      "reader or another payment method.",
-                                     comment: "Error message shown when the built-in reader cannot be used because " +
-                                     "the currency for payment is not supported by the built in reader.")
+                                     comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
+                                     "the currency for payment is not supported for Tap to Pay on iPhone.")
         }
     }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [Internal] Payments: Update StripeTerminal pod to 2.19.1 [https://github.com/woocommerce/woocommerce-ios/pull/9537]
 - [**] Adds read-only support for the Subscriptions extension in order and product details. [https://github.com/woocommerce/woocommerce-ios/pull/9541]
+- [Internal] Payments: Upate Tap to Pay connection flow strings to avoid mentioning "reader" [https://github.com/woocommerce/woocommerce-ios/pull/9563]
 
 13.3
 -----

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailed.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailed.swift
@@ -61,7 +61,7 @@ extension CardPresentModalBuiltInConnectingFailed: ReaderConnectionUnderlyingErr
         case .internalServiceError:
             return NSLocalizedString(
                 "Sorry, we could not start Tap to Pay on iPhone. Please check your connection and try again.",
-                comment: "Error message when the built-in reader connection experiences an unexpected internal service error."
+                comment: "Error message when Tap to Pay on iPhone connection experiences an unexpected internal service error."
             )
         default:
             return underlyingError.errorDescription

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailedNonRetryable.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingFailedNonRetryable.swift
@@ -56,7 +56,7 @@ extension CardPresentModalBuiltInConnectingFailedNonRetryable: ReaderConnectionU
         case .internalServiceError:
             return NSLocalizedString(
                 "Sorry, we could not start Tap to Pay on iPhone. Please check your connection and try again.",
-                comment: "Error message when the built-in reader connection experiences an unexpected internal service error."
+                comment: "Error message when Tap to Pay on iPhone connection experiences an unexpected internal service error."
             )
         default:
             return underlyingError.errorDescription

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingToReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInConnectingToReader.swift
@@ -38,13 +38,13 @@ final class CardPresentModalBuiltInConnectingToReader: CardPresentPaymentsModalV
 private extension CardPresentModalBuiltInConnectingToReader {
     enum Localization {
         static let title = NSLocalizedString(
-            "Preparing iPhone card reader",
+            "Preparing Tap to Pay on iPhone",
             comment: "Title label for modal dialog that appears when connecting to a built in card reader"
         )
 
         static let instruction = NSLocalizedString(
-            "The first time you connect, you may be prompted to accept Apple's Terms of Service.",
-            comment: "Label within the modal dialog that appears when connecting to a built in card reader"
+            "The first time you use Tap to Pay on iPhone, you may be prompted to accept Apple's Terms of Service.",
+            comment: "Label within the modal dialog that appears when starting Tap to Pay on iPhone"
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInFollowReaderInstructions.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInFollowReaderInstructions.swift
@@ -64,14 +64,15 @@ final class CardPresentModalBuiltInFollowReaderInstructions: CardPresentPayments
 private extension CardPresentModalBuiltInFollowReaderInstructions {
     enum Localization {
         static let readerIsReady = NSLocalizedString(
-            "iPhone reader is ready",
-            comment: "Indicates the status of a built in card reader. Presented to users when payment collection starts"
+            "Tap to Pay on iPhone is ready",
+            comment: "Indicates the status of Tap to Pay on iPhone collection readiness. Presented to users when payment collection starts"
         )
 
         static let followReaderInstructions = NSLocalizedString(
-            "Follow reader instructions to pay",
-            comment: "Label asking users to follow the built in reader instruction. Presented to users when a " +
-            "payment is going to be collected using the iPhone's built in reader"
+            "Follow the on-screen instructions to pay",
+            comment: "Label asking users to follow the on-screen Tap to Pay on iPhone instructions. Presented when " +
+            "a payment is going to be collected using Tap to Pay on iPhone, which results in an Apple-provided " +
+            "screen being shown with instructions for payment."
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalPreparingReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalPreparingReader.swift
@@ -1,6 +1,7 @@
 import UIKit
 
-/// Modal presented when an error occurs while connecting to a reader due to problems with the address
+/// Modal presented when the reader is being prepared to take payment.
+/// In practice, this is shown while the PaymentIntent is being created.
 ///
 final class CardPresentModalPreparingReader: CardPresentPaymentsModalViewModel {
     let cancelAction: (() -> Void)
@@ -22,7 +23,7 @@ final class CardPresentModalPreparingReader: CardPresentPaymentsModalViewModel {
 
     let auxiliaryButtonTitle: String? = nil
 
-    var bottomTitle: String? = Localization.bottomTitle
+    var bottomTitle: String?
 
     let bottomSubtitle: String? = Localization.bottomSubitle
 
@@ -30,8 +31,10 @@ final class CardPresentModalPreparingReader: CardPresentPaymentsModalViewModel {
         return topTitle
     }
 
-    init(cancelAction: @escaping () -> Void) {
+    init(bottomTitle: String = Localization.bottomTitle,
+         cancelAction: @escaping () -> Void) {
         self.cancelAction = cancelAction
+        self.bottomTitle = bottomTitle
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
@@ -53,7 +56,7 @@ private extension CardPresentModalPreparingReader {
         )
 
         static let bottomTitle = NSLocalizedString(
-            "Connecting to reader",
+            "Preparing reader",
             comment: "Bottom title of the alert presented with a spinner while the reader is being prepared"
         )
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSelectSearchType.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSelectSearchType.swift
@@ -84,7 +84,7 @@ private extension CardReaderDiscoveryMethod {
         case .localMobile:
             return NSLocalizedString(
                 "Tap to Pay on iPhone",
-                comment: "The button title on the reader type alert, for the user to choose the built-in reader.")
+                comment: "The button title on the reader type alert, for the user to choose Tap to Pay on iPhone.")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderSettingsConnectedViewModel.swift
@@ -148,7 +148,7 @@ final class BluetoothCardReaderSettingsConnectedViewModel: PaymentSettingsFlowPr
     }
 
     /// This screen is only used for managing Bluetooth card readers.
-    /// If we're connected to the built-in reader, we should disconnect, as users are unlikely to consider
+    /// If we're connected to Tap to Pay on iPhone, we should disconnect, as users are unlikely to consider
     /// another part of their phone as something they connect to and manage.
     private func disconnectFromBuiltInReader(in readers: [CardReader]) {
         if readers.includesBuiltInReader() {
@@ -268,7 +268,7 @@ final class BluetoothCardReaderSettingsConnectedViewModel: PaymentSettingsFlowPr
             newShouldShow = .isFalse
         } else if connectedReaders.includesBuiltInReader() {
             /// This screen only supports management of Bluetooth readers, and will have started disconnection
-            /// the built-in reader in this instance.
+            /// from Tap to Pay on iPhone in this instance.
             newShouldShow = .isFalse
         } else {
             newShouldShow = .isTrue

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInCardReaderPaymentAlertsProvider.swift
@@ -9,7 +9,8 @@ final class BuiltInCardReaderPaymentAlertsProvider: CardReaderTransactionAlertsP
     var amount: String = ""
 
     func preparingReader(onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        CardPresentModalPreparingReader(cancelAction: onCancel)
+        CardPresentModalPreparingReader(bottomTitle: Localization.preparingReaderBottomTitle,
+                                        cancelAction: onCancel)
     }
 
     func tapOrInsertCard(title: String,
@@ -118,5 +119,10 @@ private extension BuiltInCardReaderPaymentAlertsProvider {
                 return underlyingError.errorDescription
             }
         }
+
+        static let preparingReaderBottomTitle = NSLocalizedString(
+            "Preparing Tap to Pay on iPhone ",
+            comment: "Bottom title of the alert presented with a spinner while Tap to Pay on iPhone is being prepared"
+        )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In user-facing text, Apple and Stripe have asked that we refrain from using the term “reader” or “built-in reader”, instead referring to Tap to Pay on iPhone.

This language was used in some of the connecting modals and error messages.

This change replaces these names as required, and reduces the use of `builtInReader` in the code as well (though, it’s still part of the Stripe SDK terminology so I’ve not removed it from all parts of the code, mostly comments.)


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a US-based store with an iPhone XS or newer on iOS 16+

1. Navigate to `Menu > Payments > Collect Payment`
2. Follow the flow to make a Simple Payment
3. Select `Tap to Pay on iPhone` in the Payment Methods screen
4. Observe that the modals which follow no longer reference a "built-in reader", instead they are specific to Tap to Pay on iPhone.

Repeat the test with an external reader

Observe that the modals still reference a "reader".

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/2472348/234818482-63050085-80fa-48d1-bc85-5a1dc16e5d5a.mp4


https://user-images.githubusercontent.com/2472348/234818502-b8821699-b4eb-4a48-8847-6bfd6ac2ce3b.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
