### PR TITLE
[Min/Max Quantities] Add analytics events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -345,6 +345,12 @@ extension WooAnalyticsEvent {
         static func productVariationGenerationFailure() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productVariationGenerationFailure, properties: [:])
         }
+
+        /// Tracks when the merchant taps the Quantity Rules row for a product variation.
+        ///
+        static func quantityRulesTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productVariationDetailViewQuantityRulesTapped, properties: [:])
+        }
     }
 }
 
@@ -407,6 +413,12 @@ extension WooAnalyticsEvent {
         ///
         static func subscriptionsTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productDetailsViewSubscriptionsTapped, properties: [:])
+        }
+
+        /// Tracks when the merchant taps the Quantity Rules row.
+        ///
+        static func quantityRulesTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDetailViewQuantityRulesTapped, properties: [:])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -578,6 +578,7 @@ public enum WooAnalyticsStat: String {
     case productDetailViewBundledProductsTapped = "product_detail_view_bundled_products_tapped"
     case productDetailViewComponentsTapped = "product_details_view_components_tapped"
     case productDetailsViewSubscriptionsTapped = "product_details_view_subscriptions_tapped"
+    case productDetailViewQuantityRulesTapped = "product_detail_view_quantity_rules_tapped"
 
     // MARK: Edit Product Variation Events
     //
@@ -590,6 +591,7 @@ public enum WooAnalyticsStat: String {
     case productVariationDetailUpdateButtonTapped = "product_variation_update_button_tapped"
     case productVariationDetailUpdateSuccess = "product_variation_update_success"
     case productVariationDetailUpdateError = "product_variation_update_error"
+    case productVariationDetailViewQuantityRulesTapped = "product_variation_view_quantity_rules_tapped"
 
     case productVariationBulkUpdateSectionTapped = "product_variation_bulk_update_section_tapped"
     case productVariationBulkUpdateFieldTapped = "product_variation_bulk_update_field_tapped"

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormEventLogger.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormEventLogger.swift
@@ -23,4 +23,8 @@ struct ProductFormEventLogger: ProductFormEventLoggerProtocol {
     func logUpdateButtonTapped() {
         ServiceLocator.analytics.track(.productDetailUpdateButtonTapped)
     }
+
+    func logQuantityRulesTapped() {
+        ServiceLocator.analytics.track(event: .ProductDetail.quantityRulesTapped())
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormEventLoggerProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormEventLoggerProtocol.swift
@@ -17,4 +17,7 @@ protocol ProductFormEventLoggerProtocol {
 
     /// Called to log an event when the update CTA is tapped.
     func logUpdateButtonTapped()
+
+    /// Called to log an event when the quantity rules row is tapped.
+    func logQuantityRulesTapped()
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -467,7 +467,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
             case .noVariationsWarning:
                 return // This warning is not actionable.
             case .quantityRules:
-                // TODO: 9252 - Add analytics
+                eventLogger.logQuantityRulesTapped()
                 showQuantityRules()
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormEventLogger.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormEventLogger.swift
@@ -23,4 +23,8 @@ struct ProductVariationFormEventLogger: ProductFormEventLoggerProtocol {
     func logUpdateButtonTapped() {
         ServiceLocator.analytics.track(.productVariationDetailUpdateButtonTapped)
     }
+
+    func logQuantityRulesTapped() {
+        ServiceLocator.analytics.track(event: .Variations.quantityRulesTapped())
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9252 
⚠️ Depends on #9583
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds new tracking events for the Min/Max Quantities extension:

* Event name: `product_detail_view_quantity_rules_tapped`
   * Trigger: When the "Quantity rules" row is tapped in product details.
   * Event registration: 1576-gh-tracks-events-registration
* Event name: `product_variation_view_quantity_rules_tapped`
   * Trigger: When the "Quantity rules" row is tapped in product variation details.
   * Event registration: 1577-gh-tracks-events-registration

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Prerequisites

1. Install and activate the [Min/Max Quantities](https://woocommerce.com/products/minmax-quantities/) extension.
2. Create or edit a variable product, adding quantity rules in the General settings section and at least one variation with its own quantity rules in the variation settings.

### To test

1. Build and run the app.
2. Go to the Products tab.
3. Select the product with quantity rules.
4. Select the Quantity Rules row. Confirm the event `product_detail_view_quantity_rules_tapped` is tracked.
5. Select the Variations row to open the variations list.
6. Select a variation with quantity rules.
7. Select the Quantity Rules row. Confirm the event `product_variation_view_quantity_rules_tapped` is tracked.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
