### PR TITLE
Login: Make content on prologue screen scrollable for better accessibility

### DIFF
--- a/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
@@ -110,12 +110,7 @@ private extension LoginProloguePageTypeViewController {
         let scrollView = UIScrollView()
         view.addSubview(scrollView)
         scrollView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: Constants.stackBottomMargin),
-            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
-        ])
+        view.pinSubviewToAllEdges(scrollView, insets: .init(top: 0, left: 0, bottom: -Constants.stackBottomMargin, right: 0))
         scrollView.addSubview(stackView)
 
         // Stack view layout
@@ -126,12 +121,9 @@ private extension LoginProloguePageTypeViewController {
 
         // Set constraints
         stackView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.pinSubviewToAllEdges(stackView)
         NSLayoutConstraint.activate([
-            stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
-            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
-            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
         ])
     }
 

--- a/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginProloguePages.swift
@@ -106,24 +106,32 @@ final class LoginProloguePageTypeViewController: UIViewController {
 
 private extension LoginProloguePageTypeViewController {
     func configureStackView() {
-        view.addSubview(stackView)
+        // Scroll view to contain all contents
+        let scrollView = UIScrollView()
+        view.addSubview(scrollView)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: Constants.stackBottomMargin),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
+        ])
+        scrollView.addSubview(stackView)
 
         // Stack view layout
         stackView.axis = .vertical
         stackView.alignment = .center
         stackView.spacing = Constants.stackSpacing
 
-        // Reduce centerYAnchor constraint priority to ensure the bottom margin has higher priority, so stack view is fully visible on shorter devices
-        let verticalCentering = stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: Constants.stackVerticalOffset)
-        verticalCentering.priority = .required - 1
 
         // Set constraints
         stackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            verticalCentering,
-            stackView.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor, constant: Constants.stackBottomMargin),
-            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
         ])
     }
 
