### PR TITLE
[Store onboarding] Setting to show/hide the list

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -96,7 +96,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .readOnlyGiftCards:
             return true
         case .hideStoreOnboardingTaskList:
-            return false
+            return true
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [**] Adds read-only support for the Gift Cards extension in order details. [https://github.com/woocommerce/woocommerce-ios/pull/9558]
 - [**] Adds read-only support for the Subscriptions extension in order and product details. [https://github.com/woocommerce/woocommerce-ios/pull/9541]
 - [Internal] Payments: Upate Tap to Pay connection flow strings to avoid mentioning "reader" [https://github.com/woocommerce/woocommerce-ios/pull/9563]
+- [*] Store onboarding: Now the onboarding task list can be shown/hidden from settings and also from the dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/9572, https://github.com/woocommerce/woocommerce-ios/pull/9573]
 
 13.3
 -----
@@ -33,7 +34,7 @@
 - [**] Adds support for Product Multi-selection when creating and/or editing Orders. [https://github.com/woocommerce/woocommerce-ios/issues/8888]
 - [**] Users can now install Jetpack for their non-Jetpack sites after logging in with application passwords. [https://github.com/woocommerce/woocommerce-ios/pull/9354]
 - [*] Payments: We show a Tap to Pay on iPhone feedback survey button in the Payments menu after the first Tap to Pay on iPhone payment is taken [https://github.com/woocommerce/woocommerce-ios/pull/9366]
-- [Internal] Added SiteID to some IPP tracks events [https://github.com/woocommerce/woocommerce-ios/pull/9371]
+- [Internal] Added SiteID to some IPP tracks events [https://github.com/woocommerce/woocommerce-ios/pull/9572,]
 
 13.0
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreOnboarding.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreOnboarding.swift
@@ -36,7 +36,7 @@ extension WooAnalyticsEvent {
 extension WooAnalyticsEvent.StoreOnboarding {
     enum Source: String {
         case onboardingList = "onboarding_list"
-        case settings = "settings"
+        case settings
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreOnboarding.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreOnboarding.swift
@@ -2,9 +2,11 @@ import struct Yosemite.StoreOnboardingTask
 
 extension WooAnalyticsEvent {
     enum StoreOnboarding {
-        /// Event property keys.
-        private enum Keys {
+        /// Event property Key.
+        private enum Key {
             static let task = "task"
+            static let pendingTasks = "pending_tasks"
+            static let source = "source"
         }
 
         static func storeOnboardingShown() -> WooAnalyticsEvent {
@@ -12,16 +14,29 @@ extension WooAnalyticsEvent {
         }
 
         static func storeOnboardingTaskTapped(task: StoreOnboardingTask.TaskType) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .storeOnboardingTaskTapped, properties: [Keys.task: task.analyticsValue])
+            WooAnalyticsEvent(statName: .storeOnboardingTaskTapped, properties: [Key.task: task.analyticsValue])
         }
 
         static func storeOnboardingTaskCompleted(task: StoreOnboardingTask.TaskType) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .storeOnboardingTaskCompleted, properties: [Keys.task: task.analyticsValue])
+            WooAnalyticsEvent(statName: .storeOnboardingTaskCompleted, properties: [Key.task: task.analyticsValue])
         }
 
         static func storeOnboardingCompleted() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .storeOnboardingCompleted, properties: [:])
         }
+
+        static func storeOnboardingHideList(source: Source, pendingTasks: [StoreOnboardingTask.TaskType]) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .storeOnboardingHideList,
+                              properties: [Key.source: source.rawValue,
+                                           Key.pendingTasks: pendingTasks.map({ $0.analyticsValue }).sorted().joined(separator: ",")])
+        }
+    }
+}
+
+extension WooAnalyticsEvent.StoreOnboarding {
+    enum Source: String {
+        case onboardingList = "onboarding_list"
+        case settings = "settings"
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -173,6 +173,7 @@ public enum WooAnalyticsStat: String {
     case storeOnboardingTaskTapped = "store_onboarding_task_tapped"
     case storeOnboardingTaskCompleted = "store_onboarding_task_completed"
     case storeOnboardingCompleted = "store_onboarding_completed"
+    case storeOnboardingHideList = "store_onboarding_hide_list"
 
     // MARK: Site picker. Can be triggered by login epilogue or settings.
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -213,7 +213,9 @@ private extension SettingsViewController {
         cell.title = Localization.storeSetupList
         cell.isOn = viewModel.isStoreSetupSettingSwitchOn
         cell.onChange = { [weak self] value in
-            self?.viewModel.updateStoreSetupListVisibility(value)
+            Task {
+                await self?.viewModel.updateStoreSetupListVisibility(value)
+            }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -211,6 +211,10 @@ private extension SettingsViewController {
 
     func configureStoreSetupList(cell: SwitchTableViewCell) {
         cell.title = Localization.storeSetupList
+        cell.isOn = viewModel.isStoreSetupSettingSwitchOn
+        cell.onChange = { [weak self] value in
+            self?.viewModel.updateStoreSetupListVisibility(value)
+        }
     }
 
     func configurePrivacy(cell: BasicTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -142,6 +142,8 @@ private extension SettingsViewController {
             configureDomain(cell: cell)
         case let cell as BasicTableViewCell where row == .installJetpack:
             configureInstallJetpack(cell: cell)
+        case let cell as SwitchTableViewCell where row == .storeSetupList:
+            configureStoreSetupList(cell: cell)
         case let cell as BasicTableViewCell where row == .support:
             configureSupport(cell: cell)
         case let cell as BasicTableViewCell where row == .betaFeatures:
@@ -205,6 +207,10 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = Localization.installJetpack
+    }
+
+    func configureStoreSetupList(cell: SwitchTableViewCell) {
+        cell.title = Localization.storeSetupList
     }
 
     func configurePrivacy(cell: BasicTableViewCell) {
@@ -632,6 +638,7 @@ extension SettingsViewController {
         // Store settings
         case domain
         case installJetpack
+        case storeSetupList
 
         // Help & Feedback
         case support
@@ -680,6 +687,8 @@ extension SettingsViewController {
                 return BasicTableViewCell.self
             case .installJetpack:
                 return BasicTableViewCell.self
+            case .storeSetupList:
+                return SwitchTableViewCell.self
             case .logout, .closeAccount:
                 return BasicTableViewCell.self
             case .privacy:
@@ -751,6 +760,11 @@ private extension SettingsViewController {
         static let installJetpack = NSLocalizedString(
             "Install Jetpack",
             comment: "Navigates to Install Jetpack screen."
+        )
+
+        static let storeSetupList = NSLocalizedString(
+            "Store Setup List",
+            comment: "Controls store onboarding setup list visibility."
         )
 
         static let privacySettings = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -290,7 +290,8 @@ private extension SettingsViewModel {
                 rows.append(.installJetpack)
             }
 
-            if !defaults.completedAllStoreOnboardingTasks {
+            if !defaults.completedAllStoreOnboardingTasks,
+                featureFlagService.isFeatureFlagEnabled(.hideStoreOnboardingTaskList) {
                 rows.append(.storeSetupList)
             }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -21,6 +21,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isIPPUKExpansionEnabled: Bool
     private let isReadOnlySubscriptionsEnabled: Bool
     private let isProductDescriptionAIEnabled: Bool
+    private let isHideStoreOnboardingTaskListFeatureEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -40,7 +41,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isTapToPayOnIPhoneMilestone2On: Bool = false,
          isIPPUKExpansionEnabled: Bool = false,
          isReadOnlySubscriptionsEnabled: Bool = false,
-         isProductDescriptionAIEnabled: Bool = false) {
+         isProductDescriptionAIEnabled: Bool = false,
+         isHideStoreOnboardingTaskListFeatureEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -60,6 +62,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isIPPUKExpansionEnabled = isIPPUKExpansionEnabled
         self.isReadOnlySubscriptionsEnabled = isReadOnlySubscriptionsEnabled
         self.isProductDescriptionAIEnabled = isProductDescriptionAIEnabled
+        self.isHideStoreOnboardingTaskListFeatureEnabled = isHideStoreOnboardingTaskListFeatureEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -102,6 +105,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isReadOnlySubscriptionsEnabled
         case .productDescriptionAI:
             return isProductDescriptionAIEnabled
+        case .hideStoreOnboardingTaskList:
+            return isHideStoreOnboardingTaskListFeatureEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -9,6 +9,8 @@ final class StoreOnboardingViewModelTests: XCTestCase {
     private let placeholderTaskCount = 3
     private let freeTrialID = "1052"
     private var sessionManager: SessionManager!
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -16,12 +18,16 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         sessionManager = .makeForTesting(authenticated: true)
         stores = MockStoresManager(sessionManager: sessionManager)
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
     }
 
     override func tearDown() {
         stores = nil
         sessionManager = nil
         defaults = nil
+        analytics = nil
+        analyticsProvider = nil
         super.tearDown()
     }
 
@@ -787,6 +793,34 @@ final class StoreOnboardingViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList] as? Bool))
+    }
+
+    func test_hideTaskList_tracks_hide_list_event() async throws {
+        // Given
+        let tasks: [StoreOnboardingTask] = [
+            .init(isComplete: false, type: .addFirstProduct),
+            .init(isComplete: true, type: .storeDetails),
+            .init(isComplete: false, type: .launchStore),
+            .init(isComplete: false, type: .customizeDomains),
+            .init(isComplete: false, type: .payments)
+        ]
+        mockLoadOnboardingTasks(result: .success(tasks))
+        defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList] = nil
+        let sut = StoreOnboardingViewModel(siteID: 0,
+                                           isExpanded: false,
+                                           stores: stores,
+                                           defaults: defaults,
+                                           analytics: analytics)
+        await sut.reloadTasks()
+
+        // When
+        sut.hideTaskList()
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "store_onboarding_hide_list"}))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["source"] as? String, "onboarding_list")
+        XCTAssertEqual(eventProperties["pending_tasks"] as? String, "add_domain,launch_site,payments,products")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -17,15 +17,19 @@ final class SettingsViewModelTests: XCTestCase {
     ///
     private var stores: MockStoresManager!
 
+    private var defaults: UserDefaults!
+
     private var sessionManager: SessionManager!
 
     private var appleIDCredentialChecker: AppleIDCredentialCheckerProtocol!
 
-    override func setUp() {
+    override func setUpWithError() throws {
         super.setUp()
         storageManager = MockStorageManager()
         sessionManager = .makeForTesting(authenticated: true)
         stores = MockStoresManager(sessionManager: sessionManager)
+        let uuid = UUID().uuidString
+        defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         appleIDCredentialChecker = MockAppleIDCredentialChecker(hasAppleUserID: false)
     }
 
@@ -34,6 +38,7 @@ final class SettingsViewModelTests: XCTestCase {
         storageManager = nil
         stores = nil
         sessionManager = nil
+        defaults = nil
         super.tearDown()
     }
 
@@ -251,6 +256,91 @@ final class SettingsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.domain) })
+    }
+
+    // MARK: - `Store Setup List` row
+
+    func test_store_setup_list_row_is_shown_when_there_are_pending_onboarding_tasks() {
+        // Given
+        defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = false
+        let viewModel = SettingsViewModel(stores: stores,
+                                          storageManager: storageManager,
+                                          appleIDCredentialChecker: appleIDCredentialChecker,
+                                          defaults: defaults)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.storeSetupList) })
+    }
+
+    func test_store_setup_list_row_is_hidden_when_there_are_no_pending_onboarding_tasks() {
+        // Given
+        defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = true
+        let viewModel = SettingsViewModel(stores: stores,
+                                          storageManager: storageManager,
+                                          appleIDCredentialChecker: appleIDCredentialChecker,
+                                          defaults: defaults)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.storeSetupList) })
+    }
+
+    // MARK: - `isStoreSetupSettingSwitchOn`
+
+    func test_isStoreSetupSettingSwitchOn_is_true_when_shouldHideStoreOnboardingTaskList_is_false() {
+        // Given
+        let viewModel = SettingsViewModel(stores: stores,
+                                          storageManager: storageManager,
+                                          appleIDCredentialChecker: appleIDCredentialChecker,
+                                          defaults: defaults)
+
+        // When
+        defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList] = false
+
+        // Then
+        XCTAssertTrue(viewModel.isStoreSetupSettingSwitchOn)
+    }
+
+    func test_isStoreSetupSettingSwitchOn_is_false_when_shouldHideStoreOnboardingTaskList_is_true() {
+        // Given
+        let viewModel = SettingsViewModel(stores: stores,
+                                          storageManager: storageManager,
+                                          appleIDCredentialChecker: appleIDCredentialChecker,
+                                          defaults: defaults)
+
+        // When
+        defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList] = true
+
+        // Then
+        XCTAssertFalse(viewModel.isStoreSetupSettingSwitchOn)
+    }
+
+    // MARK: - `updateStoreSetupListVisibility` method
+
+    func test_updateStoreSetupListVisibility_updates_user_defaults() {
+        // Given
+        defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList] = nil
+        let viewModel = SettingsViewModel(stores: stores,
+                                          storageManager: storageManager,
+                                          appleIDCredentialChecker: appleIDCredentialChecker,
+                                          defaults: defaults)
+
+        // When
+        viewModel.updateStoreSetupListVisibility(false)
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList] as? Bool))
+
+        // When
+        viewModel.updateStoreSetupListVisibility(true)
+
+        // Then
+        XCTAssertFalse(try XCTUnwrap(defaults[UserDefaults.Key.shouldHideStoreOnboardingTaskList] as? Bool))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -268,11 +268,13 @@ final class SettingsViewModelTests: XCTestCase {
 
     // MARK: - `Store Setup List` row
 
-    func test_store_setup_list_row_is_shown_when_there_are_pending_onboarding_tasks() {
+    func test_store_setup_list_row_is_shown_when_there_are_pending_onboarding_tasks_and_feature_flag_on() {
         // Given
+        let featureFlagService = MockFeatureFlagService(isHideStoreOnboardingTaskListFeatureEnabled: true)
         defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = false
         let viewModel = SettingsViewModel(stores: stores,
                                           storageManager: storageManager,
+                                          featureFlagService: featureFlagService,
                                           appleIDCredentialChecker: appleIDCredentialChecker,
                                           defaults: defaults)
 
@@ -283,11 +285,30 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.storeSetupList) })
     }
 
