### PR TITLE
[Simplify Product Editing] Remove SPE experiment from add product flow

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -14,10 +14,6 @@ public enum ABTest: String, Codable, CaseIterable {
     /// Experiment ref: pbxNRc-1S0-p2
     case aaTestLoggedOut = "woocommerceios_explat_aa_test_logged_out_202212_v2"
 
-    /// A/B test for a simplified product creation and editing experience.
-    /// Experiment ref: pbxNRc-2li-p2
-    case simplifiedProductEditing = "woocommerceios_products_creation_editing_simplify_v1"
-
     /// Returns a variation for the given experiment
     ///
     public var variation: Variation? {
@@ -29,7 +25,7 @@ public enum ABTest: String, Codable, CaseIterable {
     /// When adding a new experiment, add it to the appropriate case depending on its context (logged-in or logged-out experience).
     public var context: ExperimentContext {
         switch self {
-        case .aaTestLoggedIn, .simplifiedProductEditing:
+        case .aaTestLoggedIn:
             return .loggedIn
         case .aaTestLoggedOut:
             return .loggedOut

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -68,9 +68,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .domainSettings:
             return true
         case .simplifyProductEditing:
-            // Enabled for the A/B experiment treatment group only
-            // Disabled for the control group and UI testing
-            return ABTest.simplifiedProductEditing.variation == .treatment && !isUITesting
+            return false
         case .jetpackSetupWithApplicationPassword:
             return true
         case .dashboardOnboarding:

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
@@ -10,10 +10,10 @@ struct ProductFactory {
     ///   - isVirtual: Whether the product is virtual (for simple products).
     ///   - siteID: The site ID where the product is added to.
     ///   - status: The status of the new product.
-    func createNewProduct(type: ProductType, isVirtual: Bool, siteID: Int64, status: ProductStatus = .published) -> Product? {
+    func createNewProduct(type: ProductType, isVirtual: Bool, siteID: Int64) -> Product? {
         switch type {
         case .simple, .grouped, .variable, .affiliate:
-            return createEmptyProduct(type: type, isVirtual: isVirtual, siteID: siteID, status: status)
+            return createEmptyProduct(type: type, isVirtual: isVirtual, siteID: siteID)
         default:
             return nil
         }
@@ -25,13 +25,13 @@ struct ProductFactory {
     /// - Parameters:
     ///   - existingProduct: The product to copy.
     ///   - status: The status of the new product.
-    func newProduct(from existingProduct: Product, status: ProductStatus = .published) -> Product {
-        return existingProduct.copy(productID: 0, name: "", statusKey: status.rawValue, groupedProducts: [])
+    func newProduct(from existingProduct: Product) -> Product {
+        return existingProduct.copy(productID: 0, name: "", statusKey: ProductStatus.published.rawValue, groupedProducts: [])
     }
 }
 
 private extension ProductFactory {
-    func createEmptyProduct(type: ProductType, isVirtual: Bool, siteID: Int64, status: ProductStatus) -> Product {
+    func createEmptyProduct(type: ProductType, isVirtual: Bool, siteID: Int64) -> Product {
         Product(siteID: siteID,
                 productID: 0,
                 name: "",
@@ -43,7 +43,7 @@ private extension ProductFactory {
                 dateOnSaleStart: nil,
                 dateOnSaleEnd: nil,
                 productTypeKey: type.rawValue,
-                statusKey: status.rawValue,
+                statusKey: ProductStatus.published.rawValue,
                 featured: false,
                 catalogVisibilityKey: ProductCatalogVisibility.visible.rawValue,
                 fullDescription: "",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -224,11 +224,9 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
     /// Additionally we don't take dates into consideration as we don't control their value when creating a product.
     ///
     func isEmpty() -> Bool {
-        let simplifiedEditingEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing)
         guard let emptyProduct = ProductFactory().createNewProduct(type: productType,
                                                                    isVirtual: virtual,
-                                                                   siteID: siteID,
-                                                                   status: simplifiedEditingEnabled ? .draft : .published) else {
+                                                                   siteID: siteID) else {
             return false
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -293,14 +293,6 @@ private extension ProductsViewController {
             fatalError("No source view for adding a product")
         }
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing) {
-            coordinatingController.onProductCreated = { product in
-                navigationController.dismiss(animated: true) { [weak self] in
-                    self?.didSelectProduct(product: product)
-                }
-            }
-        }
-
         coordinatingController.start()
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/ProductFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/ProductFactoryTests.swift
@@ -7,11 +7,10 @@ final class ProductFactoryTests: XCTestCase {
     private let siteID: Int64 = 134
 
     func test_created_simple_physical_product_has_expected_fields() throws {
-        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: siteID, status: .draft))
+        let product = try XCTUnwrap(ProductFactory().createNewProduct(type: .simple, isVirtual: false, siteID: siteID))
         XCTAssertEqual(product.productType, .simple)
         XCTAssertEqual(product.virtual, false)
         XCTAssertEqual(product.siteID, siteID)
-        XCTAssertEqual(product.statusKey, ProductStatus.draft.rawValue)
     }
 
     func test_created_simple_virtual_product_has_expected_fields() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9519
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We're removing the unsuccessful Simplify Product Editing (SPE) experiment from the app. To make it more reasonable for code review, this is divided into three PRs:

* #9600 (this PR)
* #9601
* #9602

The experiment has been remotely disabled already, so there should be no visible change in behavior from `trunk`.

### Changes

* Removes SPE experiment from `ABTest`.
* Disables SPE feature flag.
* Removes SPE changes from `AddProductCoordinator`, which controlled what options were presented in the bottom sheet after starting the add product flow.
* Removes SPE changes from `ProductFactory`: products should always be created with `published` status (SPE supported creating products as drafts).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Open the Products tab.
3. Tap the `+` icon to add a new product. If there are fewer than 3 products on the store, confirm you see the "Add a product" bottom sheet with options to start with a template or add a product manually. If there are 3 or more products on the store, confirm you see the bottom sheet with all product type options (to add a product manually).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Add product|Start with a template|Add manually
-|-|-
![Simulator Screenshot - iPhone 14 Pro - 2023-05-02 at 15 30 02](https://user-images.githubusercontent.com/8658164/235699948-a13d1b35-3ab0-4fb6-b80f-974d8411ace3.png)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-02 at 15 30 05](https://user-images.githubusercontent.com/8658164/235699953-e4305696-150b-4cfe-b12b-7b2c104f6f4a.png)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-02 at 15 30 08](https://user-images.githubusercontent.com/8658164/235699955-8e868b90-7620-4ec8-bfcb-8d08c999fce3.png)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
