### PR TITLE
[Store onboarding] Option to hide the list

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -93,6 +93,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .productDescriptionAI:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .hideStoreOnboardingTaskList:
+            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
         default:
             return true
         }

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -94,7 +94,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .productDescriptionAI:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .hideStoreOnboardingTaskList:
-            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
+            return false
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -195,4 +195,8 @@ public enum FeatureFlag: Int {
     /// Enables generating product description using AI.
     ///
     case productDescriptionAI
+
+    /// Ability to hide store onboarding task list
+    ///
+    case hideStoreOnboardingTaskList
 }

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -26,8 +26,8 @@ extension UserDefaults {
         case notificationsLastSeenTime
         case notificationsMarkAsReadCount
         case completedAllStoreOnboardingTasks
-        case storePhoneNumber
         case shouldHideStoreOnboardingTaskList
+        case storePhoneNumber
     }
 }
 

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -27,6 +27,7 @@ extension UserDefaults {
         case notificationsMarkAsReadCount
         case completedAllStoreOnboardingTasks
         case storePhoneNumber
+        case shouldHideStoreOnboardingTaskList
     }
 }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -168,6 +168,7 @@ final class SessionManager: SessionManagerProtocol {
         defaultStoreID = nil
         defaultSite = nil
         defaults[.completedAllStoreOnboardingTasks] = nil
+        defaults[.shouldHideStoreOnboardingTaskList] = nil
     }
 
     /// Deletes application password

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -135,6 +135,7 @@ struct StoreOnboardingView: View {
                                        totalNumberOfTasks: viewModel.taskViewModels.count,
                                        numberOfTasksCompleted: viewModel.numberOfTasksCompleted,
                                        shareFeedbackAction: shareFeedbackAction,
+                                       hideTaskListAction: viewModel.hideTaskList,
                                        isRedacted: viewModel.isRedacted)
 
                 // Task list

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -136,7 +136,8 @@ struct StoreOnboardingView: View {
                                        numberOfTasksCompleted: viewModel.numberOfTasksCompleted,
                                        shareFeedbackAction: shareFeedbackAction,
                                        hideTaskListAction: viewModel.hideTaskList,
-                                       isRedacted: viewModel.isRedacted)
+                                       isRedacted: viewModel.isRedacted,
+                                       isHideStoreOnboardingTaskListFeatureEnabled: viewModel.isHideStoreOnboardingTaskListFeatureEnabled)
 
                 // Task list
                 VStack(alignment: .leading, spacing: 0) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 import Yosemite
 import Combine