-    func test_store_setup_list_row_is_hidden_when_there_are_no_pending_onboarding_tasks() {
+    func test_store_setup_list_row_is_hidden_when_there_are_pending_onboarding_tasks_and_feature_flag_off() {
         // Given
+        let featureFlagService = MockFeatureFlagService(isHideStoreOnboardingTaskListFeatureEnabled: false)
+        defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = false
+        let viewModel = SettingsViewModel(stores: stores,
+                                          storageManager: storageManager,
+                                          featureFlagService: featureFlagService,
+                                          appleIDCredentialChecker: appleIDCredentialChecker,
+                                          defaults: defaults)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.storeSetupList) })
+    }
+
+    func test_store_setup_list_row_is_hidden_when_there_are_no_pending_onboarding_tasks_and_feature_flag_on() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isHideStoreOnboardingTaskListFeatureEnabled: true)
         defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = true
         let viewModel = SettingsViewModel(stores: stores,
                                           storageManager: storageManager,
+                                          featureFlagService: featureFlagService,
                                           appleIDCredentialChecker: appleIDCredentialChecker,
                                           defaults: defaults)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9561
<!-- Id number of the GitHub issue this PR addresses. -->

- [ ] ⚠️ Please review https://github.com/woocommerce/woocommerce-ios/pull/9572 as well

