### PR TITLE
Shipping Labels: Clear store phone numbers

### DIFF
--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -167,6 +167,7 @@ final class SessionManager: SessionManagerProtocol {
         defaultCredentials = nil
         defaultStoreID = nil
         defaultSite = nil
+        defaults[.storePhoneNumber] = nil
         defaults[.completedAllStoreOnboardingTasks] = nil
     }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -234,6 +234,7 @@ class DefaultStoresManager: StoresManager {
         // Because `defaultSite` is loaded or synced asynchronously, it is reset here so that any UI that calls this does not show outdated data.
         // For example, `sessionManager.defaultSite` is used to show site name in various screens in the app.
         sessionManager.defaultSite = nil
+        defaults[.storePhoneNumber] = nil
         defaults[.completedAllStoreOnboardingTasks] = nil
         restoreSessionSiteIfPossible()
         ServiceLocator.pushNotesManager.reloadBadgeCount()

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -127,6 +127,27 @@ class SessionManagerTests: XCTestCase {
         }
     }
 
+    /// Verifies that `storePhoneNumber` is set to `nil` upon reset
+    ///
+    func test_storePhoneNumber_is_set_to_nil_upon_reset() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
+
+        // When
+        defaults[.storePhoneNumber] = "0123456789"
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(defaults[.storePhoneNumber] as? String), "0123456789")
+
+        // When
+        sut.reset()
+
+        // Then
+        XCTAssertNil(defaults[.storePhoneNumber])
+    }
+
     /// Verifies that `completedAllStoreOnboardingTasks` is set to `nil` upon reset
     ///
     func test_completedAllStoreOnboardingTasks_is_set_to_nil_upon_reset() throws {

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -306,6 +306,26 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertTrue(mockSessionManager.deleteApplicationPasswordInvoked)
     }
 
+    func test_updating_default_storeID_sets_storePhoneNumber_to_nil() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let mockSessionManager = MockSessionManager()
+        let sut = DefaultStoresManager(sessionManager: mockSessionManager, defaults: defaults)
+
+        // When
+        defaults[.storePhoneNumber] = "0123456789"
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(defaults[.storePhoneNumber] as? String), "0123456789")
+
+        // When
+        sut.updateDefaultStore(storeID: 0)
+
+        // Then
+        XCTAssertNil(defaults[.storePhoneNumber])
+    }
+
     func test_updating_default_storeID_sets_completedAllStoreOnboardingTasks_to_nil() throws {
         // Given
         let uuid = UUID().uuidString


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of https://github.com/woocommerce/woomobile-private/issues/280
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously in #9520 I added the feature to save store phone numbers to user defaults so that users don't have to enter their numbers again every time creating a new shipping label.

However, since the phone number is never cleared from user defaults, there's a bug when the old number is used for another store after switching stores or logging out/logging in again to a different account.

This PR fixes that by clearing the stored number in user defaults upon switching stores or logging out.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Pre-requisite: Make sure that you have two Woo stores with WCShip configured.
- Log in to one of your stores if needed and switch to the Orders tab.
- Select an order that's eligible for creating shipping labels. Tap Create Shipping Label.
- If you have never saved a store number before, you will be prompted to add one in the Origin address. Enter a number and tap Continue.
- Navigate back to the Order detail screen and to the shipping label creation form again. You should not be asked to enter a number for your origin address again because it has been saved and prefilled.
- Select the Menu tab and switch to another store that also has WCShip.
- Select the Orders tab, try creating a shipping label for an order. You should be asked to enter a phone number for this store.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
