### PR TITLE
Product description AI: show a notice after generated description is copied

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationView.swift
@@ -25,6 +25,7 @@ final class ProductDescriptionGenerationHostingController: UIHostingController<P
 /// Allows the user to generate a product description using Jetpack AI given the product name and features.
 struct ProductDescriptionGenerationView: View {
     @ObservedObject private var viewModel: ProductDescriptionGenerationViewModel
+    @State private var copyTextNotice: Notice?
 
     init(viewModel: ProductDescriptionGenerationViewModel) {
         self.viewModel = viewModel
@@ -85,6 +86,7 @@ struct ProductDescriptionGenerationView: View {
                         // CTA to copy the generated text.
                         Button {
                             UIPasteboard.general.string = suggestedText
+                            copyTextNotice = .init(title: Localization.textCopiedNotice)
                             ServiceLocator.analytics.track(event: .ProductFormAI.productDescriptionAICopyButtonTapped())
                         } label: {
                             Label(Localization.copyGeneratedText, systemImage: "doc.on.doc")
@@ -122,6 +124,7 @@ struct ProductDescriptionGenerationView: View {
                 }
             }.padding(insets: Layout.insets)
         }
+        .notice($copyTextNotice, autoDismiss: true)
     }
 }
 
@@ -157,6 +160,10 @@ private extension ProductDescriptionGenerationView {
         static let copyGeneratedText = NSLocalizedString(
             "Copy",
             comment: "Button title to copy generated text in the product description AI generator view."
+        )
+        static let textCopiedNotice = NSLocalizedString(
+            "Copied!",
+            comment: "Text in the notice after copying the generated text in the product description AI generator view."
         )
         static let insertGeneratedText = NSLocalizedString("Apply",
                                                            comment: "Button title to insert AI-generated product description.")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9465 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

From a previous CR suggestion https://github.com/woocommerce/woocommerce-ios/pull/9562#discussion_r1179281629, it'd be nice to show some feedback when the generated product description is copied. This PR showed a notice using the `Notice` component at the bottom when the Copy CTA is tapped.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in to a WPCOM store if needed
- Go to the Products tab
- Create a product if needed
- Tap on an editable product
- Tap on the product description row
- Tap on the magic wand CTA above the keyboard
- Enter or update the product name
- Enter or update the product features
- Tap `Generate` --> after a few seconds, a generated text should be shown
- Tap `Copy` --> a notice "Copied!" should be shown at the bottom, and the text should be copied to the pasteboard

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

dark | light
-- | --
![Simulator Screen Shot - iPhone 14 - 2023-05-02 at 13 15 32](https://user-images.githubusercontent.com/1945542/235585050-efc7873b-1881-466a-9fa3-130544f4f0d8.png) | ![Simulator Screen Shot - iPhone 14 - 2023-05-02 at 13 15 41](https://user-images.githubusercontent.com/1945542/235585065-0e7535a4-ecfe-4aee-a310-610f67340181.png)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