## Description

We want to allow the user to hide/dismiss the Store onboarding task list.

This PR,

- Adds a setting to hide or show the onboarding list from the settings screen.
- Adds tracking event.

## Testing instructions

- Enable `hideStoreOnboardingTaskList` feature flag by returning `true` from `DefaultFeatureFlagService`
- Login into a store which has pending store onboarding tasks
- Tap `Menu` -> `Settings`
- Toggle the `Store Setup List` switch and validate that the store onboarding task list in the dashboard is shown/hidden accordingly. 
- Hiding the list from the dashboard by tapping `...` -> `Hide store setup list` should update the settings screen as well.

**Tracks**

Settings
- Tap `Menu` -> `Settings`
- Toggle the `Store Setup List` switch from ON to OFF.
- Validate that the following event is tracked.

```
Tracked store_onboarding_hide_list, properties: [AnyHashable("blog_id"): 218298555, AnyHashable("is_wpcom_store"): false, AnyHashable("pending_tasks"): "payments,store_details", AnyHashable("source"): "settings"]
```

Dashboard
- From the dashboard hide the task list by tapping `...` -> `Hide store setup list`
- Validate that the following event is tracked.

```
Tracked store_onboarding_hide_list, properties: [AnyHashable("pending_tasks"): "payments,store_details", AnyHashable("is_wpcom_store"): false, AnyHashable("blog_id"): 218298555, AnyHashable("source"): "onboarding_list"]
```

Validate that the  `pending_tasks` value matches the pending onboarding tasks. 

## Screenshots

![Simulator Screen Recording - iPhone 14 - 2023-04-28 at 07 38 08](https://user-images.githubusercontent.com/524475/235037395-1eb6ecd1-ad57-487f-9827-28a89504fbed.gif)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