+import Experiments
 
 /// View model for `StoreOnboardingView`.
 class StoreOnboardingViewModel: ObservableObject {
@@ -48,6 +49,8 @@ class StoreOnboardingViewModel: ObservableObject {
         !isExpanded && !isRedacted && (taskViewModels.count > tasksForDisplay.count)
     }
 
+    let isHideStoreOnboardingTaskListFeatureEnabled: Bool
+
     let isExpanded: Bool
 
     private let siteID: Int64
@@ -73,12 +76,14 @@ class StoreOnboardingViewModel: ObservableObject {
     init(siteID: Int64,
          isExpanded: Bool,
          stores: StoresManager = ServiceLocator.stores,
-         defaults: UserDefaults = .standard) {
+         defaults: UserDefaults = .standard,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.siteID = siteID
         self.isExpanded = isExpanded
         self.stores = stores
         self.state = .loading
         self.defaults = defaults
+        isHideStoreOnboardingTaskListFeatureEnabled = featureFlagService.isFeatureFlagEnabled(.hideStoreOnboardingTaskList)
 
         Publishers.CombineLatest3($noTasksAvailableForDisplay,
                                   defaults.publisher(for: \.completedAllStoreOnboardingTasks),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -102,6 +102,10 @@ class StoreOnboardingViewModel: ObservableObject {
             await update(state: .failed)
         }
     }
+
+    func hideTaskList() {
+        defaults[.shouldHideStoreOnboardingTaskList] = true
+    }
 }
 
 private extension StoreOnboardingViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -80,9 +80,10 @@ class StoreOnboardingViewModel: ObservableObject {
         self.state = .loading
         self.defaults = defaults
 
-        Publishers.CombineLatest($noTasksAvailableForDisplay,
-                                 defaults.publisher(for: \.completedAllStoreOnboardingTasks))
-        .map { !($0 || $1) }
+        Publishers.CombineLatest3($noTasksAvailableForDisplay,
+                                  defaults.publisher(for: \.completedAllStoreOnboardingTasks),
+                                  defaults.publisher(for: \.shouldHideStoreOnboardingTaskList))
+        .map { !($0 || $1 || $2) }
         .assign(to: &$shouldShowInDashboard)
     }
 
@@ -245,4 +246,8 @@ extension UserDefaults {
      @objc dynamic var completedAllStoreOnboardingTasks: Bool {
          bool(forKey: Key.completedAllStoreOnboardingTasks.rawValue)
      }
+
+    @objc dynamic var shouldHideStoreOnboardingTaskList: Bool {
+        bool(forKey: Key.shouldHideStoreOnboardingTaskList.rawValue)
+    }
  }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreSetupProgressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreSetupProgressView.swift
@@ -9,7 +9,11 @@ struct StoreSetupProgressView: View {
 
     let shareFeedbackAction: (() -> Void)?
 
+    let hideTaskListAction: (() -> Void)?
+
     let isRedacted: Bool
+
+    @State private var showingTaskHideListConfirmAlert: Bool = false
 
     var body: some View {
         HStack(alignment: .top) {
@@ -46,6 +50,10 @@ struct StoreSetupProgressView: View {
                 Button(Localization.shareFeedbackButton) {
                     shareFeedbackAction?()
                 }
+
+                Button(Localization.hideStoreSetupListButton) {
+                    showingTaskHideListConfirmAlert = true
+                }
             } label: {
                 Image(uiImage: .ellipsisImage)
                     .flipsForRightToLeftLayoutDirection(true)
@@ -53,6 +61,12 @@ struct StoreSetupProgressView: View {
             }
             .renderedIf(!isExpanded)
         }
+        .alert(isPresented: $showingTaskHideListConfirmAlert, content: {
+            Alert(title: Text(Localization.HideStoreSetupListAlert.title),
+                  message: Text(Localization.HideStoreSetupListAlert.message),
+                  primaryButton: .destructive(Text(Localization.HideStoreSetupListAlert.removeButton), action: hideTaskListAction),
+                  secondaryButton: .cancel())
+        })
     }
 }
 
@@ -94,14 +108,46 @@ private extension StoreSetupProgressView {
             "Share feedback",
             comment: "Title of the feedback button in the action sheet."
         )
+
+        static let hideStoreSetupListButton = NSLocalizedString(
+            "Hide store setup list",
+            comment: "Title of the Hide store setup list button in the action sheet."
+        )
+
+        enum HideStoreSetupListAlert {
+            static let title = NSLocalizedString(
+                "Hide store setup list",
+                comment: "Action title for hiding store onboarding task list"
+            )
+
+            static let message = NSLocalizedString(
+                "You can show it when you need it by going to Menu > Settings > Store",
+                comment: "Confirm message for hiding store onboarding task list"
+            )
+
+            static let removeButton = NSLocalizedString(
+                "Remove",
+                comment: "Title for the action button on the confirm alert for hiding store onboarding task list"
+            )
+        }
     }
 }
 
 
 struct StoreSetupProgressView_Previews: PreviewProvider {
     static var previews: some View {
-        StoreSetupProgressView(isExpanded: false, totalNumberOfTasks: 5, numberOfTasksCompleted: 1, shareFeedbackAction: nil, isRedacted: false)
+        StoreSetupProgressView(isExpanded: false,
+                               totalNumberOfTasks: 5,
+                               numberOfTasksCompleted: 1,
+                               shareFeedbackAction: nil,
+                               hideTaskListAction: nil,
+                               isRedacted: false)
 
-        StoreSetupProgressView(isExpanded: true, totalNumberOfTasks: 5, numberOfTasksCompleted: 1, shareFeedbackAction: nil, isRedacted: false)
+        StoreSetupProgressView(isExpanded: true,
+                               totalNumberOfTasks: 5,
+                               numberOfTasksCompleted: 1,
+                               shareFeedbackAction: nil,
+                               hideTaskListAction: nil,
+                               isRedacted: false)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreSetupProgressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreSetupProgressView.swift
@@ -15,7 +15,7 @@ struct StoreSetupProgressView: View {
 
     let isHideStoreOnboardingTaskListFeatureEnabled: Bool
 
-    @State private var showingTaskHideListConfirmAlert: Bool = false
+    @State private var showingHideStoreSetupListAlert: Bool = false
 
     var body: some View {
         HStack(alignment: .top) {
@@ -54,7 +54,7 @@ struct StoreSetupProgressView: View {
                 }
 
                 Button(Localization.hideStoreSetupListButton) {
-                    showingTaskHideListConfirmAlert = true
+                    showingHideStoreSetupListAlert = true
                 }
                 .renderedIf(isHideStoreOnboardingTaskListFeatureEnabled)
             } label: {
@@ -64,7 +64,7 @@ struct StoreSetupProgressView: View {
             }
             .renderedIf(!isExpanded)
         }
-        .alert(isPresented: $showingTaskHideListConfirmAlert, content: {
+        .alert(isPresented: $showingHideStoreSetupListAlert, content: {
             Alert(title: Text(Localization.HideStoreSetupListAlert.title),
                   message: Text(Localization.HideStoreSetupListAlert.message),
                   primaryButton: .destructive(Text(Localization.HideStoreSetupListAlert.removeButton), action: hideTaskListAction),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreSetupProgressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreSetupProgressView.swift
@@ -9,9 +9,11 @@ struct StoreSetupProgressView: View {
 
     let shareFeedbackAction: (() -> Void)?
 
-    let hideTaskListAction: (() -> Void)?
+    let hideTaskListAction: (() -> Void)
 
     let isRedacted: Bool
+
+    let isHideStoreOnboardingTaskListFeatureEnabled: Bool
 
     @State private var showingTaskHideListConfirmAlert: Bool = false
 
@@ -54,6 +56,7 @@ struct StoreSetupProgressView: View {
                 Button(Localization.hideStoreSetupListButton) {
                     showingTaskHideListConfirmAlert = true
                 }
+                .renderedIf(isHideStoreOnboardingTaskListFeatureEnabled)
             } label: {
                 Image(uiImage: .ellipsisImage)
                     .flipsForRightToLeftLayoutDirection(true)
@@ -140,14 +143,16 @@ struct StoreSetupProgressView_Previews: PreviewProvider {
                                totalNumberOfTasks: 5,
                                numberOfTasksCompleted: 1,
                                shareFeedbackAction: nil,
-                               hideTaskListAction: nil,
-                               isRedacted: false)
+                               hideTaskListAction: {},
+                               isRedacted: false,
+                               isHideStoreOnboardingTaskListFeatureEnabled: true)
 
         StoreSetupProgressView(isExpanded: true,
                                totalNumberOfTasks: 5,
                                numberOfTasksCompleted: 1,
                                shareFeedbackAction: nil,
-                               hideTaskListAction: nil,
-                               isRedacted: false)
+                               hideTaskListAction: {},
+                               isRedacted: false,
+                               isHideStoreOnboardingTaskListFeatureEnabled: true)
     }
 }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -235,6 +235,7 @@ class DefaultStoresManager: StoresManager {
         // For example, `sessionManager.defaultSite` is used to show site name in various screens in the app.
         sessionManager.defaultSite = nil
         defaults[.completedAllStoreOnboardingTasks] = nil
+        defaults[.shouldHideStoreOnboardingTaskList] = nil
         restoreSessionSiteIfPossible()
         ServiceLocator.pushNotesManager.reloadBadgeCount()
 

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -148,6 +148,27 @@ class SessionManagerTests: XCTestCase {
         XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
     }
 
+    /// Verifies that `shouldHideStoreOnboardingTaskList` is set to `nil` upon reset
+    ///
+    func test_shouldHideStoreOnboardingTaskList_is_set_to_nil_upon_reset() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
+
+        // When
+        defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList] = true
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList] as? Bool))
+
+        // When
+        sut.reset()
+
+        // Then
+        XCTAssertNil(defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList])
+    }
+
     /// Verifies that `removeDefaultCredentials` effectively nukes everything from the keychain
     ///
     func testDefaultCredentialsAreEffectivelyNuked() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -757,6 +757,37 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(sut.shouldShowInDashboard)
     }
+
+    func test_shouldShowInDashboard_is_false_when_user_has_opted_to_hide_the_list() async {
+        // Given
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: false,
+                                           stores: stores,
+                                           defaults: defaults)
+
+        // When
+        defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList] = true
+
+        // Then
+        XCTAssertFalse(sut.shouldShowInDashboard)
+    }
+
+    // MARK: - hideTaskList
+
+    func test_hideTaskList_updates_userdefaults() async {
+        // Given
+        defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList] = nil
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: false,
+                                           stores: stores,
+                                           defaults: defaults)
+
+        // When
+        sut.hideTaskList()
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList] as? Bool))
+    }
 }
 
 private extension StoreOnboardingViewModelTests {

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -326,6 +326,26 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertNil(defaults[UserDefaults.Key.completedAllStoreOnboardingTasks])
     }
 
