### PR TITLE
[Min/Max Quantities] Add support for product variation quantity rules (Networking layer)

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1182,7 +1182,11 @@ extension Networking.ProductVariation {
             shippingClass: .fake(),
             shippingClassID: .fake(),
             menuOrder: .fake(),
-            subscription: .fake()
+            subscription: .fake(),
+            minAllowedQuantity: .fake(),
+            maxAllowedQuantity: .fake(),
+            groupOfQuantity: .fake(),
+            overrideProductQuantities: .fake()
         )
     }
 }

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -634,6 +634,7 @@
 		CE132BBA223851F80029DB6C /* ProductCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE132BB9223851F80029DB6C /* ProductCategory.swift */; };
 		CE132BBC223859710029DB6C /* ProductTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE132BBB223859710029DB6C /* ProductTag.swift */; };
 		CE13680F29FA74A400EBF43C /* product-min-max-quantities.json in Resources */ = {isa = PBXBuildFile; fileRef = CE13680E29FA74A400EBF43C /* product-min-max-quantities.json */; };
+		CE13681129FA809600EBF43C /* product-variation-min-max-quantities.json in Resources */ = {isa = PBXBuildFile; fileRef = CE13681029FA809600EBF43C /* product-variation-min-max-quantities.json */; };
 		CE17C6B1229462C000AACE1C /* ProductStockStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE17C6B0229462C000AACE1C /* ProductStockStatus.swift */; };
 		CE19CB11222486A600E8AF7A /* order-statuses.json in Resources */ = {isa = PBXBuildFile; fileRef = CE19CB10222486A500E8AF7A /* order-statuses.json */; };
 		CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */ = {isa = PBXBuildFile; fileRef = CE20179220E3EFA7005B4C18 /* broken-orders.json */; };
@@ -1567,6 +1568,7 @@
 		CE132BB9223851F80029DB6C /* ProductCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategory.swift; sourceTree = "<group>"; };
 		CE132BBB223859710029DB6C /* ProductTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTag.swift; sourceTree = "<group>"; };
 		CE13680E29FA74A400EBF43C /* product-min-max-quantities.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-min-max-quantities.json"; sourceTree = "<group>"; };
+		CE13681029FA809600EBF43C /* product-variation-min-max-quantities.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-variation-min-max-quantities.json"; sourceTree = "<group>"; };
 		CE17C6B0229462C000AACE1C /* ProductStockStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatus.swift; sourceTree = "<group>"; };
 		CE19CB10222486A500E8AF7A /* order-statuses.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-statuses.json"; sourceTree = "<group>"; };
 		CE20179220E3EFA7005B4C18 /* broken-orders.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "broken-orders.json"; sourceTree = "<group>"; };
@@ -2596,6 +2598,7 @@
 				EE57C133297F985A00BC31E7 /* product-variations-bulk-create-without-data.json */,
 				EE57C132297F985A00BC31E7 /* product-variations-bulk-update-without-data.json */,
 				451274A525276C82009911FF /* product-variation.json */,
+				CE13681029FA809600EBF43C /* product-variation-min-max-quantities.json */,
 				CCEC5E9029E9BF1400912D6B /* product-variation-subscription.json */,
 				CE0A0F1E223998A00075ED8D /* products-load-all.json */,
 				EEA6583D2966B41E00112DF0 /* products-load-all-without-data.json */,
@@ -3570,6 +3573,7 @@
 				74ABA1CB213F19FE00FFAD30 /* top-performers-week.json in Resources */,
 				456930AD2652AF00009ED69D /* shipping-label-carriers-and-rates-success.json in Resources */,
 				B524194721AC643900D6FC0A /* device-settings.json in Resources */,
