### PR TITLE
[Min/Max Quantities] Add quantity rules row to product details

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -95,6 +95,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .readOnlyGiftCards:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .readOnlyMinMaxQuantities:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -199,4 +199,8 @@ public enum FeatureFlag: Int {
     /// Enables read-only support for the Gift Cards extension
     ///
     case readOnlyGiftCards
+
+    /// Enables read-only support for the Min/Max Quantities extension
+    ///
+    case readOnlyMinMaxQuantities
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -120,6 +120,8 @@ private extension DefaultProductFormTableViewModel {
                 return .subscription(viewModel: subscriptionRow(product: product, isActionable: actionable), isActionable: actionable)
             case .noVariationsWarning:
                 return .noVariationsWarning(viewModel: noVariationsWarningRow())
+            case .quantityRules:
+                return .quantityRules(viewModel: quantityRulesRow(product: product))
             default:
                 assertionFailure("Unexpected action in the settings section: \(action)")
                 return nil
@@ -598,6 +600,33 @@ private extension DefaultProductFormTableViewModel {
                                                                title: title,
                                                                isActionable: false)
     }
+
+    func quantityRulesRow(product: ProductFormDataModel) -> ProductFormSection.SettingsRow.ViewModel {
+        let icon = UIImage.productImage
+        let title = Localization.quantityRulesTitle
+
+        var quantityDetails = [String]()
+
+        if let minQuantity = product.minAllowedQuantity, minQuantity.isNotEmpty {
+            let minQuantityDescription = String.localizedStringWithFormat(Localization.minQuantityFormat, minQuantity)
+            quantityDetails.append(minQuantityDescription)
+        }
+        if let maxQuantity = product.maxAllowedQuantity, maxQuantity.isNotEmpty {
+            let maxQuantityDescription = String.localizedStringWithFormat(Localization.maxQuantityFormat, maxQuantity)
+            quantityDetails.append(maxQuantityDescription)
+        }
+        if !quantityDetails.containsMoreThanOne, let groupOf = product.groupOfQuantity, groupOf.isNotEmpty {
+            let groupOfDescription = String.localizedStringWithFormat(Localization.groupOfFormat, groupOf)
+            quantityDetails.append(groupOfDescription)
+        }
+
+        let details = quantityDetails.isEmpty ? nil : quantityDetails.joined(separator: "\n")
+
+        return ProductFormSection.SettingsRow.ViewModel(icon: icon,
+                                                        title: title,
+                                                        details: details,
+                                                        isActionable: true)
+    }
 }
 
 private extension DefaultProductFormTableViewModel {
@@ -852,5 +881,14 @@ private extension DefaultProductFormTableViewModel {
         static let noVariationsWarningTitle =
             NSLocalizedString("You can only add variable subscriptions in the web dashboard",
                               comment: "Title of the no variations warning row in the product form when a variable subscription product has no variations.")
+
+        // Quantity Rules
+        static let quantityRulesTitle = NSLocalizedString("Quantity Rules", comment: "Title for Quantity Rules row in the product form screen.")
+        static let minQuantityFormat = NSLocalizedString("Minimum quantity: %@",
+                                                          comment: "Format of the Minimum Quantity setting (with a numeric quantity) on the Quantity Rules row")
+        static let maxQuantityFormat = NSLocalizedString("Maximum quantity: %@",
+                                                       comment: "Format of the Maximum Quantity setting (with a numeric quantity) on the Quantity Rules row")
+        static let groupOfFormat = NSLocalizedString("Group of: %@",
+                                                       comment: "Format of the Group Of setting (with a numeric quantity) on the Quantity Rules row")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -179,6 +179,23 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
         product.subscription
     }
 
+    var hasQuantityRules: Bool {
+        let hasNoRules = minAllowedQuantity.isNilOrEmpty && maxAllowedQuantity.isNilOrEmpty && groupOfQuantity.isNilOrEmpty
+        return !hasNoRules
+    }
+
+    var minAllowedQuantity: String? {
+        product.minAllowedQuantity
+    }
+
+    var maxAllowedQuantity: String? {
+        product.maxAllowedQuantity
+    }
+
+    var groupOfQuantity: String? {
+        product.groupOfQuantity
+    }
+
     func isStockStatusEnabled() -> Bool {
         // Only a variable product's stock status is not editable.
         productType != .variable

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -190,6 +190,22 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
         productVariation.subscription
     }
 
+    var hasQuantityRules: Bool {
+        false // TODO: 8960 - Quantity rules in variation details
+    }
+
+    var minAllowedQuantity: String? {
+        nil // TODO: 8960 - Quantity rules in variation details
+    }
+
+    var maxAllowedQuantity: String? {
+        nil // TODO: 8960 - Quantity rules in variation details
+    }
+
+    var groupOfQuantity: String? {
+        nil // TODO: 8960 - Quantity rules in variation details
+    }
+
     // Visibility logic
 
     func allowsMultipleImages() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -41,6 +41,7 @@ enum ProductFormEditAction: Equatable {
     case subscription(actionable: Bool)
     // Variable Subscription products only
     case noVariationsWarning
+    case quantityRules
 }
 
 /// Creates actions for different sections/UI on the product form.
@@ -75,6 +76,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
     private let isBundledProductsEnabled: Bool
     private let isCompositeProductsEnabled: Bool
     private let isSubscriptionProductsEnabled: Bool
+    private let isMinMaxQuantitiesEnabled: Bool
 
     // TODO: Remove default parameter
     init(product: EditableProductModel,
@@ -90,6 +92,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
          isBundledProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productBundles),
          isCompositeProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.compositeProducts),
          isSubscriptionProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.readOnlySubscriptions),
+         isMinMaxQuantitiesEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.readOnlyMinMaxQuantities),
          variationsPrice: VariationsPrice = .unknown) {
         self.product = product
         self.formType = formType
@@ -106,6 +109,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         self.isBundledProductsEnabled = isBundledProductsEnabled
         self.isCompositeProductsEnabled = isCompositeProductsEnabled
         self.isSubscriptionProductsEnabled = isSubscriptionProductsEnabled
+        self.isMinMaxQuantitiesEnabled = isMinMaxQuantitiesEnabled
     }
 
     /// Returns an array of actions that are visible in the product form primary section.
@@ -182,12 +186,14 @@ private extension ProductFormActionsFactory {
         let shouldShowShippingSettingsRow = product.isShippingEnabled()
         let shouldShowDownloadableProduct = isDownloadableFilesSettingBased ? product.downloadable : true
         let canEditInventorySettingsRow = editable && product.hasIntegerStockQuantity
+        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.hasQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             .priceSettings(editable: editable, hideSeparator: false),
             shouldShowReviewsRow ? .reviews: nil,
             shouldShowShippingSettingsRow ? .shippingSettings(editable: editable): nil,
             .inventorySettings(editable: canEditInventorySettingsRow),
+            shouldShowQuantityRulesRow ? .quantityRules : nil,
             .addOns(editable: editable),
             .categories(editable: editable),
             .tags(editable: editable),
@@ -205,12 +211,14 @@ private extension ProductFormActionsFactory {
         let shouldShowExternalURLRow = editable || product.product.externalURL?.isNotEmpty == true
         let shouldShowSKURow = editable || product.sku?.isNotEmpty == true
         let canEditProductType = formType != .add && editable
+        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.hasQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             .priceSettings(editable: editable, hideSeparator: false),
             shouldShowReviewsRow ? .reviews: nil,
             shouldShowExternalURLRow ? .externalURL(editable: editable): nil,
             shouldShowSKURow ? .sku(editable: editable): nil,
+            shouldShowQuantityRulesRow ? .quantityRules : nil,
             .addOns(editable: editable),
             .categories(editable: editable),
             .tags(editable: editable),
@@ -225,11 +233,13 @@ private extension ProductFormActionsFactory {
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowSKURow = editable || product.sku?.isNotEmpty == true
         let canEditProductType = formType != .add && editable
+        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.hasQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             .groupedProducts(editable: editable),
             shouldShowReviewsRow ? .reviews: nil,
             shouldShowSKURow ? .sku(editable: editable): nil,
+            shouldShowQuantityRulesRow ? .quantityRules : nil,
             .addOns(editable: editable),
             .categories(editable: editable),
             .tags(editable: editable),
@@ -250,6 +260,7 @@ private extension ProductFormActionsFactory {
             let productHasNoPriceSet = variationsPrice == .unknown && product.product.variations.isNotEmpty && product.product.price.isEmpty
             return canEditProductType && (variationsHaveNoPriceSet || productHasNoPriceSet)
         }()
+        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.hasQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             .variations(hideSeparator: shouldShowNoPriceWarningRow),
@@ -258,6 +269,7 @@ private extension ProductFormActionsFactory {
             shouldShowReviewsRow ? .reviews: nil,
             .shippingSettings(editable: editable),
             .inventorySettings(editable: canEditInventorySettingsRow),
+            shouldShowQuantityRulesRow ? .quantityRules : nil,
             .addOns(editable: editable),
             .categories(editable: editable),
             .tags(editable: editable),
@@ -273,12 +285,14 @@ private extension ProductFormActionsFactory {
         let canOpenBundledProducts = product.bundledItems.isNotEmpty
         let shouldShowPriceSettingsRow = product.regularPrice.isNilOrEmpty == false
         let shouldShowReviewsRow = product.reviewsAllowed
+        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.hasQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             shouldShowBundledProductsRow ? .bundledProducts(actionable: canOpenBundledProducts) : nil,
             shouldShowPriceSettingsRow ? .priceSettings(editable: false, hideSeparator: false): nil,
             shouldShowReviewsRow ? .reviews: nil,
             .inventorySettings(editable: false),
+            shouldShowQuantityRulesRow ? .quantityRules : nil,
             .categories(editable: editable),
             .addOns(editable: editable),
             .tags(editable: editable),
@@ -294,12 +308,14 @@ private extension ProductFormActionsFactory {
         let canOpenComponents = product.compositeComponents.isNotEmpty
         let shouldShowPriceSettingsRow = product.regularPrice.isNilOrEmpty == false
         let shouldShowReviewsRow = product.reviewsAllowed
+        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.hasQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             shouldShowComponentsRow ? .components(actionable: canOpenComponents) : nil,
             shouldShowPriceSettingsRow ? .priceSettings(editable: false, hideSeparator: false): nil,
             shouldShowReviewsRow ? .reviews: nil,
             .inventorySettings(editable: false),
+            shouldShowQuantityRulesRow ? .quantityRules : nil,
             .categories(editable: editable),
             .addOns(editable: editable),
             .tags(editable: editable),
@@ -321,11 +337,13 @@ private extension ProductFormActionsFactory {
             }
         }()
         let shouldShowReviewsRow = product.reviewsAllowed
+        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.hasQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             subscriptionOrPriceRow,
             shouldShowReviewsRow ? .reviews: nil,
             .inventorySettings(editable: false),
+            shouldShowQuantityRulesRow ? .quantityRules : nil,
             .categories(editable: editable),
             .addOns(editable: editable),
             .tags(editable: editable),
@@ -340,12 +358,14 @@ private extension ProductFormActionsFactory {
         let shouldShowNoVariationsWarning = product.product.variations.isEmpty
         let shouldShowAttributesRow = product.product.attributesForVariations.isNotEmpty
         let shouldShowReviewsRow = product.reviewsAllowed
+        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.hasQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             shouldShowNoVariationsWarning ? .noVariationsWarning : .variations(hideSeparator: false),
             shouldShowAttributesRow ? .attributes(editable: editable) : nil,
             shouldShowReviewsRow ? .reviews: nil,
             .inventorySettings(editable: false),
+            shouldShowQuantityRulesRow ? .quantityRules : nil,
             .categories(editable: editable),
             .addOns(editable: editable),
             .tags(editable: editable),
@@ -359,11 +379,13 @@ private extension ProductFormActionsFactory {
     func allSettingsSectionActionsForNonCoreProduct() -> [ProductFormEditAction] {
         let shouldShowPriceSettingsRow = product.regularPrice.isNilOrEmpty == false
         let shouldShowReviewsRow = product.reviewsAllowed
+        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.hasQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             shouldShowPriceSettingsRow ? .priceSettings(editable: false, hideSeparator: false): nil,
             shouldShowReviewsRow ? .reviews: nil,
             .inventorySettings(editable: false),
+            shouldShowQuantityRulesRow ? .quantityRules : nil,
             .categories(editable: editable),
             .addOns(editable: editable),
             .tags(editable: editable),
@@ -450,6 +472,9 @@ private extension ProductFormActionsFactory {
             // The subscription row is always visible in the settings section for a subscription product.
             return true
         case .noVariationsWarning:
+            // Always visible when available
+            return true
+        case .quantityRules:
             // Always visible when available
             return true
         default:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -79,6 +79,12 @@ protocol ProductFormDataModel {
     // Subscription Products
     var subscription: ProductSubscription? { get }
 
+    // Quantity Rules (Min/Max Quantities extension)
+    var hasQuantityRules: Bool { get }
+    var minAllowedQuantity: String? { get }
+    var maxAllowedQuantity: String? { get }
+    var groupOfQuantity: String? { get }
+
     /// True if a product has been saved remotely.
     var existsRemotely: Bool { get }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -83,7 +83,8 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
              .bundledProducts,
              .components,
              .subscription,
-             .noVariationsWarning:
+             .noVariationsWarning,
+             .quantityRules:
             return [ImageAndTitleAndTextTableViewCell.self]
         case .reviews:
             return [ProductReviewsTableViewCell.self]
@@ -116,7 +117,8 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
              .bundledProducts,
              .components,
              .subscription,
-             .noVariationsWarning:
+             .noVariationsWarning,
+             .quantityRules:
             return ImageAndTitleAndTextTableViewCell.self
         case .reviews:
             return ProductReviewsTableViewCell.self

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -259,7 +259,8 @@ private extension ProductFormTableViewDataSource {
              .attributes(let viewModel, _),
              .bundledProducts(let viewModel, _),
              .components(let viewModel, _),
-             .subscription(let viewModel, _):
+             .subscription(let viewModel, _),
+             .quantityRules(let viewModel):
             configureSettings(cell: cell, viewModel: viewModel)
         case .reviews(let viewModel, let ratingCount, let averageRating):
             configureReviews(cell: cell, viewModel: viewModel, ratingCount: ratingCount, averageRating: averageRating)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -48,6 +48,7 @@ enum ProductFormSection: Equatable {
         case components(viewModel: ViewModel, isActionable: Bool)
         case subscription(viewModel: ViewModel, isActionable: Bool)
         case noVariationsWarning(viewModel: WarningViewModel)
+        case quantityRules(viewModel: ViewModel)
 
         struct ViewModel {
             let icon: UIImage

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -466,6 +466,10 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 showSubscriptionSettings()
             case .noVariationsWarning:
                 return // This warning is not actionable.
+            case .quantityRules:
+                // TODO: 9252 - Add analytics
+                // TODO: 8960 - Navigate to quantity rules view
+                return
             }
         case .optionsCTA(let rows):
             let row = rows[indexPath.row]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -834,6 +834,36 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
         assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
     }
+
+    func test_viewModel_for_product_with_min_max_quantities_shows_quantity_rules_row_in_settings_section() {
+        // Arrange
+        let product = Fixtures.physicalSimpleProductWithImages.copy(minAllowedQuantity: "4",
+                                                                    maxAllowedQuantity: "200",
+                                                                    groupOfQuantity: "4")
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isMinMaxQuantitiesEnabled: true)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .name(editable: true), .description(editable: true)]
+        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
+                                                                       .reviews,
+                                                                       .shippingSettings(editable: true),
+                                                                       .inventorySettings(editable: true),
+                                                                       .quantityRules,
+                                                                       .categories(editable: true),
+                                                                       .tags(editable: true),
+                                                                       .shortDescription(editable: true),
+                                                                       .linkedProducts(editable: true),
+                                                                       .productType(editable: true)]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
+        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
+    }
 }
 
 private extension ProductFormActionsFactoryTests {
@@ -913,6 +943,7 @@ private extension ProductFormActionsFactoryTests {
                                    isBundledProductsEnabled: Bool = false,
                                    isCompositeProductsEnabled: Bool = false,
                                    isSubscriptionProductsEnabled: Bool = false,
+                                   isMinMaxQuantitiesEnabled: Bool = false,
                                    variationsPrice: ProductFormActionsFactory.VariationsPrice = .unknown) -> ProductFormActionsFactory {
             ProductFormActionsFactory(product: product,
                                       formType: formType,
@@ -927,6 +958,7 @@ private extension ProductFormActionsFactoryTests {
                                       isBundledProductsEnabled: isBundledProductsEnabled,
                                       isCompositeProductsEnabled: isCompositeProductsEnabled,
                                       isSubscriptionProductsEnabled: isSubscriptionProductsEnabled,
+                                      isMinMaxQuantitiesEnabled: isMinMaxQuantitiesEnabled,
                                       variationsPrice: variationsPrice)
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
@@ -245,6 +245,121 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         let expectedDetails = String.localizedStringWithFormat(Localization.expiryFormat, Localization.neverExpire)
         XCTAssertEqual(subscriptionViewModel?.details, expectedDetails)
     }
+
+    func test_quantity_rules_row_returns_expected_details_for_product_with_min_and_max_quantity() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: ProductType.simple.rawValue, minAllowedQuantity: "4", maxAllowedQuantity: "200", groupOfQuantity: "2")
+        let model = EditableProductModel(product: product)
+        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let tableViewModel = DefaultProductFormTableViewModel(product: model,
+                                                              actionsFactory: actionsFactory,
+                                                              currency: "", currencyFormatter: currencyFormatter)
+
+        // Then
+        guard case let .settings(rows) = tableViewModel.sections[1] else {
+            XCTFail("Unexpected section at index 1: \(tableViewModel.sections)")
+            return
+        }
+        var quantityRulesViewModel: ProductFormSection.SettingsRow.ViewModel?
+        for row in rows {
+            if case let .quantityRules(viewModel) = row {
+                quantityRulesViewModel = viewModel
+                break
+            }
+        }
+        let expectedDetails = [String.localizedStringWithFormat(Localization.minQuantityFormat, "4"),
+                               String.localizedStringWithFormat(Localization.maxQuantityFormat, "200")].joined(separator: "\n")
+        XCTAssertEqual(quantityRulesViewModel?.details, expectedDetails)
+    }
+
+    func test_quantity_rules_row_returns_expected_details_for_product_with_min_and_groupOf_but_no_max_quantity() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: ProductType.simple.rawValue, minAllowedQuantity: "4", maxAllowedQuantity: "", groupOfQuantity: "2")
+        let model = EditableProductModel(product: product)
+        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let tableViewModel = DefaultProductFormTableViewModel(product: model,
+                                                              actionsFactory: actionsFactory,
+                                                              currency: "", currencyFormatter: currencyFormatter)
+
+        // Then
+        guard case let .settings(rows) = tableViewModel.sections[1] else {
+            XCTFail("Unexpected section at index 1: \(tableViewModel.sections)")
+            return
+        }
+        var quantityRulesViewModel: ProductFormSection.SettingsRow.ViewModel?
+        for row in rows {
+            if case let .quantityRules(viewModel) = row {
+                quantityRulesViewModel = viewModel
+                break
+            }
+        }
+        let expectedDetails = [String.localizedStringWithFormat(Localization.minQuantityFormat, "4"),
+                               String.localizedStringWithFormat(Localization.groupOfFormat, "2")].joined(separator: "\n")
+        XCTAssertEqual(quantityRulesViewModel?.details, expectedDetails)
+    }
+
+    func test_quantity_rules_row_returns_expected_details_for_product_with_max_and_groupOf_but_no_min_quantity() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: ProductType.simple.rawValue, minAllowedQuantity: "", maxAllowedQuantity: "200", groupOfQuantity: "2")
+        let model = EditableProductModel(product: product)
+        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let tableViewModel = DefaultProductFormTableViewModel(product: model,
+                                                              actionsFactory: actionsFactory,
+                                                              currency: "", currencyFormatter: currencyFormatter)
+
+        // Then
+        guard case let .settings(rows) = tableViewModel.sections[1] else {
+            XCTFail("Unexpected section at index 1: \(tableViewModel.sections)")
+            return
+        }
+        var quantityRulesViewModel: ProductFormSection.SettingsRow.ViewModel?
+        for row in rows {
+            if case let .quantityRules(viewModel) = row {
+                quantityRulesViewModel = viewModel
+                break
+            }
+        }
+        let expectedDetails = [String.localizedStringWithFormat(Localization.maxQuantityFormat, "200"),
+                               String.localizedStringWithFormat(Localization.groupOfFormat, "2")].joined(separator: "\n")
+        XCTAssertEqual(quantityRulesViewModel?.details, expectedDetails)
+    }
+
+    func test_quantity_rules_row_returns_expected_details_for_product_with_only_groupOf_quantity() {
+        // Given
+        let product = Product.fake().copy(productTypeKey: ProductType.simple.rawValue, minAllowedQuantity: "", maxAllowedQuantity: "", groupOfQuantity: "2")
+        let model = EditableProductModel(product: product)
+        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings())
+
+        // When
+        let tableViewModel = DefaultProductFormTableViewModel(product: model,
+                                                              actionsFactory: actionsFactory,
+                                                              currency: "", currencyFormatter: currencyFormatter)
+
+        // Then
+        guard case let .settings(rows) = tableViewModel.sections[1] else {
+            XCTFail("Unexpected section at index 1: \(tableViewModel.sections)")
+            return
+        }
+        var quantityRulesViewModel: ProductFormSection.SettingsRow.ViewModel?
+        for row in rows {
+            if case let .quantityRules(viewModel) = row {
+                quantityRulesViewModel = viewModel
+                break
+            }
+        }
+        let expectedDetails = String.localizedStringWithFormat(Localization.groupOfFormat, "2")
+        XCTAssertEqual(quantityRulesViewModel?.details, expectedDetails)
+    }
 }
 
 private extension DefaultProductFormTableViewModelTests {
@@ -255,5 +370,11 @@ private extension DefaultProductFormTableViewModelTests {
         static let expiryFormat = NSLocalizedString("Expire after: %@",
                                                     comment: "Format of the expiry details on the Subscription row. Reads like: 'Expire after: 1 year'.")
         static let neverExpire = NSLocalizedString("Never expire", comment: "Display label when a subscription never expires.")
+        static let minQuantityFormat = NSLocalizedString("Minimum quantity: %@",
+                                                          comment: "Format of the Minimum Quantity setting (with a numeric quantity) on the Quantity Rules row")
+        static let maxQuantityFormat = NSLocalizedString("Maximum quantity: %@",
+                                                       comment: "Format of the Maximum Quantity setting (with a numeric quantity) on the Quantity Rules row")
+        static let groupOfFormat = NSLocalizedString("Group of: %@",
+                                                       comment: "Format of the Group Of setting (with a numeric quantity) on the Quantity Rules row")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8960
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are adding read-only support for the [Min/Max Quantities](https://woocommerce.com/products/minmax-quantities/) extension in product details.

This PR adds a "Quantity Rules" row in the product details screen, when the product has min/max quantity rules set and the feature flag is enabled. The row details shows the first two quantity rules set for the product. For now, tapping the quantity rules row does nothing (navigation to a new view to be added in another PR).

### Changes

* Adds a new `readOnlyMinMaxQuantities` feature flag.
* Adds the min/max quantity settings to `ProductFormDataModel` and `EditableProductModel` (will be updated for product variations in a separate PR).
* Creates the row view model in `DefaultProductFormTableViewModel`.
* Adds the row to the settings section in `ProductFormActionsFactory` for all product types, always visible when the product has min/max quantity rules set.
* Adds unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Prerequisites

1. Install and activate the [Min/Max Quantities](https://woocommerce.com/products/minmax-quantities/) extension.
2. Create or update at least one product to add quantity rules in the product details > General settings in wp-admin.

### To test

1. Build and run the app.
2. Go to the Products tab.
3. Select a product with quantity rules set, and confirm the Quantity Rules row appears with the expected details.
4. Select a product with no quantity rules set, and confirm the Quantity Rules row does not appear.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

/|Before|After
-|-|-
Product with min/max rules|![Simulator Screenshot - iPhone 14 Pro - 2023-04-27 at 16 55 13](https://user-images.githubusercontent.com/8658164/234918745-635573a2-ef74-4db5-a120-c8c8ffb1175a.png)|![Simulator Screenshot - iPhone 14 Pro - 2023-04-27 at 16 31 42](https://user-images.githubusercontent.com/8658164/234918814-6adf0b11-9203-4f3c-ba8b-97d6ece1b61a.png)
Product with min/group of rules|![Simulator Screenshot - iPhone 14 Pro - 2023-04-27 at 16 55 17](https://user-images.githubusercontent.com/8658164/234918734-4ce318b8-736b-4603-9f70-123534e2d8cc.png)|![Simulator Screenshot - iPhone 14 Pro - 2023-04-27 at 16 31 49](https://user-images.githubusercontent.com/8658164/234918792-9bd75621-0384-4dcd-a3f0-f2f7c466a10c.png)
Product without quantity rules (no change)|![Simulator Screenshot - iPhone 14 Pro - 2023-04-27 at 16 55 42](https://user-images.githubusercontent.com/8658164/234918719-9703ed29-7c8a-4e53-8850-1de7c17da6fb.png)|![Simulator Screenshot - iPhone 14 Pro - 2023-04-27 at 16 55 04](https://user-images.githubusercontent.com/8658164/234918762-63e4813c-012e-4d7f-86c5-0b9b71ef5f63.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
