### PR TITLE
[Min/Max Quantities] Add quantity rules row to product variation details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductVariationFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductVariationFormActionsFactory.swift
@@ -5,9 +5,14 @@ struct ProductVariationFormActionsFactory: ProductFormActionsFactoryProtocol {
     private let productVariation: EditableProductVariationModel
     private let editable: Bool
 
-    init(productVariation: EditableProductVariationModel, editable: Bool) {
+    private let isMinMaxQuantitiesEnabled: Bool
+
+    init(productVariation: EditableProductVariationModel,
+         editable: Bool,
+         isMinMaxQuantitiesEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.readOnlyMinMaxQuantities)) {
         self.productVariation = productVariation
         self.editable = editable
+        self.isMinMaxQuantitiesEnabled = isMinMaxQuantitiesEnabled
     }
 
     /// Returns an array of actions that are visible in the product form primary section.
@@ -59,11 +64,13 @@ private extension ProductVariationFormActionsFactory {
                 return nil
             }
         }()
+        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && productVariation.hasQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             subscriptionOrPriceRow,
             shouldShowNoPriceWarningRow ? .noPriceWarning: nil,
             .attributes(editable: editable),
+            shouldShowQuantityRulesRow ? .quantityRules : nil,
             .status(editable: editable),
             shouldShowShippingSettingsRow ? .shippingSettings(editable: editable): nil,
             .inventorySettings(editable: canEditInventorySettingsRow),
@@ -79,7 +86,7 @@ private extension ProductVariationFormActionsFactory {
 
     func isVisibleInSettingsSection(action: ProductFormEditAction) -> Bool {
         switch action {
-        case .priceSettings, .noPriceWarning, .status, .attributes, .subscription:
+        case .priceSettings, .noPriceWarning, .status, .attributes, .subscription, .quantityRules:
             // The price settings, attributes, and visibility actions are always visible in the settings section.
             return true
         case .inventorySettings:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -147,6 +147,8 @@ private extension DefaultProductFormTableViewModel {
                 return .noPriceWarning(viewModel: noPriceWarningRow(isActionable: false))
             case .subscription(let actionable):
                 return .subscription(viewModel: subscriptionRow(product: productVariation, isActionable: actionable), isActionable: actionable)
+            case .quantityRules:
+                return .quantityRules(viewModel: quantityRulesRow(product: productVariation))
             default:
                 assertionFailure("Unexpected action in the settings section: \(action)")
                 return nil

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -191,19 +191,21 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
     }
 
     var hasQuantityRules: Bool {
-        false // TODO: 8960 - Quantity rules in variation details
+        let enabled = productVariation.overrideProductQuantities == true
+        let hasNoRules = minAllowedQuantity.isNilOrEmpty && maxAllowedQuantity.isNilOrEmpty && groupOfQuantity.isNilOrEmpty
+        return enabled && !hasNoRules
     }
 
     var minAllowedQuantity: String? {
-        nil // TODO: 8960 - Quantity rules in variation details
+        productVariation.minAllowedQuantity
     }
 
     var maxAllowedQuantity: String? {
-        nil // TODO: 8960 - Quantity rules in variation details
+        productVariation.maxAllowedQuantity
     }
 
     var groupOfQuantity: String? {
-        nil // TODO: 8960 - Quantity rules in variation details
+        productVariation.groupOfQuantity
     }
 
     // Visibility logic

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactoryTests.swift
@@ -171,7 +171,8 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
         // Arrange
         let productVariation = Fixtures.physicalProductVariationWithImages.copy(minAllowedQuantity: "4",
                                                                                 maxAllowedQuantity: "200",
-                                                                                groupOfQuantity: "4")
+                                                                                groupOfQuantity: "4",
+                                                                                overrideProductQuantities: true)
         let model = EditableProductVariationModel(productVariation: productVariation)
 
         // Action

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactoryTests.swift
@@ -166,6 +166,32 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
+
+    func test_actions_for_a_physical_ProductVariation_with_quantity_rules() {
+        // Arrange
+        let productVariation = Fixtures.physicalProductVariationWithImages.copy(minAllowedQuantity: "4",
+                                                                                maxAllowedQuantity: "200",
+                                                                                groupOfQuantity: "4")
+        let model = EditableProductVariationModel(productVariation: productVariation)
+
+        // Action
+        let factory = ProductVariationFormActionsFactory(productVariation: model, editable: true, isMinMaxQuantitiesEnabled: true)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true), .variationName, .description(editable: true)]
+        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
+                                                                       .attributes(editable: true),
+                                                                       .quantityRules,
+                                                                       .status(editable: true),
+                                                                       .shippingSettings(editable: true),
+                                                                       .inventorySettings(editable: true)]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
+        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
+    }
 }
 
 private extension ProductVariationFormActionsFactoryTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditableProductVariationModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditableProductVariationModelTests.swift