+    func test_updating_default_storeID_sets_shouldHideStoreOnboardingTaskList_to_nil() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let mockSessionManager = MockSessionManager()
+        let sut = DefaultStoresManager(sessionManager: mockSessionManager, defaults: defaults)
+
+        // When
+        defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList] = true
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList] as? Bool))
+
+        // When
+        sut.updateDefaultStore(storeID: 0)
+
+        // Then
+        XCTAssertNil(defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList])
+    }
+
     /// Verifies that user is logged out when application password regeneration fails
     ///
     func test_it_deauthenticates_upon_receiving_application_password_generation_failure_notification() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9561
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

We want to allow the user to hide/dismiss the Store onboarding task list.

This PR,

- Adds an option to store onboarding list to hide it. 
- In a later PR we will add a way to enable this from settings.

## Testing instructions

- Enable feature flag by returning `true` [here](https://github.com/woocommerce/woocommerce-ios/compare/feat/9561-option-to-hide?expand=1#diff-26c9afc49bb1f1a168517d43d5e36a64ff45adb046469369ef3e4d6800ccc19bR97)
- Login into a store which has pending store onboarding tasks
- From the dashboard store onboarding list tap on `...` -> and select `Hide store setup list`
- From the alert tap `Remove` and verify that the store onboarding task list is removed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![Simulator Screen Recording - iPhone 14 - 2023-04-28 at 07 17 11](https://user-images.githubusercontent.com/524475/235035573-a37640f0-f854-4c20-a6b0-133a18cc2670.gif)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
