### PR TITLE
[Mobile Payments] Sorting Products by popularity Analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -469,6 +469,7 @@ extension WooAnalyticsEvent {
             static let hasMultipleFeeLines = "has_multiple_fee_lines"
             static let itemType = "item_type"
             static let source = "source"
+            static let isFilterActive = "is_filter_active"
         }
 
         static func orderOpen(order: Order) -> WooAnalyticsEvent {
@@ -604,9 +605,11 @@ extension WooAnalyticsEvent {
             ])
         }
 
-        static func orderCreationProductSelectorConfirmButtonTapped(productCount: Int) -> WooAnalyticsEvent {
+        static func orderCreationProductSelectorConfirmButtonTapped(productCount: Int, sources: [String], isFilterActive: Bool) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderCreationProductSelectorConfirmButtonTapped, properties: [
-                Keys.productCount: Int64(productCount)
+                Keys.productCount: Int64(productCount),
+                Keys.source: sources.joined(separator: ","),
+                Keys.isFilterActive: isFilterActive
             ])
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -293,6 +293,9 @@ final class ProductSelectorViewModel: ObservableObject {
         guard let selectedProduct = products.first(where: { $0.productID == productID }) else {
             return
         }
+
+        updateTrackingSourceAfterSelectionStateChangedForProduct(with: productID)
+
         guard let onProductSelectionStateChanged else {
             toggleSelection(productID: productID)
             return
@@ -305,7 +308,6 @@ final class ProductSelectorViewModel: ObservableObject {
         // The selector supports multiple selection. Toggles the item, and triggers the selection
         toggleSelection(productID: productID)
         onProductSelectionStateChanged(selectedProduct)
-        updateTrackingSourceAfterSelectionStateChangedForProduct(with: productID)
     }
 
     func changeSelectionStateForVariation(with id: Int64, productID: Int64) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -387,12 +387,8 @@ final class ProductSelectorViewModel: ObservableObject {
     ///
     func completeMultipleSelection() {
         let allIDs = selectedProductIDs + selectedProductVariationIDs
-        let trackingSources = Array(productIDTrackingSources.values.map { $0.rawValue })
-        let areFiltersActive = filtersSubject.value.numberOfActiveFilters > 0
-        analytics.track(event: WooAnalyticsEvent.Orders.orderCreationProductSelectorConfirmButtonTapped(productCount: allIDs.count,
-                                                                                                        sources: trackingSources,
-                                                                                                        isFilterActive: areFiltersActive))
-
+        
+        trackConfirmButtonTapped(with: allIDs.count)
         onMultipleSelectionCompleted?(allIDs)
     }
 
@@ -818,6 +814,14 @@ extension ProductSelectorViewModel {
 
 // MARK: - Tracking
 private extension ProductSelectorViewModel {
+    func trackConfirmButtonTapped(with productsCount: Int) {
+        let trackingSources = Array(productIDTrackingSources.values.map { $0.rawValue })
+        let areFiltersActive = filtersSubject.value.numberOfActiveFilters > 0
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCreationProductSelectorConfirmButtonTapped(productCount: productsCount,
+                                                                                                        sources: trackingSources,
+                                                                                                        isFilterActive: areFiltersActive))
+    }
+
     func updateTrackingSourceAfterSelectionStateChangedForProduct(with productID: Int64) {
         guard productIDTrackingSources[productID] == nil else {
             productIDTrackingSources.removeValue(forKey: productID)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -387,7 +387,6 @@ final class ProductSelectorViewModel: ObservableObject {
     ///
     func completeMultipleSelection() {
         let allIDs = selectedProductIDs + selectedProductVariationIDs
-        
         trackConfirmButtonTapped(with: allIDs.count)
         onMultipleSelectionCompleted?(allIDs)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -820,7 +820,10 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let selectedVariationId: Int64 = 12
 
         let simplePopularProduct = Product.fake().copy(siteID: sampleSiteID, productID: mostPopularProductId, purchasable: true)
-        let variableLastSoldProduct = Product.fake().copy(siteID: sampleSiteID, productID: lastSoldProductId, purchasable: true, variations: [selectedVariationId, 20])
+        let variableLastSoldProduct = Product.fake().copy(siteID: sampleSiteID,
+                                                          productID: lastSoldProductId,
+                                                          purchasable: true,
+                                                          variations: [selectedVariationId, 20])
         let otherSimpleProduct = Product.fake().copy(siteID: sampleSiteID, productID: otherProductId, purchasable: true)
         insert(simplePopularProduct)
         insert(variableLastSoldProduct)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9540
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement the analytics for the Sorting Products based on popularity, according to the specifications (pdfdoF-2A0-p2). For that, we gather the sources of the selected products, and compose an array when the confirmation button is pressed. 
Please note that we do not track the sources when the products were already selected before starting the order detail and product selector, as in the case of the order edition: we only track those sources that were selected on that session. On top of that, we don't track sources if there are no popular or last sold products sections, or if we use the product selector for coupons.

Furthermore, we also track when the filters are active at the moment of the selection confirmation, and if a product is selected while filters are active, we track "alphabetical" as the source.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to orders
2. Create new order
3. Add products
4. Select products from the popular, last sold, or alphabetical sections.
5. Select product also after a search.

See that the sources are properly tracked:

`🔵 Tracked order_creation_product_selector_confirm_button_tapped, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("is_filter_active"): false, AnyHashable("product_count"): 4, AnyHashable("blog_id"): 215063064, AnyHashable("source"): "popular,alphabetical,recent,search"]`

4. Apply a filter
5. Select a product

See that the source is alphabetical, and if we keep the filter when tapping the confirmation button we track it:

`🔵 Tracked order_creation_product_selector_confirm_button_tapped, properties: [AnyHashable("product_count"): 1, AnyHashable("blog_id"): 215063064, AnyHashable("source"): "alphabetical", AnyHashable("is_wpcom_store"): false, AnyHashable("is_filter_active"): true]`

See also that if we deselect a product it is removed from the tracking source.
---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.