+				CE13681129FA809600EBF43C /* product-variation-min-max-quantities.json in Resources */,
 				3158A49F2729F3F600C3CFA8 /* wcpay-account-live-live.json in Resources */,
 				0359EA2927AC2AAD0048DE2D /* wcpay-charge-error.json in Resources */,
 				CC33755029C88B920006A538 /* product-composite.json in Resources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1536,7 +1536,11 @@ extension Networking.ProductVariation {
         shippingClass: NullableCopiableProp<String> = .copy,
         shippingClassID: CopiableProp<Int64> = .copy,
         menuOrder: CopiableProp<Int64> = .copy,
-        subscription: NullableCopiableProp<ProductSubscription> = .copy
+        subscription: NullableCopiableProp<ProductSubscription> = .copy,
+        minAllowedQuantity: NullableCopiableProp<String> = .copy,
+        maxAllowedQuantity: NullableCopiableProp<String> = .copy,
+        groupOfQuantity: NullableCopiableProp<String> = .copy,
+        overrideProductQuantities: NullableCopiableProp<Bool> = .copy
     ) -> Networking.ProductVariation {
         let siteID = siteID ?? self.siteID
         let productID = productID ?? self.productID
@@ -1575,6 +1579,10 @@ extension Networking.ProductVariation {
         let shippingClassID = shippingClassID ?? self.shippingClassID
         let menuOrder = menuOrder ?? self.menuOrder
         let subscription = subscription ?? self.subscription
+        let minAllowedQuantity = minAllowedQuantity ?? self.minAllowedQuantity
+        let maxAllowedQuantity = maxAllowedQuantity ?? self.maxAllowedQuantity
+        let groupOfQuantity = groupOfQuantity ?? self.groupOfQuantity
+        let overrideProductQuantities = overrideProductQuantities ?? self.overrideProductQuantities
 
         return Networking.ProductVariation(
             siteID: siteID,
@@ -1613,7 +1621,11 @@ extension Networking.ProductVariation {
             shippingClass: shippingClass,
             shippingClassID: shippingClassID,
             menuOrder: menuOrder,
-            subscription: subscription
+            subscription: subscription,
+            minAllowedQuantity: minAllowedQuantity,
+            maxAllowedQuantity: maxAllowedQuantity,
+            groupOfQuantity: groupOfQuantity,
+            overrideProductQuantities: overrideProductQuantities
         )
     }
 }

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -59,6 +59,20 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
     /// Subscription settings. Applicable to variations in variable subscription-type products only.
     public let subscription: ProductSubscription?
 
+    // MARK: Min/Max Quantities properties
+
+    /// Minimum allowed quantity for the variation. Applicable with Min/Max Quantities extension only.
+    public let minAllowedQuantity: String?
+
+    /// Maximum allowed quantity for the variation. Applicable with Min/Max Quantities extension only.
+    public let maxAllowedQuantity: String?
+
+    /// "Group of" quantity, requiring customers to purchase the variation in multiples. Applicable with Min/Max Quantities extension only.
+    public let groupOfQuantity: String?
+
+    /// Overrides the product-level quantity rules with the variation rules. Applicable with Min/Max Quantities extension only.
+    public let overrideProductQuantities: Bool?
+
     /// Computed Properties
     ///
     /// Whether the product variation has an integer (or nil) stock quantity.
@@ -110,7 +124,11 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
                 shippingClass: String?,
                 shippingClassID: Int64,
                 menuOrder: Int64,
-                subscription: ProductSubscription?) {
+                subscription: ProductSubscription?,
+                minAllowedQuantity: String?,
+                maxAllowedQuantity: String?,
+                groupOfQuantity: String?,
+                overrideProductQuantities: Bool?) {
         self.siteID = siteID
         self.productID = productID
         self.productVariationID = productVariationID
@@ -148,6 +166,10 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
         self.shippingClassID = shippingClassID
         self.menuOrder = menuOrder
         self.subscription = subscription
+        self.minAllowedQuantity = minAllowedQuantity
+        self.maxAllowedQuantity = maxAllowedQuantity
+        self.groupOfQuantity = groupOfQuantity
+        self.overrideProductQuantities = overrideProductQuantities
     }
 
     /// The public initializer for ProductVariation.
@@ -257,6 +279,21 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
         // Subscription settings for subscription variations
         let subscription = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?.extractProductSubscription()
 
+        // Min/Max Quantities properties
+        let minAllowedQuantity = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?
+            .extractStringValue(forKey: MetadataKeys.minAllowedQuantity)
+        let maxAllowedQuantity = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?
+            .extractStringValue(forKey: MetadataKeys.maxAllowedQuantity)
+        let groupOfQuantity = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?
+            .extractStringValue(forKey: MetadataKeys.groupOfQuantity)
+        let overrideProductQuantities: Bool? = {
+            guard let minMaxRules = try? container.decodeIfPresent(ProductMetadataExtractor.self, forKey: .metadata)?
+                .extractStringValue(forKey: MetadataKeys.minMaxRules) else {
+                return nil
+            }
+            return (minMaxRules as NSString).boolValue
+        }()
+
         self.init(siteID: siteID,
                   productID: productID,
                   productVariationID: productVariationID,
@@ -293,7 +330,11 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
                   shippingClass: shippingClass,
                   shippingClassID: shippingClassID,
                   menuOrder: menuOrder,
-                  subscription: subscription)
+                  subscription: subscription,
+                  minAllowedQuantity: minAllowedQuantity,
+                  maxAllowedQuantity: maxAllowedQuantity,
+                  groupOfQuantity: groupOfQuantity,
+                  overrideProductQuantities: overrideProductQuantities)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -404,6 +445,13 @@ private extension ProductVariation {
         case menuOrder          = "menu_order"
 
         case metadata           = "meta_data"
+    }
+
+    enum MetadataKeys {
+        static let minAllowedQuantity = "variation_minimum_allowed_quantity"
+        static let maxAllowedQuantity = "variation_maximum_allowed_quantity"
+        static let groupOfQuantity    = "variation_group_of_quantity"
+        static let minMaxRules        = "min_max_rules"
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
@@ -58,6 +58,19 @@ final class ProductVariationMapperTests: XCTestCase {
         XCTAssertEqual(subscriptionSettings.trialLength, "0")
         XCTAssertEqual(subscriptionSettings.trialPeriod, .month)
     }
+
+    /// Test that product variations with properties from the Min/Max Quantities extension are properly parsed.
+    ///
+    func test_min_max_quantities_are_properly_parsed() throws {
+        // Given
+        let productVariation = try XCTUnwrap(mapLoadMinMaxQuantityVariationResponse())
+
+        // Then
+        XCTAssertEqual(productVariation.minAllowedQuantity, "6")
+        XCTAssertEqual(productVariation.maxAllowedQuantity, "30")
+        XCTAssertEqual(productVariation.groupOfQuantity, "3")
+        XCTAssertEqual(productVariation.overrideProductQuantities, true)
+    }
 }
 
 /// Private Helpers
@@ -95,6 +108,12 @@ private extension ProductVariationMapperTests {
     ///
     func mapLoadSubscriptionVariationResponse() -> ProductVariation? {
         return mapProductVariation(from: "product-variation-subscription")
+    }
+
+    /// Returns the ProductVariationMapper output upon receiving `product-variation-min-max-quantities`
+    ///
+    func mapLoadMinMaxQuantityVariationResponse() -> ProductVariation? {
+        return mapProductVariation(from: "product-variation-min-max-quantities")
     }
 }
 
@@ -146,7 +165,11 @@ private extension ProductVariationMapperTests {
                                 shippingClass: "",
                                 shippingClassID: 0,
                                 menuOrder: 1,
-                                subscription: nil)
+                                subscription: nil,
+                                minAllowedQuantity: nil,
+                                maxAllowedQuantity: nil,
+                                groupOfQuantity: nil,
+                                overrideProductQuantities: nil)
     }
 
     func sampleProductVariationAttributes() -> [ProductVariationAttribute] {

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -435,7 +435,11 @@ private extension ProductVariationsRemoteTests {
                                 shippingClass: "",
                                 shippingClassID: 0,
                                 menuOrder: 1,
-                                subscription: nil)
+                                subscription: nil,
+                                minAllowedQuantity: nil,
+                                maxAllowedQuantity: nil,
+                                groupOfQuantity: nil,
+                                overrideProductQuantities: nil)
     }
 
     func sampleProductVariationAttributes() -> [ProductVariationAttribute] {

--- a/Networking/NetworkingTests/Responses/product-variation-min-max-quantities.json
+++ b/Networking/NetworkingTests/Responses/product-variation-min-max-quantities.json
@@ -1,0 +1,159 @@
+{
+    "data": {
+        "id": 488,
+        "name": "Min Max Variable Product - Blue",
+        "slug": "min-max-variable-product-blue",
+        "permalink": "https://example.com/product/min-max-variable-product/?attribute_pa_color=blue",
+        "date_created": "2023-04-01T18:21:06",
+        "date_created_gmt": "2023-04-01T17:21:06",
+        "date_modified": "2023-04-19T22:23:12",
+        "date_modified_gmt": "2023-04-19T21:23:12",
+        "type": "variation",
+        "status": "publish",
+        "featured": false,
+        "catalog_visibility": "visible",
+        "description": "<p>testing</p>\n",
+        "short_description": "",
+        "sku": "",
+        "price": "5",
+        "regular_price": "5",
+        "sale_price": "",
+        "date_on_sale_from": null,
+        "date_on_sale_from_gmt": null,
+        "date_on_sale_to": null,
+        "date_on_sale_to_gmt": null,
+        "on_sale": false,
+        "purchasable": true,
+        "total_sales": "0",
+        "virtual": false,
+        "downloadable": false,
+        "downloads": [],
+        "download_limit": -1,
+        "download_expiry": -1,
+        "external_url": "",
+        "button_text": "",
+        "tax_status": "taxable",
+        "tax_class": "",
+        "manage_stock": false,
+        "stock_quantity": null,
+        "backorders": "no",
+        "backorders_allowed": false,
+        "backordered": false,
+        "low_stock_amount": null,
+        "sold_individually": false,
+        "weight": "",
+        "dimensions": {
+            "length": "",
+            "width": "",
+            "height": ""
+        },
+        "shipping_required": true,
+        "shipping_taxable": true,
+        "shipping_class": "",
+        "shipping_class_id": 0,
+        "reviews_allowed": false,
+        "average_rating": "0.00",
+        "rating_count": 0,
+        "upsell_ids": [],
+        "cross_sell_ids": [],
+        "parent_id": 487,
+        "purchase_note": "",
+        "categories": [],
+        "tags": [],
+        "images": [],
+        "attributes": [
+            {
+                "id": 1,
+                "name": "Color",
+                "option": "Blue"
+            }
+        ],
+        "default_attributes": [],
+        "variations": [],
+        "grouped_products": [],
+        "menu_order": 1,
+        "price_html": "<span class=\"woocommerce-Price-amount amount\"><bdi><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>5.00</bdi></span><small class=\"wcsatt-sub-options\"> <span class=\"wcsatt-dash\">&mdash;</span> or subscribe and save up to</small> <span class=\"wcsatt-sub-discount\">30&#37;</span><small></small>",
+        "related_ids": [],
+        "meta_data": [
+            {
+                "id": 14244,
+                "key": "min_max_rules",
+                "value": "yes"
+            },
+            {
+                "id": 14245,
+                "key": "variation_group_of_quantity",
+                "value": "3"
+            },
+            {
+                "id": 14246,
+                "key": "variation_minimum_allowed_quantity",
+                "value": "6"
+            },
+            {
+                "id": 14247,
+                "key": "variation_maximum_allowed_quantity",
+                "value": "30"
+            },
+            {
+                "id": 14248,
+                "key": "variation_minmax_do_not_count",
+                "value": "no"
+            },
+            {
+                "id": 14249,
+                "key": "variation_minmax_cart_exclude",
+                "value": "no"
+            },
+            {
+                "id": 14250,
+                "key": "variation_minmax_category_group_of_exclude",
+                "value": "no"
+            }
+        ],
+        "stock_status": "instock",
+        "has_options": true,
+        "composite_virtual": false,
+        "composite_layout": "",
+        "composite_add_to_cart_form_location": "",
+        "composite_editable_in_cart": false,
+        "composite_sold_individually_context": "",
+        "composite_shop_price_calc": "",
+        "composite_components": [],
+        "composite_scenarios": [],
+        "bundled_by": [],
+        "bundle_stock_status": "instock",
+        "bundle_stock_quantity": null,
+        "bundle_virtual": false,
+        "bundle_layout": "",
+        "bundle_add_to_cart_form_location": "",
+        "bundle_editable_in_cart": false,
+        "bundle_sold_individually_context": "",
+        "bundle_item_grouping": "",
+        "bundle_min_size": "",
+        "bundle_max_size": "",
+        "bundled_items": [],
+        "bundle_sell_ids": [],
+        "jetpack_publicize_connections": [],
+        "jetpack_sharing_enabled": true,
+        "jetpack_likes_enabled": true,
+        "brands": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products/488"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products"
+                }
+            ],
+            "up": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products/487"
+                }
+            ]
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductVariation.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductVariation.swift
@@ -41,6 +41,10 @@ final class MockProductVariation {
                                 shippingClass: "",
                                 shippingClassID: 0,
                                 menuOrder: 1,
-                                subscription: nil)
+                                subscription: nil,
+                                minAllowedQuantity: nil,
+                                maxAllowedQuantity: nil,
+                                groupOfQuantity: nil,
+                                overrideProductQuantities: nil)
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/ProductVariation+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductVariation+ReadOnlyConvertible.swift
@@ -105,7 +105,11 @@ extension Storage.ProductVariation: ReadOnlyConvertible {
                                 shippingClass: shippingClass,
                                 shippingClassID: shippingClassID,
                                 menuOrder: menuOrder,
-                                subscription: subscription?.toReadOnly())
+                                subscription: subscription?.toReadOnly(),
+                                minAllowedQuantity: nil,
+                                maxAllowedQuantity: nil,
+                                groupOfQuantity: nil,
+                                overrideProductQuantities: nil) // TODO: 8959 - Replace with real quantity settings
     }
 }
 

--- a/Yosemite/YosemiteTests/Mocks/MockProductVariation.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockProductVariation.swift
@@ -48,7 +48,11 @@ final class MockProductVariation {
                                 shippingClass: "",
                                 shippingClassID: 0,
                                 menuOrder: 1,
-                                subscription: nil)
+                                subscription: nil,
+                                minAllowedQuantity: nil,
+                                maxAllowedQuantity: nil,
+                                groupOfQuantity: nil,
+                                overrideProductQuantities: nil)
 
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -1015,7 +1015,11 @@ private extension ProductVariationStoreTests {
                                 shippingClass: "",
                                 shippingClassID: 0,
                                 menuOrder: 8,
-                                subscription: nil)
+                                subscription: nil,
+                                minAllowedQuantity: nil,
+                                maxAllowedQuantity: nil,
+                                groupOfQuantity: nil,
+                                overrideProductQuantities: nil)
     }
 
     func sampleOrder(items: [Yosemite.OrderItem]) -> Yosemite.Order {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8959
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are adding read-only support for the [Min/Max Quantities](https://woocommerce.com/products/minmax-quantities/) extension in product details.

This PR adds support for these min/max quantity settings on a product variation in the Networking layer:

* Minimum allowed quantity (for customers purchasing the variation)
* Maximum allowed quantity (for customers purchasing the variation)
* Group of (customers must purchase the variation in multiples of this)
* Quantity Rules (overrides the product-level quantity rules at the variation level)

### Changes

* Updates the `ProductVariation` model to include the min/max quantity settings we plan to display.
* Updates generated `fake()` and `copy()` methods, and adds the new properties where the `ProductVariation` model is used.
* Adds a mock API response and new unit test for parsing a product variation with these fields.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Confirm unit tests pass and the variations list can be loaded in product details for variable products as expected.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
