### PR TITLE
Login Onboarding: Update constraints for the content stack view

### DIFF
--- a/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
@@ -15,6 +15,7 @@ final class LoginOnboardingViewController: UIViewController {
                                                                           showsSubtitle: true)
     private lazy var buttonStackView: UIStackView = .init()
     private lazy var nextButton: UIButton = createNextButton()
+    private lazy var imageView = UIImageView(image: .wooLogoPrologueImage)
 
     private let analytics: Analytics
     private let featureFlagService: FeatureFlagService
@@ -77,7 +78,6 @@ private extension LoginOnboardingViewController {
     }
 
     func configureWooLogo() {
-        let imageView = UIImageView(image: .wooLogoPrologueImage)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(imageView)
         NSLayoutConstraint.activate([
@@ -95,7 +95,12 @@ private extension LoginOnboardingViewController {
         stackView.spacing = Constants.stackViewSpacing
         stackView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(stackView)
-        view.pinSubviewToSafeArea(stackView, insets: Constants.stackViewInsets)
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: view.safeLeadingAnchor, constant: Constants.stackViewInsets.left),
+            stackView.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor, constant: -Constants.stackViewInsets.right),
+            stackView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor, constant: -Constants.stackViewInsets.bottom),
+            stackView.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: Constants.stackViewInsets.top)
+        ])
     }
 
     func configureStackViewSubviews() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9393
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Last week in #9567 I updated the constraints on the login carousel to support scrolling contents when needed. This caused a regression issue on the login onboarding screen where the image of the carousel is a bit too close the the Woo logo:

<img src="https://user-images.githubusercontent.com/5533851/235612562-29dbe3a9-9822-444a-88d2-a8db3d815622.png" width=320 />

This PR fixes this by updating the constraints of the stack view on the login onboarding screen to ensure some spacing between the logo and the contents.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Reinstall the app on your device.
- Notice that the content stack view has some spacing to Woo logo image.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Normal font size | Large font size |
| ----- | ----- |
| <img src="https://user-images.githubusercontent.com/5533851/235613300-f4aea3e6-af10-4852-a6f7-8dc1ae90972e.png" width=320 /> | <img src="https://user-images.githubusercontent.com/5533851/235613061-bb2c726f-886a-46b3-848c-d75e7b268f75.png" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
