### PR TITLE
[Min/Max Quantities] Hide quantity rules when parent product combines variations

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -5,8 +5,9 @@ final class EditableProductVariationModel {
     let productVariation: ProductVariation
 
     let allAttributes: [ProductAttribute]
+    let parentProductDisablesQuantityRules: Bool?
 
-    init(productVariation: ProductVariation, allAttributes: [ProductAttribute], parentProductSKU: String?) {
+    init(productVariation: ProductVariation, allAttributes: [ProductAttribute], parentProductSKU: String?, parentProductDisablesQuantityRules: Bool?) {
         self.allAttributes = allAttributes
 
         // API sets a variation's SKU to be its parent product's SKU by default.
@@ -14,6 +15,8 @@ final class EditableProductVariationModel {
         // As a workaround, we set a variation's SKU to nil if it has the same SKU as its parent product during initialization.
         let sku = parentProductSKU == productVariation.sku ? nil: productVariation.sku
         self.productVariation = productVariation.copy(sku: sku)
+
+        self.parentProductDisablesQuantityRules = parentProductDisablesQuantityRules
     }
 }
 
@@ -191,7 +194,7 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
     }
 
     var hasQuantityRules: Bool {
-        let enabled = productVariation.overrideProductQuantities == true
+        let enabled = productVariation.overrideProductQuantities == true && parentProductDisablesQuantityRules == false
         let hasNoRules = minAllowedQuantity.isNilOrEmpty && maxAllowedQuantity.isNilOrEmpty && groupOfQuantity.isNilOrEmpty
         return enabled && !hasNoRules
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -95,6 +95,7 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
 
     private let allAttributes: [ProductAttribute]
     private let parentProductSKU: String?
+    private let parentProductDisablesQuantityRules: Bool?
     private let productImageActionHandler: ProductImageActionHandlerProtocol
     private let storesManager: StoresManager
     private let productImagesUploader: ProductImageUploaderProtocol
@@ -103,12 +104,14 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
     init(productVariation: EditableProductVariationModel,
          allAttributes: [ProductAttribute],
          parentProductSKU: String?,
+         parentProductDisablesQuantityRules: Bool?,
          formType: ProductFormType,
          productImageActionHandler: ProductImageActionHandlerProtocol,
          storesManager: StoresManager = ServiceLocator.stores,
          productImagesUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader) {
         self.allAttributes = allAttributes
         self.parentProductSKU = parentProductSKU
+        self.parentProductDisablesQuantityRules = parentProductDisablesQuantityRules
         self.productImageActionHandler = productImageActionHandler
         self.storesManager = storesManager
         self.originalProductVariation = productVariation
@@ -190,13 +193,15 @@ extension ProductVariationFormViewModel {
         }
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(image: images.first),
                                                          allAttributes: allAttributes,
-                                                         parentProductSKU: parentProductSKU)
+                                                         parentProductSKU: parentProductSKU,
+                                                         parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
     }
 
     func updateDescription(_ newDescription: String) {
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(description: newDescription),
                                                          allAttributes: allAttributes,
-                                                         parentProductSKU: parentProductSKU)
+                                                         parentProductSKU: parentProductSKU,
+                                                         parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
     }
 
     func updatePriceSettings(regularPrice: String?,
@@ -212,7 +217,8 @@ extension ProductVariationFormViewModel {
                                                                                                                   taxStatusKey: taxStatus.rawValue,
                                                                                                                   taxClass: taxClass?.slug),
                                                          allAttributes: allAttributes,
-                                                         parentProductSKU: parentProductSKU)
+                                                         parentProductSKU: parentProductSKU,
+                                                         parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
     }
 
     func updateInventorySettings(sku: String?,
@@ -227,7 +233,8 @@ extension ProductVariationFormViewModel {
                                                                                                                   stockStatus: stockStatus,
                                                                                                                   backordersKey: backordersSetting?.rawValue),
                                                          allAttributes: allAttributes,
-                                                         parentProductSKU: parentProductSKU)
+                                                         parentProductSKU: parentProductSKU,
+                                                         parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
     }
 
     func updateShippingSettings(weight: String?, dimensions: ProductDimensions, shippingClass: String?, shippingClassID: Int64?) {
@@ -236,7 +243,8 @@ extension ProductVariationFormViewModel {
                                                  shippingClass: shippingClass ?? "",
                                                  shippingClassID: shippingClassID ?? 0),
                                                          allAttributes: allAttributes,
-                                                         parentProductSKU: parentProductSKU)
+                                                         parentProductSKU: parentProductSKU,
+                                                         parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
     }
 
     func updateProductType(productType: BottomSheetProductType) {
@@ -276,7 +284,8 @@ extension ProductVariationFormViewModel {
         let status: ProductStatus = isEnabled ? .published: .privateStatus
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(status: status),
                                                          allAttributes: allAttributes,
-                                                         parentProductSKU: parentProductSKU)
+                                                         parentProductSKU: parentProductSKU,
+                                                         parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
     }
 
     func updateDownloadableFiles(downloadableFiles: [ProductDownload], downloadLimit: Int64, downloadExpiry: Int64) {
@@ -290,7 +299,8 @@ extension ProductVariationFormViewModel {
     func updateVariationAttributes(_ attributes: [ProductVariationAttribute]) {
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(attributes: attributes),
                                                          allAttributes: allAttributes,
-                                                         parentProductSKU: parentProductSKU)
+                                                         parentProductSKU: parentProductSKU,
+                                                         parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
     }
 
     func updateProductVariations(from product: Product) {
@@ -314,7 +324,8 @@ extension ProductVariationFormViewModel {
                 ServiceLocator.analytics.track(.productVariationDetailUpdateSuccess)
                 let model = EditableProductVariationModel(productVariation: productVariation,
                                                           allAttributes: self.allAttributes,
-                                                          parentProductSKU: self.parentProductSKU)
+                                                          parentProductSKU: self.parentProductSKU,
+                                                          parentProductDisablesQuantityRules: self.parentProductDisablesQuantityRules)
                 self.resetProductVariation(model)
                 onCompletion(.success(model))
                 self.saveProductVariationImageWhenUploaded()
@@ -360,12 +371,14 @@ extension ProductVariationFormViewModel {
                     let currentProduct = self.productVariation
                     self.resetProductVariation(.init(productVariation: self.originalProductVariation.productVariation.copy(image: images.first),
                                                      allAttributes: self.allAttributes,
-                                                     parentProductSKU: self.parentProductSKU))
+                                                     parentProductSKU: self.parentProductSKU,
+                                                     parentProductDisablesQuantityRules: self.parentProductDisablesQuantityRules))
                     // Because `resetProductVariation` also internally updates the latest `productVariation`, the
                     // `productVariation` is set with the value before `resetProductVariation` to retain any local changes.
                     self.productVariation = .init(productVariation: currentProduct.productVariation,
                                                   allAttributes: self.allAttributes,
-                                                  parentProductSKU: self.parentProductSKU)
+                                                  parentProductSKU: self.parentProductSKU,
+                                                  parentProductDisablesQuantityRules: self.parentProductDisablesQuantityRules)
                 case .failure:
                     // If the variation image update request fails, the update CTA visibility is refreshed again so that the merchant can save the
                     // variation image again along with any other potential local changes.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
