### PR TITLE
[Min/Max Quantities] Add support for product and variation quantity rules (Yosemite layer)

### DIFF
--- a/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
@@ -82,6 +82,12 @@ extension Storage.Product: ReadOnlyConvertible {
         backordered = product.backordered
         bundleStockQuantity = product.bundleStockQuantity as? NSNumber
         bundleStockStatus = product.bundleStockStatus?.rawValue
+        minAllowedQuantity = product.minAllowedQuantity
+        maxAllowedQuantity = product.maxAllowedQuantity
+        groupOfQuantity = product.groupOfQuantity
+        if let productCombineVariationQuantities = product.combineVariationQuantities {
+            combineVariationQuantities = NSNumber(booleanLiteral: productCombineVariationQuantities)
+        }
     }
 
     /// Returns a ReadOnly version of the receiver.
@@ -176,10 +182,10 @@ extension Storage.Product: ReadOnlyConvertible {
                        bundledItems: bundledItemsArray.map { $0.toReadOnly() },
                        compositeComponents: compositeComponentsArray.map { $0.toReadOnly() },
                        subscription: subscription?.toReadOnly(),
-                       minAllowedQuantity: nil,
-                       maxAllowedQuantity: nil,
-                       groupOfQuantity: nil,
-                       combineVariationQuantities: nil) // TODO: 8959 - Replace with real quantity settings
+                       minAllowedQuantity: minAllowedQuantity,
+                       maxAllowedQuantity: maxAllowedQuantity,
+                       groupOfQuantity: groupOfQuantity,
+                       combineVariationQuantities: combineVariationQuantities?.boolValue)
     }
 
     // MARK: - Private Helpers

--- a/Yosemite/Yosemite/Model/Storage/ProductVariation+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductVariation+ReadOnlyConvertible.swift
@@ -59,6 +59,13 @@ extension Storage.ProductVariation: ReadOnlyConvertible {
         shippingClassID = productVariation.shippingClassID
 
         menuOrder = productVariation.menuOrder
+
+        minAllowedQuantity = productVariation.minAllowedQuantity
+        maxAllowedQuantity = productVariation.maxAllowedQuantity
+        groupOfQuantity = productVariation.groupOfQuantity
+        if let override = productVariation.overrideProductQuantities {
+            overrideProductQuantities = NSNumber(booleanLiteral: override)
+        }
     }
 
     /// Returns a ReadOnly version of the receiver.
@@ -106,10 +113,10 @@ extension Storage.ProductVariation: ReadOnlyConvertible {
                                 shippingClassID: shippingClassID,
                                 menuOrder: menuOrder,
                                 subscription: subscription?.toReadOnly(),
-                                minAllowedQuantity: nil,
-                                maxAllowedQuantity: nil,
-                                groupOfQuantity: nil,
-                                overrideProductQuantities: nil) // TODO: 8959 - Replace with real quantity settings
+                                minAllowedQuantity: minAllowedQuantity,
+                                maxAllowedQuantity: maxAllowedQuantity,
+                                groupOfQuantity: groupOfQuantity,
+                                overrideProductQuantities: overrideProductQuantities?.boolValue)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8959
⚠️ Depends on #9566
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are adding read-only support for the [Min/Max Quantities](https://woocommerce.com/products/minmax-quantities/) extension in product details.

This PR adds support for the min/max quantity settings on a product or product variation in the Yosemite layer.

### Changes

* Updates `Product+ReadOnlyConvertible` to handle the new min/max quantity settings.
* Updates `ProductVariation+ReadOnlyConvertible` to handle the new min/max quantity settings.
* Adds unit tests to check that the min/max quantity settings are persisted and converted correctly.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
These settings aren't yet used in the UI layer. Confirm the unit tests pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
