### PR TITLE
[Simplify Product Editing] Remove SPE experiment from product settings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -27,114 +27,6 @@ protocol ProductSettingsRowMediator {
 //
 enum ProductSettingsRows {
 
-    struct ProductType: ProductSettingsRowMediator {
-        private let settings: ProductSettings
-        private let supportedTypes: [Yosemite.ProductType] = [.simple, .affiliate, .grouped, .variable]
-
-        init(_ settings: ProductSettings) {
-            self.settings = settings
-        }
-
-        func configure(cell: UITableViewCell) {
-            guard let cell = cell as? TitleAndValueTableViewCell else {
-                return
-            }
-
-            if supportedTypes.contains(settings.productType) {
-                cell.accessoryType = .disclosureIndicator
-                cell.selectionStyle = .default
-                cell.apply(style: .regular)
-            } else {
-                cell.accessoryType = .none
-                cell.selectionStyle = .none
-                cell.apply(style: .nonSelectable)
-            }
-
-            let details: String
-            let hideDownloadableProductType = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing)
-            switch settings.productType {
-            case .simple:
-                switch (settings.downloadable, settings.virtual, hideDownloadableProductType) {
-                case (true, _, false):
-                    details = Localization.downloadableProductType
-                case (_, true, _):
-                    details = Localization.virtualProductType
-                case (_, false, _):
-                    details = Localization.physicalProductType
-                }
-            case .custom(let customProductType):
-                // Custom product type description is the slug, thus we replace the dash with space and capitalize the string.
-                details = customProductType.description.replacingOccurrences(of: "-", with: " ").capitalized
-            default:
-                details = settings.productType.description
-            }
-
-            cell.updateUI(title: Localization.productType, value: details)
-        }
-
-        func handleTap(sourceViewController: UIViewController, onCompletion: @escaping (ProductSettings) -> Void) {
-            guard supportedTypes.contains(settings.productType) else {
-                return
-            }
-
-            let viewProperties = BottomSheetListSelectorViewProperties(subtitle: Localization.productTypeSheetTitle)
-            let productType = BottomSheetProductType(productType: settings.productType, isVirtual: settings.virtual)
-            let command = ProductTypeBottomSheetListSelectorCommand(selected: productType) { selectedProductType in
-                sourceViewController.dismiss(animated: true, completion: nil)
-
-                let originalProductType = settings.productType
-
-                ServiceLocator.analytics.track(.productTypeChanged, withProperties: [
-                    "from": originalProductType.rawValue,
-                    "to": selectedProductType.productType.rawValue
-                ])
-
-                presentProductTypeChangeAlert(for: originalProductType, on: sourceViewController, completion: { change in
-                    guard change else {
-                        return
-                    }
-
-                    self.settings.productType = selectedProductType.productType
-                    self.settings.virtual = selectedProductType.isVirtual
-                    onCompletion(self.settings)
-                })
-            }
-            let productTypesListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
-            productTypesListPresenter.show(from: sourceViewController)
-        }
-
-        /// Product Type Change alert
-        ///
-        private func presentProductTypeChangeAlert(for productType: Yosemite.ProductType, on vc: UIViewController, completion: @escaping (Bool) -> ()) {
-            let body: String
-            switch productType {
-            case .variable:
-                body = Localization.Alert.productVariableTypeChangeMessage
-            default:
-                body = Localization.Alert.productTypeChangeMessage
-            }
-
-            let alertController = UIAlertController(title: Localization.Alert.productTypeChangeTitle,
-                                                    message: body,
-                                                    preferredStyle: .alert)
-            let cancel = UIAlertAction(title: Localization.Alert.productTypeChangeCancelButton,
-                                       style: .cancel) { (action) in
-                                           completion(false)
-                                       }
-            let confirm = UIAlertAction(title: Localization.Alert.productTypeChangeConfirmButton,
-                                        style: .default) { (action) in
-                                            completion(true)
-                                        }
-            alertController.addAction(cancel)
-            alertController.addAction(confirm)
-            vc.present(alertController, animated: true)
-        }
-
-        let reuseIdentifier: String = TitleAndValueTableViewCell.reuseIdentifier
-
-        let cellTypes: [UITableViewCell.Type] = [TitleAndValueTableViewCell.self]
-    }
-
     struct Status: ProductSettingsRowMediator {
         private let settings: ProductSettings
 
@@ -453,17 +345,6 @@ enum ProductSettingsRows {
 
 extension ProductSettingsRows {
     enum Localization {
-        // Product Type
-        static let productType = NSLocalizedString("Product Type", comment: "Product Type label in Product Settings")
-        static let downloadableProductType = NSLocalizedString("Downloadable",
-                                                               comment: "Display label for simple downloadable product type.")
-        static let virtualProductType = NSLocalizedString("Virtual",
-                                                          comment: "Display label for simple virtual product type.")
-        static let physicalProductType = NSLocalizedString("Physical",
-                                                           comment: "Display label for simple physical product type.")
-        static let productTypeSheetTitle = NSLocalizedString("Change product type",
-                                                             comment: "Message title of bottom sheet for selecting a product type")
-
         static let status = NSLocalizedString("Status", comment: "Status label in Product Settings")
         static let visibility = NSLocalizedString("Visibility", comment: "Visibility label in Product Settings")
         static let catalogVisibility = NSLocalizedString("Catalog Visibility", comment: "Catalog Visibility label in Product Settings")
@@ -473,21 +354,5 @@ extension ProductSettingsRows {
         static let slug = NSLocalizedString("Slug", comment: "Slug label in Product Settings")
         static let purchaseNote = NSLocalizedString("Purchase Note", comment: "Purchase note label in Product Settings")
         static let menuOrder = NSLocalizedString("Menu Order", comment: "Menu order label in Product Settings")
-
-        enum Alert {
-            // Product type change
-            static let productTypeChangeTitle = NSLocalizedString("Are you sure you want to change the product type?",
-                                                                  comment: "Title of the alert when a user is changing the product type")
-            static let productTypeChangeMessage = NSLocalizedString("Changing the product type will modify some of the product data",
-                                                                    comment: "Body of the alert when a user is changing the product type")
-            static let productVariableTypeChangeMessage =
-                NSLocalizedString("Changing the product type will modify some of the product data and delete all your attributes and variations",
-                                  comment: "Body of the alert when a user is changing the product type")
-
-            static let productTypeChangeCancelButton =
-                NSLocalizedString("Cancel", comment: "Cancel button on the alert when the user is cancelling the action on changing product type")
-            static let productTypeChangeConfirmButton = NSLocalizedString("Yes, change",
-                                                                          comment: "Confirmation button on the alert when the user is changing product type")
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -8,36 +8,25 @@ protocol ProductSettingsSectionMediator {
     var title: String { get }
     var rows: [ProductSettingsRowMediator] { get }
 
-    init(_ settings: ProductSettings, isDownloadableSettingEnabled: Bool)
+    init(_ settings: ProductSettings)
 }
 
 // MARK: - Sections declaration for Product Settings
 //
 enum ProductSettingsSections {
-    /// Type Setting section
-    struct ProductTypeSetting: ProductSettingsSectionMediator {
-        let title = ""
-
-        let rows: [ProductSettingsRowMediator]
-
-        init(_ settings: ProductSettings, isDownloadableSettingEnabled: Bool = false) {
-            rows = [ProductSettingsRows.ProductType(settings)]
-        }
-    }
-
     /// Publish Settings section
     struct PublishSettings: ProductSettingsSectionMediator {
         let title = NSLocalizedString("Publish Settings", comment: "Title of the Publish Settings section on Product Settings screen")
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings, isDownloadableSettingEnabled: Bool) {
+        init(_ settings: ProductSettings) {
             if settings.productType == .simple {
                 let tempRows: [ProductSettingsRowMediator?] = [ProductSettingsRows.Status(settings),
                         ProductSettingsRows.Visibility(settings),
                         ProductSettingsRows.CatalogVisibility(settings),
                         ProductSettingsRows.VirtualProduct(settings),
-                        isDownloadableSettingEnabled ? ProductSettingsRows.DownloadableProduct(settings) : nil
+                        ProductSettingsRows.DownloadableProduct(settings)
                 ]
                 rows = tempRows.compactMap { $0 }
             } else {
@@ -54,7 +43,7 @@ enum ProductSettingsSections {
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings, isDownloadableSettingEnabled: Bool = false) {
+        init(_ settings: ProductSettings) {
             rows = [ProductSettingsRows.ReviewsAllowed(settings),
             ProductSettingsRows.Slug(settings),
             ProductSettingsRows.PurchaseNote(settings),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
@@ -11,9 +11,7 @@ final class ProductSettingsViewModel {
 
     var productSettings: ProductSettings {
         didSet {
-            sections = Self.configureSections(productSettings,
-                                              isProductTypeSettingEnabled: isProductTypeSettingEnabled,
-                                              isDownloadableSettingEnabled: isDownloadableSettingEnabled)
+            sections = Self.configureSections(productSettings)
         }
     }
 
@@ -29,31 +27,20 @@ final class ProductSettingsViewModel {
     var onReload: (() -> Void)?
     var onPasswordRetrieved: ((_ password: String) -> Void)?
 
-    private let isProductTypeSettingEnabled: Bool
-    private let isDownloadableSettingEnabled: Bool
-
     init(product: Product,
          password: String?,
-         formType: ProductFormType,
-         isProductTypeSettingEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing),
-         isDownloadableSettingEnabled: Bool = !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.simplifyProductEditing)) {
+         formType: ProductFormType) {
         self.product = product
         self.password = password
-        self.isProductTypeSettingEnabled = isProductTypeSettingEnabled
-        self.isDownloadableSettingEnabled = isDownloadableSettingEnabled
         productSettings = ProductSettings(from: product, password: password)
 
         switch formType {
         case .add:
             self.password = ""
             productSettings.password = ""
-            sections = Self.configureSections(productSettings,
-                                              isProductTypeSettingEnabled: isProductTypeSettingEnabled,
-                                              isDownloadableSettingEnabled: isDownloadableSettingEnabled)
+            sections = Self.configureSections(productSettings)
         case .edit:
-            sections = Self.configureSections(productSettings,
-                                              isProductTypeSettingEnabled: isProductTypeSettingEnabled,
-                                              isDownloadableSettingEnabled: isDownloadableSettingEnabled)
+            sections = Self.configureSections(productSettings)
             /// If nil, we fetch the password from site post API because it was never fetched
             /// Skip this if the user is not authenticated with WPCom.
             if password == nil && ServiceLocator.stores.isAuthenticatedWithoutWPCom == false {
@@ -67,15 +54,11 @@ final class ProductSettingsViewModel {
                     self.onPasswordRetrieved?(password)
                     self.password = password
                     self.productSettings.password = password
-                    self.sections = Self.configureSections(self.productSettings,
-                                                           isProductTypeSettingEnabled: isProductTypeSettingEnabled,
-                                                           isDownloadableSettingEnabled: isDownloadableSettingEnabled)
+                    self.sections = Self.configureSections(self.productSettings)
                 }
             }
         case .readonly:
-            sections = Self.configureSections(productSettings,
-                                              isProductTypeSettingEnabled: isProductTypeSettingEnabled,
-                                              isDownloadableSettingEnabled: isDownloadableSettingEnabled)
+            sections = Self.configureSections(productSettings)
         }
     }
 
@@ -118,19 +101,10 @@ private extension ProductSettingsViewModel {
 // MARK: Configure sections and rows in Product Settings
 //
 private extension ProductSettingsViewModel {
-    static func configureSections(_ settings: ProductSettings,
-                                  isProductTypeSettingEnabled: Bool,
-                                  isDownloadableSettingEnabled: Bool) -> [ProductSettingsSectionMediator] {
-        if isProductTypeSettingEnabled {
-            return [ProductSettingsSections.ProductTypeSetting(settings),
-                    ProductSettingsSections.PublishSettings(settings, isDownloadableSettingEnabled: isDownloadableSettingEnabled),
-                    ProductSettingsSections.MoreOptions(settings)
-            ]
-        } else {
-            return [ProductSettingsSections.PublishSettings(settings, isDownloadableSettingEnabled: isDownloadableSettingEnabled),
-                    ProductSettingsSections.MoreOptions(settings)
-            ]
-        }
+    static func configureSections(_ settings: ProductSettings) -> [ProductSettingsSectionMediator] {
+        return [ProductSettingsSections.PublishSettings(settings),
+                ProductSettingsSections.MoreOptions(settings)
+        ]
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
@@ -21,7 +21,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
                                        downloadable: false)
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings, isDownloadableSettingEnabled: true)
+        let section = ProductSettingsSections.PublishSettings(settings)
 
         // Then
         XCTAssertNil(section.rows.first(where: {
@@ -44,7 +44,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
                                        downloadable: false)
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings, isDownloadableSettingEnabled: true)
+        let section = ProductSettingsSections.PublishSettings(settings)
 
         // Then
         XCTAssertNotNil(section.rows.first(where: {
@@ -67,7 +67,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
                                         downloadable: false)
 
           // When
-        let section = ProductSettingsSections.PublishSettings(settings, isDownloadableSettingEnabled: true)
+        let section = ProductSettingsSections.PublishSettings(settings)
 
           // Then
          XCTAssertNil(section.rows.first(where: {
@@ -90,34 +90,11 @@ final class ProductSettingsSectionsTests: XCTestCase {
                                         downloadable: false)
 
           // When
-          let section = ProductSettingsSections.PublishSettings(settings, isDownloadableSettingEnabled: true)
+          let section = ProductSettingsSections.PublishSettings(settings)
 
           // Then
          XCTAssertNotNil(section.rows.first(where: {
              $0 is ProductSettingsRows.DownloadableProduct
          }))
      }
-
-    func test_given_a_simple_product_then_it_does_not_show_the_downloadable_product_option_when_it_is_disabled() {
-       // Given
-       let settings = ProductSettings(productType: .simple,
-                                      status: .draft,
-                                      featured: false,
-                                      password: nil,
-                                      catalogVisibility: .catalog,
-                                      virtual: false,
-                                      reviewsAllowed: false,
-                                      slug: "",
-                                      purchaseNote: nil,
-                                      menuOrder: 0,
-                                      downloadable: false)
-
-        // When
-        let section = ProductSettingsSections.PublishSettings(settings, isDownloadableSettingEnabled: false)
-
-        // Then
-       XCTAssertNil(section.rows.first(where: {
-           $0 is ProductSettingsRows.DownloadableProduct
-       }))
-   }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
@@ -68,32 +68,6 @@ final class ProductSettingsViewModelTests: XCTestCase {
 
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
-
-    func test_viewmodel_has_product_type_setting_displayed_when_it_is_enabled() {
-        // Given
-        let product = Product.fake().copy(productTypeKey: "simple")
-        let viewModel = ProductSettingsViewModel(product: product, password: nil, formType: .edit, isProductTypeSettingEnabled: true)
-
-        // Then
-        XCTAssertTrue(viewModel.productSettings.productType == .simple)
-        XCTAssertFalse(viewModel.hasUnsavedChanges())
-        XCTAssertTrue(viewModel.sections.first is ProductSettingsSections.ProductTypeSetting)
-
-        // When
-        viewModel.productSettings.productType = .variable
-
-        // Then
-        XCTAssertTrue(viewModel.hasUnsavedChanges())
-    }
-
-    func test_viewmodel_hides_product_type_setting_when_it_is_disabled() {
-        // Given
-        let product = Product.fake().copy(productTypeKey: "simple")
-        let viewModel = ProductSettingsViewModel(product: product, password: nil, formType: .edit, isProductTypeSettingEnabled: false)
-
-        // Then
-        XCTAssertFalse(viewModel.sections.contains(where: { $0 is ProductSettingsSections.ProductTypeSetting }))
-    }
 }
 
 private extension ProductSettingsViewModel {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9519
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We're removing the unsuccessful Simplify Product Editing (SPE) experiment from the app. To make it more reasonable for code review, this is divided into three PRs:

* #9600
* #9601 (this PR)
* #9602

The experiment has been remotely disabled already, so there should be no visible change in behavior from `trunk`.

### Changes

* Removes `ProductType` row from `ProductSettingsRows`
* Removes `ProductTypeSetting` section from `ProductSettingsSections`.
* Always includes `DownloadableProduct` row for simple products. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Build and run the app.
2. Open the Products tab.
3. Select or add a simple product to open the product details.
4. Open the product settings for the product. Confirm there is no Product Type setting, and there is a Downloadable Product setting (toggle).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://user-images.githubusercontent.com/8658164/235702011-c2a764c9-0755-4bc3-8cab-ed7d9994dc37.png" width="300px">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
