### PR TITLE
Product description AI: analytics for the first release

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -92,7 +92,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .readOnlySubscriptions:
             return true
         case .productDescriptionAI:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [Internal] Payments: Update StripeTerminal pod to 2.19.1 [https://github.com/woocommerce/woocommerce-ios/pull/9537]
 - [**] Adds read-only support for the Subscriptions extension in order and product details. [https://github.com/woocommerce/woocommerce-ios/pull/9541]
+- [*] Product form > description editor: a magic wand button is added to the keyboard toolbar to auto-generate a product description using Jetpack AI for WPCOM stores. [https://github.com/woocommerce/woocommerce-ios/pull/9577]
 
 13.3
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductFormAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductFormAI.swift
@@ -1,0 +1,55 @@
+extension WooAnalyticsEvent {
+    enum ProductFormAI {
+        /// Event property keys.
+        private enum Key {
+            static let source = "source"
+            static let isRetry = "is_retry"
+        }
+
+        /// Tracked when the user taps on the button to start the product description AI flow.
+        static func productDescriptionAIButtonTapped(source: ProductDescriptionAISource) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDescriptionAIButtonTapped,
+                              properties: [Key.source: source.rawValue])
+        }
+
+        /// Tracked when the user taps on the button to generate a product description with AI.
+        /// - Parameter isRetry: Whether the user has generated a description in the same session before.
+        static func productDescriptionAIGenerateButtonTapped(isRetry: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDescriptionAIGenerateButtonTapped,
+                              properties: [Key.isRetry: isRetry])
+        }
+
+        /// Tracked when the user taps on the button to pause the product description generation with AI.
+        static func productDescriptionAIPauseButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDescriptionAIPauseButtonTapped, properties: [:])
+        }
+
+        /// Tracked when the user taps on the button to apply the AI-generated product description to the product.
+        static func productDescriptionAIApplyButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDescriptionAIApplyButtonTapped, properties: [:])
+        }
+
+        /// Tracked when the user taps on the button to copy the AI-generated product description.
+        static func productDescriptionAICopyButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDescriptionAICopyButtonTapped, properties: [:])
+        }
+
+        /// Tracked when the product description AI generation succeeds.
+        static func productDescriptionAIGenerationSuccess() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDescriptionAIGenerationSuccess, properties: [:])
+        }
+
+        /// Tracked when the product description AI generation fails.
+        static func productDescriptionAIGenerationFailed(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDescriptionAIGenerationFailed, properties: [:], error: error)
+        }
+    }
+}
+
+extension WooAnalyticsEvent.ProductFormAI {
+    /// Trigger of the product description AI flow. The raw value is the event property value.
+    enum ProductDescriptionAISource: String {
+        /// From product description Aztec editor.
+        case aztecEditor = "aztec_editor"
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -690,6 +690,16 @@ public enum WooAnalyticsStat: String {
     //
     case aztecEditorDoneButtonTapped = "aztec_editor_done_button_tapped"
 
+    // MARK: Product description AI
+    //
+    case productDescriptionAIButtonTapped = "product_description_ai_button_tapped"
+    case productDescriptionAIGenerateButtonTapped = "product_description_ai_generate_button_tapped"
+    case productDescriptionAIPauseButtonTapped = "product_description_ai_pause_button_tapped"
+    case productDescriptionAIApplyButtonTapped = "product_description_ai_apply_button_tapped"
+    case productDescriptionAICopyButtonTapped = "product_description_ai_copy_button_tapped"
+    case productDescriptionAIGenerationSuccess = "product_description_ai_generation_success"
+    case productDescriptionAIGenerationFailed = "product_description_ai_generation_failed"
+
     // MARK: Jetpack Tunnel Events
     //
     case jetpackTunnelTimeout = "jetpack_tunnel_timeout"

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -362,6 +362,7 @@ private extension AztecEditorViewController {
         presenter.present(controller, from: self, onDismiss: { [weak self] in
             self?.richTextView.becomeFirstResponder()
         })
+        ServiceLocator.analytics.track(event: .ProductFormAI.productDescriptionAIButtonTapped(source: .aztecEditor))
     }
 
     func dismissDescriptionGenerationBottomSheetIfNeeded() {

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -94,6 +94,7 @@ struct ProductDescriptionGenerationView: View {
                         // CTA to start or stop text generation based on the current state.
                         Button {
                             viewModel.toggleDescriptionGeneration()
+                            ServiceLocator.analytics.track(event: .ProductFormAI.productDescriptionAICopyButtonTapped())
                         } label: {
                             Image(systemName: viewModel.isGenerationInProgress ? "pause.circle": "arrow.counterclockwise")
                         }.buttonStyle(PlainButtonStyle())

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -85,6 +85,7 @@ struct ProductDescriptionGenerationView: View {
                         // CTA to copy the generated text.
                         Button {
                             UIPasteboard.general.string = suggestedText
+                            ServiceLocator.analytics.track(event: .ProductFormAI.productDescriptionAICopyButtonTapped())
                         } label: {
                             Label(Localization.copyGeneratedText, systemImage: "doc.on.doc")
                         }.buttonStyle(PlainButtonStyle())
@@ -94,7 +95,6 @@ struct ProductDescriptionGenerationView: View {
                         // CTA to start or stop text generation based on the current state.
                         Button {
                             viewModel.toggleDescriptionGeneration()
-                            ServiceLocator.analytics.track(event: .ProductFormAI.productDescriptionAICopyButtonTapped())
                         } label: {
                             Image(systemName: viewModel.isGenerationInProgress ? "pause.circle": "arrow.counterclockwise")
                         }.buttonStyle(PlainButtonStyle())

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -472,6 +472,7 @@
 		02DEA23328810B7A0057FC40 /* LoginOnboardingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DEA23228810B7A0057FC40 /* LoginOnboardingScreen.swift */; };
 		02DFECE725EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */; };
 		02E19B9C284743A40010B254 /* ProductImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E19B9B284743A40010B254 /* ProductImageUploader.swift */; };
+		02E222C829FBA60F004579A1 /* WooAnalyticsEvent+ProductFormAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E222C729FBA60F004579A1 /* WooAnalyticsEvent+ProductFormAI.swift */; };
 		02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift */; };
 		02E3B62829026C8F007E0F13 /* AccountCreationForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B62729026C8F007E0F13 /* AccountCreationForm.swift */; };
 		02E3B62D290631B3007E0F13 /* AccountCreationFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E3B62C290631B3007E0F13 /* AccountCreationFormViewModel.swift */; };