@@ -149,4 +149,50 @@ final class EditableProductVariationModelTests: XCTestCase {
         XCTAssertEqual(model.sku, sku)
         XCTAssertEqual(model.productVariation.sku, sku)
     }
+
+    // MARK: - `hasQuantityRules`
+
+    func test_hasQuantityRules_is_false_for_a_variation_with_nil_quantity_rules() {
+        // Arrange
+        let variation = ProductVariation.fake()
+
+        // Action
+        let model = EditableProductVariationModel(productVariation: variation)
+
+        // Assert
+        XCTAssertFalse(model.hasQuantityRules)
+    }
+
+    func test_hasQuantityRules_is_false_for_a_variation_with_empty_quantity_rules() {
+        // Arrange
+        let variation = ProductVariation.fake().copy(minAllowedQuantity: "", maxAllowedQuantity: "", groupOfQuantity: "", overrideProductQuantities: true)
+
+        // Action
+        let model = EditableProductVariationModel(productVariation: variation)
+
+        // Assert
+        XCTAssertFalse(model.hasQuantityRules)
+    }
+
+    func test_hasQuantityRules_is_false_for_a_variation_that_does_not_override_product_quantities() {
+        // Arrange
+        let variation = ProductVariation.fake().copy(minAllowedQuantity: "4", maxAllowedQuantity: "30", groupOfQuantity: "2", overrideProductQuantities: false)
+
+        // Action
+        let model = EditableProductVariationModel(productVariation: variation)
+
+        // Assert
+        XCTAssertFalse(model.hasQuantityRules)
+    }
+
+    func test_hasQuantityRules_is_true_for_a_variation_that_does_override_product_quantities_and_has_quantity_rules() {
+        // Arrange
+        let variation = ProductVariation.fake().copy(minAllowedQuantity: "4", maxAllowedQuantity: "30", groupOfQuantity: "2", overrideProductQuantities: true)
+
+        // Action
+        let model = EditableProductVariationModel(productVariation: variation)
+
+        // Assert
+        XCTAssertTrue(model.hasQuantityRules)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #8960
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are adding read-only support for the [Min/Max Quantities](https://woocommerce.com/products/minmax-quantities/) extension in product details.

This PR adds a "Quantity Rules" row in the product variation details screen. For variable products, each variation with quantity rules set will have the Quantity Rules row in the variation details. (The parent product can also have quantity rules, and not all variations must have quantity rules.)

The row details shows the first two quantity rules set for the product. For now, tapping the quantity rules row does nothing (navigation to a new view to be added in another PR).

### Changes

1. Adds the min/max quantity settings to `EditableProductVariationModel`.
2. Adds the row view model in `DefaultProductFormTableViewModel`.
3. Adds the row to the settings section in `ProductVariationFormActionsFactory`, always visible when the variation has min/max quantity rules set.
4. Adds unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Prerequisites

1. Install and activate the [Min/Max Quantities](https://woocommerce.com/products/minmax-quantities/) extension.
2. Create or edit a variable product, adding quantity rules to at least one of the variations.

### To test

1. Build and run the app.
2. Go to the Products tab.
3. Select the variable product with quantity rules.
4. Select Variations to open the variations list.
5. Select a variation with quantity rules set, and confirm the Quantity Rules row appears with the expected details.
6. Select a variation with no quantity rules set, and confirm the Quantity Rules row does not appear.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Variation with quantity rules|Variation with some quantity rules|Variation with no quantity rules
-|-|-
![Simulator Screenshot - iPhone 14 Pro - 2023-04-28 at 09 59 04](https://user-images.githubusercontent.com/8658164/235104069-4c9cb0ad-5c16-4b2a-8cd5-7f44d9f4e2ff.png)|![Simulator Screenshot - iPhone 14 Pro - 2023-04-28 at 09 59 07](https://user-images.githubusercontent.com/8658164/235104050-88539777-6f6d-44c1-9561-845d80cf1c9d.png)|![Simulator Screenshot - iPhone 14 Pro - 2023-04-28 at 09 59 10](https://user-images.githubusercontent.com/8658164/235104025-a6e08fe1-d7a2-42fe-b8d4-84d3e5398a8c.png)

https://user-images.githubusercontent.com/8658164/235104083-ad68ddab-3249-4167-aa8e-b53f13673dec.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