@@ -38,7 +38,8 @@ private extension ProductVariationDetailsFactory {
         let vc: UIViewController
         let productVariationModel = EditableProductVariationModel(productVariation: productVariation,
                                                                   allAttributes: parentProduct.attributes,
-                                                                  parentProductSKU: parentProduct.sku)
+                                                                  parentProductSKU: parentProduct.sku,
+                                                                  parentProductDisablesQuantityRules: parentProduct.combineVariationQuantities)
         let productImageActionHandler = productImageUploader
             .actionHandler(key: .init(siteID: productVariation.siteID,
                                       productOrVariationID: .variation(productID: productVariation.productID, variationID: productVariation.productVariationID),
@@ -48,6 +49,7 @@ private extension ProductVariationDetailsFactory {
         let viewModel = ProductVariationFormViewModel(productVariation: productVariationModel,
                                                       allAttributes: parentProduct.attributes,
                                                       parentProductSKU: parentProduct.sku,
+                                                      parentProductDisablesQuantityRules: parentProduct.combineVariationQuantities,
                                                       formType: formType,
                                                       productImageActionHandler: productImageActionHandler)
         vc = ProductFormViewController(viewModel: viewModel,

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -100,6 +100,10 @@ final class ProductVariationsViewController: UIViewController, GhostableViewCont
         product.sku
     }
 
+    private var parentProductDisablesQuantityRules: Bool? {
+        product.combineVariationQuantities
+    }
+
     private let imageService: ImageService = ServiceLocator.imageService
     private let productImageUploader: ProductImageUploaderProtocol
 
@@ -404,7 +408,8 @@ extension ProductVariationsViewController: UITableViewDataSource {
         let productVariation = resultsController.object(at: indexPath)
         let model = EditableProductVariationModel(productVariation: productVariation,
                                                   allAttributes: allAttributes,
-                                                  parentProductSKU: parentProductSKU)
+                                                  parentProductSKU: parentProductSKU,
+                                                  parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
 
         let viewModel = ProductsTabProductViewModel(productVariationModel: model)
         cell.update(viewModel: viewModel, imageService: imageService)
@@ -533,7 +538,8 @@ private extension ProductVariationsViewController {
     private func navigateToVariationDetail(for productVariation: ProductVariation) {
         let model = EditableProductVariationModel(productVariation: productVariation,
                                                   allAttributes: allAttributes,
-                                                  parentProductSKU: parentProductSKU)
+                                                  parentProductSKU: parentProductSKU,
+                                                  parentProductDisablesQuantityRules: parentProductDisablesQuantityRules)
 
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
@@ -546,6 +552,7 @@ private extension ProductVariationsViewController {
         let viewModel = ProductVariationFormViewModel(productVariation: model,
                                                       allAttributes: allAttributes,
                                                       parentProductSKU: parentProductSKU,
+                                                      parentProductDisablesQuantityRules: parentProductDisablesQuantityRules,
                                                       formType: self.viewModel.formType,
                                                       productImageActionHandler: productImageActionHandler)
         viewModel.onVariationDeletion = { [weak self] variation in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactoryTests.swift
@@ -173,7 +173,10 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
                                                                                 maxAllowedQuantity: "200",
                                                                                 groupOfQuantity: "4",
                                                                                 overrideProductQuantities: true)
-        let model = EditableProductVariationModel(productVariation: productVariation)
+        let model = EditableProductVariationModel(productVariation: productVariation,
+                                                  allAttributes: [],
+                                                  parentProductSKU: nil,
+                                                  parentProductDisablesQuantityRules: false)
 
         // Action
         let factory = ProductVariationFormActionsFactory(productVariation: model, editable: true, isMinMaxQuantitiesEnabled: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditableProductVariationModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditableProductVariationModelTests.swift
@@ -21,7 +21,10 @@ final class EditableProductVariationModelTests: XCTestCase {
         let variation = MockProductVariation().productVariation().copy(attributes: variationAttributes)
 
         // Action
-        let name = EditableProductVariationModel(productVariation: variation, allAttributes: allAttributes, parentProductSKU: nil).name
+        let name = EditableProductVariationModel(productVariation: variation,
+                                                 allAttributes: allAttributes,
+                                                 parentProductSKU: nil,
+                                                 parentProductDisablesQuantityRules: nil).name
 
         // Assert
         let expectedName = [
@@ -45,7 +48,10 @@ final class EditableProductVariationModelTests: XCTestCase {
         let variation = MockProductVariation().productVariation().copy(attributes: variationAttributes)
 
         // Action
-        let name = EditableProductVariationModel(productVariation: variation, allAttributes: allAttributes, parentProductSKU: nil).name
+        let name = EditableProductVariationModel(productVariation: variation,
+                                                 allAttributes: allAttributes,
+                                                 parentProductSKU: nil,
+                                                 parentProductDisablesQuantityRules: nil).name
 
         // Assert
         let expectedName = ["Orange", "House"].joined(separator: " - ")
@@ -130,7 +136,10 @@ final class EditableProductVariationModelTests: XCTestCase {
         let variation = MockProductVariation().productVariation().copy(sku: sku)
 
         // Action
-        let model = EditableProductVariationModel(productVariation: variation, allAttributes: [], parentProductSKU: sku)
+        let model = EditableProductVariationModel(productVariation: variation,
+                                                  allAttributes: [],
+                                                  parentProductSKU: sku,
+                                                  parentProductDisablesQuantityRules: nil)
 
         // Assert
         XCTAssertNil(model.sku)
@@ -143,7 +152,10 @@ final class EditableProductVariationModelTests: XCTestCase {
         let variation = MockProductVariation().productVariation().copy(sku: sku)
 
         // Action
-        let model = EditableProductVariationModel(productVariation: variation, allAttributes: [], parentProductSKU: "")
+        let model = EditableProductVariationModel(productVariation: variation,
+                                                  allAttributes: [],
+                                                  parentProductSKU: "",
+                                                  parentProductDisablesQuantityRules: nil)
 
         // Assert
         XCTAssertEqual(model.sku, sku)
@@ -168,7 +180,10 @@ final class EditableProductVariationModelTests: XCTestCase {
         let variation = ProductVariation.fake().copy(minAllowedQuantity: "", maxAllowedQuantity: "", groupOfQuantity: "", overrideProductQuantities: true)
 
         // Action
-        let model = EditableProductVariationModel(productVariation: variation)
+        let model = EditableProductVariationModel(productVariation: variation,
+                                                  allAttributes: [],
+                                                  parentProductSKU: nil,
+                                                  parentProductDisablesQuantityRules: false)
 
         // Assert
         XCTAssertFalse(model.hasQuantityRules)
@@ -179,7 +194,10 @@ final class EditableProductVariationModelTests: XCTestCase {
         let variation = ProductVariation.fake().copy(minAllowedQuantity: "4", maxAllowedQuantity: "30", groupOfQuantity: "2", overrideProductQuantities: false)
 
         // Action
-        let model = EditableProductVariationModel(productVariation: variation)
+        let model = EditableProductVariationModel(productVariation: variation,
+                                                  allAttributes: [],
+                                                  parentProductSKU: nil,
+                                                  parentProductDisablesQuantityRules: false)
 
         // Assert
         XCTAssertFalse(model.hasQuantityRules)
@@ -190,9 +208,26 @@ final class EditableProductVariationModelTests: XCTestCase {
         let variation = ProductVariation.fake().copy(minAllowedQuantity: "4", maxAllowedQuantity: "30", groupOfQuantity: "2", overrideProductQuantities: true)
 
         // Action
-        let model = EditableProductVariationModel(productVariation: variation)
+        let model = EditableProductVariationModel(productVariation: variation,
+                                                  allAttributes: [],
+                                                  parentProductSKU: nil,
+                                                  parentProductDisablesQuantityRules: false)
 
         // Assert
         XCTAssertTrue(model.hasQuantityRules)
+    }
+
+    func test_hasQuantityRules_is_false_when_parent_product_disables_quantity_rules() {
+        // Arrange
+        let variation = ProductVariation.fake().copy(minAllowedQuantity: "4", maxAllowedQuantity: "30", groupOfQuantity: "2", overrideProductQuantities: true)
+
+        // Action
+        let model = EditableProductVariationModel(productVariation: variation,
+                                                  allAttributes: [],
+                                                  parentProductSKU: nil,
+                                                  parentProductDisablesQuantityRules: true)
+
+        // Assert
+        XCTAssertFalse(model.hasQuantityRules)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -158,7 +158,7 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
 // Helper in unit tests
 extension EditableProductVariationModel {
     convenience init(productVariation: ProductVariation) {
-        self.init(productVariation: productVariation, allAttributes: [], parentProductSKU: nil)
+        self.init(productVariation: productVariation, allAttributes: [], parentProductSKU: nil, parentProductDisablesQuantityRules: nil)
     }
 }
 
@@ -172,6 +172,7 @@ extension ProductVariationFormViewModel {
         self.init(productVariation: productVariation,
                   allAttributes: [],
                   parentProductSKU: nil,
+                  parentProductDisablesQuantityRules: nil,
                   formType: formType,
                   productImageActionHandler: productImageActionHandler,
                   storesManager: storesManager,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9414
⚠️ Depends on #9578
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are adding read-only support for the [Min/Max Quantities](https://woocommerce.com/products/minmax-quantities/) extension in product details.

This PR hides the Quantity Rules row in variation details if the parent variable product has the "Combine variations" setting enabled. (This setting combines the quantities of all purchased variations when checking quantity rules; enabling it disables the per-variation quantity rules.)

### Changes

1. Updates `EditableProductVariationModel.hasQuantityRules` to only be `true` if the parent product has not disabled quantity rules (with the model taking a new `parentProductDisablesQuantityRules` parameter).
2. Sets `parentProductDisablesQuantityRules` based on the parent product's `combineVariationQuantities` property, in `ProductVariationDetailsFactory` and `ProductVariationsViewController`.
3. Adds/updates unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Prerequisites

1. Install and activate the [Min/Max Quantities](https://woocommerce.com/products/minmax-quantities/) extension.
4. Create or edit a variable product, adding quantity rules to at least one of the variations.

### To test

1. Build and run the app.
2. Go to the Products tab.
5. Select the variable product with quantity rules.
6. Select Variations to open the variations list.
7. Select a variation with quantity rules set, and confirm the Quantity Rules row appears with the expected details.
8. In wp-admin, open the variable product details and enable the setting **General > Combine variations**. Save the product.
9. In the app, refresh the product list to get the remote changes.
10. Open the variable product's Variations list again and select each variation to confirm no Quantity Rules rows appear.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Variable product with Combine Variations setting **disabled**:

https://user-images.githubusercontent.com/8658164/235117331-9f1431cb-d8b5-4d41-b906-5565e6e523ad.mp4

Variable product with Combine Variations setting **enabled**:

https://user-images.githubusercontent.com/8658164/235117361-292b943a-bcbf-4bd0-8841-ff39b5620524.mp4


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
