### PR TITLE
[Min/Max Quantities] Add support for product quantity rules (Networking layer)

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -856,7 +856,11 @@ extension Networking.Product {
             bundleStockQuantity: .fake(),
             bundledItems: .fake(),
             compositeComponents: .fake(),
-            subscription: .fake()
+            subscription: .fake(),
+            minAllowedQuantity: .fake(),
+            maxAllowedQuantity: .fake(),
+            groupOfQuantity: .fake(),
+            combineVariationQuantities: .fake()
         )
     }
 }

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -633,6 +633,7 @@
 		CE12FBD9221F3A6F00C59248 /* OrderStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12FBD8221F3A6F00C59248 /* OrderStatus.swift */; };
 		CE132BBA223851F80029DB6C /* ProductCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE132BB9223851F80029DB6C /* ProductCategory.swift */; };
 		CE132BBC223859710029DB6C /* ProductTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE132BBB223859710029DB6C /* ProductTag.swift */; };
+		CE13680F29FA74A400EBF43C /* product-min-max-quantities.json in Resources */ = {isa = PBXBuildFile; fileRef = CE13680E29FA74A400EBF43C /* product-min-max-quantities.json */; };
 		CE17C6B1229462C000AACE1C /* ProductStockStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE17C6B0229462C000AACE1C /* ProductStockStatus.swift */; };
 		CE19CB11222486A600E8AF7A /* order-statuses.json in Resources */ = {isa = PBXBuildFile; fileRef = CE19CB10222486A500E8AF7A /* order-statuses.json */; };
 		CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */ = {isa = PBXBuildFile; fileRef = CE20179220E3EFA7005B4C18 /* broken-orders.json */; };
@@ -1565,6 +1566,7 @@
 		CE12FBD8221F3A6F00C59248 /* OrderStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatus.swift; sourceTree = "<group>"; };
 		CE132BB9223851F80029DB6C /* ProductCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategory.swift; sourceTree = "<group>"; };
 		CE132BBB223859710029DB6C /* ProductTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTag.swift; sourceTree = "<group>"; };
+		CE13680E29FA74A400EBF43C /* product-min-max-quantities.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-min-max-quantities.json"; sourceTree = "<group>"; };
 		CE17C6B0229462C000AACE1C /* ProductStockStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatus.swift; sourceTree = "<group>"; };
 		CE19CB10222486A500E8AF7A /* order-statuses.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-statuses.json"; sourceTree = "<group>"; };
 		CE20179220E3EFA7005B4C18 /* broken-orders.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "broken-orders.json"; sourceTree = "<group>"; };
@@ -2561,6 +2563,7 @@
 				74749B98224135C4005C4CF2 /* product.json */,
 				EE6FDCFB2966A70400E1CECF /* product-without-data.json */,
 				DE5CA110288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json */,
+				CE13680E29FA74A400EBF43C /* product-min-max-quantities.json */,
 				02AAD53E250092A300BA1E26 /* product-add-or-delete.json */,
 				02698CF524C17FC1005337C4 /* product-alternative-types.json */,
 				CC01CE5729B0EBED004FF537 /* product-bundle.json */,
@@ -3515,6 +3518,7 @@
 				D865CE65278CA202002C8520 /* stripe-payment-intent-canceled.json in Resources */,
 				DE42F9672967F61D00D514C2 /* refunds-all-without-data.json in Resources */,
 				AED8AEBA272A97B400663FCC /* null-data.json in Resources */,
