### PR TITLE
[Store onboarding] Adds `hide` property to tracks event 

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreOnboarding.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreOnboarding.swift
@@ -7,6 +7,7 @@ extension WooAnalyticsEvent {
             static let task = "task"
             static let pendingTasks = "pending_tasks"
             static let source = "source"
+            static let hide = "hide"
         }
 
         static func storeOnboardingShown() -> WooAnalyticsEvent {
@@ -25,9 +26,12 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .storeOnboardingCompleted, properties: [:])
         }
 
-        static func storeOnboardingHideList(source: Source, pendingTasks: [StoreOnboardingTask.TaskType]) -> WooAnalyticsEvent {
+        static func storeOnboardingShowOrHideList(isHiding: Bool,
+                                                  source: Source,
+                                                  pendingTasks: [StoreOnboardingTask.TaskType]) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .storeOnboardingHideList,
-                              properties: [Key.source: source.rawValue,
+                              properties: [Key.hide: isHiding,
+                                           Key.source: source.rawValue,
                                            Key.pendingTasks: pendingTasks.map({ $0.analyticsValue }).sorted().joined(separator: ",")])
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -117,8 +117,9 @@ class StoreOnboardingViewModel: ObservableObject {
         let pending = taskViewModels
             .filter { !$0.isComplete }
             .map { $0.task.type }
-        analytics.track(event: .StoreOnboarding.storeOnboardingHideList(source: .onboardingList,
-                                                                        pendingTasks: pending))
+        analytics.track(event: .StoreOnboarding.storeOnboardingShowOrHideList(isHiding: true,
+                                                                              source: .onboardingList,
+                                                                              pendingTasks: pending))
         defaults[.shouldHideStoreOnboardingTaskList] = true
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -226,8 +226,8 @@ private extension SettingsViewModel {
             .filter { !$0.isComplete }
             .map { $0.task.type }
         analytics.track(event: .StoreOnboarding.storeOnboardingShowOrHideList(isHiding: defaults.shouldHideStoreOnboardingTaskList,
-                                                                        source: .settings,
-                                                                        pendingTasks: pending))
+                                                                              source: .settings,
+                                                                              pendingTasks: pending))
     }
 
     func loadWhatsNewOnWooCommerce() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -205,14 +205,12 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     func updateStoreSetupListVisibility(_ switchValue: Bool) async {
         defaults[.shouldHideStoreOnboardingTaskList] = !switchValue
 
-        if defaults.shouldHideStoreOnboardingTaskList {
-            await trackHideStoreOnboardingListEvent()
-        }
+        await trackShowOrHideStoreOnboardingListEvent()
     }
 }
 
 private extension SettingsViewModel {
-    func trackHideStoreOnboardingListEvent() async {
+    func trackShowOrHideStoreOnboardingListEvent() async {
         guard let siteID = stores.sessionManager.defaultSite?.siteID else {
             return
         }
@@ -227,7 +225,8 @@ private extension SettingsViewModel {
         let pending = viewModel.taskViewModels
             .filter { !$0.isComplete }
             .map { $0.task.type }
-        analytics.track(event: .StoreOnboarding.storeOnboardingHideList(source: .settings,
+        analytics.track(event: .StoreOnboarding.storeOnboardingShowOrHideList(isHiding: defaults.shouldHideStoreOnboardingTaskList,
+                                                                        source: .settings,
                                                                         pendingTasks: pending))
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -820,6 +820,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "store_onboarding_hide_list"}))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
         XCTAssertEqual(eventProperties["source"] as? String, "onboarding_list")
+        XCTAssertTrue(try XCTUnwrap(eventProperties["hide"] as? Bool))
         XCTAssertEqual(eventProperties["pending_tasks"] as? String, "add_domain,launch_site,payments,products")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -402,10 +402,11 @@ final class SettingsViewModelTests: XCTestCase {
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "store_onboarding_hide_list"}))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
         XCTAssertEqual(eventProperties["source"] as? String, "settings")
+        XCTAssertTrue(try XCTUnwrap(eventProperties["hide"] as? Bool))
         XCTAssertEqual(eventProperties["pending_tasks"] as? String, "add_domain,launch_site,payments,products")
     }
 
-    func test_updateStoreSetupListVisibility_does_not_track_hide_list_event_upon_showing_list() async throws {
+    func test_updateStoreSetupListVisibility_tracks_hide_list_event_upon_showing_list() async throws {
         // Given
         sessionManager.defaultSite = Site.fake()
         let tasks: [StoreOnboardingTask] = [
@@ -432,7 +433,11 @@ final class SettingsViewModelTests: XCTestCase {
         await viewModel.updateStoreSetupListVisibility(true)
 
         // Then
-        XCTAssertFalse(analyticsProvider.receivedEvents.contains(where: { $0 == "store_onboarding_hide_list"}))
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "store_onboarding_hide_list"}))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["source"] as? String, "settings")
+        XCTAssertFalse(try XCTUnwrap(eventProperties["hide"] as? Bool))
+        XCTAssertEqual(eventProperties["pending_tasks"] as? String, "add_domain,launch_site,payments,products")
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9561
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

We decided to add a `hide` property to the `store_onboarding_hide_list` event to also track when the user decides to show the store onboarding list. 

Tracking section from PT - pe5sF9-15a-p2#tracking-1

This PR,
- Updates the `store_onboarding_hide_list` by adding a `hide` property to understand whether the user shows/hides the list from the settings screen.

## Testing instructions
Settings
- Tap `Menu` -> `Settings`
- Toggle the `Store Setup List` switch from ON to OFF.
- Validate that the following event is tracked.
```
Tracked store_onboarding_hide_list, properties: [AnyHashable("is_wpcom_store"): false, AnyHashable("source"): "settings", AnyHashable("pending_tasks"): "payments,store_details", AnyHashable("blog_id"): 218298555, AnyHashable("hide"): true]
```
- Toggle the switch again and validate that the `hide` property will be true/false based on the switch value.


Dashboard
- From the dashboard hide the task list by tapping `...` -> `Hide store setup list`
- Validate that the following event is tracked.
```
Tracked store_onboarding_hide_list, properties: [AnyHashable("pending_tasks"): "payments,store_details", AnyHashable("hide"): true, AnyHashable("blog_id"): 218298555, AnyHashable("is_wpcom_store"): false, AnyHashable("source"): "onboarding_list"]
```
- Notice the `hide` property is `true` as we hide the list. 

## Screenshots
![Simulator Screen Recording - iPhone 14 - 2023-04-28 at 07 38 08](https://user-images.githubusercontent.com/524475/235037395-1eb6ecd1-ad57-487f-9827-28a89504fbed.gif)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.