@@ -2721,6 +2722,7 @@
 		02DEA23228810B7A0057FC40 /* LoginOnboardingScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingScreen.swift; sourceTree = "<group>"; };
 		02DFECE625EE338F0070F212 /* ShippingLabelCreationInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCreationInfoViewController.swift; sourceTree = "<group>"; };
 		02E19B9B284743A40010B254 /* ProductImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageUploader.swift; sourceTree = "<group>"; };
+		02E222C729FBA60F004579A1 /* WooAnalyticsEvent+ProductFormAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductFormAI.swift"; sourceTree = "<group>"; };
 		02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatusListSelectorCommand.swift; sourceTree = "<group>"; };
 		02E3B62729026C8F007E0F13 /* AccountCreationForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationForm.swift; sourceTree = "<group>"; };
 		02E3B62C290631B3007E0F13 /* AccountCreationFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationFormViewModel.swift; sourceTree = "<group>"; };
@@ -7342,6 +7344,7 @@
 				B9F3DAB029BB83E600DDD545 /* WooAnalyticsEvent+AppIntents.swift */,
 				02B21C5629C9EEF900C5623B /* WooAnalyticsEvent+StoreOnboarding.swift */,
 				DE621F6929D67E1B000DE3BD /* WooAnalyticsEvent+JetpackSetup.swift */,
+				02E222C729FBA60F004579A1 /* WooAnalyticsEvent+ProductFormAI.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -11849,6 +11852,7 @@
 				AE6C4FDF28A15BFE00EAC00D /* FeatureAnnouncementCardCell.swift in Sources */,
 				02562AD0296D1FD100980404 /* View+DividerStyle.swift in Sources */,
 				CE5F462723AAC8C0006B1A5C /* RefundDetailsViewModel.swift in Sources */,
+				02E222C829FBA60F004579A1 /* WooAnalyticsEvent+ProductFormAI.swift in Sources */,
 				D8815B132638686200EDAD62 /* CardPresentModalError.swift in Sources */,
 				020ACF88299A809000B3638B /* LearnMoreAttributedText.swift in Sources */,
 				02EAA4CA2911004B00918DAB /* TextFieldStyles.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9465 
<!-- Id number of the GitHub issue this PR addresses. -->


## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR enables the product description AI feature v1 for the upcoming release since the CTA is not very obvious for us to get user feedback, after confirming with product pecCkj-yl-p2#comment-277. I added a few Tracks events that I came up on my own, please feel free to suggest anything:

Event | Properties | Triggers
-- | -- | --
product_description_ai_button_tapped | source: aztec_editor | When the user taps on the button to start the product description AI flow.
product_description_ai_generate_button_tapped | is_retry: bool | When the user taps on the button to generate a product description with AI.
product_description_ai_apply_button_tapped |   | When the user taps on the button to apply the AI-generated product description to the product.
product_description_ai_copy_button_tapped |   | When the user taps on the button to copy the AI-generated product description.
product_description_ai_pause_button_tapped |   | When the user taps on the button to pause the product description generation with AI.
product_description_ai_generation_success |   | When the product description AI generation succeeds.
product_description_ai_generation_failed | error | When the product description AI generation fails.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in to a WPCOM store if needed
- Go to the Products tab
- Create a product if needed
- Tap on an editable product
- Tap on the product description row
- Tap on the magic wand CTA above the keyboard --> `product_description_ai_button_tapped` should be tracked with `source: aztec_editor`
- Enter or update the product name
- Enter or update the product features
- Tap `Generate` --> `product_description_ai_generate_button_tapped` should be tracked with `is_retry: false`. when the result comes back successfully, `product_description_ai_generation_success` should be tracked
- Tap `Copy` and try pasting the content somewhere in or outside of the app --> `product_description_ai_copy_button_tapped` should be tracked
- Tap the retry icon in the middle --> the icon should become a pause button. `product_description_ai_generate_button_tapped` should be tracked with `is_retry: true`
- Tap the retry icon again, and immediately tap again  --> the icon should go back to the retry icon, and `product_description_ai_pause_button_tapped` should be tracked
- Tap `Apply` --> the product description should be replaced with the generated text, and `product_description_ai_apply_button_tapped` should be tracked

---
- [x] @jaclync tests `product_description_ai_generation_failed` when generating a product description offline 


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.