+				CE13680F29FA74A400EBF43C /* product-min-max-quantities.json in Resources */,
 				02BA23CA22EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json in Resources */,
 				31A451D627863A2E00FE81AA /* stripe-account-unknown-status.json in Resources */,
 				45152819257A84A60076B03C /* product-attributes-all.json in Resources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1085,7 +1085,7 @@ extension Networking.Product {
         minAllowedQuantity: NullableCopiableProp<String> = .copy,
         maxAllowedQuantity: NullableCopiableProp<String> = .copy,
         groupOfQuantity: NullableCopiableProp<String> = .copy,
-        combineVariationQuantities: NullableCopiableProp<String> = .copy
+        combineVariationQuantities: NullableCopiableProp<Bool> = .copy
     ) -> Networking.Product {
         let siteID = siteID ?? self.siteID
         let productID = productID ?? self.productID

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1081,7 +1081,11 @@ extension Networking.Product {
         bundleStockQuantity: NullableCopiableProp<Int64> = .copy,
         bundledItems: CopiableProp<[ProductBundleItem]> = .copy,
         compositeComponents: CopiableProp<[ProductCompositeComponent]> = .copy,
-        subscription: NullableCopiableProp<ProductSubscription> = .copy
+        subscription: NullableCopiableProp<ProductSubscription> = .copy,
+        minAllowedQuantity: NullableCopiableProp<String> = .copy,
+        maxAllowedQuantity: NullableCopiableProp<String> = .copy,
+        groupOfQuantity: NullableCopiableProp<String> = .copy,
+        combineVariationQuantities: NullableCopiableProp<String> = .copy
     ) -> Networking.Product {
         let siteID = siteID ?? self.siteID
         let productID = productID ?? self.productID
@@ -1151,6 +1155,10 @@ extension Networking.Product {
         let bundledItems = bundledItems ?? self.bundledItems
         let compositeComponents = compositeComponents ?? self.compositeComponents
         let subscription = subscription ?? self.subscription
+        let minAllowedQuantity = minAllowedQuantity ?? self.minAllowedQuantity
+        let maxAllowedQuantity = maxAllowedQuantity ?? self.maxAllowedQuantity
+        let groupOfQuantity = groupOfQuantity ?? self.groupOfQuantity
+        let combineVariationQuantities = combineVariationQuantities ?? self.combineVariationQuantities
 
         return Networking.Product(
             siteID: siteID,
@@ -1220,7 +1228,11 @@ extension Networking.Product {
             bundleStockQuantity: bundleStockQuantity,
             bundledItems: bundledItems,
             compositeComponents: compositeComponents,
-            subscription: subscription
+            subscription: subscription,
+            minAllowedQuantity: minAllowedQuantity,
+            maxAllowedQuantity: maxAllowedQuantity,
+            groupOfQuantity: groupOfQuantity,
+            combineVariationQuantities: combineVariationQuantities
         )
     }
 }

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -106,6 +106,21 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
     /// Subscription settings. Applicable to subscription-type products only.
     public let subscription: ProductSubscription?
 
+    // MARK: Min/Max Quantities properties
+
+    /// Minimum allowed quantity for the product. Applicable with Min/Max Quantities extension only.
+    public let minAllowedQuantity: String?
+
+    /// Maximum allowed quantity for the product. Applicable with Min/Max Quantities extension only.
+    public let maxAllowedQuantity: String?
+
+    /// "Group of" quantity, requiring customers to purchase the product in multiples. Applicable with Min/Max Quantities extension only.
+    public let groupOfQuantity: String?
+
+    /// Combines the quantities of all purchased variations when checking quantity rules.
+    /// Applicable with variable products and Min/Max Quantities extension only.
+    public let combineVariationQuantities: String?
+
     /// Computed Properties
     ///
     public var productStatus: ProductStatus {
@@ -225,7 +240,11 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                 bundleStockQuantity: Int64?,
                 bundledItems: [ProductBundleItem],
                 compositeComponents: [ProductCompositeComponent],
-                subscription: ProductSubscription?) {
+                subscription: ProductSubscription?,
+                minAllowedQuantity: String?,
+                maxAllowedQuantity: String?,
+                groupOfQuantity: String?,
+                combineVariationQuantities: String?) {
         self.siteID = siteID
         self.productID = productID
         self.name = name
@@ -294,6 +313,10 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         self.bundledItems = bundledItems
         self.compositeComponents = compositeComponents
         self.subscription = subscription
+        self.minAllowedQuantity = minAllowedQuantity
+        self.maxAllowedQuantity = maxAllowedQuantity
+        self.groupOfQuantity = groupOfQuantity
+        self.combineVariationQuantities = combineVariationQuantities
     }
 
     /// The public initializer for Product.
@@ -462,6 +485,16 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         // Subscription properties
         let subscription = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?.extractProductSubscription()
 
+        // Min/Max Quantities properties
+        let minAllowedQuantity = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?
+            .extractStringValue(forKey: MetadataKeys.minAllowedQuantity)
+        let maxAllowedQuantity = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?
+            .extractStringValue(forKey: MetadataKeys.maxAllowedQuantity)
+        let groupOfQuantity = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?
+            .extractStringValue(forKey: MetadataKeys.groupOfQuantity)
+        let combineVariationQuantities = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?
+            .extractStringValue(forKey: MetadataKeys.allowCombination)
+
         self.init(siteID: siteID,
                   productID: productID,
                   name: name,
@@ -529,7 +562,11 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                   bundleStockQuantity: bundleStockQuantity,
                   bundledItems: bundledItems,
                   compositeComponents: compositeComponents,
-                  subscription: subscription)
+                  subscription: subscription,
+                  minAllowedQuantity: minAllowedQuantity,
+                  maxAllowedQuantity: maxAllowedQuantity,
+                  groupOfQuantity: groupOfQuantity,
+                  combineVariationQuantities: combineVariationQuantities)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -721,6 +758,13 @@ private extension Product {
         case bundledItems                   = "bundled_items"
 
         case compositeComponents    = "composite_components"
+    }
+
+    enum MetadataKeys {
+        static let minAllowedQuantity = "minimum_allowed_quantity"
+        static let maxAllowedQuantity = "maximum_allowed_quantity"
+        static let groupOfQuantity    = "group_of_quantity"
+        static let allowCombination   = "allow_combination"
     }
 }
 

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -119,7 +119,7 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
 
     /// Combines the quantities of all purchased variations when checking quantity rules.
     /// Applicable with variable products and Min/Max Quantities extension only.
-    public let combineVariationQuantities: String?
+    public let combineVariationQuantities: Bool?
 
     /// Computed Properties
     ///
@@ -244,7 +244,7 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                 minAllowedQuantity: String?,
                 maxAllowedQuantity: String?,
                 groupOfQuantity: String?,
-                combineVariationQuantities: String?) {
+                combineVariationQuantities: Bool?) {
         self.siteID = siteID
         self.productID = productID
         self.name = name
@@ -492,8 +492,13 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
             .extractStringValue(forKey: MetadataKeys.maxAllowedQuantity)
         let groupOfQuantity = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?
             .extractStringValue(forKey: MetadataKeys.groupOfQuantity)
-        let combineVariationQuantities = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?
-            .extractStringValue(forKey: MetadataKeys.allowCombination)
+        let combineVariationQuantities: Bool? = {
+            guard let allowCombination = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?
+                .extractStringValue(forKey: MetadataKeys.allowCombination) else {
+                return nil
+            }
+            return (allowCombination as NSString).boolValue
+        }()
 
         self.init(siteID: siteID,
                   productID: productID,

--- a/Networking/Networking/Model/Product/ProductMetadataExtractor.swift
+++ b/Networking/Networking/Model/Product/ProductMetadataExtractor.swift
@@ -51,6 +51,14 @@ internal struct ProductMetadataExtractor: Decodable {
         return try decoder.decode(ProductSubscription.self, from: jsonData)
     }
 
+    /// Extracts a `String` metadata value for the provided key.
+    ///
+    internal func extractStringValue(forKey key: String) -> String? {
+        let metaData = filterMetadata(with: key)
+        let keyValueMetadata = getKeyValueDictionary(from: metaData)
+        return keyValueMetadata.valueAsString(forKey: key)
+    }
+
     /// Filters product metadata using the provided prefix.
     ///
     private func filterMetadata(with prefix: String) -> [DecodableDictionary] {

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -359,6 +359,19 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(subscriptionSettings.trialLength, "1")
         XCTAssertEqual(subscriptionSettings.trialPeriod, .week)
     }
+
+    /// Test that products with properties from the Min/Max Quantities extension are properly parsed.
+    ///
+    func test_min_max_quantities_are_properly_parsed() throws {
+        // Given
+        let product = try XCTUnwrap(mapLoadMinMaxQuantitiesProductResponse())
+
+        // Then
+        XCTAssertEqual(product.minAllowedQuantity, "4")
+        XCTAssertEqual(product.maxAllowedQuantity, "200")
+        XCTAssertEqual(product.groupOfQuantity, "2")
+        XCTAssertEqual(product.combineVariationQuantities, "no")
+    }
 }
 
 
@@ -424,5 +437,11 @@ private extension ProductMapperTests {
     ///
     func mapLoadSubscriptionProductResponse() -> Product? {
         return mapProduct(from: "product-subscription")
+    }
+
+    /// Returns the ProductMapper output upon receiving `product-min-max-quantities`
+    ///
+    func mapLoadMinMaxQuantitiesProductResponse() -> Product? {
+        return mapProduct(from: "product-min-max-quantities")
     }
 }

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -370,7 +370,7 @@ final class ProductMapperTests: XCTestCase {
         XCTAssertEqual(product.minAllowedQuantity, "4")
         XCTAssertEqual(product.maxAllowedQuantity, "200")
         XCTAssertEqual(product.groupOfQuantity, "2")
-        XCTAssertEqual(product.combineVariationQuantities, "no")
+        XCTAssertEqual(product.combineVariationQuantities, false)
     }
 }
 

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -110,7 +110,11 @@ final class ProductsRemoteTests: XCTestCase {
                                       bundleStockQuantity: nil,
                                       bundledItems: [],
                                       compositeComponents: [],
-                                      subscription: nil)
+                                      subscription: nil,
+                                      minAllowedQuantity: nil,
+                                      maxAllowedQuantity: nil,
+                                      groupOfQuantity: nil,
+                                      combineVariationQuantities: nil)
         XCTAssertEqual(addedProduct, expectedProduct)
     }
 
@@ -218,7 +222,11 @@ final class ProductsRemoteTests: XCTestCase {
                                       bundleStockQuantity: nil,
                                       bundledItems: [],
                                       compositeComponents: [],
-                                      subscription: nil)
+                                      subscription: nil,
+                                      minAllowedQuantity: nil,
+                                      maxAllowedQuantity: nil,
+                                      groupOfQuantity: nil,
+                                      combineVariationQuantities: nil)
         XCTAssertEqual(deletedProduct, expectedProduct)
     }
 
@@ -752,7 +760,11 @@ private extension ProductsRemoteTests {
                        bundleStockQuantity: nil,
                        bundledItems: [],
                        compositeComponents: [],
-                       subscription: nil)
+                       subscription: nil,
+                       minAllowedQuantity: nil,
+                       maxAllowedQuantity: nil,
+                       groupOfQuantity: nil,
+                       combineVariationQuantities: nil)
     }
 
     func sampleDimensions() -> Networking.ProductDimensions {

--- a/Networking/NetworkingTests/Responses/product-min-max-quantities.json
+++ b/Networking/NetworkingTests/Responses/product-min-max-quantities.json
@@ -1,0 +1,175 @@
+{
+    "data": {
+        "id": 487,
+        "name": "Min Max Variable Product",
+        "slug": "min-max-variable-product",
+        "permalink": "https://example.com/product/min-max-variable-product/",
+        "date_created": "2023-04-01T18:21:48",
+        "date_created_gmt": "2023-04-01T17:21:48",
+        "date_modified": "2023-04-27T09:32:40",
+        "date_modified_gmt": "2023-04-27T08:32:40",
+        "type": "variable",
+        "status": "publish",
+        "featured": false,
+        "catalog_visibility": "visible",
+        "description": "<p>This is a variable product with min-max rules 😁</p>\n",
+        "short_description": "",
+        "sku": "",
+        "price": "4",
+        "regular_price": "",
+        "sale_price": "",
+        "date_on_sale_from": null,
+        "date_on_sale_from_gmt": null,
+        "date_on_sale_to": null,
+        "date_on_sale_to_gmt": null,
+        "on_sale": false,
+        "purchasable": true,
+        "total_sales": 14,
+        "virtual": false,
+        "downloadable": false,
+        "downloads": [],
+        "download_limit": -1,
+        "download_expiry": -1,
+        "external_url": "",
+        "button_text": "",
+        "tax_status": "taxable",
+        "tax_class": "",
+        "manage_stock": false,
+        "stock_quantity": null,
+        "backorders": "no",
+        "backorders_allowed": false,
+        "backordered": false,
+        "low_stock_amount": null,
+        "sold_individually": false,
+        "weight": "",
+        "dimensions": {
+            "length": "",
+            "width": "",
+            "height": ""
+        },
+        "shipping_required": true,
+        "shipping_taxable": true,
+        "shipping_class": "",
+        "shipping_class_id": 0,
+        "reviews_allowed": true,
+        "average_rating": "0.00",
+        "rating_count": 0,
+        "upsell_ids": [],
+        "cross_sell_ids": [],
+        "parent_id": 0,
+        "purchase_note": "",
+        "categories": [],
+        "tags": [],
+        "images": [],
+        "attributes": [
+            {
+                "id": 1,
+                "name": "Color",
+                "position": 0,
+                "visible": true,
+                "variation": true,
+                "options": [
+                    "Blue",
+                    "Red",
+                    "Yellow"
+                ]
+            }
+        ],
+        "default_attributes": [],
+        "variations": [
+            488,
+            489,
+            490
+        ],
+        "grouped_products": [],
+        "menu_order": 0,
+        "price_html": "<span class=\"woocommerce-Price-amount amount\"><bdi><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>4.00</bdi></span> &ndash; <span class=\"woocommerce-Price-amount amount\"><bdi><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>5.00</bdi></span><small class=\"wcsatt-sub-options\"> <span class=\"wcsatt-dash\">&mdash;</span> or subscribe and save up to</small> <span class=\"wcsatt-sub-discount\">30&#37;</span><small></small>",
+        "related_ids": [],
+        "meta_data": [
+            {
+                "id": 14134,
+                "key": "_wpcom_is_markdown",
+                "value": "1"
+            },
+            {
+                "id": 14135,
+                "key": "_last_editor_used_jetpack",
+                "value": "classic-editor"
+            },
+            {
+                "id": 14230,
+                "key": "group_of_quantity",
+                "value": "2"
+            },
+            {
+                "id": 14231,
+                "key": "minimum_allowed_quantity",
+                "value": "4"
+            },
+            {
+                "id": 14232,
+                "key": "maximum_allowed_quantity",
+                "value": "200"
+            },
+            {
+                "id": 14233,
+                "key": "allow_combination",
+                "value": "no"
+            },
+            {
+                "id": 14234,
+                "key": "minmax_do_not_count",
+                "value": "no"
+            },
+            {
+                "id": 14235,
+                "key": "minmax_cart_exclude",
+                "value": "yes"
+            },
+            {
+                "id": 14236,
+                "key": "minmax_category_group_of_exclude",
+                "value": "no"
+            }
+        ],
+        "stock_status": "instock",
+        "has_options": true,
+        "composite_virtual": false,
+        "composite_layout": "",
+        "composite_add_to_cart_form_location": "",
+        "composite_editable_in_cart": false,
+        "composite_sold_individually_context": "",
+        "composite_shop_price_calc": "",
+        "composite_components": [],
+        "composite_scenarios": [],
+        "bundled_by": [],
+        "bundle_stock_status": "instock",
+        "bundle_stock_quantity": null,
+        "bundle_virtual": false,
+        "bundle_layout": "",
+        "bundle_add_to_cart_form_location": "",
+        "bundle_editable_in_cart": false,
+        "bundle_sold_individually_context": "",
+        "bundle_item_grouping": "",
+        "bundle_min_size": "",
+        "bundle_max_size": "",
+        "bundled_items": [],
+        "bundle_sell_ids": [],
+        "jetpack_publicize_connections": [],
+        "jetpack_sharing_enabled": true,
+        "jetpack_likes_enabled": true,
+        "brands": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products/487"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products"
+                }
+            ]
+        }
+    }
+}

--- a/WooCommerce/Classes/Extensions/Product+SwiftUIPreviewHelpers.swift
+++ b/WooCommerce/Classes/Extensions/Product+SwiftUIPreviewHelpers.swift
@@ -72,7 +72,11 @@ extension Product {
                 bundleStockQuantity: nil,
                 bundledItems: [],
                 compositeComponents: [],
-                subscription: nil)
+                subscription: nil,
+                minAllowedQuantity: nil,
+                maxAllowedQuantity: nil,
+                groupOfQuantity: nil,
+                combineVariationQuantities: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
@@ -99,6 +99,10 @@ private extension ProductFactory {
                 bundleStockQuantity: nil,
                 bundledItems: [],
                 compositeComponents: [],
-                subscription: nil)
+                subscription: nil,
+                minAllowedQuantity: nil,
+                maxAllowedQuantity: nil,
+                groupOfQuantity: nil,
+                combineVariationQuantities: nil)
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockReviews.swift
@@ -123,7 +123,11 @@ extension MockReviews {
                        bundleStockQuantity: nil,
                        bundledItems: [],
                        compositeComponents: [],
-                       subscription: nil)
+                       subscription: nil,
+                       minAllowedQuantity: nil,
+                       maxAllowedQuantity: nil,
+                       groupOfQuantity: nil,
+                       combineVariationQuantities: nil)
     }
 
     func sampleDimensions() -> Networking.ProductDimensions {
@@ -274,7 +278,11 @@ extension MockReviews {
                        bundleStockQuantity: nil,
                        bundledItems: [],
                        compositeComponents: [],
-                       subscription: nil)
+                       subscription: nil,
+                       minAllowedQuantity: nil,
+                       maxAllowedQuantity: nil,
+                       groupOfQuantity: nil,
+                       combineVariationQuantities: nil)
     }
 
     func sampleDimensionsMutated() -> Networking.ProductDimensions {
@@ -400,7 +408,11 @@ extension MockReviews {
                        bundleStockQuantity: nil,
                        bundledItems: [],
                        compositeComponents: [],
-                       subscription: nil)
+                       subscription: nil,
+                       minAllowedQuantity: nil,
+                       maxAllowedQuantity: nil,
+                       groupOfQuantity: nil,
+                       combineVariationQuantities: nil)
     }
 
     func sampleVariationTypeDimensions() -> Networking.ProductDimensions {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
@@ -169,6 +169,10 @@ private extension Product_ProductFormTests {
                        bundleStockQuantity: nil,
                        bundledItems: [],
                        compositeComponents: [],
-                       subscription: nil)
+                       subscription: nil,
+                       minAllowedQuantity: nil,
+                       maxAllowedQuantity: nil,
+                       groupOfQuantity: nil,
+                       combineVariationQuantities: nil)
     }
 }

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -312,7 +312,11 @@ extension MockObjectGraph {
             bundleStockQuantity: nil,
             bundledItems: [],
             compositeComponents: [],
-            subscription: nil
+            subscription: nil,
+            minAllowedQuantity: nil,
+            maxAllowedQuantity: nil,
+            groupOfQuantity: nil,
+            combineVariationQuantities: nil
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
@@ -175,7 +175,11 @@ extension Storage.Product: ReadOnlyConvertible {
                        bundleStockQuantity: bundleStockQuantity as? Int64,
                        bundledItems: bundledItemsArray.map { $0.toReadOnly() },
                        compositeComponents: compositeComponentsArray.map { $0.toReadOnly() },
-                       subscription: subscription?.toReadOnly())
+                       subscription: subscription?.toReadOnly(),
+                       minAllowedQuantity: nil,
+                       maxAllowedQuantity: nil,
+                       groupOfQuantity: nil,
+                       combineVariationQuantities: nil) // TODO: 8959 - Replace with real quantity settings
     }
 
     // MARK: - Private Helpers

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1874,7 +1874,11 @@ private extension ProductStoreTests {
                        bundleStockQuantity: nil,
                        bundledItems: [],
                        compositeComponents: [],
-                       subscription: nil)
+                       subscription: nil,
+                       minAllowedQuantity: nil,
+                       maxAllowedQuantity: nil,
+                       groupOfQuantity: nil,
+                       combineVariationQuantities: nil)
     }
 
     func sampleDimensions() -> Networking.ProductDimensions {
@@ -2035,7 +2039,11 @@ private extension ProductStoreTests {
                        bundleStockQuantity: 0,
                        bundledItems: [.fake(), .fake()],
                        compositeComponents: [.fake(), .fake()],
-                       subscription: .fake())
+                       subscription: .fake(),
+                       minAllowedQuantity: nil,
+                       maxAllowedQuantity: nil,
+                       groupOfQuantity: nil,
+                       combineVariationQuantities: nil)
     }
 
     func sampleDimensionsMutated() -> Networking.ProductDimensions {
@@ -2170,7 +2178,11 @@ private extension ProductStoreTests {
                        bundleStockQuantity: nil,
                        bundledItems: [],
                        compositeComponents: [],
-                       subscription: nil)
+                       subscription: nil,
+                       minAllowedQuantity: nil,
+                       maxAllowedQuantity: nil,
+                       groupOfQuantity: nil,
+                       combineVariationQuantities: nil)
     }
 
     func sampleVariationTypeDimensions() -> Networking.ProductDimensions {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8959
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are adding read-only support for the [Min/Max Quantities](https://woocommerce.com/products/minmax-quantities/) extension in product details.

This PR adds support for these min/max quantity settings on a product in the Networking layer:

* Minimum allowed quantity (for customers purchasing the product)
* Maximum allowed quantity (for customers purchasing the product)
* Group of (customers must purchase the product in multiples of this)
* Combine variations (for variable products; combines the quantities of all purchased variations when checking the quantity rules)

### Changes

* Updates the `Product` model to include the min/max quantity settings we plan to display.
* Adds `ProductMetadataExtractor.extractStringValue(forKey:)` to extract a specific string value from the product metadata.
* Updates generated `fake()` and `copy()` methods, and adds the new properties where the `Product` model is used.
* Adds a mock API response and new unit test for parsing a product with these fields.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Confirm unit tests pass and all products can be loaded in the Products tab as expected.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