@@ -194,7 +202,6 @@ private extension LoginProloguePageTypeViewController {
 private extension LoginProloguePageTypeViewController {
     enum Constants {
         static let stackSpacing: CGFloat = 40 // Space between image and text
-        static let stackVerticalOffset: CGFloat = 103
         static let stackBottomMargin: CGFloat = -57 // Minimum margin between stack view and login buttons, including space required for UIPageControl
         static let imageHeightMultiplier: CGFloat = 0.35
         static let labelLeadingMargin: CGFloat = 48

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -28,6 +28,9 @@ final class LoginPrologueViewController: UIViewController {
     /// Button for users who are new to WooCommerce to learn more about WooCommerce.
     @IBOutlet private weak var newToWooCommerceButton: UIButton!
 
+    /// The WooCommerce logo on top of the screen
+    @IBOutlet private weak var topLogoImageView: UIImageView!
+
     // MARK: - Overridden Properties
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -106,17 +109,19 @@ private extension LoginPrologueViewController {
 
         addChild(carousel)
         view.addSubview(carousel.view)
-        if isNewToWooCommerceButtonShown {
-            NSLayoutConstraint.activate([
-                carousel.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                carousel.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                carousel.view.topAnchor.constraint(equalTo: view.topAnchor),
-                carousel.view.bottomAnchor.constraint(equalTo: newToWooCommerceButton.topAnchor,
-                                                      constant: -Constants.spacingBetweenCarouselAndNewToWooCommerceButton),
-            ])
-        } else {
-            view.pinSubviewToAllEdges(carousel.view)
-        }
+        let bottomConstraint: NSLayoutConstraint = {
+            guard isNewToWooCommerceButtonShown else {
+                return carousel.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            }
+            return carousel.view.bottomAnchor.constraint(equalTo: newToWooCommerceButton.topAnchor,
+                                                         constant: -Constants.spacingBetweenCarouselAndNewToWooCommerceButton)
+        }()
+        NSLayoutConstraint.activate([
+            carousel.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            carousel.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            carousel.view.topAnchor.constraint(equalTo: topLogoImageView.bottomAnchor, constant: Constants.spacingBetweenTopLogoAndCarousel),
+            bottomConstraint
+        ])
     }
 
     func setupNewToWooCommerceButton(isNewToWooCommerceButtonShown: Bool) {
@@ -145,6 +150,7 @@ private extension LoginPrologueViewController {
 private extension LoginPrologueViewController {
     enum Constants {
         static let spacingBetweenCarouselAndNewToWooCommerceButton: CGFloat = 20
+        static let spacingBetweenTopLogoAndCarousel: CGFloat = 16
         static let newToWooCommerceURL = "https://woocommerce.com/woocommerce-features"
     }
 

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -150,7 +150,7 @@ private extension LoginPrologueViewController {
 private extension LoginPrologueViewController {
     enum Constants {
         static let spacingBetweenCarouselAndNewToWooCommerceButton: CGFloat = 20
-        static let spacingBetweenTopLogoAndCarousel: CGFloat = 16
+        static let spacingBetweenTopLogoAndCarousel: CGFloat = 56
         static let newToWooCommerceURL = "https://woocommerce.com/woocommerce-features"
     }
 

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.xib
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,6 +14,7 @@
                 <outlet property="containerView" destination="o29-Vv-KDs" id="U7h-cw-w9k"/>
                 <outlet property="curvedRectangle" destination="Rhn-8s-tRs" id="fwI-6M-kbT"/>
                 <outlet property="newToWooCommerceButton" destination="IUc-Ht-iMk" id="nQg-ke-CWf"/>
+                <outlet property="topLogoImageView" destination="bNB-4i-gz9" id="waf-Yz-zqd"/>
                 <outlet property="view" destination="V2X-Xj-JeZ" id="Vob-Ki-8K1"/>
             </connections>
         </placeholder>
@@ -23,26 +24,26 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3vu-Xh-Yk9" userLabel="Bottom View">
-                    <rect key="frame" x="0.0" y="810" width="390" height="34"/>
+                    <rect key="frame" x="0.0" y="844" width="390" height="0.0"/>
                     <viewLayoutGuide key="safeArea" id="tzS-rk-lug"/>
                     <color key="backgroundColor" red="0.96470588235294119" green="0.96862745098039216" blue="0.96862745098039216" alpha="1" colorSpace="calibratedRGB"/>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o29-Vv-KDs" userLabel="Container View">
-                    <rect key="frame" x="0.0" y="810" width="390" height="0.0"/>
+                    <rect key="frame" x="0.0" y="768" width="390" height="76"/>
                     <color key="backgroundColor" red="0.96470588235294119" green="0.96862745098039216" blue="0.96862745098039216" alpha="1" colorSpace="calibratedRGB"/>
                 </view>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1" image="prologue-curved-rectangle" translatesAutoresizingMaskIntoConstraints="NO" id="Rhn-8s-tRs" userLabel="Curved ImageView">
-                    <rect key="frame" x="0.0" y="96" width="390" height="714"/>
+                    <rect key="frame" x="0.0" y="52" width="390" height="716"/>
                 </imageView>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="prologue-logo" translatesAutoresizingMaskIntoConstraints="NO" id="bNB-4i-gz9" userLabel="Top Logo">
-                    <rect key="frame" x="107" y="72" width="176" height="36"/>
+                    <rect key="frame" x="107" y="28" width="176" height="36"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="176" id="di7-9A-rnI"/>
                         <constraint firstAttribute="height" constant="36" id="gWf-lm-a4c"/>
                     </constraints>
                 </imageView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IUc-Ht-iMk">
-                    <rect key="frame" x="161.66666666666666" y="759" width="67" height="31"/>
+                    <rect key="frame" x="157.66666666666666" y="789.66666666666663" width="75" height="34.333333333333371"/>
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="plain" title="Button"/>
                 </button>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9393 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the layout of the prologue screen to make sure the carousel is pinned below the logo image, and its contents are scrollable when the device font size is big.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log out of the app if needed, notice that the prologue screen layout looks good in normal font size.
- Open device Settings > Accessibility > Increase font size on your device.
- Open the app, notice that the prologue carousel can be scrolled up to show all contents.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Normal:

<img src="https://user-images.githubusercontent.com/5533851/234864465-430a6555-1f85-42f6-a58d-3fd121b3255a.png" width=320 />

Large font size:


https://user-images.githubusercontent.com/5533851/234864759-3eddc96c-2d4d-45b1-985c-2d5012e123dc.mp4






---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
