### PR TITLE
[Min/Max Quantities] Release read-only support for min/max quantities

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -98,7 +98,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .hideStoreOnboardingTaskList:
             return true
         case .readOnlyMinMaxQuantities:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [**] Adds read-only support for the Subscriptions extension in order and product details. [https://github.com/woocommerce/woocommerce-ios/pull/9541]
 - [Internal] Payments: Upate Tap to Pay connection flow strings to avoid mentioning "reader" [https://github.com/woocommerce/woocommerce-ios/pull/9563]
 - [*] Store onboarding: Now the onboarding task list can be shown/hidden from settings and also from the dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/9572, https://github.com/woocommerce/woocommerce-ios/pull/9573]
+- [**] Adds read-only support for the Min/Max Quantities extension in product details. [https://github.com/woocommerce/woocommerce-ios/pull/9585]
 
 13.3
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

⚠️ Depends on #9584
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This releases read-only support for the Min/Max Quantities extension. It adds a "Quantity Rules" section to product and variation details, when the product or variation has quantity rules set.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Confirm the change in this PR makes the feature available to all users. If you have time, you can test the feature with the test plan in pe5pgL-2Fj-p2.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://user-images.githubusercontent.com/8658164/235158591-21c57d48-81d4-44e2-8b5d-cc9bcc838bf7.mp4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.